### PR TITLE
Enable edit button

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
@@ -51,7 +51,7 @@ describe('CreatorLock', () => {
 
     let wrapper = rtl.render(
       <Provider store={store} config={config}>
-        <CreatorLock lock={lock} transaction={transaction} />
+        <CreatorLock lock={lock} transaction={transaction} edit={() => {}} />
       </Provider>
     )
 
@@ -72,6 +72,24 @@ describe('CreatorLock', () => {
       )
     ).not.toBeNull()
   })
+
+  it('should call edit when clicked', () => {
+    const config = configure()
+    const edit = jest.fn()
+
+    const store = createUnlockStore()
+
+    let wrapper = rtl.render(
+      <Provider store={store} config={config}>
+        <CreatorLock lock={lock} transaction={transaction} edit={edit} />
+      </Provider>
+    )
+
+    rtl.fireEvent.click(wrapper.getByTitle('Edit'))
+
+    expect(edit).toHaveBeenCalled()
+  })
+
   it('should display the correct number of keys', () => {
     const config = configure()
 
@@ -86,7 +104,7 @@ describe('CreatorLock', () => {
 
     let wrapper = rtl.render(
       <Provider store={store} config={config}>
-        <CreatorLock lock={keylock} transaction={transaction} />
+        <CreatorLock lock={keylock} transaction={transaction} edit={() => {}} />
       </Provider>
     )
 
@@ -106,7 +124,11 @@ describe('CreatorLock', () => {
 
     let wrapper = rtl.render(
       <Provider store={store} config={config}>
-        <CreatorLock lock={unlimitedlock} transaction={transaction} />
+        <CreatorLock
+          lock={unlimitedlock}
+          transaction={transaction}
+          edit={() => {}}
+        />
       </Provider>
     )
 

--- a/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
@@ -17,7 +17,7 @@ describe('CreatorLocks', () => {
 
     const wrapper = rtl.render(
       <Provider store={store}>
-        <CreatorLocks />
+        <CreatorLocks edit={() => {}} />
       </Provider>
     )
 
@@ -38,7 +38,7 @@ describe('CreatorLocks', () => {
 
     let wrapper = rtl.render(
       <Provider store={store}>
-        <CreatorLocks />
+        <CreatorLocks edit={() => {}} />
       </Provider>
     )
 

--- a/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
@@ -17,7 +17,7 @@ describe('CreatorLocks', () => {
 
     const wrapper = rtl.render(
       <Provider store={store}>
-        <CreatorLocks edit={() => {}} />
+        <CreatorLocks />
       </Provider>
     )
 
@@ -38,7 +38,7 @@ describe('CreatorLocks', () => {
 
     let wrapper = rtl.render(
       <Provider store={store}>
-        <CreatorLocks edit={() => {}} />
+        <CreatorLocks />
       </Provider>
     )
 

--- a/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
@@ -41,6 +41,7 @@ describe('LockIconBar', () => {
           withdrawalTransaction={withdrawalTransaction}
           toggleCode={toggleCode}
           config={config}
+          edit={() => {}}
         />
       </Provider>
     )
@@ -81,6 +82,7 @@ describe('LockIconBar', () => {
           withdrawalTransaction={withdrawalTransaction}
           toggleCode={toggleCode}
           config={config}
+          edit={() => {}}
         />
       </Provider>
     )
@@ -88,6 +90,49 @@ describe('LockIconBar', () => {
     expect(
       wrapper.queryByText('Confirming Withdrawal', { exact: false })
     ).not.toBeNull()
-    expect(wrapper.queryByText('2/12', { exact: false })).not.toBeNull()
+    expect(
+      wrapper.queryByText(`2/${config.requiredConfirmations}`, { exact: false })
+    ).not.toBeNull()
+  })
+
+  it('should call edit when edit button is clicked', () => {
+    const config = configure()
+    const lock = {
+      id: 'lockwithdrawalconfirmingid',
+      keyPrice: '10000000000000000000',
+      expirationDuration: '172800',
+      maxNumberOfKeys: 240,
+      outstandingKeys: 3,
+      address: '0xba7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      transaction: 'deployedid',
+    }
+    const transaction = {
+      status: 'mined',
+      confirmations: 24,
+    }
+    const withdrawalTransaction = {
+      status: 'mined',
+      confirmations: 2,
+      withdrawal: 'lockwithdrawalconfirmingid',
+    }
+
+    const edit = jest.fn()
+    const store = createUnlockStore({})
+    const wrapper = rtl.render(
+      <Provider store={store}>
+        <LockIconBar
+          lock={lock}
+          transaction={transaction}
+          withdrawalTransaction={withdrawalTransaction}
+          toggleCode={toggleCode}
+          config={config}
+          edit={edit}
+        />
+      </Provider>
+    )
+
+    rtl.fireEvent.click(wrapper.getByTitle('Edit'))
+
+    expect(edit).toHaveBeenCalledWith(lock.address)
   })
 })

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import PropTypes from 'prop-types'
 
 import UnlockPropTypes from '../../propTypes'
 import LockIconBar from './lock/LockIconBar'
@@ -53,7 +54,7 @@ export class CreatorLock extends React.Component {
   render() {
     // TODO add all-time balance to lock
 
-    const { lock } = this.props
+    const { lock, edit } = this.props
     const { showEmbedCode, showKeys } = this.state
 
     // Some sanitization of strings to display
@@ -80,7 +81,11 @@ export class CreatorLock extends React.Component {
             <Balance amount={lock.balance} convertCurrency={false} />
           </Phone>
         </BalanceContainer>
-        <LockIconBar lock={lock} toggleCode={this.toggleEmbedCode} />
+        <LockIconBar
+          lock={lock}
+          toggleCode={this.toggleEmbedCode}
+          edit={edit}
+        />
         {showEmbedCode && (
           <LockPanel>
             <LockDivider />
@@ -100,6 +105,7 @@ export class CreatorLock extends React.Component {
 
 CreatorLock.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
+  edit: PropTypes.func.isRequired,
 }
 
 export default CreatorLock

--- a/unlock-app/src/components/creator/CreatorLocks.js
+++ b/unlock-app/src/components/creator/CreatorLocks.js
@@ -27,6 +27,7 @@ export class CreatorLocks extends React.Component {
     const { showDashboardForm } = this.state
     let lockFeed = Object.values(locks).reverse() // We want to display newer locks first
 
+    // key must be JSON.stringify(lock) to guarantee re-render when props change beneath
     return (
       <Locks>
         <LockHeaderRow>
@@ -44,7 +45,7 @@ export class CreatorLocks extends React.Component {
         <Errors />
         {showDashboardForm && <CreatorLockForm hideAction={this.toggleForm} />}
         {lockFeed.map(lock => (
-          <CreatorLock key={lock.address} lock={lock} edit={() => {}} />
+          <CreatorLock key={JSON.stringify(lock)} lock={lock} edit={() => {}} />
         ))}
       </Locks>
     )

--- a/unlock-app/src/components/creator/CreatorLocks.js
+++ b/unlock-app/src/components/creator/CreatorLocks.js
@@ -43,9 +43,9 @@ export class CreatorLocks extends React.Component {
         </LockHeaderRow>
         <Errors />
         {showDashboardForm && <CreatorLockForm hideAction={this.toggleForm} />}
-        {lockFeed.map(lock => {
-          return <CreatorLock key={JSON.stringify(lock)} lock={lock} />
-        })}
+        {lockFeed.map(lock => (
+          <CreatorLock key={lock.address} lock={lock} edit={() => {}} />
+        ))}
       </Locks>
     )
   }

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -15,6 +15,7 @@ export function LockIconBar({
   transaction,
   withdrawalTransaction,
   config,
+  edit,
 }) {
   if (!transaction) {
     // We assume that the lock has been succeesfuly deployed?
@@ -39,7 +40,7 @@ export function LockIconBar({
       <IconBarContainer>
         <IconBar>
           <Buttons.Withdraw as="button" lock={lock} />
-          <Buttons.Edit as="button" />
+          <Buttons.Edit as="button" action={() => edit(lock.address)} />
           {/* Reinstate when we're ready <Buttons.ExportLock /> */}
           <Buttons.Code action={toggleCode} as="button" />
         </IconBar>
@@ -66,6 +67,7 @@ export function LockIconBar({
 LockIconBar.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
   toggleCode: PropTypes.func.isRequired,
+  edit: PropTypes.func.isRequired,
   transaction: UnlockPropTypes.transaction,
   withdrawalTransaction: UnlockPropTypes.transaction,
   config: UnlockPropTypes.configuration.isRequired,

--- a/unlock-app/src/stories/creator/CreatorLock.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLock.stories.js
@@ -1,6 +1,7 @@
 import { Provider } from 'react-redux'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
 import CreatorLock from '../../components/creator/CreatorLock'
 import createUnlockStore from '../../createUnlockStore'
 
@@ -55,7 +56,7 @@ storiesOf('CreatorLock', module)
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       transaction: 'deployedid',
     }
-    return <CreatorLock lock={lock} />
+    return <CreatorLock lock={lock} edit={action('edit')} />
   })
   .add('Submitted', () => {
     const lock = {
@@ -66,7 +67,7 @@ storiesOf('CreatorLock', module)
       address: '0x127c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       transaction: 'submittedid',
     }
-    return <CreatorLock lock={lock} />
+    return <CreatorLock lock={lock} edit={action('edit')} />
   })
   .add('Confirming', () => {
     const lock = {
@@ -81,7 +82,13 @@ storiesOf('CreatorLock', module)
       status: 'mined',
       confirmations: 2,
     }
-    return <CreatorLock lock={lock} transaction={transaction} />
+    return (
+      <CreatorLock
+        lock={lock}
+        transaction={transaction}
+        edit={action('edit')}
+      />
+    )
   })
   .add('Not found', () => {
     const lock = {
@@ -92,7 +99,7 @@ storiesOf('CreatorLock', module)
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       transaction: '0x789',
     }
-    return <CreatorLock lock={lock} transaction={null} />
+    return <CreatorLock lock={lock} transaction={null} edit={action('edit')} />
   })
   .add('With key', () => {
     const lock = {
@@ -107,7 +114,13 @@ storiesOf('CreatorLock', module)
       status: 'mined',
       confirmations: 14,
     }
-    return <CreatorLock lock={lock} transaction={transaction} />
+    return (
+      <CreatorLock
+        lock={lock}
+        transaction={transaction}
+        edit={action('edit')}
+      />
+    )
   })
   .add('Withdrawal submitted', () => {
     const lock = {
@@ -119,7 +132,7 @@ storiesOf('CreatorLock', module)
       address: withdrawalSubmittedAddress,
       transaction: 'deployedid',
     }
-    return <CreatorLock lock={lock} />
+    return <CreatorLock lock={lock} edit={action('edit')} />
   })
   .add('Withdrawing', () => {
     const lock = {
@@ -131,5 +144,5 @@ storiesOf('CreatorLock', module)
       address: withdrawalConfirmingAddress,
       transaction: 'deployedid',
     }
-    return <CreatorLock lock={lock} />
+    return <CreatorLock lock={lock} edit={action('edit')} />
   })

--- a/unlock-app/src/stories/creator/LockIconBar.stories.js
+++ b/unlock-app/src/stories/creator/LockIconBar.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
 
 import { Provider } from 'react-redux'
 import LockIconBar from '../../components/creator/lock/LockIconBar'
@@ -17,5 +18,11 @@ storiesOf('LockIconBar', module)
       outstandingKeys: 3,
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
     }
-    return <LockIconBar lock={lock} toggleCode={() => {}} />
+    return (
+      <LockIconBar
+        lock={lock}
+        toggleCode={action('toggleCode')}
+        edit={action('edit')}
+      />
+    )
   })


### PR DESCRIPTION
# Description

This enables the edit button on the LockIconBar. The actual display of the edit form will be done in a separate PR, this just wires up the walls, so to speak.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
