### PR TITLE
Revised lock embed code to run from metatag

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
@@ -49,14 +49,14 @@ describe('CreatorLock', () => {
     )
 
     expect(
-      wrapper.queryByText('This content is only visible', { exact: false })
+      wrapper.queryByText('Include this script in the <head> section of your page', { exact: false })
     ).toBeNull()
 
     let codeButton = wrapper.getByTitle('Show embed code')
     rtl.fireEvent.click(codeButton)
 
     expect(
-      wrapper.queryByText('This content is only visible', { exact: false })
+      wrapper.queryByText('Include this script in the <head> section of your page', { exact: false })
     ).not.toBeNull()
   })
   it('should display the correct number of keys', () => {

--- a/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
+++ b/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
@@ -6,14 +6,9 @@ import Buttons from '../../interface/buttons/lock'
 
 export function EmbedCodeSnippet({ lock }) {
   function embedCode(lock) {
-    return `<!-- Include this script in your <head> section -->
+    return `<!-- Include this script in the <head> section of your page -->
 <script src="https://unlock-protocol.com/static/unlock.js"></script>
-
-<!-- Lock elements by wrapping them in this div -->
-<div unlock-lock="${lock.address}">
-  This content is only visible to the visitors who have a key to the lock
-  ${lock.address}
-</div>
+<meta name="lock" content="${lock.address}" />
 `
   }
 

--- a/unlock-app/src/static/unlock.js
+++ b/unlock-app/src/static/unlock.js
@@ -1,12 +1,12 @@
 window.onload = function() {
-  const lockedNode = document.querySelector('[unlock-lock]')
+  const lockedNode = document.querySelector('meta[name=lock]')
 
   // If there is no lock, do nothing!
   if (lockedNode) {
     var src = window.unlock_url || 'http://localhost:3000'
 
     var s = document.createElement('iframe')
-    src += `/paywall/${lockedNode.getAttribute('unlock-lock')}/`
+    src += `/paywall/${lockedNode.getAttribute('content')}/`
 
     s.setAttribute(
       'style',


### PR DESCRIPTION
Fixes #700.

The embed code is now much simpler. Pages just need to contain a `<meta>` tag named `lock` with `content` set to be the lock address.

<img width="985" alt="screen shot 2018-12-12 at 11 31 21 am" src="https://user-images.githubusercontent.com/624104/49894077-e1b5a380-fe01-11e8-8706-3c2c5730c427.png">
<img width="1436" alt="screen shot 2018-12-12 at 11 33 10 am" src="https://user-images.githubusercontent.com/624104/49894085-e5492a80-fe01-11e8-87c3-443cae546875.png">
