### PR TITLE
Moved dependencies to dev because they are not needed for build

### DIFF
--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -17,12 +17,9 @@
     "eslint": "^5.7.0",
     "ethereumjs-units": "^0.2.0",
     "openzeppelin-eth": "^2.0.2",
-    "shelljs": "^0.8.3",
     "truffle": "^4.1.14",
     "truffle-contract": "^3.0.6",
-    "web3-utils": "^1.0.0-beta.36",
-    "zos": "^v2.1.0-rc.0",
-    "zos-lib": "^2.0.2"
+    "web3-utils": "^1.0.0-beta.36"
   },
   "devDependencies": {
     "eslint-config-standard": "^12.0.0",
@@ -33,7 +30,10 @@
     "eslint-plugin-standard": "^4.0.0",
     "remix-ide": "^0.7.5",
     "remixd": "^0.1.8-alpha.6",
-    "solhint": "^1.4.0"
+    "shelljs": "^0.8.3",
+    "solhint": "^1.4.0",
+    "zos": "^v2.1.0-rc.0",
+    "zos-lib": "^2.0.2"
   },
   "scripts": {
     "remix": "remixd -s contracts --remix-ide http://localhost:8080 --read-only",


### PR DESCRIPTION
The rule of thumb to add dependencies vs. devDependencies is whether they are required to build or
compile the project.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread