### PR TITLE
Display label for withdrawal transactions

### DIFF
--- a/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
@@ -1,0 +1,93 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { Provider } from 'react-redux'
+
+import { LockIconBar } from '../../../../components/creator/lock/LockIconBar'
+import configure from '../../../../config'
+import createUnlockStore from '../../../../createUnlockStore'
+
+const toggleCode = jest.fn()
+
+describe('LockIconBar', () => {
+  it('should display a submitted label when withdrawal has been submitted', () => {
+    const config = configure({})
+
+    const lock = {
+      id: 'lockwithdrawalsubmittedid',
+      keyPrice: '10000000000000000000',
+      expirationDuration: '172800',
+      maxNumberOfKeys: 240,
+      outstandingKeys: 3,
+      address: '0xbc7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      transaction: 'deployedid',
+    }
+    const transaction = {
+      status: 'mined',
+      confirmations: 24,
+    }
+    const withdrawalTransaction = {
+      status: 'submitted',
+      confirmations: 0,
+      withdrawal: 'lockwithdrawalsubmittedid',
+    }
+
+    const store = createUnlockStore({})
+
+    let wrapper = rtl.render(
+      <Provider store={store}>
+        <LockIconBar
+          lock={lock}
+          transaction={transaction}
+          withdrawalTransaction={withdrawalTransaction}
+          toggleCode={toggleCode}
+          config={config}
+        />
+      </Provider>
+    )
+
+    expect(
+      wrapper.queryByText('Submitted to Network', { exact: false })
+    ).not.toBeNull()
+  })
+  it('should display a confirming label when withdrawal is confirming', () => {
+    const config = configure({})
+
+    const lock = {
+      id: 'lockwithdrawalconfirmingid',
+      keyPrice: '10000000000000000000',
+      expirationDuration: '172800',
+      maxNumberOfKeys: 240,
+      outstandingKeys: 3,
+      address: '0xba7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      transaction: 'deployedid',
+    }
+    const transaction = {
+      status: 'mined',
+      confirmations: 24,
+    }
+    const withdrawalTransaction = {
+      status: 'mined',
+      confirmations: 2,
+      withdrawal: 'lockwithdrawalconfirmingid',
+    }
+
+    const store = createUnlockStore({})
+
+    let wrapper = rtl.render(
+      <Provider store={store}>
+        <LockIconBar
+          lock={lock}
+          transaction={transaction}
+          withdrawalTransaction={withdrawalTransaction}
+          toggleCode={toggleCode}
+          config={config}
+        />
+      </Provider>
+    )
+
+    expect(
+      wrapper.queryByText('Confirming Withdrawal', { exact: false })
+    ).not.toBeNull()
+    expect(wrapper.queryByText('2/12', { exact: false })).not.toBeNull()
+  })
+})

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -54,11 +54,8 @@ export function LockIconBar({
             config.requiredConfirmations && (
             <>
               Confirming Withdrawal
-              <WithdrawalConfirmations>
-                {withdrawalTransaction.confirmations}
-/
-                {config.requiredConfirmations}
-              </WithdrawalConfirmations>
+              {withdrawalTransaction.confirmations}/
+              {config.requiredConfirmations}
             </>
         )}
       </SubStatus>
@@ -116,8 +113,4 @@ const SubStatus = styled.div`
   color: var(--green);
   text-align: right;
   padding-right: 24px;
-`
-
-const WithdrawalConfirmations = styled.span`
-  margin-left: 15px;
 `

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -53,8 +53,7 @@ export function LockIconBar({
           withdrawalTransaction.confirmations <
             config.requiredConfirmations && (
             <>
-              Confirming Withdrawal
-              {withdrawalTransaction.confirmations}/
+              Confirming Withdrawal {withdrawalTransaction.confirmations}/
               {config.requiredConfirmations}
             </>
         )}

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -8,7 +8,13 @@ import UnlockPropTypes from '../../../propTypes'
 import CreatorLockStatus from './CreatorLockStatus'
 import withConfig from '../../../utils/withConfig'
 
-export function LockIconBar({ lock, toggleCode, transaction, config }) {
+export function LockIconBar({
+  lock,
+  toggleCode,
+  transaction,
+  withdrawalTransaction,
+  config,
+}) {
   if (!transaction) {
     // We assume that the lock has been succeesfuly deployed?
     // TODO if the transaction is missing we should try to look it up from the lock address
@@ -28,14 +34,35 @@ export function LockIconBar({ lock, toggleCode, transaction, config }) {
   }
 
   return (
-    <IconBarContainer>
-      <IconBar>
-        <Buttons.Withdraw as="button" lock={lock} />
-        <Buttons.Edit as="button" />
-        {/* Reinstate when we're ready <Buttons.ExportLock /> */}
-        <Buttons.Code action={toggleCode} as="button" />
-      </IconBar>
-    </IconBarContainer>
+    <StatusBlock>
+      <IconBarContainer>
+        <IconBar>
+          <Buttons.Withdraw as="button" lock={lock} />
+          <Buttons.Edit as="button" />
+          {/* Reinstate when we're ready <Buttons.ExportLock /> */}
+          <Buttons.Code action={toggleCode} as="button" />
+        </IconBar>
+      </IconBarContainer>
+      <SubStatus>
+        {withdrawalTransaction &&
+          withdrawalTransaction.status === 'submitted' && (
+            <>Submitted to Network...</>
+        )}
+        {withdrawalTransaction &&
+          withdrawalTransaction.status === 'mined' &&
+          withdrawalTransaction.confirmations <
+            config.requiredConfirmations && (
+            <>
+              Confirming Withdrawal
+              <WithdrawalConfirmations>
+                {withdrawalTransaction.confirmations}
+/
+                {config.requiredConfirmations}
+              </WithdrawalConfirmations>
+            </>
+        )}
+      </SubStatus>
+    </StatusBlock>
   )
 }
 
@@ -43,17 +70,25 @@ LockIconBar.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
   toggleCode: PropTypes.func.isRequired,
   transaction: UnlockPropTypes.transaction,
+  withdrawalTransaction: UnlockPropTypes.transaction,
   config: UnlockPropTypes.configuration.isRequired,
 }
 
 LockIconBar.defaultProps = {
   transaction: null,
+  withdrawalTransaction: null,
 }
 
-const mapStateToProps = (state, { lock }) => {
-  const transaction = state.transactions[lock.transaction]
+const mapStateToProps = ({ transactions }, { lock }) => {
+  const transaction = transactions[lock.transaction]
+  let withdrawalTransaction = null
+  Object.keys(transactions).forEach(el => {
+    if (transactions[el].withdrawal && transactions[el].withdrawal === lock.id)
+      withdrawalTransaction = transactions[el]
+  })
   return {
     transaction,
+    withdrawalTransaction,
   }
 }
 
@@ -69,4 +104,20 @@ const IconBar = styled.div`
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(3, 24px);
+`
+
+const StatusBlock = styled.div``
+
+const SubStatus = styled.div`
+  margin-top: 13px;
+  font-size: 10px;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: normal;
+  color: var(--green);
+  text-align: right;
+  padding-right: 24px;
+`
+
+const WithdrawalConfirmations = styled.span`
+  margin-left: 15px;
 `

--- a/unlock-app/src/stories/creator/CreatorLock.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLock.stories.js
@@ -6,21 +6,31 @@ import createUnlockStore from '../../createUnlockStore'
 
 const store = createUnlockStore({
   transactions: {
-    '0x123': {
+    deployedid: {
       status: 'mined',
       confirmations: 24,
     },
-    '0x456': {
+    confirmingid: {
       status: 'mined',
       confirmations: 4,
     },
-    '0x111': {
+    submittedid: {
       status: 'submitted',
       confirmations: 0,
     },
+    withdrawalconfirmingid: {
+      status: 'mined',
+      confirmations: 2,
+      withdrawal: 'lockwithdrawalconfirmingid',
+    },
+    withdrawalsubmittedid: {
+      status: 'submitted',
+      confirmations: 0,
+      withdrawal: 'lockwithdrawalsubmittedid',
+    },
   },
   keys: {
-    '0x678': {
+    keyid: {
       transaction: '0x23749328748932748932473298473289473298',
       lockAddress: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       expiration: Math.floor(new Date().getTime() / 1000) + 86400 * 30, // 30 days from right now
@@ -41,7 +51,7 @@ storiesOf('CreatorLock', CreatorLock)
       maxNumberOfKeys: '240',
       outstandingKeys: '3',
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
-      transaction: '0x123',
+      transaction: 'deployedid',
     }
     return <CreatorLock lock={lock} />
   })
@@ -52,7 +62,7 @@ storiesOf('CreatorLock', CreatorLock)
       maxNumberOfKeys: '240',
       outstandingKeys: '3',
       address: '0x127c74abc0c4d48d1bdad5dcb26153fc8780f83e',
-      transaction: '0x111',
+      transaction: 'submittedid',
     }
     return <CreatorLock lock={lock} />
   })
@@ -63,7 +73,7 @@ storiesOf('CreatorLock', CreatorLock)
       maxNumberOfKeys: '240',
       outstandingKeys: '3',
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
-      transaction: '0x456',
+      transaction: 'confirmingid',
     }
     const transaction = {
       status: 'mined',
@@ -89,11 +99,35 @@ storiesOf('CreatorLock', CreatorLock)
       maxNumberOfKeys: '240',
       outstandingKeys: '3',
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
-      transaction: '0x123',
+      transaction: 'deployedid',
     }
     const transaction = {
       status: 'mined',
       confirmations: 14,
     }
     return <CreatorLock lock={lock} transaction={transaction} />
+  })
+  .add('Withdrawal submitted', () => {
+    const lock = {
+      id: 'lockwithdrawalsubmittedid',
+      keyPrice: '10000000000000000000',
+      expirationDuration: '172800',
+      maxNumberOfKeys: '240',
+      outstandingKeys: '3',
+      address: '0xbc7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      transaction: 'deployedid',
+    }
+    return <CreatorLock lock={lock} />
+  })
+  .add('Withdrawing', () => {
+    const lock = {
+      id: 'lockwithdrawalconfirmingid',
+      keyPrice: '10000000000000000000',
+      expirationDuration: '172800',
+      maxNumberOfKeys: '240',
+      outstandingKeys: '3',
+      address: '0xba7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      transaction: 'deployedid',
+    }
+    return <CreatorLock lock={lock} />
   })


### PR DESCRIPTION
Displays "withdrawal submitted" and "confirming" labels on lock once withdrawal has been submitted.  Includes accompanying stories and tests.

<img width="1160" alt="screen shot 2018-11-21 at 10 47 27 am" src="https://user-images.githubusercontent.com/624104/48863794-7a1ab400-ed7f-11e8-9c24-d80291d1215c.png">
<img width="1162" alt="screen shot 2018-11-21 at 10 47 34 am" src="https://user-images.githubusercontent.com/624104/48863801-7e46d180-ed7f-11e8-8651-fdf9a131531b.png">
