### PR TITLE
adding missing field when retrieving key

### DIFF
--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -1244,7 +1244,7 @@ describe('Web3Service', () => {
 
     describe('getKeysForLockOnPage', () => {
       it('should get as many owners as there are per page, starting at the right index', done => {
-        expect.assertions(3)
+        expect.assertions(8)
 
         web3Service._getKeyByLockForOwner = jest.fn(() => {
           return new Promise(resolve => {
@@ -1267,6 +1267,16 @@ describe('Web3Service', () => {
           expect(lockAddress).toEqual(lock)
           expect(page).toEqual(onPage)
           expect(keys.length).toEqual(byPage)
+          const key = keys[0]
+          expect(key.id).toEqual(
+            '0x0d370b0974454d7b0e0e3b4512c0735a6489a71a-0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+          )
+          expect(key.owner).toEqual(
+            '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+          )
+          expect(key.lock).toEqual(lockAddress)
+          expect(key.expiration).toEqual(100)
+          expect(key.data).toEqual('hello')
           done()
         })
 

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -668,7 +668,17 @@ export default class Web3Service extends EventEmitter {
         .owners(n + startIndex)
         .call()
         .then(ownerAddress => {
-          return this._getKeyByLockForOwner(lockContract, ownerAddress)
+          return this._getKeyByLockForOwner(lockContract, ownerAddress).then(
+            ([expiration, data]) => {
+              return {
+                id: keyId(lock, ownerAddress),
+                lock,
+                owner: ownerAddress,
+                expiration,
+                data,
+              }
+            }
+          )
         })
     })
     return Promise.all(keyPromises).then(keys => {


### PR DESCRIPTION
This is still using the old version of getting owners addresses (one by one) but at least
we now get all the required keys fields


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread