### PR TITLE
Exposes method providing keyholder addresses by Page

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -325,6 +325,41 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     return owners.length;
   }
 
+ /**
+  * A function which returns a subset of the keys for this Lock as an array
+  * @param _page the page of key owners requested when faceted by page size
+  * @param _pageSize the number of Key Owners requested per page
+  */
+  function getOwnersByPage(uint _page, uint _pageSize)
+    public
+    view
+    returns (address[])
+  {
+    require(outstandingKeys() > 0, "No keys to retrieve");
+    uint _startIndex = _page * _pageSize;
+    require(_startIndex >= 0 && _startIndex < outstandingKeys(), "Index must be in-bounds");
+    uint endOfPageIndex;
+
+    if (_startIndex + _pageSize > owners.length) {
+      endOfPageIndex = owners.length;
+      _pageSize =  owners.length - _startIndex;
+    } else {
+      endOfPageIndex = (_startIndex + _pageSize);
+    }
+
+    // new temp in-memory array to hold pageSize number of requested owners:
+    address[] memory ownersByPage = new address[](_pageSize);
+    uint pageIndex = 0;
+
+    // Build the requested set of owners into a new temporary array:
+    for (uint256 i = _startIndex; i < endOfPageIndex; i++) {
+      ownersByPage[pageIndex] = owners[i];
+      pageIndex++;
+    }
+
+    return ownersByPage;
+  }
+
   /**
    * A function which lets the owner of the lock expire a users' key.
    */

--- a/smart-contracts/contracts/interfaces/ILockCore.sol
+++ b/smart-contracts/contracts/interfaces/ILockCore.sol
@@ -85,4 +85,16 @@ interface ILockCore {
     external
     view
     returns (uint timestamp);
+
+  /**
+  * @param _page the page of key owners requested when faceted by page size
+  * @param _pageSize the number of Key Owners requested per page
+  */
+  function getOwnersByPage(
+    uint _page,
+    uint _pageSize
+  )
+    external
+    view
+    returns (address[]);
 }

--- a/smart-contracts/test/Lock/getOwnersByPage.js
+++ b/smart-contracts/test/Lock/getOwnersByPage.js
@@ -1,6 +1,5 @@
 
 const Units = require('ethereumjs-units')
-const Web3Utils = require('web3-utils')
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
 
