### PR TITLE
Fixing height of lock overlay on small screens

### DIFF
--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -58,6 +58,7 @@ const Banner = styled.div`
   position: fixed;
   display: grid;
   height: 30%;
+  min-height: 375px;
   left: 0;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
On smaller screens the lock overlay was falling off the bottom of the page. Discovered this while coding on my laptop in Santa Rosa without my monitor. A good lesson to check across screens!

Fix screenshot:

<img width="1430" alt="screen shot 2018-11-29 at 6 02 28 pm" src="https://user-images.githubusercontent.com/624104/49263898-2f451000-f401-11e8-9bba-c6d724ec39c9.png">
