### PR TITLE
loading account even when the network was changed

### DIFF
--- a/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
@@ -202,6 +202,7 @@ describe('Lock middleware', () => {
       const action = { type: 'FAKE_ACTION' }
       mockWeb3Service.ready = false
       mockWeb3Service.connect = jest.fn()
+      mockWeb3Service.refreshOrGetAccount = jest.fn()
       invoke(action)
 
       // Trigger the event
@@ -214,11 +215,22 @@ describe('Lock middleware', () => {
     })
 
     describe('when the network.changed is different from the store value', () => {
+      it('should get a new account', () => {
+        create()
+        const networkId = 1984
+
+        state.network.name = 1773
+        mockWeb3Service.refreshOrGetAccount = jest.fn()
+        mockWeb3Service.emit('network.changed', networkId)
+        expect(mockWeb3Service.refreshOrGetAccount).toHaveBeenCalledWith()
+      })
+
       it('should dispatch a SET_NETWORK action', () => {
         const { store } = create()
         const networkId = 1984
 
         state.network.name = 1773
+        mockWeb3Service.refreshOrGetAccount = jest.fn()
         mockWeb3Service.emit('network.changed', networkId)
         expect(store.dispatch).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -91,6 +91,8 @@ export default function lockMiddleware({ getState, dispatch }) {
     if (getState().network.name !== networkId) {
       // Set the new network, which should also clean up all reducers
       dispatch(setNetwork(networkId))
+      // So we need a new account!
+      return web3Service.refreshOrGetAccount()
     } else {
       // The network is the same, so let's refresh
       // We refresh transactions

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -22,10 +22,7 @@ class MyApp extends App {
   constructor(props, context) {
     super(props, context)
 
-    // Hack to quick the Redux lock middleware on load
     if (!config.isServer) {
-      props.reduxStore.dispatch({ type: '@@INIT' })
-
       /* eslint-disable no-console */
       console.info(`
 *********************************************************************


### PR DESCRIPTION
Fixes the need for a 2nd reload after the localstorage data was cleared