### PR TITLE
set state from props in CreatorLockForm

### DIFF
--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -23,13 +23,13 @@ export class CreatorLockForm extends React.Component {
   constructor(props, context) {
     super(props, context)
     this.state = {
-      expirationDuration: 30,
-      expirationDurationUnit: 86400, // Days
-      keyPrice: '0.01',
-      keyPriceCurrency: 'ether',
-      maxNumberOfKeys: 10,
-      unlimitedKeys: false,
-      name: 'New Lock',
+      expirationDuration: props.expirationDuration,
+      expirationDurationUnit: props.expirationDurationUnit, // Days
+      keyPrice: props.keyPrice,
+      keyPriceCurrency: props.keyPriceCurrency,
+      maxNumberOfKeys: props.maxNumberOfKeys,
+      unlimitedKeys: props.unlimitedKeys,
+      name: props.name,
     }
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleCancel = this.handleCancel.bind(this)
@@ -169,9 +169,24 @@ CreatorLockForm.propTypes = {
   account: UnlockPropTypes.account.isRequired,
   hideAction: PropTypes.func.isRequired,
   createLock: PropTypes.func.isRequired,
+  expirationDuration: PropTypes.number,
+  expirationDurationUnit: PropTypes.number,
+  keyPrice: PropTypes.string,
+  keyPriceCurrency: PropTypes.string,
+  maxNumberOfKeys: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), // string is for '∞'
+  unlimitedKeys: PropTypes.bool,
+  name: PropTypes.string,
 }
 
-CreatorLockForm.defaultProps = {}
+CreatorLockForm.defaultProps = {
+  expirationDuration: 30,
+  expirationDurationUnit: 86400, // Days
+  keyPrice: '0.01',
+  keyPriceCurrency: 'ether',
+  maxNumberOfKeys: 10,
+  unlimitedKeys: false,
+  name: 'New Lock',
+}
 
 const mapStateToProps = state => {
   return {


### PR DESCRIPTION
# Description

In preparation for #1027 this PR sets the form state from props. This also will be necessary to implement editing an existing lock.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
