### PR TITLE
Adds ability to retreive lock details by owner

### DIFF
--- a/locksmith/src/app.js
+++ b/locksmith/src/app.js
@@ -76,6 +76,19 @@ router.get('/lock/:lockAddress', function(req, res) {
   })
 })
 
+router.get('/:owner/locks', function(req, res) {
+  const owner = req.params.owner
+
+  Lock.findAll({
+    attributes: ['name', 'address'],
+    where: {
+      owner: { [Op.eq]: owner },
+    },
+  }).then(locks => {
+    res.json({ locks: locks })
+  })
+})
+
 app.use(cors())
 app.use(bodyParser.json())
 app.put(/^\/lock\/\S+/i, tokenMiddleware)


### PR DESCRIPTION
Introducing our first derivative endpoint for Locksmith, it provides the ability to receive Lock details for a given owner(address)

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
