### PR TITLE
Fixing new lock address reference issue

### DIFF
--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -31,7 +31,7 @@ export default class Web3Service extends EventEmitter {
             transaction: transaction.hash,
             address: transaction.lock,
           },
-          args.newLock
+          args.newLockAddress
         )
       },
     }


### PR DESCRIPTION
Typo fix. I think there must have been some search and replacing done on lockAddress => lock. The effect was that saved locks had an undefined address.