### PR TITLE
enable auto-building of paywall where we need it

### DIFF
--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -77,11 +77,11 @@
   },
   "engineStrict": true,
   "scripts": {
-    "dev": "npm run setup-dev && npm run set-link && nodemon src/server.js",
+    "dev": "npm run build-paywall && npm run setup-dev && npm run set-link && nodemon src/server.js",
     "set-link": "run-script-os",
     "set-link:darwin:freebsd:linux:sunos": "pushd src && (test -e artifacts && rm -f artifacts) && ln -s ../../smart-contracts/build artifacts",
     "set-link:win32": "cd src && if exist artifacts (rmdir artifacts /q /s || del artifacts) && cmd /c mklink /d artifacts ..\\..\\smart-contracts\\build",
-    "build": "next build src",
+    "build": "npm run build-paywall && next build src",
     "build-paywall": "NODE_ENV=production rollup -c rollup.paywall.config.js -o ./src/static/paywall.min.js",
     "deploy": "next export src",
     "start": "next start src",


### PR DESCRIPTION
# Description

This is the last config change needed to make paywall building seamless. By enabling it in both npm run dev and npm run build.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
