### PR TITLE
Better reponsive layout for demo page

### DIFF
--- a/unlock-app/src/pages/demo.js
+++ b/unlock-app/src/pages/demo.js
@@ -8,6 +8,7 @@ import Overlay from '../components/lock/Overlay'
 import withConfig from '../utils/withConfig'
 import ShowUnlessUserHasKeyToAnyLock from '../components/lock/ShowUnlessUserHasKeyToAnyLock'
 import { LOCK_PATH_NAME_REGEXP } from '../constants'
+import Media from '../theme/media'
 
 const Demo = ({ lock }) => {
   return (
@@ -105,12 +106,12 @@ const GlobalStyle = createGlobalStyle`
 
 const Container = styled.div`
   display: grid;
-  max-width: 1400px;
-  grid-template-columns: 1fr minmax(500px, 3fr) 1fr;
+  width: 100%;
+  grid-template-columns: 1fr minmax(500px, 800px) 1fr;
 
-  @media (max-width: 500px) {
+  ${Media.phone`
     grid-template-columns: 0px 1fr 0px;
-  }
+  `};
 `
 
 const Left = styled.div``


### PR DESCRIPTION
# Description

Fixes #782. The page-specific styles for the demo page didn't work well on large screens - 1400px was the maximum size before the whole layout would left-align. This PR allows any screen resolution, with the content sticking to a sensible maximum width, which  is center-aligned.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written correspoding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

# Screenshots:

<img width="1427" alt="screen shot 2018-12-19 at 5 16 54 pm" src="https://user-images.githubusercontent.com/624104/50257944-54022700-03b2-11e9-887a-2becd320c2f0.png">

<img width="1429" alt="screen shot 2018-12-19 at 5 17 03 pm" src="https://user-images.githubusercontent.com/624104/50257950-59f80800-03b2-11e9-80e8-ef87686b9069.png">

<img width="1428" alt="screen shot 2018-12-19 at 5 17 12 pm" src="https://user-images.githubusercontent.com/624104/50257954-5ebcbc00-03b2-11e9-963d-b672841b679b.png">

<img width="410" alt="screen shot 2018-12-19 at 5 19 10 pm" src="https://user-images.githubusercontent.com/624104/50257957-63817000-03b2-11e9-9727-0767d83c1e74.png">
