### PR TITLE
Adds unique tokenID's for Keys

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -119,7 +119,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     uint _tokenId
   ) {
     require(
-      ownerByTokenId[_tokenId] == msg.sender
+      ownerByTokenId[_tokenId] == msg.sender, "Not the key owner"
     );
     _;
   }
@@ -220,7 +220,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     hasValidKey(_from)
     onlyKeyOwnerOrApproved(_tokenId)
   {
-    require(_recipient != address(0));
+    require(_recipient != address(0), "Can't Transfer to 0x Address");
 
     uint previousExpiration = keyByOwner[_recipient].expirationTimestamp;
 
@@ -228,6 +228,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
       // The recipient did not have a key previously
       owners.push(_recipient);
       ownerByTokenId[_tokenId] = _recipient;
+      keyByOwner[_recipient].tokenId = _tokenId;
     }
 
     if (previousExpiration <= now) {
@@ -539,7 +540,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     internal
     notSoldOut()
   { // solhint-disable-line function-max-lines
-    require(_recipient != address(0));
+    require(_recipient != address(0), "Can't Purchase For 0x Address");
 
     // Let's get the actual price for the key from the Unlock smart contract
     IUnlock unlock = IUnlock(unlockProtocol);
@@ -565,15 +566,14 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     uint previousExpiration = keyByOwner[_recipient].expirationTimestamp;
     if (previousExpiration < now) {
       if (previousExpiration == 0) {
-        // This is a brand new owner, else an owner of an expired key buying an extension
-        numberOfKeysSold++;
+        // This is a brand new owner, else an owner of an expired key buying an extension.
         // We increment the tokenId counter
-        currentTokenID++;
+        numberOfKeysSold++;
         owners.push(_recipient);
         // We register the owner of the new tokenID
-        ownerByTokenId[currentTokenID] = _recipient;
-        // we assign the incremented `currentTokenID` as the tokenId for the new key
-        keyByOwner[_recipient].tokenId = currentTokenID;
+        ownerByTokenId[numberOfKeysSold] = _recipient;
+        // we assign the incremented `numberOfKeysSold` as the tokenId for the new key
+        keyByOwner[_recipient].tokenId = numberOfKeysSold;
       }
       // SafeAdd is not required here since expirationDuration is capped to a tiny value
       // (relative to the size of a uint)
@@ -595,7 +595,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     emit Transfer(
       address(0), // This is a creation.
       _recipient,
-      currentTokenID
+      numberOfKeysSold
     );
   }
 

--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -383,7 +383,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   {
     return _getApproved(_tokenId);
   }
-  
+
   /**
    * Checks if the user has a non-expired key.
    */
@@ -392,7 +392,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   )
     public
     view
-    returns (bool) 
+    returns (bool)
   {
     return keyByOwner[_owner].expirationTimestamp > now;
   }
@@ -623,7 +623,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
 
   /**
    * @dev private version of the withdraw function which handles all withdrawals from the lock.
-   * 
+   *
    * Security: Be wary of re-entrancy when calling this.
    */
   function _withdraw(uint _amount)

--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -227,12 +227,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     if (previousExpiration == 0) {
       // The recipient did not have a key previously
       owners.push(_recipient);
-      // Note: not using the tokenId above since ATM we do not transfer tokenId's
-      // this will change when we decouple tokenId from address
-      ownerByTokenId[uint(_recipient)] = _recipient;
-      // At the moment tokenId is the user's address, but as we work towards ERC721
-      // support this will change to a sequenceId assigned at purchase.
-      keyByOwner[_recipient].tokenId = uint(_recipient);
+      ownerByTokenId[_tokenId] = _recipient;
     }
 
     if (previousExpiration <= now) {
@@ -572,12 +567,13 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
       if (previousExpiration == 0) {
         // This is a brand new owner, else an owner of an expired key buying an extension
         numberOfKeysSold++;
+        // We increment the tokenId counter
+        currentTokenID++;
         owners.push(_recipient);
-        // Note: for ERC721 support we will be changing tokenId to be a sequence id instead
-        ownerByTokenId[uint(_recipient)] = _recipient;
-        // At the moment tokenId is the user's address, but as we work towards ERC721
-        // support this will change to a sequenceId assigned at purchase.
-        keyByOwner[_recipient].tokenId = uint(_recipient);
+        // We register the owner of the new tokenID
+        ownerByTokenId[currentTokenID] = _recipient;
+        // we assign the incremented `currentTokenID` as the tokenId for the new key
+        keyByOwner[_recipient].tokenId = currentTokenID;
       }
       // SafeAdd is not required here since expirationDuration is capped to a tiny value
       // (relative to the size of a uint)
@@ -599,8 +595,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     emit Transfer(
       address(0), // This is a creation.
       _recipient,
-      uint(_recipient) // Note: since each user can own a single token, we use the current
-      // owner (new!) for the token id
+      currentTokenID
     );
   }
 
@@ -632,5 +627,4 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     Ownable.owner().transfer(_amount);
     emit Withdrawal(msg.sender, _amount);
   }
