### PR TITLE
LinkedIn link no longer renders if no href provided

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -4779,14 +4779,16 @@ Object {
                   >
                     Personal site
                   </a>
-                   - 
-                  <a
-                    href="https://www.linkedin.com/in/akeemadeniji"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    LinkedIn
-                  </a>
+                  <span>
+                     - 
+                    <a
+                      href="https://www.linkedin.com/in/akeemadeniji"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      LinkedIn
+                    </a>
+                  </span>
                 </small>
               </div>
               <div
@@ -4815,14 +4817,16 @@ Object {
                   >
                     Personal site
                   </a>
-                   - 
-                  <a
-                    href="https://www.linkedin.com/in/benwerd/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    LinkedIn
-                  </a>
+                  <span>
+                     - 
+                    <a
+                      href="https://www.linkedin.com/in/benwerd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      LinkedIn
+                    </a>
+                  </span>
                 </small>
               </div>
               <div
@@ -4850,14 +4854,16 @@ Object {
                   >
                     Personal site
                   </a>
-                   - 
-                  <a
-                    href="https://www.linkedin.com/in/gbeaver/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    LinkedIn
-                  </a>
+                  <span>
+                     - 
+                    <a
+                      href="https://www.linkedin.com/in/gbeaver/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      LinkedIn
+                    </a>
+                  </span>
                 </small>
               </div>
               <div
@@ -4886,14 +4892,16 @@ Object {
                   >
                     Personal site
                   </a>
-                   - 
-                  <a
-                    href="https://www.linkedin.com/in/juliengenestoux/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    LinkedIn
-                  </a>
+                  <span>
+                     - 
+                    <a
+                      href="https://www.linkedin.com/in/juliengenestoux/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      LinkedIn
+                    </a>
+                  </span>
                 </small>
               </div>
               <div
@@ -4922,14 +4930,16 @@ Object {
                   >
                     Personal site
                   </a>
-                   - 
-                  <a
-                    href="https://www.linkedin.com/in/smombartz/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    LinkedIn
-                  </a>
+                  <span>
+                     - 
+                    <a
+                      href="https://www.linkedin.com/in/smombartz/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      LinkedIn
+                    </a>
+                  </span>
                 </small>
               </div>
             </div>
@@ -5381,14 +5391,16 @@ Object {
                 >
                   Personal site
                 </a>
-                 - 
-                <a
-                  href="https://www.linkedin.com/in/akeemadeniji"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  LinkedIn
-                </a>
+                <span>
+                   - 
+                  <a
+                    href="https://www.linkedin.com/in/akeemadeniji"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    LinkedIn
+                  </a>
+                </span>
               </small>
             </div>
             <div
@@ -5417,14 +5429,16 @@ Object {
                 >
                   Personal site
                 </a>
-                 - 
-                <a
-                  href="https://www.linkedin.com/in/benwerd/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  LinkedIn
-                </a>
+                <span>
+                   - 
+                  <a
+                    href="https://www.linkedin.com/in/benwerd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    LinkedIn
+                  </a>
+                </span>
               </small>
             </div>
             <div
@@ -5452,14 +5466,16 @@ Object {
                 >
                   Personal site
                 </a>
-                 - 
-                <a
-                  href="https://www.linkedin.com/in/gbeaver/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  LinkedIn
-                </a>
+                <span>
+                   - 
+                  <a
+                    href="https://www.linkedin.com/in/gbeaver/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    LinkedIn
+                  </a>
+                </span>
               </small>
             </div>
             <div
@@ -5488,14 +5504,16 @@ Object {
                 >
                   Personal site
                 </a>
-                 - 
-                <a
-                  href="https://www.linkedin.com/in/juliengenestoux/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  LinkedIn
-                </a>
+                <span>
+                   - 
+                  <a
+                    href="https://www.linkedin.com/in/juliengenestoux/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    LinkedIn
+                  </a>
+                </span>
               </small>
             </div>
             <div
@@ -5524,14 +5542,16 @@ Object {
                 >
                   Personal site
                 </a>
-                 - 
-                <a
-                  href="https://www.linkedin.com/in/smombartz/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  LinkedIn
-                </a>
+                <span>
+                   - 
+                  <a
+                    href="https://www.linkedin.com/in/smombartz/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    LinkedIn
+                  </a>
+                </span>
               </small>
             </div>
           </div>

--- a/unlock-app/src/pages/about.js
+++ b/unlock-app/src/pages/about.js
@@ -143,10 +143,14 @@ const Person = ({ name, picture, personalLink, linkedIn, bio }) => (
       <a href={personalLink} target="_blank" rel="noopener noreferrer">
         Personal site
       </a>
-      &nbsp;-&nbsp;
-      <a href={linkedIn} target="_blank" rel="noopener noreferrer">
-        LinkedIn
-      </a>
+      {linkedIn && (
+        <span>
+          &nbsp;-&nbsp;
+          <a href={linkedIn} target="_blank" rel="noopener noreferrer">
+            LinkedIn
+          </a>
+        </span>
+      )}
     </small>
   </Column>
 )


### PR DESCRIPTION
# Description
Previously, the Person component in `pages/about.js` assumed that there would always be a value for the LinkedIn href. As a result, if a Person was created without a `linkedIn` property, the link would render but not lead anywhere. This pull request adds a check and only render the LinkedIn link and separator if a LinkedIn account is provided.

<img width="900" alt="screen shot 2019-01-16 at 4 18 36 pm" src="https://user-images.githubusercontent.com/9300702/51279481-869c4100-19ab-11e9-8ed5-e71411a520db.png">
Left, a Person with no LinkedIn account. Right, a person with a LinkedIn account.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
