### PR TITLE
Show a message when there aren't any keys for a lock

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -27664,11 +27664,7 @@ exports[`Storyshots KeyList 0 keys 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c2 {
-  margin-top: 20px;
-}
-
-.c0 {
+    .c0 {
   cursor: default;
 }
 
@@ -27684,6 +27680,13 @@ Object {
   font-family: 'IBM Plex Sans';
   font-size: 10px;
   text-transform: uppercase;
+}
+
+.c2 {
+  margin-top: 20px;
+  margin-left: 48px;
+  margin-bottom: 10px;
+  color: var(--grey);
 }
 
 <div>
@@ -27719,7 +27722,17 @@ Object {
         </div>
         <div
           class="c2"
-        />
+        >
+          No keys have been purchased yet.
+           
+          <a
+            href="https://github.com/unlock-protocol/unlock/wiki/Introduction-to-Unlock#access-permissions-on-the-blockchain"
+          >
+            Embed your code snippet
+          </a>
+           
+          to sell keys.
+        </div>
       </div>
     </div>
   </body>,
@@ -27755,8 +27768,18 @@ Object {
         </div>
       </div>
       <div
-        class="sc-14bj30x-1 fYDZXe"
-      />
+        class="sc-4ambxn-6 bYreEG"
+      >
+        No keys have been purchased yet.
+         
+        <a
+          href="https://github.com/unlock-protocol/unlock/wiki/Introduction-to-Unlock#access-permissions-on-the-blockchain"
+        >
+          Embed your code snippet
+        </a>
+         
+        to sell keys.
+      </div>
     </div>
   </div>,
   "debug": [Function],

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -27685,7 +27685,7 @@ Object {
 .c2 {
   margin-top: 20px;
   margin-left: 48px;
-  margin-bottom: 10px;
+  margin-bottom: 30px;
   color: var(--grey);
 }
 
@@ -27768,7 +27768,7 @@ Object {
         </div>
       </div>
       <div
-        class="sc-4ambxn-6 bYreEG"
+        class="sc-4ambxn-6 cKnhun"
       >
         No keys have been purchased yet.
          

--- a/unlock-app/src/components/creator/lock/KeyList.js
+++ b/unlock-app/src/components/creator/lock/KeyList.js
@@ -132,6 +132,6 @@ const Data = styled(Cell)`
 const Message = styled.div`
   margin-top: 20px;
   margin-left: 48px;
-  margin-bottom: 10px;
+  margin-bottom: 30px;
   color: var(--grey);
 `

--- a/unlock-app/src/components/creator/lock/KeyList.js
+++ b/unlock-app/src/components/creator/lock/KeyList.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
+import Link from 'next/link'
 import UnlockPropTypes from '../../../propTypes'
 import { expirationAsDate } from '../../../utils/durations'
 import Pagination from '../../interface/pagination/Pagination'
@@ -39,14 +40,24 @@ export class KeyList extends React.Component {
           <Pagination> takes a list of items
           and a function that takes list of items and renders the list.
           This is so that the Pagination component can be reused across the app
-      */}
-        <Pagination
-          items={keys}
-          currentPage={page + 1}
-          itemCount={lock.outstandingKeys}
-          renderItems={renderItems}
-          goToPage={loadPage}
-        />
+          */
+        keys.length > 0 ? (
+          <Pagination
+            items={keys}
+            currentPage={page + 1}
+            itemCount={lock.outstandingKeys}
+            renderItems={renderItems}
+            goToPage={loadPage}
+          />
+        ) : (
+          <Message>
+            No keys have been purchased yet.{' '}
+            <Link href="https://github.com/unlock-protocol/unlock/wiki/Introduction-to-Unlock#access-permissions-on-the-blockchain">
+              Embed your code snippet
+            </Link>{' '}
+            to sell keys.
+          </Message>
+        )}
       </KeyListWrapper>
     )
   }
@@ -116,4 +127,11 @@ const Cell = styled.div``
 const Data = styled(Cell)`
   overflow: hidden;
   text-overflow: ellipsis;
+`
+
+const Message = styled.div`
+  margin-top: 20px;
+  margin-left: 48px;
+  margin-bottom: 10px;
+  color: var(--grey);
 `


### PR DESCRIPTION
# Description

Fixes  #1117. `KeyList` now provides a message indicating that there aren't any keys for a lock when there aren't any keys for a lock, rather than an empty table.

I've set the link to [here](https://github.com/unlock-protocol/unlock/wiki/Introduction-to-Unlock#access-permissions-on-the-blockchain) because that seemed like the most relevant section of the wiki. Let me know if there is a better place, or if we need to write a new section of the wiki with more detailed usage documentation.

<img width="970" alt="screen shot 2019-01-18 at 3 03 35 pm" src="https://user-images.githubusercontent.com/9300702/51410322-41eee200-1b32-11e9-9c79-e28b20f8ae19.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
