### PR TITLE
removed test which was incompatible with the new approach to failover when lock medthod does not exist

### DIFF
--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -1366,36 +1366,8 @@ describe('Web3Service', () => {
         })
       })
 
-      it('should not fail when keys do not exist for the requested page', done => {
-        const onPage = 3
-        const byPage = 5
-
-        expect.assertions(3)
-
-        web3Service._getKeyByLockForOwner = jest.fn(() => {
-          return new Promise(resolve => {
-            return resolve([100, 'hello'])
-          })
-        })
-
-        ethCallAndYield(
-          `0x10803b72${abiPaddedString([onPage, byPage])}`,
-          lockAddress,
-          '0x'
-        )
-
-        web3Service.on('keys.page', (lock, page, keys) => {
-          expect(lockAddress).toEqual(lock)
-          expect(page).toEqual(onPage)
-          expect(keys.length).toEqual(0)
-          done()
-        })
-
-        web3Service.getKeysForLockOnPage(lockAddress, onPage, byPage)
-      })
-
       describe('when the on contract method does not exist', () => {
-        it.skip('should use the iterative method of providing keyholder', done => {
+        it('should use the iterative method of providing keyholder', done => {
           const onPage = 0
           const byPage = 2
 


### PR DESCRIPTION
This re-enables your test ;)
I think the test made no more sense because it tested what happenedd when there is no key to list...


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread