### PR TITLE
Implement error meta-reducer and adjust Error component for displaying errors

### DIFF
--- a/unlock-app/.storybook/addons.js
+++ b/unlock-app/.storybook/addons.js
@@ -1,1 +1,2 @@
 import '@storybook/addon-knobs/register'
+import '@storybook/addon-actions/register'

--- a/unlock-app/src/__tests__/actions/error.test.js
+++ b/unlock-app/src/__tests__/actions/error.test.js
@@ -1,15 +1,40 @@
-import React from 'react'
-import { setError, SET_ERROR } from '../../actions/error'
+import { setError, web3Error, SET_ERROR } from '../../actions/error'
 
 describe('error actions', () => {
   it('should create an action to set the error', () => {
     const error = {
-      message: <p>This is not right</p>,
+      message: 'This is not right',
     }
     const expectedAction = {
       type: SET_ERROR,
       error,
     }
+
     expect(setError(error)).toEqual(expectedAction)
+  })
+
+  it('should format an error message correctly if passed as a string', () => {
+    const error = 'This is not right'
+    const expectedAction = {
+      type: SET_ERROR,
+      error: {
+        message: error,
+      },
+    }
+
+    expect(setError(error)).toEqual(expectedAction)
+  })
+
+  it('should create an action for web3Service errors', () => {
+    const error = 'the blockchain exploded'
+    const expectedAction = {
+      type: SET_ERROR,
+      error: {
+        message: error,
+        context: 'web3',
+      },
+    }
+
+    expect(web3Error(error)).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/__tests__/actions/error.test.js
+++ b/unlock-app/src/__tests__/actions/error.test.js
@@ -1,4 +1,4 @@
-import { setError, web3Error, SET_ERROR } from '../../actions/error'
+import { setError, SET_ERROR } from '../../actions/error'
 
 describe('error actions', () => {
   it('should create an action to set the error', () => {
@@ -23,18 +23,5 @@ describe('error actions', () => {
     }
 
     expect(setError(error)).toEqual(expectedAction)
-  })
-
-  it('should create an action for web3Service errors', () => {
-    const error = 'the blockchain exploded'
-    const expectedAction = {
-      type: SET_ERROR,
-      error: {
-        message: error,
-        context: 'web3',
-      },
-    }
-
-    expect(web3Error(error)).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/__tests__/actions/error.test.js
+++ b/unlock-app/src/__tests__/actions/error.test.js
@@ -1,27 +1,37 @@
-import { setError, SET_ERROR } from '../../actions/error'
+import {
+  setError,
+  SET_ERROR,
+  RESET_ERROR,
+  resetError,
+} from '../../actions/error'
 
 describe('error actions', () => {
   it('should create an action to set the error', () => {
-    const error = {
-      message: 'This is not right',
-    }
+    const error = 'This is not right'
+    const context = 'context'
     const expectedAction = {
       type: SET_ERROR,
+      error: { error, context },
+    }
+
+    expect(setError({ error, context })).toEqual(expectedAction)
+  })
+
+  it('should create an action to reset errors', () => {
+    const error = { message: 'error', context: 'context' }
+    const expectedAction = {
+      type: RESET_ERROR,
       error,
     }
 
-    expect(setError(error)).toEqual(expectedAction)
+    expect(resetError(error)).toEqual(expectedAction)
   })
 
-  it('should format an error message correctly if passed as a string', () => {
-    const error = 'This is not right'
+  it('should create an action with empty error to reset all errors', () => {
     const expectedAction = {
-      type: SET_ERROR,
-      error: {
-        message: error,
-      },
+      type: RESET_ERROR,
+      error: undefined,
     }
-
-    expect(setError(error)).toEqual(expectedAction)
+    expect(resetError()).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
@@ -88,6 +88,8 @@ describe('LockIconBar', () => {
     expect(
       wrapper.queryByText('Confirming Withdrawal', { exact: false })
     ).not.toBeNull()
-    expect(wrapper.queryByText('2/12', { exact: false })).not.toBeNull()
+    expect(
+      wrapper.queryByText(`2/${config.requiredConfirmations}`, { exact: false })
+    ).not.toBeNull()
   })
 })

--- a/unlock-app/src/__tests__/components/interface/Error.test.js
+++ b/unlock-app/src/__tests__/components/interface/Error.test.js
@@ -35,8 +35,10 @@ describe('Error Component', () => {
 
   describe('the the component has an error message', () => {
     it('should display the content of the children', () => {
-      const message = <p>There was an error.</p>
-      const wrapper = rtl.render(<Error close={close} error={message} />)
+      const error = {
+        message: 'There was an error.',
+      }
+      const wrapper = rtl.render(<Error close={close} error={error} />)
       expect(wrapper.queryByText('There was an error.')).not.toBeNull()
     })
   })

--- a/unlock-app/src/__tests__/components/interface/Error.test.js
+++ b/unlock-app/src/__tests__/components/interface/Error.test.js
@@ -2,44 +2,82 @@ import React from 'react'
 import * as rtl from 'react-testing-library'
 import 'jest-dom/extend-expect'
 
-import { Error } from '../../../components/interface/Error'
+import { Error, Errors } from '../../../components/interface/Error'
 
 const close = jest.fn()
 
 afterEach(rtl.cleanup)
-describe('Error Component', () => {
-  describe('when the component has no children or no message', () => {
-    it('should not render anything', () => {
-      const wrapper = rtl.render(<Error close={close} />)
-      expect(wrapper.container.firstChild).toBeNull()
+describe('Errors', () => {
+  describe('Errors Component', () => {
+    const manyErrors = [
+      {
+        message: 'The blockchain may have made your head explode',
+        context: 'Is too sexy',
+      },
+      {
+        message: 'Secondary error',
+        context: 'Thing',
+      },
+    ]
+    let wrapper, close
+    beforeEach(() => {
+      close = jest.fn()
+      wrapper = rtl.render(<Errors errors={manyErrors} close={close} />)
+    })
+    it('should clear all errors on clicking CLose All', () => {
+      rtl.fireEvent.click(wrapper.getByTitle('Close All'))
+
+      expect(close).toHaveBeenCalledWith(null)
+    })
+    it('should clear a specific error when clicking the close button of that error', () => {
+      rtl.fireEvent.click(
+        wrapper.getByTitle(
+          'dismiss "The blockchain may have made your head explode" error'
+        )
+      )
+
+      expect(close).toHaveBeenCalledWith(manyErrors[0])
+    })
+    it('should render as many errors as there are in the error array plus 1 for the close all button', () => {
+      rtl.fireEvent.click(wrapper.getByTitle('dismiss "Secondary error" error'))
+
+      expect(close).toHaveBeenCalledWith(manyErrors[1])
     })
   })
-
-  describe('when the component has a children', () => {
-    it('should display the content of the children', () => {
-      const wrapper = rtl.render(
-        <Error close={close}>There was an error.</Error>
-      )
-      expect(wrapper.queryByText('There was an error.')).not.toBeNull()
+  describe('Error Sub-component', () => {
+    describe('when the component has no children or no message', () => {
+      it('should not render anything', () => {
+        const wrapper = rtl.render(<Error close={close} />)
+        expect(wrapper.container.firstChild).toBeNull()
+      })
     })
 
-    it('should dispatch a setError element when clicking on the close icon', () => {
-      const close = jest.fn()
-      const wrapper = rtl.render(
-        <Error close={close}>There was an error.</Error>
-      )
-      rtl.fireEvent.click(wrapper.getByTitle(/close/i))
-      expect(close).toHaveBeenCalledTimes(1)
-    })
-  })
+    describe('when the component has a children', () => {
+      it('should display the content of the children', () => {
+        const wrapper = rtl.render(
+          <Error close={close}>There was an error.</Error>
+        )
+        expect(wrapper.queryByText('There was an error.')).not.toBeNull()
+      })
 
-  describe('the the component has an error message', () => {
-    it('should display the content of the children', () => {
-      const error = {
-        message: 'There was an error.',
-      }
-      const wrapper = rtl.render(<Error close={close} error={error} />)
-      expect(wrapper.queryByText('There was an error.')).not.toBeNull()
+      it('should dispatch a setError element when clicking on the close icon', () => {
+        const close = jest.fn()
+        const wrapper = rtl.render(
+          <Error close={close}>There was an error.</Error>
+        )
+        rtl.fireEvent.click(wrapper.getByTitle(/close/i))
+        expect(close).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('the the component has an error message', () => {
+      it('should display the content of the children', () => {
+        const error = {
+          message: 'There was an error.',
+        }
+        const wrapper = rtl.render(<Error close={close} error={error} />)
+        expect(wrapper.queryByText('There was an error.')).not.toBeNull()
+      })
     })
   })
 })

--- a/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
@@ -340,7 +340,7 @@ describe('Lock middleware', () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       setError({
         message: 'this was broken',
-        context: 'Web3',
+        context: 'Web3 error: this was broken',
         originalError: { message: 'this was broken', code: 1 },
       })
     )

--- a/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
@@ -13,7 +13,7 @@ import { SET_ACCOUNT, UPDATE_ACCOUNT } from '../../actions/accounts'
 import { SET_NETWORK } from '../../actions/network'
 import { SET_PROVIDER } from '../../actions/provider'
 import { ADD_TRANSACTION, UPDATE_TRANSACTION } from '../../actions/transaction'
-import { SET_ERROR } from '../../actions/error'
+import { setError } from '../../actions/error'
 
 /**
  * Fake state
@@ -336,11 +336,12 @@ describe('Lock middleware', () => {
 
   it('it should handle error events triggered by the web3Service', () => {
     const { store } = create()
-    mockWeb3Service.emit('error', { message: 'this was broken' })
+    mockWeb3Service.emit('error', { message: 'this was broken', code: 1 })
     expect(store.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: SET_ERROR,
-        error: expect.anything(), // not sure how to test against jsx
+      setError({
+        message: 'this was broken',
+        context: 'Web3',
+        originalError: { message: 'this was broken', code: 1 },
       })
     )
   })

--- a/unlock-app/src/__tests__/reducers/errorConditionsReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/errorConditionsReducer.test.js
@@ -1,0 +1,128 @@
+import { addLock, updateLock } from '../../actions/lock'
+import errorsReducer from '../../reducers/errorConditionsReducer'
+import { setError } from '../../actions/error'
+import { addKey, updateKey } from '../../actions/key'
+
+describe('error conditions reducer', () => {
+  let next
+  let reducer
+
+  beforeEach(() => {
+    next = jest.fn()
+    reducer = errorsReducer(next)
+  })
+  it('should set error if ADD_LOCK has a mismatch', () => {
+    reducer(undefined, addLock('0xdeadbeef', { address: '0x04h0h0h0' }))
+    expect(next).toHaveBeenCalledWith(
+      undefined,
+      setError({
+        message: 'Mismatch in lock address',
+        context: 'Lock: 0x04h0h0h0, Action: 0xdeadbeef',
+      })
+    )
+  })
+
+  it('should set an error if ADD_LOCK for an existing lock', () => {
+    const state = {
+      locks: {
+        '0xdeadbeef': {},
+      },
+    }
+
+    reducer(state, addLock('0xdeadbeef', { address: '0xdeadbeef' }))
+
+    expect(next).toHaveBeenCalledWith(
+      state,
+      setError({
+        message: 'Lock already exists',
+        context: 'Lock: 0xdeadbeef',
+      })
+    )
+  })
+
+  it('should set an error if UPDATE_LOCK is called and the lock to be updated does not match action address', () => {
+    reducer(undefined, updateLock('0xdeadbeef', { address: '0x04h0h0h0' }))
+
+    expect(next).toHaveBeenCalledWith(
+      undefined,
+      setError({
+        message: 'Could not change the lock address',
+        context: 'Action: 0xdeadbeef, Update: 0x04h0h0h0',
+      })
+    )
+  })
+
+  it('should set an error if UPDATE_LOCK is called on a non-existing lock', () => {
+    const state = {
+      locks: {},
+    }
+
+    reducer(state, updateLock('0xdeadbeef', { address: '0xdeadbeef' }))
+
+    expect(next).toHaveBeenCalledWith(
+      state,
+      setError({
+        message: 'Could not update missing lock',
+        context: 'Address: 0xdeadbeef',
+      })
+    )
+  })
+
+  it('should set an error if ADD_KEY is called with non-matching ids', () => {
+    reducer(undefined, addKey('0xdeadbeef', { id: '0x04h0h0h0' }))
+
+    expect(next).toHaveBeenCalledWith(
+      undefined,
+      setError({
+        message: 'Could not add key with wrong id',
+        context: 'Key: 0x04h0h0h0, Action: 0xdeadbeef',
+      })
+    )
+  })
+
+  it('should set an error if ADD_KEY is called with an existing key id', () => {
+    const state = {
+      keys: {
+        '0xdeadbeef': {},
+      },
+    }
+
+    reducer(state, addKey('0xdeadbeef', { id: '0xdeadbeef' }))
+
+    expect(next).toHaveBeenCalledWith(
+      state,
+      setError({
+        message: 'Could not add already existing key',
+        context: 'Key: 0xdeadbeef',
+      })
+    )
+  })
+
+  it('should set an error if UPDATE_KEY is called with non-matching ids', () => {
+    reducer(undefined, updateKey('0xdeadbeef', { id: '0x04h0h0h0' }))
+
+    expect(next).toHaveBeenCalledWith(
+      undefined,
+      setError({
+        message: 'Could not change the key id',
+        context: 'Key: 0xdeadbeef, Id: 0x04h0h0h0',
+      })
+    )
+  })
+
+  it('should set an error if UPDATE_KEY is called on a non-existing key', () => {
+    const state = {
+      keys: {},
+    }
+
+    reducer(state, updateKey('0xdeadbeef', { id: '0xdeadbeef' }))
+
+    expect(next).toHaveBeenCalledWith(
+      state,
+      setError({
+        message: 'Could not update missing key',
+        context: 'Key: 0xdeadbeef',
+      })
+    )
+  })
+})

--- a/unlock-app/src/__tests__/reducers/errorReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/errorReducer.test.js
@@ -1,47 +1,45 @@
-import reducer from '../../reducers/errorReducer'
-import { SET_ERROR } from '../../actions/error'
+import reducer, { initialState } from '../../reducers/errorReducer'
+import { setError, resetError } from '../../actions/error'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
 
 describe('error reducer', () => {
-  const error = 'Something was wrong'
+  const action = setError({ message: 'hi', context: 'there' })
+  const error = action.error
+  const error2 = setError({ message: 'two', context: 'hi' }).error
 
   it('should return the initial state', () => {
-    expect(reducer(undefined, {})).toEqual(null)
+    expect(reducer(undefined, {})).toEqual([])
   })
 
   it('should return the initial state when receveing SET_PROVIDER', () => {
     expect(
-      reducer(
-        {
-          error,
-        },
-        {
-          type: SET_PROVIDER,
-        }
-      )
-    ).toEqual(null)
+      reducer([error], {
+        type: SET_PROVIDER,
+      })
+    ).toEqual([])
   })
 
   it('should return the initial state when receveing SET_NETWORK', () => {
     expect(
-      reducer(
-        {
-          error,
-        },
-        {
-          type: SET_NETWORK,
-        }
-      )
-    ).toEqual(null)
+      reducer([error], {
+        type: SET_NETWORK,
+      })
+    ).toEqual([])
   })
 
   it('should set the error accordingly when receiving SET_ERROR', () => {
-    expect(
-      reducer(undefined, {
-        type: SET_ERROR,
-        error,
-      })
-    ).toEqual(error)
+    expect(reducer(undefined, action)).toEqual([error])
+  })
+
+  it('should reset all errors if RESET_ERROR with no specific error received', () => {
+    expect(reducer([1, 2], resetError())).toBe(initialState)
+  })
+
+  it('should reset only a specific error if RESET_ERROR is called with that error', () => {
+    const startState = [error, error2]
+
+    expect(reducer(startState, resetError(error))).toEqual([error2])
+    expect(reducer(startState, resetError(error2))).toEqual([error])
   })
 })

--- a/unlock-app/src/__tests__/reducers/errorReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/errorReducer.test.js
@@ -1,11 +1,10 @@
-import React from 'react'
 import reducer from '../../reducers/errorReducer'
 import { SET_ERROR } from '../../actions/error'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
 
 describe('error reducer', () => {
-  const error = <p>Something was wrong</p>
+  const error = 'Something was wrong'
 
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual(null)

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -19912,12 +19912,10 @@ Object {
 }
 
 .c5 .c2:nth-child(1) {
-  grid-row: 0;
   pointer-events: none;
 }
 
 .c5 .c2:nth-child(2) {
-  grid-row: 1;
   pointer-events: none;
   display: none;
 }
@@ -20159,12 +20157,10 @@ Object {
 }
 
 .c5 .c2:nth-child(1) {
-  grid-row: 0;
   pointer-events: none;
 }
 
 .c5 .c2:nth-child(2) {
-  grid-row: 1;
   pointer-events: none;
   display: none;
 }
@@ -20397,21 +20393,11 @@ Object {
   align-self: center;
 }
 
-<<<<<<< HEAD
-.c4 .c1:nth-child(1) {
-  pointer-events: none;
-}
-
-.c4 .c1:nth-child(2) {
-=======
 .c5 .c2:nth-child(1) {
-  grid-row: 0;
   pointer-events: none;
 }
 
 .c5 .c2:nth-child(2) {
-  grid-row: 1;
->>>>>>> more work on error reform
   pointer-events: none;
   display: none;
 }
@@ -20656,21 +20642,11 @@ Object {
   align-self: center;
 }
 
-<<<<<<< HEAD
-.c4 .c1:nth-child(1) {
-  pointer-events: none;
-}
-
-.c4 .c1:nth-child(2) {
-=======
 .c5 .c2:nth-child(1) {
-  grid-row: 0;
   pointer-events: none;
 }
 
 .c5 .c2:nth-child(2) {
-  grid-row: 1;
->>>>>>> more work on error reform
   pointer-events: none;
   display: none;
 }

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -19867,11 +19867,11 @@ Object {
 }
 `;
 
-exports[`Storyshots Error Error with Markup 1`] = `
+exports[`Storyshots Error Error from redux store (dev) 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c2 {
+    .c3 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -19882,25 +19882,25 @@ Object {
   border: 0;
 }
 
-.c2 > svg {
+.c3 > svg {
   fill: white;
   height: 16px;
   width: 16px;
 }
 
-.c2:hover {
+.c3:hover {
   background-color: var(--link);
 }
 
-.c2:hover > svg {
+.c3:hover > svg {
   fill: white;
 }
 
-.c1:hover .c3 {
+.c2:hover .c4 {
   display: grid;
 }
 
-.c4 .c1 {
+.c5 .c2 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -19911,34 +19911,59 @@ Object {
   align-self: center;
 }
 
-.c4 .c1:nth-child(1) {
+.c5 .c2:nth-child(1) {
+  grid-row: 0;
   pointer-events: none;
 }
 
-.c4 .c1:nth-child(2) {
+.c5 .c2:nth-child(2) {
+  grid-row: 1;
   pointer-events: none;
   display: none;
 }
 
-.c4 .c1 > svg {
+.c5 .c2 > svg {
   fill: var(--grey);
 }
 
-.c4 .c1:hover > svg {
+.c5 .c2:hover > svg {
   fill: var(--grey);
 }
 
-.c5 .c1 {
+.c6 .c2 {
   margin: 24px;
 }
 
-.c5 .c1 small {
+.c6 .c2 small {
   display: block;
   color: var(--grey);
   text-align: center;
   top: 5px;
   width: 100%;
   text-align: center;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 8px;
+}
+
+.c1 p.context {
+  color: red;
+  font-style: italic;
+  font-size: 14px;
+  margin-top: 0;
+}
+
+.c1 p.context::before {
+  content: 'Context:';
+  padding-right: 10px;
 }
 
 .c0 {
@@ -19972,18 +19997,20 @@ Object {
       <section
         class="c0"
       >
-        <p>
-          We could not process that transaction.
-           
-          <a
-            href="."
+        <div
+          class="c1"
+        >
+          <p>
+            The blockchain may have made your head explode
+          </p>
+          <p
+            class="context"
           >
-            Retry
-          </a>
-          .
-        </p>
+            Is too sexy
+          </p>
+        </div>
         <button
-          class="c1 c2"
+          class="c2 c3"
         >
           <svg
             viewBox="0 0 24 24"
@@ -20008,18 +20035,518 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-1jlw4h4-0 iuQwRB"
+      class="sc-1jlw4h4-1 jJUArm"
     >
-      <p>
-        We could not process that transaction.
-         
-        <a
-          href="."
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          The blockchain may have made your head explode
+        </p>
+        <p
+          class="context"
         >
-          Retry
-        </a>
-        .
-      </p>
+          Is too sexy
+        </p>
+      </div>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Error Error from redux store (production) 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c3 {
+  background-color: var(--grey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 16px;
+  width: 16px;
+  display: grid;
+  padding: 0;
+  border: 0;
+}
+
+.c3 > svg {
+  fill: white;
+  height: 16px;
+  width: 16px;
+}
+
+.c3:hover {
+  background-color: var(--link);
+}
+
+.c3:hover > svg {
+  fill: white;
+}
+
+.c2:hover .c4 {
+  display: grid;
+}
+
+.c5 .c2 {
+  background-color: var(--white);
+  -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  opacity: 1;
+  pointer-events: visible;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5 .c2:nth-child(1) {
+  grid-row: 0;
+  pointer-events: none;
+}
+
+.c5 .c2:nth-child(2) {
+  grid-row: 1;
+  pointer-events: none;
+  display: none;
+}
+
+.c5 .c2 > svg {
+  fill: var(--grey);
+}
+
+.c5 .c2:hover > svg {
+  fill: var(--grey);
+}
+
+.c6 .c2 {
+  margin: 24px;
+}
+
+.c6 .c2 small {
+  display: block;
+  color: var(--grey);
+  text-align: center;
+  top: 5px;
+  width: 100%;
+  text-align: center;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 8px;
+}
+
+.c1 p.context {
+  color: red;
+  font-style: italic;
+  font-size: 14px;
+  margin-top: 0;
+}
+
+.c1 p.context::before {
+  content: 'Context:';
+  padding-right: 10px;
+}
+
+.c0 {
+  grid-template-columns: 1fr 20px;
+  display: grid;
+  border: 1px solid var(--lightgrey);
+  border-radius: 4px;
+  font-size: 16px;
+  justify-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-right: 8px;
+  grid-gap: 8px;
+}
+
+.c0 a {
+  color: var(--red);
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+        rel="stylesheet"
+      />
+      <section
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            The blockchain may have made your head explode
+          </p>
+          
+        </div>
+        <button
+          class="c2 c3"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+      rel="stylesheet"
+    />
+    <section
+      class="sc-1jlw4h4-1 jJUArm"
+    >
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          The blockchain may have made your head explode
+        </p>
+        
+      </div>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Error Error with Markup 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c3 {
+  background-color: var(--grey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 16px;
+  width: 16px;
+  display: grid;
+  padding: 0;
+  border: 0;
+}
+
+.c3 > svg {
+  fill: white;
+  height: 16px;
+  width: 16px;
+}
+
+.c3:hover {
+  background-color: var(--link);
+}
+
+.c3:hover > svg {
+  fill: white;
+}
+
+.c2:hover .c4 {
+  display: grid;
+}
+
+.c5 .c2 {
+  background-color: var(--white);
+  -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  opacity: 1;
+  pointer-events: visible;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+<<<<<<< HEAD
+.c4 .c1:nth-child(1) {
+  pointer-events: none;
+}
+
+.c4 .c1:nth-child(2) {
+=======
+.c5 .c2:nth-child(1) {
+  grid-row: 0;
+  pointer-events: none;
+}
+
+.c5 .c2:nth-child(2) {
+  grid-row: 1;
+>>>>>>> more work on error reform
+  pointer-events: none;
+  display: none;
+}
+
+.c5 .c2 > svg {
+  fill: var(--grey);
+}
+
+.c5 .c2:hover > svg {
+  fill: var(--grey);
+}
+
+.c6 .c2 {
+  margin: 24px;
+}
+
+.c6 .c2 small {
+  display: block;
+  color: var(--grey);
+  text-align: center;
+  top: 5px;
+  width: 100%;
+  text-align: center;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 8px;
+}
+
+.c1 p.context {
+  color: red;
+  font-style: italic;
+  font-size: 14px;
+  margin-top: 0;
+}
+
+.c1 p.context::before {
+  content: 'Context:';
+  padding-right: 10px;
+}
+
+.c0 {
+  grid-template-columns: 1fr 20px;
+  display: grid;
+  border: 1px solid var(--lightgrey);
+  border-radius: 4px;
+  font-size: 16px;
+  justify-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-right: 8px;
+  grid-gap: 8px;
+}
+
+.c0 a {
+  color: var(--red);
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+        rel="stylesheet"
+      />
+      <section
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            We could not process that transaction.
+             
+            <a
+              href="."
+            >
+              Retry
+            </a>
+          </p>
+          
+        </div>
+        <button
+          class="c2 c3"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+      rel="stylesheet"
+    />
+    <section
+      class="sc-1jlw4h4-1 jJUArm"
+    >
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          We could not process that transaction.
+           
+          <a
+            href="."
+          >
+            Retry
+          </a>
+        </p>
+        
+      </div>
       <button
         class="sc-850ddk-0 hOXoMo"
       >
@@ -20089,7 +20616,7 @@ exports[`Storyshots Error Simple Error 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c2 {
+    .c3 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -20100,25 +20627,25 @@ Object {
   border: 0;
 }
 
-.c2 > svg {
+.c3 > svg {
   fill: white;
   height: 16px;
   width: 16px;
 }
 
-.c2:hover {
+.c3:hover {
   background-color: var(--link);
 }
 
-.c2:hover > svg {
+.c3:hover > svg {
   fill: white;
 }
 
-.c1:hover .c3 {
+.c2:hover .c4 {
   display: grid;
 }
 
-.c4 .c1 {
+.c5 .c2 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -20129,34 +20656,67 @@ Object {
   align-self: center;
 }
 
+<<<<<<< HEAD
 .c4 .c1:nth-child(1) {
   pointer-events: none;
 }
 
 .c4 .c1:nth-child(2) {
+=======
+.c5 .c2:nth-child(1) {
+  grid-row: 0;
+  pointer-events: none;
+}
+
+.c5 .c2:nth-child(2) {
+  grid-row: 1;
+>>>>>>> more work on error reform
   pointer-events: none;
   display: none;
 }
 
-.c4 .c1 > svg {
+.c5 .c2 > svg {
   fill: var(--grey);
 }
 
-.c4 .c1:hover > svg {
+.c5 .c2:hover > svg {
   fill: var(--grey);
 }
 
-.c5 .c1 {
+.c6 .c2 {
   margin: 24px;
 }
 
-.c5 .c1 small {
+.c6 .c2 small {
   display: block;
   color: var(--grey);
   text-align: center;
   top: 5px;
   width: 100%;
   text-align: center;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 8px;
+}
+
+.c1 p.context {
+  color: red;
+  font-style: italic;
+  font-size: 14px;
+  margin-top: 0;
+}
+
+.c1 p.context::before {
+  content: 'Context:';
+  padding-right: 10px;
 }
 
 .c0 {
@@ -20190,11 +20750,16 @@ Object {
       <section
         class="c0"
       >
-        <p>
-          We could not process that transaction.
-        </p>
+        <div
+          class="c1"
+        >
+          <p>
+            We could not process that transaction.
+          </p>
+          
+        </div>
         <button
-          class="c1 c2"
+          class="c2 c3"
         >
           <svg
             viewBox="0 0 24 24"
@@ -20219,11 +20784,16 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-1jlw4h4-0 iuQwRB"
+      class="sc-1jlw4h4-1 jJUArm"
     >
-      <p>
-        We could not process that transaction.
-      </p>
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          We could not process that transaction.
+        </p>
+        
+      </div>
       <button
         class="sc-850ddk-0 hOXoMo"
       >

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -20009,6 +20009,70 @@ Object {
         </div>
         <button
           class="c2 c3"
+          title="dismiss \\"The blockchain may have made your head explode\\" error"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+      <section
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            Secondary error
+          </p>
+          <p
+            class="context"
+          >
+            Thing
+          </p>
+        </div>
+        <button
+          class="c2 c3"
+          title="dismiss \\"Secondary error\\" error"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+      <section
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            Close all
+          </p>
+        </div>
+        <button
+          class="c2 c3"
+          title="Close All"
         >
           <svg
             viewBox="0 0 24 24"
@@ -20049,6 +20113,70 @@ Object {
       </div>
       <button
         class="sc-850ddk-0 hOXoMo"
+        title="dismiss \\"The blockchain may have made your head explode\\" error"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+    <section
+      class="sc-1jlw4h4-1 jJUArm"
+    >
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          Secondary error
+        </p>
+        <p
+          class="context"
+        >
+          Thing
+        </p>
+      </div>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+        title="dismiss \\"Secondary error\\" error"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+    <section
+      class="sc-1jlw4h4-1 jJUArm"
+    >
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          Close all
+        </p>
+      </div>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+        title="Close All"
       >
         <svg
           viewBox="0 0 24 24"
@@ -20246,10 +20374,68 @@ Object {
           <p>
             The blockchain may have made your head explode
           </p>
-          
         </div>
         <button
           class="c2 c3"
+          title="dismiss \\"The blockchain may have made your head explode\\" error"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+      <section
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            Secondary error
+          </p>
+        </div>
+        <button
+          class="c2 c3"
+          title="dismiss \\"Secondary error\\" error"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+      <section
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            Close all
+          </p>
+        </div>
+        <button
+          class="c2 c3"
+          title="Close All"
         >
           <svg
             viewBox="0 0 24 24"
@@ -20282,10 +20468,68 @@ Object {
         <p>
           The blockchain may have made your head explode
         </p>
-        
       </div>
       <button
         class="sc-850ddk-0 hOXoMo"
+        title="dismiss \\"The blockchain may have made your head explode\\" error"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+    <section
+      class="sc-1jlw4h4-1 jJUArm"
+    >
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          Secondary error
+        </p>
+      </div>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+        title="dismiss \\"Secondary error\\" error"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+    <section
+      class="sc-1jlw4h4-1 jJUArm"
+    >
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          Close all
+        </p>
+      </div>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+        title="Close All"
       >
         <svg
           viewBox="0 0 24 24"
@@ -20489,10 +20733,10 @@ Object {
               Retry
             </a>
           </p>
-          
         </div>
         <button
           class="c2 c3"
+          title="dismiss \\"We could not process that transaction., ,[object Object]\\" error"
         >
           <svg
             viewBox="0 0 24 24"
@@ -20531,10 +20775,446 @@ Object {
             Retry
           </a>
         </p>
-        
       </div>
       <button
         class="sc-850ddk-0 hOXoMo"
+        title="dismiss \\"We could not process that transaction., ,[object Object]\\" error"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Error Errors (no errors) 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+        rel="stylesheet"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+      rel="stylesheet"
+    />
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Error Errors 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c3 {
+  background-color: var(--grey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 16px;
+  width: 16px;
+  display: grid;
+  padding: 0;
+  border: 0;
+}
+
+.c3 > svg {
+  fill: white;
+  height: 16px;
+  width: 16px;
+}
+
+.c3:hover {
+  background-color: var(--link);
+}
+
+.c3:hover > svg {
+  fill: white;
+}
+
+.c2:hover .c4 {
+  display: grid;
+}
+
+.c5 .c2 {
+  background-color: var(--white);
+  -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  opacity: 1;
+  pointer-events: visible;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5 .c2:nth-child(1) {
+  pointer-events: none;
+}
+
+.c5 .c2:nth-child(2) {
+  pointer-events: none;
+  display: none;
+}
+
+.c5 .c2 > svg {
+  fill: var(--grey);
+}
+
+.c5 .c2:hover > svg {
+  fill: var(--grey);
+}
+
+.c6 .c2 {
+  margin: 24px;
+}
+
+.c6 .c2 small {
+  display: block;
+  color: var(--grey);
+  text-align: center;
+  top: 5px;
+  width: 100%;
+  text-align: center;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 8px;
+}
+
+.c1 p.context {
+  color: red;
+  font-style: italic;
+  font-size: 14px;
+  margin-top: 0;
+}
+
+.c1 p.context::before {
+  content: 'Context:';
+  padding-right: 10px;
+}
+
+.c0 {
+  grid-template-columns: 1fr 20px;
+  display: grid;
+  border: 1px solid var(--lightgrey);
+  border-radius: 4px;
+  font-size: 16px;
+  justify-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-right: 8px;
+  grid-gap: 8px;
+}
+
+.c0 a {
+  color: var(--red);
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+        rel="stylesheet"
+      />
+      <section
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            The blockchain may have made your head explode
+          </p>
+          <p
+            class="context"
+          >
+            Is too sexy
+          </p>
+        </div>
+        <button
+          class="c2 c3"
+          title="dismiss \\"The blockchain may have made your head explode\\" error"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+      <section
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            Secondary error
+          </p>
+          <p
+            class="context"
+          >
+            Thing
+          </p>
+        </div>
+        <button
+          class="c2 c3"
+          title="dismiss \\"Secondary error\\" error"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+      <section
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            Close all
+          </p>
+        </div>
+        <button
+          class="c2 c3"
+          title="Close All"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+      rel="stylesheet"
+    />
+    <section
+      class="sc-1jlw4h4-1 jJUArm"
+    >
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          The blockchain may have made your head explode
+        </p>
+        <p
+          class="context"
+        >
+          Is too sexy
+        </p>
+      </div>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+        title="dismiss \\"The blockchain may have made your head explode\\" error"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+    <section
+      class="sc-1jlw4h4-1 jJUArm"
+    >
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          Secondary error
+        </p>
+        <p
+          class="context"
+        >
+          Thing
+        </p>
+      </div>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+        title="dismiss \\"Secondary error\\" error"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+    <section
+      class="sc-1jlw4h4-1 jJUArm"
+    >
+      <div
+        class="sc-1jlw4h4-0 hYVayb"
+      >
+        <p>
+          Close all
+        </p>
+      </div>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+        title="Close All"
       >
         <svg
           viewBox="0 0 24 24"
@@ -20732,10 +21412,10 @@ Object {
           <p>
             We could not process that transaction.
           </p>
-          
         </div>
         <button
           class="c2 c3"
+          title="dismiss \\"We could not process that transaction.\\" error"
         >
           <svg
             viewBox="0 0 24 24"
@@ -20768,10 +21448,10 @@ Object {
         <p>
           We could not process that transaction.
         </p>
-        
       </div>
       <button
         class="sc-850ddk-0 hOXoMo"
+        title="dismiss \\"We could not process that transaction.\\" error"
       >
         <svg
           viewBox="0 0 24 24"

--- a/unlock-app/src/actions/error.js
+++ b/unlock-app/src/actions/error.js
@@ -1,16 +1,17 @@
 export const SET_ERROR = 'SET_ERROR'
+export const RESET_ERROR = 'RESET_ERROR'
 
 export const setError = error => ({
   type: SET_ERROR,
-  error: error.message
-    ? error
-    : {
-      message: error,
-    },
+  error:
+    !error || error.message
+      ? error
+      : {
+        message: error,
+      },
 })
 
-export const web3Error = error =>
-  setError({
-    message: error,
-    context: 'web3',
-  })
+export const resetError = id => ({
+  type: RESET_ERROR,
+  id,
+})

--- a/unlock-app/src/actions/error.js
+++ b/unlock-app/src/actions/error.js
@@ -2,5 +2,15 @@ export const SET_ERROR = 'SET_ERROR'
 
 export const setError = error => ({
   type: SET_ERROR,
-  error,
+  error: error.message
+    ? error
+    : {
+      message: error,
+    },
 })
+
+export const web3Error = error =>
+  setError({
+    message: error,
+    context: 'web3',
+  })

--- a/unlock-app/src/actions/error.js
+++ b/unlock-app/src/actions/error.js
@@ -3,15 +3,10 @@ export const RESET_ERROR = 'RESET_ERROR'
 
 export const setError = error => ({
   type: SET_ERROR,
-  error:
-    !error || error.message
-      ? error
-      : {
-        message: error,
-      },
+  error,
 })
 
-export const resetError = id => ({
+export const resetError = error => ({
   type: RESET_ERROR,
-  id,
+  error,
 })

--- a/unlock-app/src/components/interface/Error.js
+++ b/unlock-app/src/components/interface/Error.js
@@ -5,14 +5,23 @@ import styled from 'styled-components'
 import { setError } from '../../actions/error'
 import Buttons from './buttons/layout'
 
+const dev = process.env.NODE_ENV !== 'production'
+
 export const Error = ({ children, error, close }) => {
-  const content = children || error
+  const content = children || (error && error.message)
   if (!content) {
     return null
   }
   return (
     <Wrapper>
-      {content}
+      <ErrorInfo>
+        {dev && error && error.context ? (
+          <p className="context">{error.context}</p>
+        ) : (
+          ''
+        )}
+        <p>{content}</p>
+      </ErrorInfo>
       <Buttons.Close as="button" onClick={close} size="16px">
         X
       </Buttons.Close>
@@ -45,6 +54,20 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(Error)
+
+const ErrorInfo = styled.div`
+  display: flex;
+  flex-direction: row;
+  padding: 8px;
+  & p.context {
+    color: red;
+  }
+
+  & p.context::after {
+    content: ':';
+    padding-right: 10px;
+  }
+`
 
 const Wrapper = styled.section`
   grid-template-columns: 1fr 20px;

--- a/unlock-app/src/components/interface/Error.js
+++ b/unlock-app/src/components/interface/Error.js
@@ -13,12 +13,12 @@ export const Error = ({ children, error, close, dev }) => {
   return (
     <Wrapper>
       <ErrorInfo>
+        <p>{content}</p>
         {dev && error && error.context ? (
           <p className="context">{error.context}</p>
         ) : (
           ''
         )}
-        <p>{content}</p>
       </ErrorInfo>
       <Buttons.Close as="button" onClick={close} size="16px">
         X
@@ -43,7 +43,7 @@ Error.propTypes = {
     message: PropTypes.string.isRequired,
     context: PropTypes.string,
   }),
-  dev: PropTypes.string,
+  dev: PropTypes.bool,
   close: PropTypes.func.isRequired,
 }
 
@@ -60,14 +60,17 @@ export default connect(
 
 const ErrorInfo = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   padding: 8px;
   & p.context {
     color: red;
+    font-style: italic;
+    font-size: 14px;
+    margin-top: 0;
   }
 
-  & p.context::after {
-    content: ':';
+  & p.context::before {
+    content: 'Context:';
     padding-right: 10px;
   }
 `

--- a/unlock-app/src/components/interface/Error.js
+++ b/unlock-app/src/components/interface/Error.js
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { resetError } from '../../actions/error'
 import Buttons from './buttons/layout'
 
-export const Error = ({ children, error, close, dev }) => {
+export const Error = ({ children, error, close, dev, title }) => {
   const content = children || (error && error.message)
   const context = dev && error && error.context
   if (!content) {
@@ -17,29 +17,33 @@ export const Error = ({ children, error, close, dev }) => {
         <p>{content}</p>
         {context ? <p className="context">{context}</p> : null}
       </ErrorInfo>
-      <Buttons.Close as="button" onClick={() => close(error)} size="16px">
+      <Buttons.Close
+        as="button"
+        size="16px"
+        onClick={() => close(error)}
+        title={title || `dismiss "${content}" error`}
+      >
         X
       </Buttons.Close>
     </Wrapper>
   )
 }
 
-export const Errors = ({ errors, ...props }) => {
+export const Errors = ({ errors, close, ...props }) => {
   return (
     <>
       {errors.map((error, i) => (
-        <Error tabIndex={i} key={error} error={error} {...props} />
+        <Error
+          tabIndex={i}
+          key={error.message}
+          error={error}
+          close={close}
+          {...props}
+        />
       ))}
       {errors.length ? (
-        <Error>
-          <span
-            onKeypress={e => e.which === 13 && props.close()}
-            tabIndex={errors.length}
-            role="button"
-            onClick={props.close()}
-          >
-            Close all
-          </span>
+        <Error close={close} title="Close All">
+          Close all
         </Error>
       ) : null}
     </>
@@ -80,12 +84,14 @@ Error.propTypes = {
   }),
   dev: PropTypes.bool,
   close: PropTypes.func.isRequired,
+  title: PropTypes.string,
 }
 
 Error.defaultProps = {
   children: null,
   error: null,
   dev: process.env.NODE_ENV !== 'production',
+  title: '',
 }
 
 export default connect(

--- a/unlock-app/src/components/interface/Error.js
+++ b/unlock-app/src/components/interface/Error.js
@@ -5,9 +5,7 @@ import styled from 'styled-components'
 import { setError } from '../../actions/error'
 import Buttons from './buttons/layout'
 
-const dev = process.env.NODE_ENV !== 'production'
-
-export const Error = ({ children, error, close }) => {
+export const Error = ({ children, error, close, dev }) => {
   const content = children || (error && error.message)
   if (!content) {
     return null
@@ -41,13 +39,18 @@ const mapDispatchToProps = dispatch => ({
 
 Error.propTypes = {
   children: PropTypes.node,
-  error: PropTypes.node,
+  error: PropTypes.shape({
+    message: PropTypes.string.isRequired,
+    context: PropTypes.string,
+  }),
+  dev: PropTypes.string,
   close: PropTypes.func.isRequired,
 }
 
 Error.defaultProps = {
   children: null,
   error: null,
+  dev: process.env.NODE_ENV !== 'production',
 }
 
 export default connect(

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -55,7 +55,7 @@ export const createUnlockStore = (
     provider: providerReducer,
     transactions: transactionsReducer,
     currency: currencyReducer,
-    error: errorReducer,
+    errors: errorReducer,
   }
 
   // Cleanup the defaultState to remove all null values so that we do not overwrite existing

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -33,6 +33,8 @@ import modalReducer, {
   initialState as defaultModals,
 } from './reducers/modalsReducer'
 
+import errorConditionsReducer from './reducers/errorConditionsReducer'
+
 // Middlewares
 import lockMiddleware from './middlewares/lockMiddleware'
 import currencyConversionMiddleware from './middlewares/currencyConversionMiddleware'
@@ -74,7 +76,7 @@ export const createUnlockStore = (
       provider: defaultProvider,
       transactions: defaultTransactions,
       currency: defaultCurrency,
-      error: defaultError,
+      errors: defaultError,
     },
     {
       provider: Object.keys(config.providers)[0],
@@ -92,7 +94,7 @@ export const createUnlockStore = (
     global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 
   return createStore(
-    combineReducers(reducers),
+    errorConditionsReducer(combineReducers(reducers)),
     initialState,
     composeEnhancers(applyMiddleware(...middlewares))
   )

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -99,7 +99,7 @@ export default function lockMiddleware({ getState, dispatch }) {
   })
 
   web3Service.on('error', error => {
-    dispatch(setError(<p>{error.message}</p>))
+    dispatch(setError(error.message))
   })
 
   /**

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -1,6 +1,5 @@
 /* eslint no-console: 0 */ // TODO: remove me when this is clean
 
-import React from 'react'
 import { LOCATION_CHANGE } from 'react-router-redux'
 import {
   ADD_LOCK,

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -98,7 +98,13 @@ export default function lockMiddleware({ getState, dispatch }) {
   })
 
   web3Service.on('error', error => {
-    dispatch(setError(error.message))
+    dispatch(
+      setError({
+        message: error.message,
+        context: 'Web3',
+        originalError: error,
+      })
+    )
   })
 
   /**

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -101,7 +101,7 @@ export default function lockMiddleware({ getState, dispatch }) {
     dispatch(
       setError({
         message: error.message,
-        context: 'Web3',
+        context: `Web3 error: ${error.message}`,
         originalError: error,
       })
     )

--- a/unlock-app/src/reducers/errorConditionsReducer.js
+++ b/unlock-app/src/reducers/errorConditionsReducer.js
@@ -4,6 +4,7 @@ import { ADD_KEY, UPDATE_KEY } from '../actions/key'
 import { setError } from '../actions/error'
 
 const errorConditionsReducers = next => (state, action) => {
+  const nextState = next(state, action)
   if (action.type === ADD_LOCK) {
     if (action.lock.address && action.lock.address !== action.address) {
       return next(
@@ -93,7 +94,7 @@ const errorConditionsReducers = next => (state, action) => {
     }
   }
 
-  return next(state, action)
+  return next(nextState, action)
 }
 
 export default errorConditionsReducers

--- a/unlock-app/src/reducers/errorConditionsReducer.js
+++ b/unlock-app/src/reducers/errorConditionsReducer.js
@@ -1,0 +1,99 @@
+import { ADD_LOCK, UPDATE_LOCK } from '../actions/lock'
+import { ADD_KEY, UPDATE_KEY } from '../actions/key'
+
+import { setError } from '../actions/error'
+
+const errorConditionsReducers = next => (state, action) => {
+  if (action.type === ADD_LOCK) {
+    if (action.lock.address && action.lock.address !== action.address) {
+      return next(
+        state,
+        setError({
+          message: 'Mismatch in lock address',
+          context: `Lock: ${action.lock.address}, Action: ${action.address}`,
+        })
+      )
+    }
+
+    if (state.locks[action.address]) {
+      return next(
+        state,
+        setError({
+          message: 'Lock already exists',
+          context: `Lock: ${action.address}`,
+        })
+      )
+    }
+  } else if (action.type === UPDATE_LOCK) {
+    if (action.update.address && action.update.address !== action.address) {
+      return next(
+        state,
+        setError({
+          message: 'Could not change the lock address',
+          context: `Action: ${action.address}, Update: ${
+            action.update.address
+          }`,
+        })
+      )
+    }
+
+    if (!state[action.address]) {
+      return next(
+        state,
+        setError({
+          message: 'Could not update missing lock',
+          context: `Address: ${action.address}`,
+        })
+      )
+    }
+
+    return {
+      ...state,
+      [action.address]: Object.assign(state[action.address], action.update),
+    }
+  } else if (action.type === ADD_KEY) {
+    if (action.key.id && action.key.id !== action.id) {
+      return next(
+        state,
+        setError({
+          message: 'Could not add key with wrong id',
+          context: `Key: ${action.key.id}, Action: ${action.id}`,
+        })
+      )
+    }
+
+    if (state.keys[action.id]) {
+      return next(
+        state,
+        setError({
+          message: 'Could not add already existing key',
+          context: `Key: ${action.id}`,
+        })
+      )
+    }
+  } else if (action.type === UPDATE_KEY) {
+    if (action.update.id && action.update.id !== action.id) {
+      return next(
+        state,
+        setError({
+          message: 'Could not change the key id',
+          context: `Key: ${action.id}, Id: ${action.update.id}`,
+        })
+      )
+    }
+
+    if (!state[action.id]) {
+      return next(
+        state,
+        setError({
+          message: 'Could not update missing key',
+          context: `Key: ${action.id}`,
+        })
+      )
+    }
+  }
+
+  return next(state, action)
+}
+
+export default errorConditionsReducers

--- a/unlock-app/src/reducers/errorReducer.js
+++ b/unlock-app/src/reducers/errorReducer.js
@@ -1,8 +1,14 @@
-import { SET_ERROR } from '../actions/error'
+import { SET_ERROR, RESET_ERROR } from '../actions/error'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 
-export const initialState = null
+export const initialState = {}
+
+let errorKey = 0
+
+function nextKey() {
+  return errorKey++
+}
 
 const errorReducer = (state = initialState, action) => {
   if ([SET_PROVIDER, SET_NETWORK].indexOf(action.type) > -1) {
@@ -10,7 +16,20 @@ const errorReducer = (state = initialState, action) => {
   }
 
   if (action.type === SET_ERROR) {
-    return action.error
+    const next = nextKey()
+    return {
+      ...state,
+      [next]: {
+        id: next,
+        error: action.error,
+      },
+    }
+  }
+
+  if (action.type === RESET_ERROR) {
+    const nextState = { ...state }
+    delete nextState[action.id]
+    return nextState
   }
 
   return state

--- a/unlock-app/src/reducers/errorReducer.js
+++ b/unlock-app/src/reducers/errorReducer.js
@@ -2,13 +2,7 @@ import { SET_ERROR, RESET_ERROR } from '../actions/error'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 
-export const initialState = {}
-
-let errorKey = 0
-
-function nextKey() {
-  return errorKey++
-}
+export const initialState = []
 
 const errorReducer = (state = initialState, action) => {
   if ([SET_PROVIDER, SET_NETWORK].indexOf(action.type) > -1) {
@@ -16,19 +10,13 @@ const errorReducer = (state = initialState, action) => {
   }
 
   if (action.type === SET_ERROR) {
-    const next = nextKey()
-    return {
-      ...state,
-      [next]: {
-        id: next,
-        error: action.error,
-      },
-    }
+    return [...state, action.error]
   }
 
   if (action.type === RESET_ERROR) {
-    const nextState = { ...state }
-    delete nextState[action.id]
+    if (!action.error) return initialState
+    const nextState = [...state]
+    nextState.splice(nextState.indexOf(action.error), 1)
     return nextState
   }
 

--- a/unlock-app/src/stories/interface/Error.stories.js
+++ b/unlock-app/src/stories/interface/Error.stories.js
@@ -10,7 +10,7 @@ const close = () => {}
 const store = createUnlockStore({
   error: {
     message: 'The blockchain may have made your head explode',
-    context: 'awesomeness',
+    context: 'Context',
   },
 })
 
@@ -35,6 +35,9 @@ storiesOf('Error', module)
       </Error>
     )
   })
-  .add('Error from redux store', () => {
+  .add('Error from redux store (dev)', () => {
     return <ConnectedError close={close} />
+  })
+  .add('Error from redux store (production)', () => {
+    return <ConnectedError close={close} dev={false} />
   })

--- a/unlock-app/src/stories/interface/Error.stories.js
+++ b/unlock-app/src/stories/interface/Error.stories.js
@@ -10,28 +10,21 @@ const close = () => {}
 const store = createUnlockStore({
   error: {
     message: 'The blockchain may have made your head explode',
-    context: 'Context',
+    context: 'Is too sexy',
   },
 })
 
 storiesOf('Error', module)
   .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('Simple Error', () => {
-    return (
-      <Error close={close}>
-        <p>We could not process that transaction.</p>
-      </Error>
-    )
+    return <Error close={close}>We could not process that transaction.</Error>
   })
   .add('Error with Markup', () => {
     return (
       <Error close={close}>
-        <p>
-          We could not process that transaction. 
-          {' '}
-          <a href=".">Retry</a>
-.
-        </p>
+        We could not process that transaction. 
+        {' '}
+        <a href=".">Retry</a>
       </Error>
     )
   })

--- a/unlock-app/src/stories/interface/Error.stories.js
+++ b/unlock-app/src/stories/interface/Error.stories.js
@@ -1,11 +1,10 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
 import { Provider } from 'react-redux'
 import ConnectedError, { Error, Errors } from '../../components/interface/Error'
 
 import createUnlockStore from '../../createUnlockStore'
-
-const close = () => {}
 
 const manyErrors = [
   {
@@ -25,9 +24,11 @@ const store = createUnlockStore({
 storiesOf('Error', module)
   .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('Simple Error', () => {
+    const close = action('close')
     return <Error close={close}>We could not process that transaction.</Error>
   })
   .add('Error with Markup', () => {
+    const close = action('close')
     return (
       <Error close={close}>
         We could not process that transaction. 
@@ -37,14 +38,16 @@ storiesOf('Error', module)
     )
   })
   .add('Errors', () => {
+    const close = action('close')
     return <Errors close={close} errors={manyErrors} />
   })
   .add('Errors (no errors)', () => {
+    const close = action('close')
     return <Errors close={close} errors={[]} />
   })
   .add('Error from redux store (dev)', () => {
-    return <ConnectedError close={close} />
+    return <ConnectedError />
   })
   .add('Error from redux store (production)', () => {
-    return <ConnectedError close={close} dev={false} />
+    return <ConnectedError dev={false} />
   })

--- a/unlock-app/src/stories/interface/Error.stories.js
+++ b/unlock-app/src/stories/interface/Error.stories.js
@@ -1,10 +1,21 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Error } from '../../components/interface/Error'
+import { Provider } from 'react-redux'
+import ConnectedError, { Error } from '../../components/interface/Error'
+
+import createUnlockStore from '../../createUnlockStore'
 
 const close = () => {}
 
+const store = createUnlockStore({
+  error: {
+    message: 'The blockchain may have made your head explode',
+    context: 'awesomeness',
+  },
+})
+
 storiesOf('Error', module)
+  .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('Simple Error', () => {
     return (
       <Error close={close}>
@@ -23,4 +34,7 @@ storiesOf('Error', module)
         </p>
       </Error>
     )
+  })
+  .add('Error from redux store', () => {
+    return <ConnectedError close={close} />
   })

--- a/unlock-app/src/stories/interface/Error.stories.js
+++ b/unlock-app/src/stories/interface/Error.stories.js
@@ -1,17 +1,25 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Provider } from 'react-redux'
-import ConnectedError, { Error } from '../../components/interface/Error'
+import ConnectedError, { Error, Errors } from '../../components/interface/Error'
 
 import createUnlockStore from '../../createUnlockStore'
 
 const close = () => {}
 
-const store = createUnlockStore({
-  error: {
+const manyErrors = [
+  {
     message: 'The blockchain may have made your head explode',
     context: 'Is too sexy',
   },
+  {
+    message: 'Secondary error',
+    context: 'Thing',
+  },
+]
+
+const store = createUnlockStore({
+  errors: manyErrors,
 })
 
 storiesOf('Error', module)
@@ -27,6 +35,12 @@ storiesOf('Error', module)
         <a href=".">Retry</a>
       </Error>
     )
+  })
+  .add('Errors', () => {
+    return <Errors close={close} errors={manyErrors} />
+  })
+  .add('Errors (no errors)', () => {
+    return <Errors close={close} errors={[]} />
   })
   .add('Error from redux store (dev)', () => {
     return <ConnectedError close={close} />


### PR DESCRIPTION
# Description

This PR adds a meta-reducer to set error conditions when actions are sent. This also changes the Error component to allow displaying multiple error conditions, and adds a dismissal mechanism. It also adds error context, which is only displayed in development.

<img width="1677" alt="screen shot 2019-01-09 at 3 27 19 pm" src="https://user-images.githubusercontent.com/98250/50926474-16c60d80-1423-11e9-97bf-9a3df174a0f9.png">
<img width="1677" alt="screen shot 2019-01-09 at 3 27 13 pm" src="https://user-images.githubusercontent.com/98250/50926475-16c60d80-1423-11e9-9b6e-0d7df680673a.png">
<img width="1677" alt="screen shot 2019-01-09 at 3 27 05 pm" src="https://user-images.githubusercontent.com/98250/50926476-16c60d80-1423-11e9-9992-77a5b05159b9.png">
<img width="1677" alt="screen shot 2019-01-09 at 3 26 58 pm" src="https://user-images.githubusercontent.com/98250/50926477-16c60d80-1423-11e9-9df6-8cd0af37c683.png">

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
