### PR TITLE
Unlock.js autodetects domain it's hosted from

### DIFF
--- a/unlock-app/src/static/unlock.js
+++ b/unlock-app/src/static/unlock.js
@@ -2,12 +2,15 @@ window.onload = function() {
   // Initialize source domain
   var src = window.unlock_url || 'http://localhost:3000'
 
-  // Get the domain and URI scheme of host we're loading this script from
-  let scripts = document.getElementsByTagName('script')
-  for (let i = 0; i < scripts.length; i++) {
-    let pattern = /static\/unlock/i
-    if (pattern.test(scripts[i].getAttribute('src')))
-      src = scripts[i].getAttribute('src').replace('/static/unlock.js', '')
+  // Setting window.unlock_url hard sets the domain and URI scheme - if this is set, no need to auto-detect
+  if (!window.unlock_url) {
+    // Get the domain and URI scheme of host we're loading this script from
+    let scripts = document.getElementsByTagName('script')
+    for (let i = 0; i < scripts.length; i++) {
+      let pattern = /static\/unlock/i
+      if (pattern.test(scripts[i].getAttribute('src')))
+        src = scripts[i].getAttribute('src').replace('/static/unlock.js', '')
+    }
   }
 
   const lockedNode = document.querySelector('meta[name=lock]')

--- a/unlock-app/src/static/unlock.js
+++ b/unlock-app/src/static/unlock.js
@@ -1,10 +1,19 @@
 window.onload = function() {
+  // Initialize source domain
+  var src = window.unlock_url || 'http://localhost:3000'
+
+  // Get the domain and URI scheme of host we're loading this script from
+  let scripts = document.getElementsByTagName('script')
+  for (let i = 0; i < scripts.length; i++) {
+    let pattern = /static\/unlock/i
+    if (pattern.test(scripts[i].getAttribute('src')))
+      src = scripts[i].getAttribute('src').replace('/static/unlock.js', '')
+  }
+
   const lockedNode = document.querySelector('meta[name=lock]')
 
   // If there is no lock, do nothing!
   if (lockedNode) {
-    var src = window.unlock_url || 'http://localhost:3000'
-
     var s = document.createElement('iframe')
     src += `/paywall/${lockedNode.getAttribute('content')}/`
 


### PR DESCRIPTION
This is one of two PRs that will make it easier to test from staging, and also for third parties to self-host Unlock code and run code. Previously, unlock.js's hosted domain needed to be configured. Now it's autodetected - although it can still be hand-configured.