### PR TITLE
Using pastel rather than light to compute icon colors

### DIFF
--- a/unlock-app/src/components/lock/Icon.js
+++ b/unlock-app/src/components/lock/Icon.js
@@ -74,7 +74,7 @@ export function Icon({ lock }) {
     scheme
       .from_hex(mainColor)
       .scheme('triade')
-      .variation('light')
+      .variation('pastel')
     colors = scheme.colors().map(c => `#${c}`)
   }
   const innerCircles = circles(address)


### PR DESCRIPTION
Fixes #671

We were using `color-scheme`'s `light` option, which is described in the documentation as follows: "Very light, almost washed-out colors." Which is the reported issue.

This PR switches to using `pastel`: "Produces pastel colors, which have in HSV high value and low-intermediate saturation."

## Screenshot

<img width="994" alt="screen shot 2018-12-18 at 3 14 42 pm" src="https://user-images.githubusercontent.com/624104/50188801-aae6fe00-02d7-11e9-8d43-6580ec9ef6f6.png">
