### PR TITLE
update lock prop type to include missing fields, fix prop type errors it uncovered

### DIFF
--- a/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
+++ b/unlock-app/src/__tests__/components/creator/lock/LockIconBar.test.js
@@ -19,7 +19,7 @@ describe('LockIconBar', () => {
     lock = {
       id: 'lockwithdrawalsubmittedid',
       keyPrice: '10000000000000000000',
-      expirationDuration: '172800',
+      expirationDuration: 172800,
       maxNumberOfKeys: 240,
       outstandingKeys: 3,
       address: '0xbc7c74abc0c4d48d1bdad5dcb26153fc8780f83e',

--- a/unlock-app/src/propTypes.js
+++ b/unlock-app/src/propTypes.js
@@ -10,6 +10,9 @@ export const account = PropTypes.shape({
 })
 
 export const lock = PropTypes.shape({
+  address,
+  name: PropTypes.string,
+  expirationDuration: PropTypes.number,
   keyPrice: PropTypes.string,
   maxNumberOfKeys: PropTypes.number,
   owner: PropTypes.string,

--- a/unlock-app/src/stories/creator/LockIconBar.stories.js
+++ b/unlock-app/src/stories/creator/LockIconBar.stories.js
@@ -13,7 +13,7 @@ storiesOf('LockIconBar', module)
   .add('LockIconBar', () => {
     const lock = {
       keyPrice: '10000000000000000000',
-      expirationDuration: '172800',
+      expirationDuration: 172800,
       maxNumberOfKeys: 240,
       outstandingKeys: 3,
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',

--- a/unlock-app/src/stories/creator/Paywall.stories.js
+++ b/unlock-app/src/stories/creator/Paywall.stories.js
@@ -8,7 +8,7 @@ const lock = {
   address: '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e',
   name: 'My Blog',
   keyPrice: '27000000000000000',
-  expirationDuration: '172800',
+  expirationDuration: 172800,
   maxNumberOfKeys: 240,
   outstandingKeys: 3,
 }
@@ -17,7 +17,7 @@ const lockedState = {
     '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e': {
       address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       keyPrice: '10000000000000000000',
-      expirationDuration: '86400',
+      expirationDuration: 86400,
       maxNumberOfKeys: 800,
       outstandingKeys: 32,
     },


### PR DESCRIPTION
# Description

In preparation for #1075 update the prop type for `lock` to include missing fields, and fix tests/stories that use the incorrect type `string` instead of `number` for `expirationDuration`

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
