### PR TITLE
Fixing withdrawal display label

### DIFF
--- a/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
@@ -28,7 +28,7 @@ describe('LockIconBar', () => {
     const withdrawalTransaction = {
       status: 'submitted',
       confirmations: 0,
-      withdrawal: 'lockwithdrawalsubmittedid',
+      withdrawal: '0xbc7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
     }
 
     const store = createUnlockStore({})

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -79,7 +79,10 @@ const mapStateToProps = ({ transactions }, { lock }) => {
   const transaction = transactions[lock.transaction]
   let withdrawalTransaction = null
   Object.keys(transactions).forEach(el => {
-    if (transactions[el].withdrawal && transactions[el].withdrawal === lock.id)
+    if (
+      transactions[el].withdrawal &&
+      transactions[el].withdrawal === lock.address
+    )
       withdrawalTransaction = transactions[el]
   })
   return {

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -498,6 +498,7 @@ export default class Web3Service extends EventEmitter {
       createdAt: new Date().getTime(),
       lock: lock.address,
       account: account.address,
+      withdrawal: lock.address,
     }
 
     this.sendTransaction(

--- a/unlock-app/src/stories/creator/CreatorLock.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLock.stories.js
@@ -21,12 +21,12 @@ const store = createUnlockStore({
     withdrawalconfirmingid: {
       status: 'mined',
       confirmations: 2,
-      withdrawal: 'lockwithdrawalconfirmingid',
+      withdrawal: 'withdrawalconfirmingaddress',
     },
     withdrawalsubmittedid: {
       status: 'submitted',
       confirmations: 0,
-      withdrawal: 'lockwithdrawalsubmittedid',
+      withdrawal: 'withdrawalsubmittedaddress',
     },
   },
   keys: {
@@ -114,7 +114,7 @@ storiesOf('CreatorLock', CreatorLock)
       expirationDuration: '172800',
       maxNumberOfKeys: '240',
       outstandingKeys: '3',
-      address: '0xbc7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      address: 'withdrawalsubmittedaddress',
       transaction: 'deployedid',
     }
     return <CreatorLock lock={lock} />
@@ -126,7 +126,7 @@ storiesOf('CreatorLock', CreatorLock)
       expirationDuration: '172800',
       maxNumberOfKeys: '240',
       outstandingKeys: '3',
-      address: '0xba7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      address: 'withdrawalconfirmingaddress',
       transaction: 'deployedid',
     }
     return <CreatorLock lock={lock} />


### PR DESCRIPTION
The withdrawal display code depended on lock IDs. It now works on addresses, and is displaying properly again.