### PR TITLE
Enable edit form for lock

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
@@ -75,4 +75,29 @@ describe('CreatorLocks', () => {
 
     expect(createLock).toHaveBeenCalled()
   })
+  it('should enable editing of an existing lock when edit is pressed', () => {
+    const locks = {
+      '0x1234567890': {
+        address: '0x1234567890',
+        transaction: 'transactionid',
+        keyPrice: '100000000000000000',
+        balance: '1',
+        expirationDuration: 100,
+      },
+    }
+
+    const store = createUnlockStore({})
+
+    const wrapper = rtl.render(
+      <Provider store={store}>
+        <CreatorLocks createLock={() => {}} locks={locks} />
+      </Provider>
+    )
+    wrapper.debug()
+
+    const editButton = wrapper.getByTitle('Edit')
+    rtl.fireEvent.click(editButton)
+
+    expect(wrapper.queryByValue('0.01')).not.toBeNull()
+  })
 })

--- a/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
@@ -17,7 +17,7 @@ describe('CreatorLocks', () => {
 
     const wrapper = rtl.render(
       <Provider store={store}>
-        <CreatorLocks />
+        <CreatorLocks account={{}} createLock={() => {}} />
       </Provider>
     )
 
@@ -38,7 +38,7 @@ describe('CreatorLocks', () => {
 
     let wrapper = rtl.render(
       <Provider store={store}>
-        <CreatorLocks />
+        <CreatorLocks account={{}} createLock={() => {}} />
       </Provider>
     )
 
@@ -63,7 +63,7 @@ describe('CreatorLocks', () => {
 
     const wrapper = rtl.render(
       <Provider store={store}>
-        <CreatorLocks createLock={createLock} />
+        <CreatorLocks createLock={createLock} account={{}} />
       </Provider>
     )
 
@@ -86,18 +86,19 @@ describe('CreatorLocks', () => {
       },
     }
 
-    const store = createUnlockStore({})
+    const store = createUnlockStore({
+      account: {},
+    })
 
     const wrapper = rtl.render(
       <Provider store={store}>
-        <CreatorLocks createLock={() => {}} locks={locks} />
+        <CreatorLocks createLock={() => {}} locks={locks} account={{}} />
       </Provider>
     )
-    wrapper.debug()
 
     const editButton = wrapper.getByTitle('Edit')
     rtl.fireEvent.click(editButton)
 
-    expect(wrapper.queryByValue('0.01')).not.toBeNull()
+    expect(wrapper.queryByValue('0.1')).not.toBeNull() // queryByValue only matches form fields
   })
 })

--- a/unlock-app/src/components/creator/CreatorLocks.js
+++ b/unlock-app/src/components/creator/CreatorLocks.js
@@ -16,8 +16,45 @@ export class CreatorLocks extends React.Component {
     const { showForm } = this.props
     this.state = {
       showDashboardForm: !!showForm,
+      editingLocks: {},
     }
     this.toggleForm = this.toggleForm.bind(this)
+  }
+
+  getLockElement(lock) {
+    const key = JSON.stringify(lock)
+    const { editingLocks } = this.state
+    if (editingLocks[lock.address]) {
+      return (
+        <CreatorLockForm
+          key={key}
+          createLock={() => {}}
+          hideAction={() => this.stopEditingLock(lock.address)}
+          {...lock}
+        />
+      )
+    }
+    return (
+      <CreatorLock
+        key={key}
+        lock={lock}
+        edit={() => this.editLock(lock.address)}
+      />
+    )
+  }
+
+  editLock(address) {
+    this.setState(state => ({
+      editingLocks: { ...state.editingLocks, [address]: true },
+    }))
+  }
+
+  stopEditingLock(address) {
+    this.setState(state => {
+      const editingLocks = { ...state.editingLocks }
+      delete editingLocks[address]
+      return { editingLocks }
+    })
   }
 
   toggleForm() {
@@ -52,9 +89,7 @@ export class CreatorLocks extends React.Component {
             createLock={createLock}
           />
         )}
-        {lockFeed.map(lock => {
-          return <CreatorLock key={JSON.stringify(lock)} lock={lock} />
-        })}
+        {lockFeed.map(lock => this.getLockElement(lock))}
       </Locks>
     )
   }


### PR DESCRIPTION
# Description

This enables the edit form on the dashboard. saving edits is a no-op.

![out](https://user-images.githubusercontent.com/98250/51285961-e5b78100-19be-11e9-968d-9550d01a2409.gif)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
