### PR TITLE
Upgrade zOS to v2.0.1

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -27,11 +27,12 @@ pragma solidity 0.4.24;
  */
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "zos-lib/contracts/Initializable.sol";
 import "./PublicLock.sol";
 import "./interfaces/IUnlock.sol";
 
 
-contract Unlock is IUnlock, Ownable {
+contract Unlock is IUnlock, Ownable, Initializable {
 
   /**
    * The struct for a lock
@@ -63,19 +64,16 @@ contract Unlock is IUnlock, Ownable {
     address indexed newLockAddress
   );
 
-  bool internal initialized;
-
   // Use initialize instead of a constructor to support proxies (for upgradeability via zos).
   function initialize(
     address _owner
   )
     public
+    initializer()
   {
-    require(!initialized);
     owner = _owner;
     grossNetworkProduct = 0;
     totalDiscountGranted = 0;
-    initialized = true;
   }
 
   /**

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -21,7 +21,7 @@
     "truffle": "^4.1.14",
     "truffle-contract": "^3.0.6",
     "web3-utils": "^1.0.0-beta.36",
-    "zos-lib": "^1.4.1"
+    "zos-lib": "^2.0.1"
   },
   "devDependencies": {
     "eslint-config-standard": "^12.0.0",

--- a/smart-contracts/test/Unlock/UnlockProxy.js
+++ b/smart-contracts/test/Unlock/UnlockProxy.js
@@ -13,9 +13,9 @@ contract('Unlock', function (accounts) {
   describe('Proxy Unlock contract', function () {
     beforeEach(async function () {
       const implV1 = await Unlock.new()
-      this.proxy = await AdminUpgradeabilityProxy.new(implV1.address, { from: proxyOwner })
+      const initV1Call = zos.encodeCall('initialize', ['address'], [unlockOwner])
+      this.proxy = await AdminUpgradeabilityProxy.new(implV1.address, initV1Call, { from: proxyOwner })
       this.unlock = await Unlock.at(this.proxy.address)
-      await this.unlock.initialize(unlockOwner)
     })
 
     describe('should function as a proxy', function () {

--- a/smart-contracts/zos.json
+++ b/smart-contracts/zos.json
@@ -1,4 +1,5 @@
 {
+  "zosversion": "2",
   "name": "lock",
   "version": "0.1.0",
   "contracts": {


### PR DESCRIPTION
Fixes  the current zOS version by upgrading to v2.0.1

## Proposed Changes

- Change version in `package.json` to : `"zos-lib": "^2.0.1"`
- Add zOS version to `zos.json` : `"zosversion": "2",`
- Import & inherit`Initializable.sol` in `Unlock.sol`
- Use `initializer()` modifier instead of current solution. It seems to be a more robust check of conditions and is recommended by zOS.
