### PR TITLE
Ensuring fonts are properly loaded in server-rendered pages

### DIFF
--- a/unlock-app/src/pages/_document.js
+++ b/unlock-app/src/pages/_document.js
@@ -16,6 +16,11 @@ export default class MyDocument extends Document {
         <Head>
           <meta name='viewport' content='width=device-width, initial-scale=1' />
           <link rel='shortcut icon' href='/static/favicon.ico' />
+          <style>
+            @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600,700);
+            @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Mono:200i,200,500);
+            @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Serif:300,400);
+          </style>
           {this.props.styleTags}
         </Head>
         <body>

--- a/unlock-app/src/pages/_document.js
+++ b/unlock-app/src/pages/_document.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Document, { Head, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
-import { globalFonts } from '../theme/globalStyle'
+import { globalStyle } from '../theme/globalStyle'
 
 export default class MyDocument extends Document {
   static getInitialProps ({ renderPage }) {
@@ -18,7 +18,7 @@ export default class MyDocument extends Document {
           <meta name='viewport' content='width=device-width, initial-scale=1' />
           <link rel='shortcut icon' href='/static/favicon.ico' />
           <style>
-            {globalFonts}
+            {globalStyle}
           </style>
           {this.props.styleTags}
         </Head>

--- a/unlock-app/src/pages/_document.js
+++ b/unlock-app/src/pages/_document.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Document, { Head, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
+import { globalFonts } from '../theme/globalStyle'
 
 export default class MyDocument extends Document {
   static getInitialProps ({ renderPage }) {
@@ -17,9 +18,7 @@ export default class MyDocument extends Document {
           <meta name='viewport' content='width=device-width, initial-scale=1' />
           <link rel='shortcut icon' href='/static/favicon.ico' />
           <style>
-            @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600,700);
-            @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Mono:200i,200,500);
-            @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Serif:300,400);
+            {globalFonts}
           </style>
           {this.props.styleTags}
         </Head>

--- a/unlock-app/src/theme/globalStyle.js
+++ b/unlock-app/src/theme/globalStyle.js
@@ -4,14 +4,10 @@ import { createGlobalStyle } from 'styled-components'
  * Shared CSS accross all components. Injected wtih styled-components' createGlobalStyle
  */
 
-export const globalFonts = `
+export const globalStyle = `
   @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600,700);
   @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Mono:200i,200,500);
   @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Serif:300,400);
-`
-
-export default createGlobalStyle`
-  ${globalFonts}
 
   :root {
     --white: #ffffff;
@@ -51,4 +47,8 @@ export default createGlobalStyle`
   a:visited {
     color: var(--link);
   }
+`
+
+export default createGlobalStyle`
+  ${globalStyle}
 `

--- a/unlock-app/src/theme/globalStyle.js
+++ b/unlock-app/src/theme/globalStyle.js
@@ -4,11 +4,15 @@ import { createGlobalStyle } from 'styled-components'
  * Shared CSS accross all components. Injected wtih styled-components' createGlobalStyle
  */
 
-export default createGlobalStyle`
+export const globalFonts = `
   @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600,700);
   @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Mono:200i,200,500);
   @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Serif:300,400);
-            
+`
+
+export default createGlobalStyle`
+  ${globalFonts}
+
   :root {
     --white: #ffffff;
     --red: #ed663a;

--- a/unlock-app/src/theme/globalStyle.js
+++ b/unlock-app/src/theme/globalStyle.js
@@ -5,10 +5,10 @@ import { createGlobalStyle } from 'styled-components'
  */
 
 export default createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600,700');
-  @import url('https://fonts.googleapis.com/css?family=IBM+Plex+Mono:200i,200,500');
-  @import url('https://fonts.googleapis.com/css?family=IBM+Plex+Serif:300,400');
-
+  @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600,700);
+  @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Mono:200i,200,500);
+  @import url(https://fonts.googleapis.com/css?family=IBM+Plex+Serif:300,400);
+            
   :root {
     --white: #ffffff;
     --red: #ed663a;
@@ -38,7 +38,6 @@ export default createGlobalStyle`
     font-size: 15px;
     font-weight: 500;
   }
-
 
   a {
     text-decoration: none;


### PR DESCRIPTION
Fixes #400


I moved the font import statements to a shareable constant and ensured they were loaded from the server side too. That's all it was - styles are being loaded properly (tested with JS off, etc).