### PR TITLE
Switch `approved` to key from uint

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -68,7 +68,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   // be a single approved beneficiary
   // Note 2: for transfer, both addresses will be different
   // Note 3: for sales (new keys on restricted locks), both addresses will be the same
-  mapping (address => address) internal approved;
+  mapping (uint => address) internal approved;
 
   /**
    * MODIFIERS
@@ -212,6 +212,9 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     // Effectively expiring the key for the previous owner
     keyByOwner[_from].expirationTimestamp = now;
 
+    // Clear any previous approvals
+    approved[_tokenId] = address(0);
+
     // trigger event
     emit Transfer(
       _from,
@@ -252,7 +255,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   {
     require(_approved != address(0));
 
-    approved[address(_tokenId)] = _approved;
+    approved[_tokenId] = _approved;
     emit Approval(address(_tokenId), _approved, _tokenId);
   }
 
@@ -508,7 +511,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     view
     returns (address)
   {
-    address approvedRecipient = approved[address(_tokenId)];
+    address approvedRecipient = approved[_tokenId];
     require(approvedRecipient != address(0));
     return approvedRecipient;
   }


### PR DESCRIPTION
# Description

Per the ERC721 standard, approvals should be per tokenID (uint) instead of owner (address).

The data is the same, we are just changing the type to better align with the ERC721 standard.  Tests work as is, the address type is automatically cast to uint without creating any issues.  This will be okay until tokenID no longer equals the owner address (coming in a future PR).

This is a pre-req for https://github.com/unlock-protocol/unlock/issues/748

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
