### PR TITLE
re-organize LockIconBar test in preparation for adding new tests

### DIFF
--- a/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
@@ -6,13 +6,17 @@ import { LockIconBar } from '../../../../components/creator/lock/LockIconBar'
 import configure from '../../../../config'
 import createUnlockStore from '../../../../createUnlockStore'
 
-const toggleCode = jest.fn()
-
 describe('LockIconBar', () => {
-  it('should display a submitted label when withdrawal has been submitted', () => {
-    const config = configure()
+  let config
+  let lock
+  let transaction
+  let withdrawalTransaction
+  let store
+  let toggleCode
+  beforeEach(() => {
+    config = configure()
 
-    const lock = {
+    lock = {
       id: 'lockwithdrawalsubmittedid',
       keyPrice: '10000000000000000000',
       expirationDuration: '172800',
@@ -21,18 +25,21 @@ describe('LockIconBar', () => {
       address: '0xbc7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       transaction: 'deployedid',
     }
-    const transaction = {
+    transaction = {
       status: 'mined',
       confirmations: 24,
     }
-    const withdrawalTransaction = {
+    withdrawalTransaction = {
       status: 'submitted',
       confirmations: 0,
       withdrawal: '0xbc7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
     }
 
-    const store = createUnlockStore({})
+    store = createUnlockStore({})
+    toggleCode = jest.fn()
+  })
 
+  it('should display a submitted label when withdrawal has been submitted', () => {
     let wrapper = rtl.render(
       <Provider store={store}>
         <LockIconBar
@@ -49,29 +56,16 @@ describe('LockIconBar', () => {
       wrapper.queryByText('Submitted to Network', { exact: false })
     ).not.toBeNull()
   })
-  it('should display a confirming label when withdrawal is confirming', () => {
-    const config = configure()
 
-    const lock = {
-      id: 'lockwithdrawalconfirmingid',
-      keyPrice: '10000000000000000000',
-      expirationDuration: '172800',
-      maxNumberOfKeys: 240,
-      outstandingKeys: 3,
-      address: '0xba7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
-      transaction: 'deployedid',
-    }
-    const transaction = {
-      status: 'mined',
-      confirmations: 24,
-    }
-    const withdrawalTransaction = {
+  it('should display a confirming label when withdrawal is confirming', () => {
+    config.requiredConfirmations = 12
+    withdrawalTransaction = {
       status: 'mined',
       confirmations: 2,
       withdrawal: 'lockwithdrawalconfirmingid',
     }
 
-    const store = createUnlockStore({})
+    store = createUnlockStore({})
 
     let wrapper = rtl.render(
       <Provider store={store}>


### PR DESCRIPTION
# Description

In preparation for #1055, this refactors the `LockIconBar.test.js` to remove redundancy and also to guarantee that the final test works correctly in all environments (in the vs code jest runner, requiredConfirmations is 6 for some reason, instead of 12)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
