### PR TITLE
mapping of fatal error type to error component

### DIFF
--- a/unlock-app/src/components/creator/FatalError.js
+++ b/unlock-app/src/components/creator/FatalError.js
@@ -112,6 +112,13 @@ export const MissingAccount = () => (
   </DefaultError>
 )
 
+export const mapping = {
+  FATAL_MISSING_PROVIDER: MissingProvider,
+  FATAL_NO_USER_ACCOUNT: MissingAccount,
+  FATAL_WRONG_NETWORK: WrongNetwork,
+  '*': DefaultError,
+}
+
 export default {
   DefaultError,
   WrongNetwork,


### PR DESCRIPTION
# Description

A simple mapping of fatal error type to the error component that defines it - this is what makes the more flexible implementation of `GlobalErrorConsumer` possible (PR coming next).

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
