### PR TITLE
Waiting for document.body before processing locks

### DIFF
--- a/unlock-app/src/paywall-builder/index.js
+++ b/unlock-app/src/paywall-builder/index.js
@@ -1,4 +1,5 @@
 import { listenForNewLocks } from './mutationobserver'
 import buildPaywall from './build'
 
-listenForNewLocks(lock => buildPaywall(window, document, lock), document.head)
+window.onload = () =>
+  listenForNewLocks(lock => buildPaywall(window, document, lock), document.head)


### PR DESCRIPTION
# Description

Fixes #945 

It turns out that `document.body` isn't guaranteed to exist if Metamask isn't present (although interestingly, it's populated if it is). So the script fails out if we haven't waited for the page to load, because at the time we discover new locks, the page body might not exist. This waits until we have a populated page. The paywall works again in a blockchain-incapable browser.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

