### PR TITLE
Embed code is served from current site domain

### DIFF
--- a/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
+++ b/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
@@ -6,8 +6,11 @@ import Buttons from '../../interface/buttons/lock'
 
 export function EmbedCodeSnippet({ lock }) {
   function embedCode(lock) {
+    // Autodetect current domain
+    let domain = window.location.origin
+
     return `<!-- Include this script in the <head> section of your page -->
-<script src="https://unlock-protocol.com/static/unlock.js"></script>
+<script src="${domain}/static/unlock.js"></script>
 <meta name="lock" content="${lock.address}" />
 `
   }


### PR DESCRIPTION
This is the second of two PRs that ensure our embed code can be served from any domain. This will improve testing from dev and staging, and better allow third parties to host Unlock code.