### PR TITLE
No longer rounds eth balances up

### DIFF
--- a/unlock-app/src/__tests__/components/helpers/BalanceProvider.test.js
+++ b/unlock-app/src/__tests__/components/helpers/BalanceProvider.test.js
@@ -120,10 +120,10 @@ describe('BalanceProvider Component', () => {
     })
   })
 
-  describe('when the balance would round up using toFixed', () => {
+  describe('when the balance would round up', () => {
     const amount = '1998887'
 
-    it('shows the balance in Eth would round up', () => {
+    it('shows the balance in Eth without rounding up', () => {
       renderIt({
         amount,
         render: ethValue => {

--- a/unlock-app/src/__tests__/components/helpers/BalanceProvider.test.js
+++ b/unlock-app/src/__tests__/components/helpers/BalanceProvider.test.js
@@ -120,6 +120,19 @@ describe('BalanceProvider Component', () => {
     })
   })
 
+  describe('when the balance would round up using toFixed', () => {
+    const amount = '1998887'
+
+    it('shows the balance in Eth would round up', () => {
+      renderIt({
+        amount,
+        render: ethValue => {
+          expect(ethValue).toEqual('1.99')
+        },
+      })
+    })
+  })
+
   describe('when the balance converts to > $1000 ', () => {
     const amount = '20000000'
 

--- a/unlock-app/src/selectors/currency.js
+++ b/unlock-app/src/selectors/currency.js
@@ -12,7 +12,7 @@ export function formatEth(eth) {
   if (numericalEth < MINIMUM_THRESHOLD && numericalEth > 0) return '< 0.0001'
   if (numericalEth < 1)
     return parseFloat(numericalEth.toPrecision(SIGNIFICANT_DIGITS)).toString()
-  return numericalEth.toFixed(DECIMAL_PLACES)
+  return numericalEth.toFixed(DECIMAL_PLACES + 6).slice(0, -6) // Using extra decimal places and slicing them to prevent adverse rounding up
 }
 
 /**


### PR DESCRIPTION
Refs #772 

This PR puts measures in place to prevent the eth balance from rounding up. For example, @smombartz was seeing a balance of 3.00 when his actual balance was 2.998. We both felt that this was (1) weird (2) misrepresentative of the balance in the account.