### PR TITLE
Issue245

### DIFF
--- a/unlock-app/package-lock.json
+++ b/unlock-app/package-lock.json
@@ -2571,6 +2571,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -9603,6 +9612,21 @@
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
       "integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ="
+    },
+    "jest-mock-axios": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/jest-mock-axios/-/jest-mock-axios-2.1.11.tgz",
+      "integrity": "sha512-rxF13chmHuelAh/rysNQEY4YqmOO94XmBO5Mk2+edFh2dOwe3j/XIRSnY8+m61t1658AU6nGoTh1s7tCgvridg==",
+      "dev": true,
+      "requires": {
+        "jest-mock-promise": "^1.0.23"
+      }
+    },
+    "jest-mock-promise": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/jest-mock-promise/-/jest-mock-promise-1.0.23.tgz",
+      "integrity": "sha1-ySH9a1EqxUYJftvPR389QWllfkA=",
+      "dev": true
     },
     "jest-regex-util": {
       "version": "23.3.0",

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -7,6 +7,7 @@
     "@storybook/addon-jest": "^4.0.0",
     "@storybook/react": "4.0.0",
     "@svgr/cli": "^3.1.0",
+    "axios": "^0.18.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",
@@ -91,5 +92,8 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "devDependencies": {
+    "jest-mock-axios": "^2.1.11"
+  }
 }

--- a/unlock-app/src/__mocks__/axios.js
+++ b/unlock-app/src/__mocks__/axios.js
@@ -1,0 +1,2 @@
+import mockAxios from 'jest-mock-axios'
+export default mockAxios

--- a/unlock-app/src/__tests__/actions/currencyconvert.test.js
+++ b/unlock-app/src/__tests__/actions/currencyconvert.test.js
@@ -1,0 +1,28 @@
+import { setConversionRate, SET_ETHER_CONVERSION_RATE } from '../../actions/currencyconvert'
+
+describe('currency conversion actions', () => {
+
+  it('should create an action to set a currency conversion rate for USD', () => {
+    const rateFor1Eth = '195.99'
+    const convertedRate = 195.99
+    const currency = 'USD'
+    const expectedAction = {
+      type: SET_ETHER_CONVERSION_RATE,
+      rateFor1Eth: convertedRate,
+      currency,
+    }
+    expect(setConversionRate(currency, rateFor1Eth)).toEqual(expectedAction)
+  })
+
+  it('should create an action to set a currency conversion rate for EUR', () => {
+    const rateFor1Eth = '200.30'
+    const convertedRate = 200.30
+    const currency = 'EUR'
+    const expectedAction = {
+      type: SET_ETHER_CONVERSION_RATE,
+      rateFor1Eth: convertedRate,
+      currency,
+    }
+    expect(setConversionRate(currency, rateFor1Eth)).toEqual(expectedAction)
+  })
+})

--- a/unlock-app/src/__tests__/components/creator/CreatorAccount.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorAccount.test.js
@@ -12,8 +12,12 @@ describe('CreatorAccount', () => {
     const network = {
       name: 4,
     }
+    const conversion = {
+      USD: 195.99
+    }
 
-    const wrapper = shallow(<CreatorAccount account={account} network={network} />)
+    const wrapper = shallow(<CreatorAccount account={account} network={network} conversion={conversion} />)
     expect(wrapper.find('Balance').first().props().amount).toEqual('17.73')
+    expect(wrapper.find('Balance').first().props().conversion).toEqual({ USD: 195.99 })
   })
 })

