### PR TITLE
fix flash of lock on locked page after purchase of the lock

### DIFF
--- a/unlock-app/src/__tests__/components/lock/ShowUnlessUserHasKeyToAnyLock.test.js
+++ b/unlock-app/src/__tests__/components/lock/ShowUnlessUserHasKeyToAnyLock.test.js
@@ -49,8 +49,11 @@ describe('ShowUnlessUserHasKeyToAnyLock', () => {
       expect(wrapper.queryByText('Show me')).toBeNull()
     })
 
-    it('should show the children if there is a modal', () => {
+    it('should show nothing if accounts are not loaded and 500ms has not elapsed (no flash)', () => {
       expect.assertions(1)
+
+      jest.useFakeTimers()
+
       const keys = [
         {
           id: 'keyId',
@@ -64,6 +67,29 @@ describe('ShowUnlessUserHasKeyToAnyLock', () => {
           Show me
         </ShowUnlessUserHasKeyToAnyLock>
       )
+      jest.advanceTimersByTime(199)
+
+      expect(wrapper.queryByText('Show me')).toBe(null)
+    })
+
+    it('should show the children if there is a modal', () => {
+      expect.assertions(1)
+
+      jest.useFakeTimers()
+      const keys = [
+        {
+          id: 'keyId',
+          lock: '0xLock',
+          owner: '0x123',
+        },
+      ]
+
+      const wrapper = rtl.render(
+        <ShowUnlessUserHasKeyToAnyLock keys={keys} modalShown>
+          Show me
+        </ShowUnlessUserHasKeyToAnyLock>
+      )
+      jest.runAllTimers()
 
       expect(wrapper.queryByText('Show me')).not.toBe(null)
     })
@@ -72,12 +98,15 @@ describe('ShowUnlessUserHasKeyToAnyLock', () => {
   describe('if there is no valid key', () => {
     it('should show the children', () => {
       expect.assertions(1)
+
+      jest.useFakeTimers()
       const keys = []
       const wrapper = rtl.render(
         <ShowUnlessUserHasKeyToAnyLock keys={keys} modalShown>
           Show me
         </ShowUnlessUserHasKeyToAnyLock>
       )
+      jest.runAllTimers()
 
       expect(wrapper.queryByText('Show me')).not.toBe(null)
     })

--- a/unlock-app/src/__tests__/components/lock/ShowUnlessUserHasKeyToAnyLock.test.js
+++ b/unlock-app/src/__tests__/components/lock/ShowUnlessUserHasKeyToAnyLock.test.js
@@ -49,7 +49,7 @@ describe('ShowUnlessUserHasKeyToAnyLock', () => {
       expect(wrapper.queryByText('Show me')).toBeNull()
     })
 
-    it('should show nothing if accounts are not loaded and 500ms has not elapsed (no flash)', () => {
+    it('should show nothing if accounts are not loaded and 200ms has not elapsed (no flash)', () => {
       expect.assertions(1)
 
       jest.useFakeTimers()

--- a/unlock-app/src/components/lock/ShowUnlessUserHasKeyToAnyLock.js
+++ b/unlock-app/src/components/lock/ShowUnlessUserHasKeyToAnyLock.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { Component } from 'react'
+import React, { Component } from 'react'
+import SuspendedError from '../helpers/SuspendedError'
 import UnlockPropTypes from '../../propTypes'
 import { lockPage, unlockPage } from '../../services/iframeService'
 
@@ -30,7 +31,7 @@ export class ShowUnlessUserHasKeyToAnyLock extends Component {
     }
 
     // There is no valid key or we shown the modal previously
-    return children
+    return <SuspendedError>{children}</SuspendedError>
   }
 }
 


### PR DESCRIPTION
# Description

This fixes #792 

No visual change to content occurs, so no screenshots attached. The only change is that instead of a brief flash of the "purchase a lock" page, the content takes slightly longer to load and then displays only the content.

However, because there is no flash of the lock, it appears to load much faster! I am not sure if this is a mental trick or if the fact that we aren't rendering the entire iframe and then removing it is actually slower.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written correspoding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
