### PR TITLE
Add truffle compile to test script

### DIFF
--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -86,7 +86,7 @@
     "setup-dev": "run-script-os",
     "setup-dev:darwin:freebsd:linux:sunos": "cd .. && (npm run start-ganache -- -b 3 &) && npm run deploy-lock",
     "setup-dev:win32": "cd .. && (START /b npm run start-ganache -- -b 3 ) && npm run deploy-lock",
-    "test": "UNLOCK_ENV=test jest --env=jsdom",
+    "test": "cd ../smart-contracts && truffle compile && cd ../unlock-app && UNLOCK_ENV=test jest --env=jsdom",
     "lint": "eslint .",
     "reformat": "prettier-eslint \"src/**/*.js\" --write",
     "fail-pending-changes": "./scripts/pending-changes.sh",


### PR DESCRIPTION
This PR adds a "truffle compile" step to the "test" script in `/unlock-app/package.json`.
Without it, `npm run test` will fail if run before `npm run dev`. Note that only contracts with changes will be compiled, so if `npm run test` is rn after `npm run dev` no extra compilation occurs.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
