### PR TITLE
Revert "lift createLock up to CreatorLocks from CreatorLockForm (#1061)"

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
@@ -54,25 +54,4 @@ describe('CreatorLocks', () => {
     expect(wrapper.queryByValue('New Lock')).toBeNull()
     expect(wrapper.queryByText('Submit')).toBeNull()
   })
-  it('should call createLock when submit button is pressed', () => {
-    const createLock = jest.fn()
-
-    const store = createUnlockStore({
-      account: {},
-    })
-
-    const wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks createLock={createLock} />
-      </Provider>
-    )
-
-    const createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
-
-    const submitButton = wrapper.getByText('Submit')
-    rtl.fireEvent.click(submitButton)
-
-    expect(createLock).toHaveBeenCalled()
-  })
 })

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -16,6 +16,7 @@ import {
   LockKeys,
 } from './CreatorLock'
 import { LockStatus } from './lock/CreatorLockStatus'
+import { createLock } from '../../actions/lock'
 
 export class CreatorLockForm extends React.Component {
   constructor(props, context) {
@@ -242,7 +243,14 @@ const mapStateToProps = state => {
   }
 }
 
-export default connect(mapStateToProps)(CreatorLockForm)
+const mapDispatchToProps = dispatch => ({
+  createLock: lock => dispatch(createLock(lock)),
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(CreatorLockForm)
 
 const LockLabelUnlimited = styled(LockLabel)`
   font-size: 11px;

--- a/unlock-app/src/components/creator/CreatorLocks.js
+++ b/unlock-app/src/components/creator/CreatorLocks.js
@@ -1,14 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
-import { connect } from 'react-redux'
-import PropTypes from 'prop-types'
-
 import UnlockPropTypes from '../../propTypes'
 import CreatorLock, { LockRowGrid, PhoneLockRowGrid } from './CreatorLock'
 import CreatorLockForm from './CreatorLockForm'
 import Errors from '../interface/Errors'
 import Media, { NoPhone, Phone } from '../../theme/media'
-import { createLock } from '../../actions/lock'
 
 export class CreatorLocks extends React.Component {
   constructor(props, context) {
@@ -27,7 +23,7 @@ export class CreatorLocks extends React.Component {
   }
 
   render() {
-    const { locks, createLock } = this.props
+    const { locks } = this.props
     const { showDashboardForm } = this.state
     let lockFeed = Object.values(locks).reverse() // We want to display newer locks first
 
@@ -46,12 +42,7 @@ export class CreatorLocks extends React.Component {
           <CreateButton onClick={this.toggleForm}>Create Lock</CreateButton>
         </LockHeaderRow>
         <Errors />
-        {showDashboardForm && (
-          <CreatorLockForm
-            hideAction={this.toggleForm}
-            createLock={createLock}
-          />
-        )}
+        {showDashboardForm && <CreatorLockForm hideAction={this.toggleForm} />}
         {lockFeed.map(lock => {
           return <CreatorLock key={JSON.stringify(lock)} lock={lock} />
         })}
@@ -61,7 +52,6 @@ export class CreatorLocks extends React.Component {
 }
 
 CreatorLocks.propTypes = {
-  createLock: PropTypes.func.isRequired,
   locks: UnlockPropTypes.locks,
   showForm: UnlockPropTypes.showDashboardForm,
 }
@@ -71,14 +61,7 @@ CreatorLocks.defaultProps = {
   showForm: false,
 }
 
-const mapDispatchToProps = dispatch => ({
-  createLock: lock => dispatch(createLock(lock)),
-})
-
-export default connect(
-  undefined, // no mapStateToProps for CreatorLocks, we only use mapDispatchToProps
-  mapDispatchToProps
-)(CreatorLocks)
+export default CreatorLocks
 
 const Locks = styled.section`
   display: grid;

--- a/unlock-app/src/stories/creator/CreatorLockForm.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm.stories.js
@@ -16,7 +16,7 @@ const store = createUnlockStore({
 storiesOf('CreatorLockForm', module)
   .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('Default', () => {
-    return <CreatorLockForm hideAction={() => {}} createLock={() => {}} />
+    return <CreatorLockForm hideAction={() => {}} />
   })
   .add('With existing lock', () => {
     // TODO: implement this
@@ -28,11 +28,5 @@ storiesOf('CreatorLockForm', module)
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       name: 'Existing Lock',
     }
-    return (
-      <CreatorLockForm
-        lock={lock}
-        hideAction={() => {}}
-        createLock={() => {}}
-      />
-    )
+    return <CreatorLockForm lock={lock} hideAction={() => {}} />
   })


### PR DESCRIPTION
This reverts commit ca262984aa8a818c971e932768ccdb0131c1c8f9.

# Description

Move `createLock` back into `CreatorLock` from `CreatorLocks`

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
