### PR TITLE
use our custom server, not next start

### DIFF
--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -82,7 +82,7 @@
     "build": "npm run build-paywall && next build src",
     "build-paywall": "NODE_ENV=production rollup -c rollup.paywall.config.js -o ./src/static/paywall.min.js",
     "deploy": "next export src",
-    "start": "next start src",
+    "start": "NODE_ENV=production node src/server.js",
     "setup-dev": "run-script-os",
     "setup-dev:darwin:freebsd:linux:sunos": "cd .. && (npm run start-ganache -- -b 3 &) && npm run deploy-lock",
     "setup-dev:win32": "cd .. && (START /b npm run start-ganache -- -b 3 ) && npm run deploy-lock",


### PR DESCRIPTION
# Description

Due to the need to use our custom server (defined in src/server.js and src/_server.js), we can't use npm start. This will break any pages with parameters, specifically demo.js and paywall.js.

The only thing to check is whether I am correct in assuming that npm start is intended to run the production version of the server or not.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
