### PR TITLE
Quick fix for logo dimensions

### DIFF
--- a/unlock-app/src/components/interface/svg/UnlockWordMark.js
+++ b/unlock-app/src/components/interface/svg/UnlockWordMark.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const SvgUnlockWordMark = props => (
-  <svg viewBox="0 0 24 24" {...props}>
+  <svg viewBox="0 0 30 30" {...props}>
     <path
       fill="#ED6E82"
       fillRule="evenodd"

--- a/unlock-app/src/components/interface/svg/UnlockWordMark.js
+++ b/unlock-app/src/components/interface/svg/UnlockWordMark.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const SvgUnlockWordMark = props => (
-  <svg viewBox="0 0 30 30" {...props}>
+  <svg {...props}>
     <path
       fill="#ED6E82"
       fillRule="evenodd"


### PR DESCRIPTION
Refs #506


  - Adjusts wordmark logo viewBox so full logo is on display

There are still some alignment issues to fix but this solves the most obvious optical problem for now.