### PR TITLE
Moving CI commands down to individual applications for better integration

### DIFF
--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -38,7 +38,8 @@
   "scripts": {
     "remix": "remixd -s contracts --remix-ide http://localhost:8080 --read-only",
     "test": "truffle test",
-    "lint": "solhint contracts/**/*.sol"
+    "lint": "solhint contracts/**/*.sol",
+    "ci": "npm run lint && npm run test --  --network test"
   },
   "author": "",
   "license": "ISC"

--- a/tests.sh
+++ b/tests.sh
@@ -4,25 +4,10 @@
 
 # Solidity tests
 cd /home/unlock/smart-contracts
-# missing npm module from the truffle/ci image
-npm install
+npm ci
+CI=1 npm run ci
 
-truffle test --network test || exit 1
-npm run lint || exit 1
-
-# React tests && linting
+# React application
 cd /home/unlock/unlock-app
-npm install
-CI=1 npm test || exit 1
-npm run lint || exit 1
-# Check that the styling guide is respected
-npm run reformat
-cd .. # Back to root
-CHANGED=$(git diff-index --name-only HEAD -- | grep -v package-lock.json | grep -v npm-shrinkwrap.json)
-if [ -z "$CHANGED" ]; then
-  echo "Format discrepancies. Please run \`npm run reformat\` before your commit."
-  echo "Files with wrong format:"
-  git diff $CHANGED
-  exit 1
-fi
-
+npm ci
+CI=1 npm run ci

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -79,11 +79,13 @@
     "setup-dev:darwin:freebsd:linux:sunos": "cd .. && (npm run start-ganache -- -b 3 &) && npm run deploy-lock",
     "setup-dev:win32": "cd .. && (START /b npm run start-ganache -- -b 3 ) && npm run deploy-lock",
     "test": "NODE_ENV=test jest --env=jsdom",
-    "lint": "./node_modules/eslint/bin/eslint.js .",
-    "reformat": "npx prettier-eslint --write \"src/**/*.js\"",
+    "lint": "eslint .",
+    "reformat": "prettier-eslint \"src/**/*.js\" --write",
+    "fail-pending-changes": "git diff-index --quiet HEAD --",
     "storybook": "start-storybook -p 9001 -c .storybook -s src",
     "svg-2-components": "./node_modules/@svgr/cli/bin/svgr --title-prop --no-dimensions -d src/components/interface/svg/ src/static/images/svg/",
-    "eslint-check": "eslint --print-config . | eslint-config-prettier-check"
+    "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
+    "ci": "npm run lint && npm test && npm run reformat && npm run fail-pending-changes"
   },
   "lint-staged": {
     "linters": {


### PR DESCRIPTION
Based on the feedback we got from @heewa last week I am simplifying our test.sh script so that each "project" has its own CI scripts. This provides better isolation and a similar pattern should be used for the next micro services.


(Delete this, but please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.)


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)