### PR TITLE
enable edit in CreatorLock

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
@@ -72,6 +72,25 @@ describe('CreatorLock', () => {
       )
     ).not.toBeNull()
   })
+  it('should call edit when the button is clicked', () => {
+    const config = configure()
+
+    const store = createUnlockStore()
+
+    const edit = jest.fn()
+
+    let wrapper = rtl.render(
+      <Provider store={store} config={config}>
+        <CreatorLock lock={lock} transaction={transaction} edit={edit} />
+      </Provider>
+    )
+
+    let editButton = wrapper.getByTitle('Edit')
+    rtl.fireEvent.click(editButton)
+
+    expect(edit).toHaveBeenCalledTimes(1)
+    expect(edit).toHaveBeenCalledWith(lock.address)
+  })
   it('should display the correct number of keys', () => {
     const config = configure()
 

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import PropTypes from 'prop-types'
 
 import UnlockPropTypes from '../../propTypes'
 import LockIconBar from './lock/LockIconBar'
@@ -53,7 +54,7 @@ export class CreatorLock extends React.Component {
   render() {
     // TODO add all-time balance to lock
 
-    const { lock } = this.props
+    const { lock, edit } = this.props
     const { showEmbedCode, showKeys } = this.state
 
     // Some sanitization of strings to display
@@ -80,7 +81,11 @@ export class CreatorLock extends React.Component {
             <Balance amount={lock.balance} convertCurrency={false} />
           </Phone>
         </BalanceContainer>
-        <LockIconBar lock={lock} toggleCode={this.toggleEmbedCode} />
+        <LockIconBar
+          lock={lock}
+          toggleCode={this.toggleEmbedCode}
+          edit={edit}
+        />
         {showEmbedCode && (
           <LockPanel>
             <LockDivider />
@@ -100,6 +105,11 @@ export class CreatorLock extends React.Component {
 
 CreatorLock.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
+  edit: PropTypes.func, // no-op for now, we will change to isRequired when wiring up the action
+}
+
+CreatorLock.defaultProps = {
+  edit: () => {},
 }
 
 export default CreatorLock

--- a/unlock-app/src/stories/creator/CreatorLock.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLock.stories.js
@@ -1,6 +1,7 @@
 import { Provider } from 'react-redux'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
 import CreatorLock from '../../components/creator/CreatorLock'
 import createUnlockStore from '../../createUnlockStore'
 
@@ -55,7 +56,7 @@ storiesOf('CreatorLock', module)
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       transaction: 'deployedid',
     }
-    return <CreatorLock lock={lock} />
+    return <CreatorLock lock={lock} edit={action('edit')} />
   })
   .add('Submitted', () => {
     const lock = {
@@ -66,7 +67,7 @@ storiesOf('CreatorLock', module)
       address: '0x127c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       transaction: 'submittedid',
     }
-    return <CreatorLock lock={lock} />
+    return <CreatorLock lock={lock} edit={action('edit')} />
   })
   .add('Confirming', () => {
     const lock = {
@@ -81,7 +82,13 @@ storiesOf('CreatorLock', module)
       status: 'mined',
       confirmations: 2,
     }
-    return <CreatorLock lock={lock} transaction={transaction} />
+    return (
+      <CreatorLock
+        lock={lock}
+        transaction={transaction}
+        edit={action('edit')}
+      />
+    )
   })
   .add('Not found', () => {
     const lock = {
@@ -92,7 +99,7 @@ storiesOf('CreatorLock', module)
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       transaction: '0x789',
     }
-    return <CreatorLock lock={lock} transaction={null} />
+    return <CreatorLock lock={lock} transaction={null} edit={action('edit')} />
   })
   .add('With key', () => {
     const lock = {
@@ -107,7 +114,13 @@ storiesOf('CreatorLock', module)
       status: 'mined',
       confirmations: 14,
     }
-    return <CreatorLock lock={lock} transaction={transaction} />
+    return (
+      <CreatorLock
+        lock={lock}
+        transaction={transaction}
+        edit={action('edit')}
+      />
+    )
   })
   .add('Withdrawal submitted', () => {
     const lock = {
@@ -119,7 +132,7 @@ storiesOf('CreatorLock', module)
       address: withdrawalSubmittedAddress,
       transaction: 'deployedid',
     }
-    return <CreatorLock lock={lock} />
+    return <CreatorLock lock={lock} edit={action('edit')} />
   })
   .add('Withdrawing', () => {
     const lock = {
@@ -131,5 +144,5 @@ storiesOf('CreatorLock', module)
       address: withdrawalConfirmingAddress,
       transaction: 'deployedid',
     }
-    return <CreatorLock lock={lock} />
+    return <CreatorLock lock={lock} edit={action('edit')} />
   })


### PR DESCRIPTION
# Description

This enables the edit action in `CreatorLock`, and passes it to `LockIconBar`

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
