### PR TITLE
GlobalErrorConsumer component

### DIFF
--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -1,0 +1,171 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+
+import GlobalErrorConsumer, {
+  displayError,
+} from '../../../components/interface/GlobalErrorConsumer'
+import { GlobalErrorContext } from '../../../utils/GlobalErrorProvider'
+import {
+  FATAL_NO_USER_ACCOUNT,
+  FATAL_MISSING_PROVIDER,
+  FATAL_WRONG_NETWORK,
+} from '../../../errors'
+
+const Provider = GlobalErrorContext.Provider
+
+describe('GlobalErrorConsumer', () => {
+  it('passes error initialized with metadata to displayError prop', () => {
+    expect.assertions(4)
+
+    const listen = jest.fn(() => <div>internal</div>)
+    const wrapper = rtl.render(
+      <Provider
+        value={{
+          error: FATAL_NO_USER_ACCOUNT,
+          errorMetadata: { thing: 'thingy' },
+        }}
+      >
+        <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
+      </Provider>
+    )
+
+    expect(wrapper.queryByText('internal')).not.toBeNull()
+    expect(listen).toHaveBeenCalledTimes(1)
+
+    // this next part tests to see if we got the error element and the children
+    const Error = listen.mock.calls[0][0]
+
+    const errorWrapper = rtl.render(Error)
+    expect(errorWrapper.queryByText('Need account')).not.toBeNull()
+
+    const children = listen.mock.calls[0][1]
+
+    const childrenWrapper = rtl.render(children)
+    expect(childrenWrapper.queryByText('hi')).not.toBeNull()
+  })
+  it('passes false to displayError prop if no error condition is present', () => {
+    expect.assertions(3)
+
+    const listen = jest.fn(() => <div>internal</div>)
+    const wrapper = rtl.render(
+      <Provider
+        value={{
+          error: false,
+          errorMetadata: {},
+        }}
+      >
+        <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
+      </Provider>
+    )
+
+    expect(wrapper.queryByText('internal')).not.toBeNull()
+    expect(listen).toHaveBeenCalledTimes(1)
+
+    expect(listen.mock.calls[0][0]).toBe(false)
+  })
+  describe('error mappings', () => {
+    it('FATAL_MISSING_PROVIDER', () => {
+      expect.assertions(2)
+
+      const listen = jest.fn(() => <div>internal</div>)
+      rtl.render(
+        <Provider
+          value={{
+            error: FATAL_MISSING_PROVIDER,
+            errorMetadata: {},
+          }}
+        >
+          <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
+        </Provider>
+      )
+
+      expect(listen).toHaveBeenCalledTimes(1)
+
+      const Error = listen.mock.calls[0][0]
+      const errorWrapper = rtl.render(Error)
+      expect(errorWrapper.queryByText('Wallet missing')).not.toBeNull()
+    })
+    it('FATAL_WRONG_NETWORK', () => {
+      expect.assertions(2)
+
+      const listen = jest.fn(() => <div>internal</div>)
+      rtl.render(
+        <Provider
+          value={{
+            error: FATAL_WRONG_NETWORK,
+            errorMetadata: {
+              requiredNetwork: 'CBS',
+              currentNetwork: 'Fox News',
+            },
+          }}
+        >
+          <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
+        </Provider>
+      )
+
+      expect(listen).toHaveBeenCalledTimes(1)
+
+      const Error = listen.mock.calls[0][0]
+      const errorWrapper = rtl.render(Error)
+      expect(errorWrapper.queryByText('Network mismatch')).not.toBeNull()
+    })
+    it('FATAL_NO_USER_ACCOUNT', () => {
+      expect.assertions(2)
+
+      const listen = jest.fn(() => <div>internal</div>)
+      rtl.render(
+        <Provider
+          value={{
+            error: FATAL_NO_USER_ACCOUNT,
+            errorMetadata: {},
+          }}
+        >
+          <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
+        </Provider>
+      )
+
+      expect(listen).toHaveBeenCalledTimes(1)
+
+      const Error = listen.mock.calls[0][0]
+      const errorWrapper = rtl.render(Error)
+      expect(errorWrapper.queryByText('Need account')).not.toBeNull()
+    })
+    it('anything else (*)', () => {
+      expect.assertions(2)
+
+      const listen = jest.fn(() => <div>internal</div>)
+      rtl.render(
+        <Provider
+          value={{
+            error: 'GOBBLEDEGOOK_ERROR',
+            errorMetadata: {},
+          }}
+        >
+          <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
+        </Provider>
+      )
+
+      expect(listen).toHaveBeenCalledTimes(1)
+
+      const Error = listen.mock.calls[0][0]
+      const errorWrapper = rtl.render(Error)
+      expect(errorWrapper.queryByText('Fatal Error')).not.toBeNull()
+    })
+  })
+  describe('displayError', () => {
+    it('displays the error if initialized', () => {
+      const wrapper = rtl.render(
+        displayError(<div>Error Message</div>, <div>children</div>)
+      )
+
+      expect(wrapper.queryByText('Error Message')).not.toBeNull()
+      expect(wrapper.queryByText('children')).toBeNull()
+    })
+    it('displays the children if no error is initialized', () => {
+      const wrapper = rtl.render(displayError(false, <div>children</div>))
+
+      expect(wrapper.queryByText('Error Message')).toBeNull()
+      expect(wrapper.queryByText('children')).not.toBeNull()
+    })
+  })
+})

