### PR TITLE
Forcing withdrawal button to update

### DIFF
--- a/unlock-app/src/components/creator/CreatorLocks.js
+++ b/unlock-app/src/components/creator/CreatorLocks.js
@@ -39,7 +39,7 @@ export class CreatorLocks extends React.Component {
         <Error />
         {showDashboardForm && <CreatorLockForm hideAction={this.toggleForm} />}
         {Object.values(locks).map(lock => {
-          return <CreatorLock key={lock.address} lock={lock} />
+          return <CreatorLock key={JSON.stringify(lock)} lock={lock} />
         })}
       </Locks>
     )


### PR DESCRIPTION
So it turns out that:

1. `CreatorLock` is initially drawn before `lock.balance` is known
2. When `CreatorLock` updates to show a balance, React decides that there's no need to update the withdrawal button, because it thinks no relevant props have changed

In order to fix that, I'm now passing balance as a separate prop. And I hate myself for it a little bit. But here it is.

This PR restores the "withdraw" button when lock has a balance.