### PR TITLE
modify PR template to explain that config must be in its own PR

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,12 @@
 # Description
 
-(Delete this, but please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.)
+*(Delete this, but please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.)*
 
 # Checklist:
 
 - [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
+  - [ ] This PR only contains configuration changes (package.json, etc.)
+  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
 - [ ] My code follows the style guidelines of this project, including naming conventions
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have added tests that prove my fix is effective or that my feature works


### PR DESCRIPTION
# Description

Fixes #832 by adding sub-categories to the PR template like below and slightly adjusting formatting:

```markdown
# Description

*(Delete this, but please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.)*

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
```

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
