### PR TITLE
Disabled withdrawal button displayed when balance is 0

### DIFF
--- a/unlock-app/src/__tests__/components/interface/Button.test.js
+++ b/unlock-app/src/__tests__/components/interface/Button.test.js
@@ -2,7 +2,9 @@ import React from 'react'
 import * as rtl from 'react-testing-library'
 import 'jest-dom/extend-expect'
 
-import Button from '../../../components/interface/buttons/Button'
+import Button, {
+  DisabledButton,
+} from '../../../components/interface/buttons/Button'
 
 jest.mock('next/link', () => {
   return ({ children }) => children
@@ -51,5 +53,32 @@ describe('Button', () => {
 
     expect(buttonClicked).toEqual(true)
     expect(wrapperClicked).toEqual(false)
+  })
+  it('should not run an action from a disabled button', () => {
+    let buttonClicked = false
+    let wrapperClicked = false
+
+    const buttonAction = () => {
+      buttonClicked = true
+    }
+    const wrapperAction = () => {
+      wrapperClicked = false
+    }
+
+    // role and onKeyDown action here are to comply with accessibility rules
+    let wrapper = rtl.render(
+      <div
+        onClick={wrapperAction}
+        onKeyDown={wrapperAction}
+        role="presentation"
+      >
+        <DisabledButton action={buttonAction}>Click me</DisabledButton>
+      </div>
+    )
+
+    let button = wrapper.getByText('Click me')
+    rtl.fireEvent.click(button)
+
+    expect(buttonClicked).toEqual(false)
   })
 })

