### PR TITLE
refreshing a lock's data after it has been deployed

### DIFF
--- a/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
@@ -141,17 +141,18 @@ describe('Lock middleware', () => {
   })
 
   it('it should handle lock.saved events triggered by the web3Service', () => {
-    expect.assertions(2)
+    expect.assertions(3)
     const { store } = create()
     const lock = {}
     const address = '0x123'
     mockWeb3Service.refreshAccountBalance = jest.fn()
-    mockWeb3Service.getKeyByLockForOwner = jest.fn()
+    mockWeb3Service.getLock = jest.fn()
 
     mockWeb3Service.emit('lock.saved', lock, address)
     expect(mockWeb3Service.refreshAccountBalance).toHaveBeenCalledWith(
       state.account
     )
+    expect(mockWeb3Service.getLock).toHaveBeenCalledWith(address)
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: LOCK_DEPLOYED,

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -52,6 +52,7 @@ export default function lockMiddleware({ getState, dispatch }) {
       })
     )
     web3Service.refreshAccountBalance(getState().account)
+    web3Service.getLock(address)
   })
 
   /**


### PR DESCRIPTION
Fixes bug where previously deployed locks did not show any value for expiration, price of keys ... etc