--- a/unlock-app/src/components/interface/GlobalErrorConsumer.js
+++ b/unlock-app/src/components/interface/GlobalErrorConsumer.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { GlobalErrorContext } from '../../utils/GlobalErrorProvider'
+import { mapping } from '../creator/FatalError'
+import Layout from './Layout'
+
+const Consumer = GlobalErrorContext.Consumer
+
+export const displayError = (error, children) => {
+  if (error) return <Layout title="">{error}</Layout>
+  return <>{children}</>
+}
+
+export default function GlobalErrorConsumer({ displayError, children }) {
+  return (
+    <Consumer>
+      {({ error, errorMetadata }) => {
+        // if the error condition exists, set it to the mapped fatal error component
+        // or to the fallback
+        // if no error exists, set it to false
+        const Error = error ? mapping[error] || mapping['*'] : false
+
+        // call displayError with either false or the error element, and our child elements
+        return displayError(Error && <Error {...errorMetadata} />, children)
+      }}
+    </Consumer>
+  )
+}
+
+GlobalErrorConsumer.propTypes = {
+  children: PropTypes.node.isRequired,
+  displayError: PropTypes.func,
+}
+
+GlobalErrorConsumer.defaultProps = {
+  displayError,
+}


### PR DESCRIPTION
# Description

This component implements the consumer portion of the `GlobalErrorProvider`. It will be rebased on #1169 when that is approved.

The `GlobalErrorConsumer` component implements a simple idea: We want to be able to define the components that wrap our error component, but do not want to deal with the implementation details of the error components themselves. To do this, the consumer takes as a prop `displayError`: a function that receives as its parameters the error element (not component) and children element(s). Because these are passed as elements, they can be used directly in jsx (as `{error}` and `{children}` for example).

Thus, the `withConfig` implementation of this would be:

```js
function displayErrorWithConfig(error, children) {
  const { router } = props
  if (router && !Component.skipConstraints && error) {
    return (
      <Layout title="">{error}</Layout>
    )
  }
  return <>{children}</>
}
```

and withConfig would simply call:

```js
  return (
    <GlobalErrorConsumer displayError={displayErrorWithConfig}>
      <ConfigContext.Consumer>
        {config => <Component {...props} config={config} />}
      </ConfigContext.Consumer>
    </GlobalErrorConsumer>
```

For the paywall, we might use

```js
displayErrorForPaywall(error, children) {
  return (
    <>
      {children}
      {error}
    </>
  )
}
```

and then we can pass the locks as children to the GlobalErrorConsumer, so that we always display the locks even if there is an error, but provide the error message context for those who are misconfigured in some way.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
