### PR TITLE
Not throwing errors in reducers but keep state unchanged

### DIFF
--- a/unlock-app/src/__tests__/reducers/keysReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/keysReducer.test.js
@@ -41,7 +41,7 @@ describe('keys reducer', () => {
   })
 
   describe('ADD_KEY', () => {
-    it('should refuse to add a key with the wrong id', () => {
+    it('should refuse to add a key with the wrong id and keep state intact', () => {
       const id = '0x123'
 
       const state = {}
@@ -54,12 +54,10 @@ describe('keys reducer', () => {
         },
       }
 
-      expect(() => {
-        reducer(state, action)
-      }).toThrowError('Could not add key with wrong id')
+      expect(reducer(state, action)).toEqual(state)
     })
 
-    it('should refuse to overwrite keys', () => {
+    it('should refuse to overwrite keys and keep state unchanged', () => {
       const id = '0x123'
 
       const state = {
@@ -76,9 +74,7 @@ describe('keys reducer', () => {
         },
       }
 
-      expect(() => {
-        reducer(state, action)
-      }).toThrowError('Could not add already existing key')
+      expect(reducer(state, action)).toEqual(state)
     })
 
     it('should add the key by its id accordingly when receiving ADD_KEY', () => {
@@ -145,7 +141,7 @@ describe('keys reducer', () => {
   })
 
   describe('UPDATE_KEY', () => {
-    it('should trigger an error if trying to update the key id', () => {
+    it('should keep state unchanged if trying to update the key id', () => {
       const key = {
         id: 'keyId',
         expiration: 0,
@@ -162,12 +158,10 @@ describe('keys reducer', () => {
           id: 'newKeyId',
         },
       }
-      expect(() => {
-        reducer(state, action)
-      }).toThrowError('Could not change the key id')
+      expect(reducer(state, action)).toEqual(state)
     })
 
-    it('should throw when the key being updated does not exist', () => {
+    it('should keep state unchanged when the key being updated does not exist', () => {
       const key = {
         id: 'keyId',
         expiration: 0,
@@ -184,9 +178,7 @@ describe('keys reducer', () => {
           data: 'world',
         },
       }
-      expect(() => {
-        reducer(state, action)
-      }).toThrowError('Could not update missing key')
+      expect(reducer(state, action)).toEqual(state)
     })
 
     it('should update the keys values', () => {

--- a/unlock-app/src/__tests__/reducers/locksReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/locksReducer.test.js
@@ -111,7 +111,7 @@ describe('locks reducer', () => {
   })
 
   describe('ADD_LOCK', () => {
-    it('should raise an error if the address is a mismatch', () => {
+    it('should keep state unchanged if the address is a mismatch', () => {
       const state = {}
       const action = {
         type: ADD_LOCK,
@@ -120,12 +120,10 @@ describe('locks reducer', () => {
           address: '0x456',
         },
       }
-      expect(() => {
-        reducer(state, action)
-      }).toThrowError('Mismatch in lock address')
+      expect(reducer(state, action)).toEqual(state)
     })
 
-    it('should raise an error if the lock was previously added', () => {
+    it('should keep state unchanged if the lock was previously added', () => {
       const state = {
         '0x123': {},
       }
@@ -136,9 +134,7 @@ describe('locks reducer', () => {
           address: '0x123',
         },
       }
-      expect(() => {
-        reducer(state, action)
-      }).toThrowError('Lock already exists')
+      expect(reducer(state, action)).toEqual(state)
     })
 
     it('should add the lock and add its address', () => {
@@ -164,7 +160,7 @@ describe('locks reducer', () => {
   })
 
   describe('UPDATE_LOCK', () => {
-    it('should trigger an error if trying to update the lock address', () => {
+    it('should keep state unchanged if trying to update the lock address', () => {
       const state = {
         '0x123': {
           name: 'hello',
@@ -178,12 +174,10 @@ describe('locks reducer', () => {
           address: '0x456',
         },
       }
-      expect(() => {
-        reducer(state, action)
-      }).toThrowError('Could not change the lock address')
+      expect(reducer(state, action)).toEqual(state)
     })
 
-    it('should throw when the lock being updated does not exist', () => {
+    it('should keep state unchanged when the lock being updated does not exist', () => {
       const state = {
         '0x123': {
           name: 'hello',
@@ -197,9 +191,7 @@ describe('locks reducer', () => {
           address: '0x456',
         },
       }
-      expect(() => {
-        reducer(state, action)
-      }).toThrowError('Could not update missing lock')
+      expect(reducer(state, action)).toEqual(state)
     })
 
     it('should update the locks values', () => {

--- a/unlock-app/src/__tests__/reducers/transactionsReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/transactionsReducer.test.js
@@ -103,7 +103,7 @@ describe('transaction reducer', () => {
   })
 
   describe('when receiving UPDATE_TRANSACTION', () => {
-    it('should raise an error when trying to update the hash', () => {
+    it('should not change state when trying to update the hash', () => {
       const transaction = {
         status: 'pending',
         confirmations: 0,
@@ -120,12 +120,10 @@ describe('transaction reducer', () => {
           hash: '0x456',
         },
       }
-      expect(() => {
-        reducer(state, action)
-      }).toThrow(/Could not change the transaction hash/)
+      expect(reducer(state, action)).toEqual(state)
     })
 
-    it('should raise an error when trying to update a transaction which does not exist', () => {
+    it('should not change state when trying to update a transaction which does not exist', () => {
       const transaction = {
         status: 'pending',
         confirmations: 0,
@@ -140,9 +138,7 @@ describe('transaction reducer', () => {
           hash: '0x123',
         },
       }
-      expect(() => {
-        reducer(state, action)
-      }).toThrow(/Could not update missing transaction/)
+      expect(reducer(state, action)).toEqual(state)
     })
 
     it('should update an existing transaction', () => {

--- a/unlock-app/src/reducers/keysReducer.js
+++ b/unlock-app/src/reducers/keysReducer.js
@@ -24,11 +24,13 @@ const keysReducer = (state = initialState, action) => {
 
   if (action.type === ADD_KEY) {
     if (action.key.id && action.key.id !== action.id) {
-      throw new Error('Could not add key with wrong id')
+      // 'Could not add key with wrong id' => Let's not change state
+      return state
     }
 
     if (state[action.id]) {
-      throw new Error('Could not add already existing key')
+      // 'Could not add already existing key' => Let's not change state
+      return state
     }
 
     return {
@@ -42,11 +44,13 @@ const keysReducer = (state = initialState, action) => {
 
   if (action.type === UPDATE_KEY) {
     if (action.update.id && action.update.id !== action.id) {
-      throw new Error('Could not change the key id')
+      // 'Could not change the key id' => Let's not change state
+      return state
     }
 
     if (!state[action.id]) {
-      throw new Error('Could not update missing key')
+      // 'Could not update missing key' => Let's not change state
+      return state
     }
 
     return {

--- a/unlock-app/src/reducers/locksReducer.js
+++ b/unlock-app/src/reducers/locksReducer.js
@@ -17,11 +17,13 @@ const locksReducer = (state = initialState, action) => {
 
   if (action.type === ADD_LOCK) {
     if (action.lock.address && action.lock.address !== action.address) {
-      throw new Error('Mismatch in lock address')
+      // 'Mismatch in lock address' => Let's not change state
+      return state
     }
 
     if (state[action.address]) {
-      throw new Error('Lock already exists')
+      // 'Lock already exists' => Let's not change state
+      return state
     }
 
     return {
@@ -68,11 +70,13 @@ const locksReducer = (state = initialState, action) => {
   // This will change the locks value... except for its address!
   if (action.type === UPDATE_LOCK) {
     if (action.update.address && action.update.address !== action.address) {
-      throw new Error('Could not change the lock address')
+      // 'Could not change the lock address' => Let's not change state
+      return state
     }
 
     if (!state[action.address]) {
-      throw new Error('Could not update missing lock')
+      // 'Could not update missing lock' => Let's not change state
+      return state
     }
 
     return {

--- a/unlock-app/src/reducers/transactionsReducer.js
+++ b/unlock-app/src/reducers/transactionsReducer.js
@@ -25,11 +25,13 @@ const transactionsReducer = (transactions = initialState, action) => {
   // Replace the transaction with the updated value
   if (action.type === UPDATE_TRANSACTION) {
     if (action.update.hash && action.update.hash !== action.hash) {
-      throw new Error('Could not change the transaction hash')
+      // 'Could not change the transaction hash' => Let's not change state
+      return transactions
     }
 
     if (!transactions[action.hash]) {
-      throw new Error('Could not update missing transaction')
+      // 'Could not update missing transaction' => Let's not change state
+      return transactions
     }
 
     return {


### PR DESCRIPTION
This is after @cellog noted that we should not throw errors in reducers inside PR #837



- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)