### PR TITLE
disable non-editable fields when editing a lock

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -15493,6 +15493,10 @@ Object {
   border: 1px solid var(--red);
 }
 
+.c0 input:disabled {
+  color: var(--silver);
+}
+
 .c7 {
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -15761,7 +15765,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="xrsnj2-0 sc-1u8ov25-1 dBHNok"
+      class="xrsnj2-0 sc-1u8ov25-1 eGbxwb"
     >
       <svg
         viewBox="0 0 216 216"
@@ -15962,21 +15966,14 @@ exports[`Storyshots CreatorLockForm With existing lock 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c6 {
+    .c5 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c6:before {
+.c5:before {
   content: '三';
-}
-
-.c4 {
-  color: var(--link);
-  font-size: 11px;
-  width: 100%;
-  padding: 5px;
 }
 
 .c0 {
@@ -16027,7 +16024,11 @@ Object {
   border: 1px solid var(--red);
 }
 
-.c7 {
+.c0 input:disabled {
+  color: var(--silver);
+}
+
+.c6 {
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
@@ -16069,19 +16070,19 @@ Object {
   width: 80%;
 }
 
-.c5 {
+.c4 {
   white-space: nowrap;
   text-transform: uppercase;
   white-space: nowrap;
 }
 
-.c5 input[type='text'],
-.c5 input[type='number'] {
+.c4 input[type='text'],
+.c4 input[type='number'] {
   min-width: 30px;
   width: 50%;
 }
 
-.c8 {
+.c7 {
   cursor: pointer;
   font: inherit;
   font-size: 13px;
@@ -16095,7 +16096,7 @@ Object {
   padding: 0;
 }
 
-.c9 {
+.c8 {
   cursor: pointer;
   font: inherit;
   font-size: 10px;
@@ -16216,10 +16217,10 @@ Object {
         >
           <input
             data-valid="true"
+            disabled=""
             name="name"
-            required=""
             type="text"
-            value="New Lock"
+            value="Existing Lock"
           />
         </div>
         <div
@@ -16227,12 +16228,12 @@ Object {
         >
           <input
             data-valid="true"
+            disabled=""
             inputmode="numeric"
             name="expirationDuration"
-            required=""
             step="1"
             type="number"
-            value="30"
+            value="2"
           />
            
           days
@@ -16242,22 +16243,17 @@ Object {
         >
           <input
             data-valid="true"
+            disabled=""
             name="maxNumberOfKeys"
-            required=""
             type="text"
-            value="10"
+            value="240"
           />
-          <div
-            class="c4"
-          >
-            Unlimited
-          </div>
         </div>
         <span
-          class="c5"
+          class="c4"
         >
           <span
-            class="c6"
+            class="c5"
           />
           <input
             data-valid="true"
@@ -16266,22 +16262,22 @@ Object {
             required=""
             step="0.00001"
             type="number"
-            value="0.01"
+            value="10"
           />
         </span>
         <div>
           -
         </div>
         <div
-          class="c7"
+          class="c6"
         >
           <button
-            class="c8"
+            class="c7"
           >
             Submit
           </button>
           <button
-            class="c9"
+            class="c8"
           >
             Cancel
           </button>
@@ -16295,7 +16291,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="xrsnj2-0 sc-1u8ov25-1 dBHNok"
+      class="xrsnj2-0 sc-1u8ov25-1 eGbxwb"
     >
       <svg
         viewBox="0 0 216 216"
@@ -16374,10 +16370,10 @@ Object {
       >
         <input
           data-valid="true"
+          disabled=""
           name="name"
-          required=""
           type="text"
-          value="New Lock"
+          value="Existing Lock"
         />
       </div>
       <div
@@ -16385,12 +16381,12 @@ Object {
       >
         <input
           data-valid="true"
+          disabled=""
           inputmode="numeric"
           name="expirationDuration"
-          required=""
           step="1"
           type="number"
-          value="30"
+          value="2"
         />
          
         days
@@ -16400,16 +16396,11 @@ Object {
       >
         <input
           data-valid="true"
+          disabled=""
           name="maxNumberOfKeys"
-          required=""
           type="text"
-          value="10"
+          value="240"
         />
-        <div
-          class="xrsnj2-1 sc-1u8ov25-0 eiQcmf"
-        >
-          Unlimited
-        </div>
       </div>
       <span
         class="buwkmd-5 sc-1u8ov25-6 jyspKX"
@@ -16424,7 +16415,7 @@ Object {
           required=""
           step="0.00001"
           type="number"
-          value="0.01"
+          value="10"
         />
       </span>
       <div>

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -136,7 +136,6 @@ export class CreatorLockForm extends React.Component {
 
   render() {
     const { pending } = this.props
-    const disableEdit = !pending
     const {
       expirationDuration,
       maxNumberOfKeys,
@@ -157,8 +156,8 @@ export class CreatorLockForm extends React.Component {
             onChange={this.handleChange}
             defaultValue={name}
             data-valid={valid.name}
-            required={!disableEdit}
-            disabled={disableEdit}
+            required={pending}
+            disabled={!pending}
           />
         </FormLockName>
         <FormLockDuration>
@@ -170,8 +169,8 @@ export class CreatorLockForm extends React.Component {
             onChange={this.handleChange}
             defaultValue={expirationDuration}
             data-valid={valid.expirationDuration}
-            required={!disableEdit}
-            disabled={disableEdit}
+            required={pending}
+            disabled={!pending}
           />{' '}
           days
         </FormLockDuration>
@@ -182,10 +181,10 @@ export class CreatorLockForm extends React.Component {
             onChange={this.handleChange}
             value={maxNumberOfKeys}
             data-valid={valid.maxNumberOfKeys}
-            required={!disableEdit}
-            disabled={disableEdit}
+            required={pending}
+            disabled={!pending}
           />
-          {!disableEdit && !unlimitedKeys && (
+          {pending && !unlimitedKeys && (
             <LockLabelUnlimited onClick={this.handleUnlimitedClick}>
               Unlimited
             </LockLabelUnlimited>

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -135,6 +135,8 @@ export class CreatorLockForm extends React.Component {
   }
 
   render() {
+    const { address } = this.props
+    const disableEdit = !!address
     const {
       expirationDuration,
       maxNumberOfKeys,
@@ -155,7 +157,8 @@ export class CreatorLockForm extends React.Component {
             onChange={this.handleChange}
             defaultValue={name}
             data-valid={valid.name}
-            required
+            required={!disableEdit}
+            disabled={disableEdit}
           />
         </FormLockName>
         <FormLockDuration>
@@ -167,7 +170,8 @@ export class CreatorLockForm extends React.Component {
             onChange={this.handleChange}
             defaultValue={expirationDuration}
             data-valid={valid.expirationDuration}
-            required
+            required={!disableEdit}
+            disabled={disableEdit}
           />{' '}
           days
         </FormLockDuration>
@@ -178,9 +182,10 @@ export class CreatorLockForm extends React.Component {
             onChange={this.handleChange}
             value={maxNumberOfKeys}
             data-valid={valid.maxNumberOfKeys}
-            required
+            required={!disableEdit}
+            disabled={disableEdit}
           />
-          {!unlimitedKeys && (
+          {!disableEdit && !unlimitedKeys && (
             <LockLabelUnlimited onClick={this.handleUnlimitedClick}>
               Unlimited
             </LockLabelUnlimited>
@@ -275,6 +280,10 @@ const FormLockRow = styled(LockRow)`
 
   input[data-valid='false'] {
     border: 1px solid var(--red);
+  }
+
+  input:disabled {
+    color: var(--dimgrey);
   }
 `
 

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -135,8 +135,8 @@ export class CreatorLockForm extends React.Component {
   }
 
   render() {
-    const { address } = this.props
-    const disableEdit = address.length === 42
+    const { pending } = this.props
+    const disableEdit = !pending
     const {
       expirationDuration,
       maxNumberOfKeys,
@@ -227,6 +227,7 @@ CreatorLockForm.propTypes = {
   maxNumberOfKeys: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), // string is for '∞'
   name: PropTypes.string,
   address: PropTypes.string,
+  pending: PropTypes.bool,
   convert: PropTypes.bool, // this prop is to allow form field validation tests to test edge cases
 }
 
@@ -239,6 +240,7 @@ CreatorLockForm.defaultProps = {
   name: 'New Lock',
   address: uniqid(), // for new locks, we don't have an address, so use a temporary one
   convert: true,
+  pending: false,
 }
 
 const mapStateToProps = state => {

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -283,7 +283,7 @@ const FormLockRow = styled(LockRow)`
   }
 
   input:disabled {
-    color: var(--dimgrey);
+    color: var(--silver);
   }
 `
 

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -136,7 +136,7 @@ export class CreatorLockForm extends React.Component {
 
   render() {
     const { address } = this.props
-    const disableEdit = !!address
+    const disableEdit = address.length === 42
     const {
       expirationDuration,
       maxNumberOfKeys,

--- a/unlock-app/src/components/creator/CreatorLocks.js
+++ b/unlock-app/src/components/creator/CreatorLocks.js
@@ -50,6 +50,7 @@ export class CreatorLocks extends React.Component {
           <CreatorLockForm
             hideAction={this.toggleForm}
             createLock={createLock}
+            pending
           />
         )}
         {lockFeed.map(lock => {

--- a/unlock-app/src/stories/creator/CreatorLockForm.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm.stories.js
@@ -22,13 +22,13 @@ storiesOf('CreatorLockForm', module)
     // TODO: implement this
     const lock = {
       keyPrice: '10000000000000000000',
-      expirationDuration: '172800',
+      expirationDuration: 172800,
       maxNumberOfKeys: 240,
       outstandingKeys: 3,
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       name: 'Existing Lock',
     }
     return (
-      <CreatorLockForm {...lock} hideAction={() => {}} createLock={() => {}} />
+      <CreatorLockForm hideAction={() => {}} createLock={() => {}} {...lock} />
     )
   })

--- a/unlock-app/src/stories/creator/CreatorLockForm.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm.stories.js
@@ -24,7 +24,7 @@ storiesOf('CreatorLockForm', module)
     // TODO: implement this
     const lock = {
       keyPrice: '10000000000000000000',
-      expirationDuration: '172800',
+      expirationDuration: 172800,
       maxNumberOfKeys: 240,
       outstandingKeys: 3,
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',

--- a/unlock-app/src/stories/creator/CreatorLockForm.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm.stories.js
@@ -16,7 +16,9 @@ const store = createUnlockStore({
 storiesOf('CreatorLockForm', module)
   .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('Default', () => {
-    return <CreatorLockForm hideAction={() => {}} createLock={() => {}} />
+    return (
+      <CreatorLockForm hideAction={() => {}} createLock={() => {}} pending />
+    )
   })
   .add('With existing lock', () => {
     // TODO: implement this

--- a/unlock-app/src/stories/creator/CreatorLockForm.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm.stories.js
@@ -29,10 +29,6 @@ storiesOf('CreatorLockForm', module)
       name: 'Existing Lock',
     }
     return (
-      <CreatorLockForm
-        lock={lock}
-        hideAction={() => {}}
-        createLock={() => {}}
-      />
+      <CreatorLockForm {...lock} hideAction={() => {}} createLock={() => {}} />
     )
   })

--- a/unlock-app/src/stories/creator/CreatorLockForm.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm.stories.js
@@ -24,7 +24,7 @@ storiesOf('CreatorLockForm', module)
     // TODO: implement this
     const lock = {
       keyPrice: '10000000000000000000',
-      expirationDuration: 172800,
+      expirationDuration: '172800',
       maxNumberOfKeys: 240,
       outstandingKeys: 3,
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',


### PR DESCRIPTION
# Description

When editing a lock, we only want key price to be editable (currently). This PR disables all other fields and dims the text as a visual indicator.

<img width="1383" alt="screen shot 2019-01-16 at 6 59 45 pm" src="https://user-images.githubusercontent.com/98250/51286423-ef41e880-19c0-11e9-81de-7e25f8ddd069.png">
<img width="1383" alt="screen shot 2019-01-16 at 6 59 39 pm" src="https://user-images.githubusercontent.com/98250/51286424-ef41e880-19c0-11e9-8179-4f6467b90df9.png">

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
