### PR TITLE
fix typos in errorsReducer

### DIFF
--- a/unlock-app/src/__tests__/reducers/errorsReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/errorsReducer.test.js
@@ -13,7 +13,7 @@ describe('errors reducer', () => {
     expect(reducer(undefined, {})).toBe(initialState)
   })
 
-  it('should return the initial state when receveing SET_PROVIDER', () => {
+  it('should return the initial state when receiving SET_PROVIDER', () => {
     expect(
       reducer([error], {
         type: SET_PROVIDER,
@@ -21,7 +21,7 @@ describe('errors reducer', () => {
     ).toBe(initialState)
   })
 
-  it('should return the initial state when receveing SET_NETWORK', () => {
+  it('should return the initial state when receiving SET_NETWORK', () => {
     expect(
       reducer([error], {
         type: SET_NETWORK,


### PR DESCRIPTION
# Description

2 small typos in the description

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
