### PR TITLE
create symlink during 'npm run dev', os compat with 'run-script-os'

### DIFF
--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -67,7 +67,10 @@
   },
   "engineStrict": true,
   "scripts": {
-    "dev": "npm run setup-dev && nodemon src/server.js",
+    "dev": "npm run setup-dev && npm run set-link && nodemon src/server.js",
+    "set-link": "run-script-os",
+    "set-link:darwin:freebsd:linux:sunos": "cd src && (rm artifacts -f) && ln -s ../../smart-contracts/build artifacts",
+    "set-link:win32": "cd src && if exist artifacts (rmdir artifacts /q /s || del artifacts) && cmd /c mklink /d artifacts ..\\..\\smart-contracts\\build",
     "build": "next build src",
     "export": "next export src",
     "start": "NODE_ENV=production node src/server.js",


### PR DESCRIPTION
Fixes #
#594 
## Proposed Changes
create symlink during 'npm run dev' command
    - if symlink file exists, delete it and create a new one
    - symlink folder 'smart-contracts/build' with target 'unlock-app/src/artifacts'
different command versions for unix/win using run-script-os

## Tested for
- ubuntu 18.04.1 LTS
- Windows 10 (home)

