### PR TITLE
Deploys humans.txt and robots.txt

### DIFF
--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -1,5 +1,18 @@
+const fs = require('fs')
+const { join } = require('path')
+const { promisify } = require('util')
+
+const copyFile = promisify(fs.copyFile)
+
 module.exports = {
-  exportPathMap: function () {
+  exportPathMap: async (defaultPathMap, { dev, dir, outDir }) => {
+
+    // Export robots.txt and humans.txt in non-dev environments
+    if (!dev && outDir) {
+      await copyFile(join(dir, 'static', 'robots.txt'), join(outDir, 'robots.txt'))
+      await copyFile(join(dir, 'static', 'humans.txt'), join(outDir, 'humans.txt'))
+    }
+
     return {
       '/': { page: '/' },
       '/about': { page: '/about' },


### PR DESCRIPTION
Fixes #474

There's no hard and fast way to do this in next.js. This should hopefully copy humans.txt and robots.txt to the root in production and staging environments.


  - Copy robots.txt and humans.txt as part of exportPathMap