### PR TITLE
Responsive interface for dashboard + framework for all pages

### DIFF
--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
@@ -202,6 +202,7 @@ exports[`withConfig High Order Component when the current network is not in the 
   color: var(--darkgrey);
   display: grid;
   row-gap: 24px;
+  width: 100%;
 }
 
 .c13 {
@@ -244,9 +245,10 @@ exports[`withConfig High Order Component when the current network is not in the 
   color: var(--dimgrey);
 }
 
-@media (max-width:600px) {
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
   .c4 {
     grid-template-columns: 1fr 48px;
+    height: 35px;
   }
 }
 
@@ -256,7 +258,7 @@ exports[`withConfig High Order Component when the current network is not in the 
   }
 }
 
-@media (max-width:600px) {
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
   .c10 {
     display: grid;
   }
@@ -268,14 +270,25 @@ exports[`withConfig High Order Component when the current network is not in the 
   }
 }
 
-@media (max-width:500px) {
-  .c1 > * {
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
+  .c1 {
     display: none;
   }
 }
 
-@media (max-width:500px) {
-  .c16 > * {
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
+  .c16 {
     display: none;
   }
 }

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
@@ -202,6 +202,7 @@ exports[`withConfig High Order Component when the current network is not in the 
   color: var(--darkgrey);
   display: grid;
   row-gap: 24px;
+  width: 100%;
 }
 
 .c13 {
@@ -244,9 +245,10 @@ exports[`withConfig High Order Component when the current network is not in the 
   color: var(--dimgrey);
 }
 
-@media (max-width:600px) {
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
   .c4 {
     grid-template-columns: 1fr 48px;
+    height: 35px;
   }
 }
 
@@ -256,7 +258,7 @@ exports[`withConfig High Order Component when the current network is not in the 
   }
 }
 
-@media (max-width:600px) {
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
   .c10 {
     display: grid;
   }
@@ -268,14 +270,25 @@ exports[`withConfig High Order Component when the current network is not in the 
   }
 }
 
-@media (max-width:500px) {
-  .c1 > * {
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
+  .c1 {
     display: none;
   }
 }
 
-@media (max-width:500px) {
-  .c16 > * {
+@media only screen and (min-device-width:300px) and (max-device-width:736px) {
+  .c16 {
     display: none;
   }
 }

--- a/unlock-app/src/components/creator/CreatorAccount.js
+++ b/unlock-app/src/components/creator/CreatorAccount.js
@@ -5,6 +5,7 @@ import Jazzicon from 'react-jazzicon'
 import UnlockPropTypes from '../../propTypes'
 import { ETHEREUM_NETWORKS_NAMES } from '../../constants'
 
+import Media, { NoPhone } from '../../theme/media'
 import Buttons from '../interface/buttons/lock'
 import Balance from '../helpers/Balance'
 
@@ -30,10 +31,14 @@ export function CreatorAccount({ account, network }) {
         <Label>Balance</Label>
         <Label>Earning</Label>
         <DoubleHeightCell>
-          <Buttons.Upload as="button" />
+          <NoPhone>
+            <Buttons.Upload as="button" />
+          </NoPhone>
         </DoubleHeightCell>
         <DoubleHeightCell>
-          <Buttons.Etherscan as="button" />
+          <NoPhone>
+            <Buttons.Etherscan as="button" />
+          </NoPhone>
         </DoubleHeightCell>
         <DoubleHeightCell>
           {/* reinstate download / export functionality when we're ready <Buttons.Download /> */}
@@ -77,6 +82,10 @@ const AccountDetails = styled.div`
   row-gap: 8px;
   column-gap: 16px;
   grid-template-columns: 40px 200px repeat(2, 100px) repeat(3, 24px) 1fr;
+  ${Media.phone`
+    column-gap: 2px;
+    grid-template-columns: 45px 145px repeat(2, 80px);
+  `};
 `
 
 const DoubleHeightCell = styled.div`
@@ -86,6 +95,9 @@ const DoubleHeightCell = styled.div`
   align-self: start;
   font-size: 24px;
   align-content: start;
+  ${Media.phone`
+    height: 0px;
+  `};
 `
 
 const Label = styled.div`

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -8,6 +8,7 @@ import EmbedCodeSnippet from './lock/EmbedCodeSnippet'
 import KeyList from './lock/KeyList'
 import Duration from '../helpers/Duration'
 import Balance from '../helpers/Balance'
+import Media, { NoPhone, Phone } from '../../theme/media'
 
 const LockKeysNumbers = ({ lock }) => (
   <LockKeys>
@@ -57,10 +58,11 @@ export class CreatorLock extends React.Component {
     let name = lock.name || 'New Lock'
     return (
       <LockRow onClick={this.toggleKeys}>
-        <Icon lock={lock} />
+        <DoubleHeightCell>
+          <Icon lock={lock} />
+        </DoubleHeightCell>
         <LockName>
           {name}
-
           <LockAddress>{!lock.pending && lock.address}</LockAddress>
         </LockName>
         <LockDuration>
@@ -68,7 +70,14 @@ export class CreatorLock extends React.Component {
         </LockDuration>
         <LockKeysNumbers lock={lock} />
         <Balance amount={lock.keyPrice} />
-        <Balance amount={lock.balance} />
+        <BalanceContainer>
+          <NoPhone>
+            <Balance amount={lock.balance} />
+          </NoPhone>
+          <Phone>
+            <Balance amount={lock.balance} convertCurrency={false} />
+          </Phone>
+        </BalanceContainer>
         <LockIconBar lock={lock} toggleCode={this.toggleEmbedCode} />
         {showEmbedCode && (
           <LockPanel>
@@ -97,6 +106,9 @@ export default CreatorLock
 export const LockRowGrid =
   'grid-template-columns: 32px minmax(100px, 1fr) repeat(4, minmax(56px, 100px)) minmax(174px, 1fr);'
 
+export const PhoneLockRowGrid =
+  'grid-template-columns: 43px minmax(80px, 140px) repeat(2, minmax(56px, 80px)); grid-auto-flow: column;'
+
 export const LockRow = styled.div`
   font-family: 'IBM Plex Mono', 'Courier New', Serif;
   font-weight: 200;
@@ -107,10 +119,14 @@ export const LockRow = styled.div`
   box-shadow: 0 0 40px 0 rgba(0, 0, 0, 0.08);
   border-radius: 4px;
   display: grid;
-  grid-gap: 16px;
-  ${LockRowGrid} grid-template-rows: 84px;
-  grid-column-gap: 16px;
   grid-row-gap: 0;
+  ${Media.nophone`
+    ${LockRowGrid} grid-template-rows: 84px;
+    grid-column-gap: 16px;
+  `} ${Media.phone`
+    grid-column-gap: 4px;
+    ${PhoneLockRowGrid}
+  `}
   align-items: start;
   cursor: pointer;
 
@@ -119,9 +135,20 @@ export const LockRow = styled.div`
   }
 `
 
+export const DoubleHeightCell = styled.div`
+  grid-row: span 2;
+`
+
+export const BalanceContainer = styled.div``
+
 export const LockName = styled.div`
   color: var(--link);
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  ${Media.phone`
+    grid-column: span 2;
+  `};
 `
 
 export const LockAddress = styled.div`
@@ -139,6 +166,9 @@ export const LockKeys = styled.div``
 
 const LockPanel = styled.div`
   grid-column: 1 / span 7;
+  ${Media.phone`
+    display: none;
+  `};
 `
 
 const LockDivider = styled.div`

--- a/unlock-app/src/components/creator/CreatorLocks.js
+++ b/unlock-app/src/components/creator/CreatorLocks.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
 import UnlockPropTypes from '../../propTypes'
-import CreatorLock, { LockRowGrid } from './CreatorLock'
+import CreatorLock, { LockRowGrid, PhoneLockRowGrid } from './CreatorLock'
 import CreatorLockForm from './CreatorLockForm'
 import Error from '../interface/Error'
+import Media, { NoPhone, Phone } from '../../theme/media'
 
 export class CreatorLocks extends React.Component {
   constructor(props, context) {
@@ -32,9 +33,12 @@ export class CreatorLocks extends React.Component {
           <LockHeader>Locks</LockHeader>
           <LockMinorHeader>Name / Address</LockMinorHeader>
           <LockMinorHeader>Duration</LockMinorHeader>
-          <LockMinorHeader>Quantity</LockMinorHeader>
+          <Quantity>Quantity</Quantity>
           <LockMinorHeader>Price</LockMinorHeader>
-          <LockMinorHeader>Balance / Earnings</LockMinorHeader>
+          <LockMinorHeader>
+            <NoPhone>Balance / Earnings</NoPhone>
+            <Phone>Balance</Phone>
+          </LockMinorHeader>
           <CreateButton onClick={this.toggleForm}>Create Lock</CreateButton>
         </LockHeaderRow>
         <Error />
@@ -72,6 +76,10 @@ const LockHeaderRow = styled.div`
   display: grid;
   grid-gap: 16px;
   ${LockRowGrid} align-items: center;
+  ${Media.phone`
+    ${PhoneLockRowGrid} align-items: start;
+    grid-gap: 4px;
+  `};
 `
 
 const LockHeader = styled.div`
@@ -83,6 +91,9 @@ const LockHeader = styled.div`
   line-height: normal;
   letter-spacing: normal;
   color: var(--grey);
+  ${Media.phone`
+    grid-row: span 2;
+  `};
 `
 
 const LockMinorHeader = styled.div`
@@ -95,6 +106,12 @@ const LockMinorHeader = styled.div`
   letter-spacing: 1px;
   text-transform: uppercase;
   color: var(--darkgrey);
+`
+
+export const Quantity = styled(LockMinorHeader)`
+  ${Media.phone`
+    grid-row: span 2;
+  `};
 `
 
 export const ActionButton = styled.button`
@@ -111,4 +128,7 @@ export const ActionButton = styled.button`
 const CreateButton = styled(ActionButton)`
   padding: 10px;
   align-self: end;
+  ${Media.phone`
+    display: none;
+  `};
 `

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import Buttons from '../../interface/buttons/lock'
 import UnlockPropTypes from '../../../propTypes'
 import CreatorLockStatus from './CreatorLockStatus'
+import Media from '../../../theme/media'
 import withConfig from '../../../utils/withConfig'
 
 export function LockIconBar({
@@ -97,6 +98,9 @@ const IconBarContainer = styled.div`
   display: grid;
   justify-items: end;
   padding-right: 24px;
+  ${Media.phone`
+    display: none;
+  `};
 `
 
 const IconBar = styled.div`

--- a/unlock-app/src/components/interface/Header.js
+++ b/unlock-app/src/components/interface/Header.js
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { WordMarkLogo } from './Logo'
 import Buttons from './buttons/layout'
 import { ButtonLink } from './buttons/Button'
+import Media from '../../theme/media'
 
 export default class Header extends React.PureComponent {
   constructor(props) {
@@ -41,14 +42,11 @@ export default class Header extends React.PureComponent {
           <Buttons.Jobs />
           <Buttons.Github />
         </DesktopButtons>
-        <MobileToggle
-          visibilityToggle={menu ? true : false}
-          onClick={this.toggleMenu}
-        >
+        <MobileToggle visibilityToggle={!!menu} onClick={this.toggleMenu}>
           <Buttons.Bars size="48px" />
           <Buttons.ChevronUp size="48px" />
         </MobileToggle>
-        <MobilePopover visibilityToggle={menu ? true : false}>
+        <MobilePopover visibilityToggle={!!menu}>
           <Buttons.About size="48px" />
           <Buttons.Jobs size="48px" />
           <Buttons.Github size="48px" />
@@ -75,10 +73,10 @@ const TopHeader = styled.header`
   grid-auto-flow: column;
   align-items: center;
   height: 70px;
-
-  @media (max-width: 600px) {
+  ${Media.phone`
     grid-template-columns: 1fr 48px;
-  }
+    height: 35px;
+  `};
 `
 
 const Title = styled.h1`
@@ -131,9 +129,9 @@ const MobileToggle = styled.div`
     }
   }
 
-  @media (max-width: 600px) {
+  ${Media.phone`
     display: grid;
-  }
+  `};
 `
 
 const MobilePopover = styled.div`

--- a/unlock-app/src/components/interface/Layout.js
+++ b/unlock-app/src/components/interface/Layout.js
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import Header from './Header'
 import Footer from './Footer'
 import { RoundedLogo } from './Logo'
+import Media from '../../theme/media'
 
 export default function Layout({ forContent, title, children }) {
   return (
@@ -43,30 +44,31 @@ Layout.defaultProps = {
 const Container = styled.div`
   display: grid;
   grid-template-columns: 1fr minmax(280px, 4fr) 1fr;
+  ${Media.phone`
+    display: flex;
+    padding-left: 6px;
+    padding-right: 6px;
+  `};
 `
 
 const Left = styled.div`
   display: grid;
   align-items: start;
   height: 24px;
-
-  & > * {
-    @media (max-width: 500px) {
-      display: none;
-    }
-  }
+  ${Media.phone`
+    display: none;
+  `};
 `
 
 const Right = styled.div`
-  & > * {
-    @media (max-width: 500px) {
-      display: none;
-    }
-  }
+  ${Media.phone`
+    display: none;
+  `};
 `
 
 const Content = styled.div`
   color: var(--darkgrey);
   display: grid;
   row-gap: 24px;
+  width: 100%;
 `

--- a/unlock-app/src/theme/media.js
+++ b/unlock-app/src/theme/media.js
@@ -1,0 +1,64 @@
+import styled, { css } from 'styled-components'
+
+let sizes = {
+  desktop: {
+    min: 1200,
+    max: false,
+  },
+  tablet: {
+    min: 737,
+    max: 1200,
+  },
+  phone: {
+    min: 300,
+    max: 736,
+  },
+}
+
+sizes.nophone = {
+  min: sizes.phone.max,
+  max: false,
+}
+sizes.nodesktop = {
+  max: sizes.desktop.min,
+  min: sizes.phone.min,
+}
+
+const Media = Object.keys(sizes).reduce((acc, label) => {
+  acc[label] = (...args) => css`
+    @media only screen and (min-device-width: ${sizes[label].min}px) ${sizes[
+  label
+].max
+  ? `and (max-device-width: ${sizes[label].max}px)`
+  : ''} {
+      ${css(...args)};
+    }
+  `
+  return acc
+}, {})
+
+export const NoPhone = styled.div`
+  ${Media.phone`
+    display: none;
+  `};
+`
+
+export const Phone = styled.div`
+  ${Media.nophone`
+    display: none;
+  `};
+`
+
+export const Mobile = styled.div`
+  ${Media.desktop`
+    display: none;
+  `};
+`
+
+export const Desktop = styled.div`
+  ${Media.nodesktop`
+    display: none;
+  `};
+`
+
+export default Media


### PR DESCRIPTION
Fixes #710 (attempt number two).

## Proposed Changes

- Includes a new `media` object that we can use to format for phones, tablets, and laptops / desktops
- Provides responsive styles for dashboard
- Provides responsive styles for content / all pages

## Screenshots

Dashboard (mobile):

<img width="437" alt="screen shot 2018-12-18 at 2 18 50 pm" src="https://user-images.githubusercontent.com/624104/50187790-15963a80-02d4-11e9-8729-cb3798e68b0b.png">

Homepage (mobile):

<img width="437" alt="screen shot 2018-12-18 at 2 19 07 pm" src="https://user-images.githubusercontent.com/624104/50187797-1fb83900-02d4-11e9-874a-21ff60c2c45c.png">

About (mobile):

<img width="432" alt="screen shot 2018-12-18 at 2 19 13 pm" src="https://user-images.githubusercontent.com/624104/50187815-2c3c9180-02d4-11e9-8708-63f0ace5fda7.png">

Dashboard (desktop):

<img width="1089" alt="screen shot 2018-12-18 at 2 19 50 pm" src="https://user-images.githubusercontent.com/624104/50187825-378fbd00-02d4-11e9-86e3-7b686ef512e9.png">

Homepage (desktop):

<img width="975" alt="screen shot 2018-12-18 at 2 19 40 pm" src="https://user-images.githubusercontent.com/624104/50187837-3eb6cb00-02d4-11e9-9395-72debb71aea4.png">
