### PR TITLE
disabling no-empty-blocks on ILockPublic

### DIFF
--- a/smart-contracts/contracts/interfaces/ILockPublic.sol
+++ b/smart-contracts/contracts/interfaces/ILockPublic.sol
@@ -1,3 +1,5 @@
+/* solhint-disable no-empty-blocks */
+
 pragma solidity 0.4.24;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";


### PR DESCRIPTION
Fixes master which is currently broken because of that solhint rule