### PR TITLE
Fix unlimited infinity symbol display in CreatorLockForm

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -210,6 +210,7 @@ describe('CreatorLockForm', () => {
     it('max number of keys is infinity', () => {
       const wrapper = makeLockForm({ maxNumberOfKeys: '∞' })
 
+      expect(wrapper.getByDisplayValue('∞')).not.toBeNull()
       expect(wrapper.getByValue('∞').dataset.valid).toBe('true')
     })
     it('key price is a positive number', () => {

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -15652,11 +15652,9 @@ Object {
         >
           <input
             data-valid="true"
-            inputmode="numeric"
             name="maxNumberOfKeys"
             required=""
-            step="1"
-            type="number"
+            type="text"
             value="10"
           />
           <div
@@ -15812,11 +15810,9 @@ Object {
       >
         <input
           data-valid="true"
-          inputmode="numeric"
           name="maxNumberOfKeys"
           required=""
-          step="1"
-          type="number"
+          type="text"
           value="10"
         />
         <div
@@ -16190,11 +16186,9 @@ Object {
         >
           <input
             data-valid="true"
-            inputmode="numeric"
             name="maxNumberOfKeys"
             required=""
-            step="1"
-            type="number"
+            type="text"
             value="10"
           />
           <div
@@ -16350,11 +16344,9 @@ Object {
       >
         <input
           data-valid="true"
-          inputmode="numeric"
           name="maxNumberOfKeys"
           required=""
-          step="1"
-          type="number"
+          type="text"
           value="10"
         />
         <div

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -144,6 +144,7 @@ export class CreatorLockForm extends React.Component {
       valid,
     } = this.state
 
+    // NOTE: maxNumberOfKeys must be a text input in order to support the infinity symbol
     return (
       <FormLockRow>
         <Icon />

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -172,9 +172,7 @@ export class CreatorLockForm extends React.Component {
         </FormLockDuration>
         <FormLockKeys>
           <input
-            type="number"
-            step="1"
-            inputMode="numeric"
+            type="text"
             name="maxNumberOfKeys"
             onChange={this.handleChange}
             value={maxNumberOfKeys}


### PR DESCRIPTION
# Description

Setting the input type to number for `maxNumberOfKeys` inadvertantly broke the display of the infinity symbol. This PR fixes it and adds a line to a test to make sure it doesn't happen again

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
