### PR TITLE
Edit form no longer complains about unlimited keys

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -209,7 +209,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     external
     payable
     notSoldOut()
-    hasKey(_from)
+    hasValidKey(_from)
     onlyKeyOwnerOrApproved(_tokenId)
   {
     require(_recipient != address(0));

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -71,7 +71,7 @@ contract('Lock ERC721', (accounts) => {
             assert(false, 'This should not succeed')
           })
           .catch(error => {
-            assert.equal(error.message, 'VM Exception while processing transaction: revert No such key')
+            assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
           })
       })
 
@@ -173,7 +173,7 @@ contract('Lock ERC721', (accounts) => {
               assert(false, 'This should not succeed')
             })
             .catch(error => {
-              assert.equal(error.message, 'VM Exception while processing transaction: revert')
+              assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
               // Ensuring that ownership of the key did not change
               return locks['FIRST'].keyExpirationTimestampFor(from)
             }).then((expirationTimestamp) => {

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -91,6 +91,15 @@ contract('Lock ERC721', (accounts) => {
           assert(_numberOfOwners.eq(numberOfOwners.plus(1)))
         })
       })
+
+      it('should fail if I transfer from the same account again', async () => {
+        try {
+          await lock.transferFrom(accounts[1], accounts[5], accounts[1], { from: accounts[1] })
+          assert.fail('Expected revert')
+        } catch (error) {
+          assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
+        }
+      })
     })
 
     describe('after a transfer to an existing owner', () => {
@@ -98,7 +107,7 @@ contract('Lock ERC721', (accounts) => {
 
       before(async () => {
         numberOfOwners = await lock.numberOfOwners()
-        await lock.transferFrom(accounts[1], accounts[2], accounts[1], { from: accounts[1] })
+        await lock.transferFrom(accounts[2], accounts[3], accounts[2], { from: accounts[2] })
       })
   
       it('should have the right number of keys', () => {

--- a/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
@@ -152,16 +152,20 @@ describe('Lock middleware', () => {
   })
 
   it('it should handle lock.saved events triggered by the web3Service', () => {
-    expect.assertions(3)
+    expect.assertions(4)
     const { store } = create()
     const lock = {}
     const address = '0x123'
     mockWeb3Service.refreshAccountBalance = jest.fn()
     mockWeb3Service.getLock = jest.fn()
+    mockWeb3Service.getPastLockTransactions = jest.fn()
 
     mockWeb3Service.emit('lock.saved', lock, address)
     expect(mockWeb3Service.refreshAccountBalance).toHaveBeenCalledWith(
       state.account
+    )
+    expect(mockWeb3Service.getPastLockTransactions).toHaveBeenCalledWith(
+      address
     )
     expect(mockWeb3Service.getLock).toHaveBeenCalledWith(address)
     expect(store.dispatch).toHaveBeenCalledWith(

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -275,7 +275,7 @@ describe('Web3Service', () => {
   })
 
   describe('once connected', () => {
-    const lockAddress = '0x0d370b0974454d7b0e0e3b4512c0735a6489a71a'
+    const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
     const netVersion = Math.floor(Math.random() * 100000)
 
     beforeEach(done => {
@@ -380,6 +380,43 @@ describe('Web3Service', () => {
 
           return web3Service.refreshOrGetAccount(account)
         })
+      })
+    })
+
+    describe('getPastLockTransactions', () => {
+      it('should getPastEvents for the Lock contract', done => {
+        expect.assertions(1)
+
+        const events = [
+          {
+            logIndex: '0x0',
+            transactionIndex: '0x0',
+            transactionHash:
+              '0x7fffd5b8afefc854b04a06330dcf1a5b098c1b8df78da2f7b549fd2cfdd8eab7',
+            blockHash:
+              '0x249aaf2ec8abc3b45fc63d346170d6d9eebb1750e12808153667ba01bef9757f',
+            blockNumber: '0x5d',
+            address: '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f',
+            data:
+              '0x000000000000000000000000000000000000000000000000002386f26fc100000000000000000000000000000000000000000000000000000de0b6b3a7640000',
+            topics: [
+              '0x8aa4fa52648a6d15edce8a179c792c86f3719d0cc3c572cf90f91948f0f2cb68',
+            ],
+            type: 'mined',
+          },
+        ]
+
+        ethGetLogs('0x0', 'latest', [], lockAddress, events)
+
+        web3Service.once('transaction.new', transaction => {
+          expect(transaction.hash).toEqual(
+            '0x7fffd5b8afefc854b04a06330dcf1a5b098c1b8df78da2f7b549fd2cfdd8eab7'
+          )
+          done()
+        })
+
+        web3Service.getTransaction = jest.fn()
+        web3Service.getPastLockTransactions(lockAddress)
       })
     })
 

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -1352,6 +1352,37 @@ describe('Web3Service', () => {
 
         web3Service.getKeysForLockOnPage(lockAddress, onPage, byPage)
       })
+
+      describe('when the on contract method raises an error', () => {
+        it('should use the iterative method of providing keyholder', done => {
+          const onPage = 0
+          const byPage = 5
+
+          expect.assertions(3)
+
+          jest
+            .spyOn(web3Service, '_genKeyOwnersFromLockContract')
+            .mockImplementation(() => {
+              return Promise.reject()
+            })
+          jest
+            .spyOn(web3Service, '_genKeyOwnersFromLockContractIterative')
+            .mockImplementation(() => {
+              return Promise.resolve([])
+            })
+
+          web3Service.getKeysForLockOnPage(lockAddress, onPage, byPage)
+
+          web3Service.on('keys.page', (lock, page) => {
+            expect(lockAddress).toEqual(lock)
+            expect(page).toEqual(onPage)
+            expect(
+              web3Service._genKeyOwnersFromLockContractIterative
+            ).toHaveBeenCalledTimes(1)
+            done()
+          })
+        })
+      })
     })
   })
 })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -37626,6 +37626,69 @@ Object {
 }
 `;
 
+exports[`Storyshots Paywall the paywall overlay, unlocked 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots PendingKeyLock waiting for mining confirmation 1`] = `
 Object {
   "asFragment": [Function],

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -34634,6 +34634,57 @@ Object {
   padding-top: 16px;
 }
 
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-family: 'Roboto',sans-serif;
+  font-weight: 300;
+  font-size: 12px;
+  color: var(--darkgrey);
+  background-color: var(--white);
+  justify-self: right;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  grid-row: 2;
+  grid-column: 1;
+  width: 120px;
+  height: 80px;
+  margin-right: -33px;
+}
+
+.c9 > * {
+  justify-self: left;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin-left: -14px;
+}
+
+.c9 > p {
+  margin-left: auto;
+  margin-right: auto;
+  width: 63px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  justify-self: center;
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: normal;
+  line-height: normal;
+  font-size: 12px;
+  color: var(--darkgrey);
+}
+
 .c4 {
   display: grid;
   justify-items: stretch;
@@ -34736,57 +34787,6 @@ Object {
   padding: 0px;
   grid-row: 2;
   grid-column: 1;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
-  font-family: 'Roboto',sans-serif;
-  font-weight: 300;
-  font-size: 12px;
-  color: var(--darkgrey);
-  background-color: var(--white);
-  justify-self: right;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  grid-row: 2;
-  grid-column: 1;
-  width: 120px;
-  height: 80px;
-  margin-right: -33px;
-}
-
-.c9 > * {
-  justify-self: left;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  margin-left: -14px;
-}
-
-.c9 > p {
-  margin-left: auto;
-  margin-right: auto;
-  width: 63px;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  justify-self: center;
-  font-family: Roboto;
-  font-style: normal;
-  font-weight: normal;
-  line-height: normal;
-  font-size: 12px;
-  color: var(--darkgrey);
 }
 
 <div>
@@ -35006,7 +35006,7 @@ Object {
             </li>
           </ul>
           <footer
-            class="vaayz9-4 eCqFRG"
+            class="sc-1ws9jnj-7 ctqObv"
           >
             <div
               class="cenpj1-0 dhCRxc"
@@ -35106,6 +35106,57 @@ Object {
   grid-template-rows: 40px 30px;
   grid-gap: 8px;
   padding-top: 16px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-family: 'Roboto',sans-serif;
+  font-weight: 300;
+  font-size: 12px;
+  color: var(--darkgrey);
+  background-color: var(--white);
+  justify-self: right;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  grid-row: 2;
+  grid-column: 1;
+  width: 120px;
+  height: 80px;
+  margin-right: -33px;
+}
+
+.c9 > * {
+  justify-self: left;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin-left: -14px;
+}
+
+.c9 > p {
+  margin-left: auto;
+  margin-right: auto;
+  width: 63px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  justify-self: center;
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: normal;
+  line-height: normal;
+  font-size: 12px;
+  color: var(--darkgrey);
 }
 
 .c4 {
@@ -35210,57 +35261,6 @@ Object {
   padding: 0px;
   grid-row: 2;
   grid-column: 1;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
-  font-family: 'Roboto',sans-serif;
-  font-weight: 300;
-  font-size: 12px;
-  color: var(--darkgrey);
-  background-color: var(--white);
-  justify-self: right;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  grid-row: 2;
-  grid-column: 1;
-  width: 120px;
-  height: 80px;
-  margin-right: -33px;
-}
-
-.c9 > * {
-  justify-self: left;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  margin-left: -14px;
-}
-
-.c9 > p {
-  margin-left: auto;
-  margin-right: auto;
-  width: 63px;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  justify-self: center;
-  font-family: Roboto;
-  font-style: normal;
-  font-weight: normal;
-  line-height: normal;
-  font-size: 12px;
-  color: var(--darkgrey);
 }
 
 <div>
@@ -35530,7 +35530,7 @@ Object {
             </li>
           </ul>
           <footer
-            class="vaayz9-4 eCqFRG"
+            class="sc-1ws9jnj-7 ctqObv"
           >
             <div
               class="cenpj1-0 dhCRxc"

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -33,7 +33,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -143,7 +143,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         About
       </small>
@@ -896,7 +896,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1000,7 +1000,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Source Code
       </small>
@@ -1085,7 +1085,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1193,7 +1193,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Join us
       </small>
@@ -1278,7 +1278,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1386,7 +1386,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Newsletter
       </small>
@@ -1471,7 +1471,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1579,7 +1579,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Telegram
       </small>
@@ -1664,7 +1664,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1772,7 +1772,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Twitter
       </small>
@@ -1857,7 +1857,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1963,7 +1963,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Copy
       </small>
@@ -2048,7 +2048,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2154,7 +2154,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Download
       </small>
@@ -2239,7 +2239,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2351,7 +2351,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Edit
       </small>
@@ -2436,7 +2436,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2542,7 +2542,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Etherscan
       </small>
@@ -2627,7 +2627,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2733,7 +2733,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Export
       </small>
@@ -2818,7 +2818,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2938,7 +2938,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Preview lock
       </small>
@@ -3023,7 +3023,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -3129,7 +3129,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Show embed code
       </small>
@@ -3214,7 +3214,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -3320,7 +3320,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Upload
       </small>
@@ -3405,7 +3405,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -3511,7 +3511,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Withdraw balance
       </small>
@@ -3596,7 +3596,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -3702,7 +3702,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Withdraw balance
       </small>
@@ -4270,7 +4270,7 @@ Object {
 .c8 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -5276,7 +5276,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -5298,7 +5298,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -5318,7 +5318,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -5340,7 +5340,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -5781,7 +5781,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               About
             </small>
@@ -5803,7 +5803,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Join us
             </small>
@@ -5823,7 +5823,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Source Code
             </small>
@@ -5845,7 +5845,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Telegram
             </small>
@@ -5967,7 +5967,7 @@ Object {
 .c8 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -6772,7 +6772,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -6794,7 +6794,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -6814,7 +6814,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -6836,7 +6836,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -7016,7 +7016,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               About
             </small>
@@ -7038,7 +7038,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Join us
             </small>
@@ -7058,7 +7058,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Source Code
             </small>
@@ -7080,7 +7080,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Telegram
             </small>
@@ -7202,7 +7202,7 @@ Object {
 .c8 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -8377,7 +8377,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -8399,7 +8399,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -8419,7 +8419,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -8441,7 +8441,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -9058,7 +9058,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               About
             </small>
@@ -9080,7 +9080,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Join us
             </small>
@@ -9100,7 +9100,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Source Code
             </small>
@@ -9122,7 +9122,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Telegram
             </small>
@@ -10770,7 +10770,7 @@ Object {
 .c16 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -11449,7 +11449,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Withdraw balance
               </small>
@@ -11473,7 +11473,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -11494,7 +11494,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -11586,7 +11586,7 @@ Object {
 .c16 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -12265,7 +12265,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Withdraw balance
               </small>
@@ -12289,7 +12289,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -12310,7 +12310,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -13048,7 +13048,7 @@ Object {
 .c16 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -13727,7 +13727,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Withdraw balance
               </small>
@@ -13751,7 +13751,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -13772,7 +13772,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -13890,7 +13890,7 @@ Object {
 .c17 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -14585,7 +14585,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -14606,7 +14606,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -14700,7 +14700,7 @@ Object {
 .c16 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -15384,7 +15384,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Withdraw balance
               </small>
@@ -15408,7 +15408,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -15429,7 +15429,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -18721,7 +18721,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -20526,7 +20526,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -20548,7 +20548,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -20568,7 +20568,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -20590,7 +20590,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -21042,7 +21042,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Withdraw balance
                     </small>
@@ -21066,7 +21066,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Edit
                     </small>
@@ -21087,7 +21087,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Show embed code
                     </small>
@@ -21318,7 +21318,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Withdraw balance
                     </small>
@@ -21342,7 +21342,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Edit
                     </small>
@@ -21363,7 +21363,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Show embed code
                     </small>
@@ -21594,7 +21594,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Withdraw balance
                     </small>
@@ -21618,7 +21618,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Edit
                     </small>
@@ -21639,7 +21639,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Show embed code
                     </small>
@@ -22799,7 +22799,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -23309,7 +23309,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -23331,7 +23331,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -23351,7 +23351,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -23373,7 +23373,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -23548,7 +23548,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -24065,7 +24065,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -24087,7 +24087,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -24107,7 +24107,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -24129,7 +24129,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -24311,7 +24311,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -24821,7 +24821,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -24843,7 +24843,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -24863,7 +24863,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -24885,7 +24885,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -25034,7 +25034,7 @@ Object {
 .c3 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -25241,7 +25241,7 @@ Object {
           />
         </svg>
         <small
-          class="sc-850ddk-1 kizSum"
+          class="sc-850ddk-1 fnqGzL"
         >
           About
         </small>
@@ -25263,7 +25263,7 @@ Object {
           />
         </svg>
         <small
-          class="sc-850ddk-1 kizSum"
+          class="sc-850ddk-1 fnqGzL"
         >
           Join us
         </small>
@@ -25283,7 +25283,7 @@ Object {
           />
         </svg>
         <small
-          class="sc-850ddk-1 kizSum"
+          class="sc-850ddk-1 fnqGzL"
         >
           Source Code
         </small>
@@ -25305,7 +25305,7 @@ Object {
           />
         </svg>
         <small
-          class="sc-850ddk-1 kizSum"
+          class="sc-850ddk-1 fnqGzL"
         >
           Telegram
         </small>
@@ -25422,7 +25422,7 @@ Object {
 .c5 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -25778,7 +25778,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             About
           </small>
@@ -25800,7 +25800,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Join us
           </small>
@@ -25820,7 +25820,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Source Code
           </small>
@@ -25842,7 +25842,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Telegram
           </small>
@@ -25994,7 +25994,7 @@ Object {
 .c5 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -26330,7 +26330,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             About
           </small>
@@ -26352,7 +26352,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Join us
           </small>
@@ -26372,7 +26372,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Source Code
           </small>
@@ -26394,7 +26394,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Telegram
           </small>
@@ -26546,7 +26546,7 @@ Object {
 .c5 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -26882,7 +26882,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             About
           </small>
@@ -26904,7 +26904,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Join us
           </small>
@@ -26924,7 +26924,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Source Code
           </small>
@@ -26946,7 +26946,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Telegram
           </small>
@@ -30773,7 +30773,7 @@ Object {
 .c8 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -31313,7 +31313,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -31335,7 +31335,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -31355,7 +31355,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -31377,7 +31377,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -31444,7 +31444,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               About
             </small>
@@ -31466,7 +31466,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Join us
             </small>
@@ -31486,7 +31486,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Source Code
             </small>
@@ -31508,7 +31508,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Telegram
             </small>
@@ -31630,7 +31630,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -32078,7 +32078,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -32100,7 +32100,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -32120,7 +32120,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -32142,7 +32142,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -33669,7 +33669,7 @@ Object {
 .c6 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -33884,7 +33884,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Copy
           </small>
@@ -33913,7 +33913,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Preview lock
           </small>
@@ -34000,7 +34000,7 @@ Object {
 .c4 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -34203,7 +34203,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Withdraw balance
             </small>
@@ -34227,7 +34227,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Edit
             </small>
@@ -34248,7 +34248,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Show embed code
             </small>

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
@@ -67,7 +67,7 @@ exports[`withConfig High Order Component when the current network is not in the 
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
@@ -67,7 +67,7 @@ exports[`withConfig High Order Component when the current network is not in the 
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -85,6 +85,7 @@ export class CreatorLock extends React.Component {
           {...lock}
           hideAction={() => this.setState({ editing: false })}
           createLock={lock => this.updateLock(lock)}
+          editing={editing}
         />
       )
     }

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -25,8 +25,6 @@ import {
 } from './LockStyles'
 import { updateKeyPrice } from '../../actions/lock'
 
-import { INFINITY } from '../../constants'
-
 const LockKeysNumbers = ({ lock }) => (
   <LockKeys>
     {lock.outstandingKeys !== null &&
@@ -34,7 +32,7 @@ const LockKeysNumbers = ({ lock }) => (
     typeof lock.outstandingKeys !== 'undefined' &&
     typeof lock.maxNumberOfKeys !== 'undefined'
       ? `${lock.outstandingKeys}/${
-          lock.maxNumberOfKeys > 0 ? lock.maxNumberOfKeys : INFINITY
+          lock.maxNumberOfKeys > 0 ? lock.maxNumberOfKeys : '∞'
         }`
       : ' - '}
   </LockKeys>
@@ -85,7 +83,6 @@ export class CreatorLock extends React.Component {
           {...lock}
           hideAction={() => this.setState({ editing: false })}
           createLock={lock => this.updateLock(lock)}
-          editing={editing}
         />
       )
     }

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -40,6 +40,9 @@ export class CreatorLockForm extends React.Component {
     if (props.convert) {
       keyPrice = Web3Utils.fromWei(keyPrice, props.keyPriceCurrency)
       expirationDuration = expirationDuration / props.expirationDurationUnit
+      // Unlimited keys is represented as zero, so when we load a lock
+      // that has `maxNumberOfKeys` set to zero, convert it to the
+      // infinity symbol before displaying it.
       if (maxNumberOfKeys === 0) {
         maxNumberOfKeys = INFINITY
       }

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -207,7 +207,7 @@ export class CreatorLockForm extends React.Component {
   }
 
   render() {
-    const { pending, editing } = this.props
+    const { pending } = this.props
     const {
       expirationDuration,
       maxNumberOfKeys,
@@ -233,37 +233,29 @@ export class CreatorLockForm extends React.Component {
           />
         </FormLockName>
         <FormLockDuration>
-          {editing ? (
-            expirationDuration
-          ) : (
-            <input
-              type="number"
-              step="1"
-              inputMode="numeric"
-              name="expirationDuration"
-              onChange={this.handleChange}
-              defaultValue={expirationDuration}
-              data-valid={valid.expirationDuration}
-              required={pending}
-              disabled={!pending}
-            />
-          )}{' '}
+          <input
+            type="number"
+            step="1"
+            inputMode="numeric"
+            name="expirationDuration"
+            onChange={this.handleChange}
+            defaultValue={expirationDuration}
+            data-valid={valid.expirationDuration}
+            required={pending}
+            disabled={!pending}
+          />{' '}
           days
         </FormLockDuration>
         <FormLockKeys>
-          {editing ? (
-            maxNumberOfKeys || '∞'
-          ) : (
-            <input
-              type="text"
-              name="maxNumberOfKeys"
-              onChange={this.handleChange}
-              value={maxNumberOfKeys}
-              data-valid={valid.maxNumberOfKeys}
-              required={pending}
-              disabled={!pending}
-            />
-          )}
+          <input
+            type="text"
+            name="maxNumberOfKeys"
+            onChange={this.handleChange}
+            value={maxNumberOfKeys}
+            data-valid={valid.maxNumberOfKeys}
+            required={pending}
+            disabled={!pending}
+          />
           {pending && !unlimitedKeys && (
             <LockLabelUnlimited onClick={this.handleUnlimitedClick}>
               Unlimited
@@ -310,7 +302,6 @@ CreatorLockForm.propTypes = {
   address: PropTypes.string,
   pending: PropTypes.bool,
   convert: PropTypes.bool, // this prop is to allow form field validation tests to test edge cases
-  editing: PropTypes.bool,
 }
 
 CreatorLockForm.defaultProps = {
@@ -323,7 +314,6 @@ CreatorLockForm.defaultProps = {
   address: uniqid(), // for new locks, we don't have an address, so use a temporary one
   convert: true,
   pending: false,
-  editing: false,
 }
 
 const mapStateToProps = state => {

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -36,17 +36,21 @@ export class CreatorLockForm extends React.Component {
     super(props, context)
     let expirationDuration = props.expirationDuration
     let keyPrice = props.keyPrice
+    let maxNumberOfKeys = props.maxNumberOfKeys
     if (props.convert) {
       keyPrice = Web3Utils.fromWei(keyPrice, props.keyPriceCurrency)
       expirationDuration = expirationDuration / props.expirationDurationUnit
+      if (maxNumberOfKeys === 0) {
+        maxNumberOfKeys = INFINITY
+      }
     }
     this.state = {
       expirationDuration: expirationDuration,
       expirationDurationUnit: props.expirationDurationUnit, // Days
       keyPrice: keyPrice,
       keyPriceCurrency: props.keyPriceCurrency,
-      maxNumberOfKeys: props.maxNumberOfKeys,
-      unlimitedKeys: props.maxNumberOfKeys === INFINITY,
+      maxNumberOfKeys,
+      unlimitedKeys: maxNumberOfKeys === INFINITY,
       name: props.name,
       address: props.address,
     }

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -203,7 +203,7 @@ export class CreatorLockForm extends React.Component {
   }
 
   render() {
-    const { pending } = this.props
+    const { pending, editing } = this.props
     const {
       expirationDuration,
       maxNumberOfKeys,
@@ -229,29 +229,37 @@ export class CreatorLockForm extends React.Component {
           />
         </FormLockName>
         <FormLockDuration>
-          <input
-            type="number"
-            step="1"
-            inputMode="numeric"
-            name="expirationDuration"
-            onChange={this.handleChange}
-            defaultValue={expirationDuration}
-            data-valid={valid.expirationDuration}
-            required={pending}
-            disabled={!pending}
-          />{' '}
+          {editing ? (
+            expirationDuration
+          ) : (
+            <input
+              type="number"
+              step="1"
+              inputMode="numeric"
+              name="expirationDuration"
+              onChange={this.handleChange}
+              defaultValue={expirationDuration}
+              data-valid={valid.expirationDuration}
+              required={pending}
+              disabled={!pending}
+            />
+          )}{' '}
           days
         </FormLockDuration>
         <FormLockKeys>
-          <input
-            type="text"
-            name="maxNumberOfKeys"
-            onChange={this.handleChange}
-            value={maxNumberOfKeys}
-            data-valid={valid.maxNumberOfKeys}
-            required={pending}
-            disabled={!pending}
-          />
+          {editing ? (
+            maxNumberOfKeys || '∞'
+          ) : (
+            <input
+              type="text"
+              name="maxNumberOfKeys"
+              onChange={this.handleChange}
+              value={maxNumberOfKeys}
+              data-valid={valid.maxNumberOfKeys}
+              required={pending}
+              disabled={!pending}
+            />
+          )}
           {pending && !unlimitedKeys && (
             <LockLabelUnlimited onClick={this.handleUnlimitedClick}>
               Unlimited
@@ -298,6 +306,7 @@ CreatorLockForm.propTypes = {
   address: PropTypes.string,
   pending: PropTypes.bool,
   convert: PropTypes.bool, // this prop is to allow form field validation tests to test edge cases
+  editing: PropTypes.bool,
 }
 
 CreatorLockForm.defaultProps = {
@@ -310,6 +319,7 @@ CreatorLockForm.defaultProps = {
   address: uniqid(), // for new locks, we don't have an address, so use a temporary one
   convert: true,
   pending: false,
+  editing: false,
 }
 
 const mapStateToProps = state => {

--- a/unlock-app/src/components/interface/buttons/Button.js
+++ b/unlock-app/src/components/interface/buttons/Button.js
@@ -87,7 +87,7 @@ export const ButtonLink = styled.a`
 export const Label = styled.small`
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
   font-weight: 400;

--- a/unlock-app/src/components/lock/LockStyles.js
+++ b/unlock-app/src/components/lock/LockStyles.js
@@ -79,3 +79,40 @@ export const LockName = styled(LockDetail)`
   white-space: normal;
   font-size: 12px;
 `
+
+export const Colophon = styled.footer`
+  display: flex;
+  flex-direction: row;
+  align-content: center;
+  font-family: 'Roboto', sans-serif;
+  font-weight: 300;
+  font-size: 12px;
+  color: var(--darkgrey);
+  background-color: var(--white);
+  justify-self: right;
+  align-self: center;
+  grid-row: 2;
+  grid-column: 1;
+  width: 120px;
+  height: 80px;
+  margin-right: -33px;
+
+  & > * {
+    justify-self: left;
+    align-self: center;
+    margin-left: -14px;
+  }
+  & > p {
+    margin-left: auto;
+    margin-right: auto;
+    width: 63px;
+    align-self: center;
+    justify-self: center;
+    font-family: Roboto;
+    font-style: normal;
+    font-weight: normal;
+    line-height: normal;
+    font-size: 12px;
+    color: var(--darkgrey);
+  }
+`

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -2,12 +2,11 @@ import styled from 'styled-components'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { RoundedLogo } from '../interface/Logo'
 import Lock from './Lock'
 import UnlockPropTypes from '../../propTypes'
 import { hideModal, showModal } from '../../actions/modal'
 import { unlockPage } from '../../services/iframeService'
-import { Colophon } from './LockStyles'
+import LockedFlag from './UnlockFlag'
 
 export const Overlay = ({ locks, hideModal, showModal }) => (
   <FullPage>
@@ -25,10 +24,7 @@ export const Overlay = ({ locks, hideModal, showModal }) => (
           />
         ))}
       </Locks>
-      <Colophon>
-        <RoundedLogo size="28px" />
-        <p>Powered by Unlock</p>
-      </Colophon>
+      <LockedFlag />
     </Banner>
   </FullPage>
 )

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -7,6 +7,7 @@ import Lock from './Lock'
 import UnlockPropTypes from '../../propTypes'
 import { hideModal, showModal } from '../../actions/modal'
 import { unlockPage } from '../../services/iframeService'
+import { Colophon } from './LockStyles'
 
 export const Overlay = ({ locks, hideModal, showModal }) => (
   <FullPage>
@@ -98,41 +99,4 @@ const Locks = styled.ul`
   padding: 0px;
   grid-row: 2;
   grid-column: 1;
-`
-
-const Colophon = styled.footer`
-  display: flex;
-  flex-direction: row;
-  align-content: center;
-  font-family: 'Roboto', sans-serif;
-  font-weight: 300;
-  font-size: 12px;
-  color: var(--darkgrey);
-  background-color: var(--white);
-  justify-self: right;
-  align-self: center;
-  grid-row: 2;
-  grid-column: 1;
-  width: 120px;
-  height: 80px;
-  margin-right: -33px;
-
-  & > * {
-    justify-self: left;
-    align-self: center;
-    margin-left: -14px;
-  }
-  & > p {
-    margin-left: auto;
-    margin-right: auto;
-    width: 63px;
-    align-self: center;
-    justify-self: center;
-    font-family: Roboto;
-    font-style: normal;
-    font-weight: normal;
-    line-height: normal;
-    font-size: 12px;
-    color: var(--darkgrey);
-  }
 `

--- a/unlock-app/src/components/lock/UnlockFlag.js
+++ b/unlock-app/src/components/lock/UnlockFlag.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Colophon } from './LockStyles'
+import { RoundedLogo } from '../interface/Logo'
+
+export default function LockedFlag() {
+  return (
+    <Colophon>
+      <RoundedLogo size="28px" />
+      <p>Powered by Unlock</p>
+    </Colophon>
+  )
+}

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -69,6 +69,7 @@ export default function configure(
       `http://${runtimeConfig.httpProvider}:8545`
     )
     services['storage'] = { host: 'http://127.0.0.1:8080' }
+    isRequiredNetwork = networkId => networkId === 1337
   }
 
   if (env === 'dev') {

--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -72,3 +72,5 @@ export const MAX_DEVICE_WIDTHS = {
 }
 
 export const INFINITY = '∞'
+
+export const SHOW_FLAG_FOR = 2000 // milliseconds

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -69,6 +69,7 @@ export default function lockMiddleware({ getState, dispatch }) {
     )
     web3Service.refreshAccountBalance(getState().account)
     web3Service.getLock(address)
+    web3Service.getPastLockTransactions(address)
   })
 
   /**

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -677,9 +677,68 @@ export default class Web3Service extends EventEmitter {
     })
   }
 
+  _emitKeyOwners(lock, page, keyPromises) {
+    return Promise.all(keyPromises).then(keys => {
+      this.emit('keys.page', lock, page, keys.filter(key => !!key))
+    })
+  }
+
+  _packageKeyholderInfo(lock, lockContract, ownerAddress) {
+    return this._getKeyByLockForOwner(lockContract, ownerAddress).then(
+      ([expiration, data]) => {
+        return {
+          id: keyId(lock, ownerAddress),
+          lock,
+          owner: ownerAddress,
+          expiration,
+          data,
+        }
+      }
+    )
+  }
+
+  _genKeyOwnersFromLockContractIterative(lock, lockContract, page, byPage) {
+    const startIndex = page * byPage
+    return new Promise(resolve => {
+      let keyPromises = Array.from(Array(byPage).keys()).map(n => {
+        return lockContract.methods
+          .owners(n + startIndex)
+          .call()
+          .then(ownerAddress => {
+            return this._packageKeyholderInfo(lock, lockContract, ownerAddress)
+          })
+          .catch(() => {
+            return null
+          })
+      })
+
+      resolve(keyPromises)
+    })
+  }
+
+  _genKeyOwnersFromLockContract(lock, lockContract, page, byPage) {
+    return new Promise((resolve, reject) => {
+      lockContract.methods
+        .getOwnersByPage(page, byPage)
+        .call()
+        .then(ownerAddresses => {
+          let keyPromises = ownerAddresses.map(ownerAddress => {
+            return this._packageKeyholderInfo(lock, lockContract, ownerAddress)
+          })
+
+          resolve(keyPromises)
+        })
+        .catch(error => reject(error))
+    })
+  }
+
   /**
    * This loads and returns the keys for a lock per page
    * we fetch byPage number of keyOwners and dispatch for futher details.
+   *
+   * This method will attempt to retrieve keyholders directly from the smart contract, if this
+   * raises and exception the code will attempt to iteratively retrieve the keyholders.
+   * (Relevant to issue #1116)
    * @param {PropTypes.string}
    * @param {PropTypes.integer}
    * @param {PropTypes.integer}
@@ -687,27 +746,15 @@ export default class Web3Service extends EventEmitter {
   getKeysForLockOnPage(lock, page, byPage) {
     const lockContract = new this.web3.eth.Contract(LockContract.abi, lock)
 
-    lockContract.methods
-      .getOwnersByPage(page, byPage)
-      .call()
-      .then(ownerAddresses => {
-        const keyPromises = ownerAddresses.map(ownerAddress => {
-          return this._getKeyByLockForOwner(lockContract, ownerAddress).then(
-            ([expiration, data]) => {
-              return {
-                id: keyId(lock, ownerAddress),
-                lock,
-                owner: ownerAddress,
-                expiration,
-                data,
-              }
-            }
-          )
-        })
-
-        return Promise.all(keyPromises).then(keys => {
-          this.emit('keys.page', lock, page, keys)
-        })
+    this._genKeyOwnersFromLockContract(lock, lockContract, page, byPage)
+      .then(keyPromises => this._emitKeyOwners(lock, page, keyPromises))
+      .catch(() => {
+        this._genKeyOwnersFromLockContractIterative(
+          lock,
+          lockContract,
+          page,
+          byPage
+        ).then(keyPromises => this._emitKeyOwners(lock, page, keyPromises))
       })
   }
 

--- a/unlock-app/src/stories/creator/Paywall.stories.js
+++ b/unlock-app/src/stories/creator/Paywall.stories.js
@@ -5,24 +5,23 @@ import Paywall from '../../pages/paywall'
 import createUnlockStore from '../../createUnlockStore'
 
 const lock = {
-  address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
-  keyPrice: '10000000000000000000',
-  expirationDuration: '86400',
-  maxNumberOfKeys: 800,
-  outstandingKeys: 32,
+  address: '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e',
+  name: 'My Blog',
+  keyPrice: '27000000000000000',
+  expirationDuration: '172800',
+  maxNumberOfKeys: 240,
+  outstandingKeys: 3,
 }
-
-const store = createUnlockStore({
+const lockedState = {
   locks: {
-    '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e': lock,
-    '0xab7c74abc0c4d48d1bdad5dcb26153fc87ffffff': {
-      address: '0xab7c74abc0c4d48d1bdad5dcb26153fc87ffffff',
-      name: 'My Blog',
-      keyPrice: '27000000000000000',
-      expirationDuration: '172800',
-      maxNumberOfKeys: 240,
-      outstandingKeys: 3,
+    '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e': {
+      address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      keyPrice: '10000000000000000000',
+      expirationDuration: '86400',
+      maxNumberOfKeys: 800,
+      outstandingKeys: 32,
     },
+    '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e': lock,
   },
   router: {
     location: {
@@ -32,10 +31,53 @@ const store = createUnlockStore({
   currency: {
     USD: 195.99,
   },
-})
+}
+const unlockedState = {
+  ...lockedState,
+  account: {
+    address: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+    balance: '989898989898',
+  },
+  keys: {
+    '0xab7c74abc0c4d48d1bdad5dcb26153fc87eeeeee': {
+      lock: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+      expiration: new Date('December 31, 3000 12:00:00').getTime() / 1000,
+      transaction:
+        '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876',
+    },
+  },
+  transactions: {
+    '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876': {
+      hash:
+        '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876',
+      type: 'LOCK_CREATION',
+      lock: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      status: 'mined',
+      confirmations: 200,
+    },
+  },
+  router: {
+    location: {
+      pathname: '/demo/0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+    },
+  },
+}
+const lockedStore = createUnlockStore(lockedState)
+const unlockedStore = createUnlockStore(unlockedState)
 
 storiesOf('Paywall', module)
-  .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('the paywall overlay', () => {
-    return <Paywall />
+    return (
+      <Provider store={lockedStore}>
+        <Paywall />
+      </Provider>
+    )
+  })
+  .add('the paywall overlay, unlocked', () => {
+    return (
+      <Provider store={unlockedStore}>
+        <Paywall />
+      </Provider>
+    )
   })

--- a/unlock-app/src/theme/globalStyle.js
+++ b/unlock-app/src/theme/globalStyle.js
@@ -23,6 +23,7 @@ const globalStyle = `
     --pink: #ed6e82;
 
     --foreground: 9001;
+    --alwaysontop: 100000;
   }
 
   * {


### PR DESCRIPTION
# Description

This PR fixes #1118. When the form is being edited, a 0 value for `maxNumberOfKeys` is converted into the infinity constant, which now allows the form validation to proceed successfully.

<img width="872" alt="screen shot 2019-01-18 at 6 45 22 pm" src="https://user-images.githubusercontent.com/9300702/51418407-5db5b080-1b51-11e9-84e0-b017357a4362.png">
<img width="890" alt="screen shot 2019-01-18 at 6 45 06 pm" src="https://user-images.githubusercontent.com/9300702/51418408-5db5b080-1b51-11e9-87b6-a271fab17210.png">
<img width="894" alt="screen shot 2019-01-18 at 6 44 57 pm" src="https://user-images.githubusercontent.com/9300702/51418409-5db5b080-1b51-11e9-8432-622d7d50ec1c.png">

Per @smombartz's point about the design, I think we should move forward with changing those disabled fields into just text, and I will file a separate PR in the future to do so.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
