### PR TITLE
Edit form no longer complains about unlimited keys

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -56,6 +56,20 @@ describe('CreatorLockForm', () => {
       .forEach(error => expect(resetError).toHaveBeenCalledWith(error))
   }
 
+  describe('things that should not fail', () => {
+    it('properly handle unlimited keys when editing', () => {
+      const wrapper = makeLockForm({ maxNumberOfKeys: 0, convert: true })
+
+      const submit = wrapper.getByText('Submit')
+      expect(submit).not.toBeNull()
+
+      rtl.fireEvent.click(submit)
+      // The error most likely to occur in this instance is
+      // FORM_MAX_KEYS_INVALID.
+      expectErrors([])
+    })
+  })
+
   describe('invalid values', () => {
     it('name is empty', () => {
       const wrapper = makeLockForm({ name: '' })

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -36,17 +36,24 @@ export class CreatorLockForm extends React.Component {
     super(props, context)
     let expirationDuration = props.expirationDuration
     let keyPrice = props.keyPrice
+    let maxNumberOfKeys = props.maxNumberOfKeys
     if (props.convert) {
       keyPrice = Web3Utils.fromWei(keyPrice, props.keyPriceCurrency)
       expirationDuration = expirationDuration / props.expirationDurationUnit
+      // Unlimited keys is represented as zero, so when we load a lock that
+      // has `maxNumberOfKeys` set to zero, convert it to the infinity symbol
+      // before displaying it.
+      if (maxNumberOfKeys === 0) {
+        maxNumberOfKeys = INFINITY
+      }
     }
     this.state = {
       expirationDuration: expirationDuration,
       expirationDurationUnit: props.expirationDurationUnit, // Days
       keyPrice: keyPrice,
       keyPriceCurrency: props.keyPriceCurrency,
-      maxNumberOfKeys: props.maxNumberOfKeys,
-      unlimitedKeys: props.maxNumberOfKeys === INFINITY,
+      maxNumberOfKeys,
+      unlimitedKeys: maxNumberOfKeys === INFINITY,
       name: props.name,
       address: props.address,
     }


### PR DESCRIPTION
# Description
This PR fixes #1118. When the form is being edited, a 0 value for `maxNumberOfKeys` is converted into the infinity constant, which now allows the form validation to proceed successfully. This PR includes a regression test that specifies that no errors should occur under this circumstance.

<img width="871" alt="screen shot 2019-01-22 at 9 09 49 am" src="https://user-images.githubusercontent.com/9300702/51540932-9a212f00-1e25-11e9-9d0d-18885d43339d.png">
<img width="873" alt="screen shot 2019-01-22 at 9 10 01 am" src="https://user-images.githubusercontent.com/9300702/51540933-9a212f00-1e25-11e9-8ed4-891c3971dcc7.png">
<img width="882" alt="screen shot 2019-01-22 at 9 10 28 am" src="https://user-images.githubusercontent.com/9300702/51540934-9a212f00-1e25-11e9-9895-bac0543a06c3.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
