### PR TITLE
handle duplication problems in error setting/resetting

### DIFF
--- a/unlock-app/src/__tests__/reducers/errorsReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/errorsReducer.test.js
@@ -37,6 +37,15 @@ describe('errors reducer', () => {
     expect(reducer([error], action2)).toEqual([error, error2])
   })
 
+  it('should not set the same error twice', () => {
+    expect(reducer([error], action)).toEqual([error])
+  })
+
+  it('should not change state if RESET_ERROR with non-existing error is called', () => {
+    const state = ['some other error']
+    expect(reducer(state, resetError('non-existing'))).toBe(state)
+  })
+
   it('should reset all errors if RESET_ERROR with no specific error received', () => {
     expect(reducer([1, 2], resetError())).toBe(initialState)
   })

--- a/unlock-app/src/reducers/errorsReducer.js
+++ b/unlock-app/src/reducers/errorsReducer.js
@@ -10,11 +10,13 @@ const errorsReducer = (state = initialState, action) => {
   }
 
   if (action.type === SET_ERROR) {
+    if (state.includes(action.error)) return state
     return [...state, action.error]
   }
 
   if (action.type === RESET_ERROR) {
     if (!action.error) return initialState
+    if (!state.includes(action.error)) return state
     const newState = [...state]
     const newIndex = newState.indexOf(action.error)
     if (newIndex >= 0) newState.splice(newIndex, 1)


### PR DESCRIPTION
# Description

As evidenced by the 2 tests added in this PR, the original implementation of resetError and setError did not handle the case where `setError` is called twice with the same error, or when `resetError` is called with an error that is not in the state. In the first case, it would add the error twice, and result in a dangling error when removed. In the second case, we would change state, triggering a re-render, even though nothing actually changed.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
