### PR TITLE
disable scroll when paywall is active

### DIFF
--- a/unlock-app/src/__tests__/paywall-builder/build.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/build.test.js
@@ -101,14 +101,9 @@ describe('buildPaywall', () => {
         callbacks.message({ data: 'unlocked' })
         callbacks.message({ data: 'unlocked' })
 
-<<<<<<< HEAD
-        expect(mockHide).toHaveBeenCalledWith('iframe')
+        expect(mockHide).toHaveBeenCalledWith('iframe', document)
         expect(mockHide).toHaveBeenCalledTimes(1)
         expect(mockShow).toHaveBeenCalledTimes(1)
-=======
-        expect(mockHide).toHaveBeenCalledWith('iframe', document)
-        expect(mockShow).not.toHaveBeenCalled()
->>>>>>> disable scroll when paywall is active
       })
     })
   })

--- a/unlock-app/src/__tests__/paywall-builder/build.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/build.test.js
@@ -86,7 +86,7 @@ describe('buildPaywall', () => {
       it('triggers show on locked event', () => {
         callbacks.message({ data: 'locked' })
 
-        expect(mockShow).toHaveBeenCalledWith('iframe')
+        expect(mockShow).toHaveBeenCalledWith('iframe', document)
         expect(mockHide).not.toHaveBeenCalled()
       })
       it('does not trigger show on locked event if already unlocked', () => {
@@ -101,9 +101,14 @@ describe('buildPaywall', () => {
         callbacks.message({ data: 'unlocked' })
         callbacks.message({ data: 'unlocked' })
 
+<<<<<<< HEAD
         expect(mockHide).toHaveBeenCalledWith('iframe')
         expect(mockHide).toHaveBeenCalledTimes(1)
         expect(mockShow).toHaveBeenCalledTimes(1)
+=======
+        expect(mockHide).toHaveBeenCalledWith('iframe', document)
+        expect(mockShow).not.toHaveBeenCalled()
+>>>>>>> disable scroll when paywall is active
       })
     })
   })

--- a/unlock-app/src/__tests__/paywall-builder/iframe.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/iframe.test.js
@@ -34,7 +34,8 @@ describe('iframe', () => {
     it('adds iframe if not present', () => {
       const document = {
         body: {
-          appendChild: jest.fn(),
+          insertAdjacentElement: jest.fn(),
+          style: {},
         },
         querySelector() {
           return false
@@ -42,7 +43,10 @@ describe('iframe', () => {
       }
       add(document, 'hi')
 
-      expect(document.body.appendChild).toHaveBeenCalledWith('hi')
+      expect(document.body.insertAdjacentElement).toHaveBeenCalledWith(
+        'afterbegin',
+        'hi'
+      )
     })
     it('ignores add if present', () => {
       const document = {
@@ -63,11 +67,20 @@ describe('iframe', () => {
     const iframe = {
       style: {},
     }
+    const document = {
+      body: {
+        style: {},
+      },
+    }
 
-    show(iframe)
+    show(iframe, document)
     expect(iframe.style).toEqual({
       display: 'block',
       'z-index': '2147483647',
+    })
+
+    expect(document.body.style).toEqual({
+      overflow: 'hidden',
     })
   })
 
@@ -75,11 +88,20 @@ describe('iframe', () => {
     const iframe = {
       style: {},
     }
-    hide(iframe)
+    const document = {
+      body: {
+        style: { overflow: 'hidden' },
+      },
+    }
+    hide(iframe, document)
 
     expect(iframe.style).toEqual({
       backgroundColor: 'transparent',
       backgroundImage: 'none',
+    })
+
+    expect(document.body.style).toEqual({
+      overflow: '',
     })
   })
 })

--- a/unlock-app/src/paywall-builder/build.js
+++ b/unlock-app/src/paywall-builder/build.js
@@ -18,11 +18,11 @@ export default function buildPaywall(window, document, lockAddress) {
     event => {
       if (event.data === 'locked' && !locked) {
         locked = true
-        show(iframe)
+        show(iframe, document)
       }
       if (event.data === 'unlocked' && locked) {
         locked = false
-        hide(iframe)
+        hide(iframe, document)
       }
     },
     false

--- a/unlock-app/src/paywall-builder/iframe.js
+++ b/unlock-app/src/paywall-builder/iframe.js
@@ -21,19 +21,19 @@ export function getIframe(document, src) {
 
 export function add(document, iframe) {
   if (document.querySelector('iframe[data-unlock]')) return false
-  // TODO use insertAdjacentElement, requires changing the way messages are passed, but this will put the iframe on top of locked content
-  // document.body.insertAdjacentElement('afterbegin', iframe)
+  document.body.insertAdjacentElement('afterbegin', iframe)
 
-  document.body.appendChild(iframe)
   return iframe
 }
 
-export function show(iframe) {
+export function show(iframe, document) {
+  document.body.style.overflow = 'hidden'
   iframe.style.display = 'block'
   iframe.style['z-index'] = '2147483647'
 }
 
-export function hide(iframe) {
+export function hide(iframe, document) {
+  document.body.style.overflow = ''
   iframe.style.backgroundColor = 'transparent'
   iframe.style.backgroundImage = 'none'
 }


### PR DESCRIPTION
# Description

Fixes #913 by inserting the paywall on top of content and then disabling overflow on body. Caveat: on mobile safari this solution may not work, I don't have an iphone with which to test it.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
