### PR TITLE
Adds backport to support key enumeration for first version of Rinkeby Locks

### DIFF
--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -1315,6 +1315,37 @@ describe('Web3Service', () => {
 
         web3Service.getKeysForLockOnPage(lockAddress, onPage, byPage)
       })
+
+      describe('when the on contract method raises an error', () => {
+        it('should use the iterative method of providing keyholder', done => {
+          const onPage = 0
+          const byPage = 5
+
+          expect.assertions(3)
+
+          jest
+            .spyOn(web3Service, '_genKeyOwnersFromLockContract')
+            .mockImplementation(() => {
+              return Promise.reject()
+            })
+          jest
+            .spyOn(web3Service, '_genKeyOwnersFromLockContractIterative')
+            .mockImplementation(() => {
+              return Promise.resolve([])
+            })
+
+          web3Service.getKeysForLockOnPage(lockAddress, onPage, byPage)
+
+          web3Service.on('keys.page', (lock, page) => {
+            expect(lockAddress).toEqual(lock)
+            expect(page).toEqual(onPage)
+            expect(
+              web3Service._genKeyOwnersFromLockContractIterative
+            ).toHaveBeenCalledTimes(1)
+            done()
+          })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
This code change is more to support our staging and should support or latest locks going forward

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
