### PR TITLE
First stage: Error context for global usage

### DIFF
--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider.test.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import * as rtl from 'react-testing-library'
+
+import GlobalErrorProvider, {
+  GlobalErrorContext,
+} from '../../utils/GlobalErrorProvider'
+import createUnlockStore from '../../createUnlockStore'
+import configuration from '../../config'
+
+const config = configuration()
+
+describe('GlobalErrorProvider', () => {
+  function makeTestStore(newValues = {}) {
+    return createUnlockStore({
+      account: {
+        address: '0xdeadbeef',
+        balance: '1000',
+      },
+      network: {
+        name: 1337,
+      },
+      router: {
+        route: '/somewhere',
+      },
+      ...newValues,
+    })
+  }
+
+  function PeekAtContextConsumer() {
+    return (
+      <GlobalErrorContext.Consumer>
+        {({ error, errorMetadata }) => (
+          <div>
+            <span data-testid="error">{JSON.stringify(error)}</span>
+            <span data-testid="errorMetadata">
+              {JSON.stringify(errorMetadata)}
+            </span>
+          </div>
+        )}
+      </GlobalErrorContext.Consumer>
+    )
+  }
+  it('should populate with no error normally', () => {
+    expect.assertions(2)
+
+    const store = makeTestStore()
+    const wrapper = rtl.render(
+      <Provider store={store}>
+        <GlobalErrorProvider>
+          <PeekAtContextConsumer />
+        </GlobalErrorProvider>
+      </Provider>
+    )
+
+    expect(wrapper.getByTestId('error')).toHaveTextContent('false')
+    expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent('{}')
+  })
+  xit('should populate with missing provider error if no wallet is set up', () => {})
+  xit('should populate with wrong network error if the wallet is set up on a different network', () => {})
+  xit('should populate with missing account error if account is not set', () => {})
+})

--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider/missingProvider.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider/missingProvider.test.js
@@ -1,32 +1,46 @@
 import React from 'react'
 import { Provider } from 'react-redux'
 import * as rtl from 'react-testing-library'
+import createUnlockStore from '../../../createUnlockStore'
 
