### PR TITLE
Adding netlify redirect for paywall

### DIFF
--- a/unlock-app/src/static/_redirects
+++ b/unlock-app/src/static/_redirects
@@ -2,3 +2,4 @@
 # See https://www.netlify.com/docs/redirects/#rewrites-and-proxying
 
 /demo/* /demo 200
+/paywall/* /paywall 200


### PR DESCRIPTION
Refs #777. Netlify can't access the paywall URL.