### PR TITLE
Truncates ETH Balances presented on front end

### DIFF
--- a/unlock-app/src/__tests__/components/helpers/Balance.test.js
+++ b/unlock-app/src/__tests__/components/helpers/Balance.test.js
@@ -4,16 +4,41 @@ import { render } from 'enzyme'
 import { Balance } from '../../../components/helpers/Balance'
 
 describe('Balance Component', () => {
+  const unit = 'szabo'  
 
-  const amount = '100000000'
-  const unit = 'szabo'
+  describe('when the balance is < 0.0001 Eth', () => {
+    const amount = '70'  
+      
+    const wrapper = render(<Balance
+      amount={amount}
+      unit={unit} />)
 
-  const wrapper = render(<Balance
-    amount={amount}
-    unit={unit} />)
-
-  it('shows the balance in Eth', () => {
-    expect(wrapper.text()).toEqual('三 100')
+    it('shows the default minimum value of 三 < 0.0001', () => {
+      expect(wrapper.text()).toEqual('三 < 0.0001')
+    })
   })
 
+  describe('when the balance is > 0.0001 Eth and less than 1 Eth', () => {
+    const amount = '75800'      
+  
+    const wrapper = render(<Balance
+      amount={amount}
+      unit={unit} />)
+  
+    it('shows the balance in Eth to two decimal places', () => {
+      expect(wrapper.text()).toEqual('三 0.076')
+    })
+  })
+
+  describe('when the balance is > 1 Eth ', () => {
+    const amount = '2000000'      
+  
+    const wrapper = render(<Balance
+      amount={amount}
+      unit={unit} />)
+  
+    it('shows the balance in Eth to two decimal places', () => {
+      expect(wrapper.text()).toEqual('三 2.00')
+    })
+  })
 })

--- a/unlock-app/src/components/helpers/Balance.js
+++ b/unlock-app/src/components/helpers/Balance.js
@@ -11,9 +11,33 @@ import Web3Utils from 'web3-utils'
 export function Balance({ amount, unit = 'wei' }) {
   let inWei = Web3Utils.toWei(amount || '0', unit)
   let inEth = Web3Utils.fromWei(inWei, 'ether')
+  let ethWithPresentation = BalancePresenter(inEth)
+ 
   return (<BalanceWithUnit>
-    三 {inEth}
+    三 {ethWithPresentation}
   </BalanceWithUnit>)
+}
+
+/**
+ * Provide a representaion of Eth Balances suitable for the Unlock frontend
+ * application.
+ * @param {string} eth: An amount of Eth 
+ */
+function BalancePresenter(eth){  
+  const DECIMAL_PLACES = 2
+  const SIGNIFICANT_DIGITS = 2
+  const MINIMUM_THRESHOLD = 0.0001
+
+  let numericalEth = Number(eth)
+  
+  switch(true){
+  case numericalEth < MINIMUM_THRESHOLD:
+    return '< 0.0001'
+  case numericalEth < 1:
+    return parseFloat(numericalEth.toPrecision(SIGNIFICANT_DIGITS))
+  default:
+    return numericalEth.toFixed(DECIMAL_PLACES)
+  }
 }
 
 Balance.propTypes = {


### PR DESCRIPTION
As part of making the frontend more approachable, the following presentation logic has been applied where balances are currently being presented:

* Users with less than 0.0001 Eth will now see "< 0.0001"
* Users with greater than 0.0001 Eth but less than 1 ETh will now see their balance including at most two non-zero digits.
* User with > 1 Eth will see their balance truncated to two decimals.

 #325 