### PR TITLE
Convert lock to form editable version, if requested

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -14,6 +14,7 @@ describe('CreatorLockForm', () => {
         hideAction={hideAction}
         createLock={createLock}
         account={{ address: 'hi' }}
+        convert={false}
         {...values}
       />
     )
@@ -212,7 +213,7 @@ describe('CreatorLockForm', () => {
       expect(wrapper.getByValue('0.01').dataset.valid).toBe('true')
     })
     it('submit button is enabled and activates on submit', () => {
-      const wrapper = makeLockForm()
+      const wrapper = makeLockForm({ convert: true })
 
       const submit = wrapper.getByText('Submit')
       expect(submit).not.toBeNull()

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -20,10 +20,16 @@ import { LockStatus } from './lock/CreatorLockStatus'
 export class CreatorLockForm extends React.Component {
   constructor(props, context) {
     super(props, context)
+    let expirationDuration = props.expirationDuration
+    let keyPrice = props.keyPrice
+    if (props.convert) {
+      keyPrice = Web3Utils.fromWei(keyPrice, props.keyPriceCurrency)
+      expirationDuration = expirationDuration / props.expirationDurationUnit
+    }
     this.state = {
-      expirationDuration: props.expirationDuration,
+      expirationDuration: expirationDuration,
       expirationDurationUnit: props.expirationDurationUnit, // Days
-      keyPrice: props.keyPrice,
+      keyPrice: keyPrice,
       keyPriceCurrency: props.keyPriceCurrency,
       maxNumberOfKeys: props.maxNumberOfKeys,
       unlimitedKeys: props.maxNumberOfKeys === '∞',
@@ -217,16 +223,18 @@ CreatorLockForm.propTypes = {
   maxNumberOfKeys: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), // string is for '∞'
   name: PropTypes.string,
   address: PropTypes.string,
+  convert: PropTypes.bool,
 }
 
 CreatorLockForm.defaultProps = {
-  expirationDuration: 30,
+  expirationDuration: 30 * 86400,
   expirationDurationUnit: 86400, // Days
-  keyPrice: '0.01',
+  keyPrice: '10000000000000000',
   keyPriceCurrency: 'ether',
   maxNumberOfKeys: 10,
   name: 'New Lock',
   address: uniqid(), // for new locks, we don't have an address, so use a temporary one
+  convert: true,
 }
 
 const mapStateToProps = state => {


### PR DESCRIPTION
# Description

Prior to this PR, the only format that `CreatorLockForm` received lock properties in was the default values used to populate the form fields. This has `expirationDuration` formatted as days, instead of seconds, and `keyPrice` formatted in eth instead of in wei.

This diverges from the format that the rest of the unlock app receives a lock in. This PR changes the `CreatorLockForm` so that it expects props, by default, to be in the standard format with `expirationDuration` in seconds, and `keyPrice` in wei. Conversion to the human-readable form values happens in the constructor. Output is still converted in `saveLock` to the standard format.

It is expected that in a future PR, the ethereum-specific stuff will be extracted to web3service when that makes sense.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
