### PR TITLE
Handling missing keys on page

### DIFF
--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -680,9 +680,13 @@ export default class Web3Service extends EventEmitter {
             }
           )
         })
+        .catch(() => {
+          // Triggered when there are missing keys
+          return null
+        })
     })
     return Promise.all(keyPromises).then(keys => {
-      this.emit('keys.page', lock, page, keys)
+      this.emit('keys.page', lock, page, keys.filter(key => !!key))
     })
   }
 


### PR DESCRIPTION
If the number of keys does not "complete" the page the EVM triggered an error which prevented us from 
retrieving the whole page. Not anymore!


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - X ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread