### PR TITLE
Allow an infinite number of keys

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -124,7 +124,12 @@ contract PublicLock is ILockPublic {
       owner = _owner;
       expirationDuration = _expirationDuration;
       keyPrice = _keyPrice;
-      maxNumberOfKeys = _maxNumberOfKeys;
+      if (_maxNumberOfKeys == uint256(-1)) {
+        maxNumberOfKeys = uint256(-1);
+      } else {
+        maxNumberOfKeys = _maxNumberOfKeys;
+      }
+
     }
 
   /**

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -37,5 +37,45 @@ exports.shouldCreateLock = function (accounts) {
       let unlockProtocol = await publicLock.unlockProtocol()
       assert.equal(unlockProtocol, this.unlock.address)
     })
+
+    describe('Create a Lock with infinite keys', function () {
+      let transaction
+      before(async function () {
+        transaction = await this.unlock.createLock(
+          60 * 60 * 24 * 30, // expirationDuration: 30 days
+          Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
+          -1 // maxNumberOfKeys
+          , {
+            from: accounts[0]
+          })
+      })
+
+      it('should have created the lock with an infinite number of keys', async function () {
+        let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
+        const maxNumberOfKeys = await publicLock.maxNumberOfKeys()
+        console.log(maxNumberOfKeys)
+        assert.equal(maxNumberOfKeys.toNumber(10), 1.157920892373162e+77)
+      })
+    })
+
+    describe('Create a Lock with 0 keys', function () {
+      let transaction
+      before(async function () {
+        transaction = await this.unlock.createLock(
+          60 * 60 * 24 * 30, // expirationDuration: 30 days
+          Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
+          0 // maxNumberOfKeys
+          , {
+            from: accounts[0]
+          })
+      })
+
+      it('should have created the lock with 0 keys', async function () {
+        let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
+        const maxNumberOfKeys = await publicLock.maxNumberOfKeys()
+        console.log(maxNumberOfKeys)
+        assert.equal(maxNumberOfKeys.toNumber(10), 0)
+      })
+    })
   })
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

- allow a value of -1 to be passed to the constructor for `PublicLock.sol`, setting the value of `maxNumberOfKeys` to be 2^256-1, or infinite for all intents and purposes.
-
-
