### PR TITLE
make keys proptype more explicit

### DIFF
--- a/unlock-app/src/propTypes.js
+++ b/unlock-app/src/propTypes.js
@@ -48,7 +48,7 @@ export const key = PropTypes.shape({
   expiration: PropTypes.number,
 })
 
-export const keys = PropTypes.shape({})
+export const keys = PropTypes.objectOf(key)
 
 export const network = PropTypes.shape({})
 


### PR DESCRIPTION
# Description

The keys proptype can and should use the `objectOf` prop-type instead of a generic `shape({})`

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
