### PR TITLE
Buttons now get their line-height property from the size property

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -13,6 +13,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -125,7 +126,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 hBjuko"
+      class="sc-850ddk-0 kaWqFM"
       href="/about"
       title="About"
     >
@@ -207,6 +208,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -296,7 +298,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 hBjuko"
+      class="sc-850ddk-0 kaWqFM"
     >
       <svg
         viewBox="0 0 56 42"
@@ -370,6 +372,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -461,7 +464,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 hBjuko"
+      class="sc-850ddk-0 kaWqFM"
     >
       <svg
         viewBox="0 0 58 32"
@@ -537,6 +540,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 100px;
 }
 
 .c1 > svg {
@@ -628,7 +632,7 @@ Object {
       rel="stylesheet"
     />
     <button
-      class="sc-850ddk-0 cohgaO"
+      class="sc-850ddk-0 gKoqip"
     >
       <svg
         viewBox="0 0 24 24"
@@ -704,6 +708,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 16px;
 }
 
 .c1 > svg {
@@ -795,7 +800,7 @@ Object {
       rel="stylesheet"
     />
     <button
-      class="sc-850ddk-0 bMCxsZ"
+      class="sc-850ddk-0 eVetTd"
     >
       <svg
         viewBox="0 0 24 24"
@@ -871,6 +876,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -980,7 +986,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 hBjuko"
+      class="sc-850ddk-0 kaWqFM"
       href="https://github.com/unlock-protocol/unlock"
       title="Source Code"
     >
@@ -1059,6 +1065,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -1170,7 +1177,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 hBjuko"
+      class="sc-850ddk-0 kaWqFM"
       href="/jobs"
       title="Join us"
     >
@@ -1251,6 +1258,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -1362,7 +1370,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 hBjuko"
+      class="sc-850ddk-0 kaWqFM"
       href="/newsletter"
       title="Newsletter"
     >
@@ -1443,6 +1451,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -1554,7 +1563,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 hBjuko"
+      class="sc-850ddk-0 kaWqFM"
       href="https://t.me/unlockprotocol"
       title="Telegram"
     >
@@ -1635,6 +1644,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -1746,7 +1756,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 hBjuko"
+      class="sc-850ddk-0 kaWqFM"
       href="/twitter"
       title="Twitter"
     >
@@ -1827,6 +1837,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -1937,7 +1948,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       title="Copy"
     >
       <svg
@@ -2017,6 +2028,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -2127,7 +2139,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       title="Download"
     >
       <svg
@@ -2207,6 +2219,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -2320,7 +2333,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       title="Edit"
     >
       <svg
@@ -2403,6 +2416,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -2513,7 +2527,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       title="Etherscan"
     >
       <svg
@@ -2593,6 +2607,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -2703,7 +2718,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       title="Export"
     >
       <svg
@@ -2783,6 +2798,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -2900,7 +2916,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       href="/demo/0xabc"
       title="Preview lock"
     >
@@ -2987,6 +3003,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -3097,7 +3114,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       title="Show embed code"
     >
       <svg
@@ -3177,6 +3194,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -3287,7 +3305,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       title="Upload"
     >
       <svg
@@ -3367,6 +3385,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -3477,7 +3496,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       title="Withdraw balance"
     >
       <svg
@@ -3557,6 +3576,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c1 > svg {
@@ -3667,7 +3687,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="sc-850ddk-0 cjssoo"
+      class="sc-850ddk-0 kiVDOG"
       title="Withdraw balance"
     >
       <svg
@@ -3747,6 +3767,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c2 > svg {
@@ -3860,7 +3881,7 @@ Object {
       rel="stylesheet"
     />
     <a
-      class="nk4431-2 ewyzVv sc-850ddk-0 hNdccX"
+      class="nk4431-2 ewyzVv sc-850ddk-0 doxKED"
     >
       <svg
         class="nk4431-0 jIPREr"
@@ -4203,6 +4224,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c7 > svg {
@@ -4228,6 +4250,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c10 > svg {
@@ -5236,7 +5259,7 @@ Object {
             class="sc-1glv5oz-2 bijesQ"
           >
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/about"
               title="About"
             >
@@ -5259,7 +5282,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/jobs"
               title="Join us"
             >
@@ -5281,7 +5304,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://github.com/unlock-protocol/unlock"
               title="Source Code"
             >
@@ -5301,7 +5324,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://t.me/unlockprotocol"
               title="Telegram"
             >
@@ -5327,7 +5350,7 @@ Object {
             class="sc-1glv5oz-3 eGBYUU"
           >
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 56 42"
@@ -5342,7 +5365,7 @@ Object {
               
             </a>
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 58 32"
@@ -5741,7 +5764,7 @@ Object {
           class="sc-2ix2yp-0 clvjsX"
         >
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="/about"
             title="About"
           >
@@ -5764,7 +5787,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="/jobs"
             title="Join us"
           >
@@ -5786,7 +5809,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="https://github.com/unlock-protocol/unlock"
             title="Source Code"
           >
@@ -5806,7 +5829,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="https://t.me/unlockprotocol"
             title="Telegram"
           >
@@ -5898,6 +5921,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c7 > svg {
@@ -5923,6 +5947,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c10 > svg {
@@ -6730,7 +6755,7 @@ Object {
             class="sc-1glv5oz-2 bijesQ"
           >
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/about"
               title="About"
             >
@@ -6753,7 +6778,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/jobs"
               title="Join us"
             >
@@ -6775,7 +6800,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://github.com/unlock-protocol/unlock"
               title="Source Code"
             >
@@ -6795,7 +6820,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://t.me/unlockprotocol"
               title="Telegram"
             >
@@ -6821,7 +6846,7 @@ Object {
             class="sc-1glv5oz-3 eGBYUU"
           >
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 56 42"
@@ -6836,7 +6861,7 @@ Object {
               
             </a>
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 58 32"
@@ -6974,7 +6999,7 @@ Object {
           class="sc-2ix2yp-0 clvjsX"
         >
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="/about"
             title="About"
           >
@@ -6997,7 +7022,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="/jobs"
             title="Join us"
           >
@@ -7019,7 +7044,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="https://github.com/unlock-protocol/unlock"
             title="Source Code"
           >
@@ -7039,7 +7064,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="https://t.me/unlockprotocol"
             title="Telegram"
           >
@@ -7131,6 +7156,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c7 > svg {
@@ -7156,6 +7182,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c10 > svg {
@@ -8333,7 +8360,7 @@ Object {
             class="sc-1glv5oz-2 bijesQ"
           >
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/about"
               title="About"
             >
@@ -8356,7 +8383,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/jobs"
               title="Join us"
             >
@@ -8378,7 +8405,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://github.com/unlock-protocol/unlock"
               title="Source Code"
             >
@@ -8398,7 +8425,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://t.me/unlockprotocol"
               title="Telegram"
             >
@@ -8424,7 +8451,7 @@ Object {
             class="sc-1glv5oz-3 eGBYUU"
           >
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 56 42"
@@ -8439,7 +8466,7 @@ Object {
               
             </a>
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 58 32"
@@ -9014,7 +9041,7 @@ Object {
           class="sc-2ix2yp-0 clvjsX"
         >
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="/about"
             title="About"
           >
@@ -9037,7 +9064,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="/jobs"
             title="Join us"
           >
@@ -9059,7 +9086,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="https://github.com/unlock-protocol/unlock"
             title="Source Code"
           >
@@ -9079,7 +9106,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="https://t.me/unlockprotocol"
             title="Telegram"
           >
@@ -10723,6 +10750,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c15 > svg {
@@ -11406,7 +11434,7 @@ Object {
             class="sc-1dp5gbn-1 hxNcaM"
           >
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Withdraw balance"
             >
               <svg
@@ -11427,7 +11455,7 @@ Object {
               </small>
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Edit"
             >
               <svg
@@ -11451,7 +11479,7 @@ Object {
               </small>
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Show embed code"
             >
               <svg
@@ -11538,6 +11566,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c15 > svg {
@@ -12221,7 +12250,7 @@ Object {
             class="sc-1dp5gbn-1 hxNcaM"
           >
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Withdraw balance"
             >
               <svg
@@ -12242,7 +12271,7 @@ Object {
               </small>
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Edit"
             >
               <svg
@@ -12266,7 +12295,7 @@ Object {
               </small>
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Show embed code"
             >
               <svg
@@ -12999,6 +13028,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c15 > svg {
@@ -13682,7 +13712,7 @@ Object {
             class="sc-1dp5gbn-1 hxNcaM"
           >
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Withdraw balance"
             >
               <svg
@@ -13703,7 +13733,7 @@ Object {
               </small>
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Edit"
             >
               <svg
@@ -13727,7 +13757,7 @@ Object {
               </small>
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Show embed code"
             >
               <svg
@@ -13814,6 +13844,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c16 > svg {
@@ -13839,6 +13870,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c15 > svg {
@@ -14519,7 +14551,7 @@ Object {
             class="sc-1dp5gbn-1 hxNcaM"
           >
             <button
-              class="sc-850ddk-0 fKWICS"
+              class="sc-850ddk-0 gDgfza"
             >
               <svg
                 name="Withdraw"
@@ -14535,7 +14567,7 @@ Object {
               
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Edit"
             >
               <svg
@@ -14559,7 +14591,7 @@ Object {
               </small>
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Show embed code"
             >
               <svg
@@ -14648,6 +14680,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c15 > svg {
@@ -15336,7 +15369,7 @@ Object {
             class="sc-1dp5gbn-1 hxNcaM"
           >
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Withdraw balance"
             >
               <svg
@@ -15357,7 +15390,7 @@ Object {
               </small>
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Edit"
             >
               <svg
@@ -15381,7 +15414,7 @@ Object {
               </small>
             </button>
             <button
-              class="sc-850ddk-0 cjssoo"
+              class="sc-850ddk-0 kiVDOG"
               title="Show embed code"
             >
               <svg
@@ -18616,6 +18649,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c40 > svg {
@@ -18641,6 +18675,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c8 > svg {
@@ -18666,6 +18701,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c11 > svg {
@@ -20473,7 +20509,7 @@ Object {
             class="sc-1glv5oz-2 bijesQ"
           >
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/about"
               title="About"
             >
@@ -20496,7 +20532,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/jobs"
               title="Join us"
             >
@@ -20518,7 +20554,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://github.com/unlock-protocol/unlock"
               title="Source Code"
             >
@@ -20538,7 +20574,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://t.me/unlockprotocol"
               title="Telegram"
             >
@@ -20564,7 +20600,7 @@ Object {
             class="sc-1glv5oz-3 eGBYUU"
           >
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 56 42"
@@ -20579,7 +20615,7 @@ Object {
               
             </a>
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 58 32"
@@ -20991,7 +21027,7 @@ Object {
                   class="sc-1dp5gbn-1 hxNcaM"
                 >
                   <button
-                    class="sc-850ddk-0 cjssoo"
+                    class="sc-850ddk-0 kiVDOG"
                     title="Withdraw balance"
                   >
                     <svg
@@ -21012,7 +21048,7 @@ Object {
                     </small>
                   </button>
                   <button
-                    class="sc-850ddk-0 cjssoo"
+                    class="sc-850ddk-0 kiVDOG"
                     title="Edit"
                   >
                     <svg
@@ -21036,7 +21072,7 @@ Object {
                     </small>
                   </button>
                   <button
-                    class="sc-850ddk-0 cjssoo"
+                    class="sc-850ddk-0 kiVDOG"
                     title="Show embed code"
                   >
                     <svg
@@ -21267,7 +21303,7 @@ Object {
                   class="sc-1dp5gbn-1 hxNcaM"
                 >
                   <button
-                    class="sc-850ddk-0 cjssoo"
+                    class="sc-850ddk-0 kiVDOG"
                     title="Withdraw balance"
                   >
                     <svg
@@ -21288,7 +21324,7 @@ Object {
                     </small>
                   </button>
                   <button
-                    class="sc-850ddk-0 cjssoo"
+                    class="sc-850ddk-0 kiVDOG"
                     title="Edit"
                   >
                     <svg
@@ -21312,7 +21348,7 @@ Object {
                     </small>
                   </button>
                   <button
-                    class="sc-850ddk-0 cjssoo"
+                    class="sc-850ddk-0 kiVDOG"
                     title="Show embed code"
                   >
                     <svg
@@ -21543,7 +21579,7 @@ Object {
                   class="sc-1dp5gbn-1 hxNcaM"
                 >
                   <button
-                    class="sc-850ddk-0 cjssoo"
+                    class="sc-850ddk-0 kiVDOG"
                     title="Withdraw balance"
                   >
                     <svg
@@ -21564,7 +21600,7 @@ Object {
                     </small>
                   </button>
                   <button
-                    class="sc-850ddk-0 cjssoo"
+                    class="sc-850ddk-0 kiVDOG"
                     title="Edit"
                   >
                     <svg
@@ -21588,7 +21624,7 @@ Object {
                     </small>
                   </button>
                   <button
-                    class="sc-850ddk-0 cjssoo"
+                    class="sc-850ddk-0 kiVDOG"
                     title="Show embed code"
                   >
                     <svg
@@ -22151,6 +22187,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 16px;
 }
 
 .c3 > svg {
@@ -22356,7 +22393,7 @@ Object {
         </p>
       </div>
       <button
-        class="sc-850ddk-0 bMCxsZ"
+        class="sc-850ddk-0 eVetTd"
       >
         <svg
           viewBox="0 0 24 24"
@@ -22386,7 +22423,7 @@ Object {
         </p>
       </div>
       <button
-        class="sc-850ddk-0 bMCxsZ"
+        class="sc-850ddk-0 eVetTd"
       >
         <svg
           viewBox="0 0 24 24"
@@ -22416,7 +22453,7 @@ Object {
         </p>
       </div>
       <button
-        class="sc-850ddk-0 bMCxsZ"
+        class="sc-850ddk-0 eVetTd"
       >
         <svg
           viewBox="0 0 24 24"
@@ -22493,6 +22530,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 16px;
 }
 
 .c3 > svg {
@@ -22638,7 +22676,7 @@ Object {
         </p>
       </div>
       <button
-        class="sc-850ddk-0 bMCxsZ"
+        class="sc-850ddk-0 eVetTd"
       >
         <svg
           viewBox="0 0 24 24"
@@ -22715,6 +22753,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c8 > svg {
@@ -22740,6 +22779,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c11 > svg {
@@ -23252,7 +23292,7 @@ Object {
             class="sc-1glv5oz-2 bijesQ"
           >
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/about"
               title="About"
             >
@@ -23275,7 +23315,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/jobs"
               title="Join us"
             >
@@ -23297,7 +23337,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://github.com/unlock-protocol/unlock"
               title="Source Code"
             >
@@ -23317,7 +23357,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://t.me/unlockprotocol"
               title="Telegram"
             >
@@ -23343,7 +23383,7 @@ Object {
             class="sc-1glv5oz-3 eGBYUU"
           >
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 56 42"
@@ -23358,7 +23398,7 @@ Object {
               
             </a>
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 58 32"
@@ -23462,6 +23502,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c8 > svg {
@@ -23487,6 +23528,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c11 > svg {
@@ -24006,7 +24048,7 @@ Object {
             class="sc-1glv5oz-2 bijesQ"
           >
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/about"
               title="About"
             >
@@ -24029,7 +24071,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/jobs"
               title="Join us"
             >
@@ -24051,7 +24093,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://github.com/unlock-protocol/unlock"
               title="Source Code"
             >
@@ -24071,7 +24113,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://t.me/unlockprotocol"
               title="Telegram"
             >
@@ -24097,7 +24139,7 @@ Object {
             class="sc-1glv5oz-3 eGBYUU"
           >
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 56 42"
@@ -24112,7 +24154,7 @@ Object {
               
             </a>
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 58 32"
@@ -24223,6 +24265,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c8 > svg {
@@ -24248,6 +24291,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c11 > svg {
@@ -24760,7 +24804,7 @@ Object {
             class="sc-1glv5oz-2 bijesQ"
           >
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/about"
               title="About"
             >
@@ -24783,7 +24827,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/jobs"
               title="Join us"
             >
@@ -24805,7 +24849,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://github.com/unlock-protocol/unlock"
               title="Source Code"
             >
@@ -24825,7 +24869,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://t.me/unlockprotocol"
               title="Telegram"
             >
@@ -24851,7 +24895,7 @@ Object {
             class="sc-1glv5oz-3 eGBYUU"
           >
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 56 42"
@@ -24866,7 +24910,7 @@ Object {
               
             </a>
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 58 32"
@@ -24970,6 +25014,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c2 > svg {
@@ -25179,7 +25224,7 @@ Object {
       class="sc-2ix2yp-0 clvjsX"
     >
       <a
-        class="sc-850ddk-0 hBjuko"
+        class="sc-850ddk-0 kaWqFM"
         href="/about"
         title="About"
       >
@@ -25202,7 +25247,7 @@ Object {
         </small>
       </a>
       <a
-        class="sc-850ddk-0 hBjuko"
+        class="sc-850ddk-0 kaWqFM"
         href="/jobs"
         title="Join us"
       >
@@ -25224,7 +25269,7 @@ Object {
         </small>
       </a>
       <a
-        class="sc-850ddk-0 hBjuko"
+        class="sc-850ddk-0 kaWqFM"
         href="https://github.com/unlock-protocol/unlock"
         title="Source Code"
       >
@@ -25244,7 +25289,7 @@ Object {
         </small>
       </a>
       <a
-        class="sc-850ddk-0 hBjuko"
+        class="sc-850ddk-0 kaWqFM"
         href="https://t.me/unlockprotocol"
         title="Telegram"
       >
@@ -25331,6 +25376,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c4 > svg {
@@ -25356,6 +25402,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c7 > svg {
@@ -25714,7 +25761,7 @@ Object {
         class="sc-1glv5oz-2 bijesQ"
       >
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="/about"
           title="About"
         >
@@ -25737,7 +25784,7 @@ Object {
           </small>
         </a>
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="/jobs"
           title="Join us"
         >
@@ -25759,7 +25806,7 @@ Object {
           </small>
         </a>
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="https://github.com/unlock-protocol/unlock"
           title="Source Code"
         >
@@ -25779,7 +25826,7 @@ Object {
           </small>
         </a>
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="https://t.me/unlockprotocol"
           title="Telegram"
         >
@@ -25805,7 +25852,7 @@ Object {
         class="sc-1glv5oz-3 eGBYUU"
       >
         <a
-          class="sc-850ddk-0 jJVfEK"
+          class="sc-850ddk-0 bRsbmn"
         >
           <svg
             viewBox="0 0 56 42"
@@ -25820,7 +25867,7 @@ Object {
           
         </a>
         <a
-          class="sc-850ddk-0 jJVfEK"
+          class="sc-850ddk-0 bRsbmn"
         >
           <svg
             viewBox="0 0 58 32"
@@ -25901,6 +25948,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c4 > svg {
@@ -25926,6 +25974,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c7 > svg {
@@ -26264,7 +26313,7 @@ Object {
         class="sc-1glv5oz-2 bijesQ"
       >
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="/about"
           title="About"
         >
@@ -26287,7 +26336,7 @@ Object {
           </small>
         </a>
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="/jobs"
           title="Join us"
         >
@@ -26309,7 +26358,7 @@ Object {
           </small>
         </a>
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="https://github.com/unlock-protocol/unlock"
           title="Source Code"
         >
@@ -26329,7 +26378,7 @@ Object {
           </small>
         </a>
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="https://t.me/unlockprotocol"
           title="Telegram"
         >
@@ -26355,7 +26404,7 @@ Object {
         class="sc-1glv5oz-3 eGBYUU"
       >
         <a
-          class="sc-850ddk-0 jJVfEK"
+          class="sc-850ddk-0 bRsbmn"
         >
           <svg
             viewBox="0 0 56 42"
@@ -26370,7 +26419,7 @@ Object {
           
         </a>
         <a
-          class="sc-850ddk-0 jJVfEK"
+          class="sc-850ddk-0 bRsbmn"
         >
           <svg
             viewBox="0 0 58 32"
@@ -26451,6 +26500,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c4 > svg {
@@ -26476,6 +26526,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c7 > svg {
@@ -26814,7 +26865,7 @@ Object {
         class="sc-1glv5oz-2 bijesQ"
       >
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="/about"
           title="About"
         >
@@ -26837,7 +26888,7 @@ Object {
           </small>
         </a>
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="/jobs"
           title="Join us"
         >
@@ -26859,7 +26910,7 @@ Object {
           </small>
         </a>
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="https://github.com/unlock-protocol/unlock"
           title="Source Code"
         >
@@ -26879,7 +26930,7 @@ Object {
           </small>
         </a>
         <a
-          class="sc-850ddk-0 hBjuko"
+          class="sc-850ddk-0 kaWqFM"
           href="https://t.me/unlockprotocol"
           title="Telegram"
         >
@@ -26905,7 +26956,7 @@ Object {
         class="sc-1glv5oz-3 eGBYUU"
       >
         <a
-          class="sc-850ddk-0 jJVfEK"
+          class="sc-850ddk-0 bRsbmn"
         >
           <svg
             viewBox="0 0 56 42"
@@ -26920,7 +26971,7 @@ Object {
           
         </a>
         <a
-          class="sc-850ddk-0 jJVfEK"
+          class="sc-850ddk-0 bRsbmn"
         >
           <svg
             viewBox="0 0 58 32"
@@ -30653,6 +30704,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c7 > svg {
@@ -30678,6 +30730,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c10 > svg {
@@ -31220,7 +31273,7 @@ Object {
             class="sc-1glv5oz-2 bijesQ"
           >
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/about"
               title="About"
             >
@@ -31243,7 +31296,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/jobs"
               title="Join us"
             >
@@ -31265,7 +31318,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://github.com/unlock-protocol/unlock"
               title="Source Code"
             >
@@ -31285,7 +31338,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://t.me/unlockprotocol"
               title="Telegram"
             >
@@ -31311,7 +31364,7 @@ Object {
             class="sc-1glv5oz-3 eGBYUU"
           >
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 56 42"
@@ -31326,7 +31379,7 @@ Object {
               
             </a>
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 58 32"
@@ -31351,7 +31404,7 @@ Object {
           class="sc-2ix2yp-0 clvjsX"
         >
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="/about"
             title="About"
           >
@@ -31374,7 +31427,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="/jobs"
             title="Join us"
           >
@@ -31396,7 +31449,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="https://github.com/unlock-protocol/unlock"
             title="Source Code"
           >
@@ -31416,7 +31469,7 @@ Object {
             </small>
           </a>
           <a
-            class="sc-850ddk-0 hBjuko"
+            class="sc-850ddk-0 kaWqFM"
             href="https://t.me/unlockprotocol"
             title="Telegram"
           >
@@ -31508,6 +31561,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c8 > svg {
@@ -31533,6 +31587,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c11 > svg {
@@ -31983,7 +32038,7 @@ Object {
             class="sc-1glv5oz-2 bijesQ"
           >
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/about"
               title="About"
             >
@@ -32006,7 +32061,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="/jobs"
               title="Join us"
             >
@@ -32028,7 +32083,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://github.com/unlock-protocol/unlock"
               title="Source Code"
             >
@@ -32048,7 +32103,7 @@ Object {
               </small>
             </a>
             <a
-              class="sc-850ddk-0 hBjuko"
+              class="sc-850ddk-0 kaWqFM"
               href="https://t.me/unlockprotocol"
               title="Telegram"
             >
@@ -32074,7 +32129,7 @@ Object {
             class="sc-1glv5oz-3 eGBYUU"
           >
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 56 42"
@@ -32089,7 +32144,7 @@ Object {
               
             </a>
             <a
-              class="sc-850ddk-0 jJVfEK"
+              class="sc-850ddk-0 bRsbmn"
             >
               <svg
                 viewBox="0 0 58 32"
@@ -32804,6 +32859,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 50px;
 }
 
 .c5 > svg {
@@ -33037,7 +33093,7 @@ Object {
         class="sc-1ws9jnj-2 gOgmYt"
       >
         <a
-          class="nk4431-2 ewyzVv sc-850ddk-0 gxCdlg"
+          class="nk4431-2 ewyzVv sc-850ddk-0 jXTyKj"
         >
           <svg
             class="nk4431-0 jIPREr"
@@ -33570,6 +33626,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c5 > svg {
@@ -33789,7 +33846,7 @@ Object {
         class="sc-1uq8tkh-0 dzUjcy"
       >
         <button
-          class="sc-850ddk-0 cjssoo"
+          class="sc-850ddk-0 kiVDOG"
           title="Copy"
         >
           <svg
@@ -33810,7 +33867,7 @@ Object {
           </small>
         </button>
         <a
-          class="sc-850ddk-0 cjssoo"
+          class="sc-850ddk-0 kiVDOG"
           href="/demo/0xa62142888aba8370742be823c1782d17a0389da1"
           target="_blank"
           title="Preview lock"
@@ -33900,6 +33957,7 @@ Object {
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c3 > svg {
@@ -34107,7 +34165,7 @@ Object {
           class="sc-1dp5gbn-1 hxNcaM"
         >
           <button
-            class="sc-850ddk-0 cjssoo"
+            class="sc-850ddk-0 kiVDOG"
             title="Withdraw balance"
           >
             <svg
@@ -34128,7 +34186,7 @@ Object {
             </small>
           </button>
           <button
-            class="sc-850ddk-0 cjssoo"
+            class="sc-850ddk-0 kiVDOG"
             title="Edit"
           >
             <svg
@@ -34152,7 +34210,7 @@ Object {
             </small>
           </button>
           <button
-            class="sc-850ddk-0 cjssoo"
+            class="sc-850ddk-0 kiVDOG"
             title="Show embed code"
           >
             <svg

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
@@ -21,6 +21,7 @@ exports[`withConfig High Order Component when the current network is not in the 
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c8 > svg {
@@ -46,6 +47,7 @@ exports[`withConfig High Order Component when the current network is not in the 
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c11 > svg {

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
@@ -21,6 +21,7 @@ exports[`withConfig High Order Component when the current network is not in the 
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 24px;
 }
 
 .c8 > svg {
@@ -46,6 +47,7 @@ exports[`withConfig High Order Component when the current network is not in the 
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: 48px;
 }
 
 .c11 > svg {

--- a/unlock-app/src/components/interface/buttons/Button.js
+++ b/unlock-app/src/components/interface/buttons/Button.js
@@ -67,6 +67,7 @@ export const ButtonLink = styled.a`
   display: inline-block;
   padding: 0;
   border: 0;
+  line-height: ${props => props.size || ' 24px'};
 
   > svg {
     fill: ${props => props.fillColor || 'white'};


### PR DESCRIPTION
# Description

Fixes #783. This PR ensures that the BaseButton always has a `line-height` equal to its `size` property, so that the different kinds of buttons will always have the same vertical spacing between the icon and the label. Simply setting a unitless `line-height` would result in the buttons in the header having different spacing from the buttons on the lock due to the differences in parent font size between them.

<img width="199" alt="screen shot 2019-01-18 at 11 57 16 am" src="https://user-images.githubusercontent.com/9300702/51401488-e3693a00-1b18-11e9-8310-aaa1a5e852ce.png">
<img width="227" alt="screen shot 2019-01-18 at 11 57 50 am" src="https://user-images.githubusercontent.com/9300702/51401489-e3693a00-1b18-11e9-9b77-8deef36e4148.png">

We may want to create a new issue to address the way the embed code text spills over the lock border.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
