### PR TITLE
Add a requiredNetworkId property to the configuration

### DIFF
--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -58,6 +58,7 @@ export default function configure(
   let providers = {}
   let isRequiredNetwork = () => false
   let requiredNetwork = 'Dev'
+  let requiredNetworkId = 101
   let requiredConfirmations = 12
   let unlockAddress = ''
   let services = {}
@@ -100,6 +101,7 @@ export default function configure(
 
     // In staging, the network can only be rinkeby
     isRequiredNetwork = networkId => networkId === 4
+    requiredNetworkId = 4
     requiredNetwork = ETHEREUM_NETWORKS_NAMES[4][0]
 
     // Address for the Unlock smart contract
@@ -115,6 +117,7 @@ export default function configure(
 
     // In prod, the network can only be mainnet
     isRequiredNetwork = networkId => networkId === 1
+    requiredNetworkId = 1
     requiredNetwork = ETHEREUM_NETWORKS_NAMES[1][0]
   }
 

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -58,7 +58,7 @@ export default function configure(
   let providers = {}
   let isRequiredNetwork = () => false
   let requiredNetwork = 'Dev'
-  let requiredNetworkId = 101
+  let requiredNetworkId = 1984
   let requiredConfirmations = 12
   let unlockAddress = ''
   let services = {}
@@ -102,7 +102,6 @@ export default function configure(
     // In staging, the network can only be rinkeby
     isRequiredNetwork = networkId => networkId === 4
     requiredNetworkId = 4
-    requiredNetwork = ETHEREUM_NETWORKS_NAMES[4][0]
 
     // Address for the Unlock smart contract
     unlockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
@@ -118,7 +117,10 @@ export default function configure(
     // In prod, the network can only be mainnet
     isRequiredNetwork = networkId => networkId === 1
     requiredNetworkId = 1
-    requiredNetwork = ETHEREUM_NETWORKS_NAMES[1][0]
+  }
+
+  if (env === 'prod' || env === 'staging') {
+    requiredNetwork = ETHEREUM_NETWORKS_NAMES[requiredNetworkId][0]
   }
 
   return {

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -126,6 +126,7 @@ export default function configure(
     env,
     providers,
     isRequiredNetwork,
+    requiredNetworkId,
     requiredNetwork,
     requiredConfirmations,
     unlockAddress,


### PR DESCRIPTION
# Description

In order to handle #966, we need to know the numeric ID of the required network so that we can set it as the initial state for the network reducer. This pull request adds a property to the configuration containing the appropriate network ID for the current environment.

Let me know if it would be better to create an `ETHEREUM_NETWORKS_IDS` constant and refer to that instead.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
