### PR TITLE
fix header display

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -4270,7 +4270,7 @@ Object {
 .c3 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4282,7 +4282,7 @@ Object {
 .c5 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4519,9 +4519,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c9 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c11 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c11 {
+    display: none;
   }
 }
 
@@ -5203,7 +5215,7 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 ghlVGF"
+          class="sc-1glv5oz-0 cOQbpj"
         >
           <a
             href="/"
@@ -5221,7 +5233,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 cojjOP"
+            class="sc-1glv5oz-2 bijesQ"
           >
             <a
               class="sc-850ddk-0 fgimlS"
@@ -5312,7 +5324,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 hEoKnM"
+            class="sc-1glv5oz-3 eGBYUU"
           >
             <a
               class="sc-850ddk-0 kIaKVN"
@@ -5348,7 +5360,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 fsowbd"
+            class="sc-1glv5oz-4 gFLKTL"
           />
         </header>
         <section
@@ -5953,7 +5965,7 @@ Object {
 .c3 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -5965,7 +5977,7 @@ Object {
 .c5 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -6262,9 +6274,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c9 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c11 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c11 {
+    display: none;
   }
 }
 
@@ -6685,7 +6709,7 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 ghlVGF"
+          class="sc-1glv5oz-0 cOQbpj"
         >
           <a
             href="/"
@@ -6703,7 +6727,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 cojjOP"
+            class="sc-1glv5oz-2 bijesQ"
           >
             <a
               class="sc-850ddk-0 fgimlS"
@@ -6794,7 +6818,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 hEoKnM"
+            class="sc-1glv5oz-3 eGBYUU"
           >
             <a
               class="sc-850ddk-0 kIaKVN"
@@ -6830,7 +6854,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 fsowbd"
+            class="sc-1glv5oz-4 gFLKTL"
           />
         </header>
         <h1
@@ -7174,7 +7198,7 @@ Object {
 .c3 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7186,7 +7210,7 @@ Object {
 .c5 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7416,9 +7440,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c9 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c11 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c11 {
+    display: none;
   }
 }
 
@@ -8276,7 +8312,7 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 ghlVGF"
+          class="sc-1glv5oz-0 cOQbpj"
         >
           <a
             href="/"
@@ -8294,7 +8330,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 cojjOP"
+            class="sc-1glv5oz-2 bijesQ"
           >
             <a
               class="sc-850ddk-0 fgimlS"
@@ -8385,7 +8421,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 hEoKnM"
+            class="sc-1glv5oz-3 eGBYUU"
           >
             <a
               class="sc-850ddk-0 kIaKVN"
@@ -8421,7 +8457,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 fsowbd"
+            class="sc-1glv5oz-4 gFLKTL"
           />
         </header>
         <section
@@ -16711,7 +16747,7 @@ Object {
 .c4 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -16727,7 +16763,7 @@ Object {
 .c6 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -17018,9 +17054,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c10 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c12 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
   }
 }
 
@@ -18330,7 +18378,7 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 ghlVGF"
+          class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
             class="sc-1glv5oz-1 jZepcb"
@@ -18338,7 +18386,7 @@ Object {
             Creator Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 cojjOP"
+            class="sc-1glv5oz-2 bijesQ"
           >
             <a
               class="sc-850ddk-0 fgimlS"
@@ -18429,7 +18477,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 hEoKnM"
+            class="sc-1glv5oz-3 eGBYUU"
           >
             <a
               class="sc-850ddk-0 kIaKVN"
@@ -18465,7 +18513,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 fsowbd"
+            class="sc-1glv5oz-4 gFLKTL"
           />
         </header>
         <section
@@ -20657,7 +20705,7 @@ Object {
 .c4 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -20673,7 +20721,7 @@ Object {
 .c6 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -20837,9 +20885,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c10 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c12 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
   }
 }
 
@@ -21099,13 +21159,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 ghlVGF"
+          class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
             class="sc-1glv5oz-1 jZepcb"
           />
           <div
-            class="sc-1glv5oz-2 cojjOP"
+            class="sc-1glv5oz-2 bijesQ"
           >
             <a
               class="sc-850ddk-0 fgimlS"
@@ -21196,7 +21256,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 hEoKnM"
+            class="sc-1glv5oz-3 eGBYUU"
           >
             <a
               class="sc-850ddk-0 kIaKVN"
@@ -21232,7 +21292,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 fsowbd"
+            class="sc-1glv5oz-4 gFLKTL"
           />
         </header>
         <section
@@ -21392,7 +21452,7 @@ Object {
 .c4 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -21408,7 +21468,7 @@ Object {
 .c6 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -21572,9 +21632,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c10 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c12 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
   }
 }
 
@@ -21841,13 +21913,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 ghlVGF"
+          class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
             class="sc-1glv5oz-1 jZepcb"
           />
           <div
-            class="sc-1glv5oz-2 cojjOP"
+            class="sc-1glv5oz-2 bijesQ"
           >
             <a
               class="sc-850ddk-0 fgimlS"
@@ -21938,7 +22010,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 hEoKnM"
+            class="sc-1glv5oz-3 eGBYUU"
           >
             <a
               class="sc-850ddk-0 kIaKVN"
@@ -21974,7 +22046,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 fsowbd"
+            class="sc-1glv5oz-4 gFLKTL"
           />
         </header>
         <section
@@ -22141,7 +22213,7 @@ Object {
 .c4 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -22157,7 +22229,7 @@ Object {
 .c6 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -22321,9 +22393,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c10 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c12 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
   }
 }
 
@@ -22583,13 +22667,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 ghlVGF"
+          class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
             class="sc-1glv5oz-1 jZepcb"
           />
           <div
-            class="sc-1glv5oz-2 cojjOP"
+            class="sc-1glv5oz-2 bijesQ"
           >
             <a
               class="sc-850ddk-0 fgimlS"
@@ -22680,7 +22764,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 hEoKnM"
+            class="sc-1glv5oz-3 eGBYUU"
           >
             <a
               class="sc-850ddk-0 kIaKVN"
@@ -22716,7 +22800,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 fsowbd"
+            class="sc-1glv5oz-4 gFLKTL"
           />
         </header>
         <section
@@ -23230,7 +23314,7 @@ Object {
 .c0 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23242,7 +23326,7 @@ Object {
 .c2 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23345,9 +23429,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c6 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c8 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c8 {
+    display: none;
   }
 }
 
@@ -23513,7 +23609,7 @@ Object {
       rel="stylesheet"
     />
     <header
-      class="sc-1glv5oz-0 ghlVGF"
+      class="sc-1glv5oz-0 cOQbpj"
     >
       <a
         href="/"
@@ -23531,7 +23627,7 @@ Object {
         </svg>
       </a>
       <div
-        class="sc-1glv5oz-2 cojjOP"
+        class="sc-1glv5oz-2 bijesQ"
       >
         <a
           class="sc-850ddk-0 fgimlS"
@@ -23622,7 +23718,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-3 hEoKnM"
+        class="sc-1glv5oz-3 eGBYUU"
       >
         <a
           class="sc-850ddk-0 kIaKVN"
@@ -23658,7 +23754,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-4 fsowbd"
+        class="sc-1glv5oz-4 gFLKTL"
       />
     </header>
   </div>,
@@ -23784,7 +23880,7 @@ Object {
 .c0 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23800,7 +23896,7 @@ Object {
 .c2 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23903,9 +23999,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c6 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c8 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c8 {
+    display: none;
   }
 }
 
@@ -24061,7 +24169,7 @@ Object {
       rel="stylesheet"
     />
     <header
-      class="sc-1glv5oz-0 ghlVGF"
+      class="sc-1glv5oz-0 cOQbpj"
     >
       <h1
         class="sc-1glv5oz-1 jZepcb"
@@ -24069,7 +24177,7 @@ Object {
         Roses are red
       </h1>
       <div
-        class="sc-1glv5oz-2 cojjOP"
+        class="sc-1glv5oz-2 bijesQ"
       >
         <a
           class="sc-850ddk-0 fgimlS"
@@ -24160,7 +24268,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-3 hEoKnM"
+        class="sc-1glv5oz-3 eGBYUU"
       >
         <a
           class="sc-850ddk-0 kIaKVN"
@@ -24196,7 +24304,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-4 fsowbd"
+        class="sc-1glv5oz-4 gFLKTL"
       />
     </header>
   </div>,
@@ -24322,7 +24430,7 @@ Object {
 .c0 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -24338,7 +24446,7 @@ Object {
 .c2 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -24441,9 +24549,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c6 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c8 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c8 {
+    display: none;
   }
 }
 
@@ -24599,7 +24719,7 @@ Object {
       rel="stylesheet"
     />
     <header
-      class="sc-1glv5oz-0 ghlVGF"
+      class="sc-1glv5oz-0 cOQbpj"
     >
       <h1
         class="sc-1glv5oz-1 jZepcb"
@@ -24607,7 +24727,7 @@ Object {
         Unlock
       </h1>
       <div
-        class="sc-1glv5oz-2 cojjOP"
+        class="sc-1glv5oz-2 bijesQ"
       >
         <a
           class="sc-850ddk-0 fgimlS"
@@ -24698,7 +24818,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-3 hEoKnM"
+        class="sc-1glv5oz-3 eGBYUU"
       >
         <a
           class="sc-850ddk-0 kIaKVN"
@@ -24734,7 +24854,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-4 fsowbd"
+        class="sc-1glv5oz-4 gFLKTL"
       />
     </header>
   </div>,
@@ -28516,7 +28636,7 @@ Object {
 .c3 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -28528,7 +28648,7 @@ Object {
 .c5 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -28673,9 +28793,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c9 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c11 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c11 {
+    display: none;
   }
 }
 
@@ -28983,7 +29115,7 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 ghlVGF"
+          class="sc-1glv5oz-0 cOQbpj"
         >
           <a
             href="/"
@@ -29001,7 +29133,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 cojjOP"
+            class="sc-1glv5oz-2 bijesQ"
           >
             <a
               class="sc-850ddk-0 fgimlS"
@@ -29092,7 +29224,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 hEoKnM"
+            class="sc-1glv5oz-3 eGBYUU"
           >
             <a
               class="sc-850ddk-0 kIaKVN"
@@ -29128,7 +29260,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 fsowbd"
+            class="sc-1glv5oz-4 gFLKTL"
           />
         </header>
         <footer
@@ -29366,7 +29498,7 @@ Object {
 .c4 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -29382,7 +29514,7 @@ Object {
 .c6 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -29506,9 +29638,21 @@ Object {
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c10 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c12 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
   }
 }
 
@@ -29744,7 +29888,7 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 ghlVGF"
+          class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
             class="sc-1glv5oz-1 jZepcb"
@@ -29752,7 +29896,7 @@ Object {
             Unlock Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 cojjOP"
+            class="sc-1glv5oz-2 bijesQ"
           >
             <a
               class="sc-850ddk-0 fgimlS"
@@ -29843,7 +29987,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 hEoKnM"
+            class="sc-1glv5oz-3 eGBYUU"
           >
             <a
               class="sc-850ddk-0 kIaKVN"
@@ -29879,7 +30023,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 fsowbd"
+            class="sc-1glv5oz-4 gFLKTL"
           />
         </header>
       </div>

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
@@ -84,7 +84,7 @@ exports[`withConfig High Order Component when the current network is not in the 
 .c4 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -100,7 +100,7 @@ exports[`withConfig High Order Component when the current network is not in the 
 .c6 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -264,9 +264,21 @@ exports[`withConfig High Order Component when the current network is not in the 
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c10 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c12 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
   }
 }
 

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
@@ -84,7 +84,7 @@ exports[`withConfig High Order Component when the current network is not in the 
 .c4 {
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -100,7 +100,7 @@ exports[`withConfig High Order Component when the current network is not in the 
 .c6 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(4,24px);
+  grid-template-columns: repeat(4,24px);
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -264,9 +264,21 @@ exports[`withConfig High Order Component when the current network is not in the 
   }
 }
 
+@media only screen and (min-device-width:736px) {
+  .c10 {
+    display: none;
+  }
+}
+
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c12 {
     display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
   }
 }
 

--- a/unlock-app/src/components/interface/Header.js
+++ b/unlock-app/src/components/interface/Header.js
@@ -83,7 +83,7 @@ Header.defaultProps = {
 const TopHeader = styled.header`
   display: grid;
   grid-gap: 0;
-  grid-template-columns: 1fr repeat(${() => navigationButtons.length}, 24px);
+  grid-template-columns: 1fr auto;
   grid-auto-flow: column;
   align-items: center;
   height: 70px;
@@ -103,7 +103,7 @@ const Title = styled.h1`
 const DesktopButtons = styled.div`
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: 1fr repeat(${() => navigationButtons.length}, 24px);
+  grid-template-columns: repeat(${() => navigationButtons.length}, 24px);
   grid-auto-flow: column;
   align-items: center;
   height: 100%;
@@ -148,6 +148,9 @@ const MobileToggle = styled.div`
   ${Media.phone`
     display: grid;
   `};
+  ${Media.nophone`
+    display: none;
+  `};
 `
 
 const MobilePopover = styled.div`
@@ -185,5 +188,8 @@ const MobilePopover = styled.div`
 
   ${Media.phone`
     display: grid;
+  `};
+  ${Media.nophone`
+    display: none;
   `};
 `


### PR DESCRIPTION
# Description

There were 2 issues causing wonky display of the header. This PR fixes #877 (again, this time correctly) and also removes the blank space on desktop that was occupied by the mobile popover.

<img width="1171" alt="screen shot 2019-01-17 at 12 33 57 pm" src="https://user-images.githubusercontent.com/98250/51337078-30370d00-1a54-11e9-8c1f-ebae9fee8d2b.png">

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
