### PR TITLE
Adds Locksmith integration to Unlock-app

### DIFF
--- a/unlock-app/jest.config.js
+++ b/unlock-app/jest.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   setupFiles: ['<rootDir>/.jest/register-context.js'],
   setupTestFrameworkScriptFile: '<rootDir>/jest.setup.js',
-  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  testPathIgnorePatterns: [
+    '<rootDir>/.next/',
+    '<rootDir>/node_modules/',
+    '<rootDir>/src/__tests__/utils/fixtures/',
+  ],
   transform: {
     '^.+\\.(js|jsx)$': '<rootDir>/node_modules/babel-jest',
   },

--- a/unlock-app/src/__tests__/actions/storage.test.js
+++ b/unlock-app/src/__tests__/actions/storage.test.js
@@ -1,0 +1,33 @@
+import {
+  setLockName,
+  storageError,
+  SET_LOCK_NAME,
+  STORAGE_ERROR,
+} from '../../actions/storage'
+
+describe('Storage action', () => {
+  it('should create an action to set a lock', () => {
+    const address = '0x2129127646'
+    const name = 'A Lock Name'
+
+    const expectation = {
+      type: SET_LOCK_NAME,
+      address: address,
+      name: name,
+    }
+    expect(setLockName(address, name)).toEqual(expectation)
+  })
+})
+
+describe('Storage error', () => {
+  it('should create an action emitting a storage error', () => {
+    const error = 'a fancy error'
+
+    const expectation = {
+      type: STORAGE_ERROR,
+      error: error,
+    }
+
+    expect(storageError(error)).toEqual(expectation)
+  })
+})

--- a/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
@@ -83,9 +83,16 @@ jest.mock('../../services/web3Service', () => {
   }
 })
 
