### PR TITLE
Adding the missing command to use cache on docker builds

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -14,4 +14,4 @@ if [ "$IMAGE_CACHE" != "" ]; then
  ARGS="$ARGS --cache-from $IMAGE_CACHE"
 fi
 
-docker build -t $IMAGE_NAME -f $DOCKERFILE $REPO_ROOT
+docker build -t $IMAGE_NAME -f $DOCKERFILE $ARGS $REPO_ROOT


### PR DESCRIPTION
Not sure what happened here but for some reason we are not using the cached image :/
:facepalm:


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread