### PR TITLE
Added env shim to travis.ci for Locksmith DB  details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: generic
 env:
-  - DB_USERNAME='locksmith_test'
-  - DB_PASSWORD='password'
-  - DB_NAME='locksmith_test'
-  - DB_HOSTNAME='db'
+  global:
+    - DB_USERNAME='locksmith_test'
+    - DB_PASSWORD='password'
+    - DB_NAME='locksmith_test'
+    - DB_HOSTNAME='db'
 services:
   - docker
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: generic
+env:
+  - DB_USERNAME='locksmith_test'
+  - DB_PASSWORD='password'
+  - DB_NAME='locksmith_test'
+  - DB_HOSTNAME='db'
 services:
   - docker
 before_script:

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -11,9 +11,9 @@ services:
     expose:
       - 5432
     environment:
-      POSTGRES_USER: "locksmith_test"
-      POSTGRES_PASSWORD: "password" 
-      POSTGRES_DB: "locksmith_test"     
+      POSTGRES_USER: "${DB_USERNAME}"
+      POSTGRES_PASSWORD: "${DB_PASSWORD}" 
+      POSTGRES_DB: "${DB_NAME}"     
   unlock:
     image: unlock
     user: node


### PR DESCRIPTION
GH forks are unable to access Travis env variables but they can set their own via the `.travis.yml`.  The docker compose file has been updated to start the test postgres instance with matching credentials

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
