### PR TITLE
Detect network changes and dispatch

### DIFF
--- a/unlock-app/src/__tests__/middlewares/networkVersionDetectMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/networkVersionDetectMiddleware.test.js
@@ -1,9 +1,8 @@
 import { setNetwork } from '../../actions/network'
+import middleware from '../../middlewares/networkVersionDetectMiddleware'
 
 describe('network change detection middleware', () => {
   it('network change on initialize', done => {
-    const middleware = require('../../middlewares/networkVersionDetectMiddleware')
-      .default
     const store = {
       dispatch: jest.fn(),
       getState() {
@@ -28,8 +27,6 @@ describe('network change detection middleware', () => {
   })
 
   it('network change on interval', done => {
-    const middleware = require('../../middlewares/networkVersionDetectMiddleware')
-      .default
     const store = {
       dispatch: jest.fn(),
       getState() {
@@ -62,8 +59,6 @@ describe('network change detection middleware', () => {
   })
 
   it('no network change', done => {
-    const middleware = require('../../middlewares/networkVersionDetectMiddleware')
-      .default
     const store = {
       dispatch: jest.fn(),
       getState() {

--- a/unlock-app/src/__tests__/middlewares/networkVersionDetectMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/networkVersionDetectMiddleware.test.js
@@ -2,22 +2,29 @@ import { setNetwork } from '../../actions/network'
 import middleware from '../../middlewares/networkVersionDetectMiddleware'
 
 describe('network change detection middleware', () => {
-  it('network change on initialize', done => {
-    const store = {
+  let store
+
+  window.web3 = {
+    version: {},
+  }
+
+  beforeEach(() => {
+    window.web3.version.getNetwork = () => {
+      return Promise.resolve('hi')
+    }
+    store = {
       dispatch: jest.fn(),
       getState() {
         return { network: { name: 'nothi' } }
       },
     }
+  })
 
-    window.web3 = {
-      version: {
-        getNetwork: () => {
-          return Promise.resolve('hi')
-        },
-      },
-    }
+  afterEach(() => {
+    jest.clearAllTimers()
+  })
 
+  it('network change on initialize', done => {
     middleware(store)
 
     setTimeout(() => {
@@ -27,29 +34,10 @@ describe('network change detection middleware', () => {
   })
 
   it('network change on interval', done => {
-    const store = {
-      dispatch: jest.fn(),
-      getState() {
-        return { network: { name: 'hi' } }
-      },
-    }
-
-    window.web3 = {
-      version: {
-        getNetwork: () => {
-          return Promise.resolve('hi')
-        },
-      },
-    }
-
     middleware(store)
 
-    window.web3 = {
-      version: {
-        getNetwork: () => {
-          return Promise.resolve('nothi')
-        },
-      },
+    window.web3.version.getNetwork = () => {
+      return Promise.resolve('nothi')
     }
 
     setTimeout(() => {
@@ -66,22 +54,10 @@ describe('network change detection middleware', () => {
       },
     }
 
-    window.web3 = {
-      version: {
-        getNetwork: () => {
-          return Promise.resolve('hi')
-        },
-      },
-    }
-
     middleware(store)
 
-    window.web3 = {
-      version: {
-        getNetwork: () => {
-          return Promise.resolve('hi')
-        },
-      },
+    window.web3.version.getNetwork = () => {
+      return Promise.resolve('hi')
     }
 
     setTimeout(() => {

--- a/unlock-app/src/__tests__/middlewares/networkVersionDetectMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/networkVersionDetectMiddleware.test.js
@@ -1,0 +1,66 @@
+import { setNetwork } from '../../actions/network'
+
+afterEach(() => mockAxios.reset())
+
+describe('network change detection middleware', () => {
+  const response1 = {
+    data: { base: 'ETH', currency: 'USD', amount: '195.99' },
+  }
+  const response2 = {
+    data: { base: 'ETH', currency: 'USD', amount: '198.20' },
+  }
+  const APIaddress = 'https://api.coinbase.com/v2/prices/ETH-USD/buy'
+
+  it('service called, action dispatched to set currency conversion rate', () => {
+    jest.useFakeTimers()
+    const middleware = require('../../middlewares/currencyConversionMiddleware')
+      .default
+    const store = {
+      dispatch: jest.fn(),
+      getState() {
+        return { currency: { USD: 1 } }
+      },
+    }
+
+    middleware(store)
+
+    expect(mockAxios.get).toHaveBeenCalledWith(APIaddress)
+    mockAxios.mockResponse({ data: response1 })
+    expect(store.dispatch).toHaveBeenCalledWith(
+      setConversionRate('USD', '195.99')
+    )
+
+    store.dispatch = jest.fn() // reset
+    mockAxios.reset()
+
+    jest.advanceTimersByTime(10000) // test the setInterval
+
+    expect(mockAxios.get).toHaveBeenCalledWith(APIaddress)
+    mockAxios.mockResponse({ data: response2 })
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      setConversionRate('USD', '198.20')
+    )
+  })
+  it('service called, values are the same, so don\'t dispatch', () => {
+    jest.useFakeTimers()
+    const middleware = require('../../middlewares/currencyConversionMiddleware')
+      .default
+    const store = {
+      dispatch: jest.fn(),
+    }
+
+    middleware(store)
+    store.dispatch = jest.fn() // reset
+    store.getState = () => ({ currency: { USD: 195.99 } })
+
+    mockAxios.reset()
+
+    jest.advanceTimersByTime(10000) // test the setInterval
+
+    expect(mockAxios.get).toHaveBeenCalledWith(APIaddress)
+    mockAxios.mockResponse({ data: response1 })
+
+    expect(store.dispatch).not.toHaveBeenCalled()
+  })
+})

--- a/unlock-app/src/middlewares/networkVersionDetectMiddleware.js
+++ b/unlock-app/src/middlewares/networkVersionDetectMiddleware.js
@@ -1,7 +1,7 @@
 import { setNetwork } from '../actions/network'
 
 export function checkNetwork(store) {
-  if (!window.web3) return
+  if (!window || !window.web3) return
   window.web3.version.getNetwork().then(id => {
     if (store.getState().network.name !== id) {
       store.dispatch(setNetwork(id))

--- a/unlock-app/src/middlewares/networkVersionDetectMiddleware.js
+++ b/unlock-app/src/middlewares/networkVersionDetectMiddleware.js
@@ -1,23 +1,17 @@
-export default store => {
-  axios
-    .get('https://api.coinbase.com/v2/prices/ETH-USD/buy')
-    .then(info =>
-      store.dispatch(
-        setConversionRate(info.data.data.currency, info.data.data.amount)
-      )
-    )
-  setInterval(() => {
-    axios.get('https://api.coinbase.com/v2/prices/ETH-USD/buy').then(info => {
-      const {
-        data: {
-          data: { currency, amount },
-        },
-      } = info
-      const current = store.getState().currency[currency]
-      if (current === +amount) return
+import { setNetwork } from '../actions/network'
 
-      store.dispatch(setConversionRate(currency, amount))
-    })
-  }, 10000)
+export function checkNetwork(store) {
+  if (!window.web3) return
+  window.web3.version.getNetwork().then(id => {
+    if (store.getState().network.name !== id) {
+      store.dispatch(setNetwork(id))
+    }
+  })
+}
+
+export default store => {
+  checkNetwork(store)
+  const checkAgain = checkNetwork.bind(null, store)
+  setInterval(checkAgain, 1000)
   return next => action => next(action)
 }

--- a/unlock-app/src/middlewares/networkVersionDetectMiddleware.js
+++ b/unlock-app/src/middlewares/networkVersionDetectMiddleware.js
@@ -1,0 +1,23 @@
+export default store => {
+  axios
+    .get('https://api.coinbase.com/v2/prices/ETH-USD/buy')
+    .then(info =>
+      store.dispatch(
+        setConversionRate(info.data.data.currency, info.data.data.amount)
+      )
+    )
+  setInterval(() => {
+    axios.get('https://api.coinbase.com/v2/prices/ETH-USD/buy').then(info => {
+      const {
+        data: {
+          data: { currency, amount },
+        },
+      } = info
+      const current = store.getState().currency[currency]
+      if (current === +amount) return
+
+      store.dispatch(setConversionRate(currency, amount))
+    })
+  }, 10000)
+  return next => action => next(action)
+}


### PR DESCRIPTION
# Description

This fixes #428 by creating a middleware that polls to detect network changes every second. If detected, it dispatches a redux action to update the store

An unresolved question: This action should trigger the lock middleware to reset the account.
Currently that only happens on a `network.changed` event. Should I move that code so that
both locations will trigger the account reset as well?

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
