### PR TITLE
make ErrorMessage test for messages tell you which error has no message

### DIFF
--- a/unlock-app/src/__tests__/components/helpers/ErrorMessage.test.js
+++ b/unlock-app/src/__tests__/components/helpers/ErrorMessage.test.js
@@ -5,7 +5,12 @@ import ErrorMessage from '../../../components/helpers/ErrorMessage'
 describe('Errors', () => {
   it('all known errors should have a default message', () => {
     Object.keys(Errors).forEach(error => {
-      expect(ErrorMessage(error)).not.toBe(null)
+      try {
+        expect(ErrorMessage(error)).not.toBe(null)
+      } catch (e) {
+        // this allows us to see which error has no default message
+        expect('has a default message').toBe(error)
+      }
     })
   })
 


### PR DESCRIPTION
# Description

When adding a bunch of errors, this will make the test tell you which error message is not present.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
