### PR TITLE
Better handle long lock names in key purchase UI

### DIFF
--- a/unlock-app/src/components/lock/ConfirmingKeyLock.js
+++ b/unlock-app/src/components/lock/ConfirmingKeyLock.js
@@ -8,11 +8,12 @@ import {
   LockDetails,
   TransactionStatus,
   LockDetail,
+  LockName,
 } from './LockStyles'
 import BalanceProvider from '../helpers/BalanceProvider'
 import withConfig from '../../utils/withConfig'
 
-const ConfirmingKeyLock = ({ lock, transaction, config }) => (
+export const ConfirmingKeyLock = ({ lock, transaction, config }) => (
   <LockWrapper>
     <Header>Payment Received</Header>
     <LockBody>
@@ -26,18 +27,20 @@ const ConfirmingKeyLock = ({ lock, transaction, config }) => (
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
-          <LockDetails>
-            <LockDetail>{lock.name}</LockDetail>
-            <LockDetail bold>
-              {ethPrice}
-              {' '}
+          <>
+            <LockName>{lock.name}</LockName>
+            <LockDetails>
+              <LockDetail bold>
+                {ethPrice}
+                {' '}
 ETH
-            </LockDetail>
-            <LockDetail>
+              </LockDetail>
+              <LockDetail>
 $
-              {fiatPrice}
-            </LockDetail>
-          </LockDetails>
+                {fiatPrice}
+              </LockDetail>
+            </LockDetails>
+          </>
         )}
       />
     </LockBody>

--- a/unlock-app/src/components/lock/LockStyles.js
+++ b/unlock-app/src/components/lock/LockStyles.js
@@ -74,3 +74,8 @@ export const LockDetails = styled.div`
   justify-items: center;
   align-content: center;
 `
+
+export const LockName = styled(LockDetail)`
+  white-space: normal;
+  font-size: 12px;
+`

--- a/unlock-app/src/components/lock/PendingKeyLock.js
+++ b/unlock-app/src/components/lock/PendingKeyLock.js
@@ -11,7 +11,7 @@ import {
 } from './LockStyles'
 import BalanceProvider from '../helpers/BalanceProvider'
 
-const PendingKeyLock = ({ lock }) => (
+export const PendingKeyLock = ({ lock }) => (
   <LockWrapper>
     <Header>Payment sent</Header>
     <LockBody>
@@ -20,18 +20,20 @@ const PendingKeyLock = ({ lock }) => (
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
-          <LockDetails>
-            <LockDetail>{lock.name}</LockDetail>
-            <LockDetail bold>
-              {ethPrice}
-              {' '}
+          <>
+            <LockName>{lock.name}</LockName>
+            <LockDetails>
+              <LockDetail bold>
+                {ethPrice}
+                {' '}
 ETH
-            </LockDetail>
-            <LockDetail>
+              </LockDetail>
+              <LockDetail>
 $
-              {fiatPrice}
-            </LockDetail>
-          </LockDetails>
+                {fiatPrice}
+              </LockDetail>
+            </LockDetails>
+          </>
         )}
       />
     </LockBody>
@@ -47,4 +49,9 @@ export default PendingKeyLock
 const Header = styled(LockHeader)`
   background-color: var(--link);
   color: var(--offwhite);
+`
+
+const LockName = styled(LockDetail)`
+  white-space: normal;
+  font-size: 12px;
 `

--- a/unlock-app/src/components/lock/PendingKeyLock.js
+++ b/unlock-app/src/components/lock/PendingKeyLock.js
@@ -8,6 +8,7 @@ import {
   LockDetails,
   TransactionStatus,
   LockDetail,
+  LockName,
 } from './LockStyles'
 import BalanceProvider from '../helpers/BalanceProvider'
 
@@ -49,9 +50,4 @@ export default PendingKeyLock
 const Header = styled(LockHeader)`
   background-color: var(--link);
   color: var(--offwhite);
-`
-
-const LockName = styled(LockDetail)`
-  white-space: normal;
-  font-size: 12px;
 `

--- a/unlock-app/src/stories/lock/ConfirmingKeyLock.stories.js
+++ b/unlock-app/src/stories/lock/ConfirmingKeyLock.stories.js
@@ -1,0 +1,54 @@
+import { Provider } from 'react-redux'
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import createUnlockStore from '../../createUnlockStore'
+import { ConfirmingKeyLock } from '../../components/lock/ConfirmingKeyLock'
+
+const lock = {
+  address: '0x123',
+  name: 'Monthly',
+  keyPrice: '1203120301203013000',
+  fiatPrice: 240.38,
+}
+
+const lockWithAnAnnoyingName = {
+  address: '0x456',
+  name: 'Time And Relative Dimension In Space',
+  keyPrice: '1203120301203013000',
+  fiatPrice: 240.38,
+}
+
+const transaction = {
+  confirmations: 3,
+}
+
+const config = {
+  requiredConfirmations: 6,
+}
+
+const store = createUnlockStore({
+  currency: {
+    USD: 195.99,
+  },
+})
+
+storiesOf('ConfirmingKeyLock', ConfirmingKeyLock)
+  .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
+  .add('waiting for confirmation', () => {
+    return (
+      <ConfirmingKeyLock
+        lock={lock}
+        transaction={transaction}
+        config={config}
+      />
+    )
+  })
+  .add('with an annoyingly long name', () => {
+    return (
+      <ConfirmingKeyLock
+        lock={lockWithAnAnnoyingName}
+        transaction={transaction}
+        config={config}
+      />
+    )
+  })

--- a/unlock-app/src/stories/lock/PendingKeyLock.stories.js
+++ b/unlock-app/src/stories/lock/PendingKeyLock.stories.js
@@ -1,0 +1,34 @@
+import { Provider } from 'react-redux'
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import createUnlockStore from '../../createUnlockStore'
+import { PendingKeyLock } from '../../components/lock/PendingKeyLock'
+
+const lock = {
+  address: '0x123',
+  name: 'Monthly',
+  keyPrice: '1203120301203013000',
+  fiatPrice: 240.38,
+}
+
+const lockWithAnAnnoyingName = {
+  address: '0x456',
+  name: 'Time And Relative Dimension In Space',
+  keyPrice: '1203120301203013000',
+  fiatPrice: 240.38,
+}
+
+const store = createUnlockStore({
+  currency: {
+    USD: 195.99,
+  },
+})
+
+storiesOf('PendingKeyLock', PendingKeyLock)
+  .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
+  .add('waiting for mining confirmation', () => {
+    return <PendingKeyLock lock={lock} />
+  })
+  .add('with an annoyingly long name', () => {
+    return <PendingKeyLock lock={lockWithAnAnnoyingName} />
+  })


### PR DESCRIPTION
I was seeing this kind of thing in the demo UI:

<img width="314" alt="screen shot 2018-11-30 at 5 51 58 pm" src="https://user-images.githubusercontent.com/624104/49323369-43574300-f4cf-11e8-919e-710db0aa158a.png">

This update ensures long names wrap more cleanly:

<img width="210" alt="screen shot 2018-11-30 at 6 38 29 pm" src="https://user-images.githubusercontent.com/624104/49323371-523df580-f4cf-11e8-9769-d8f27da912f3.png"><img width="215" alt="screen shot 2018-11-30 at 6 38 22 pm" src="https://user-images.githubusercontent.com/624104/49323370-4f430500-f4cf-11e8-9f0b-b8c251d1ff91.png"><img width="210" alt="screen shot 2018-11-30 at 6 45 46 pm" src="https://user-images.githubusercontent.com/624104/49323428-4a328580-f4d0-11e8-9f42-89618dca04a9.png"><img width="212" alt="screen shot 2018-11-30 at 6 45 51 pm" src="https://user-images.githubusercontent.com/624104/49323430-4dc60c80-f4d0-11e8-89a6-491a02731c27.png">
