### PR TITLE
Bind is required

### DIFF
--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -14,6 +14,7 @@ export class CreatorLock extends React.Component {
     this.state = {
       showEmbedCode: false,
     }
+    this.toggleEmbedCode = this.toggleEmbedCode.bind(this)
   }
 
   toggleEmbedCode() {


### PR DESCRIPTION
It turns out that we really do need to bind methods if we want them to use `this`.