### PR TITLE
Store keyPrice in memory to save gas

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -377,12 +377,13 @@ contract PublicLock is ILockPublic {
     IUnlock unlock = IUnlock(unlockProtocol);
     uint discount;
     uint tokens;
-    (discount, tokens) = unlock.computeAvailableDiscountFor(_recipient, keyPrice);
-    uint netPrice = keyPrice;
-    if (discount > keyPrice) {
+    uint inMemoryKeyPrice = keyPrice;
+    (discount, tokens) = unlock.computeAvailableDiscountFor(_recipient, inMemoryKeyPrice);
+    uint netPrice = inMemoryKeyPrice;
+    if (discount > inMemoryKeyPrice) {
       netPrice = 0;
     } else {
-      netPrice = keyPrice - discount;
+      netPrice = inMemoryKeyPrice - discount;
     }
 
     // We explicitly allow for greater amounts to allow "donations" or partial refunds after


### PR DESCRIPTION

The variable `keyPrice` is saved in storage. Each time we use it, it has to be read (loaded) from storage (opcode SLOAD). Each "SLOAD" costs 200 gas. If we save `keyPrice` into a local (in memory) variable `inMemoryKeyPrice`, each time we use this new variable it is read from memory (opcode MLOAD). Each "MLOAD" costs 3 gas. This small change replaces 4 "SLOADS" with 4 "MLOADS", saving 788 gas.
## Proposed Changes

 - In `PublicLock.sol._purchaseFor()` , an new (in-memory) variable is introduced. `uint inMemoryKeyPrice = keyPrice;` is then used throughout the rest of the function in place of `keyPrice`.

## Reference
This link demonstrates why this saves gas:
https://ethereum.stackexchange.com/questions/21253/do-sload-operations-get-cached-in-solidity