### PR TITLE
New unlocked paywall story

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -37626,6 +37626,69 @@ Object {
 }
 `;
 
+exports[`Storyshots Paywall the paywall overlay, unlocked 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots PendingKeyLock waiting for mining confirmation 1`] = `
 Object {
   "asFragment": [Function],

--- a/unlock-app/src/stories/creator/Paywall.stories.js
+++ b/unlock-app/src/stories/creator/Paywall.stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react'
 import Paywall from '../../pages/paywall'
 import createUnlockStore from '../../createUnlockStore'
 
-const myLock = {
+const lock = {
   address: '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e',
   name: 'My Blog',
   keyPrice: '27000000000000000',
@@ -21,11 +21,11 @@ const lockedState = {
       maxNumberOfKeys: 800,
       outstandingKeys: 32,
     },
-    '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e': myLock,
+    '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e': lock,
   },
   router: {
     location: {
-      pathname: '/demo/' + myLock.address,
+      pathname: '/demo/' + lock.address,
     },
   },
   currency: {

--- a/unlock-app/src/stories/creator/Paywall.stories.js
+++ b/unlock-app/src/stories/creator/Paywall.stories.js
@@ -4,38 +4,80 @@ import { storiesOf } from '@storybook/react'
 import Paywall from '../../pages/paywall'
 import createUnlockStore from '../../createUnlockStore'
 
-const lock = {
-  address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
-  keyPrice: '10000000000000000000',
-  expirationDuration: '86400',
-  maxNumberOfKeys: 800,
-  outstandingKeys: 32,
+const myLock = {
+  address: '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e',
+  name: 'My Blog',
+  keyPrice: '27000000000000000',
+  expirationDuration: '172800',
+  maxNumberOfKeys: 240,
+  outstandingKeys: 3,
 }
-
-const store = createUnlockStore({
+const lockedState = {
   locks: {
-    '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e': lock,
-    '0xab7c74abc0c4d48d1bdad5dcb26153fc87ffffff': {
-      address: '0xab7c74abc0c4d48d1bdad5dcb26153fc87ffffff',
-      name: 'My Blog',
-      keyPrice: '27000000000000000',
-      expirationDuration: '172800',
-      maxNumberOfKeys: 240,
-      outstandingKeys: 3,
+    '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e': {
+      address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      keyPrice: '10000000000000000000',
+      expirationDuration: '86400',
+      maxNumberOfKeys: 800,
+      outstandingKeys: 32,
     },
+    '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e': myLock,
   },
   router: {
     location: {
-      pathname: '/demo/' + lock.address,
+      pathname: '/demo/' + myLock.address,
     },
   },
   currency: {
     USD: 195.99,
   },
-})
+}
+const unlockedState = {
+  ...lockedState,
+  account: {
+    address: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+    balance: '989898989898',
+  },
+  keys: {
+    '0xab7c74abc0c4d48d1bdad5dcb26153fc87eeeeee': {
+      lock: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+      expiration: new Date('December 31, 3000 12:00:00').getTime() / 1000,
+      transaction:
+        '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876',
+    },
+  },
+  transactions: {
+    '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876': {
+      hash:
+        '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876',
+      type: 'LOCK_CREATION',
+      lock: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+      status: 'mined',
+      confirmations: 200,
+    },
+  },
+  router: {
+    location: {
+      pathname: '/demo/0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+    },
+  },
+}
+const lockedStore = createUnlockStore(lockedState)
+const unlockedStore = createUnlockStore(unlockedState)
 
 storiesOf('Paywall', module)
-  .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('the paywall overlay', () => {
-    return <Paywall />
+    return (
+      <Provider store={lockedStore}>
+        <Paywall />
+      </Provider>
+    )
+  })
+  .add('the paywall overlay, unlocked', () => {
+    return (
+      <Provider store={unlockedStore}>
+        <Paywall />
+      </Provider>
+    )
   })


### PR DESCRIPTION
# Description

This adds a new storybook story for the unlocked paywall. Currently it is blank, but when #980 is implemented, it will show the paywall flag.

<img width="1655" alt="screen shot 2019-01-19 at 5 29 44 pm" src="https://user-images.githubusercontent.com/98250/51433037-eeeb5c80-1c0f-11e9-8589-69fc2420120d.png">
<img width="1655" alt="screen shot 2019-01-19 at 5 29 40 pm" src="https://user-images.githubusercontent.com/98250/51433038-eeeb5c80-1c0f-11e9-963e-ffc78b1e7bd9.png">

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