-
 }

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -1,84 +1,84 @@
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
-
 const deployLocks = require('../../helpers/deployLocks')
 const shouldFail = require('../../helpers/shouldFail')
 const Unlock = artifacts.require('../../Unlock.sol')
 
-let unlock, locks
+let unlock, locks, ID
 
-contract('Lock ERC721', (accounts) => {
-  before(() => {
-    return Unlock.deployed()
-      .then(_unlock => {
-        unlock = _unlock
-        return deployLocks(unlock)
-      })
-      .then(_locks => {
-        locks = _locks
-      })
+contract('Lock ERC721', accounts => {
+  before(async () => {
+    unlock = await Unlock.deployed()
+    locks = await deployLocks(unlock)
   })
 
   describe('approve', () => {
     describe('when the token does not exist', () => {
       it('should fail', async () => {
-        await shouldFail(locks['FIRST']
-          .approve(accounts[2], accounts[1], {
+        await shouldFail(
+          locks['FIRST'].approve(accounts[2], 42, {
             from: accounts[1]
-          }), '')
+          }),
+          'Not the key owner'
+        )
       })
     })
 
     describe('when the key exists', () => {
       before(() => {
-        return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
-          value: Units.convert('0.01', 'eth', 'wei'),
-          from: accounts[1]
-        })
+        return locks['FIRST'].purchaseFor(
+          accounts[1],
+          Web3Utils.toHex('Satoshi'),
+          {
+            value: Units.convert('0.01', 'eth', 'wei'),
+            from: accounts[1]
+          }
+        )
       })
 
       describe('when the sender is not the token owner', () => {
         it('should fail', async () => {
-          await shouldFail(locks['FIRST']
-            .approve(accounts[2], accounts[1], {
+          ID = await locks['FIRST'].getTokenIdFor(accounts[1])
+          await shouldFail(
+            locks['FIRST'].approve(accounts[2], ID, {
               from: accounts[2]
-            }), '')
+            }),
+            'Not the key owner'
+          )
         })
       })
 
       describe('when the sender is self approving', () => {
         it('should fail', async () => {
-          await shouldFail(locks['FIRST']
-            .approve(accounts[1], accounts[1], {
+          await shouldFail(
+            locks['FIRST'].approve(accounts[1], ID, {
               from: accounts[1]
-            }), 'You can\'t approve yourself')
+            }),
+            "You can't approve yourself"
+          )
         })
       })
 
       describe('when the approval succeeds', () => {
         let event
-        before(() => {
-          return locks['FIRST']
-            .approve(accounts[2], accounts[1], {
-              from: accounts[1]
-            })
-            .then((result) => {
-              event = result.logs[0]
-            })
+        before(async () => {
+          let result = await locks['FIRST'].approve(accounts[2], ID, {
+            from: accounts[1]
+          })
+          event = result.logs[0]
         })
 
         it('should assign the approvedForTransfer value', () => {
-          return locks['FIRST'].getApproved.call(accounts[1])
-            .then((approved) => {
-              assert.equal(approved, accounts[2])
-            })
+          return locks['FIRST'].getApproved.call(ID).then(approved => {
+            assert.equal(approved, accounts[2])
+          })
         })
 
         it('should trigger the Approval event', () => {
           assert.equal(event.event, 'Approval')
           assert.equal(event.args._owner, accounts[1])
           assert.equal(event.args._approved, accounts[2])
-          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.numberToHex(event.args._tokenId)), Web3Utils.toChecksumAddress(accounts[1]))
+          assert(event.args._tokenId.eq(ID))
         })
       })
     })

--- a/smart-contracts/test/Lock/erc721/getApproved.js
+++ b/smart-contracts/test/Lock/erc721/getApproved.js
@@ -3,16 +3,23 @@ const shouldFail = require('../../helpers/shouldFail')
 const Unlock = artifacts.require('../../Unlock.sol')
 const Zos = require('zos')
 const TestHelper = Zos.TestHelper
+const Web3Utils = require('web3-utils')
+const Units = require('ethereumjs-units')
 
-let locks
+let locks, ID
 
-contract('Lock ERC721', (accounts) => {
+contract('Lock ERC721', accounts => {
   const proxyAdmin = accounts[1]
   const unlockOwner = accounts[2]
+  const keyPurchaser = accounts[3]
 
   before(async function () {
     this.project = await TestHelper({ from: proxyAdmin })
-    this.proxy = await this.project.createProxy(Unlock, { initMethod: 'initialize', initArgs: [unlockOwner], initFrom: unlockOwner })
+    this.proxy = await this.project.createProxy(Unlock, {
+      initMethod: 'initialize',
+      initArgs: [unlockOwner],
+      initFrom: unlockOwner
+    })
     this.unlock = await Unlock.at(this.proxy.address)
     locks = await deployLocks(this.unlock)
   })
@@ -21,13 +28,29 @@ contract('Lock ERC721', (accounts) => {
     let lockOwner
 
     before(() => {
-      return locks['FIRST'].owner.call().then((_owner) => {
+      return locks['FIRST'].owner.call().then(_owner => {
         lockOwner = _owner
       })
     })
+    before(async function () {
+      await locks['FIRST'].purchaseFor(
+        keyPurchaser,
+        Web3Utils.toHex('Vitalik'),
+        {
+          value: Units.convert('0.01', 'eth', 'wei'),
+          from: keyPurchaser
+        }
+      )
+      ID = await locks['FIRST'].getTokenIdFor(keyPurchaser)
+    })
 
-    it('should fail if no one was approved for a key', async () => {
-      await shouldFail(locks['FIRST'].getApproved.call(accounts[1]), 'No approved recipient exists')
+    describe('getApproved', () => {
+      it('should fail if no one was approved for a key', async () => {
+        await shouldFail(
+          locks['FIRST'].getApproved.call(ID),
+          'No approved recipient exists'
+        )
+      })
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/getTokenIdFor.js
+++ b/smart-contracts/test/Lock/erc721/getTokenIdFor.js
@@ -8,7 +8,7 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC721', (accounts) => {
+contract('Lock ERC721', accounts => {
   before(async () => {
     unlock = await Unlock.deployed()
     locks = await deployLocks(unlock)
@@ -16,18 +16,27 @@ contract('Lock ERC721', (accounts) => {
 
   describe('getTokenIdFor', () => {
     it('should abort when the key has no owner', async () => {
-      await shouldFail(locks['FIRST'].getTokenIdFor.call(accounts[3]), 'No such key')
+      await shouldFail(
+        locks['FIRST'].getTokenIdFor.call(accounts[3]),
+        'No such key'
+      )
     })
 
-    it('should return the tokenId for the owner\'s key', async () => {
-      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
-        value: Units.convert('0.01', 'eth', 'wei'),
-        from: accounts[1]
-      })
-      let address = new BigNumber(await locks['FIRST'].getTokenIdFor.call(accounts[1]))
+    it("should return the tokenId for the owner's key", async () => {
+      await locks['FIRST'].purchaseFor(
+        accounts[1],
+        Web3Utils.toHex('Satoshi'),
+        {
+          value: Units.convert('0.01', 'eth', 'wei'),
+          from: accounts[1]
+        }
+      )
+      let ID = new BigNumber(
+        await locks['FIRST'].getTokenIdFor.call(accounts[1])
+      )
       // Note that as we implement ERC721 support, the tokenId will no longer
       // be the same as the user's address
-      assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(address)), Web3Utils.toChecksumAddress(accounts[1]))
+      assert(ID.eq(1))
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/ownerOf.js
+++ b/smart-contracts/test/Lock/erc721/ownerOf.js
@@ -7,33 +7,29 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC721', (accounts) => {
-  before(() => {
-    return Unlock.deployed()
-      .then(_unlock => {
-        unlock = _unlock
-        return deployLocks(unlock)
-      })
-      .then(_locks => {
-        locks = _locks
-      })
+contract('Lock ERC721', accounts => {
+  before(async () => {
+    unlock = await Unlock.deployed()
+    locks = await deployLocks(unlock)
   })
 
   describe('ownerOf', () => {
     it('should abort when the key has no owner', async () => {
-      await shouldFail(locks['FIRST']
-        .ownerOf.call(accounts[3]), 'No such key')
+      await shouldFail(locks['FIRST'].ownerOf.call(accounts[3]), 'No such key')
     })
 
-    it('should return the owner of the key', () => {
-      return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
-        value: Units.convert('0.01', 'eth', 'wei'),
-        from: accounts[1]
-      }).then(() => {
-        return locks['FIRST'].ownerOf.call(accounts[1])
-      }).then(address => {
-        assert.equal(address, accounts[1])
-      })
+    it('should return the owner of the key', async () => {
+      await locks['FIRST'].purchaseFor(
+        accounts[1],
+        Web3Utils.toHex('Satoshi'),
+        {
+          value: Units.convert('0.01', 'eth', 'wei'),
+          from: accounts[1]
+        }
+      )
+      let ID = await locks['FIRST'].getTokenIdFor(accounts[1])
+      let address = await locks['FIRST'].ownerOf.call(ID)
+      assert.equal(address, accounts[1])
     })
   })
 })

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -8,7 +8,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let lock
 
-contract('Lock ERC721', (accounts) => {
+contract('Lock ERC721', accounts => {
   before(() => {
     return Unlock.deployed()
       .then(unlock => {
@@ -58,7 +58,7 @@ contract('Lock ERC721', (accounts) => {
         lock.owners(1),
         lock.owners(2),
         lock.owners(3)
-      ]).then((owners) => {
+      ]).then(owners => {
         assert.deepEqual(owners.sort(), accounts.slice(1, 5).sort())
       })
     })
@@ -72,12 +72,21 @@ contract('Lock ERC721', (accounts) => {
 
       before(async () => {
         numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
-        await lock.transferFrom(accounts[1], accounts[5], accounts[1], { from: accounts[1] })
+        let ID = await lock.getTokenIdFor(accounts[1])
+        await lock.transferFrom(accounts[1], accounts[5], ID, {
+          from: accounts[1]
+        })
       })
 
       it('should have the right number of keys', async () => {
         const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
         assert.equal(outstandingKeys.toFixed(), 4)
+      })
+
+      it('should have the right number of keys', () => {
+        return lock.outstandingKeys().then(outstandingKeys => {
+          assert.equal(outstandingKeys, 4)
+        })
       })
 
       it('should have the right number of owners', async () => {
@@ -86,8 +95,12 @@ contract('Lock ERC721', (accounts) => {
       })
 
       it('should fail if I transfer from the same account again', async () => {
-        await shouldFail(lock.transferFrom(accounts[1], accounts[5], accounts[1], { from: accounts[1] }),
-          'Key is not valid')
+        await shouldFail(
+          lock.transferFrom(accounts[1], accounts[5], accounts[1], {
+            from: accounts[1]
+          }),
+          'Key is not valid'
+        )
       })
     })
 
@@ -96,12 +109,21 @@ contract('Lock ERC721', (accounts) => {
 
       before(async () => {
         numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
-        await lock.transferFrom(accounts[2], accounts[3], accounts[2], { from: accounts[2] })
+        let ID = await lock.getTokenIdFor(accounts[2])
+        await lock.transferFrom(accounts[2], accounts[3], ID, {
+          from: accounts[2]
+        })
       })
 
       it('should have the right number of keys', async () => {
         const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
         assert.equal(outstandingKeys.toFixed(), 4)
+      })
+
+      it('should have the right number of keys', () => {
+        return lock.outstandingKeys().then(outstandingKeys => {
+          assert.equal(outstandingKeys, 4)
+        })
       })
 
       it('should have the right number of owners', async () => {


### PR DESCRIPTION
 

This PR fixes #748 by introducing the use of sequential, unique, immutable tokenID's, with the first key purchased assigned the `tokenId` of `1`, and so on.
Testing for tokenID's was already done, so this was mostly a matter of modifying tests to pass the correct ID (rather than the address of the owner) where required. There is much work to do in refactoring tests to use async/await syntax, but this PR is big enough already. 



- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
