### PR TITLE
Chris adjust default network value

### DIFF
--- a/unlock-app/src/__tests__/reducers/networkReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/networkReducer.test.js
@@ -6,7 +6,7 @@ describe('network reducer', () => {
 
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual({
-      name: 0,
+      name: 1984,
     })
   })
 

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -131,12 +131,10 @@ export default function lockMiddleware({ getState, dispatch }) {
    * as well as reset all the reducers
    */
   web3Service.on('network.changed', networkId => {
-    if (getState().network.name !== networkId) {
-      // Set the new network, which should also clean up all reducers
-      // And we need a new account!
-      dispatch(setNetwork(networkId))
-      return web3Service.refreshOrGetAccount()
-    }
+    // Set the new network, which should also clean up all reducers
+    // And we need a new account!
+    dispatch(setNetwork(networkId))
+    return web3Service.refreshOrGetAccount()
   })
 
   /**

--- a/unlock-app/src/reducers/networkReducer.js
+++ b/unlock-app/src/reducers/networkReducer.js
@@ -1,7 +1,11 @@
 import { SET_NETWORK } from '../actions/network'
+import configure from '../config'
+
+const config = configure()
+const name = config.requiredNetworkId
 
 export const initialState = {
-  name: 0,
+  name,
 }
 
 const networkReducer = (state = initialState, action) => {


### PR DESCRIPTION
# Description
This pull request fixes #966, using the new `requiredNetworkId` property in config to set the initial network id to the appropriate value. Note that while this changes which error is briefly flashed as the page is rendered, there is still a flash because the `SET_ACCOUNT` action won't have occurred by the time the page renders.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
