### PR TITLE
transferFrom requires `hasValidKey`

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -210,7 +210,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     external
     payable
     notSoldOut()
-    hasKey(_from)
+    hasValidKey(_from)
     onlyKeyOwnerOrApproved(_tokenId)
   {
     require(_recipient != address(0));

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -71,7 +71,7 @@ contract('Lock ERC721', (accounts) => {
             assert(false, 'This should not succeed')
           })
           .catch(error => {
-            assert.equal(error.message, 'VM Exception while processing transaction: revert No such key')
+            assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
           })
       })
 
@@ -173,7 +173,7 @@ contract('Lock ERC721', (accounts) => {
               assert(false, 'This should not succeed')
             })
             .catch(error => {
-              assert.equal(error.message, 'VM Exception while processing transaction: revert')
+              assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
               // Ensuring that ownership of the key did not change
               return locks['FIRST'].keyExpirationTimestampFor(from)
             }).then((expirationTimestamp) => {

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -91,6 +91,15 @@ contract('Lock ERC721', (accounts) => {
           assert(_numberOfOwners.eq(numberOfOwners.plus(1)))
         })
       })
+
+      it('should fail if I transfer from the same account again', async () => {
+        try {
+          await lock.transferFrom(accounts[1], accounts[5], accounts[1], { from: accounts[1] })
+          assert.fail('Expected revert')
+        } catch (error) {
+          assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
+        }
+      })
     })
 
     describe('after a transfer to an existing owner', () => {
@@ -98,7 +107,7 @@ contract('Lock ERC721', (accounts) => {
 
       before(async () => {
         numberOfOwners = await lock.numberOfOwners()
-        await lock.transferFrom(accounts[1], accounts[2], accounts[1], { from: accounts[1] })
+        await lock.transferFrom(accounts[2], accounts[3], accounts[2], { from: accounts[2] })
       })
   
       it('should have the right number of keys', () => {


### PR DESCRIPTION
# Description

It does not make sense to transfer an expired key to anyone.  Changing the modifier to require a key which is not expired vs any key.

Previously, the following line could have resulted in stealing time from another user.  Basically I transfer you an expired key, an action you cannot reject, and it causes your currently valid key to become expired.

```
keyByOwner[_recipient].expirationTimestamp =
        keyByOwner[_from].expirationTimestamp + previousExpiration - now;
```

Added a test in `owners.js` to explicitly confirm that you cannot transfer an expired key.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
