### PR TITLE
Disables withdraw button when transaction has been submitted

### DIFF
--- a/unlock-app/src/__tests__/components/creator/lock/Withdraw.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/Withdraw.test.js
@@ -26,4 +26,51 @@ describe('Withdraw', () => {
 
     expect(withdrawFromLock).toHaveBeenCalled()
   })
+  it('should disable the button when the lock has no balance', () => {
+    const keylock = {
+      id: 'lockid',
+      address: '0x1234567890',
+      transaction: 'transactionid',
+      keyPrice: '1',
+      balance: '0',
+      outstandingKeys: 1,
+      maxNumberOfKeys: 10,
+      expirationDuration: 100,
+    }
+    const withdrawFromLock = jest.fn()
+
+    let wrapper = rtl.render(
+      <Withdraw lock={keylock} withdraw={withdrawFromLock} />
+    )
+
+    let withdrawButton = wrapper.queryByTitle('Withdraw balance')
+    expect(withdrawButton).toBeNull()
+  })
+  it('should disable the button when a withdrawal is in process', () => {
+    const keylock = {
+      id: 'lockid',
+      address: '0x1234567890',
+      transaction: 'transactionid',
+      keyPrice: '1',
+      balance: '1',
+      outstandingKeys: 1,
+      maxNumberOfKeys: 10,
+      expirationDuration: 100,
+    }
+    const withdrawalTransaction = {
+      status: 'submitted',
+    }
+    const withdrawFromLock = jest.fn()
+
+    let wrapper = rtl.render(
+      <Withdraw
+        lock={keylock}
+        withdraw={withdrawFromLock}
+        withdrawalTransaction={withdrawalTransaction}
+      />
+    )
+
+    let withdrawButton = wrapper.queryByTitle('Withdraw balance')
+    expect(withdrawButton).toBeNull()
+  })
 })

--- a/unlock-app/src/components/interface/buttons/lock/Withdraw.js
+++ b/unlock-app/src/components/interface/buttons/lock/Withdraw.js
@@ -7,8 +7,19 @@ import Button, { DisabledButton } from '../Button'
 import UnlockPropTypes from '../../../../propTypes'
 import { withdrawFromLock } from '../../../../actions/lock'
 
-export const Withdraw = ({ lock, withdraw, account, ...props }) => {
-  if (lock.balance > 0) {
+export const Withdraw = ({
+  lock,
+  withdrawalTransaction,
+  withdraw,
+  account,
+  ...props
+}) => {
+  if (
+    !(
+      lock.balance == 0 ||
+      (withdrawalTransaction && withdrawalTransaction.status === 'submitted')
+    )
+  ) {
     return (
       <Button
         label="Withdraw balance"
@@ -33,22 +44,29 @@ export const Withdraw = ({ lock, withdraw, account, ...props }) => {
 
 Withdraw.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
-  transaction: UnlockPropTypes.transaction,
+  withdrawalTransaction: UnlockPropTypes.transaction,
   withdraw: PropTypes.func,
   account: UnlockPropTypes.account,
 }
 
 Withdraw.defaultProps = {
-  transaction: null,
+  withdrawalTransaction: null,
   account: null,
   withdraw: () => {},
 }
 
 const mapStateToProps = ({ account, transactions }, { lock }) => {
-  const transaction = transactions[lock.transaction]
+  let withdrawalTransaction = null
+  Object.keys(transactions).forEach(el => {
+    if (
+      transactions[el].withdrawal &&
+      transactions[el].withdrawal === lock.address
+    )
+      withdrawalTransaction = transactions[el]
+  })
   return {
     account,
-    transaction,
+    withdrawalTransaction,
   }
 }
 


### PR DESCRIPTION
# Description

Refs #796. The withdrawal button is now disabled both when a transaction is submitted and when the balance is 0.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
