### PR TITLE
use CSS variable for z-index

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -33,7 +33,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -143,7 +143,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         About
       </small>
@@ -896,7 +896,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1000,7 +1000,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Source Code
       </small>
@@ -1085,7 +1085,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1193,7 +1193,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Join us
       </small>
@@ -1278,7 +1278,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1386,7 +1386,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Newsletter
       </small>
@@ -1471,7 +1471,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1579,7 +1579,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Telegram
       </small>
@@ -1664,7 +1664,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1772,7 +1772,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Twitter
       </small>
@@ -1857,7 +1857,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -1963,7 +1963,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Copy
       </small>
@@ -2048,7 +2048,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2154,7 +2154,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Download
       </small>
@@ -2239,7 +2239,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2351,7 +2351,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Edit
       </small>
@@ -2436,7 +2436,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2542,7 +2542,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Etherscan
       </small>
@@ -2627,7 +2627,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2733,7 +2733,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Export
       </small>
@@ -2818,7 +2818,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -2938,7 +2938,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Preview lock
       </small>
@@ -3023,7 +3023,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -3129,7 +3129,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Show embed code
       </small>
@@ -3214,7 +3214,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -3320,7 +3320,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Upload
       </small>
@@ -3405,7 +3405,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -3511,7 +3511,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Withdraw balance
       </small>
