### PR TITLE
Ensure lock address is passed explicitly

### DIFF
--- a/unlock-app/src/components/creator/Locks.js
+++ b/unlock-app/src/components/creator/Locks.js
@@ -6,7 +6,7 @@ import Icon from '../lock/Icon'
 
 const LockInList = (props) => {
   return (<li className="list-group-item">
-    <Icon lock={props.lock} />
+    <Icon lock={props.lock} address={props.lock.address} />
     <Link to={`/creator/lock/${props.lock.address}`}>
       {props.lock.address}
     </Link>


### PR DESCRIPTION
This was throwing an error when run, because the icon was expecting an address to be passed as a string.