### PR TITLE
set isRequiredNetwork for testing purposes

### DIFF
--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -69,6 +69,7 @@ export default function configure(
       `http://${runtimeConfig.httpProvider}:8545`
     )
     services['storage'] = { host: 'http://127.0.0.1:8080' }
+    isRequiredNetwork = networkId => networkId === 1337
   }
 
   if (env === 'dev') {


### PR DESCRIPTION
# Description

In order to test for different network matches, the `isRequiredNetwork` function from config must be set up. Currently, it uses the default value, which always returns false. This PR makes it return true if and only if the network is extremely leet.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