@@ -3596,7 +3596,7 @@ Object {
 .c2 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -3702,7 +3702,7 @@ Object {
         />
       </svg>
       <small
-        class="sc-850ddk-1 kizSum"
+        class="sc-850ddk-1 fnqGzL"
       >
         Withdraw balance
       </small>
@@ -4270,7 +4270,7 @@ Object {
 .c8 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -5276,7 +5276,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -5298,7 +5298,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -5318,7 +5318,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -5340,7 +5340,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -5781,7 +5781,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               About
             </small>
@@ -5803,7 +5803,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Join us
             </small>
@@ -5823,7 +5823,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Source Code
             </small>
@@ -5845,7 +5845,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Telegram
             </small>
@@ -5967,7 +5967,7 @@ Object {
 .c8 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -6772,7 +6772,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -6794,7 +6794,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -6814,7 +6814,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -6836,7 +6836,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -7016,7 +7016,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               About
             </small>
@@ -7038,7 +7038,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Join us
             </small>
@@ -7058,7 +7058,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Source Code
             </small>
@@ -7080,7 +7080,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Telegram
             </small>
@@ -7202,7 +7202,7 @@ Object {
 .c8 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -8377,7 +8377,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -8399,7 +8399,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -8419,7 +8419,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -8441,7 +8441,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -9058,7 +9058,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               About
             </small>
@@ -9080,7 +9080,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Join us
             </small>
@@ -9100,7 +9100,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Source Code
             </small>
@@ -9122,7 +9122,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Telegram
             </small>
@@ -10770,7 +10770,7 @@ Object {
 .c16 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -11449,7 +11449,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Withdraw balance
               </small>
@@ -11473,7 +11473,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -11494,7 +11494,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -11586,7 +11586,7 @@ Object {
 .c16 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -12265,7 +12265,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Withdraw balance
               </small>
@@ -12289,7 +12289,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -12310,7 +12310,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -13048,7 +13048,7 @@ Object {
 .c16 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -13727,7 +13727,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Withdraw balance
               </small>
@@ -13751,7 +13751,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -13772,7 +13772,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -13890,7 +13890,7 @@ Object {
 .c17 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -14585,7 +14585,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -14606,7 +14606,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -14700,7 +14700,7 @@ Object {
 .c16 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -15384,7 +15384,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Withdraw balance
               </small>
@@ -15408,7 +15408,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Edit
               </small>
@@ -15429,7 +15429,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Show embed code
               </small>
@@ -18721,7 +18721,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -20526,7 +20526,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -20548,7 +20548,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -20568,7 +20568,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -20590,7 +20590,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -21042,7 +21042,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Withdraw balance
                     </small>
@@ -21066,7 +21066,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Edit
                     </small>
@@ -21087,7 +21087,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Show embed code
                     </small>
@@ -21318,7 +21318,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Withdraw balance
                     </small>
@@ -21342,7 +21342,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Edit
                     </small>
@@ -21363,7 +21363,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Show embed code
                     </small>
@@ -21594,7 +21594,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Withdraw balance
                     </small>
@@ -21618,7 +21618,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Edit
                     </small>
@@ -21639,7 +21639,7 @@ Object {
                       />
                     </svg>
                     <small
-                      class="sc-850ddk-1 kizSum"
+                      class="sc-850ddk-1 fnqGzL"
                     >
                       Show embed code
                     </small>
@@ -22799,7 +22799,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -23309,7 +23309,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -23331,7 +23331,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -23351,7 +23351,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -23373,7 +23373,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -23548,7 +23548,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -24065,7 +24065,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -24087,7 +24087,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -24107,7 +24107,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -24129,7 +24129,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -24311,7 +24311,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -24821,7 +24821,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -24843,7 +24843,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -24863,7 +24863,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -24885,7 +24885,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -25034,7 +25034,7 @@ Object {
 .c3 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -25241,7 +25241,7 @@ Object {
           />
         </svg>
         <small
-          class="sc-850ddk-1 kizSum"
+          class="sc-850ddk-1 fnqGzL"
         >
           About
         </small>
@@ -25263,7 +25263,7 @@ Object {
           />
         </svg>
         <small
-          class="sc-850ddk-1 kizSum"
+          class="sc-850ddk-1 fnqGzL"
         >
           Join us
         </small>
@@ -25283,7 +25283,7 @@ Object {
           />
         </svg>
         <small
-          class="sc-850ddk-1 kizSum"
+          class="sc-850ddk-1 fnqGzL"
         >
           Source Code
         </small>
@@ -25305,7 +25305,7 @@ Object {
           />
         </svg>
         <small
-          class="sc-850ddk-1 kizSum"
+          class="sc-850ddk-1 fnqGzL"
         >
           Telegram
         </small>
@@ -25422,7 +25422,7 @@ Object {
 .c5 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -25778,7 +25778,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             About
           </small>
@@ -25800,7 +25800,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Join us
           </small>
@@ -25820,7 +25820,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Source Code
           </small>
@@ -25842,7 +25842,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Telegram
           </small>
@@ -25994,7 +25994,7 @@ Object {
 .c5 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -26330,7 +26330,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             About
           </small>
@@ -26352,7 +26352,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Join us
           </small>
@@ -26372,7 +26372,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Source Code
           </small>
@@ -26394,7 +26394,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Telegram
           </small>
@@ -26546,7 +26546,7 @@ Object {
 .c5 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -26882,7 +26882,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             About
           </small>
@@ -26904,7 +26904,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Join us
           </small>
@@ -26924,7 +26924,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Source Code
           </small>
@@ -26946,7 +26946,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Telegram
           </small>
@@ -30773,7 +30773,7 @@ Object {
 .c8 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -31313,7 +31313,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -31335,7 +31335,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -31355,7 +31355,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -31377,7 +31377,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -31444,7 +31444,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               About
             </small>
@@ -31466,7 +31466,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Join us
             </small>
@@ -31486,7 +31486,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Source Code
             </small>
@@ -31508,7 +31508,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Telegram
             </small>
@@ -31630,7 +31630,7 @@ Object {
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -32078,7 +32078,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 About
               </small>
@@ -32100,7 +32100,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Join us
               </small>
@@ -32120,7 +32120,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Source Code
               </small>
@@ -32142,7 +32142,7 @@ Object {
                 />
               </svg>
               <small
-                class="sc-850ddk-1 kizSum"
+                class="sc-850ddk-1 fnqGzL"
               >
                 Telegram
               </small>
@@ -33669,7 +33669,7 @@ Object {
 .c6 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -33884,7 +33884,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Copy
           </small>
@@ -33913,7 +33913,7 @@ Object {
             />
           </svg>
           <small
-            class="sc-850ddk-1 kizSum"
+            class="sc-850ddk-1 fnqGzL"
           >
             Preview lock
           </small>
@@ -34000,7 +34000,7 @@ Object {
 .c4 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;
@@ -34203,7 +34203,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Withdraw balance
             </small>
@@ -34227,7 +34227,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Edit
             </small>
@@ -34248,7 +34248,7 @@ Object {
               />
             </svg>
             <small
-              class="sc-850ddk-1 kizSum"
+              class="sc-850ddk-1 fnqGzL"
             >
               Show embed code
             </small>

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
@@ -67,7 +67,7 @@ exports[`withConfig High Order Component when the current network is not in the 
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/wrongNetwork.test.js.snap
@@ -67,7 +67,7 @@ exports[`withConfig High Order Component when the current network is not in the 
 .c9 {
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
   font-weight: 400;

--- a/unlock-app/src/components/interface/buttons/Button.js
+++ b/unlock-app/src/components/interface/buttons/Button.js
@@ -87,7 +87,7 @@ export const ButtonLink = styled.a`
 export const Label = styled.small`
   display: none;
   position: relative;
-  z-index: 30000;
+  z-index: var(--alwaysontop);
   white-space: nowrap;
   font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
   font-weight: 400;

--- a/unlock-app/src/theme/globalStyle.js
+++ b/unlock-app/src/theme/globalStyle.js
@@ -23,6 +23,7 @@ const globalStyle = `
     --pink: #ed6e82;
 
     --foreground: 9001;
+    --alwaysontop: 100000;
   }
 
   * {


### PR DESCRIPTION
# Description

This fixes #943 by replacing a hard-coded value with a new CSS variable "alwaysontop" which can be used to push buttons on top of other components around them. Note that there was only location in the codebase that did not already use the existing "foreground" variable for z-index. This PR fixes the one aberration.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
