### PR TITLE
Removing name from pending lock for now

### DIFF
--- a/unlock-app/src/components/lock/ConfirmingKeyLock.js
+++ b/unlock-app/src/components/lock/ConfirmingKeyLock.js
@@ -28,7 +28,6 @@ export const ConfirmingKeyLock = ({ lock, transaction, config }) => (
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
           <>
-            <LockName>{lock.name}</LockName>
             <LockDetails>
               <LockDetail bold>
                 {ethPrice}

--- a/unlock-app/src/components/lock/ConfirmingKeyLock.js
+++ b/unlock-app/src/components/lock/ConfirmingKeyLock.js
@@ -8,7 +8,6 @@ import {
   LockDetails,
   TransactionStatus,
   LockDetail,
-  LockName,
 } from './LockStyles'
 import BalanceProvider from '../helpers/BalanceProvider'
 import withConfig from '../../utils/withConfig'

--- a/unlock-app/src/components/lock/PendingKeyLock.js
+++ b/unlock-app/src/components/lock/PendingKeyLock.js
@@ -8,7 +8,6 @@ import {
   LockDetails,
   TransactionStatus,
   LockDetail,
-  LockName,
 } from './LockStyles'
 import BalanceProvider from '../helpers/BalanceProvider'
 

--- a/unlock-app/src/components/lock/PendingKeyLock.js
+++ b/unlock-app/src/components/lock/PendingKeyLock.js
@@ -22,7 +22,6 @@ export const PendingKeyLock = ({ lock }) => (
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
           <>
-            <LockName>{lock.name}</LockName>
             <LockDetails>
               <LockDetail bold>
                 {ethPrice}


### PR DESCRIPTION
My previous fix for lock names doesn't make sense in a world where we're not storing the lock name on-chain (or in localStorage). It created a giant white space and busted the dimensions of the badge. This PR removes the name from display for now. This could be reinstated later once the name is back. (cc @smombartz for design input.)

<img width="213" alt="screen shot 2018-12-10 at 10 47 27 am" src="https://user-images.githubusercontent.com/624104/49753697-0296c100-fc69-11e8-8156-ac2acbd72ce4.png">
<img width="210" alt="screen shot 2018-12-10 at 10 47 21 am" src="https://user-images.githubusercontent.com/624104/49753698-0296c100-fc69-11e8-824f-4de31e7dea73.png">
