### PR TITLE
replace NoSSR with BrowserOnly

### DIFF
--- a/unlock-app/src/__tests__/components/helpers/BrowserOnly.test.js
+++ b/unlock-app/src/__tests__/components/helpers/BrowserOnly.test.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import ReactDOMServer from 'react-dom/server'
+import * as rtl from 'react-testing-library'
+import BrowserOnly from '../../../components/helpers/BrowserOnly'
+
+describe('BrowserOnly', () => {
+  const tester = (
+    <BrowserOnly>
+      <div>first</div>
+      <div>second</div>
+    </BrowserOnly>
+  )
+  it('renders children in the browser', () => {
+    const element = rtl.render(tester)
+    expect(element.queryByText('first')).not.toBeNull()
+    expect(element.queryByText('second')).not.toBeNull()
+  })
+  it('does not render children on the server', () => {
+    const output = ReactDOMServer.renderToStaticMarkup(tester)
+    expect(output).toBe('')
+  })
+})

--- a/unlock-app/src/components/developer/DeveloperOverlay.js
+++ b/unlock-app/src/components/developer/DeveloperOverlay.js
@@ -1,19 +1,19 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import NoSSR from 'react-no-ssr'
 import styled from 'styled-components'
 import { func } from 'prop-types'
 
 import UnlockPropTypes from '../../propTypes'
 import { setProvider } from '../../actions/provider'
 import withConfig from '../../utils/withConfig'
+import BrowserOnly from '../helpers/BrowserOnly'
 
 export function DeveloperOverlay({ config, selected, setProvider }) {
   const providers = Object.keys(config.providers)
   if (config.env !== 'dev') return null
 
   return (
-    <NoSSR>
+    <BrowserOnly>
       <Overlay>
         <Inner>
           <select
@@ -31,7 +31,7 @@ export function DeveloperOverlay({ config, selected, setProvider }) {
           <div>Choose Provider</div>
         </Inner>
       </Overlay>
-    </NoSSR>
+    </BrowserOnly>
   )
 }
 

--- a/unlock-app/src/components/helpers/BrowserOnly.js
+++ b/unlock-app/src/components/helpers/BrowserOnly.js
@@ -1,0 +1,27 @@
+import { Component } from 'react'
+import PropTypes from 'prop-types'
+
+export default class BrowserOnly extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  }
+  constructor(props) {
+    super(props)
+    this.state = {
+      show: false,
+    }
+  }
+
+  componentDidMount() {
+    this.setState({ show: true })
+  }
+
+  render() {
+    const { show } = this.state
+
+    if (!show) return null
+
+    const { children } = this.props
+    return children
+  }
+}

--- a/unlock-app/src/pages/dashboard.js
+++ b/unlock-app/src/pages/dashboard.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import NoSSR from 'react-no-ssr'
 import Head from 'next/head'
 import UnlockPropTypes from '../propTypes'
 import Layout from '../components/interface/Layout'
 import CreatorAccount from '../components/creator/CreatorAccount'
 import CreatorLocks from '../components/creator/CreatorLocks'
 import DeveloperOverlay from '../components/developer/DeveloperOverlay'
+import BrowserOnly from '../components/helpers/BrowserOnly'
 import withConfig from '../utils/withConfig'
 import { pageTitle } from '../constants'
 
@@ -16,11 +16,11 @@ export const Dashboard = ({ account, network, locks }) => {
       <Head>
         <title>{pageTitle('Dashboard')}</title>
       </Head>
-      <NoSSR>
+      <BrowserOnly>
         <CreatorAccount network={network} account={account} />
         <CreatorLocks locks={locks} />
         <DeveloperOverlay />
-      </NoSSR>
+      </BrowserOnly>
     </Layout>
   )
 }

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -1,20 +1,20 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import NoSSR from 'react-no-ssr'
 import UnlockPropTypes from '../propTypes'
 import Overlay from '../components/lock/Overlay'
 import DeveloperOverlay from '../components/developer/DeveloperOverlay'
 import ShowUnlessUserHasKeyToAnyLock from '../components/lock/ShowUnlessUserHasKeyToAnyLock'
 import { LOCK_PATH_NAME_REGEXP } from '../constants'
