### PR TITLE
Bumping fonts to their own component to fix storybook

### DIFF
--- a/unlock-app/.storybook/config.js
+++ b/unlock-app/.storybook/config.js
@@ -1,20 +1,22 @@
 import React from 'react'
-import { configure, addDecorator } from '@storybook/react';
-import StoryRouter from 'storybook-react-router';
+import { configure, addDecorator } from '@storybook/react'
+import StoryRouter from 'storybook-react-router'
 import GlobalStyle from '../src/theme/globalStyle'
+import Fonts from '../src/theme/fonts'
 
 const req = require.context('../src/stories', true, /\.stories\.js$/)
 
 function loadStories() {
-  req.keys().forEach((filename) => req(filename))
+  req.keys().forEach(filename => req(filename))
 }
 
-const GlobalStyleDecorator = (storyFn) => (
+const GlobalStyleDecorator = storyFn => (
   <React.Fragment>
+    <Fonts />
     <GlobalStyle />
-    { storyFn() }
+    {storyFn()}
   </React.Fragment>
-);
+)
 
 addDecorator(GlobalStyleDecorator)
 addDecorator(StoryRouter())

--- a/unlock-app/src/pages/_document.js
+++ b/unlock-app/src/pages/_document.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Document, { Head, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
+import Fonts from '../theme/fonts'
 
 export default class MyDocument extends Document {
   static getInitialProps({ renderPage }) {
@@ -17,10 +18,7 @@ export default class MyDocument extends Document {
       <html lang="en">
         <Head>
           <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <link
-            href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
-            rel="stylesheet"
-          />
+          <Fonts />
           <link rel="shortcut icon" href="/static/favicon.ico" />
           {this.props.styleTags}
         </Head>

--- a/unlock-app/src/theme/fonts.js
+++ b/unlock-app/src/theme/fonts.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const Fonts = () => (
+  <link
+    href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+    rel="stylesheet"
+  />
+)
+
+export default Fonts


### PR DESCRIPTION
Fonts weren't displaying in storybook. This reinstates them, without duplicating the font `link` tag in multiple places.

Here's a screenshot of the dashboard within storybook post-change:

<img width="829" alt="screen shot 2018-11-21 at 2 46 20 pm" src="https://user-images.githubusercontent.com/624104/48872169-d213e380-ed9c-11e8-9439-58214d597e3f.png">
