### PR TITLE
add constant for flag time before it is hidden

### DIFF
--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -72,3 +72,5 @@ export const MAX_DEVICE_WIDTHS = {
 }
 
 export const INFINITY = '∞'
+
+export const SHOW_FLAG_FOR = 2000 // milliseconds


### PR DESCRIPTION
# Description

In preparation for #980, add a new constant that will be used for determining how long the unlocked paywall flag stays open

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
