### PR TITLE
Only rm artifacts/ if it exists

### DIFF
--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "dev": "npm run setup-dev && npm run set-link && nodemon src/server.js",
     "set-link": "run-script-os",
-    "set-link:darwin:freebsd:linux:sunos": "cd src && (rm artifacts -f) && ln -s ../../smart-contracts/build artifacts",
+    "set-link:darwin:freebsd:linux:sunos": "pushd src && (test -e artifacts && rm -f artifacts) && ln -s ../../smart-contracts/build artifacts",
     "set-link:win32": "cd src && if exist artifacts (rmdir artifacts /q /s || del artifacts) && cmd /c mklink /d artifacts ..\\..\\smart-contracts\\build",
     "build": "next build src",
     "export": "next export src",


### PR DESCRIPTION
I needed to do this to stop errors with `npm run-dev` on macOS.