### PR TITLE
make preview snippet button open in new tab

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -30361,6 +30361,7 @@ Object {
           <a
             class="c4 c5"
             href="/demo/0xa62142888aba8370742be823c1782d17a0389da1"
+            target="_blank"
             title="Preview lock"
           >
             <svg
@@ -30439,6 +30440,7 @@ Object {
         <a
           class="sc-850ddk-0 iWrhly"
           href="/demo/0xa62142888aba8370742be823c1782d17a0389da1"
+          target="_blank"
           title="Preview lock"
         >
           <svg

--- a/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
+++ b/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
@@ -76,4 +76,4 @@ const CodeSnippet = styled.textarea`
   font-weight: 300;
   color: var(--darkgrey);
   min-height: 170px;
-`~
+`

--- a/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
+++ b/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
@@ -28,7 +28,7 @@ export function EmbedCodeSnippet({ lock }) {
         <CopyToClipboard text={embedCode(lock)}>
           <Buttons.Copy as="button" />
         </CopyToClipboard>
-        <Buttons.Preview lock={lock} />
+        <Buttons.Preview lock={lock} target="_blank" />
       </Actions>
     </CodeControls>
   )
@@ -76,4 +76,4 @@ const CodeSnippet = styled.textarea`
   font-weight: 300;
   color: var(--darkgrey);
   min-height: 170px;
-`
+`~


### PR DESCRIPTION
# Description

The preview lock button now opens a new tab.

![opens in new tab](https://user-images.githubusercontent.com/98250/50695993-42ed2300-100c-11e9-9be7-ba2f5e3ea7d0.gif)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
