### PR TITLE
Appending '&& cd ../tests && npm ci' to postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start-ganache": "ganache-cli -i 1984 --mnemonic 'hello unlock save the web'",
-    "postinstall": "cd smart-contracts && npm ci && cd ../unlock-app && npm ci",
+    "postinstall": "cd smart-contracts && npm ci && cd ../unlock-app && npm ci && cd ../tests && npm ci",
     "deploy-lock": "cd smart-contracts && npm run deploy",
     "build": "cd smart-contracts && npm run build && cd ../unlock-app && npm run build",
     "start": "cd unlock-app && npm run start",


### PR DESCRIPTION
# Description

Adds `&& cd ../tests && npm ci` to `postinstall` so that the `/tests` directory is covered
Fixes #899

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
