### PR TITLE
add edit callback to LockIconBar

### DIFF
--- a/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
@@ -73,9 +73,10 @@ describe('LockIconBar', () => {
       </Provider>
     )
 
-    expect(
-      wrapper.queryByText('Submitted to Network', { exact: false })
-    ).not.toBeNull()
+    rtl.fireEvent.click(wrapper.getByTitle('Edit'))
+
+    expect(edit).toHaveBeenCalledTimes(1)
+    expect(edit).toHaveBeenCalledWith(lock.address)
   })
 
   it('should display a confirming label when withdrawal is confirming', () => {

--- a/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
@@ -57,6 +57,27 @@ describe('LockIconBar', () => {
     ).not.toBeNull()
   })
 
+  it('should trigger edit when clicked', () => {
+    const edit = jest.fn()
+
+    let wrapper = rtl.render(
+      <Provider store={store}>
+        <LockIconBar
+          lock={lock}
+          transaction={transaction}
+          withdrawalTransaction={withdrawalTransaction}
+          toggleCode={toggleCode}
+          config={config}
+          edit={edit}
+        />
+      </Provider>
+    )
+
+    expect(
+      wrapper.queryByText('Submitted to Network', { exact: false })
+    ).not.toBeNull()
+  })
+
   it('should display a confirming label when withdrawal is confirming', () => {
     config.requiredConfirmations = 12
     withdrawalTransaction = {

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -15,6 +15,7 @@ export function LockIconBar({
   transaction,
   withdrawalTransaction,
   config,
+  edit,
 }) {
   if (!transaction) {
     // We assume that the lock has been succeesfuly deployed?
@@ -39,7 +40,7 @@ export function LockIconBar({
       <IconBarContainer>
         <IconBar>
           <Buttons.Withdraw as="button" lock={lock} />
-          <Buttons.Edit as="button" />
+          <Buttons.Edit as="button" action={() => edit(lock.address)} />
           {/* Reinstate when we're ready <Buttons.ExportLock /> */}
           <Buttons.Code action={toggleCode} as="button" />
         </IconBar>
@@ -66,6 +67,7 @@ export function LockIconBar({
 LockIconBar.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
   toggleCode: PropTypes.func.isRequired,
+  edit: PropTypes.func, // this will be required when we wire it up, no-op for now
   transaction: UnlockPropTypes.transaction,
   withdrawalTransaction: UnlockPropTypes.transaction,
   config: UnlockPropTypes.configuration.isRequired,
@@ -74,6 +76,7 @@ LockIconBar.propTypes = {
 LockIconBar.defaultProps = {
   transaction: null,
   withdrawalTransaction: null,
+  edit: () => {},
 }
 
 const mapStateToProps = ({ transactions }, { lock }) => {

--- a/unlock-app/src/stories/creator/LockIconBar.stories.js
+++ b/unlock-app/src/stories/creator/LockIconBar.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
 
 import { Provider } from 'react-redux'
 import LockIconBar from '../../components/creator/lock/LockIconBar'
@@ -17,5 +18,11 @@ storiesOf('LockIconBar', module)
       outstandingKeys: 3,
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
     }
-    return <LockIconBar lock={lock} toggleCode={() => {}} />
+    return (
+      <LockIconBar
+        lock={lock}
+        toggleCode={action('toggleCode')}
+        edit={action('edit')}
+      />
+    )
   })


### PR DESCRIPTION
# Description

This adds an edit callback to LockIconBar only. Initially, it is not required, and has a default value. As it gets wired up the component chain, this will change.

Because there was also a lot of duplication of setup code in the LockIconBar test, this also extracts common setup into a beforeEach().

The storybook story simply wires up the actions so the action logger shows which button was clicked and what it was called with.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
