### PR TITLE
Rename `Lock.sol` and `ILock.sol` to `PublicLock.sol`  and `ILockPublic.sol`

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.24;
 
-import "./interfaces/ILock.sol";
+import "./interfaces/ILockPublic.sol";
 import "./Unlock.sol";
 
 /**
@@ -14,7 +14,7 @@ import "./Unlock.sol";
  *  TODO: consider using a _private version for each method that is being invoked by the
  * public one as this seems to be a pattern.
  */
-contract Lock is ILock {
+contract PublicLock is ILockPublic {
 
   // The struct for a key
   struct Key {
@@ -347,7 +347,7 @@ contract Lock is ILock {
   {
     keyByOwner[_owner].expirationTimestamp = now; // Effectively expiring the key
   }
-  
+
   /**
    * A function which lets the owner of the lock to change the price for future purchases.
    */

--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -26,7 +26,7 @@ pragma solidity 0.4.24;
  */
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "./Lock.sol";
+import "./PublicLock.sol";
 
 
 contract Unlock is Ownable {
@@ -67,7 +67,7 @@ contract Unlock is Ownable {
   function initialize(
     address _owner
   )
-    public 
+    public
   {
     require(!initialized);
     owner = _owner;
@@ -81,17 +81,17 @@ contract Unlock is Ownable {
   * This deploys a lock for a creator. It also keeps track of the deployed lock.
   */
   function createLock(
-    Lock.KeyReleaseMechanisms _keyReleaseMechanism,
+    PublicLock.KeyReleaseMechanisms _keyReleaseMechanism,
     uint _expirationDuration,
     uint _keyPrice,
     uint _maxNumberOfKeys
   )
     public
-    returns (Lock lock)
+    returns (PublicLock lock)
   {
 
     // create lock
-    Lock newLock = new Lock(
+    PublicLock newPublicLock = new PublicLock(
       msg.sender,
       _keyReleaseMechanism,
       _expirationDuration,
@@ -100,17 +100,17 @@ contract Unlock is Ownable {
     );
 
     // Assign the new Lock
-    locks[address(newLock)] = LockBalances({
+    locks[address(newPublicLock)] = LockBalances({
       deployed: true,
       totalSales: 0,
       yieldedDiscountTokens: 0
     });
 
     // trigger event
-    emit NewLock(msg.sender, address(newLock));
+    emit NewLock(msg.sender, address(newPublicLock));
 
     // return the created lock
-    return newLock;
+    return newPublicLock;
   }
 
   /**

--- a/smart-contracts/contracts/UnlockTestV3.sol
+++ b/smart-contracts/contracts/UnlockTestV3.sol
@@ -10,7 +10,7 @@ pragma solidity 0.4.24;
  */
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "./Lock.sol";
+import "./PublicLock.sol";
 
 
 contract UnlockTestV3 is Ownable {

--- a/smart-contracts/contracts/interfaces/ILockPublic.sol
+++ b/smart-contracts/contracts/interfaces/ILockPublic.sol
@@ -16,5 +16,5 @@ import "./ILockCore.sol";
  *    and assign its previous expiration date to the new owner. This is important because it prevents
  *    some abuse around referrals.
  */
-contract ILock is ILockCore, ERC721, Ownable {
+contract ILockPublic is ILockCore, ERC721, Ownable {
 }

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -1,5 +1,5 @@
 const Units = require('ethereumjs-units')
-const Lock = artifacts.require('../../Lock.sol')
+const PublicLock = artifacts.require('../../PublicLock.sol')
 
 exports.shouldCreateLock = function (accounts) {
   describe('createLock', function () {
@@ -16,9 +16,9 @@ exports.shouldCreateLock = function (accounts) {
     })
 
     it('should have kept track of the Lock inside Unlock with the right balances', async function () {
-      let lock = Lock.at(transaction.logs[0].args.newLockAddress)
+      let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
       // This is a bit of a dumb test because when the lock is missing, the value are 0 anyway...
-      let [deployed, totalSales, yieldedDiscountTokens] = await this.unlock.locks(lock.address)
+      let [deployed, totalSales, yieldedDiscountTokens] = await this.unlock.locks(publicLock.address)
       assert(deployed)
       assert.equal(totalSales.toNumber(), 0)
       assert.equal(yieldedDiscountTokens.toNumber(), 0)
@@ -34,8 +34,8 @@ exports.shouldCreateLock = function (accounts) {
     })
 
     it('should have created the lock with the right address for unlock', async function () {
-      let lock = Lock.at(transaction.logs[0].args.newLockAddress)
-      let unlockProtocol = await lock.unlockProtocol()
+      let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
+      let unlockProtocol = await publicLock.unlockProtocol()
       assert.equal(unlockProtocol, this.unlock.address)
     })
   })

--- a/smart-contracts/test/helpers/deployLocks.js
+++ b/smart-contracts/test/helpers/deployLocks.js
@@ -1,7 +1,7 @@
-const Lock = artifacts.require('./Lock.sol')
+const PublicLock = artifacts.require('./PublicLock.sol')
 const Locks = require('../fixtures/locks')
 
-module.exports = function deployLocks (unlock) {
+module.exports = function deployLocks(unlock) {
   let locks = {}
 
   return Promise.all(
@@ -14,7 +14,7 @@ module.exports = function deployLocks (unlock) {
       ).then((tx) => {
         // THIS API IS LIKELY TO BREAK BECAUSE IT ASSUMES SO MUCH
         const evt = tx.logs[0]
-        locks[name] = Lock.at(evt.args.newLockAddress)
+        locks[name] = PublicLock.at(evt.args.newLockAddress)
         locks[name].params = Locks[name]
       })
     })


### PR DESCRIPTION
This clarifies the type of the default Lock contract as being public.


## Proposed Changes

  #### Modify all `Lock.sol` references in these files:
  - Unlock.sol
  - UnlockTestV3.sol
  - createLock.js
  - deployLocks.js
