### PR TITLE
Add tokenId to key and a method to getTokenIdFor(account)

### DIFF
--- a/smart-contracts/README.md
+++ b/smart-contracts/README.md
@@ -64,6 +64,7 @@ These are the function which change some parameters for the Lock or check its st
 
 - setKeyPrice (TODO) : updates the price of new keys
 - outstandingKeys : get the number of outstanding keys
+- numberOfOwners : get the total number of unique owners (both expired and valid).  This may be larger than outstandingKeys.
 - balanceOf (ERC721) : get the number of keys for a given owner (0 or 1)
 - ownerOf (ERC721) : get the owner of a key (if applicable)
 - keyDataFor : get the value of the data field for a key

--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -340,18 +340,6 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   }
 
   /**
-   * Public function which returns the total number of unique keys sold (both 
-   * expired and valid)
-   */
-  function outstandingKeys()
-    public
-    view
-    returns (uint)
-  {
-    return numberOfKeysSold;
-  }
-
-  /**
    * Public function which returns the total number of unique owners (both expired
    * and valid).  This may be larger than outstandingKeys.
    */
@@ -361,6 +349,18 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     returns (uint)
   {
     return owners.length;
+  }
+
+  /**
+   * Public function which returns the total number of unique keys sold (both 
+   * expired and valid)
+   */
+  function outstandingKeys()
+    public
+    view
+    returns (uint)
+  {
+    return numberOfKeysSold;
   }
 
  /**

--- a/smart-contracts/contracts/interfaces/ILockCore.sol
+++ b/smart-contracts/contracts/interfaces/ILockCore.sol
@@ -57,6 +57,15 @@ interface ILockCore {
     external;
 
   /**
+   * Public function which returns the total number of unique owners (both expired
+   * and valid).  This may be larger than outstandingKeys.
+   */
+  function numberOfOwners()
+    external
+    view
+    returns (uint);
+
+  /**
    * Public function which returns the total number of keys (both expired and valid)
    */
   function outstandingKeys()

--- a/smart-contracts/test/Lock/erc721/getTokenIdFor.js
+++ b/smart-contracts/test/Lock/erc721/getTokenIdFor.js
@@ -1,0 +1,37 @@
+
+const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
+
+const deployLocks = require('../../helpers/deployLocks')
+const Unlock = artifacts.require('../../Unlock.sol')
+
+let unlock, locks
+
+contract('Lock ERC721', (accounts) => {
+  before(async () => {
+    unlock = await Unlock.deployed()
+    locks = await deployLocks(unlock)
+  })
+
+  describe('getTokenIdFor', () => {
+    it('should abort when the key has no owner', async () => {
+      try {
+        await locks['FIRST'].getTokenIdFor(accounts[3])
+        assert.fail('Expected revert')
+      } catch (error) {
+        assert.equal(error.message, 'VM Exception while processing transaction: revert No such key')
+      }
+    })
+
+    it('should return the tokenId for the owner\'s key', async () => {
+      await locks['FIRST'].purchaseFor(accounts[1], 'Satoshi', {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[1]
+      })
+      let address = await locks['FIRST'].getTokenIdFor(accounts[1])
+      // Note that as we implement ERC721 support, the tokenId will no longer
+      // be the same as the user's address
+      assert(address.eq(new BigNumber(accounts[1])))
+    })
+  })
+})


### PR DESCRIPTION
# Description

This is part of ERC721 support, allowing us to map from tokenId to owner address and then owner address to key.  When we do this, having the tokenId in the key structure will allow us to discover the tokenId for an owner by their address (i.e. it enables the getTokenIdFor method when tokenId changes to a sequenceID).

We could have flipped this around, adding the owner to the key struct instead of the tokenId.  With this approach we would map address to tokenId and tokenId to key.  However since we support 1 key per address it seems we would want to continue primarily referring to key's by address.

The new tests are basically a copy paste of ownerOf slightly modified for checking getTokenIdFor.  I also switched to an async style for readability.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
