### PR TITLE
Reduce ganache blocktime to 0 for local testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start-ganache": "ganache-cli -b 3 -i 1984 --mnemonic 'hello unlock save the web'",
+    "start-ganache": "ganache-cli -i 1984 --mnemonic 'hello unlock save the web'",
     "postinstall": "cd smart-contracts && npm install && cd ../unlock-app && npm install",
     "deploy-lock": "cd smart-contracts && truffle deploy --reset"
   },

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -69,7 +69,7 @@
     "build": "next build src",
     "export": "next export src",
     "start": "NODE_ENV=production node src/server.js",
-    "setup-dev": "cd .. && (npm run start-ganache &) && npm run deploy-lock",
+    "setup-dev": "cd .. && (npm run start-ganache -- -b 3 &) && npm run deploy-lock",
     "test": "NODE_ENV=test jest --env=jsdom",
     "lint": "./node_modules/eslint/bin/eslint.js .",
     "reformat": "npx prettier-eslint --write \"src/**/*.js\"",


### PR DESCRIPTION

## Proposed Changes

- Removes `-b 3` from  the npm script "start-ganache" 
- Adds `-- -b 3` to the npm script "setup-dev": "cd .. && (npm run start-ganache -- -b 3 &) && npm run deploy-lock",
-
