### PR TITLE
Styling currency conversions

### DIFF
--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -183,11 +183,3 @@ const LockDivider = styled.div`
   height: 1px;
   background-color: var(--lightgrey);
 `
-
-/* Saving for use with sub-values that need to be added in a future PR
-const LockValueSub = styled.div`
-  font-size: 0.6em;
-  color: var(--grey);
-  margin-top: 5px;
-`
-*/

--- a/unlock-app/src/components/helpers/Balance.js
+++ b/unlock-app/src/components/helpers/Balance.js
@@ -39,12 +39,14 @@ export function Balance({ amount, unit, conversion, EthComponent, convertCurrenc
         </BalanceWithUnit>
       </Currency>
       { convertCurrency ?
-        <Currency>
-          <USD />
-          <BalanceWithUnit>
-            {convertedUSDValue}
-          </BalanceWithUnit>
-        </Currency> :
+        <SubBalance>
+          <Currency>
+            <USD />
+            <BalanceWithUnit>
+              {convertedUSDValue}
+            </BalanceWithUnit>
+          </Currency>
+        </SubBalance>:
         '' }
     </BalanceWithConversion>
   )
@@ -98,6 +100,12 @@ export const USD = styled(CurrencySymbol)`
 export const BalanceWithUnit = styled.span`
   white-space: nowrap;
   text-transform: uppercase;
+`
+
+const SubBalance = styled.div`
+  font-size: 10px;
+  color: var(--darkgrey);
+  margin-top: 5px;
 `
 
 function mapStateToProps({ currency: conversion }) {


### PR DESCRIPTION
Uses the already-defined sub-balance style, but moves it into `<Balance />` for integrated display with currency conversions.

<img width="1160" alt="screen shot 2018-11-14 at 4 25 37 pm" src="https://user-images.githubusercontent.com/624104/48521613-11d14d00-e82a-11e8-89e7-e992b996756c.png">
