### PR TITLE
Fixing typo in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 - [ ] My code follows the style guidelines of this project, including naming conventions
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] If my code adds or changes components, I have written correspoding stories with Storybook
+- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
 - [ ] I have performed a self-review of my own code
 - [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
 


### PR DESCRIPTION
# Description

Fixes a minor typo in the PR template. I can't believe I didn't spot this before. Sorry about that.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written correspoding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
