### PR TITLE
implement passing in lock address for editing a lock

### DIFF
--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -93,7 +93,7 @@ export class CreatorLockForm extends React.Component {
     const { valid } = this.state
     if (Object.keys(valid).filter(key => !valid[key]).length) return false
 
-    const { account, createLock, hideAction } = this.props
+    const { account, createLock, hideAction, address } = this.props
     const {
       expirationDuration,
       expirationDurationUnit,
@@ -105,7 +105,7 @@ export class CreatorLockForm extends React.Component {
     } = this.state
 
     const lock = {
-      address: uniqid(), // The lock does not have an address yet, so we use a 'temporary' one
+      address: address,
       name: name,
       expirationDuration: expirationDuration * expirationDurationUnit,
       keyPrice: Web3Utils.toWei(keyPrice.toString(10), keyPriceCurrency),
@@ -210,6 +210,7 @@ CreatorLockForm.propTypes = {
   keyPriceCurrency: PropTypes.string,
   maxNumberOfKeys: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), // string is for '∞'
   name: PropTypes.string,
+  address: PropTypes.string,
 }
 
 CreatorLockForm.defaultProps = {
@@ -219,6 +220,7 @@ CreatorLockForm.defaultProps = {
   keyPriceCurrency: 'ether',
   maxNumberOfKeys: 10,
   name: 'New Lock',
+  address: uniqid(), // for new locks, we don't have an address, so use a temporary one
 }
 
 const mapStateToProps = state => {


### PR DESCRIPTION
# Description

In order to edit a lock, we need to ensure we have access to its address. This PR enables passing in the existing lock's address to the form.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