+import BrowserOnly from '../components/helpers/BrowserOnly'
 
 const Paywall = ({ lock }) => {
   return (
-    <NoSSR>
+    <BrowserOnly>
       <ShowUnlessUserHasKeyToAnyLock locks={lock ? [lock] : []}>
         <Overlay locks={lock ? [lock] : []} />
         <DeveloperOverlay />
       </ShowUnlessUserHasKeyToAnyLock>
-    </NoSSR>
+    </BrowserOnly>
   )
 }
 

--- a/unlock-app/src/pages/provider.js
+++ b/unlock-app/src/pages/provider.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import NoSSR from 'react-no-ssr'
 import Link from 'next/link'
 import Head from 'next/head'
 import { connect } from 'react-redux'
@@ -9,6 +8,7 @@ import UnlockPropTypes from '../propTypes'
 import { setProvider } from '../actions/provider'
 import withConfig from '../utils/withConfig'
 import { pageTitle } from '../constants'
+import BrowserOnly from '../components/helpers/BrowserOnly'
 
 export function Web3Provider({ setProvider, config, provider }) {
   return (
@@ -16,7 +16,7 @@ export function Web3Provider({ setProvider, config, provider }) {
       <Head>
         <title>{pageTitle('Pick Web3 Provider')}</title>
       </Head>
-      <NoSSR>
+      <BrowserOnly>
         <div>
           <p>Pick web3 provider:</p>
           <select
@@ -37,7 +37,7 @@ export function Web3Provider({ setProvider, config, provider }) {
             <a>Return</a>
           </Link>
         </p>
-      </NoSSR>
+      </BrowserOnly>
     </Layout>
   )
 }
@@ -68,9 +68,9 @@ const Page = withConfig(
 )
 
 const ProviderPage = pageProps => (
-  <NoSSR>
+  <BrowserOnly>
     <Page {...pageProps} />
-  </NoSSR>
+  </BrowserOnly>
 )
 
 export default ProviderPage

--- a/unlock-app/src/pages/staticdemo.js
+++ b/unlock-app/src/pages/staticdemo.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import Head from 'next/head'
 import { connect } from 'react-redux'
-import NoSSR from 'react-no-ssr'
 import styled, { createGlobalStyle } from 'styled-components'
 import PropTypes from 'prop-types'
 import UnlockPropTypes from '../propTypes'
@@ -11,6 +10,7 @@ import DeveloperOverlay from '../components/developer/DeveloperOverlay'
 import ShowUnlessUserHasKeyToAnyLock from '../components/lock/ShowUnlessUserHasKeyToAnyLock'
 import { LOCK_PATH_NAME_REGEXP } from '../constants'
 import Media from '../theme/media'
+import BrowserOnly from '../components/helpers/BrowserOnly'
 
 const Demo = ({ lock, locks }) => {
   return (
@@ -71,7 +71,7 @@ const Demo = ({ lock, locks }) => {
         </Body>
       </Content>
       <Right />
-      <NoSSR>
+      <BrowserOnly>
         <div
           style={{
             position: 'fixed',
@@ -88,7 +88,7 @@ const Demo = ({ lock, locks }) => {
             <DeveloperOverlay />
           </ShowUnlessUserHasKeyToAnyLock>
         </div>
-      </NoSSR>
+      </BrowserOnly>
     </Container>
   )
 }


### PR DESCRIPTION
# Description

This replaces the NoSSR dep, which is 3 years out of date, with a simple internal component, `BrowserOnly`

This is in my opinion a more intuitive name for new users than "NoSSR"

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
