### PR TITLE
Propose adding interface IUnlock.sol to save gas.

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.4.24;
 
 import "./interfaces/ILockPublic.sol";
-import "./Unlock.sol";
+import "./interfaces/IUnlock.sol";
 
 /**
  * TODO: consider error codes rather than strings
@@ -243,6 +243,18 @@ contract PublicLock is ILockPublic {
   }
 
   /**
+   * A function which lets the owner of the lock to change the price for future purchases.
+   */
+  function updateKeyPrice(
+    uint _keyPrice
+  )
+    external
+    onlyOwner
+  {
+    keyPrice = _keyPrice;
+  }
+
+  /**
    * In the specific case of a Lock, each owner can own only at most 1 key.
    * @return The number of NFTs owned by `_owner`, either 0 or 1.
   */
@@ -311,18 +323,6 @@ contract PublicLock is ILockPublic {
   }
 
   /**
-   * A function which lets the owner of the lock to change the price for future purchases.
-   */
-  function updateKeyPrice(
-    uint _keyPrice
-  )
-    external
-    onlyOwner
-  {
-    keyPrice = _keyPrice;
-  }
-
-  /**
   * @dev Returns the key's data field for a given owner.
   * @param _owner address of the user for whom we search the key
   */
@@ -374,7 +374,7 @@ contract PublicLock is ILockPublic {
     require(_recipient != address(0));
 
     // Let's get the actual price for the key from the Unlock smart contract
-    Unlock unlock = Unlock(unlockProtocol);
+    IUnlock unlock = IUnlock(unlockProtocol);
     uint discount;
     uint tokens;
     (discount, tokens) = unlock.computeAvailableDiscountFor(_recipient, keyPrice);

--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -3,10 +3,11 @@ pragma solidity 0.4.24;
 /**
  * @title The Unlock contract
  * @author Julien Genestoux (unlock-protocol.com)
- * This smart contract has 2 main roles:
+ * This smart contract has 3 main roles:
  *  1. Distribute discounts to discount token holders
  *  2. Grant dicount tokens to users making referrals and/or publishers granting discounts.
- * In order to achieve these 2 elements, it keeps track of several things such as
+ *  3. Create & deploy Public Lock contracts.
+ * In order to achieve these 3 elements, it keeps track of several things such as
  *  a. Deployed locks addresses and balances of discount tokens granted by each lock.
  *  b. The total network product (sum of all key sales, net of discounts)
  *  c. Total of discounts granted
@@ -27,9 +28,10 @@ pragma solidity 0.4.24;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "./PublicLock.sol";
+import "./interfaces/IUnlock.sol";
 
 
-contract Unlock is Ownable {
+contract Unlock is IUnlock, Ownable {
 
   /**
    * The struct for a lock
@@ -63,7 +65,7 @@ contract Unlock is Ownable {
 
   bool internal initialized;
 
-  // Use initialize instead of a constructor to support proxies (for upgradeability).
+  // Use initialize instead of a constructor to support proxies (for upgradeability via zos).
   function initialize(
     address _owner
   )
@@ -86,7 +88,7 @@ contract Unlock is Ownable {
     uint _maxNumberOfKeys
   )
     public
-    returns (PublicLock lock)
+    returns (ILockCore lock)
   {
 
     // create lock
@@ -123,7 +125,7 @@ contract Unlock is Ownable {
     uint _keyPrice // solhint-disable-line no-unused-vars
   )
     public
-    pure
+    view
     returns (uint discount, uint tokens)
   {
     // TODO: implement me

--- a/smart-contracts/contracts/UnlockTestV2.sol
+++ b/smart-contracts/contracts/UnlockTestV2.sol
@@ -31,7 +31,7 @@ contract UnlockTestV2 is Unlock {
     uint _keyPrice // solhint-disable-line no-unused-vars
   )
     public
-    pure
+    view
     returns (uint discount, uint tokens)
   {
     // an example modification

--- a/smart-contracts/contracts/interfaces/ILockPublic.sol
+++ b/smart-contracts/contracts/interfaces/ILockPublic.sol
@@ -18,5 +18,5 @@ import "./ILockCore.sol";
  *    and assign its previous expiration date to the new owner. This is important because it prevents
  *    some abuse around referrals.
  */
-contract ILockPublic is ILockCore, ERC721, Ownable {
+contract ILockPublic is ILockCore, ERC721, Ownable { // solhint-disable-line no-empty-blocks
 }

--- a/smart-contracts/contracts/interfaces/IUnlock.sol
+++ b/smart-contracts/contracts/interfaces/IUnlock.sol
@@ -1,0 +1,73 @@
+pragma solidity 0.4.24;
+
+import "./ILockCore.sol";
+
+/**
+ * @title The Unlock Interface
+ * @author Nick Furfaro (unlock-protocol.com)
+**/
+
+interface IUnlock {
+
+
+  // Events
+  event NewLock(
+    address indexed lockOwner,
+    address indexed newLockAddress
+  );
+
+  // Use initialize instead of a constructor to support proxies (for upgradeability via zos).
+  function initialize(address _owner) public;
+
+  /**
+  * @dev Create lock
+  * This deploys a lock for a creator. It also keeps track of the deployed lock.
+  * Return type `ILockCore` is the most specific interface from which all lock types inherit.
+  */
+  function createLock(
+    uint _expirationDuration,
+    uint _keyPrice,
+    uint _maxNumberOfKeys
+  )
+    public
+    returns (ILockCore lock);
+
+    /**
+   * This function returns the discount available for a user, when purchasing a
+   * a key from a lock.
+   * This does not modify the state. It returns both the discount and the number of tokens
+   * consumed to grant that discount.
+   */
+  function computeAvailableDiscountFor(
+    address _purchaser, // solhint-disable-line no-unused-vars
+    uint _keyPrice // solhint-disable-line no-unused-vars
+  )
+    public
+    view
+    returns (uint discount, uint tokens);
+
+    /**
+   * This function keeps track of the added GDP, as well as grants of discount tokens
+   * to the referrer, if applicable.
+   * The number of discount tokens granted is based on the value of the referal,
+   * the current growth rate and the lock's discount token distribution rate
+   * This function is invoked by a previously deployed lock only.
+   */
+  function recordKeyPurchase(
+    uint _value,
+    address _referrer // solhint-disable-line no-unused-vars
+  )
+    public;
+
+    /**
+   * This function will keep track of consumed discounts by a given user.
+   * It will also grant discount tokens to the creator who is granting the discount based on the
+   * amount of discount and compensation rate.
+   * This function is invoked by a previously deployed lock only.
+   */
+  function recordConsumedDiscount(
+    uint _discount,
+    uint _tokens // solhint-disable-line no-unused-vars
+  )
+    public;
+}


### PR DESCRIPTION
Using the IUnlock interface inside of the Lock contracts
(instead of the entire Unlock contract) should save a lot of gas.


## Proposed Changes

  - Add interface `IUnlock` - & include `import "./ILockCore.sol";`
  - Import`IUnlock` in `PublicLock.sol`
  - Cast `unlock` as type `IUnlock`(interface) instead of type `Unlock` (contract)
  - In `Unlock.sol`, - Change `returns (PublicLock lock)` to `returns (ILockCore lock)` to match `IUnlock.sol`
  - Change imports & inheritance in `Unlock.sol`
  - in `UnlockTestV2.sol`, change `computeAvailableDiscountFor()` from `pure` to `view` to remove conflicts with `Unlock.sol` and `IUnlock.sol`.

## Other Considerations
  - All tests are passsing.
  - I ran a quick experiment in remix to check gas usage and didn’t find any difference?  In theory it should be much better.  See reference here: https://ethereum.stackexchange.com/questions/45290/import-in-solidity-does-it-affect-the-gas
  - It is worth noting that in `IUnlock.sol`, `the createLock()` function return type is:
 `returns (ILockCore lock);` . Technically the `createLock()` function in `PublicLock.sol` returns a type `PublicLock`, but this still works because `PublicLock` is `ILockCore` via inheritance.
