### PR TITLE
Remove 2nd deployer.deploy from migrations

### DIFF
--- a/smart-contracts/migrations/3_create_proxy.js
+++ b/smart-contracts/migrations/3_create_proxy.js
@@ -11,7 +11,6 @@ module.exports = function deployProxy (deployer, network, accounts) {
   deployer.then(() => {
     if (network === 'test') {
       console.log("Skipping proxy creation in 3_create_proxy.js while on network 'test'. Exiting...")
-      return deployer.deploy(Unlock, unlockOwner)
     } else {
       if (
         shell.exec(


### PR DESCRIPTION
In truffle migrations, `2_deploy_unlock` there was a second unneeded call to deployer.deploy in the test network case. When testing, all further deployments/upgrades to unlock are handled in the tests themselves.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