+let mockGenerateJWTToken = jest.fn(() => Promise.resolve())
+
+jest.mock('../../utils/signature', () => () => {
+  return mockGenerateJWTToken()
+})
+
 beforeEach(() => {
   // Reset the mock
   mockWeb3Service = new MockWebService()
+  mockGenerateJWTToken = jest.fn(() => Promise.resolve())
 
   // Reset state!
   account = {
@@ -447,6 +454,7 @@ describe('Lock middleware', () => {
       lock,
       store.getState().account
     )
+    expect(mockGenerateJWTToken).toHaveBeenCalled()
     expect(next).toHaveBeenCalledWith(action)
   })
 
@@ -597,6 +605,28 @@ describe('Lock middleware', () => {
         '0.03'
       )
       expect(next).toHaveBeenCalledWith(action)
+    })
+  })
+
+  describe('LOCK_DEPLOYED', () => {
+    describe('when the action contains the lock address on chain', () => {
+      it('should store the update', () => {
+        const { next, invoke } = create()
+        let action = { type: LOCK_DEPLOYED, address: '0x4242424242', lock }
+
+        invoke(action)
+        expect(mockGenerateJWTToken).toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith(action)
+      })
+
+      it('should not store the update', () => {
+        const { next, invoke } = create()
+        let action = { type: LOCK_DEPLOYED }
+
+        invoke(action)
+        expect(mockGenerateJWTToken).not.toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith(action)
+      })
     })
   })
 })

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,0 +1,115 @@
+import storageMiddleware from '../../middlewares/storageMiddleware'
+
+/**
+ * This is a "fake" middleware caller
+ * Taken from https://redux.js.org/recipes/writing-tests#middleware
+ */
+
+let state
+let account
+let lock
+let network
+
+const create = () => {
+  const store = {
+    getState: jest.fn(() => state),
+    dispatch: jest.fn(() => true),
+  }
+  const next = jest.fn()
+  const handler = storageMiddleware(store)
+  const invoke = action => handler(next)(action)
+  return { next, invoke, store }
+}
+
+let mockStoreLockDetails = jest.fn(() => Promise.resolve())
+let mockUpdateLockDetails = jest.fn(() => Promise.resolve())
+let mockLockLookUp = jest.fn(() => Promise.resolve())
+
+jest.mock('../../services/storageService', () => () => ({
+  storeLockDetails: mockStoreLockDetails,
+  updateLockDetails: mockUpdateLockDetails,
+  lockLookUp: mockLockLookUp,
+}))
+
+describe('Storage middleware', () => {
+  beforeEach(() => {
+    account = {
+      address: '0xabc',
+    }
+    network = {
+      name: 'test',
+    }
+    lock = {
+      address: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      keyPrice: '100',
+      owner: account.address,
+    }
+    state = {
+      account,
+      network,
+      provider: 'HTTP',
+      locks: {
+        [lock.address]: lock,
+      },
+      keys: {},
+    }
+  })
+
+  describe('handling STORE_LOCK_CREATION', () => {
+    it('dispatches to the appropriate storage middleware handler', () => {
+      const { next, invoke } = create()
+      const action = { type: 'STORE_LOCK_CREATION' }
+      invoke(action)
+      expect(mockStoreLockDetails).toHaveBeenCalled()
+      expect(next).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('handling UPDATE_LOCK', () => {
+    describe('when the update is a transaction', () => {
+      it('calls the next middleware', () => {
+        const { next, invoke } = create()
+        const action = { type: 'UPDATE_LOCK', update: { transaction: 'foo' } }
+        invoke(action)
+        expect(mockLockLookUp).not.toBeCalled()
+        expect(next).toHaveBeenCalledTimes(1)
+      })
+    })
+    describe('when the update is not a transaction', () => {
+      it('dispatches to the appropriate storage middleware handler', () => {
+        const { next, invoke } = create()
+        const action = { type: 'UPDATE_LOCK', update: { foo: 'foo' } }
+        invoke(action)
+        expect(mockLockLookUp).toBeCalled()
+        expect(next).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('handling STORE_LOCK_UPDATE', () => {
+    describe('when the lock and new details are provide', () => {
+      it('dispatches to the appropriate storage middleware handler', () => {
+        const { next, invoke } = create()
+        const action = {
+          type: 'STORE_LOCK_UPDATE',
+          address: '0xfff',
+          lock: { address: '0x3f3f3' },
+        }
+        invoke(action)
+        expect(mockLockLookUp).toBeCalled()
+        expect(next).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    // describe('when lock or new details are not provided', () => {
+    //   it('does not dispatch to the appropriate storage middleware handler', () => {
+    //     mockWeb3Service.ready = true
+    //     const { next, invoke } = create()
+    //     const action = { type: 'LOCK_DEPLOYED', address: '0x2223' }
+    //     invoke(action)
+    //     expect(storageMiddlewareHander.lockDeployed).not.toBeCalled()
+    //     expect(next).toHaveBeenCalledTimes(1)
+    //   })
+    // })
+  })
+})

--- a/unlock-app/src/__tests__/reducers/locksReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/locksReducer.test.js
@@ -11,6 +11,7 @@ import { SET_ACCOUNT } from '../../actions/accounts'
 import { DELETE_TRANSACTION } from '../../actions/transaction'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
+import { SET_LOCK_NAME } from '../../actions/storage'
 
 describe('locks reducer', () => {
   const lock = {
@@ -110,6 +111,23 @@ describe('locks reducer', () => {
     ).toEqual({
       [lock.address]: lock,
     })
+  })
+
+  it('should add the name and address of a lock when receiving SET_LOCK_NAME', () => {
+    const lockName = 'foo'
+    const state = reducer(
+      {
+        [lock.address]: lock,
+      },
+      {
+        type: SET_LOCK_NAME,
+        address: lock.address,
+        name: lockName,
+      }
+    )
+
+    expect(state).toHaveProperty(`${lock.address}.name`, lockName)
+    expect(state).toHaveProperty(`${lock.address}.address`, '123')
   })
 
   describe('DELETE_LOCK', () => {

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -1,0 +1,93 @@
+import http from 'jest-mock-axios'
+import StorageService from '../../services/storageService'
+
+afterEach(() => http.reset())
+
+describe('StorageService', () => {
+  const serviceHost = 'http://127.0.0.1:8080'
+  const storageService = new StorageService(serviceHost)
+  const successFn = jest.fn(),
+    failureFn = jest.fn()
+
+  describe('lockLookUp', () => {
+    describe('when the requested lock exists', () => {
+      it('returns the details', () => {
+        storageService.lockLookUp('0x42').then(successFn)
+        http.mockResponse()
+        expect(successFn).toHaveBeenCalled()
+        expect(http.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x42`)
+      })
+    })
+
+    describe('when the requested lock doesnt exist', () => {
+      it('raises an appropriate error', () => {
+        storageService.lockLookUp('0x1234243').catch(failureFn)
+        http.mockError()
+        expect(http.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x1234243`)
+        expect(failureFn).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('storeLockDetails', () => {
+    describe('when storing a new lock', () => {
+      it('returns a successful promise', () => {
+        storageService
+          .storeLockDetails({ name: 'lock_name', address: 'lock_address' })
+          .then(successFn)
+        http.mockResponse()
+        expect(http.post).toHaveBeenCalledWith(`${serviceHost}/lock`, {
+          name: 'lock_name',
+          address: 'lock_address',
+        })
+        expect(successFn).toHaveBeenCalled()
+      })
+    })
+
+    describe('when attempting to store an existing lock', () => {
+      it('returns a failure promise', () => {
+        storageService
+          .storeLockDetails({ name: 'lock_name', address: 'existing_address' })
+          .then(failureFn)
+        http.mockError()
+        expect(http.post).toHaveBeenCalledWith(`${serviceHost}/lock`, {
+          name: 'lock_name',
+          address: 'existing_address',
+        })
+        expect(failureFn).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('updateLockDetails', () => {
+    describe('when a lock can be updated', () => {
+      it('returns a successful promise', () => {
+        storageService
+          .updateLockDetails('lock_address', {
+            name: 'new_lock_name',
+            address: 'lock_address',
+          })
+          .then(successFn)
+        http.mockResponse()
+        expect(http.put).toHaveBeenCalledWith(
+          `${serviceHost}/lock/lock_address`,
+          {
+            name: 'new_lock_name',
+            address: 'lock_address',
+          }
+        )
+        expect(successFn).toHaveBeenCalled()
+      })
+    })
+
+    describe('when a lock can not be updated', () => {
+      storageService.updateLockDetails('lock_address').catch(failureFn)
+      http.mockError()
+      expect(http.put).toHaveBeenCalledWith(
+        `${serviceHost}/lock/lock_address`,
+        undefined
+      )
+      expect(failureFn).toHaveBeenCalled()
+    })
+  })
+})

--- a/unlock-app/src/__tests__/utils/fixtures/signatureData.js
+++ b/unlock-app/src/__tests__/utils/fixtures/signatureData.js
@@ -1,0 +1,15 @@
+const validSignature = {
+  address: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+  signature:
+    'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJkYXRhIjoiZGRkIiwiaWF0IjoxNTQ2MjE5NjI3LCJleHAiOjE1NDYyMTk2MzAsImlzcyI6IjB4YWFhZGVlZDRjMGI4NjFjYjM2ZjRjZTAwNmE5YzkwYmEyZTQzZmRjMiJ9.0xd64fd442c30596b2861f60d8e55207aa239df32303689463ea4f5ab48ee9c4992eb6db40d8f8c5b568413f3963edfdb708ed788369c87fc93b1aca95222e54e401',
+  data: { data: 'ddd' },
+}
+
+const invalidSignature = {
+  address: '0xf8aDE52fE03Fceb34458baC79EeBa0bE5344182d',
+  signature: 'sqfgewge',
+  data: { data: 'ddd' },
+}
+
+exports.valid = validSignature
+exports.invalid = invalidSignature

--- a/unlock-app/src/__tests__/utils/fixtures/signatureFixture.json
+++ b/unlock-app/src/__tests__/utils/fixtures/signatureFixture.json
@@ -1,0 +1,147 @@
+[
+  {
+    "scope": "http://127.0.0.1:8545",
+    "method": "POST",
+    "path": "/",
+    "body": {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "net_version",
+      "params": []
+    },
+    "status": 200,
+    "response": {
+      "id": 1,
+      "jsonrpc": "2.0",
+      "result": "1984"
+    },
+    "rawHeaders": [
+      "Access-Control-Allow-Headers",
+      "Origin, X-Requested-With, Content-Type, Accept, User-Agent",
+      "Access-Control-Allow-Origin",
+      "*",
+      "Access-Control-Allow-Methods",
+      "*",
+      "Content-Type",
+      "application/json",
+      "Date",
+      "Wed, 02 Jan 2019 19:57:43 GMT",
+      "Connection",
+      "keep-alive",
+      "Transfer-Encoding",
+      "chunked"
+    ]
+  },
+  {
+    "scope": "http://127.0.0.1:8545",
+    "method": "POST",
+    "path": "/",
+    "body": {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "eth_sign",
+      "params": [
+        "0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2",
+        "0x65794a68624763694f694a756232356c4969776964486c77496a6f69536c6455496e302e65794a6b59585268496a6f695a47526b4969776961574630496a6f784e5451324d6a45354e6a49334c434a6c654841694f6a45314e4459794d546b324d7a4173496d6c7a63794936496a4234595746685a47566c5a44526a4d4749344e6a466a596a4d325a6a526a5a5441774e6d4535597a6b77596d45795a54517a5a6d526a4d694a39"
+      ]
+    },
+    "status": 200,
+    "response": {
+      "id": 2,
+      "jsonrpc": "2.0",
+      "result": "0xd64fd442c30596b2861f60d8e55207aa239df32303689463ea4f5ab48ee9c4992eb6db40d8f8c5b568413f3963edfdb708ed788369c87fc93b1aca95222e54e401"
+    },
+    "rawHeaders": [
+      "Access-Control-Allow-Headers",
+      "Origin, X-Requested-With, Content-Type, Accept, User-Agent",
+      "Access-Control-Allow-Origin",
+      "*",
+      "Access-Control-Allow-Methods",
+      "*",
+      "Content-Type",
+      "application/json",
+      "Date",
+      "Wed, 02 Jan 2019 19:57:43 GMT",
+      "Connection",
+      "keep-alive",
+      "Transfer-Encoding",
+      "chunked"
+    ]
+  },
+  {
+    "scope": "http://127.0.0.1:8545",
+    "method": "POST",
+    "path": "/",
+    "body": {
+      "jsonrpc": "2.0",
+      "id": 3,
+      "method": "net_version",
+      "params": []
+    },
+    "status": 200,
+    "response": {
+      "id": 3,
+      "jsonrpc": "2.0",
+      "result": "1984"
+    },
+    "rawHeaders": [
+      "Access-Control-Allow-Headers",
+      "Origin, X-Requested-With, Content-Type, Accept, User-Agent",
+      "Access-Control-Allow-Origin",
+      "*",
+      "Access-Control-Allow-Methods",
+      "*",
+      "Content-Type",
+      "application/json",
+      "Date",
+      "Wed, 02 Jan 2019 19:57:43 GMT",
+      "Connection",
+      "keep-alive",
+      "Transfer-Encoding",
+      "chunked"
+    ]
+  },
+  {
+    "scope": "http://127.0.0.1:8545",
+    "method": "POST",
+    "path": "/",
+    "body": {
+      "jsonrpc": "2.0",
+      "id": 4,
+      "method": "eth_sign",
+      "params": [
+        "0xf8ade52fe03fceb34458bac79eeba0be5344182d",
+        "0x65794a68624763694f694a756232356c4969776964486c77496a6f69536c6455496e302e65794a6b59585268496a6f695a47526b4969776961574630496a6f784e5451324d6a45354e6a49334c434a6c654841694f6a45314e4459794d546b324d7a4173496d6c7a63794936496a42345a6a6868524555314d6d5a464d444e47593256694d7a51304e54686959554d334f55566c516d4577596b55314d7a51304d5467795a434a39"
+      ]
+    },
+    "status": 200,
+    "response": {
+      "id": 4,
+      "jsonrpc": "2.0",
+      "error": {
+        "message": "cannot sign data; no private key",
+        "code": -32000,
+        "data": {
+          "stack": "Error: cannot sign data; no private key\n    at StateManager.sign (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/lib/statemanager.js:476:11)\n    at GethApiDouble.eth_sign (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/lib/subproviders/geth_api_double.js:279:25)\n    at GethApiDouble.handleRequest (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/lib/subproviders/geth_api_double.js:105:10)\n    at next (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/node_modules/web3-provider-engine/index.js:116:18)\n    at GethDefaults.handleRequest (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/lib/subproviders/gethdefaults.js:15:12)\n    at next (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/node_modules/web3-provider-engine/index.js:116:18)\n    at SubscriptionSubprovider.FilterSubprovider.handleRequest (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/node_modules/web3-provider-engine/subproviders/filters.js:89:7)\n    at SubscriptionSubprovider.handleRequest (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/node_modules/web3-provider-engine/subproviders/subscriptions.js:136:49)\n    at next (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/node_modules/web3-provider-engine/index.js:116:18)\n    at DelayedBlockFilter.handleRequest (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/lib/subproviders/delayedblockfilter.js:31:3)\n    at next (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/node_modules/web3-provider-engine/index.js:116:18)\n    at RequestFunnel.handleRequest (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/lib/subproviders/requestfunnel.js:32:12)\n    at next (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/node_modules/web3-provider-engine/index.js:116:18)\n    at Web3ProviderEngine._handleAsync (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/node_modules/web3-provider-engine/index.js:103:3)\n    at Timeout._onTimeout (/Users/akeem/projects/unlock/node_modules/ganache-cli/node_modules/ganache-core/node_modules/web3-provider-engine/index.js:87:12)\n    at listOnTimeout (timers.js:324:15)\n    at processTimers (timers.js:268:5)",
+          "name": "Error"
+        }
+      }
+    },
+    "rawHeaders": [
+      "Access-Control-Allow-Headers",
+      "Origin, X-Requested-With, Content-Type, Accept, User-Agent",
+      "Access-Control-Allow-Origin",
+      "*",
+      "Access-Control-Allow-Methods",
+      "*",
+      "Content-Type",
+      "application/json",
+      "Date",
+      "Wed, 02 Jan 2019 19:57:43 GMT",
+      "Connection",
+      "keep-alive",
+      "Transfer-Encoding",
+      "chunked"
+    ]
+  }
+]

--- a/unlock-app/src/__tests__/utils/signature.test.js
+++ b/unlock-app/src/__tests__/utils/signature.test.js
@@ -1,0 +1,74 @@
+import EventEmitter from 'events'
+import generateJWTToken from '../../utils/signature'
+import Web3Service from '../../services/web3Service'
+import configure from '../../config'
+
+const signatureData = require('./fixtures/signatureData')
+
+class MockWebService extends EventEmitter {
+  constructor() {
+    super()
+    this.ready = true
+  }
+}
+
+let mockWeb3Service = new MockWebService()
+
+jest.mock('../../services/web3Service', () => {
+  return function() {
+    return mockWeb3Service
+  }
+})
+
+const { providers } = configure(global)
+
+describe('generateJWTToken', () => {
+  describe('when authorized to sign the payload', () => {
+    beforeEach(() => {
+      const validSignature =
+        '0xd64fd442c30596b2861f60d8e55207aa239df32303689463ea4f5' +
+        'ab48ee9c4992eb6db40d8f8c5b568413f3963edfdb708ed788369c87' +
+        'fc93b1aca95222e54e401'
+
+      mockWeb3Service.signData = jest.fn((account, data, callback) => {
+        callback(null, validSignature)
+      })
+    })
+
+    it('generates a JWT signed by the address holder', done => {
+      Date.now = jest.fn(() => 1546219627000)
+      let web3Service = new Web3Service(providers)
+
+      generateJWTToken(
+        web3Service,
+        signatureData.valid.address,
+        signatureData.valid.data
+      ).then(result => {
+        expect(result).toBe(signatureData.valid.signature)
+        done()
+      })
+    })
+  })
+
+  describe('when unauthorized to sign the payload', () => {
+    beforeEach(() => {
+      mockWeb3Service.signData = jest.fn((account, data, callback) => {
+        callback(new Error())
+      })
+    })
+
+    it('returns a Promise.reject', done => {
+      Date.now = jest.fn(() => 1546219627000)
+      let web3Service = new Web3Service(providers)
+
+      generateJWTToken(
+        web3Service,
+        signatureData.invalid.address,
+        signatureData.invalid.data
+      ).catch(error => {
+        expect(error).not.toBeNull()
+        done()
+      })
+    })
+  })
+})

--- a/unlock-app/src/__tests__/utils/withConfig/missingProvidersWithConfig.test.js
+++ b/unlock-app/src/__tests__/utils/withConfig/missingProvidersWithConfig.test.js
@@ -26,6 +26,7 @@ jest.mock('../../../config', () =>
       providers: {},
       isRequiredNetwork: () => true,
       requiredNetwork: 'dev',
+      services: { storage: { host: 'http://atest.url' } },
     }
   })
 )

--- a/unlock-app/src/__tests__/utils/withConfig/wrongNetwork.test.js
+++ b/unlock-app/src/__tests__/utils/withConfig/wrongNetwork.test.js
@@ -22,6 +22,7 @@ jest.mock('../../../config', () =>
       },
       isRequiredNetwork: () => false,
       requiredNetwork: 'dev',
+      services: { storage: { host: 'http://atest.url' } },
     }
   })
 )

--- a/unlock-app/src/actions/signature.js
+++ b/unlock-app/src/actions/signature.js
@@ -1,0 +1,8 @@
+export const SIGNATURE_ERROR = 'SIGNATURE_ERROR'
+
+export function signatureError(error) {
+  return {
+    type: 'SIGNATURE_ERROR',
+    error: error,
+  }
+}

--- a/unlock-app/src/actions/storage.js
+++ b/unlock-app/src/actions/storage.js
@@ -1,0 +1,38 @@
+export const SET_LOCK_NAME = 'SET_LOCK_NAME'
+export const STORAGE_ERROR = 'STORAGE_ERROR'
+export const STORE_LOCK_CREATION = 'STORE_LOCK_CREATION'
+export const STORE_LOCK_UPDATE = 'STORE_LOCK_UPDATE'
+
+export function setLockName(address, name) {
+  return {
+    type: 'SET_LOCK_NAME',
+    address: address,
+    name: name,
+  }
+}
+
+export function storageError(error) {
+  return {
+    type: 'STORAGE_ERROR',
+    error: error,
+  }
+}
+
+export function storeLockCreation(owner, lock, token) {
+  return {
+    type: 'STORE_LOCK_CREATION',
+    owner: owner,
+    lock: lock,
+    token: token,
+  }
+}
+
+export function storeLockUpdate(owner, currentLock, token, update) {
+  return {
+    type: 'STORE_LOCK_UPDATE',
+    owner: owner,
+    lockAddress: currentLock,
+    token: token,
+    update: update,
+  }
+}

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -60,12 +60,14 @@ export default function configure(
   let requiredNetwork = 'Dev'
   let requiredConfirmations = 12
   let unlockAddress = ''
+  let services = {}
 
   if (env === 'test') {
     // In test, we fake the HTTP provider
     providers['HTTP'] = new Web3.providers.HttpProvider(
       `http://${runtimeConfig.httpProvider}:8545`
     )
+    services['storage'] = { host: 'http://127.0.0.1:8080' }
   }
 
   if (env === 'dev') {
@@ -74,6 +76,7 @@ export default function configure(
     providers['HTTP'] = new Web3.providers.HttpProvider(
       `http://${runtimeConfig.httpProvider}:8545`
     )
+    services['storage'] = { host: 'http://127.0.0.1:8080' }
 
     // If there is an existing web3 injected provider, we also add this one to the list of possible providers
     if (typeof environment.web3 !== 'undefined') {
@@ -123,5 +126,6 @@ export default function configure(
     requiredNetwork,
     requiredConfirmations,
     unlockAddress,
+    services,
   }
 }

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -39,6 +39,7 @@ import modalReducer, {
 // Middlewares
 import lockMiddleware from './middlewares/lockMiddleware'
 import currencyConversionMiddleware from './middlewares/currencyConversionMiddleware'
+import storageMiddleware from './middlewares/storageMiddleware'
 
 const config = configure()
 
@@ -92,6 +93,10 @@ export const createUnlockStore = (
     currencyConversionMiddleware,
     routerMiddleware(history),
   ]
+
+  if (config.services.storage) {
+    middlewares.push(storageMiddleware)
+  }
 
   const composeEnhancers =
     global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -1,0 +1,68 @@
+import { UPDATE_LOCK } from '../actions/lock'
+import StorageService from '../services/storageService'
+import {
+  setLockName,
+  storageError,
+  STORE_LOCK_CREATION,
+  STORE_LOCK_UPDATE,
+} from '../actions/storage'
+
+import configure from '../config'
+
+const { services } = configure(global)
+
+export default function storageMiddleware({ dispatch }) {
+  const storageService = new StorageService(services.storage.host)
+  return function(next) {
+    return function(action) {
+      switch (action.type) {
+        case STORE_LOCK_CREATION:
+          storageService
+            .storeLockDetails(action.lock, action.token)
+            .catch(error => {
+              dispatch(storageError(error))
+            })
+          break
+        case UPDATE_LOCK:
+          if (!action.update.transaction) {
+            storageService
+              .lockLookUp(action.address)
+              .then(results => {
+                dispatch(setLockName(action.address, results.data.name))
+              })
+              .catch(error => {
+                dispatch(storageError(error))
+              })
+          }
+          break
+        case STORE_LOCK_UPDATE:
+          storageService
+            .updateLockDetails(
+              action.lockAddress,
+              {
+                currentAddress: action.lockAddress,
+                address: action.update,
+                owner: action.owner,
+              },
+              action.token
+            )
+            .then(() => {
+              storageService
+                .lockLookUp(action.update)
+                .then(results => {
+                  dispatch(setLockName(action.update, results.data.name))
+                })
+                .catch(error => {
+                  dispatch(storageError(error))
+                })
+            })
+            .catch(error => {
+              dispatch(storageError(error))
+            })
+
+          break
+      }
+      next(action)
+    }
+  }
+}

--- a/unlock-app/src/reducers/locksReducer.js
+++ b/unlock-app/src/reducers/locksReducer.js
@@ -9,6 +9,7 @@ import {
 import { DELETE_TRANSACTION } from '../actions/transaction'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
+import { SET_LOCK_NAME } from '../actions/storage'
 
 export const initialState = {}
 
@@ -112,6 +113,17 @@ const locksReducer = (state = initialState, action) => {
   ) {
     const { [action.transaction.lock]: lockToRemove, ...otherLocks } = state
     return otherLocks
+  }
+
+  if (action.type === SET_LOCK_NAME) {
+    if (action.address && action.name) {
+      return {
+        ...state,
+        [action.address]: Object.assign(state[action.address], {
+          name: action.name,
+        }),
+      }
+    }
   }
 
   return state

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -1,0 +1,35 @@
+import axios from 'axios'
+
+export default class StorageService {
+  constructor(host) {
+    this.HOST = host
+  }
+
+  genAuthorizationHeader = token => {
+    return { Authorization: ` Bearer ${token}` }
+  }
+
+  lockLookUp(address) {
+    return axios.get(`${this.HOST}/lock/${address}`)
+  }
+
+  storeLockDetails(lock, token) {
+    if (token) {
+      return axios.post(`${this.HOST}/lock`, lock, {
+        headers: this.genAuthorizationHeader(token),
+      })
+    } else {
+      return axios.post(`${this.HOST}/lock`, lock)
+    }
+  }
+
+  updateLockDetails(address, update, token) {
+    if (token) {
+      return axios.put(`${this.HOST}/lock/${address}`, update, {
+        headers: this.genAuthorizationHeader(token),
+      })
+    } else {
+      return axios.put(`${this.HOST}/lock/${address}`, update)
+    }
+  }
+}

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -728,4 +728,11 @@ export default class Web3Service extends EventEmitter {
       }
     )
   }
+
+  /*
+   *  Signs data for the given account
+   */
+  signData(account, data, callback) {
+    this.web3.eth.sign(data, account, callback)
+  }
 }

--- a/unlock-app/src/utils/signature.js
+++ b/unlock-app/src/utils/signature.js
@@ -1,0 +1,21 @@
+var jwt = require('jsonwebtoken')
+
+export default function generateJWTToken(web3Service, address, data) {
+  let payload = jwt.sign(data, null, {
+    algorithm: 'none',
+    issuer: address,
+    expiresIn: '3s',
+  })
+
+  payload = payload.substring(0, payload.length - 1)
+
+  return new Promise((resolve, reject) => {
+    web3Service.signData(address, payload, (error, signature) => {
+      if (signature) {
+        resolve(`${payload}.${signature}`)
+      } else {
+        reject(error)
+      }
+    })
+  })
+}


### PR DESCRIPTION
Integration introducing locksmith the unlock application

This pull request represents the second half of our integration work and should ideally be merged in after Locksmith has made its way into the larger code base 

If/when the configuration details for the storage are not present unlock-app will not send or request data from Locksmith

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
