### PR TITLE
refactor CreatorLockForms test

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -1,72 +1,26 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
-import { Provider } from 'react-redux'
 
-import { CreatorLocks } from '../../../components/creator/CreatorLocks'
-import createUnlockStore from '../../../createUnlockStore'
-
-jest.mock('next/link', () => {
-  return ({ children }) => children
-})
+import { CreatorLockForm } from '../../../components/creator/CreatorLockForm'
 
 describe('CreatorLockForm', () => {
-  it('should display when create lock button is clicked', () => {
-    const store = createUnlockStore({
-      account: {},
-    })
+  let hideAction
+  let createLock
+  let wrapper
 
-    let wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks />
-      </Provider>
+  beforeEach(() => {
+    hideAction = jest.fn()
+    createLock = jest.fn()
+
+    wrapper = rtl.render(
+      <CreatorLockForm
+        hideAction={hideAction}
+        createLock={createLock}
+        account={{ address: 'hi' }}
+      />
     )
-
-    expect(wrapper.queryByValue('New Lock')).toBeNull()
-    expect(wrapper.queryByText('Submit')).toBeNull()
-
-    let createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
-
-    expect(wrapper.queryByValue('New Lock')).not.toBeNull()
-    expect(wrapper.queryByText('Submit')).not.toBeNull()
-  })
-  it('should disappear when cancel button is clicked', () => {
-    const store = createUnlockStore({
-      account: {},
-    })
-
-    let wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks />
-      </Provider>
-    )
-
-    let createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
-
-    expect(wrapper.queryByValue('New Lock')).not.toBeNull()
-    expect(wrapper.queryByText('Submit')).not.toBeNull()
-
-    let cancelButton = wrapper.getByText('Cancel')
-    rtl.fireEvent.click(cancelButton)
-
-    expect(wrapper.queryByValue('New Lock')).toBeNull()
-    expect(wrapper.queryByText('Submit')).toBeNull()
   })
   it('should not allow a form with invalid data to be submitted', () => {
-    const store = createUnlockStore({
-      account: {},
-    })
-
-    let wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks />
-      </Provider>
-    )
-
-    let createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
-
     // Setting name to be an invalid value (empty)
     let name = wrapper.queryByValue('New Lock')
     rtl.fireEvent.change(name, { target: { value: '' } })
@@ -78,18 +32,6 @@ describe('CreatorLockForm', () => {
   })
   it('should signal field as invalid if the data is not valid', () => {
     expect.assertions(12)
-    const store = createUnlockStore({
-      account: {},
-    })
-
-    let wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks />
-      </Provider>
-    )
-
-    let createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
 
     // Setting name to be an invalid value (empty)
     let name = wrapper.queryByValue('New Lock')
@@ -126,18 +68,6 @@ describe('CreatorLockForm', () => {
 
   it('should not consider maxNumberOfKeys to be invalid when using the infinity symbol', () => {
     expect.assertions(5)
-    const store = createUnlockStore({
-      account: {},
-    })
-
-    let wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks />
-      </Provider>
-    )
-
-    let createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
 
     // Setting maxNumberOfKeys to be an invalid value (a string)
     let maxNumberOfKeys = wrapper.queryByValue('10')
@@ -156,21 +86,6 @@ describe('CreatorLockForm', () => {
   })
 
   it('should display infinity symbol when unlimited is clicked and mark the field as valid', () => {
-    const store = createUnlockStore({
-      account: {},
-    })
-
-    let wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks />
-      </Provider>
-    )
-
-    expect(wrapper.queryByText('Unlimited')).toBeNull()
-
-    let createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
-
     let unlimitedLabel = wrapper.queryByText('Unlimited')
     expect(unlimitedLabel).not.toBeNull()
     expect(wrapper.queryByText('Submit')).not.toBeNull()
@@ -180,21 +95,6 @@ describe('CreatorLockForm', () => {
     expect(wrapper.queryByValue('∞')).not.toBeNull()
   })
   it('should enable the "Unlimited" label after infinity is replaced with a finite number', () => {
-    const store = createUnlockStore({
-      account: {},
-    })
-
-    let wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks />
-      </Provider>
-    )
-
-    expect(wrapper.queryByText('Unlimited')).toBeNull()
-
-    let createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
-
     let unlimitedLabel = wrapper.queryByText('Unlimited')
     expect(unlimitedLabel).not.toBeNull()
     expect(wrapper.queryByText('Submit')).not.toBeNull()

--- a/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { Provider } from 'react-redux'
+
+import { CreatorLocks } from '../../../components/creator/CreatorLocks'
+import createUnlockStore from '../../../createUnlockStore'
+
+jest.mock('next/link', () => {
+  return ({ children }) => children
+})
+
+describe('CreatorLocks', () => {
+  it('should display form when create lock button is clicked', () => {
+    const store = createUnlockStore({
+      account: {},
+    })
+
+    const wrapper = rtl.render(
+      <Provider store={store}>
+        <CreatorLocks />
+      </Provider>
+    )
+
+    expect(wrapper.queryByValue('New Lock')).toBeNull()
+    expect(wrapper.queryByText('Submit')).toBeNull()
+
+    const createButton = wrapper.getByText('Create Lock')
+    rtl.fireEvent.click(createButton)
+
+    expect(wrapper.queryByValue('New Lock')).not.toBeNull()
+    expect(wrapper.queryByText('Submit')).not.toBeNull()
+  })
+
+  it('should disappear when cancel button is clicked', () => {
+    const store = createUnlockStore({
+      account: {},
+    })
+
+    let wrapper = rtl.render(
+      <Provider store={store}>
+        <CreatorLocks />
+      </Provider>
+    )
+
+    let createButton = wrapper.getByText('Create Lock')
+    rtl.fireEvent.click(createButton)
+
+    expect(wrapper.queryByValue('New Lock')).not.toBeNull()
+    expect(wrapper.queryByText('Submit')).not.toBeNull()
+
+    let cancelButton = wrapper.getByText('Cancel')
+    rtl.fireEvent.click(cancelButton)
+
+    expect(wrapper.queryByValue('New Lock')).toBeNull()
+    expect(wrapper.queryByText('Submit')).toBeNull()
+  })
+})

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -19,7 +19,7 @@ import {
 import { LockStatus } from './lock/CreatorLockStatus'
 import { createLock } from '../../actions/lock'
 
-class CreatorLockForm extends React.Component {
+export class CreatorLockForm extends React.Component {
   constructor(props, context) {
     super(props, context)
     this.state = {


### PR DESCRIPTION
# Description

This PR addresses a minor logic flaw I discovered while implementing #797. Basically, the `CreatorLockForm.test.js` file is a mixture of integration tests making sure that `CreatorLockForm` works and `CreatorLocks` works.

This PR separates the 2 `CreatorLocks` tests into their own file, and vastly simplifies `CreatorLockForm` tests to remove the unnecessary steps that using `CreatorLocks` required.

This PR is a necessary prerequisite to implementing #797 because the logic for validating forms is very complex, and all of the `CreatorLocks` stuff makes the tests much harder to reason through. So, this is more than just a "nice-to-have" refactor (otherwise I wouldn't do it).

Once this PR (and a few other small ones to follow) is accepted, the PR for #797 will be smaller, and adhere to the "1 PR, 1 purpose" rule.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
