### PR TITLE
Add numberOfKeysSold

### DIFF
--- a/smart-contracts/test/Lock/Lock.js
+++ b/smart-contracts/test/Lock/Lock.js
@@ -25,14 +25,16 @@ contract('Lock', (accounts) => {
       lock.expirationDuration.call(),
       lock.keyPrice.call(),
       lock.maxNumberOfKeys.call(),
-      lock.outstandingKeys.call()
+      lock.outstandingKeys.call(),
+      lock.numberOfOwners.call()
     ]).then(
       ([
         owner,
         expirationDuration,
         keyPrice,
         maxNumberOfKeys,
-        outstandingKeys
+        outstandingKeys,
+        numberOfOwners
       ]) => {
         assert.strictEqual(owner, accounts[0])
         assert(expirationDuration.eq(60 * 60 * 24 * 30))
@@ -42,6 +44,7 @@ contract('Lock', (accounts) => {
         )
         assert(maxNumberOfKeys.eq(10))
         assert(outstandingKeys.eq(0))
+        assert(numberOfOwners.eq(0))
       }
     )
   })

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -47,6 +47,12 @@ contract('Lock ERC721', (accounts) => {
       })
     })
 
+    it('should have the right number of owners', () => {
+      return lock.numberOfOwners().then((numberOfOwners) => {
+        assert.equal(numberOfOwners, 4)
+      })
+    })
+
     it('should allow for access to an individual key owner', () => {
       return Promise.all([
         lock.owners(0),
@@ -59,10 +65,52 @@ contract('Lock ERC721', (accounts) => {
     })
 
     it('should fail to access to an individual key owner when out of bounds', () => {
-      return lock.owners(5).then((missing) => {
+      return lock.owners(6).then((missing) => {
         assert(false, 'This should have failed')
       }).catch(error => {
         assert.equal(error.message, 'VM Exception while processing transaction: invalid opcode')
+      })
+    })
+
+    describe('after a transfer to a new address', () => {
+      let numberOfOwners
+
+      before(async () => {
+        numberOfOwners = await lock.numberOfOwners()
+        await lock.transferFrom(accounts[1], accounts[5], accounts[1], { from: accounts[1] })
+      })
+  
+      it('should have the right number of keys', () => {
+        return lock.outstandingKeys().then((outstandingKeys) => {
+          assert.equal(outstandingKeys, 4)
+        })
+      })
+  
+      it('should have the right number of owners', () => {
+        return lock.numberOfOwners().then((_numberOfOwners) => {
+          assert(_numberOfOwners.eq(numberOfOwners.plus(1)))
+        })
+      })
+    })
+
+    describe('after a transfer to an existing owner', () => {
+      let numberOfOwners
+
+      before(async () => {
+        numberOfOwners = await lock.numberOfOwners()
+        await lock.transferFrom(accounts[1], accounts[2], accounts[1], { from: accounts[1] })
+      })
+  
+      it('should have the right number of keys', () => {
+        return lock.outstandingKeys().then((outstandingKeys) => {
+          assert.equal(outstandingKeys, 4)
+        })
+      })
+  
+      it('should have the right number of owners', () => {
+        return lock.numberOfOwners().then((_numberOfOwners) => {
+          assert(_numberOfOwners.eq(numberOfOwners))
+        })
       })
     })
   })

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -132,7 +132,7 @@ contract('Lock', (accounts) => {
       })
 
       describe('when the key was successfuly purchased', () => {
-        let outstandingKeys, balance, now
+        let outstandingKeys, numberOfOwners, balance, now
 
         before(() => {
           balance = web3.eth.getBalance(locks['FIRST'].address)
@@ -140,9 +140,13 @@ contract('Lock', (accounts) => {
             .then(_outstandingKeys => {
               outstandingKeys = parseInt(_outstandingKeys)
               now = parseInt(new Date().getTime() / 1000)
-              return locks['FIRST'].purchaseFor(accounts[0], 'Julien', {
-                value: Units.convert('0.01', 'eth', 'wei')
-              })
+              return locks['FIRST'].numberOfOwners()
+                .then(_numberOfOwners => {
+                  numberOfOwners = parseInt(_numberOfOwners)
+                  return locks['FIRST'].purchaseFor(accounts[0], 'Julien', {
+                    value: Units.convert('0.01', 'eth', 'wei')
+                  })
+                })
             })
         })
 
@@ -175,6 +179,17 @@ contract('Lock', (accounts) => {
               assert.equal(
                 parseInt(_outstandingKeys),
                 outstandingKeys + 1
+              )
+            })
+        })
+
+        it('should have increased the number of owners', () => {
+          return locks['FIRST'].numberOfOwners
+            .call()
+            .then(_numberOfOwners => {
+              assert.equal(
+                parseInt(_numberOfOwners),
+                numberOfOwners + 1
               )
             })
         })


### PR DESCRIPTION
# Description

Add a counter to track each unique key purchased.  And update the notSoldOut check to use this new counter instead of the owner count.

To-date we have been using the number of owners as a proxy for the number of keys sold.  It's up for debate on if purchasing a key second hand should count towards the total number of keys available or not... however it's a concern to use the owner count because one bad actor could move a single key across accounts they control and cause the Lock to appear as sold out.

This is a pre-req for #748 as we will use this counter to define the tokenID in a future PR.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
