### PR TITLE
Adding a reducer and action for list of keys on a given page for a lock

### DIFF
--- a/unlock-app/src/__tests__/actions/keysPages.test.js
+++ b/unlock-app/src/__tests__/actions/keysPages.test.js
@@ -1,0 +1,19 @@
+import {
+  setKeysOnPageForLock,
+  SET_KEYS_ON_PAGE_FOR_LOCK,
+} from '../../actions/keysPages'
+
+describe('key actions', () => {
+  it('should create an action to set the keys for lock on a given page', () => {
+    const page = '10'
+    const lock = '0x123'
+    const keys = [{}, {}]
+    const expectedAction = {
+      type: SET_KEYS_ON_PAGE_FOR_LOCK,
+      page,
+      lock,
+      keys,
+    }
+    expect(setKeysOnPageForLock(page, lock, keys)).toEqual(expectedAction)
+  })
+})

--- a/unlock-app/src/__tests__/reducers/keysPagesReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/keysPagesReducer.test.js
@@ -1,0 +1,70 @@
+import reducer from '../../reducers/keysPagesReducer'
+import { SET_KEYS_ON_PAGE_FOR_LOCK } from '../../actions/keysPages'
+import { SET_PROVIDER } from '../../actions/provider'
+import { SET_NETWORK } from '../../actions/network'
+
+describe('keys page reducer', () => {
+  const oneKey = {
+    id: 'keyId',
+    expiration: 0,
+    data: 'hello',
+  }
+
+  const anotherKey = {
+    id: 'keyId2',
+    expiration: 100,
+    data: 'world',
+  }
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual({})
+  })
+
+  it('should return the initial state when receveing SET_PROVIDER', () => {
+    const state = {
+      '0x123': {
+        keys: [],
+        page: 100,
+      },
+    }
+    expect(
+      reducer(state, {
+        type: SET_PROVIDER,
+      })
+    ).toEqual({})
+  })
+
+  it('should return the initial state when receveing SET_NETWORK', () => {
+    const state = {
+      '0x123': {
+        keys: [],
+        page: 100,
+      },
+    }
+
+    expect(
+      reducer(state, {
+        type: SET_NETWORK,
+      })
+    ).toEqual({})
+  })
+
+  describe('SET_KEYS_ON_PAGE_FOR_LOCK', () => {
+    it('should set the keys on that page accordingly', () => {
+      const state = {}
+      const action = {
+        type: SET_KEYS_ON_PAGE_FOR_LOCK,
+        page: 0,
+        lock: '0x123',
+        keys: [oneKey, anotherKey],
+      }
+
+      expect(reducer(state, action)).toEqual({
+        '0x123': {
+          page: 0,
+          keys: [oneKey, anotherKey],
+        },
+      })
+    })
+  })
+})

--- a/unlock-app/src/actions/keysPages.js
+++ b/unlock-app/src/actions/keysPages.js
@@ -1,0 +1,8 @@
+export const SET_KEYS_ON_PAGE_FOR_LOCK = 'SET_KEYS_ON_PAGE_FOR_LOCK'
+
+export const setKeysOnPageForLock = (page, lock, keys) => ({
+  type: SET_KEYS_ON_PAGE_FOR_LOCK,
+  page,
+  lock,
+  keys,
+})

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -8,6 +8,9 @@ import configure from './config'
 import keysReducer, {
   initialState as defaultKeys,
 } from './reducers/keysReducer'
+import keysPagesReducer, {
+  initialState as defaultKeysPages,
+} from './reducers/keysPagesReducer'
 import locksReducer, {
   initialState as defaultLocks,
 } from './reducers/locksReducer'
@@ -47,6 +50,7 @@ export const createUnlockStore = (
     router: connectRouter(history),
     account: accountReducer,
     keys: keysReducer,
+    keysForLockByPage: keysPagesReducer,
     locks: locksReducer,
     modals: modalReducer,
     network: networkReducer,
@@ -68,6 +72,7 @@ export const createUnlockStore = (
     {
       account: defaultAccount,
       keys: defaultKeys,
+      keysForLockByPage: defaultKeysPages,
       locks: defaultLocks,
       modals: defaultModals,
       network: defaultNetwork,

--- a/unlock-app/src/reducers/keysPagesReducer.js
+++ b/unlock-app/src/reducers/keysPagesReducer.js
@@ -1,0 +1,25 @@
+import { SET_KEYS_ON_PAGE_FOR_LOCK } from '../actions/keysPages'
+import { SET_PROVIDER } from '../actions/provider'
+import { SET_NETWORK } from '../actions/network'
+
+export const initialState = {}
+
+const keysPagesReducer = (state = initialState, action) => {
+  if ([SET_PROVIDER, SET_NETWORK].indexOf(action.type) > -1) {
+    return initialState
+  }
+
+  if (action.type === SET_KEYS_ON_PAGE_FOR_LOCK) {
+    return {
+      [action.lock]: {
+        page: action.page,
+        keys: action.keys,
+      },
+      ...state,
+    }
+  }
+
+  return state
+}
+
+export default keysPagesReducer


### PR DESCRIPTION
This is to implement showing a list of keys for a lock on a creator dashboard


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread