### PR TITLE
Adjusts config to run smart contract test coverage

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -2,9 +2,10 @@ version: '3'
 services:
   ganache:
     restart: always
-    image: trufflesuite/ganache-cli
+    image: trufflesuite/ganache-cli:v6.1.6
     expose:
       - 8545
+    command: ["-h=0.0.0.0"]
   unlock:
     build:
       context: ..

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -24,7 +24,8 @@
     "eslint-plugin-mocha": "^4.12.1",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-standard": "^3.0.1"
+    "eslint-plugin-standard": "^3.0.1",
+    "solhint":"^1.2.1"
   },
   "scripts": {
     "test": "truffle test",


### PR DESCRIPTION
While running through the project setup, I noticed that the smart contract tests weren't running when utilizing the docker compose config. 

With some digging, it looks like the root cause may be attributed to an unexpected change to the upstream `trufflesuite/ganache-cli` image. The `latest` version of this image at the time of writing is `6.1.6`.

The approach taken in this PR is to provide an explict version to the dependency.
https://github.com/trufflesuite/ganache-cli/issues/553

I also noticed that `solhint` wasn't available within the testing environment, so that has been added as well.