### PR TITLE
Refactored config to use next/config

### DIFF
--- a/unlock-app/jest.setup.js
+++ b/unlock-app/jest.setup.js
@@ -3,3 +3,11 @@
 import 'jest-dom/extend-expect'
 import 'react-testing-library/cleanup-after-each'
 import 'jest-styled-components'
+
+import { setConfig } from 'next/config'
+import config from './next.config'
+
+// Make sure you can use getConfig
+setConfig({
+  publicRuntimeConfig: config.publicRuntimeConfig,
+})

--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -6,6 +6,9 @@ const withSourceMaps = require('@zeit/next-source-maps')
 const copyFile = promisify(fs.copyFile)
 
 module.exports = withSourceMaps({
+  publicRuntimeConfig: {
+    unlockEnv: process.env.UNLOCK_ENV || 'dev',
+  },
   webpack(config) {
     return config
   },

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -78,7 +78,7 @@
     "setup-dev": "run-script-os",
     "setup-dev:darwin:freebsd:linux:sunos": "cd .. && (npm run start-ganache -- -b 3 &) && npm run deploy-lock",
     "setup-dev:win32": "cd .. && (START /b npm run start-ganache -- -b 3 ) && npm run deploy-lock",
-    "test": "NODE_ENV=test jest --env=jsdom",
+    "test": "UNLOCK_ENV=test jest --env=jsdom",
     "lint": "eslint .",
     "reformat": "prettier-eslint \"src/**/*.js\" --write",
     "fail-pending-changes": "./scripts/pending-changes.sh",

--- a/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
@@ -45,9 +45,7 @@ const transaction = {
 
 describe('CreatorLock', () => {
   it('should show embed code when the button is clicked', () => {
-    const config = configure({
-      requiredConfirmations: 6,
-    })
+    const config = configure()
 
     const store = createUnlockStore()
 
@@ -75,9 +73,7 @@ describe('CreatorLock', () => {
     ).not.toBeNull()
   })
   it('should display the correct number of keys', () => {
-    const config = configure({
-      requiredConfirmations: 6,
-    })
+    const config = configure()
 
     const store = createUnlockStore({
       transactions: {
@@ -97,9 +93,7 @@ describe('CreatorLock', () => {
     expect(wrapper.queryByText('1/10')).not.toBeNull()
   })
   it('should display infinite keys correctly', () => {
-    const config = configure({
-      requiredConfirmations: 6,
-    })
+    const config = configure()
 
     const store = createUnlockStore({
       transactions: {

--- a/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
@@ -10,7 +10,7 @@ const toggleCode = jest.fn()
 
 describe('LockIconBar', () => {
   it('should display a submitted label when withdrawal has been submitted', () => {
-    const config = configure({})
+    const config = configure()
 
     const lock = {
       id: 'lockwithdrawalsubmittedid',
@@ -50,7 +50,7 @@ describe('LockIconBar', () => {
     ).not.toBeNull()
   })
   it('should display a confirming label when withdrawal is confirming', () => {
-    const config = configure({})
+    const config = configure()
 
     const lock = {
       id: 'lockwithdrawalconfirmingid',

--- a/unlock-app/src/__tests__/config.test.js
+++ b/unlock-app/src/__tests__/config.test.js
@@ -2,7 +2,7 @@ import configure from '../config'
 
 describe('config', () => {
   describe('dev', () => {
-    let config = configure(global, { NODE_ENV: 'dev' })
+    let config = configure(global, { unlockEnv: 'dev' })
 
     it('should require a dev network', () => {
       expect(config.isRequiredNetwork(0)).toEqual(false)
@@ -31,11 +31,8 @@ describe('config', () => {
               isMetaMask: true,
             },
           },
-          location: {
-            hostname: 'localhost',
-          },
         },
-        { NODE_ENV: 'dev' }
+        { unlockEnv: 'dev' }
       )
       expect(config.providers).toMatchObject({
         HTTP: {
@@ -52,16 +49,16 @@ describe('config', () => {
   })
 
   describe('staging', () => {
-    let config = configure({
-      web3: {
-        currentProvider: {
-          isMetaMask: true,
+    let config = configure(
+      {
+        web3: {
+          currentProvider: {
+            isMetaMask: true,
+          },
         },
       },
-      location: {
-        hostname: 'staging.unlock-protocol.com',
-      },
-    })
+      { unlockEnv: 'staging' }
+    )
 
     it('should require rinkeby', () => {
       expect(config.isRequiredNetwork(0)).toEqual(false)
@@ -81,11 +78,7 @@ describe('config', () => {
   })
 
   describe('production', () => {
-    let config = configure({
-      location: {
-        hostname: 'unlock-protocol.com',
-      },
-    })
+    let config = configure(global, { unlockEnv: 'prod' })
 
     it('should require mainnet', () => {
       expect(config.isRequiredNetwork(0)).toEqual(false)

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -195,7 +195,7 @@ describe('Web3Service', () => {
     let enable
 
     beforeEach(done => {
-      const { providers } = configure(global)
+      const { providers } = configure()
       nock.cleanAll()
 
       enable = providers.HTTP.enable = jest.fn(() => Promise.resolve())
@@ -229,7 +229,7 @@ describe('Web3Service', () => {
     let enable, error
 
     beforeEach(done => {
-      const { providers } = configure(global)
+      const { providers } = configure()
       nock.cleanAll()
 
       enable = providers.HTTP.enable = jest.fn(() => Promise.reject())

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -1,4 +1,5 @@
 import Web3 from 'web3'
+import getConfig from 'next/config'
 import { ETHEREUM_NETWORKS_NAMES } from './constants'
 
 // There is no standard way to detect the provider name...
@@ -39,32 +40,20 @@ export function getCurrentProvider(environment) {
 }
 
 /**
- * This function, based on the environment will return the list of providers available, the one that is used, as well as the list of networks and the one that is being used.
+ * This function, based on the environment will return the list of providers available, the one that
+ * is used, as well as the list of networks and the one that is being used.
  * In dev/testing, the provider can be anything and the network can be anything too.
  * In staging, the provider needs to be an ingested web3 provider, and the network needs to be rinkeby
  * In prod, the provider needs to be an ingested web3 provider and the network needs to be mainnet
- * We set UNLOCK_ENV on the deployment platform to STAGING or PROD.
  * @param {*} environment (in the JS sense: `window` most likely)
  */
-export default function configure(environment, envVars = process.env) {
+export default function configure(
+  environment = global,
+  runtimeConfig = getConfig().publicRuntimeConfig
+) {
   const isServer = typeof window === 'undefined'
 
-  let env = 'dev' // default
-  if (
-    (environment.location &&
-      environment.location.hostname === 'staging.unlock-protocol.com') ||
-    envVars['UNLOCK_ENV'] === 'staging'
-  ) {
-    env = 'staging'
-  } else if (
-    (environment.location &&
-      environment.location.hostname === 'unlock-protocol.com') ||
-    envVars['UNLOCK_ENV'] === 'prod'
-  ) {
-    env = 'prod'
-  } else if (envVars['NODE_ENV'] === 'test') {
-    env = 'test'
-  }
+  const env = runtimeConfig.unlockEnv
 
   let providers = {}
   let isRequiredNetwork = () => false

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -38,7 +38,7 @@ import modalReducer, {
 import lockMiddleware from './middlewares/lockMiddleware'
 import currencyConversionMiddleware from './middlewares/currencyConversionMiddleware'
 
-const config = configure(global)
+const config = configure()
 
 export const createUnlockStore = (
   defaultState = {},

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -8,7 +8,7 @@ import { createUnlockStore } from '../createUnlockStore'
 
 import GlobalStyle from '../theme/globalStyle'
 
-const config = configure(global)
+const config = configure()
 
 const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
 

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -7,7 +7,7 @@ import UnlockContract from '../artifacts/contracts/Unlock.json'
 import configure from '../config'
 import { TRANSACTION_TYPES } from '../constants'
 
-const { providers } = configure(global)
+const { providers } = configure()
 
 export const keyId = (lock, owner) => [lock, owner].join('-')
 

--- a/unlock-app/src/utils/withConfig.js
+++ b/unlock-app/src/utils/withConfig.js
@@ -14,7 +14,7 @@ import { ETHEREUM_NETWORKS_NAMES } from '../constants'
  * Taken from https://reactjs.org/docs/context.html#consuming-context-with-a-hoc
  */
 
-const config = configure(global)
+const config = configure()
 const ConfigContext = React.createContext(config)
 
 /**


### PR DESCRIPTION
Instead of reading env variables directly in config.js (which did not work) we are now using 
next/config to inject them at build time.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)