### PR TITLE
remove conflicts between prettier and eslint

### DIFF
--- a/unlock-app/.eslintrc.js
+++ b/unlock-app/.eslintrc.js
@@ -5,6 +5,8 @@ module.exports = {
     'eslint:recommended',
     'plugin:react/recommended',
     'prettier',
+    'prettier/react',
+    'prettier/standard',
   ],
   env: {
     es6: true,
@@ -14,25 +16,22 @@ module.exports = {
   },
   plugins: ['mocha'],
   parser: 'babel-eslint',
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
   rules: {
-    'react/jsx-wrap-multilines': false,
     'react/prefer-stateless-function': [2],
-    indent: ['error', 2],
     'linebreak-style': ['error', 'unix'],
-    quotes: ['error', 'single'],
-    semi: ['error', 'never'],
-    'no-multiple-empty-lines': [
+    quotes: [
       'error',
-      {
-        max: 1,
-        maxEOF: 0,
-        maxBOF: 0,
-      },
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false },
     ],
     'brace-style': 0,
     'react/forbid-prop-types': 2,
-    'comma-dangle': [2, 'always-multiline'],
-    'eol-last': ['error'],
+    indent: 0, // this conflicts with prettier and is not needed
     'jsx-a11y/anchor-is-valid': [
       'error',
       {

--- a/unlock-app/.prettierrc
+++ b/unlock-app/.prettierrc
@@ -1,4 +1,5 @@
 {
   "trailingComma": "es5",
-  "singleQuote": true
+  "singleQuote": true,
+  "semi": false,
 }


### PR DESCRIPTION
# Description

eslint and prettier had some conflicts, which caused eslint to freak out when prettier reformatted some constructs. In particular, case constructs were always formatted incorrectly for eslint. This PR removes those conflicts based on the output of the `eslint-config-prettier-check` tool described at https://github.com/prettier/eslint-config-prettier#cli-helper-tool

Note that with these changes, there are some formatting changes in 26 files, which will be submitted as a follow-up PR.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
