### PR TITLE
Fix spelling in Wallet Missing error

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -23989,7 +23989,7 @@ Object {
                 Wallet missing
               </h1>
               <p>
-                It looks like you’re using an incompatible browser or are missig a crypto wallet. If you’re using Chrome or Firefox you can install
+                It looks like you’re using an incompatible browser or are missing a crypto wallet. If you’re using Chrome or Firefox you can install
                  
                 <a
                   href="https://metamask.io/"
@@ -24189,7 +24189,7 @@ Object {
               Wallet missing
             </h1>
             <p>
-              It looks like you’re using an incompatible browser or are missig a crypto wallet. If you’re using Chrome or Firefox you can install
+              It looks like you’re using an incompatible browser or are missing a crypto wallet. If you’re using Chrome or Firefox you can install
                
               <a
                 href="https://metamask.io/"

--- a/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
+++ b/unlock-app/src/__tests__/utils/withConfig/__snapshots__/missingProvidersWithConfig.test.js.snap
@@ -517,7 +517,7 @@ exports[`withConfig High Order Component when the current network is not in the 
           Wallet missing
         </h1>
         <p>
-          It looks like you’re using an incompatible browser or are missig a crypto wallet. If you’re using Chrome or Firefox you can install
+          It looks like you’re using an incompatible browser or are missing a crypto wallet. If you’re using Chrome or Firefox you can install
            
           <a
             href="https://metamask.io/"

--- a/unlock-app/src/components/creator/FatalError.js
+++ b/unlock-app/src/components/creator/FatalError.js
@@ -100,7 +100,7 @@ export const MissingProvider = () => (
     illustration="/static/images/illustrations/wallet.svg"
   >
     <p>
-      It looks like you’re using an incompatible browser or are missig a crypto
+      It looks like you’re using an incompatible browser or are missing a crypto
       wallet. If you’re using Chrome or Firefox you can install{' '}
       <a href="https://metamask.io/">Metamask</a>.
     </p>


### PR DESCRIPTION
# Description

Found a spelling error in the Wallet Missing error message. :s/missig/missing
<img width="857" alt="screen shot 2019-01-22 at 11 02 16 am" src="https://user-images.githubusercontent.com/9300702/51548255-fbe99500-1e35-11e9-9371-cebb7e20bf7a.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
