### PR TITLE
assigning types to transaction based on their data/input

### DIFF
--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -24,6 +24,15 @@ export const pageTitle = title => {
 }
 
 /**
+ * Transaction types
+ */
+export const TRANSACTION_TYPES = {
+  LOCK_CREATION: 'LOCK_CREATION',
+  KEY_PURCHASE: 'KEY_PURCHASE',
+  WITHDRAWAL: 'WITHDRAWAL',
+}
+
+/**
  * Matches /lock /demo or /paywall
  */
 export const LOCK_PATH_NAME_REGEXP = /\/[a-z0-9]+\/(0x[a-fA-F0-9]{40}).*/

--- a/unlock-app/src/propTypes.js
+++ b/unlock-app/src/propTypes.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import { TRANSACTION_TYPES } from './constants'
 
 export const address = PropTypes.string
 
@@ -22,6 +23,7 @@ export const transaction = PropTypes.shape({
   hash: PropTypes.string,
   lock: PropTypes.string,
   name: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(TRANSACTION_TYPES)),
 })
 
 export const conversion = PropTypes.objectOf(PropTypes.number)


### PR DESCRIPTION
This will be useful for #703 and more. We get the transaction type from the smart contract
function signature.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)