### PR TITLE
Enforce a maximum value for `expirationDuration`

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -32,7 +32,7 @@ import "./PublicLock.sol";
 import "./interfaces/IUnlock.sol";
 
 
-/// @dev Must list the direct base contracts in the order from “most base-like” to “most derived”. 
+/// @dev Must list the direct base contracts in the order from “most base-like” to “most derived”.
 /// https://solidity.readthedocs.io/en/latest/contracts.html#multiple-inheritance-and-linearization
 contract Unlock is IUnlock, Initializable, Ownable {
 
@@ -91,6 +91,8 @@ contract Unlock is IUnlock, Initializable, Ownable {
     public
     returns (ILockCore lock)
   {
+    // enforce the maximum _expirationDuration
+    require(_expirationDuration <= 3153600000, "Expiration Duration exceeds 100 years");
 
     // create lock
     PublicLock newPublicLock = new PublicLock(

--- a/smart-contracts/test/Unlock/behaviors/createLockWithExcessiveDuration.js
+++ b/smart-contracts/test/Unlock/behaviors/createLockWithExcessiveDuration.js
@@ -1,0 +1,30 @@
+const Units = require('ethereumjs-units')
+const Unlock = artifacts.require('../Unlock.sol')
+
+contract('PublicLock', accounts => {
+  describe('createLock with excessive expirationDuration', function () {
+    let unlock
+    // set duration to be > 100 years
+    const excessiveDuration = 3153600000 + 1
+
+    before(async () => {
+      unlock = await Unlock.deployed()
+    })
+
+    it('should fail to create a lock with an excessive expirationDuration', async function () {
+      try {
+        await unlock.createLock(
+          excessiveDuration, // expirationDuration: 30 days
+          Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
+          100 // maxNumberOfKeys
+          , {
+            from: accounts[0]
+          })
+      } catch (error) {
+        assert.equal(error.message, 'VM Exception while processing transaction: revert Expiration Duration exceeds 100 years')
+        return
+      }
+      assert.fail('Should have failed')
+    })
+  })
+})


### PR DESCRIPTION
This PR addresses part of issue #1110. 
Specifically,  It sets a maximum cap (100 years) on the value of the `expirationDuration` when creating a lock.


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
