### PR TITLE
Extract flag from paywall Overlay into its own file

### DIFF
--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -2,12 +2,11 @@ import styled from 'styled-components'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { RoundedLogo } from '../interface/Logo'
 import Lock from './Lock'
 import UnlockPropTypes from '../../propTypes'
 import { hideModal, showModal } from '../../actions/modal'
 import { unlockPage } from '../../services/iframeService'
-import { Colophon } from './LockStyles'
+import LockedFlag from './UnlockFlag'
 
 export const Overlay = ({ locks, hideModal, showModal }) => (
   <FullPage>
@@ -25,10 +24,7 @@ export const Overlay = ({ locks, hideModal, showModal }) => (
           />
         ))}
       </Locks>
-      <Colophon>
-        <RoundedLogo size="28px" />
-        <p>Powered by Unlock</p>
-      </Colophon>
+      <LockedFlag />
     </Banner>
   </FullPage>
 )

--- a/unlock-app/src/components/lock/UnlockFlag.js
+++ b/unlock-app/src/components/lock/UnlockFlag.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Colophon } from './LockStyles'
+import { RoundedLogo } from '../interface/Logo'
+
+export default function LockedFlag() {
+  return (
+    <Colophon>
+      <RoundedLogo size="28px" />
+      <p>Powered by Unlock</p>
+    </Colophon>
+  )
+}


### PR DESCRIPTION
# Description

In preparation for implementing #980, this extracts the Colophon portion of the Overlay into `UnlockFlag` so that it is simple to extend this to implement the unlocked version of the flag.

P.S. It could be called `UnlockFlags` or just `Flags` as well, because it will contain 2 flags: the locked and unlocked version. I'd love a judgment call on this as part of the review

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
