### PR TITLE
Add mapping tokenId -> ownerAddress

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -60,6 +60,12 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   // return 0 values when missing a key)
   mapping (address => Key) internal keyByOwner;
 
+  // Each tokenId can have at most exactly one owner at a time.
+  // Returns 0 if the token does not exist
+  // TODO: once we decouple tokenId from owner address (incl in js), then we can consider
+  // merging this with numberOfKeysSold into an array instead.
+  mapping (uint => address) internal ownerByTokenId;
+
   // Addresses of owners are also stored in an array.
   // Addresses are never removed by design to avoid abuses around referals
   address[] public owners;
@@ -103,7 +109,17 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     uint _tokenId
   ) {
     require(
-      address(_tokenId) == msg.sender
+      ownerByTokenId[_tokenId] == msg.sender
+    );
+    _;
+  }
+  
+  // Ensures that a key has an owner
+  modifier isKey(
+    uint _tokenId
+  ) {
+    require(
+      ownerByTokenId[_tokenId] != address(0), "No such key"
     );
     _;
   }
@@ -115,7 +131,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     uint _tokenId
   ) {
     require(
-      address(_tokenId) == msg.sender
+      ownerByTokenId[_tokenId] == msg.sender
       || _getApproved(_tokenId) == msg.sender
     , "Only key owner or approved owner");
     _;
@@ -188,7 +204,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     external
     payable
     notSoldOut()
-    hasKey(address(_tokenId))
+    hasKey(_from)
     onlyKeyOwnerOrApproved(_tokenId)
   {
     require(_recipient != address(0));
@@ -198,6 +214,9 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     if (previousExpiration == 0) {
       // The recipient did not have a key previously
       owners.push(_recipient);
+      // Note: not using the tokenId above since ATM we do not transfer tokenId's
+      // this will change when we decouple tokenId from address
+      ownerByTokenId[uint(_recipient)] = _recipient;
     }
 
     if (previousExpiration <= now) {
@@ -259,7 +278,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     require(_approved != address(0));
 
     approved[_tokenId] = _approved;
-    emit Approval(address(_tokenId), _approved, _tokenId);
+    emit Approval(ownerByTokenId[_tokenId], _approved, _tokenId);
   }
 
   /**
@@ -300,10 +319,10 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   )
     external
     view
-    hasKey(address(_tokenId))
+    isKey(_tokenId)
     returns (address)
   {
-    return address(_tokenId);
+    return ownerByTokenId[_tokenId];
   }
 
   /**
@@ -495,6 +514,8 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
       { // This is a brand new owner, else an owner of an expired key buying an extension
         numberOfKeysSold++;
         owners.push(_recipient);
+        // Note: for ERC721 support we will be changing tokenId to be a sequence id instead
+        ownerByTokenId[uint(_recipient)] = _recipient;
       }
       keyByOwner[_recipient].expirationTimestamp = now + expirationDuration;
     } else {


### PR DESCRIPTION
# Description

This mapping allows us to discover an owner, and therefore a key, from a tokenId.  This gets us one step closer to decoupling tokenId from ownerAddress.

Each tokenId can have at most exactly one owner at a time.  At the moment tokenId is still defined by the owner's address, but eventually this will change to a sequence Id.  When that happens we can consider using an array of token -> address instead (and possibly replace numberOfKeysSold with that array.length).

Existing tests should confirm these changes do not cause regressions.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
