### PR TITLE
Generate jsx for errors from error metadata, with localization

### DIFF
--- a/unlock-app/src/__tests__/actions/error.test.js
+++ b/unlock-app/src/__tests__/actions/error.test.js
@@ -3,6 +3,9 @@ import {
   SET_ERROR,
   RESET_ERROR,
   resetError,
+  metadataError,
+  WEB3_ERROR,
+  web3Error,
 } from '../../actions/error'
 
 describe('error actions', () => {
@@ -32,5 +35,31 @@ describe('error actions', () => {
       error: undefined,
     }
     expect(resetError()).toEqual(expectedAction)
+  })
+
+  it('metadataError', () => {
+    const expectedAction = {
+      type: 'hi',
+      error: {
+        metadata: 'there',
+        type: 'hi',
+      },
+    }
+    expect(metadataError('there', 'hi')).toEqual(expectedAction)
+  })
+
+  it('web3Error', () => {
+    const expectedAction = {
+      type: WEB3_ERROR,
+      error: {
+        metadata: {
+          originalError: {
+            message: 'hi',
+          },
+        },
+        type: WEB3_ERROR,
+      },
+    }
+    expect(web3Error({ message: 'hi' })).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/__tests__/actions/error.test.js
+++ b/unlock-app/src/__tests__/actions/error.test.js
@@ -1,15 +1,36 @@
-import React from 'react'
-import { setError, SET_ERROR } from '../../actions/error'
+import {
+  setError,
+  SET_ERROR,
+  RESET_ERROR,
+  resetError,
+} from '../../actions/error'
 
 describe('error actions', () => {
   it('should create an action to set the error', () => {
-    const error = {
-      message: <p>This is not right</p>,
-    }
+    const error = 'This is not right'
     const expectedAction = {
       type: SET_ERROR,
       error,
     }
+
     expect(setError(error)).toEqual(expectedAction)
+  })
+
+  it('should create an action to reset errors', () => {
+    const error = 'error'
+    const expectedAction = {
+      type: RESET_ERROR,
+      error,
+    }
+
+    expect(resetError(error)).toEqual(expectedAction)
+  })
+
+  it('should create an action with empty error to reset all errors', () => {
+    const expectedAction = {
+      type: RESET_ERROR,
+      error: undefined,
+    }
+    expect(resetError()).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/__tests__/components/helpers/ErrorMapper.test.js
+++ b/unlock-app/src/__tests__/components/helpers/ErrorMapper.test.js
@@ -1,0 +1,20 @@
+import * as rtl from 'react-testing-library'
+import React from 'react'
+
+import { ErrorMapper } from '../../../components/helpers/ErrorMapper'
+import { web3Error } from '../../../actions/error'
+
+describe('ErrorMapper', () => {
+  it('maps web3 errors to the en error message', () => {
+    const error = web3Error({ message: 'error' }).error
+
+    const component = rtl.render(<ErrorMapper error={error} locale="en" />)
+    expect(component.queryByText('Web3 error: error')).not.toBeNull()
+  })
+  it('maps web3 errors to the fr error message', () => {
+    const error = web3Error({ message: 'error' }).error
+
+    const component = rtl.render(<ErrorMapper error={error} locale="fr" />)
+    expect(component.queryByText('Web3 erreur: error')).not.toBeNull()
+  })
+})

--- a/unlock-app/src/__tests__/components/interface/Error.test.js
+++ b/unlock-app/src/__tests__/components/interface/Error.test.js
@@ -3,6 +3,7 @@ import * as rtl from 'react-testing-library'
 import 'jest-dom/extend-expect'
 
 import { Error } from '../../../components/interface/Error'
+import { web3Error } from '../../../actions/error'
 
 const close = jest.fn()
 
@@ -15,7 +16,7 @@ describe('Error Component', () => {
     })
   })
 
-  describe('when the component has a children', () => {
+  describe('when the component has children', () => {
     it('should display the content of the children', () => {
       const wrapper = rtl.render(
         <Error close={close}>There was an error.</Error>
@@ -33,11 +34,20 @@ describe('Error Component', () => {
     })
   })
 
-  describe('the the component has an error message', () => {
-    it('should display the content of the children', () => {
-      const message = <p>There was an error.</p>
-      const wrapper = rtl.render(<Error close={close} error={message} />)
-      expect(wrapper.queryByText('There was an error.')).not.toBeNull()
+  describe('when the component is passed error metadata', () => {
+    it('should display a formatted error message based on the metadata', () => {
+      const error = web3Error({ message: 'error message' }).error
+      const close = () => {}
+      const wrapper = rtl.render(<Error close={close} error={error} />)
+      expect(wrapper.queryByText('Web3 error: error message')).not.toBeNull()
+    })
+    it('should display a formatted error message based on the metadata and locale', () => {
+      const error = web3Error({ message: 'error message' }).error
+      const close = () => {}
+      const wrapper = rtl.render(
+        <Error close={close} error={error} locale="fr" />
+      )
+      expect(wrapper.queryByText('Web3 erreur: error message')).not.toBeNull()
     })
   })
 })

--- a/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
@@ -13,7 +13,7 @@ import { SET_ACCOUNT, UPDATE_ACCOUNT } from '../../actions/accounts'
 import { SET_NETWORK } from '../../actions/network'
 import { SET_PROVIDER } from '../../actions/provider'
 import { ADD_TRANSACTION, UPDATE_TRANSACTION } from '../../actions/transaction'
-import { SET_ERROR } from '../../actions/error'
+import { WEB3_ERROR } from '../../actions/error'
 
 /**
  * Fake state
@@ -336,13 +336,17 @@ describe('Lock middleware', () => {
 
   it('it should handle error events triggered by the web3Service', () => {
     const { store } = create()
-    mockWeb3Service.emit('error', { message: 'this was broken' })
-    expect(store.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: SET_ERROR,
-        error: expect.anything(), // not sure how to test against jsx
-      })
-    )
+    const error = { message: 'this was broken' }
+    mockWeb3Service.emit('error', error)
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: WEB3_ERROR,
+      error: {
+        metadata: {
+          originalError: error,
+        },
+        type: WEB3_ERROR,
+      },
+    })
   })
 
   describe('when web3Service is not ready', () => {

--- a/unlock-app/src/__tests__/reducers/errorReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/errorReducer.test.js
@@ -1,48 +1,45 @@
-import React from 'react'
-import reducer from '../../reducers/errorReducer'
-import { SET_ERROR } from '../../actions/error'
+import reducer, { initialState } from '../../reducers/errorReducer'
+import { setError, resetError } from '../../actions/error'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
 
 describe('error reducer', () => {
-  const error = <p>Something was wrong</p>
+  const action = setError({ message: 'hi', context: 'there' })
+  const error = action.error
+  const error2 = setError({ message: 'two', context: 'hi' }).error
 
   it('should return the initial state', () => {
-    expect(reducer(undefined, {})).toEqual(null)
+    expect(reducer(undefined, {})).toEqual([])
   })
 
   it('should return the initial state when receveing SET_PROVIDER', () => {
     expect(
-      reducer(
-        {
-          error,
-        },
-        {
-          type: SET_PROVIDER,
-        }
-      )
-    ).toEqual(null)
+      reducer([error], {
+        type: SET_PROVIDER,
+      })
+    ).toEqual([])
   })
 
   it('should return the initial state when receveing SET_NETWORK', () => {
     expect(
-      reducer(
-        {
-          error,
-        },
-        {
-          type: SET_NETWORK,
-        }
-      )
-    ).toEqual(null)
+      reducer([error], {
+        type: SET_NETWORK,
+      })
+    ).toEqual([])
   })
 
   it('should set the error accordingly when receiving SET_ERROR', () => {
-    expect(
-      reducer(undefined, {
-        type: SET_ERROR,
-        error,
-      })
-    ).toEqual(error)
+    expect(reducer(undefined, action)).toEqual([error])
+  })
+
+  it('should reset all errors if RESET_ERROR with no specific error received', () => {
+    expect(reducer([1, 2], resetError())).toBe(initialState)
+  })
+
+  it('should reset only a specific error if RESET_ERROR is called with that error', () => {
+    const startState = [error, error2]
+
+    expect(reducer(startState, resetError(error))).toEqual([error2])
+    expect(reducer(startState, resetError(error2))).toEqual([error])
   })
 })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -20279,6 +20279,418 @@ Object {
 }
 `;
 
+exports[`Storyshots Error Web3 error (fr) 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c2 {
+  background-color: var(--grey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 16px;
+  width: 16px;
+  display: grid;
+  padding: 0;
+  border: 0;
+}
+
+.c2 > svg {
+  fill: white;
+  height: 16px;
+  width: 16px;
+}
+
+.c2:hover {
+  background-color: var(--link);
+}
+
+.c2:hover > svg {
+  fill: white;
+}
+
+.c1:hover .c3 {
+  display: grid;
+}
+
+.c4 .c1 {
+  background-color: var(--white);
+  -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  opacity: 1;
+  pointer-events: visible;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c4 .c1:nth-child(1) {
+  pointer-events: none;
+}
+
+.c4 .c1:nth-child(2) {
+  pointer-events: none;
+  display: none;
+}
+
+.c4 .c1 > svg {
+  fill: var(--grey);
+}
+
+.c4 .c1:hover > svg {
+  fill: var(--grey);
+}
+
+.c5 .c1 {
+  margin: 24px;
+}
+
+.c5 .c1 small {
+  display: block;
+  color: var(--grey);
+  text-align: center;
+  top: 5px;
+  width: 100%;
+  text-align: center;
+}
+
+.c0 {
+  grid-template-columns: 1fr 20px;
+  display: grid;
+  border: 1px solid var(--lightgrey);
+  border-radius: 4px;
+  font-size: 16px;
+  justify-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-right: 8px;
+  grid-gap: 8px;
+}
+
+.c0 a {
+  color: var(--red);
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+        rel="stylesheet"
+      />
+      <section
+        class="c0"
+      >
+        <p>
+          Web3 erreur: 
+          something went wrong
+        </p>
+        <button
+          class="c1 c2"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+      rel="stylesheet"
+    />
+    <section
+      class="sc-1jlw4h4-0 iuQwRB"
+    >
+      <p>
+        Web3 erreur: 
+        something went wrong
+      </p>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Error Web3 error 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c2 {
+  background-color: var(--grey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 16px;
+  width: 16px;
+  display: grid;
+  padding: 0;
+  border: 0;
+}
+
+.c2 > svg {
+  fill: white;
+  height: 16px;
+  width: 16px;
+}
+
+.c2:hover {
+  background-color: var(--link);
+}
+
+.c2:hover > svg {
+  fill: white;
+}
+
+.c1:hover .c3 {
+  display: grid;
+}
+
+.c4 .c1 {
+  background-color: var(--white);
+  -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  opacity: 1;
+  pointer-events: visible;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c4 .c1:nth-child(1) {
+  pointer-events: none;
+}
+
+.c4 .c1:nth-child(2) {
+  pointer-events: none;
+  display: none;
+}
+
+.c4 .c1 > svg {
+  fill: var(--grey);
+}
+
+.c4 .c1:hover > svg {
+  fill: var(--grey);
+}
+
+.c5 .c1 {
+  margin: 24px;
+}
+
+.c5 .c1 small {
+  display: block;
+  color: var(--grey);
+  text-align: center;
+  top: 5px;
+  width: 100%;
+  text-align: center;
+}
+
+.c0 {
+  grid-template-columns: 1fr 20px;
+  display: grid;
+  border: 1px solid var(--lightgrey);
+  border-radius: 4px;
+  font-size: 16px;
+  justify-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-right: 8px;
+  grid-gap: 8px;
+}
+
+.c0 a {
+  color: var(--red);
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+        rel="stylesheet"
+      />
+      <section
+        class="c0"
+      >
+        <p>
+          Web3 error: 
+          something went wrong
+        </p>
+        <button
+          class="c1 c2"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </button>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700"
+      rel="stylesheet"
+    />
+    <section
+      class="sc-1jlw4h4-0 iuQwRB"
+    >
+      <p>
+        Web3 error: 
+        something went wrong
+      </p>
+      <button
+        class="sc-850ddk-0 hOXoMo"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </button>
+    </section>
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots FatalError Network mismatch 1`] = `
 Object {
   "asFragment": [Function],

--- a/unlock-app/src/actions/error.js
+++ b/unlock-app/src/actions/error.js
@@ -1,8 +1,9 @@
 export const SET_ERROR = 'SET_ERROR'
 export const RESET_ERROR = 'RESET_ERROR'
+export const WEB3_ERROR = 'WEB3_ERROR'
 
-export const setError = error => ({
-  type: SET_ERROR,
+export const setError = (error, type = 'SET_ERROR') => ({
+  type,
   error,
 })
 
@@ -10,3 +11,10 @@ export const resetError = error => ({
   type: RESET_ERROR,
   error,
 })
+
+export const metadataError = (metadata, type) => {
+  return setError({ metadata, type }, type)
+}
+
+export const web3Error = originalError =>
+  metadataError({ originalError }, WEB3_ERROR)

--- a/unlock-app/src/actions/error.js
+++ b/unlock-app/src/actions/error.js
@@ -1,6 +1,12 @@
 export const SET_ERROR = 'SET_ERROR'
+export const RESET_ERROR = 'RESET_ERROR'
 
 export const setError = error => ({
   type: SET_ERROR,
+  error,
+})
+
+export const resetError = error => ({
+  type: RESET_ERROR,
   error,
 })

--- a/unlock-app/src/components/helpers/ErrorMapper.js
+++ b/unlock-app/src/components/helpers/ErrorMapper.js
@@ -1,0 +1,28 @@
+/* eslint-disable react/display-name */
+/* eslint-disable react/prop-types */
+import React from 'react'
+import * as errors from '../../actions/error'
+
+export const messageTemplates = {
+  [errors.WEB3_ERROR]: {
+    validate: error =>
+      error.metadata &&
+      error.metadata.originalError &&
+      error.metadata.originalError.message,
+    en: ({ originalError: { message } }) => <p>Web3 error: {message}</p>,
+    fr: ({ originalError: { message } }) => <p>Web3 erreur: {message}</p>,
+  },
+  [errors.SET_ERROR]: {
+    validate: error => typeof error === 'string',
+    en: error => <p>{error}</p>,
+  },
+}
+
+export function ErrorMapper({ error, locale }) {
+  if (!messageTemplates[error.type].validate(error)) {
+    throw new Error('Internal error: improperly formatted error')
+  }
+  const template =
+    messageTemplates[error.type][locale] || messageTemplates[error.type].en
+  return template(error.metadata ? error.metadata : error)
+}

--- a/unlock-app/src/components/interface/Error.js
+++ b/unlock-app/src/components/interface/Error.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { setError } from '../../actions/error'
+import { resetError } from '../../actions/error'
 import Buttons from './buttons/layout'
 
 export const Error = ({ children, error, close }) => {
@@ -26,7 +26,7 @@ const mapStateToProps = ({ errors }) => ({
 
 const mapDispatchToProps = dispatch => ({
   close: () => {
-    dispatch(setError(null))
+    dispatch(resetError())
   },
 })
 

--- a/unlock-app/src/components/interface/Error.js
+++ b/unlock-app/src/components/interface/Error.js
@@ -2,11 +2,14 @@ import { connect } from 'react-redux'
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { resetError } from '../../actions/error'
 import Buttons from './buttons/layout'
 
-export const Error = ({ children, error, close }) => {
-  const content = children || error
+import { resetError } from '../../actions/error'
+import { ErrorMapper } from '../helpers/ErrorMapper'
+
+export const Error = ({ children, error, close, locale = 'en' }) => {
+  const content =
+    children || (error && <ErrorMapper error={error} locale={locale} />)
   if (!content) {
     return null
   }
@@ -20,8 +23,9 @@ export const Error = ({ children, error, close }) => {
   )
 }
 
-const mapStateToProps = ({ errors }) => ({
+const mapStateToProps = ({ errors, locale = 'en' }) => ({
   error: errors.length ? errors[errors.length - 1] : null,
+  locale,
 })
 
 const mapDispatchToProps = dispatch => ({
@@ -32,13 +36,15 @@ const mapDispatchToProps = dispatch => ({
 
 Error.propTypes = {
   children: PropTypes.node,
-  error: PropTypes.node,
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   close: PropTypes.func.isRequired,
+  locale: PropTypes.string,
 }
 
 Error.defaultProps = {
   children: null,
   error: null,
+  locale: 'en',
 }
 
 export default connect(

--- a/unlock-app/src/components/interface/Error.js
+++ b/unlock-app/src/components/interface/Error.js
@@ -20,8 +20,8 @@ export const Error = ({ children, error, close }) => {
   )
 }
 
-const mapStateToProps = ({ error }) => ({
-  error,
+const mapStateToProps = ({ errors }) => ({
+  error: errors.length ? errors[errors.length - 1] : null,
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -53,7 +53,7 @@ export const createUnlockStore = (
     provider: providerReducer,
     transactions: transactionsReducer,
     currency: currencyReducer,
-    error: errorReducer,
+    errors: errorReducer,
   }
 
   // Cleanup the defaultState to remove all null values so that we do not overwrite existing
@@ -74,7 +74,7 @@ export const createUnlockStore = (
       provider: defaultProvider,
       transactions: defaultTransactions,
       currency: defaultCurrency,
-      error: defaultError,
+      errors: defaultError,
     },
     {
       provider: Object.keys(config.providers)[0],

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -1,6 +1,5 @@
 /* eslint no-console: 0 */ // TODO: remove me when this is clean
 
-import React from 'react'
 import { LOCATION_CHANGE } from 'react-router-redux'
 import {
   ADD_LOCK,
@@ -14,7 +13,7 @@ import {
 import { PURCHASE_KEY, updateKey, addKey } from '../actions/key'
 import { setAccount, updateAccount, SET_ACCOUNT } from '../actions/accounts'
 import { setNetwork, SET_NETWORK } from '../actions/network'
-import { setError } from '../actions/error'
+import { web3Error } from '../actions/error'
 import { SET_PROVIDER } from '../actions/provider'
 import { addTransaction, updateTransaction } from '../actions/transaction'
 import { LOCK_PATH_NAME_REGEXP } from '../constants'
@@ -99,7 +98,7 @@ export default function lockMiddleware({ getState, dispatch }) {
   })
 
   web3Service.on('error', error => {
-    dispatch(setError(<p>{error.message}</p>))
+    dispatch(web3Error(error))
   })
 
   /**

--- a/unlock-app/src/reducers/errorReducer.js
+++ b/unlock-app/src/reducers/errorReducer.js
@@ -1,8 +1,8 @@
-import { SET_ERROR } from '../actions/error'
+import { SET_ERROR, RESET_ERROR } from '../actions/error'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 
-export const initialState = null
+export const initialState = []
 
 const errorReducer = (state = initialState, action) => {
   if ([SET_PROVIDER, SET_NETWORK].indexOf(action.type) > -1) {
@@ -10,7 +10,14 @@ const errorReducer = (state = initialState, action) => {
   }
 
   if (action.type === SET_ERROR) {
-    return action.error
+    return [...state, action.error]
+  }
+
+  if (action.type === RESET_ERROR) {
+    if (!action.error) return initialState
+    const nextState = [...state]
+    nextState.splice(nextState.indexOf(action.error), 1)
+    return nextState
   }
 
   return state

--- a/unlock-app/src/stories/interface/Error.stories.js
+++ b/unlock-app/src/stories/interface/Error.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Error } from '../../components/interface/Error'
+import { web3Error } from '../../actions/error'
 
 const close = () => {}
 
@@ -20,4 +21,12 @@ storiesOf('Error', module)
         </p>
       </Error>
     )
+  })
+  .add('Web3 error', () => {
+    const error = web3Error({ message: 'something went wrong' }).error
+    return <Error close={close} error={error} />
+  })
+  .add('Web3 error (fr)', () => {
+    const error = web3Error({ message: 'something went wrong' }).error
+    return <Error close={close} error={error} locale="fr" />
   })


### PR DESCRIPTION
# Description

Fixes #876 by implementing an error mapper.

Error messages are no longer generated at the source, but instead are created at display time using a locale-aware mapper of error metadata to jsx.

<img width="1413" alt="screen shot 2019-01-10 at 7 44 01 pm" src="https://user-images.githubusercontent.com/98250/51006191-1d7e7e80-1510-11e9-9b03-82c4174059c5.png">
<img width="1413" alt="screen shot 2019-01-10 at 7 43 57 pm" src="https://user-images.githubusercontent.com/98250/51006192-1d7e7e80-1510-11e9-830b-1430796ba147.png">


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
