### PR TITLE
fixing issue with redux store which prevented new state to be taken into account

### DIFF
--- a/unlock-app/src/__tests__/reducers/keysPagesReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/keysPagesReducer.test.js
@@ -66,5 +66,28 @@ describe('keys page reducer', () => {
         },
       })
     })
+
+    it('should set the keys on that page accordingly even when a value was previously set', () => {
+      const state = {
+        '0x123': {
+          page: 1,
+          keys: [],
+        },
+      }
+
+      const action = {
+        type: SET_KEYS_ON_PAGE_FOR_LOCK,
+        page: 0,
+        lock: '0x123',
+        keys: [oneKey, anotherKey],
+      }
+
+      expect(reducer(state, action)).toEqual({
+        '0x123': {
+          page: 0,
+          keys: [oneKey, anotherKey],
+        },
+      })
+    })
   })
 })

--- a/unlock-app/src/reducers/keysPagesReducer.js
+++ b/unlock-app/src/reducers/keysPagesReducer.js
@@ -11,11 +11,11 @@ const keysPagesReducer = (state = initialState, action) => {
 
   if (action.type === SET_KEYS_ON_PAGE_FOR_LOCK) {
     return {
+      ...state,
       [action.lock]: {
         page: action.page,
         keys: action.keys,
       },
-      ...state,
     }
   }
 


### PR DESCRIPTION
Added the test which would have prevented this from happening :0


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X]] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)