@@ -29,61 +28,52 @@ contract('Lock', (accounts) => {
     })
 
     describe('when there are less owners than the page size', () => {
-      it('should return all of the key owners', () => {
-        return locks['FIRST'].purchaseFor(accounts[1], 'something', {
-          value: Units.convert('0.01', 'eth', 'wei')
-        }).then((f) => {
-          return locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
-            .then((result) => {
-              assert.equal(result.length, 1)
-              assert.include(result, accounts[1])
-            })
-        })
+      it('should return all of the key owners', async () => {
+        await locks['FIRST'].purchaseFor(accounts[1], 'alpha', { value: Units.convert('0.01', 'eth', 'wei') })
+        let result = await locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
+        assert.equal(result.length, 1)
+        assert.include(result, accounts[1])
       })
     })
 
     describe('when there are more owners than the page size', () => {
-      it('return page size number of key owners', () => {
-        return locks['FIRST'].purchaseFor(accounts[1], 'something', {
+      it('return page size number of key owners', async () => {
+        await locks['FIRST'].purchaseFor(accounts[1], 'alpha', {
           value: Units.convert('0.01', 'eth', 'wei')
-        }).then(() => {
-          return locks['FIRST'].purchaseFor(accounts[2], 'something_else', {
-            value: Units.convert('0.01', 'eth', 'wei')
-          }).then(() => {
-            return locks['FIRST'].purchaseFor(accounts[3], 'something_else_2', {
-              value: Units.convert('0.01', 'eth', 'wei')
-            }).then((f) => {
-              return locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
-                .then((result) => {
-                  assert.equal(result.length, 2)
-                  assert.include(result, accounts[1])
-                  assert.include(result, accounts[2])
-                })
-            })
-          })
         })
+
+        await locks['FIRST'].purchaseFor(accounts[2], 'beta', {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+
+        await locks['FIRST'].purchaseFor(accounts[3], 'gamma', {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+
+        let result = await locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
+        assert.equal(result.length, 2)
+        assert.include(result, accounts[1])
+        assert.include(result, accounts[2])
       })
     })
 
     describe('when requesting a secondary page', () => {
-      it('return page size number of key owners', () => {
-        return locks['FIRST'].purchaseFor(accounts[1], 'something', {
+      it('return page size number of key owners', async () => {
+        await locks['FIRST'].purchaseFor(accounts[1], 'alpha', {
           value: Units.convert('0.01', 'eth', 'wei')
-        }).then(() => {
-          return locks['FIRST'].purchaseFor(accounts[2], 'something_else', {
-            value: Units.convert('0.01', 'eth', 'wei')
-          }).then(() => {
-            return locks['FIRST'].purchaseFor(accounts[3], 'something_else_2', {
-              value: Units.convert('0.01', 'eth', 'wei')
-            }).then((f) => {
-              return locks['FIRST'].getOwnersByPage.call(1, 2, { from: accounts[0] })
-                .then((result) => {
-                  assert.equal(result.length, 1)
-                  assert.equal(accounts[3], result[0])
-                })
-            })
-          })
         })
+
+        await locks['FIRST'].purchaseFor(accounts[2], 'beta', {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+
+        await locks['FIRST'].purchaseFor(accounts[3], 'gamma', {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+
+        let result = await locks['FIRST'].getOwnersByPage.call(1, 2, { from: accounts[0] })
+        assert.equal(result.length, 1)
+        assert.equal(accounts[3], result[0])
       })
     })
   })

--- a/smart-contracts/test/Lock/getOwnersByPage.js
+++ b/smart-contracts/test/Lock/getOwnersByPage.js
@@ -1,0 +1,90 @@
+
+const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+const deployLocks = require('../helpers/deployLocks')
+const Unlock = artifacts.require('../Unlock.sol')
+
+let unlock, locks
+
+contract('Lock', (accounts) => {
+  before(() => {
+    return Unlock.deployed()
+      .then(_unlock => {
+        unlock = _unlock
+        return deployLocks(unlock)
+      })
+      .then(_locks => {
+        locks = _locks
+      })
+  })
+
+  describe('getOwnersByPage', () => {
+    describe('when there are 0 key owners', () => {
+      it('should return an error', () => {
+        return locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[5] })
+          .catch(error => {
+            assert.equal(error.message, 'VM Exception while processing transaction: revert No keys to retrieve')
+          })
+      })
+    })
+
+    describe('when there are less owners than the page size', () => {
+      it('should return all of the key owners', () => {
+        return locks['FIRST'].purchaseFor(accounts[1], 'something', {
+          value: Units.convert('0.01', 'eth', 'wei')
+        }).then((f) => {
+          return locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
+            .then((result) => {
+              assert.equal(result.length, 1)
+              assert.include(result, accounts[1])
+            })
+        })
+      })
+    })
+
+    describe('when there are more owners than the page size', () => {
+      it('return page size number of key owners', () => {
+        return locks['FIRST'].purchaseFor(accounts[1], 'something', {
+          value: Units.convert('0.01', 'eth', 'wei')
+        }).then(() => {
+          return locks['FIRST'].purchaseFor(accounts[2], 'something_else', {
+            value: Units.convert('0.01', 'eth', 'wei')
+          }).then(() => {
+            return locks['FIRST'].purchaseFor(accounts[3], 'something_else_2', {
+              value: Units.convert('0.01', 'eth', 'wei')
+            }).then((f) => {
+              return locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
+                .then((result) => {
+                  assert.equal(result.length, 2)
+                  assert.include(result, accounts[1])
+                  assert.include(result, accounts[2])
+                })
+            })
+          })
+        })
+      })
+    })
+
+    describe('when requesting a secondary page', () => {
+      it('return page size number of key owners', () => {
+        return locks['FIRST'].purchaseFor(accounts[1], 'something', {
+          value: Units.convert('0.01', 'eth', 'wei')
+        }).then(() => {
+          return locks['FIRST'].purchaseFor(accounts[2], 'something_else', {
+            value: Units.convert('0.01', 'eth', 'wei')
+          }).then(() => {
+            return locks['FIRST'].purchaseFor(accounts[3], 'something_else_2', {
+              value: Units.convert('0.01', 'eth', 'wei')
+            }).then((f) => {
+              return locks['FIRST'].getOwnersByPage.call(1, 2, { from: accounts[0] })
+                .then((result) => {
+                  assert.equal(result.length, 1)
+                  assert.equal(accounts[3], result[0])
+                })
+            })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Based on @nfurfaro 's work of paginating key details, a method returning keys holders
has been added.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
