### PR TITLE
Adding the next/config stuff back again

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -26,6 +26,12 @@ contract PublicLock is ILockCore, ERC165, IERC721, Ownable {
     bytes data; // Note: This can be expensive?
   }
 
+  // Events
+  event PriceChanged(
+    uint indexed keyPrice
+  );
+
+
   // Fields
   // Unlock Protocol address
   // TODO: should we make that private/internal?
@@ -258,6 +264,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, Ownable {
     onlyOwner
   {
     keyPrice = _keyPrice;
+    emit PriceChanged(keyPrice);
   }
 
   /**

--- a/smart-contracts/test/Lock/updateKeyPrice.js
+++ b/smart-contracts/test/Lock/updateKeyPrice.js
@@ -3,48 +3,54 @@ const Units = require('ethereumjs-units')
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
 
-let unlock, locks
+let unlock, locks, keyPriceBefore, transaction
 
 contract('Lock', (accounts) => {
-  before(() => {
-    return Unlock.deployed()
-      .then(_unlock => {
-        unlock = _unlock
-        return deployLocks(unlock)
-      })
-      .then(_locks => {
-        locks = _locks
-      })
-      .then(() => {
-        // Increases the price from the default 0.01, 'eth'.
-        locks['FIRST'].updateKeyPrice(Units.convert('0.1', 'eth', 'wei'))
-      })
-  })
-
   describe('updateKeyPrice', () => {
-    it('should fail if the price is not enough', () => {
-      return locks['FIRST']
-        .purchaseFor(accounts[0], 'Julien', {
-          value: Units.convert('0.01', 'eth', 'wei')
-        })
-        .then(() => {
-          assert.fail()
-        })
-        .catch(error => {
-          assert.equal(error.message, 'VM Exception while processing transaction: revert Insufficient funds')
-          // Making sure we do not have a key set!
-          return locks['FIRST'].keyExpirationTimestampFor(accounts[0])
-            .catch(error => {
-              assert.equal(error.message, 'VM Exception while processing transaction: revert No such key')
-            })
-        })
+    before(async () => {
+      unlock = await Unlock.deployed()
+      locks = await deployLocks(unlock)
+      keyPriceBefore = await locks['FIRST'].keyPrice()
+      assert.equal(keyPriceBefore.toNumber(), 10000000000000000)
+      transaction = await locks['FIRST'].updateKeyPrice(Units.convert('0.3', 'eth', 'wei'))
     })
 
-    it('should purchase when the correct amount of ETH is sent', () => {
-      return locks['FIRST']
-        .purchaseFor(accounts[0], 'Julien', {
-          value: Units.convert('0.1', 'eth', 'wei')
-        })
+    it('should change the actual keyPrice', async () => {
+      const keyPriceAfter = await locks['FIRST'].keyPrice()
+      assert.equal(keyPriceAfter.toNumber(), 300000000000000000)
+    })
+
+    it('should trigger an event', () => {
+      const event = transaction.logs.find((log) => {
+        return log.event === 'PriceChanged'
+      })
+      assert(event)
+      assert.equal(event.args.keyPrice.toNumber(), 300000000000000000)
+    })
+
+    describe('when the sender is not the lock owner', () => {
+      let keyPrice, error
+      before(async () => {
+        keyPrice = await locks['FIRST'].keyPrice()
+        try {
+          await locks['FIRST'].updateKeyPrice(
+            Units.convert('0.3', 'eth', 'wei'),
+            {
+              from: accounts[3]
+            })
+        } catch (_error) {
+          error = _error
+        }
+      })
+
+      it('should fail', async () => {
+        assert(error)
+      })
+
+      it('should leave the price unchanged', async () => {
+        const keyPriceAfter = await locks['FIRST'].keyPrice()
+        assert.equal(keyPrice.toNumber(), keyPriceAfter)
+      })
     })
   })
 })


### PR DESCRIPTION
This time with the bit which was previously missing and preventing storybook from running correctly.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)