--- a/unlock-app/src/__tests__/components/helpers/Balance.test.js
+++ b/unlock-app/src/__tests__/components/helpers/Balance.test.js
@@ -9,13 +9,22 @@ describe('Balance Component', () => {
   describe('when the balance is 0 Eth', () => {
     const amount = '0'
 
-    const wrapper = render(<Balance
-      amount={amount}
-      unit={unit}
-    />)
+    it('no conversion data available', () => {
+      const wrapper = render(<Balance
+        amount={amount}
+        unit={unit}
+        conversion={{ USD: undefined }}
+      />)
 
-    it('shows the value of 三 0', () => {
-      expect(wrapper.text()).toEqual('三 0')
+      expect(wrapper.text()).toEqual('0---')
+    })
+    it('USD conversion data available', () => {
+      const wrapper = render(<Balance
+        amount={amount}
+        unit={unit}
+        conversion={{ USD: 195.99 }}
+      />)
+      expect(wrapper.text()).toEqual('00')
     })
   })
 
@@ -25,10 +34,11 @@ describe('Balance Component', () => {
     const wrapper = render(<Balance
       amount={amount}
       unit={unit}
+      conversion={{ USD: 195.99 }}
     />)
 
     it('shows the default minimum value of 三 < 0.0001', () => {
-      expect(wrapper.text()).toEqual('三 < 0.0001')
+      expect(wrapper.text()).toEqual('< 0.00010.014')
     })
   })
 
@@ -38,10 +48,11 @@ describe('Balance Component', () => {
     const wrapper = render(<Balance
       amount={amount}
       unit={unit}
+      conversion={{ USD: 195.99 }}
     />)
 
     it('shows the balance in Eth to two decimal places', () => {
-      expect(wrapper.text()).toEqual('三 0.076')
+      expect(wrapper.text()).toEqual('0.07614.86')
     })
   })
 
@@ -51,10 +62,11 @@ describe('Balance Component', () => {
     const wrapper = render(<Balance
       amount={amount}
       unit={unit}
+      conversion={{ USD: 195.99 }}
     />)
 
     it('shows the balance in Eth to two decimal places', () => {
-      expect(wrapper.text()).toEqual('三 2.00')
+      expect(wrapper.text()).toEqual('2.00391.98')
     })
   })
 })

--- a/unlock-app/src/__tests__/components/helpers/Balance.test.js
+++ b/unlock-app/src/__tests__/components/helpers/Balance.test.js
@@ -5,6 +5,7 @@ import { Balance } from '../../../components/helpers/Balance'
 
 describe('Balance Component', () => {
   const unit = 'szabo'
+  const conversion = { USD: 195.99 }
 
   describe('when the balance is 0 Eth', () => {
     const amount = '0'
@@ -22,7 +23,7 @@ describe('Balance Component', () => {
       const wrapper = render(<Balance
         amount={amount}
         unit={unit}
-        conversion={{ USD: 195.99 }}
+        conversion={conversion}
       />)
       expect(wrapper.text()).toEqual('00')
     })
@@ -34,7 +35,7 @@ describe('Balance Component', () => {
     const wrapper = render(<Balance
       amount={amount}
       unit={unit}
-      conversion={{ USD: 195.99 }}
+      conversion={conversion}
     />)
 
     it('shows the default minimum value of 三 < 0.0001', () => {
@@ -48,7 +49,7 @@ describe('Balance Component', () => {
     const wrapper = render(<Balance
       amount={amount}
       unit={unit}
-      conversion={{ USD: 195.99 }}
+      conversion={conversion}
     />)
 
     it('shows the balance in Eth to two decimal places', () => {
@@ -62,11 +63,81 @@ describe('Balance Component', () => {
     const wrapper = render(<Balance
       amount={amount}
       unit={unit}
-      conversion={{ USD: 195.99 }}
+      conversion={conversion}
     />)
 
     it('shows the balance in Eth to two decimal places', () => {
       expect(wrapper.text()).toEqual('2.00391.98')
+    })
+  })
+
+  describe('when the balance converts to > $1000 ', () => {
+    const amount = '20000000'
+
+    const wrapper = render(<Balance
+      amount={amount}
+      unit={unit}
+      conversion={conversion}
+    />)
+
+    it('shows the balance in dollars in locale format without decimal', () => {
+      expect(wrapper.text()).toEqual('20.003,920')
+    })
+  })
+
+  describe('when the balance converts to > $100k ', () => {
+    const amount = '2000000000'
+
+    const wrapper = render(<Balance
+      amount={amount}
+      unit={unit}
+      conversion={conversion}
+    />)
+
+    it('shows the balance in thousands of dollars postfixed with k', () => {
+      expect(wrapper.text()).toEqual('2000.00392k')
+    })
+  })
+
+  describe('when the balance converts to > $1m ', () => {
+    const amount = '20000000000'
+
+    const wrapper = render(<Balance
+      amount={amount}
+      unit={unit}
+      conversion={conversion}
+    />)
+
+    it('shows the balance in millions of dollars postfixed with m', () => {
+      expect(wrapper.text()).toEqual('20000.003.9m')
+    })
+  })
+
+  describe('when the balance converts to > $1b ', () => {
+    const amount = '20000000000000'
+
+    const wrapper = render(<Balance
+      amount={amount}
+      unit={unit}
+      conversion={conversion}
+    />)
+
+    it('shows the balance in billions of dollars postfixed with b', () => {
+      expect(wrapper.text()).toEqual('20000000.003.9b')
+    })
+  })
+
+  describe('when the balance converts to > $1b, unit is eth (used in lock form)', () => {
+    const amount = '9999999'
+
+    const wrapper = render(<Balance
+      amount={amount}
+      unit='eth'
+      conversion={conversion}
+    />)
+
+    it('shows the balance in billions of dollars postfixed with b', () => {
+      expect(wrapper.text()).toEqual('9999999.002b')
     })
   })
 })

--- a/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
@@ -1,0 +1,21 @@
+import mockAxios from 'jest-mock-axios'
+import { setConversionRate } from '../../actions/currencyconvert'
+
+afterEach(() => mockAxios.reset())
+
+describe('Currency conversion service retrieval middleware', () => {
+  test('service called, action dispatched to set currency conversion rate', () => {
+    jest.useFakeTimers()
+    const middleware = require('../../middlewares/currencyConversionMiddleware').default
+    const store = {
+      dispatch: jest.fn()
+    }
+
+    middleware(store)
+    jest.advanceTimersByTime(10000)
+    expect(mockAxios.get).toHaveBeenCalledWith('https://api.coinbase.com/v2/prices/ETH-USD/buy')
+    mockAxios.mockResponse({"data":{"base":"ETH","currency":"USD","amount":"195.99"}})
+
+    expect(store.dispatch).toHaveBeenCalledWith(setConversionRate('USD', '195.99'))
+  })
+})

--- a/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
@@ -4,18 +4,54 @@ import { setConversionRate } from '../../actions/currencyconvert'
 afterEach(() => mockAxios.reset())
 
 describe('Currency conversion service retrieval middleware', () => {
+  const response1 = {"data":{"base":"ETH","currency":"USD","amount":"195.99"}}
+  const response2 = {"data":{"base":"ETH","currency":"USD","amount":"198.20"}}
+  const APIaddress = 'https://api.coinbase.com/v2/prices/ETH-USD/buy'
+
   test('service called, action dispatched to set currency conversion rate', () => {
     jest.useFakeTimers()
     const middleware = require('../../middlewares/currencyConversionMiddleware').default
     const store = {
-      dispatch: jest.fn()
+      dispatch: jest.fn(),
+      getState() {
+        return { currency: { USD: 1 }}
+      }
     }
 
     middleware(store)
-    jest.advanceTimersByTime(10000)
-    expect(mockAxios.get).toHaveBeenCalledWith('https://api.coinbase.com/v2/prices/ETH-USD/buy')
-    mockAxios.mockResponse({"data":{"base":"ETH","currency":"USD","amount":"195.99"}})
 
+    expect(mockAxios.get).toHaveBeenCalledWith(APIaddress)
+    mockAxios.mockResponse({ data: response1 })
     expect(store.dispatch).toHaveBeenCalledWith(setConversionRate('USD', '195.99'))
+
+    store.dispatch = jest.fn() // reset
+    mockAxios.reset()
+
+    jest.advanceTimersByTime(10000) // test the setInterval
+
+    expect(mockAxios.get).toHaveBeenCalledWith(APIaddress)
+    mockAxios.mockResponse({ data: response2 })
+
+    expect(store.dispatch).toHaveBeenCalledWith(setConversionRate('USD', '198.20'))
+  })
+  test('service called, values are the same, so don\'t dispatch', () => {
+    jest.useFakeTimers()
+    const middleware = require('../../middlewares/currencyConversionMiddleware').default
+    const store = {
+      dispatch: jest.fn(),
+    }
+
+    middleware(store)
+    store.dispatch = jest.fn() // reset
+    store.getState = () => ({ currency: { USD: 195.99 }})
+
+    mockAxios.reset()
+
+    jest.advanceTimersByTime(10000) // test the setInterval
+
+    expect(mockAxios.get).toHaveBeenCalledWith(APIaddress)
+    mockAxios.mockResponse({ data: response1 })
+
+    expect(store.dispatch).not.toHaveBeenCalled()
   })
 })

--- a/unlock-app/src/__tests__/reducers/currencyReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/currencyReducer.test.js
@@ -1,0 +1,25 @@
+import reducer, { initialState } from '../../reducers/currencyReducer'
+import { setConversionRate } from '../../actions/currencyconvert'
+
+describe('currency conversion reducer', () => {
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toBe(initialState)
+  })
+
+  it('should set the conversion rate for USD when receiving a rate for USD', () => {
+    expect(reducer(undefined, setConversionRate('USD', '123'))).toEqual({
+      USD: 123
+    })
+  })
+
+  it('should set the conversion rate for EUR when receiving a rate for EUR', () => {
+    expect(reducer({
+      USD: 123
+    }, setConversionRate('EUR', '321'))).toEqual({
+      USD: 123,
+      EUR: 321
+    })
+  })
+
+})

--- a/unlock-app/src/actions/currencyconvert.js
+++ b/unlock-app/src/actions/currencyconvert.js
@@ -1,0 +1,9 @@
+export const SET_ETHER_CONVERSION_RATE = 'SET_ETHER_CONVERSION_RATE'
+
+export function setConversionRate(currency, rateFor1Eth) {
+  return {
+    type: SET_ETHER_CONVERSION_RATE,
+    rateFor1Eth: +rateFor1Eth,
+    currency
+  }
+}

--- a/unlock-app/src/components/creator/CreatorAccount.js
+++ b/unlock-app/src/components/creator/CreatorAccount.js
@@ -8,7 +8,7 @@ import { ETHEREUM_NETWORKS_NAMES } from '../../constants'
 import Buttons from '../interface/buttons/lock'
 import Balance from '../helpers/Balance'
 
-export function CreatorAccount({ account, network }) {
+export function CreatorAccount({ account, network, conversion }) {
   const networkName = ETHEREUM_NETWORKS_NAMES[network.name[0]] || 'Unknown Network'
   // Using https://github.com/MetaMask/metamask-extension/blob/develop/ui/lib/icon-factory.js#L60 to make sure jazzicons are consistent between Metamask and unlock.
   const iconSeed = parseInt(account.address.slice(2, 10), 16)
@@ -38,7 +38,7 @@ export function CreatorAccount({ account, network }) {
         </DoubleHeightCell>
         <DoubleHeightCell />
         <Address>{account.address}</Address>
-        <Value><Balance amount={account.balance} /></Value>
+        <Value><Balance amount={account.balance} conversion={conversion} /></Value>
         <Value>0.00</Value>
       </AccountDetails>
     </Account>

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -15,6 +15,7 @@ export class CreatorLock extends React.Component {
     super(props)
     this.state = {
       showEmbedCode: false,
+      usdConvertedPrice: 1
     }
     this.toggleEmbedCode = this.toggleEmbedCode.bind(this)
   }
@@ -29,7 +30,7 @@ export class CreatorLock extends React.Component {
     // TODO add USD values to lock
     // TODO add all-time balance to lock
 
-    const { lock, transaction, config } = this.props
+    const { lock, transaction, config, conversion } = this.props
 
     // Some sanitization of strings to display
     let name = lock.name || 'New Lock'
@@ -67,8 +68,8 @@ export class CreatorLock extends React.Component {
 /
           {lock.maxNumberOfKeys}
         </LockKeys>
-        <Balance amount={lock.keyPrice} />
-        <Balance amount={lock.balance} />
+        <Balance amount={lock.keyPrice} conversion={conversion}/>
+        <Balance amount={lock.balance} conversion={conversion} />
         {lockComponentStatusBlock}
         {status === 'deployed' && this.state.showEmbedCode &&
           <LockCode>
@@ -85,6 +86,7 @@ CreatorLock.propTypes = {
   lock: UnlockPropTypes.lock,
   transaction: UnlockPropTypes.transaction,
   config: UnlockPropTypes.configuration,
+  conversion: UnlockPropTypes.conversion
 }
 
 const mapStateToProps = (state, { lock }) => {
@@ -92,6 +94,7 @@ const mapStateToProps = (state, { lock }) => {
   return {
     transaction,
     lock,
+    conversion: state.currency
   }
 }
 
@@ -161,13 +164,5 @@ const LockValueSub = styled.div`
   font-size: 0.6em;
   color: var(--grey);
   margin-top: 5px;
-`
-*/
-
-/* Saving for use with sub-values that need to be added in a future PR
-const LockValueUsd = styled.div`
-  &:before {
-    content: "$ ";
-  }
 `
 */

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux'
 import UnlockPropTypes from '../../propTypes'
 
 import Icon from '../lock/Icon'
-import { BalanceWithUnit } from '../helpers/Balance'
+import { Balance, BalanceWithUnit } from '../helpers/Balance'
 import { LockRow, LockName, LockDuration, LockKeys } from './CreatorLock'
 import { LockStatus } from './lock/CreatorLockStatus'
 import { createLock } from '../../actions/lock'
@@ -21,12 +21,30 @@ class CreatorLockForm extends React.Component {
       expirationDurationUnit: 86400, // Days
       keyPrice: '0.01',
       keyPriceCurrency: 'ether',
+      keyPriceUSD: '---',
       maxNumberOfKeys: 10,
       name: 'New Lock',
     }
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleCancel = this.handleCancel.bind(this)
     this.handleChange = this.handleChange.bind(this)
+    this.ethPrice = ({ value }) => (
+      <FormBalanceWithUnit>
+        <input type="text" id="keyPrice" onChange={this.handleChange} defaultValue={value} />
+      </FormBalanceWithUnit>
+    )
+
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (!state.keyPrice.length || props.conversion.USD === 'undefined' || isNaN(+state.keyPrice)) {
+      return {
+        keyPriceUSD: '---',
+      }
+    }
+    return {
+      keyPriceUSD: +state.keyPrice * props.conversion.USD
+    }
   }
 
   handleChange (event) {
@@ -53,6 +71,7 @@ class CreatorLockForm extends React.Component {
   }
 
   render() {
+    const { conversion } = this.props
     return (
       <FormLockRow>
         <Icon />
@@ -67,10 +86,7 @@ days
         <FormLockKeys>
           <input type="text" id="maxNumberOfKeys" onChange={this.handleChange} defaultValue={this.state.maxNumberOfKeys} />
         </FormLockKeys>
-        <FormBalanceWithUnit>
-          三
-          <input type="text" id="keyPrice" onChange={this.handleChange} defaultValue={this.state.keyPrice} />
-        </FormBalanceWithUnit>
+        <Balance unit='eth' amount={this.state.keyPrice} conversion={conversion} EthComponent={this.ethPrice}/>
         <div>-</div>
         <LockSubmit onClick={this.handleSubmit}>
           Submit
@@ -93,6 +109,7 @@ CreatorLockForm.propTypes = {
 const mapStateToProps = state => {
   return {
     account: state.network.account,
+    conversion: state.currency,
   }
 }
 

--- a/unlock-app/src/components/helpers/Balance.js
+++ b/unlock-app/src/components/helpers/Balance.js
@@ -8,9 +8,14 @@ import Web3Utils from 'web3-utils'
  * @param {*} amount: the amount to convert to Eth
  * @param {string} unit: the unit of the amount to convert to Eth
  */
-export function Balance({ amount, unit = 'wei', conversion = { USD: undefined } }) {
-  const inWei = Web3Utils.toWei(amount || '0', unit)
-  const inEth = Web3Utils.fromWei(inWei, 'ether')
+export function Balance({ amount, unit = 'wei', conversion = { USD: undefined }, EthComponent = ({ value }) => value }) {
+  let inEth
+  if (unit === 'wei') {
+    const inWei = Web3Utils.toWei(amount || '0', unit)
+    inEth = Web3Utils.fromWei(inWei, 'ether')
+  } else {
+    inEth = +amount
+  }
   const ethWithPresentation = BalancePresenter(inEth)
   let convertedUSDValue
   if (!conversion.USD) {
@@ -24,7 +29,7 @@ export function Balance({ amount, unit = 'wei', conversion = { USD: undefined } 
       <Currency>
         <Eth/>
         <BalanceWithUnit>
-          {ethWithPresentation}
+          <EthComponent value={ethWithPresentation} />
         </BalanceWithUnit>
       </Currency>
       <Currency>

--- a/unlock-app/src/components/helpers/Balance.js
+++ b/unlock-app/src/components/helpers/Balance.js
@@ -8,16 +8,33 @@ import Web3Utils from 'web3-utils'
  * @param {*} amount: the amount to convert to Eth
  * @param {string} unit: the unit of the amount to convert to Eth
  */
-export function Balance({ amount, unit = 'wei' }) {
-  let inWei = Web3Utils.toWei(amount || '0', unit)
-  let inEth = Web3Utils.fromWei(inWei, 'ether')
-  let ethWithPresentation = BalancePresenter(inEth)
+export function Balance({ amount, unit = 'wei', conversion = { USD: undefined } }) {
+  const inWei = Web3Utils.toWei(amount || '0', unit)
+  const inEth = Web3Utils.fromWei(inWei, 'ether')
+  const ethWithPresentation = BalancePresenter(inEth)
+  let convertedUSDValue
+  if (!conversion.USD) {
+    convertedUSDValue = '---'
+  } else {
+    convertedUSDValue = BalancePresenter(inEth * conversion.USD)
+  }
 
-  return (<BalanceWithUnit>
-    三 
-    {' '}
-    {ethWithPresentation}
-  </BalanceWithUnit>)
+  return (
+    <BalanceWithConversion>
+      <Currency>
+        <Eth/>
+        <BalanceWithUnit>
+          {ethWithPresentation}
+        </BalanceWithUnit>
+      </Currency>
+      <Currency>
+        <USD/>
+        <BalanceWithUnit>
+          {convertedUSDValue}
+        </BalanceWithUnit>
+      </Currency>
+    </BalanceWithConversion>
+  )
 }
 
 /**
@@ -46,6 +63,33 @@ Balance.propTypes = {
   amount: PropTypes.string,
   unit: PropTypes.string,
 }
+
+export const BalanceWithConversion = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+export const Currency = styled.span`
+  display: flex;
+  flex-direction: row;
+  
+`
+
+export const CurrencySymbol = styled.span`
+  width: 20px;
+`
+
+export const Eth = styled(CurrencySymbol)`
+  &:before {
+    content: "三";
+  }
+`
+
+export const USD = styled(CurrencySymbol)`
+  &:before {
+    content: "$";
+  }
+`
 
 export const BalanceWithUnit = styled.span`
   white-space: nowrap;

--- a/unlock-app/src/components/helpers/Balance.js
+++ b/unlock-app/src/components/helpers/Balance.js
@@ -7,21 +7,23 @@ import Web3Utils from 'web3-utils'
  * Component which shows a balance in Eth
  * @param {*} amount: the amount to convert to Eth
  * @param {string} unit: the unit of the amount to convert to Eth
+ * @param {object} conversion: a hash of conversion values for ether to currencies
+ * @param {function} EthComponent: a React component that displays an ether value
  */
 export function Balance({ amount, unit = 'wei', conversion = { USD: undefined }, EthComponent = ({ value }) => value }) {
   let inEth
-  if (unit === 'wei') {
+  if (unit !== 'dollars' && unit !== 'eth') {
     const inWei = Web3Utils.toWei(amount || '0', unit)
     inEth = Web3Utils.fromWei(inWei, 'ether')
   } else {
     inEth = +amount
   }
-  const ethWithPresentation = BalancePresenter(inEth)
+  const ethWithPresentation = BalancePresenter(inEth, 'ether')
   let convertedUSDValue
   if (!conversion.USD) {
     convertedUSDValue = '---'
   } else {
-    convertedUSDValue = BalancePresenter(inEth * conversion.USD)
+    convertedUSDValue = BalancePresenter(inEth * conversion.USD, 'dollars')
   }
 
   return (
@@ -43,24 +45,43 @@ export function Balance({ amount, unit = 'wei', conversion = { USD: undefined },
 }
 
 /**
- * Provide a representaion of Eth Balances suitable for the Unlock frontend
+ * Provide a representation of Eth Balances suitable for the Unlock frontend
  * application.
  * @param {string} eth: An amount of Eth
+ * @param {string} currency: currency type, either ether or some real currency like dollars
  */
-function BalancePresenter(eth){
+function BalancePresenter(eth, currency = 'ether'){
   const DECIMAL_PLACES = 2
   const SIGNIFICANT_DIGITS = 2
   const MINIMUM_THRESHOLD = 0.0001
 
   let numericalEth = Number(eth)
 
+  if (currency !== 'ether') {
+    switch(true) {
+      case numericalEth < 1 && numericalEth > 0.01:
+        return parseFloat(numericalEth.toPrecision(SIGNIFICANT_DIGITS))
+      case numericalEth < 0.01:
+        return '0'
+      case numericalEth >= 1000 && numericalEth < 1e5 :
+        return Math.round(numericalEth).toLocaleString()
+      case numericalEth >= 1e5 && numericalEth < 1e6 :
+        return (+((numericalEth/1e3).toFixed(1))).toLocaleString() + 'k'
+      case numericalEth >= 1e6 && numericalEth < 1e9 :
+        return (+((numericalEth/1e6).toFixed(1))).toLocaleString() + 'm'
+      case numericalEth >= 1e9 :
+        return (+((numericalEth/1e9).toFixed(1))).toLocaleString() + 'b'
+      default:
+        return numericalEth.toFixed(DECIMAL_PLACES)
+    }
+  }
   switch(true) {
-  case numericalEth < MINIMUM_THRESHOLD && numericalEth > 0 :
-    return '< 0.0001'
-  case numericalEth < 1:
-    return parseFloat(numericalEth.toPrecision(SIGNIFICANT_DIGITS))
-  default:
-    return numericalEth.toFixed(DECIMAL_PLACES)
+    case numericalEth < MINIMUM_THRESHOLD && numericalEth > 0 :
+      return '< 0.0001'
+    case numericalEth < 1:
+      return parseFloat(numericalEth.toPrecision(SIGNIFICANT_DIGITS))
+    default:
+      return numericalEth.toFixed(DECIMAL_PLACES)
   }
 }
 

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -13,6 +13,7 @@ import currencyReducer, { initialState as defaultCurrency } from './reducers/cur
 
 // Middlewares
 import lockMiddleware from './middlewares/lockMiddleware'
+import currencyConversionMiddleware from './middlewares/currencyConversionMiddleware'
 
 const config = configure(global)
 
@@ -41,6 +42,7 @@ export default function createUnlockStore(defaultState = loadState()) {
 
   const middlewares = [
     lockMiddleware,
+    currencyConversionMiddleware,
   ]
 
   return createStore(

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -9,6 +9,7 @@ import locksReducer, { initialState as defaultLocks } from './reducers/locksRedu
 import networkReducer, { initialState as defaultNetwork } from './reducers/networkReducer'
 import providerReducer, { initialState as defaultProvider } from './reducers/providerReducer'
 import transactionReducer, { initialState as defaultTransactions } from './reducers/transactionReducer'
+import currencyReducer, { initialState as defaultCurrency } from './reducers/currencyReducer'
 
 // Middlewares
 import lockMiddleware from './middlewares/lockMiddleware'
@@ -22,6 +23,7 @@ export default function createUnlockStore(defaultState = loadState()) {
     network: networkReducer,
     provider: providerReducer,
     transactions: transactionReducer,
+    currency: currencyReducer,
   }
 
   // We build the initial state by taking first each reducer's default values
@@ -32,6 +34,7 @@ export default function createUnlockStore(defaultState = loadState()) {
     network: defaultNetwork,
     provider: defaultProvider,
     transactions: defaultTransactions,
+    currency: defaultCurrency,
   }, {
     provider: Object.keys(config.providers)[0],
   }, defaultState)

--- a/unlock-app/src/middlewares/currencyConversionMiddleware.js
+++ b/unlock-app/src/middlewares/currencyConversionMiddleware.js
@@ -1,0 +1,10 @@
+import { setConversionRate } from '../actions/currencyconvert'
+import axios from 'axios'
+
+export default store => {
+  setInterval(() => {
+    axios.get('https://api.coinbase.com/v2/prices/ETH-USD/buy')
+      .then(info => store.dispatch(setConversionRate(info.data.currency, info.data.amount)))
+  }, 10000)
+  return next => action => next(action)
+}

--- a/unlock-app/src/middlewares/currencyConversionMiddleware.js
+++ b/unlock-app/src/middlewares/currencyConversionMiddleware.js
@@ -2,9 +2,17 @@ import { setConversionRate } from '../actions/currencyconvert'
 import axios from 'axios'
 
 export default store => {
+  axios.get('https://api.coinbase.com/v2/prices/ETH-USD/buy')
+    .then(info => store.dispatch(setConversionRate(info.data.data.currency, info.data.data.amount)))
   setInterval(() => {
     axios.get('https://api.coinbase.com/v2/prices/ETH-USD/buy')
-      .then(info => store.dispatch(setConversionRate(info.data.currency, info.data.amount)))
+      .then(info => {
+        const { data: { data: { currency, amount }}} = info
+        const current = store.getState().currency[currency]
+        if (current === +amount) return
+
+        store.dispatch(setConversionRate(currency, amount))
+      })
   }, 10000)
   return next => action => next(action)
 }

--- a/unlock-app/src/pages/dashboard.js
+++ b/unlock-app/src/pages/dashboard.js
@@ -9,7 +9,7 @@ import CreatorLocks from '../components/creator/CreatorLocks'
 import withConfig from '../utils/withConfig'
 import { pageTitle } from '../constants'
 
-export const Dashboard = ({account, network, locks}) => {
+export const Dashboard = ({account, network, locks, conversion }) => {
   if (!account) {
     return null //loading
   }
@@ -20,7 +20,7 @@ export const Dashboard = ({account, network, locks}) => {
         <title>{pageTitle('Dashboard')}</title>
       </Head>
       <NoSSR>
-        <CreatorAccount network={network} account={account} />
+        <CreatorAccount network={network} account={account} conversion={conversion} />
         <CreatorLocks locks={locks} />
       </NoSSR>
     </Layout>
@@ -33,6 +33,7 @@ Dashboard.propTypes = {
   account: UnlockPropTypes.account,
   network: UnlockPropTypes.network,
   locks: UnlockPropTypes.locks,
+  conversion: UnlockPropTypes.conversion,
 }
 
 const mapStateToProps = state => {
@@ -40,6 +41,7 @@ const mapStateToProps = state => {
     account: state.network.account, // TODO change account to base level
     network: state.network,
     locks: state.locks,
+    conversion: state.currency,
   }
 }
 

--- a/unlock-app/src/propTypes.js
+++ b/unlock-app/src/propTypes.js
@@ -25,6 +25,8 @@ export const transaction = PropTypes.shape({
   name: PropTypes.string,
 })
 
+export const conversion = PropTypes.objectOf(PropTypes.number)
+
 export const children = PropTypes.shape({})
 
 export const component = PropTypes.func
@@ -63,6 +65,7 @@ export default {
   children,
   component,
   configuration,
+  conversion,
   layout,
   lock,
   locks,

--- a/unlock-app/src/reducers/currencyReducer.js
+++ b/unlock-app/src/reducers/currencyReducer.js
@@ -1,0 +1,15 @@
+import { SET_ETHER_CONVERSION_RATE } from '../actions/currencyconvert'
+
+export const initialState = {
+  USD: undefined
+}
+
+const currencyReducer = (state = initialState, action) => {
+  if (action.type === SET_ETHER_CONVERSION_RATE) {
+    return { ...state, [action.currency]: action.rateFor1Eth }
+  }
+
+  return state
+}
+
+export default currencyReducer

--- a/unlock-app/src/stories/creator/CreatorAccount.stories.js
+++ b/unlock-app/src/stories/creator/CreatorAccount.stories.js
@@ -10,7 +10,10 @@ storiesOf('CreatorAccount', CreatorAccount)
     const network = {
       name: 4,
     }
+    const conversion = {
+      USD: 195.99
+    }
     return (
-      <CreatorAccount network={network} account={account} />
+      <CreatorAccount network={network} account={account} conversion={conversion} />
     )
   })

--- a/unlock-app/src/stories/creator/CreatorLock.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLock.stories.js
@@ -15,6 +15,9 @@ const store = createUnlockStore({
       confirmations: 4,
     },
   },
+  currency: {
+    USD: 195.99
+  }
 })
 
 storiesOf('CreatorLock', CreatorLock)
@@ -46,7 +49,7 @@ storiesOf('CreatorLock', CreatorLock)
       confirmations: 2,
     }
     return (
-      <CreatorLock lock={lock} transaction={transaction} />
+      <CreatorLock lock={lock} transaction={transaction}  />
     )
   })
   .add('Not found', () => {

--- a/unlock-app/src/stories/creator/CreatorLockForm.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm.stories.js
@@ -4,7 +4,11 @@ import { storiesOf } from '@storybook/react'
 import CreatorLockForm from '../../components/creator/CreatorLockForm'
 import createUnlockStore from '../../createUnlockStore'
 
-const store = createUnlockStore()
+const store = createUnlockStore({
+  currency: {
+    USD: 195.99
+  }
+})
 
 storiesOf('CreatorLockForm', CreatorLockForm)
   .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)

--- a/unlock-app/src/stories/creator/Dashboard.stories.js
+++ b/unlock-app/src/stories/creator/Dashboard.stories.js
@@ -15,6 +15,9 @@ storiesOf('Dashboard', Dashboard)
     const network = {
       name: 4,
     }
+    const conversion = {
+      USD: 195.99
+    }
     const transactions = {
       0x1234: {
         hash: '0x12345678',
@@ -49,6 +52,6 @@ storiesOf('Dashboard', Dashboard)
       },
     }
     return (
-      <Dashboard network={network} account={account} transactions={transactions} locks={locks} />
+      <Dashboard network={network} account={account} transactions={transactions} locks={locks} conversion={conversion} />
     )
   })


### PR DESCRIPTION
Fixes #245 

This implements an automatic currency conversion from ether to US Dollars based on the current market rate.

## Proposed Changes

  - store the ether->USD conversion rate in the redux store (new action, reducer)
  - use a new simple middleware to retrieve the current conversion rate every 10 seconds (this can be done outside middleware, but it makes it easier to find where side effects occur if we group them together)
  - encapsulate all display logic inside the `Balance` component. This allows us to pass in the input to display in the CreatorLockForm instead of just a static value
  - As a result, CreatorLockForm updates the USD value as you type the ether value
  - All places Balance is used, the conversion happens, on the Dashboard as well as for each individual lock
  - full tests and storybook stories for all changes are implemented.
  - Balance display is fancier for dollars, and supports abbreviating as the number increases, from normal "0.03" "123.03" to thousands "3,456" 100 thousands "234k" millions "1.2m" and billion+ "123.4b" This can (and should) be modified as desired, as it introduces issues of locale and translation. The current solution is American English-centric
 
### Caveats:

  - Although the design of the reducer plans for future conversion to a user's preferred currency, this would require rewriting. I chose simplicity over flexibility. Rewriting will be relatively straightforward
  - The lock form could choose to implement a kind of toggle that allows users to enter the USD value and auto-calculate the ether value instead. This would involve a button that swaps the input so that we enter the dollar amount and calculate the ether amount in gDSFP and would be relatively straightforward to implement.
  - The CSS is rather inelegant, perhaps there is a better way to do this?
  - a new dependency on axios is introduced (and as a consequence, jest-axios-mock). If Unlock will limit dashboard users to browsers that support fetch, the dependency can be removed
  - I really don't like `BalancePresenter` now, it does two things and looks odd. I recommend splitting off into a separate file and removing the clever use of switch/case and instead using if/else
  - testing via enzyme is a bad idea, enzyme has had a lot of trouble keeping pace with changes in React. A better choice is react-testing-library. In my experience converting the react-redux tests from enzyme to rtl, it was only about an hour's work, and they have many more tests than Unlock does currently. With this switch, the tests for Balance could become more fine-grained quite easily, so we can test the eth and dollar amounts separately instead of in that mish-mash you see now.
  - naming: I am not sure the names I have chosen are ideal with both `currency` and `conversion` used. Perhaps you have an opinion on whether they should be more unified into some kind of naming convention?

P.S. happy halloween!