--- a/unlock-app/src/__tests__/components/interface/Button.test.js
+++ b/unlock-app/src/__tests__/components/interface/Button.test.js
@@ -61,7 +61,6 @@ describe('Button', () => {
       buttonClicked = true
     }
 
-    // role and onKeyDown action here are to comply with accessibility rules
     let wrapper = rtl.render(
       <DisabledButton action={buttonAction}>Click me</DisabledButton>
     )

--- a/unlock-app/src/__tests__/components/interface/Button.test.js
+++ b/unlock-app/src/__tests__/components/interface/Button.test.js
@@ -56,24 +56,14 @@ describe('Button', () => {
   })
   it('should not run an action from a disabled button', () => {
     let buttonClicked = false
-    let wrapperClicked = false
 
     const buttonAction = () => {
       buttonClicked = true
     }
-    const wrapperAction = () => {
-      wrapperClicked = false
-    }
 
     // role and onKeyDown action here are to comply with accessibility rules
     let wrapper = rtl.render(
-      <div
-        onClick={wrapperAction}
-        onKeyDown={wrapperAction}
-        role="presentation"
-      >
-        <DisabledButton action={buttonAction}>Click me</DisabledButton>
-      </div>
+      <DisabledButton action={buttonAction}>Click me</DisabledButton>
     )
 
     let button = wrapper.getByText('Click me')

--- a/unlock-app/src/components/interface/buttons/Button.js
+++ b/unlock-app/src/components/interface/buttons/Button.js
@@ -39,7 +39,6 @@ LayoutButton.propTypes = {
 
 LayoutButton.defaultProps = {
   children: null,
-  disabled: false,
   backgroundColor: 'var(--grey)',
   backgroundHoverColor: 'var(--link)',
   fillColor: 'white',

--- a/unlock-app/src/components/interface/buttons/Button.js
+++ b/unlock-app/src/components/interface/buttons/Button.js
@@ -39,15 +39,68 @@ LayoutButton.propTypes = {
 
 LayoutButton.defaultProps = {
   children: null,
+  disabled: false,
   backgroundColor: 'var(--grey)',
   backgroundHoverColor: 'var(--link)',
   fillColor: 'white',
   fillHoverColor: 'white',
 }
 
-export const BaseButton = ({ href, label, children, action, ...props }) => {
+export const DisabledButton = ({
+  children,
+  backgroundColor,
+  backgroundHoverColor,
+  fillColor,
+  fillHoverColor,
+  ...props
+}) => {
+  return (
+    <BaseButton
+      backgroundColor={backgroundColor}
+      backgroundHoverColor={backgroundHoverColor}
+      fillColor={fillColor}
+      fillHoverColor={fillHoverColor}
+      {...props}
+    >
+      {children}
+    </BaseButton>
+  )
+}
+
+DisabledButton.propTypes = {
+  children: PropTypes.node,
+  backgroundColor: PropTypes.string,
+  backgroundHoverColor: PropTypes.string,
+  fillColor: PropTypes.string,
+  fillHoverColor: PropTypes.string,
+  disabled: PropTypes.bool,
+}
+
+DisabledButton.defaultProps = {
+  children: null,
+  disabled: true,
+  backgroundColor: 'white',
+  backgroundHoverColor: 'white',
+  fillColor: 'var(--lightgrey)',
+  fillHoverColor: 'var(--lightgrey)',
+}
+
+export const BaseButton = ({
+  href,
+  label,
+  children,
+  action,
+  disabled,
+  ...props
+}) => {
   const button = (
-    <ButtonLink href={href} onClick={e => clickAction(e, action)} {...props}>
+    <ButtonLink
+      href={href}
+      onClick={e => {
+        if (!disabled) return clickAction(e, action)
+      }}
+      {...props}
+    >
       {children}
       {label && <Label>{label}</Label>}
     </ButtonLink>

--- a/unlock-app/src/components/interface/buttons/lock/Withdraw.js
+++ b/unlock-app/src/components/interface/buttons/lock/Withdraw.js
@@ -3,23 +3,41 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import Svg from '../../svg'
-import Button from '../Button'
+import Button, { DisabledButton } from '../Button'
 import UnlockPropTypes from '../../../../propTypes'
 import { withdrawFromLock } from '../../../../actions/lock'
 
-export const Withdraw = ({ lock, withdraw, account, ...props }) => (
-  <Button
-    title="Withdraw balance"
-    action={() => {
-      if (lock.balance > 0) {
-        withdraw(lock, account)
-      }
-    }}
-    {...props}
-  >
-    <Svg.Withdraw name="Withdraw" />
-  </Button>
-)
+export const Withdraw = ({ lock, withdraw, account, ...props }) => {
+  if (lock.balance > 0) {
+    return (
+      <Button
+        title="Withdraw balance"
+        action={() => {
+          if (lock.balance > 0) {
+            withdraw(lock, account)
+          }
+        }}
+        {...props}
+      >
+        <Svg.Withdraw name="Withdraw" />
+      </Button>
+    )
+  } else {
+    return (
+      <DisabledButton
+        title="Withdraw balance"
+        action={() => {
+          if (lock.balance > 0) {
+            withdraw(lock, account)
+          }
+        }}
+        {...props}
+      >
+        <Svg.Withdraw name="Withdraw" />
+      </DisabledButton>
+    )
+  }
+}
 
 Withdraw.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,

--- a/unlock-app/src/components/interface/buttons/lock/Withdraw.js
+++ b/unlock-app/src/components/interface/buttons/lock/Withdraw.js
@@ -24,15 +24,7 @@ export const Withdraw = ({ lock, withdraw, account, ...props }) => {
     )
   } else {
     return (
-      <DisabledButton
-        title="Withdraw balance"
-        action={() => {
-          if (lock.balance > 0) {
-            withdraw(lock, account)
-          }
-        }}
-        {...props}
-      >
+      <DisabledButton title="Withdraw balance" {...props}>
         <Svg.Withdraw name="Withdraw" />
       </DisabledButton>
     )

--- a/unlock-app/src/stories/lock/Lock.stories.js
+++ b/unlock-app/src/stories/lock/Lock.stories.js
@@ -111,7 +111,7 @@ storiesOf('Lock', Lock)
     }
     return (
       <Lock
-        lock={lock}
+        lock={lockWithBalance}
         transaction={null}
         lockKey={null}
         purchaseKey={purchaseKey}

--- a/unlock-app/src/stories/lock/Lock.stories.js
+++ b/unlock-app/src/stories/lock/Lock.stories.js
@@ -101,3 +101,21 @@ storiesOf('Lock', Lock)
       />
     )
   })
+  .add('with a balance', () => {
+    const lockWithBalance = {
+      address: '0x123',
+      name: 'Monthly',
+      keyPrice: '1203120301203013000',
+      fiatPrice: 240.38,
+      balance: 5,
+    }
+    return (
+      <Lock
+        lock={lock}
+        transaction={null}
+        lockKey={null}
+        purchaseKey={purchaseKey}
+        config={config}
+      />
+    )
+  })


### PR DESCRIPTION
Disabled buttons are lighter (cc @smombartz for design feedback) and don't trigger any attached action.

<img width="968" alt="screen shot 2018-12-03 at 12 35 15 pm" src="https://user-images.githubusercontent.com/624104/49400403-0a021b80-f6f9-11e8-9a29-ad7b9a7f3524.png">
