### PR TITLE
Format repo with npm run reformat (followup to #971)

### DIFF
--- a/unlock-app/.eslintrc.js
+++ b/unlock-app/.eslintrc.js
@@ -5,6 +5,8 @@ module.exports = {
     'eslint:recommended',
     'plugin:react/recommended',
     'prettier',
+    'prettier/react',
+    'prettier/standard',
   ],
   env: {
     es6: true,
@@ -14,25 +16,22 @@ module.exports = {
   },
   plugins: ['mocha'],
   parser: 'babel-eslint',
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
   rules: {
-    'react/jsx-wrap-multilines': false,
     'react/prefer-stateless-function': [2],
-    indent: ['error', 2],
     'linebreak-style': ['error', 'unix'],
-    quotes: ['error', 'single'],
-    semi: ['error', 'never'],
-    'no-multiple-empty-lines': [
+    quotes: [
       'error',
-      {
-        max: 1,
-        maxEOF: 0,
-        maxBOF: 0,
-      },
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false },
     ],
     'brace-style': 0,
     'react/forbid-prop-types': 2,
-    'comma-dangle': [2, 'always-multiline'],
-    'eol-last': ['error'],
+    indent: 0, // this conflicts with prettier and is not needed
     'jsx-a11y/anchor-is-valid': [
       'error',
       {

--- a/unlock-app/.prettierrc
+++ b/unlock-app/.prettierrc
@@ -1,4 +1,5 @@
 {
   "trailingComma": "es5",
-  "singleQuote": true
+  "singleQuote": true,
+  "semi": false,
 }

--- a/unlock-app/src/__tests__/components/page/OpenGraphTags.test.js
+++ b/unlock-app/src/__tests__/components/page/OpenGraphTags.test.js
@@ -12,19 +12,19 @@ describe('OpenGraphTags', () => {
   it('should render open graph tags based on default values', () => {
     const tags = rtl.render(<OpenGraphTags />)
     expect(
-      tags.container.querySelector('meta[property=\'og:title\']').content
+      tags.container.querySelector("meta[property='og:title']").content
     ).toBe(pageTitle())
     expect(
-      tags.container.querySelector('meta[property=\'og:description\']').content
+      tags.container.querySelector("meta[property='og:description']").content
     ).toBe(PAGE_DESCRIPTION)
     expect(
-      tags.container.querySelector('meta[property=\'og:image\']').content
+      tags.container.querySelector("meta[property='og:image']").content
     ).toBe(PAGE_DEFAULT_IMAGE)
     expect(
-      tags.container.querySelector('meta[property=\'og:type\']').content
+      tags.container.querySelector("meta[property='og:type']").content
     ).toBe('website')
     expect(
-      tags.container.querySelector('meta[property=\'og:url\']').content
+      tags.container.querySelector("meta[property='og:url']").content
     ).toBe(CANONICAL_BASE_URL + '/')
   })
 
@@ -42,19 +42,19 @@ describe('OpenGraphTags', () => {
       />
     )
     expect(
-      tags.container.querySelector('meta[property=\'og:title\']').content
+      tags.container.querySelector("meta[property='og:title']").content
     ).toBe(title)
     expect(
-      tags.container.querySelector('meta[property=\'og:description\']').content
+      tags.container.querySelector("meta[property='og:description']").content
     ).toBe(description)
     expect(
-      tags.container.querySelector('meta[property=\'og:image\']').content
+      tags.container.querySelector("meta[property='og:image']").content
     ).toBe(image)
     expect(
-      tags.container.querySelector('meta[property=\'og:type\']').content
+      tags.container.querySelector("meta[property='og:type']").content
     ).toBe('website')
     expect(
-      tags.container.querySelector('meta[property=\'og:url\']').content
+      tags.container.querySelector("meta[property='og:url']").content
     ).toBe(CANONICAL_BASE_URL + path)
   })
 })

--- a/unlock-app/src/__tests__/components/page/TwitterTags.test.js
+++ b/unlock-app/src/__tests__/components/page/TwitterTags.test.js
@@ -11,13 +11,13 @@ describe('TwitterTags', () => {
   it('should render twitter tags based on default values', () => {
     const tags = rtl.render(<TwitterTags />)
     expect(
-      tags.container.querySelector('meta[name=\'twitter:title\']').content
+      tags.container.querySelector("meta[name='twitter:title']").content
     ).toBe(pageTitle())
     expect(
-      tags.container.querySelector('meta[name=\'twitter:description\']').content
+      tags.container.querySelector("meta[name='twitter:description']").content
     ).toBe(PAGE_DESCRIPTION)
     expect(
-      tags.container.querySelector('meta[name=\'twitter:image\']').content
+      tags.container.querySelector("meta[name='twitter:image']").content
     ).toBe(PAGE_DEFAULT_IMAGE)
   })
 
@@ -29,13 +29,13 @@ describe('TwitterTags', () => {
       <TwitterTags title={title} description={description} image={image} />
     )
     expect(
-      tags.container.querySelector('meta[name=\'twitter:title\']').content
+      tags.container.querySelector("meta[name='twitter:title']").content
     ).toBe(title)
     expect(
-      tags.container.querySelector('meta[name=\'twitter:description\']').content
+      tags.container.querySelector("meta[name='twitter:description']").content
     ).toBe(description)
     expect(
-      tags.container.querySelector('meta[name=\'twitter:image\']').content
+      tags.container.querySelector("meta[name='twitter:image']").content
     ).toBe(image)
   })
 })

--- a/unlock-app/src/__tests__/constants.js
+++ b/unlock-app/src/__tests__/constants.js
@@ -3,11 +3,11 @@ import { pageTitle } from '../constants'
 describe('constants', () => {
   describe('pageTitle', () => {
     it('should return title correctly with no subtitle', () => {
-      expect(pageTitle()).toBe('Unlock: The Web\'s new business model')
+      expect(pageTitle()).toBe("Unlock: The Web's new business model")
     })
     it('should return title correctly a subtitle', () => {
       expect(pageTitle('Foo')).toBe(
-        'Foo | Unlock: The Web\'s new business model'
+        "Foo | Unlock: The Web's new business model"
       )
     })
   })

--- a/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
@@ -43,7 +43,7 @@ describe('Currency conversion service retrieval middleware', () => {
       setConversionRate('USD', '198.20')
     )
   })
-  it('service called, values are the same, so don\'t dispatch', () => {
+  it("service called, values are the same, so don't dispatch", () => {
     jest.useFakeTimers()
     const middleware = require('../../middlewares/currencyConversionMiddleware')
       .default

--- a/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
@@ -392,7 +392,7 @@ describe('Lock middleware', () => {
     })
   })
 
-  it('should handle CREATE_LOCK by calling web3Service\'s createLock', () => {
+  it("should handle CREATE_LOCK by calling web3Service's createLock", () => {
     const { next, invoke, store } = create()
     const action = { type: CREATE_LOCK, lock }
     mockWeb3Service.createLock = jest.fn()
@@ -405,7 +405,7 @@ describe('Lock middleware', () => {
     expect(next).toHaveBeenCalledWith(action)
   })
 
-  it('should handle PURCHASE_KEY by calling web3Service\'s purchaseKey', () => {
+  it("should handle PURCHASE_KEY by calling web3Service's purchaseKey", () => {
     const { next, invoke } = create()
     const action = { type: PURCHASE_KEY, key }
     mockWeb3Service.purchaseKey = jest.fn()
@@ -421,7 +421,7 @@ describe('Lock middleware', () => {
     expect(next).toHaveBeenCalledWith(action)
   })
 
-  it('should handle LOCATION_CHANGE by calling web3Service\'s getLock', () => {
+  it("should handle LOCATION_CHANGE by calling web3Service's getLock", () => {
     const { next, invoke } = create()
     const action = {
       type: LOCATION_CHANGE,

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -4087,8 +4087,7 @@ Object {
               class="c5"
             >
               1.20
-               
-              ETH
+               ETH
             </div>
             <div
               class="c6"
@@ -4133,8 +4132,7 @@ Object {
             class="sc-1ws9jnj-3 cLmyvU"
           >
             1.20
-             
-            ETH
+             ETH
           </div>
           <div
             class="sc-1ws9jnj-3 DzGdM"
@@ -5039,8 +5037,7 @@ Object {
               >
                 with us
               </a>
-               
-              or simply
+               or simply
                
               <a
                 href="mailto:hello@unlock-protocol.com"
@@ -5642,8 +5639,7 @@ Object {
             >
               with us
             </a>
-             
-            or simply
+             or simply
              
             <a
               href="mailto:hello@unlock-protocol.com"
@@ -6485,8 +6481,7 @@ Object {
               >
                 with us
               </a>
-               
-              or simply
+               or simply
                
               <a
                 href="mailto:hello@unlock-protocol.com"
@@ -6865,8 +6860,7 @@ Object {
             >
               with us
             </a>
-             
-            or simply
+             or simply
              
             <a
               href="mailto:hello@unlock-protocol.com"
@@ -8078,8 +8072,7 @@ Object {
               >
                 with us
               </a>
-               
-              or simply
+               or simply
                
               <a
                 href="mailto:hello@unlock-protocol.com"
@@ -8895,8 +8888,7 @@ Object {
             >
               with us
             </a>
-             
-            or simply
+             or simply
              
             <a
               href="mailto:hello@unlock-protocol.com"
@@ -19973,8 +19965,7 @@ Object {
         class="c0"
       >
         <p>
-          We could not process that transaction.
-           
+          We could not process that transaction. 
           <a
             href="."
           >
@@ -20011,8 +20002,7 @@ Object {
       class="sc-1jlw4h4-0 iuQwRB"
     >
       <p>
-        We could not process that transaction.
-         
+        We could not process that transaction. 
         <a
           href="."
         >
@@ -26717,8 +26707,7 @@ Object {
             class="c3"
           >
             1.20
-             
-            Eth
+             Eth
           </div>
           <div
             class="c4"
@@ -26751,8 +26740,7 @@ Object {
           class="pehlmj-2 eKLwob"
         >
           1.20
-           
-          Eth
+           Eth
         </div>
         <div
           class="pehlmj-3 cblYxB"
@@ -26907,8 +26895,7 @@ Object {
             class="c3"
           >
             1.20
-             
-            Eth
+             Eth
           </div>
           <div
             class="c4"
@@ -26940,8 +26927,7 @@ Object {
           class="pehlmj-2 eKLwob"
         >
           1.20
-           
-          Eth
+           Eth
         </div>
         <div
           class="pehlmj-3 cblYxB"
@@ -27152,8 +27138,7 @@ Object {
               class="c5"
             >
               1.20
-               
-              ETH
+               ETH
             </div>
             <div
               class="c6"
@@ -27198,8 +27183,7 @@ Object {
             class="sc-1ws9jnj-3 cLmyvU"
           >
             1.20
-             
-            ETH
+             ETH
           </div>
           <div
             class="sc-1ws9jnj-3 DzGdM"
@@ -27737,8 +27721,7 @@ Object {
               class="c5"
             >
               1.20
-               
-              ETH
+               ETH
             </div>
             <div
               class="c6"
@@ -27779,8 +27762,7 @@ Object {
             class="sc-1ws9jnj-3 cLmyvU"
           >
             1.20
-             
-            ETH
+             ETH
           </div>
           <div
             class="sc-1ws9jnj-3 DzGdM"
@@ -27936,8 +27918,7 @@ Object {
             class="c3"
           >
             1.20
-             
-            Eth
+             Eth
           </div>
           <div
             class="c4"
@@ -27969,8 +27950,7 @@ Object {
           class="pehlmj-2 eKLwob"
         >
           1.20
-           
-          Eth
+           Eth
         </div>
         <div
           class="pehlmj-3 cblYxB"
@@ -29153,13 +29133,11 @@ Object {
           <strong>
             Pellentesque habitant morbi tristique
           </strong>
-           
-          senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
+           senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
           <em>
             Aenean ultricies mi vitae est.
           </em>
-           
-          Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+           Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
           <code>
             commodo vitae
           </code>
@@ -29169,8 +29147,7 @@ Object {
           >
             Donec non enim
           </a>
-           
-          in turpis pulvinar facilisis. Ut felis.
+           in turpis pulvinar facilisis. Ut felis.
         </p>
         <h2>
           Header Level 2
@@ -29228,8 +29205,7 @@ Object {
                     class="c7"
                   >
                     0.12
-                     
-                    Eth
+                     Eth
                   </div>
                   <div
                     class="c8"
@@ -29277,13 +29253,11 @@ Object {
         <strong>
           Pellentesque habitant morbi tristique
         </strong>
-         
-        senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
+         senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
         <em>
           Aenean ultricies mi vitae est.
         </em>
-         
-        Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+         Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
         <code>
           commodo vitae
         </code>
@@ -29293,8 +29267,7 @@ Object {
         >
           Donec non enim
         </a>
-         
-        in turpis pulvinar facilisis. Ut felis.
+         in turpis pulvinar facilisis. Ut felis.
       </p>
       <h2>
         Header Level 2
@@ -29352,8 +29325,7 @@ Object {
                   class="pehlmj-2 eKLwob"
                 >
                   0.12
-                   
-                  Eth
+                   Eth
                 </div>
                 <div
                   class="pehlmj-3 cblYxB"
@@ -29597,13 +29569,11 @@ Object {
           <strong>
             Pellentesque habitant morbi tristique
           </strong>
-           
-          senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
+           senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
           <em>
             Aenean ultricies mi vitae est.
           </em>
-           
-          Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+           Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
           <code>
             commodo vitae
           </code>
@@ -29613,8 +29583,7 @@ Object {
           >
             Donec non enim
           </a>
-           
-          in turpis pulvinar facilisis. Ut felis.
+           in turpis pulvinar facilisis. Ut felis.
         </p>
         <h2>
           Header Level 2
@@ -29672,8 +29641,7 @@ Object {
                     class="c7"
                   >
                     0.01
-                     
-                    Eth
+                     Eth
                   </div>
                   <div
                     class="c8"
@@ -29698,8 +29666,7 @@ Object {
                     class="c7"
                   >
                     0.1
-                     
-                    Eth
+                     Eth
                   </div>
                   <div
                     class="c8"
@@ -29747,13 +29714,11 @@ Object {
         <strong>
           Pellentesque habitant morbi tristique
         </strong>
-         
-        senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
+         senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
         <em>
           Aenean ultricies mi vitae est.
         </em>
-         
-        Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+         Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
         <code>
           commodo vitae
         </code>
@@ -29763,8 +29728,7 @@ Object {
         >
           Donec non enim
         </a>
-         
-        in turpis pulvinar facilisis. Ut felis.
+         in turpis pulvinar facilisis. Ut felis.
       </p>
       <h2>
         Header Level 2
@@ -29822,8 +29786,7 @@ Object {
                   class="pehlmj-2 eKLwob"
                 >
                   0.01
-                   
-                  Eth
+                   Eth
                 </div>
                 <div
                   class="pehlmj-3 cblYxB"
@@ -29848,8 +29811,7 @@ Object {
                   class="pehlmj-2 eKLwob"
                 >
                   0.1
-                   
-                  Eth
+                   Eth
                 </div>
                 <div
                   class="pehlmj-3 cblYxB"
@@ -30142,8 +30104,7 @@ Object {
               class="c5"
             >
               1.20
-               
-              ETH
+               ETH
             </div>
             <div
               class="c6"
@@ -30184,8 +30145,7 @@ Object {
             class="sc-1ws9jnj-3 cLmyvU"
           >
             1.20
-             
-            ETH
+             ETH
           </div>
           <div
             class="sc-1ws9jnj-3 DzGdM"

--- a/unlock-app/src/components/creator/CreatorAccount.js
+++ b/unlock-app/src/components/creator/CreatorAccount.js
@@ -35,7 +35,7 @@ export function CreatorAccount({ account, network }) {
         <Label>Balance</Label>
         <Label>Earning</Label>
         {/* reinstate upload / etherscan / download / export functionality when we're ready  */
-          enableTheseButtons ? (
+        enableTheseButtons ? (
           <>
             <DoubleHeightCell>
               <NoPhone>
@@ -58,15 +58,14 @@ export function CreatorAccount({ account, network }) {
               </NoPhone>
             </DoubleHeightCell>
           </>
-          ) : (
+        ) : (
           <>
             <DoubleHeightCell />
             <DoubleHeightCell />
             <DoubleHeightCell />
             <DoubleHeightCell />
           </>
-          )}
-        {' '}
+        )}{' '}
         {/* eslint-disable-line */
         /* prettier formats this as 12 spaces, eslint wants 10 :/ */}
         <Address>{account.address}</Address>

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -17,8 +17,8 @@ const LockKeysNumbers = ({ lock }) => (
     typeof lock.outstandingKeys !== 'undefined' &&
     typeof lock.maxNumberOfKeys !== 'undefined'
       ? `${lock.outstandingKeys}/${
-        lock.maxNumberOfKeys > 0 ? lock.maxNumberOfKeys : '∞'
-      }`
+          lock.maxNumberOfKeys > 0 ? lock.maxNumberOfKeys : '∞'
+        }`
       : ' - '}
   </LockKeys>
 )

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -127,8 +127,7 @@ class CreatorLockForm extends React.Component {
             name="expirationDuration"
             onChange={this.handleChange}
             defaultValue={expirationDuration}
-          />
-          {' '}
+          />{' '}
           days
         </FormLockDuration>
         <FormLockKeys>

--- a/unlock-app/src/components/creator/FatalError.js
+++ b/unlock-app/src/components/creator/FatalError.js
@@ -101,10 +101,8 @@ export const MissingProvider = () => (
   >
     <p>
       It looks like you’re using an incompatible browser or are missig a crypto
-      wallet. If you’re using Chrome or Firefox you can install
-      {' '}
-      <a href="https://metamask.io/">Metamask</a>
-.
+      wallet. If you’re using Chrome or Firefox you can install{' '}
+      <a href="https://metamask.io/">Metamask</a>.
     </p>
   </DefaultError>
 )

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -48,7 +48,7 @@ export function LockIconBar({
         {withdrawalTransaction &&
           withdrawalTransaction.status === 'submitted' && (
             <>Submitted to Network...</>
-        )}
+          )}
         {withdrawalTransaction &&
           withdrawalTransaction.status === 'mined' &&
           withdrawalTransaction.confirmations <
@@ -57,7 +57,7 @@ export function LockIconBar({
               Confirming Withdrawal {withdrawalTransaction.confirmations}/
               {config.requiredConfirmations}
             </>
-        )}
+          )}
       </SubStatus>
     </StatusBlock>
   )

--- a/unlock-app/src/components/interface/Header.js
+++ b/unlock-app/src/components/interface/Header.js
@@ -57,12 +57,12 @@ export default class Header extends React.PureComponent {
         <MobilePopover visibilityToggle={!!menu}>
           {menu
             ? navigationButtons.map(NavButton => (
-              <NavButton
-                key={NavButton}
-                size="48px"
-                onClick={this.toggleMenu}
-              />
-            ))
+                <NavButton
+                  key={NavButton}
+                  size="48px"
+                  onClick={this.toggleMenu}
+                />
+              ))
             : ''}
         </MobilePopover>
       </TopHeader>
@@ -91,7 +91,7 @@ const TopHeader = styled.header`
   ${Media.phone`
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: ${props =>
-    props.visibilityToggle ? '[first] auto [second]' : '[first]'} auto;
+      props.visibilityToggle ? '[first] auto [second]' : '[first]'} auto;
     height: auto;
   `};
 `

--- a/unlock-app/src/components/interface/Signature.js
+++ b/unlock-app/src/components/interface/Signature.js
@@ -4,17 +4,10 @@ import { Section, CallToAction } from '../Components'
 const Signature = () => (
   <Section>
     <CallToAction>
-      Check out our open source code on
-      {' '}
-      <a href="https://github.com/unlock-protocol/unlock">GitHub</a>
-, come work
-      {' '}
-      <a href="/jobs">with us</a>
-      {' '}
-or simply
-      {' '}
-      <a href="mailto:hello@unlock-protocol.com">get in touch</a>
-.
+      Check out our open source code on{' '}
+      <a href="https://github.com/unlock-protocol/unlock">GitHub</a>, come work{' '}
+      <a href="/jobs">with us</a> or simply{' '}
+      <a href="mailto:hello@unlock-protocol.com">get in touch</a>.
     </CallToAction>
   </Section>
 )

--- a/unlock-app/src/components/lock/ConfirmingKeyLock.js
+++ b/unlock-app/src/components/lock/ConfirmingKeyLock.js
@@ -19,24 +19,15 @@ export const ConfirmingKeyLock = ({ lock, transaction, config }) => (
       <TransactionStatus>
         Waiting for confirmation.
         <br />
-        {transaction.confirmations}
-/
-        {config.requiredConfirmations}
+        {transaction.confirmations}/{config.requiredConfirmations}
       </TransactionStatus>
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
           <>
             <LockDetails>
-              <LockDetail bold>
-                {ethPrice}
-                {' '}
-ETH
-              </LockDetail>
-              <LockDetail>
-$
-                {fiatPrice}
-              </LockDetail>
+              <LockDetail bold>{ethPrice} ETH</LockDetail>
+              <LockDetail>${fiatPrice}</LockDetail>
             </LockDetails>
           </>
         )}

--- a/unlock-app/src/components/lock/Lock.js
+++ b/unlock-app/src/components/lock/Lock.js
@@ -48,15 +48,8 @@ export const Lock = ({
           amount={lock.keyPrice}
           render={(ethPrice, fiatPrice) => (
             <LockBody>
-              <EthPrice>
-                {ethPrice}
-                {' '}
-Eth
-              </EthPrice>
-              <FiatPrice>
-$
-                {fiatPrice}
-              </FiatPrice>
+              <EthPrice>{ethPrice} Eth</EthPrice>
+              <FiatPrice>${fiatPrice}</FiatPrice>
             </LockBody>
           )}
         />

--- a/unlock-app/src/components/lock/PendingKeyLock.js
+++ b/unlock-app/src/components/lock/PendingKeyLock.js
@@ -22,15 +22,8 @@ export const PendingKeyLock = ({ lock }) => (
         render={(ethPrice, fiatPrice) => (
           <>
             <LockDetails>
-              <LockDetail bold>
-                {ethPrice}
-                {' '}
-ETH
-              </LockDetail>
-              <LockDetail>
-$
-                {fiatPrice}
-              </LockDetail>
+              <LockDetail bold>{ethPrice} ETH</LockDetail>
+              <LockDetail>${fiatPrice}</LockDetail>
             </LockDetails>
           </>
         )}

--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -20,7 +20,7 @@ export const ETHEREUM_NETWORKS_NAMES = {
 export const pageTitle = title => {
   let pageTitle = ''
   if (title) pageTitle += `${title} | `
-  return (pageTitle += 'Unlock: The Web\'s new business model')
+  return (pageTitle += "Unlock: The Web's new business model")
 }
 
 /**

--- a/unlock-app/src/pages/demo.js
+++ b/unlock-app/src/pages/demo.js
@@ -23,8 +23,7 @@ const Demo = ({ lock, domain }) => {
           <Title>Demoing the Unlock Paywall</Title>
           <Subtitle>
             Unlock Times shows off its new subscription paywall that’s easy to
-            use and streamlined for readers and publishers.
-            {' '}
+            use and streamlined for readers and publishers.{' '}
           </Subtitle>
           <Section>
             <Article>

--- a/unlock-app/src/pages/index.js
+++ b/unlock-app/src/pages/index.js
@@ -90,13 +90,13 @@ const ImageWithHover = styled.div`
   height: 200px;
   &:hover {
     background: url(${props =>
-    `/static/images/pages/png/${props.base}-hover.png`})
+        `/static/images/pages/png/${props.base}-hover.png`})
       no-repeat center/contain;
   }
   /* // Preload to avoid flickering effect */
   &:after {
     content: url(${props =>
-    `/static/images/pages/png/${props.base}-hover.png`});
+      `/static/images/pages/png/${props.base}-hover.png`});
     display: none;
   }
 `

--- a/unlock-app/src/pages/jobs.js
+++ b/unlock-app/src/pages/jobs.js
@@ -25,13 +25,13 @@ export const Jobs = () => (
       <TwitterTags
         title={pageTitle('Work at Unlock')}
         description={
-          'We\'re looking for world-class engineers who want to fix the Web forever.'
+          "We're looking for world-class engineers who want to fix the Web forever."
         }
       />
       <OpenGraphTags
         title={pageTitle('Work at Unlock')}
         description={
-          'We\'re looking for world-class engineers who want to fix the Web forever.'
+          "We're looking for world-class engineers who want to fix the Web forever."
         }
         canonicalPath="/jobs"
       />
@@ -56,8 +56,7 @@ export const Jobs = () => (
         <UnorderedList>
           <ListItem>
             Comprehensive health care (including dental and vision) for you,
-            100% paid by Unlock (75% for your dependents).
-            {' '}
+            100% paid by Unlock (75% for your dependents).{' '}
           </ListItem>
           <ListItem>Unlimited personal and vacation days.</ListItem>
           <ListItem>
@@ -66,8 +65,7 @@ export const Jobs = () => (
           <ListItem>
             Monthly wellness stipend that can be used for a gym membership,
             nutrition counseling, yoga or meditation classes, or any other
-            wellness activity of your choice.
-            {' '}
+            wellness activity of your choice.{' '}
           </ListItem>
           <ListItem>
             Your choice of technical setup (laptop, monitors and software
@@ -89,27 +87,23 @@ export const Jobs = () => (
       <ShortColumn>
         <OrderedList>
           <ListItem>
-            Initial chat conversation with our founder Julien (find him in our
-            {' '}
+            Initial chat conversation with our founder Julien (find him in our{' '}
             <a href="https://t.me/unlockprotocol">Telegram group</a>
             !).
           </ListItem>
           <ListItem>
             Open Source Bounty assignment: all of Unlock&#39;s code is public.
-            We&#39;ll ask you to submit a pull request for
-            {' '}
+            We&#39;ll ask you to submit a pull request for{' '}
             <a href="https://github.com/unlock-protocol/unlock/issues">
               one of the issues
-            </a>
-            {' '}
+            </a>{' '}
             which has a bounty (look for the
             <Gitcoin>
               <span role="img" aria-label="bounty">
                 💰
               </span>
               gitcoin
-            </Gitcoin>
-            {' '}
+            </Gitcoin>{' '}
             label).
           </ListItem>
           <ListItem>
@@ -135,12 +129,10 @@ export const Jobs = () => (
         <SubTitle>About You</SubTitle>
 
         <Paragraph>
-          Do you think that the web&#39;s
-          {' '}
+          Do you think that the web&#39;s{' '}
           <a href="https://www.theatlantic.com/technology/archive/2014/08/advertising-is-the-internets-original-sin/376041/">
             original sin
-          </a>
-          {' '}
+          </a>{' '}
           is its lack of business model? Do you think that individuals,
           democracies and the web, deserve better than click-bait, information
           overload and fake news?
@@ -238,13 +230,11 @@ export const Jobs = () => (
         <Title>Applications</Title>
         <Paragraph>
           If you are interested in applying for a position at Unlock, please
-          send an email containing your resume, Github, and LinkedIn to
-          {' '}
+          send an email containing your resume, Github, and LinkedIn to{' '}
           <a href="mailto:julien@unlock-protocol.com">
             julien@unlock-protocol.com
           </a>
-          , and reach out to Julien in our
-          {' '}
+          , and reach out to Julien in our{' '}
           <a href="https://t.me/unlockprotocol">Telegram group</a>
           !).
         </Paragraph>
@@ -258,12 +248,10 @@ export const Jobs = () => (
         <SubTitle>About You</SubTitle>
 
         <Paragraph>
-          Do you think that the web&#39;s
-          {' '}
+          Do you think that the web&#39;s{' '}
           <a href="https://www.theatlantic.com/technology/archive/2014/08/advertising-is-the-internets-original-sin/376041/">
             original sin
-          </a>
-          {' '}
+          </a>{' '}
           is its lack of business model? Do you think that individuals,
           democracies and the web, deserve better than click-bait, information
           overload and fake news?
@@ -325,8 +313,7 @@ export const Jobs = () => (
           <ListItem>2+ years of experience in software engineering</ListItem>
           <ListItem>
             Deep working knowledge/expertise with modern client side JavaScript
-            applications and frameworks (React, Redux, SASS...)
-            {' '}
+            applications and frameworks (React, Redux, SASS...){' '}
           </ListItem>
           <ListItem>
             Advanced knowledge of the web stack and standards (ES6/7, PWA...)

--- a/unlock-app/src/pages/staticdemo.js
+++ b/unlock-app/src/pages/staticdemo.js
@@ -26,8 +26,7 @@ const Demo = ({ lock, locks }) => {
           <Title>Demoing the Unlock Paywall</Title>
           <Subtitle>
             Unlock Times shows off its new subscription paywall that’s easy to
-            use and streamlined for readers and publishers.
-            {' '}
+            use and streamlined for readers and publishers.{' '}
           </Subtitle>
           <Section>
             <Article>

--- a/unlock-app/src/stories/interface/Error.stories.js
+++ b/unlock-app/src/stories/interface/Error.stories.js
@@ -16,10 +16,7 @@ storiesOf('Error', module)
     return (
       <Error close={close}>
         <p>
-          We could not process that transaction. 
-          {' '}
-          <a href=".">Retry</a>
-.
+          We could not process that transaction. <a href=".">Retry</a>.
         </p>
       </Error>
     )

--- a/unlock-app/src/stories/lock/Overlay.stories.js
+++ b/unlock-app/src/stories/lock/Overlay.stories.js
@@ -15,24 +15,17 @@ const render = locks => (
     <h1>HTML Ipsum Presents</h1>
 
     <p>
-      <strong>Pellentesque habitant morbi tristique</strong>
-      {' '}
-senectus et netus
+      <strong>Pellentesque habitant morbi tristique</strong> senectus et netus
       et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat
       vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet
       quam egestas semper.
-      <em>Aenean ultricies mi vitae est.</em>
-      {' '}
-Mauris placerat eleifend leo.
+      <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo.
       Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi,
       condimentum sed,
-      <code>commodo vitae</code>
-, ornare sit amet, wisi. Aenean fermentum, elit
+      <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit
       eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus
       enim ac dui.
-      <a href=".">Donec non enim</a>
-      {' '}
-in turpis pulvinar facilisis. Ut felis.
+      <a href=".">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.
     </p>
 
     <h2>Header Level 2</h2>

--- a/unlock-app/src/theme/media.js
+++ b/unlock-app/src/theme/media.js
@@ -28,10 +28,10 @@ sizes.nodesktop = {
 const Media = Object.keys(sizes).reduce((acc, label) => {
   acc[label] = (...args) => css`
     @media only screen and (min-device-width: ${sizes[label].min}px) ${sizes[
-  label
-].max
-  ? `and (max-device-width: ${sizes[label].max}px)`
-  : ''} {
+        label
+      ].max
+        ? `and (max-device-width: ${sizes[label].max}px)`
+        : ''} {
       ${css(...args)};
     }
   `


### PR DESCRIPTION
# Description

eslint and prettier had some conflicts, which caused eslint to freak out when prettier reformatted some constructs. In particular, case constructs were always formatted incorrectly for eslint. This PR removes those conflicts based on the output of the eslint-config-prettier-check tool described at https://github.com/prettier/eslint-config-prettier#cli-helper-tool

Note that with these changes, there are some formatting changes in 26 files.

The primary changes are:

- single quotes that require escaping like `'this thing\'s quote'` are now `"this thing's quote"`
- enforcement of every React thing being on its own line is removed, so many lines are smoother
- some indentation is changed that were conflicts between eslint and prettier, in `? :` and some arrow functions that are multi-line

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
