### PR TITLE
Update icons with more shapes, rotation, and mirroring.

### DIFF
--- a/unlock-app/src/components/lock/Icon.js
+++ b/unlock-app/src/components/lock/Icon.js
@@ -3,12 +3,66 @@ import ColorScheme from 'color-scheme'
 
 import UnlockPropTypes from '../../propTypes'
 
+const originalIcon = [
+  { x: 195.75, y: 114.75 },
+  { x: 33.75, y: 162 },
+  { x: 121.5, y: 0 },
+]
+
+const stripedIcon = [{ x: 108, y: 108 }, { x: 146, y: 147 }, { x: 216, y: 216 }]
+
+const chompIcon = [{ x: 108, y: 108 }, { x: 108, y: -64 }, { x: 108, y: 280 }]
+
+const biteIcon = [{ x: 108, y: 108 }, { x: 108, y: 0 }, { x: 108, y: 216 }]
+
+const tailIcon = [{ x: 108, y: 108 }, { x: 64, y: 0 }, { x: 64, y: 216 }]
+
+const triadIcon = [{ x: 108, y: 108 }, { x: 32, y: 0 }, { x: 32, y: 216 }]
+
+/**
+ * This selects a set of 3 circles (specified by position) to use to construct the lock icon.
+ * @param {string} address
+ * @returns {object}
+ */
+function circles(address) {
+  const options = [
+    originalIcon,
+    stripedIcon,
+    chompIcon,
+    biteIcon,
+    tailIcon,
+    triadIcon,
+  ]
+  const n = parseInt(address) % options.length
+  return options[n]
+}
+
+/**
+ * This computes how much rotation to apply to the lock glyph
+ * @param {string} address
+ * @returns {number}
+ */
+function degreesOfRotation(address) {
+  const n = parseInt(address)
+  return (n % 36) * 10
+}
+
+/**
+ * This returns either instructions to mirror the icon and then translate it back to
+ * the origin, or do nothing depending on lock address.
+ * @param {string} address
+ * @returns {string}
+ */
+function translateAndScale(address) {
+  const n = parseInt(address)
+  return n % 2 == 0 ? '' : 'tranlate(216, 0) scale(-1, 1)'
+}
+
 /**
  * This generates a lock icon unique for each lock
- * At this point, it only changes the colors of the 3 inner circles based on the lock address
- * @todo Customize position of circles
- * @body In order to get more unique lock icons we should also position (x, y and z) the inner circles
- * more uniquely based on the lock address... the challenge is to not have any white space.
+ * It changes the colors of the 3 inner circles and applies a rotation and permutation of layer order
+ * based on the lock address
+ * @todo Figure out proper output for falsy lock address?
  * @param {UnlockPropTypes.lock} lock
  */
 export function Icon({ lock }) {
@@ -22,7 +76,7 @@ export function Icon({ lock }) {
       .variation('light')
     colors = scheme.colors().map(c => `#${c}`)
   }
-
+  const innerCircles = circles(lock.address)
   return (
     <svg
       viewBox="0 0 216 216"
@@ -37,21 +91,36 @@ export function Icon({ lock }) {
         <mask id="b" fill="#fff">
           <use xlinkHref="#a" />
         </mask>
-        <circle
-          fill={colors[0]}
-          mask="url(#b)"
-          cx={195.75}
-          cy={114.75}
-          r={114.75}
-        />
-        <circle
-          fill={colors[1]}
-          mask="url(#b)"
-          cx={33.75}
-          cy={162}
-          r={114.75}
-        />
-        <circle fill={colors[2]} mask="url(#b)" cx={121.5} r={114.75} />
+        <g
+          transform={
+            'rotate(' +
+            degreesOfRotation(lock.address) +
+            ', 108, 108)' +
+            translateAndScale(lock.address)
+          }
+        >
+          <circle
+            fill={colors[0]}
+            mask="url(#b)"
+            cx={innerCircles[0].x}
+            cy={innerCircles[0].y}
+            r="114.75"
+          />
+          <circle
+            fill={colors[1]}
+            mask="url(#b)"
+            cx={innerCircles[1].x}
+            cy={innerCircles[1].y}
+            r="114.75"
+          />
+          <circle
+            fill={colors[2]}
+            mask="url(#b)"
+            cx={innerCircles[2].x}
+            cy={innerCircles[2].y}
+            r="114.75"
+          />
+        </g>
         <mask id="d" fill="#fff">
           <use xlinkHref="#c" />
         </mask>

--- a/unlock-app/src/components/lock/Icon.js
+++ b/unlock-app/src/components/lock/Icon.js
@@ -68,15 +68,17 @@ function translateAndScale(address) {
 export function Icon({ lock }) {
   const scheme = new ColorScheme()
   let colors = ['#8c8c8c', '#e8e8e8', '#c3c3c3']
+  let address = '0x000000'
   if (lock && !lock.pending) {
-    const mainColor = lock.address.substring(2, 8).toUpperCase()
+    address = lock.address
+    const mainColor = address.substring(2, 8).toUpperCase()
     scheme
       .from_hex(mainColor)
       .scheme('triade')
       .variation('light')
     colors = scheme.colors().map(c => `#${c}`)
   }
-  const innerCircles = circles(lock.address)
+  const innerCircles = circles(address)
   return (
     <svg
       viewBox="0 0 216 216"
@@ -94,9 +96,9 @@ export function Icon({ lock }) {
         <g
           transform={
             'rotate(' +
-            degreesOfRotation(lock.address) +
+            degreesOfRotation(address) +
             ', 108, 108)' +
-            translateAndScale(lock.address)
+            translateAndScale(address)
           }
         >
           <circle

--- a/unlock-app/src/components/lock/Icon.js
+++ b/unlock-app/src/components/lock/Icon.js
@@ -62,7 +62,6 @@ function translateAndScale(address) {
  * This generates a lock icon unique for each lock
  * It changes the colors of the 3 inner circles and applies a rotation and permutation of layer order
  * based on the lock address
- * @todo Figure out proper output for falsy lock address?
  * @param {UnlockPropTypes.lock} lock
  */
 export function Icon({ lock }) {

--- a/unlock-app/src/stories/lock/Icon.stories.js
+++ b/unlock-app/src/stories/lock/Icon.stories.js
@@ -4,7 +4,7 @@ import { Icon } from '../../components/lock/Icon'
 
 storiesOf('Icon', Icon)
   .add('with a falsy lock address', () => {
-    const lock = { address: '' }
+    const lock = { pending: true, address: '' }
     return <Icon lock={lock} />
   })
   .add('with a lock address', () => {

--- a/unlock-app/src/stories/lock/Icon.stories.js
+++ b/unlock-app/src/stories/lock/Icon.stories.js
@@ -4,14 +4,14 @@ import { Icon } from '../../components/lock/Icon'
 
 storiesOf('Icon', Icon)
   .add('with a falsy lock address', () => {
-    const address = ''
-    return <Icon address={address} />
+    const lock = { address: '' }
+    return <Icon lock={lock} />
   })
   .add('with a lock address', () => {
-    const address = '0xa62142888aba8370742be823c1782d17a0389da1'
-    return <Icon address={address} />
+    const lock = { address: '0xa62142888aba8370742be823c1782d17a0389da1' }
+    return <Icon lock={lock} />
   })
   .add('with a different lock address', () => {
-    const address = '0xc3672ef6721d1151699a8acd2072d529e73c6662'
-    return <Icon address={address} />
+    const lock = { address: '0xc3672ef6721d1151699a8acd2072d529e73c6662' }
+    return <Icon lock={lock} />
   })


### PR DESCRIPTION
This pull request modifies the Icon component to include more variation in shapes (6 total, including the original icon).

The new shapes are as follows:
![screen shot 2018-12-04 at 6 59 25 pm](https://user-images.githubusercontent.com/9300702/49483201-52583100-f800-11e8-8090-22bcedfb409c.png)
_stripedIcon_

![screen shot 2018-12-04 at 7 07 36 pm](https://user-images.githubusercontent.com/9300702/49483214-5be19900-f800-11e8-84c4-014bebd59e91.png)
_chompIcon_

![screen shot 2018-12-04 at 7 06 43 pm](https://user-images.githubusercontent.com/9300702/49483221-62701080-f800-11e8-91e6-924201cecf3f.png)
_biteIcon_

![screen shot 2018-12-04 at 7 09 31 pm](https://user-images.githubusercontent.com/9300702/49483230-6c920f00-f800-11e8-92a2-8043aa8a82ad.png)
_tailIcon_

![screen shot 2018-12-04 at 7 09 14 pm](https://user-images.githubusercontent.com/9300702/49483238-73208680-f800-11e8-805e-5e5fe468f915.png)
and _triadIcon_

(I hope these names make it easier to refer to a given icon easily)

Please let me know if there are any edits I should make. I suspect we may want to update the storybook to show an example of at least each different shape.

Fixes #219 

## Proposed Changes

- Add new shapes
- Add rotation of inner part of icon, in 10-degree increments based on lock address
- Add horizontal mirroring of inner part of icon, based on lock address
- Fix existing examples in Storybook for icons (looks like they were constructed based on an older revision of the icon component and needed to have a lock object passed in rather than a bare address)
