### PR TITLE
Fixing indentation on PR bullets

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@ Fixes #
 
 ## Proposed Changes
 
-  -
-  -
-  -
+-
+-
+-


### PR DESCRIPTION
- Makes change bullets on pull requests top-level
- GitHub's markdown lists second and subsequent bullets as being nested otherwise
- It's annoying