### PR TITLE
Style update - uint vs uint256

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -97,7 +97,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
 
   // Ensure that the caller owns the key
   modifier onlyKeyOwner(
-    uint256 _tokenId
+    uint _tokenId
   ) {
     require(
       address(_tokenId) == msg.sender
@@ -109,7 +109,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   // or that the caller has been approved
   // for ownership of that key
   modifier onlyKeyOwnerOrApproved(
-    uint256 _tokenId
+    uint _tokenId
   ) {
     require(
       address(_tokenId) == msg.sender
@@ -180,7 +180,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   function transferFrom(
     address _from,
     address _recipient,
-    uint256 _tokenId
+    uint _tokenId
   )
     external
     payable
@@ -231,7 +231,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     external
     onlyOwner
   {
-    uint256 balance = address(this).balance;
+    uint balance = address(this).balance;
     require(balance > 0, "Not enough funds");
     address owner = Ownable.owner();
     owner.transfer(balance);
@@ -244,7 +244,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
    */
   function approve(
     address _approved,
-    uint256 _tokenId
+    uint _tokenId
   )
     external
     payable
@@ -265,7 +265,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     external
     onlyOwner
   {
-    uint256 oldKeyPrice = keyPrice;
+    uint oldKeyPrice = keyPrice;
     keyPrice = _keyPrice;
     emit PriceChanged(oldKeyPrice, keyPrice);
   }
@@ -279,7 +279,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   )
     external
     view
-    returns (uint256)
+    returns (uint)
   {
     require(_owner != address(0), "Invalid address");
     return keyByOwner[_owner].expirationTimestamp > 0 ? 1 : 0;
@@ -290,7 +290,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
    * @return The address of the owner of the NFT, if applicable
   */
   function ownerOf(
-    uint256 _tokenId
+    uint _tokenId
   )
     external
     view
@@ -305,7 +305,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
    * Will return the approved recipient for a key, if any.
    */
   function getApproved(
-    uint256 _tokenId
+    uint _tokenId
   )
     external
     view
@@ -352,7 +352,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     uint pageIndex = 0;
 
     // Build the requested set of owners into a new temporary array:
-    for (uint256 i = _startIndex; i < endOfPageIndex; i++) {
+    for (uint i = _startIndex; i < endOfPageIndex; i++) {
       ownersByPage[pageIndex] = owners[i];
       pageIndex++;
     }
@@ -415,12 +415,12 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
    * @param from The address which previously owned the token
    * @param tokenId The NFT identifier which is being transferred
    * @param data Additional data with no specified format
-   * @return `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
+   * @return `bytes4(keccak256("onERC721Received(address,address,uint,bytes)"))`
    */
   function onERC721Received(
     address operator, // solhint-disable-line no-unused-vars
     address from, // solhint-disable-line no-unused-vars
-    uint256 tokenId, // solhint-disable-line no-unused-vars
+    uint tokenId, // solhint-disable-line no-unused-vars
     bytes data // solhint-disable-line no-unused-vars
   )
     public
@@ -491,7 +491,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     emit Transfer(
       address(0), // This is a creation.
       _recipient,
-      uint256(_recipient) // Note: since each user can own a single token, we use the current
+      uint(_recipient) // Note: since each user can own a single token, we use the current
       // owner (new!) for the token id
     );
   }
@@ -502,7 +502,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
    * actually exists.
    */
   function _getApproved(
-    uint256 _tokenId
+    uint _tokenId
   )
     internal
     view

--- a/smart-contracts/contracts/interfaces/IERC721.sol
+++ b/smart-contracts/contracts/interfaces/IERC721.sol
@@ -12,13 +12,13 @@ interface IERC721 {
   ///  (`to` == 0). Exception: during contract creation, any number of NFTs
   ///  may be created and assigned without emitting Transfer. At the time of
   ///  any transfer, the approved address for that NFT (if any) is reset to none.
-  event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
+  event Transfer(address indexed _from, address indexed _to, uint indexed _tokenId);
 
   /// @dev This emits when the approved address for an NFT is changed or
   ///  reaffirmed. The zero address indicates there is no approved address.
   ///  When a Transfer event emits, this also indicates that the approved
   ///  address for that NFT (if any) is reset to none.
-  event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+  event Approval(address indexed _owner, address indexed _approved, uint indexed _tokenId);
 
   /// @dev This emits when an operator is enabled or disabled for an owner.
   ///  The operator can manage all NFTs of the owner.
@@ -34,7 +34,7 @@ interface IERC721 {
   /// @param _from The current owner of the NFT
   /// @param _to The new owner
   /// @param _tokenId The NFT to transfer
-  function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
+  function transferFrom(address _from, address _to, uint _tokenId) external payable;
 
   /// @notice Set or reaffirm the approved address for an NFT
   /// @dev The zero address indicates there is no approved address.
@@ -42,21 +42,21 @@ interface IERC721 {
   ///  operator of the current owner.
   /// @param _approved The new approved NFT controller
   /// @param _tokenId The NFT to approve
-  function approve(address _approved, uint256 _tokenId) external payable;
+  function approve(address _approved, uint _tokenId) external payable;
 
   /// @notice Count all NFTs assigned to an owner
   /// @dev NFTs assigned to the zero address are considered invalid, and this
   ///  function throws for queries about the zero address.
   /// @param _owner An address for whom to query the balance
   /// @return The number of NFTs owned by `_owner`, possibly zero
-  function balanceOf(address _owner) external view returns (uint256);
+  function balanceOf(address _owner) external view returns (uint);
 
   /// @notice Find the owner of an NFT
   /// @dev NFTs assigned to zero address are considered invalid, and queries
   ///  about them do throw.
   /// @param _tokenId The identifier for an NFT
   /// @return The address of the owner of the NFT
-  function ownerOf(uint256 _tokenId) external view returns (address);
+  function ownerOf(uint _tokenId) external view returns (address);
 
   /// @notice Transfers the ownership of an NFT from one address to another address
   /// @dev Throws unless `msg.sender` is the current owner, an authorized
@@ -65,12 +65,12 @@ interface IERC721 {
   ///  `_tokenId` is not a valid NFT. When transfer is complete, this function
   ///  checks if `_to` is a smart contract (code size > 0). If so, it calls
   ///  `onERC721Received` on `_to` and throws if the return value is not
-  ///  `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`.
+  ///  `bytes4(keccak256("onERC721Received(address,address,uint,bytes)"))`.
   /// @param _from The current owner of the NFT
   /// @param _to The new owner
   /// @param _tokenId The NFT to transfer
   /// @param data Additional data with no specified format, sent in call to `_to`
-  // function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable;
+  // function safeTransferFrom(address _from, address _to, uint _tokenId, bytes data) external payable;
 
   /// @notice Transfers the ownership of an NFT from one address to another address
   /// @dev This works identically to the other function with an extra data parameter,
@@ -78,7 +78,7 @@ interface IERC721 {
   /// @param _from The current owner of the NFT
   /// @param _to The new owner
   /// @param _tokenId The NFT to transfer
-  // function safeTransferFrom(address _from, address _to, uint256 _tokenId) external payable;
+  // function safeTransferFrom(address _from, address _to, uint _tokenId) external payable;
 
   /// @notice Enable or disable approval for a third party ("operator") to manage
   ///  all of `msg.sender`'s assets.
@@ -92,7 +92,7 @@ interface IERC721 {
   /// @dev Throws if `_tokenId` is not a valid NFT
   /// @param _tokenId The NFT to find the approved address for
   /// @return The approved address for this NFT, or the zero address if there is none
-  function getApproved(uint256 _tokenId) external view returns (address);
+  function getApproved(uint _tokenId) external view returns (address);
 
   /// @notice Query if an address is an authorized operator for another address
   /// @param _owner The address that owns the NFTs
@@ -111,12 +111,12 @@ interface IERC721 {
 //     /// @param _from The address which previously owned the token
 //     /// @param _tokenId The NFT identifier which is being transferred
 //     /// @param _data Additional data with no specified format
-//     /// @return `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
+//     /// @return `bytes4(keccak256("onERC721Received(address,address,uint,bytes)"))`
 //     /// unless throwing
     // function onERC721Received(
     //   address _operator,
     //   address _from,
-    //   uint256 _tokenId,
+    //   uint _tokenId,
     //   bytes _data
     // )
     // external

--- a/smart-contracts/contracts/interfaces/IERC721Receiver.sol
+++ b/smart-contracts/contracts/interfaces/IERC721Receiver.sol
@@ -19,12 +19,12 @@ interface IERC721Receiver {
    * @param from The address which previously owned the token
    * @param tokenId The NFT identifier which is being transferred
    * @param data Additional data with no specified format
-   * @return `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
+   * @return `bytes4(keccak256("onERC721Received(address,address,uint,bytes)"))`
    */
   function onERC721Received(
     address operator,
     address from,
-    uint256 tokenId,
+    uint tokenId,
     bytes data
   )
     public


### PR DESCRIPTION
# Description

This is just a style change, no functional impact.

At the moment we are inconsistent about how `uint256` is declared.  Sometimes we have `uint` and other times `uint256`.  In Solidity, both these keywords mean the same thing.  i.e. `uint` is a `uint256`.  I believe we should pick one or the other and use it consistently.

I propose we use `uint`.  The reason for this is because that is the uint256 is the native type for operations in Solidity.  This means if you use a different sized int, it must first be casted to uint256 in order to perform an operation.  For example:

```
  // cost 172
  function a()
    public
  {
      uint a = 5;
      uint b = 2;
      uint c = a + b;
  }
  
  // cost 194
  function b()
    public
  {
      uint8 a = 5;
      uint8 b = 2;
      uint8 c = a + b;
  }
```

There may be benefit in using smaller sized ints when storing data, but not for normal usage.  That's why I prefer using `uint` as the standard, calling attention to anytime we use a smaller sized int as we should be more cautious there.

But ultimately it's just nice to be consistent.  So if you would rather use `uint256` instead, I can update this PR.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
