### PR TITLE
Fixes "submitted" label on new locks

### DIFF
--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -54,7 +54,7 @@ export class CreatorLock extends React.Component {
     } else if (transaction.status === 'submitted') {
       lockComponentStatusBlock = <CreatorLockStatus lock={lock} status="Submitted" />
     } else if (transaction.status === 'mined' &&
-        transaction.confirmations < config.requiredConfirmations) {
+      transaction.confirmations < config.requiredConfirmations) {
       lockComponentStatusBlock = <CreatorLockStatus
         lock={lock}
         status="Confirming"

--- a/unlock-app/src/components/creator/lock/CreatorLockStatus.js
+++ b/unlock-app/src/components/creator/lock/CreatorLockStatus.js
@@ -53,7 +53,6 @@ const Status = styled.div`
   justify-content: center;
   font-size: 13px;
   align-self: end;
-  justify-content: center;
 `
 
 const Confirmations = styled.div`

--- a/unlock-app/src/components/creator/lock/CreatorLockStatus.js
+++ b/unlock-app/src/components/creator/lock/CreatorLockStatus.js
@@ -10,15 +10,17 @@ export function CreatorLockStatus({ config, status, confirmations }) {
       <Status>
         {status}
       </Status>
-      {confirmations &&
-        <Confirmations>
-          {confirmations}
-          {' '}
-          /
-          {' '}
-          {config.requiredConfirmations}
-        </Confirmations>
-      }
+      <Confirmations>
+        {confirmations > 0 &&
+          <>
+            {confirmations}
+            {' '}
+            /
+            {' '}
+            {config.requiredConfirmations}
+          </>
+        }
+      </Confirmations>
     </LockStatus>
   )
 }
@@ -51,6 +53,7 @@ const Status = styled.div`
   justify-content: center;
   font-size: 13px;
   align-self: end;
+  justify-content: center;
 `
 
 const Confirmations = styled.div`

--- a/unlock-app/src/stories/creator/CreatorLock.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLock.stories.js
@@ -14,6 +14,10 @@ const store = createUnlockStore({
       status: 'mined',
       confirmations: 4,
     },
+    '0x111': {
+      status: 'submitted',
+      confirmations: 0,
+    },
   },
   keys: {
     '0x678': {
@@ -38,6 +42,19 @@ storiesOf('CreatorLock', CreatorLock)
       outstandingKeys: '3',
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       transaction: '0x123',
+    }
+    return (
+      <CreatorLock lock={lock} />
+    )
+  })
+  .add('Submitted', () => {
+    const lock = {
+      keyPrice: '10000000000000000000',
+      expirationDuration: '172800',
+      maxNumberOfKeys: '240',
+      outstandingKeys: '3',
+      address: '0x127c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      transaction: '0x111',
     }
     return (
       <CreatorLock lock={lock} />


### PR DESCRIPTION
New locks had a funky "submitted" label that was bottom-aligned on the lock and displayed an erroneous 0. This PR fixes these issues and adds a new story for "submitted" locks, to more easily check this interface state.