-import GlobalErrorProvider, {
+jest.mock('../../../config', () =>
+  jest.fn().mockImplementation(() => {
+    return {
+      providers: {},
+      isRequiredNetwork: () => true,
+      requiredNetwork: 'dev',
+      services: { storage: { host: 'http://atest.url' } },
+    }
+  })
+)
+
+const {
+  default: GlobalErrorProvider,
   GlobalErrorContext,
-} from '../../utils/GlobalErrorProvider'
-import createUnlockStore from '../../createUnlockStore'
-import configuration from '../../config'
-
-const config = configuration()
+} = require('../../../utils/GlobalErrorProvider')
 
 describe('GlobalErrorProvider', () => {
   function makeTestStore(newValues = {}) {
-    return createUnlockStore({
-      account: {
-        address: '0xdeadbeef',
-        balance: '1000',
+    return createUnlockStore(
+      {
+        account: {
+          address: '0xdeadbeef',
+          balance: '1000',
+        },
+        network: {
+          name: 1337,
+        },
+        router: {
+          route: '/somewhere',
+        },
+        ...newValues,
       },
-      network: {
-        name: 1337,
-      },
-      router: {
-        route: '/somewhere',
-      },
-      ...newValues,
-    })
+      undefined,
+      true
+    )
   }
 
+  // eslint-disable-next-line
   function PeekAtContextConsumer() {
     return (
       <GlobalErrorContext.Consumer>
@@ -41,7 +55,7 @@ describe('GlobalErrorProvider', () => {
       </GlobalErrorContext.Consumer>
     )
   }
-  it('should populate with no error normally', () => {
+  it('should populate with missing provider error if no wallet is set up', () => {
     expect.assertions(2)
 
     const store = makeTestStore()
@@ -53,10 +67,7 @@ describe('GlobalErrorProvider', () => {
       </Provider>
     )
 
-    expect(wrapper.getByTestId('error')).toHaveTextContent('false')
+    expect(wrapper.getByTestId('error')).toHaveTextContent('MISSING_PROVIDER')
     expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent('{}')
   })
-  xit('should populate with missing provider error if no wallet is set up', () => {})
-  xit('should populate with wrong network error if the wallet is set up on a different network', () => {})
-  xit('should populate with missing account error if account is not set', () => {})
 })

--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider/missingProvider.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider/missingProvider.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import * as rtl from 'react-testing-library'
 import createUnlockStore from '../../../createUnlockStore'
+import { FATAL_MISSING_PROVIDER } from '../../../errors'
 
 jest.mock('../../../config', () =>
   jest.fn().mockImplementation(() => {
@@ -67,7 +68,9 @@ describe('GlobalErrorProvider', () => {
       </Provider>
     )
 
-    expect(wrapper.getByTestId('error')).toHaveTextContent('MISSING_PROVIDER')
+    expect(wrapper.getByTestId('error')).toHaveTextContent(
+      FATAL_MISSING_PROVIDER
+    )
     expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent('{}')
   })
 })

--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
@@ -130,5 +130,21 @@ describe('GlobalErrorProvider', () => {
       )
     })
   })
-  xit('should populate with missing account error if account is not set', () => {})
+  it('should populate with missing account error if account is not set', () => {
+    expect.assertions(2)
+
+    const store = makeTestStore({
+      account: false,
+    })
+    const wrapper = rtl.render(
+      <Provider store={store}>
+        <GlobalErrorProvider>
+          <PeekAtContextConsumer />
+        </GlobalErrorProvider>
+      </Provider>
+    )
+
+    expect(wrapper.getByTestId('error')).toHaveTextContent('NO_USER_ACCOUNT')
+    expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent('')
+  })
 })

--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import * as rtl from 'react-testing-library'
+import createUnlockStore from '../../../createUnlockStore'
+import GlobalErrorProvider, {
+  GlobalErrorContext,
+} from '../../../utils/GlobalErrorProvider'
+
+describe('GlobalErrorProvider', () => {
+  function makeTestStore(newValues = {}) {
+    return createUnlockStore(
+      {
+        account: {
+          address: '0xdeadbeef',
+          balance: '1000',
+        },
+        network: {
+          name: 1337,
+        },
+        router: {
+          route: '/somewhere',
+        },
+        ...newValues,
+      },
+      undefined,
+      true
+    )
+  }
+  // eslint-disable-next-line
+  function PeekAtContextConsumer() {
+    return (
+      <GlobalErrorContext.Consumer>
+        {({ error, errorMetadata }) => (
+          <div>
+            <span data-testid="error">{JSON.stringify(error)}</span>
+            <span data-testid="errorMetadata">
+              {JSON.stringify(errorMetadata)}
+            </span>
+          </div>
+        )}
+      </GlobalErrorContext.Consumer>
+    )
+  }
+  it('should populate with no error normally', () => {
+    expect.assertions(2)
+
+    const store = makeTestStore()
+    const wrapper = rtl.render(
+      <Provider store={store}>
+        <GlobalErrorProvider>
+          <PeekAtContextConsumer />
+        </GlobalErrorProvider>
+      </Provider>
+    )
+
+    expect(wrapper.getByTestId('error')).toHaveTextContent('false')
+    expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent('{}')
+  })
+  xit('should populate with wrong network error if the wallet is set up on a different network', () => {})
+  xit('should populate with missing account error if account is not set', () => {})
+})

--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
@@ -5,6 +5,7 @@ import createUnlockStore from '../../../createUnlockStore'
 import GlobalErrorProvider, {
   GlobalErrorContext,
 } from '../../../utils/GlobalErrorProvider'
+import { FATAL_NO_USER_ACCOUNT, FATAL_WRONG_NETWORK } from '../../../errors'
 
 describe('GlobalErrorProvider', () => {
   function makeTestStore(newValues = {}) {
@@ -73,7 +74,9 @@ describe('GlobalErrorProvider', () => {
         </Provider>
       )
 
-      expect(wrapper.getByTestId('error')).toHaveTextContent('WRONG_NETWORK')
+      expect(wrapper.getByTestId('error')).toHaveTextContent(
+        FATAL_WRONG_NETWORK
+      )
       expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent(
         JSON.stringify({
           currentNetwork: 'Mainnet',
@@ -97,7 +100,9 @@ describe('GlobalErrorProvider', () => {
         </Provider>
       )
 
-      expect(wrapper.getByTestId('error')).toHaveTextContent('WRONG_NETWORK')
+      expect(wrapper.getByTestId('error')).toHaveTextContent(
+        FATAL_WRONG_NETWORK
+      )
       expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent(
         JSON.stringify({
           currentNetwork: 'Rinkeby',
@@ -121,7 +126,9 @@ describe('GlobalErrorProvider', () => {
         </Provider>
       )
 
-      expect(wrapper.getByTestId('error')).toHaveTextContent('WRONG_NETWORK')
+      expect(wrapper.getByTestId('error')).toHaveTextContent(
+        FATAL_WRONG_NETWORK
+      )
       expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent(
         JSON.stringify({
           currentNetwork: 'Unknown Network',
@@ -144,7 +151,9 @@ describe('GlobalErrorProvider', () => {
       </Provider>
     )
 
-    expect(wrapper.getByTestId('error')).toHaveTextContent('NO_USER_ACCOUNT')
+    expect(wrapper.getByTestId('error')).toHaveTextContent(
+      FATAL_NO_USER_ACCOUNT
+    )
     expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent('')
   })
 })

--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
@@ -56,6 +56,79 @@ describe('GlobalErrorProvider', () => {
     expect(wrapper.getByTestId('error')).toHaveTextContent('false')
     expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent('{}')
   })
-  xit('should populate with wrong network error if the wallet is set up on a different network', () => {})
+  describe('should populate with wrong network error if the wallet is set up on a different network', () => {
+    it('mainnet', () => {
+      expect.assertions(2)
+
+      const store = makeTestStore({
+        network: {
+          name: 1,
+        },
+      })
+      const wrapper = rtl.render(
+        <Provider store={store}>
+          <GlobalErrorProvider>
+            <PeekAtContextConsumer />
+          </GlobalErrorProvider>
+        </Provider>
+      )
+
+      expect(wrapper.getByTestId('error')).toHaveTextContent('WRONG_NETWORK')
+      expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent(
+        JSON.stringify({
+          currentNetwork: 'Mainnet',
+          requiredNetwork: 'Dev',
+        })
+      )
+    })
+    it('rinkeby', () => {
+      expect.assertions(2)
+
+      const store = makeTestStore({
+        network: {
+          name: 4,
+        },
+      })
+      const wrapper = rtl.render(
+        <Provider store={store}>
+          <GlobalErrorProvider>
+            <PeekAtContextConsumer />
+          </GlobalErrorProvider>
+        </Provider>
+      )
+
+      expect(wrapper.getByTestId('error')).toHaveTextContent('WRONG_NETWORK')
+      expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent(
+        JSON.stringify({
+          currentNetwork: 'Rinkeby',
+          requiredNetwork: 'Dev',
+        })
+      )
+    })
+    it('unknown network', () => {
+      expect.assertions(2)
+
+      const store = makeTestStore({
+        network: {
+          name: 6,
+        },
+      })
+      const wrapper = rtl.render(
+        <Provider store={store}>
+          <GlobalErrorProvider>
+            <PeekAtContextConsumer />
+          </GlobalErrorProvider>
+        </Provider>
+      )
+
+      expect(wrapper.getByTestId('error')).toHaveTextContent('WRONG_NETWORK')
+      expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent(
+        JSON.stringify({
+          currentNetwork: 'Unknown Network',
+          requiredNetwork: 'Dev',
+        })
+      )
+    })
+  })
   xit('should populate with missing account error if account is not set', () => {})
 })

--- a/unlock-app/src/utils/GlobalErrorProvider.js
+++ b/unlock-app/src/utils/GlobalErrorProvider.js
@@ -100,9 +100,12 @@ export class GlobalErrorProvider extends Component {
 
     // Ensuring that an account is defined
     if (!account) {
-      return this.setState({
-        error: 'NO_USER_ACCOUNT',
-        errorMetadata: {},
+      return this.setState(state => {
+        if (state.error === 'NO_USER_ACCOUNT') return null
+        return {
+          error: 'NO_USER_ACCOUNT',
+          errorMetadata: {},
+        }
       })
     }
 

--- a/unlock-app/src/utils/GlobalErrorProvider.js
+++ b/unlock-app/src/utils/GlobalErrorProvider.js
@@ -66,7 +66,10 @@ export class GlobalErrorProvider extends Component {
 
     // Ensuring that we have at least 1 provider
     if (Object.keys(config.providers).length === 0) {
-      return this.setState({ error: 'MISSING_PROVIDER', errorMetadata: {} }) // TODO: put in constants
+      return this.setState(state => {
+        if (state.error === 'MISSING_PROVIDER') return null
+        return { error: 'MISSING_PROVIDER', errorMetadata: {} }
+      }) // TODO: put in constants
     }
 
     // Ensuring that the provider is using the right network!
@@ -75,7 +78,6 @@ export class GlobalErrorProvider extends Component {
       config.isRequiredNetwork &&
       !config.isRequiredNetwork(network.name)
     ) {
-      console.log(config.isRequiredNetwork())
       return this.setState(state => {
         if (
           state.error === 'WRONG_NETWORK' &&

--- a/unlock-app/src/utils/GlobalErrorProvider.js
+++ b/unlock-app/src/utils/GlobalErrorProvider.js
@@ -9,6 +9,11 @@ import PropTypes from 'prop-types'
 import configure from '../config'
 import UnlockPropTypes from '../propTypes'
 import { ETHEREUM_NETWORKS_NAMES } from '../constants'
+import {
+  FATAL_MISSING_PROVIDER,
+  FATAL_WRONG_NETWORK,
+  FATAL_NO_USER_ACCOUNT,
+} from '../errors'
 
 export const GlobalErrorContext = createContext()
 
@@ -56,8 +61,8 @@ export class GlobalErrorProvider extends Component {
   detectMissingProvider(state) {
     // Ensuring that we have at least 1 provider
     if (Object.keys(config.providers).length === 0) {
-      if (state.error === 'MISSING_PROVIDER') return null
-      return { error: 'MISSING_PROVIDER', errorMetadata: {} }
+      if (state.error === FATAL_MISSING_PROVIDER) return null
+      return { error: FATAL_MISSING_PROVIDER, errorMetadata: {} }
     }
   }
 
@@ -73,13 +78,13 @@ export class GlobalErrorProvider extends Component {
         ? ETHEREUM_NETWORKS_NAMES[network.name][0]
         : 'Unknown Network'
       if (
-        state.error === 'WRONG_NETWORK' &&
+        state.error === FATAL_WRONG_NETWORK &&
         state.errorMetadata.currentNetwork === currentNetwork
       ) {
         return null
       }
       return {
-        error: 'WRONG_NETWORK', // TODO: put this in constants
+        error: FATAL_WRONG_NETWORK,
         errorMetadata: {
           currentNetwork: currentNetwork,
           requiredNetwork: config.requiredNetwork,
@@ -92,9 +97,9 @@ export class GlobalErrorProvider extends Component {
     const { account } = this.props
     // Ensuring that an account is defined
     if (!account) {
-      if (state.error === 'NO_USER_ACCOUNT') return null
+      if (state.error === FATAL_NO_USER_ACCOUNT) return null
       return {
-        error: 'NO_USER_ACCOUNT',
+        error: FATAL_NO_USER_ACCOUNT,
         errorMetadata: {},
       }
     }

--- a/unlock-app/src/utils/GlobalErrorProvider.js
+++ b/unlock-app/src/utils/GlobalErrorProvider.js
@@ -79,16 +79,19 @@ export class GlobalErrorProvider extends Component {
       !config.isRequiredNetwork(network.name)
     ) {
       return this.setState(state => {
+        const currentNetwork = ETHEREUM_NETWORKS_NAMES[network.name]
+          ? ETHEREUM_NETWORKS_NAMES[network.name][0]
+          : 'Unknown Network'
         if (
           state.error === 'WRONG_NETWORK' &&
-          state.currentNetwork === ETHEREUM_NETWORKS_NAMES[network.name][0]
+          state.errorMetadata.currentNetwork === currentNetwork
         ) {
           return null
         }
         return {
           error: 'WRONG_NETWORK', // TODO: put this in constants
           errorMetadata: {
-            currentNetwork: ETHEREUM_NETWORKS_NAMES[network.name][0],
+            currentNetwork: currentNetwork,
             requiredNetwork: config.requiredNetwork,
           },
         }

--- a/unlock-app/src/utils/GlobalErrorProvider.js
+++ b/unlock-app/src/utils/GlobalErrorProvider.js
@@ -1,0 +1,122 @@
+/* eslint-disable react/no-unused-state */
+// eslint does not recognize that the state is used directly in the context consumer
+// and destructuring would just force unnecessary re-renders
+
+import { connect } from 'react-redux'
+import React, { Component, createContext } from 'react'
+import PropTypes from 'prop-types'
+
+import configure from '../config'
+import UnlockPropTypes from '../propTypes'
+import { ETHEREUM_NETWORKS_NAMES } from '../constants'
+
+export const GlobalErrorContext = createContext()
+
+export function mapStateToProps({ router, network, account }) {
+  return {
+    router,
+    network,
+    account,
+  }
+}
+
+const config = configure()
+
+export class GlobalErrorProvider extends Component {
+  static propTypes = {
+    network: UnlockPropTypes.network.isRequired,
+    account: UnlockPropTypes.account.isRequired,
+    router: PropTypes.shape({
+      location: PropTypes.shape({
+        pathname: PropTypes.string.isRequired,
+        search: PropTypes.string.isRequired,
+        hash: PropTypes.string.isRequired,
+      }),
+      action: PropTypes.string,
+    }).isRequired,
+    children: PropTypes.node.isRequired,
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      error: false,
+      errorMetadata: {},
+    }
+  }
+
+  componentDidMount() {
+    this.detectErrors()
+  }
+
+  componentDidUpdate() {
+    this.detectErrors()
+  }
+
+  detectErrors() {
+    const { router, network, account } = this.props
+    if (config.isServer) {
+      return this.setState(state => {
+        if (state.error) {
+          return { error: false, errorMetadata: {} }
+        }
+        return null // don't modify errors state unless we have an error condition to clear
+      })
+    }
+
+    // Ensuring that we have at least 1 provider
+    if (Object.keys(config.providers).length === 0) {
+      return this.setState({ error: 'MISSING_PROVIDER', errorMetadata: {} }) // TODO: put in constants
+    }
+
+    // Ensuring that the provider is using the right network!
+    if (
+      router.route !== '/provider' &&
+      config.isRequiredNetwork &&
+      !config.isRequiredNetwork(network.name)
+    ) {
+      console.log(config.isRequiredNetwork())
+      return this.setState(state => {
+        if (
+          state.error === 'WRONG_NETWORK' &&
+          state.currentNetwork === ETHEREUM_NETWORKS_NAMES[network.name][0]
+        ) {
+          return null
+        }
+        return {
+          error: 'WRONG_NETWORK', // TODO: put this in constants
+          errorMetadata: {
+            currentNetwork: ETHEREUM_NETWORKS_NAMES[network.name][0],
+            requiredNetwork: config.requiredNetwork,
+          },
+        }
+      })
+    }
+
+    // Ensuring that an account is defined
+    if (!account) {
+      return this.setState({
+        error: 'NO_USER_ACCOUNT',
+        errorMetadata: {},
+      })
+    }
+
+    this.setState(state => {
+      if (state.error) {
+        return { error: false, errorMetadata: {} }
+      }
+      return null // don't modify errors state unless we have an error condition to clear
+    })
+  }
+
+  render() {
+    const { children } = this.props
+    return (
+      <GlobalErrorContext.Provider value={this.state}>
+        {children}
+      </GlobalErrorContext.Provider>
+    )
+  }
+}
+
+export default connect(mapStateToProps)(GlobalErrorProvider)


### PR DESCRIPTION
# Description

This PR provides the abstract logic of defining global error conditions involving the state of the user's wallet. It detects 3 conditions:

1. wallet not installed or not logged in
2. user's wallet is on a different network from the app
3. user has no account on this network

It uses React context to propagate this to any child.

This flexibility allows us to use it on any page, since it does not force UI change. The UI can be implemented in multiple ways with this design. For instance, the `withConfig` way of usurping control to display a full-app error on the dashboard, and also as a localized error inside of the paywall where a lock would normally display (for #1093). It can also be ignored on the homepage, removing the need for special tricks to ensure the UI is not taken over.

This PR does not wire up any existing component to the provider, that will follow in future PRs.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
