### PR TITLE
Require expirationDuration to be < 100 years.

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -156,7 +156,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     uint _maxNumberOfKeys
   )
   public {
-    require(_expirationDuration < 100 * 365 * 24 * 60 * 60, "Expiration duration must be less than 100 years");
+    require(_expirationDuration <= 100 * 365 * 24 * 60 * 60, "Expiration duration exceeds 100 years");
     unlockProtocol = msg.sender; // Make sure we link back to Unlock's smart contract.
     Ownable.initialize(_owner);
     ERC165.initialize();

--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -156,6 +156,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     uint _maxNumberOfKeys
   )
   public {
+    require(_expirationDuration < 100 * 365 * 24 * 60 * 60, "Expiration duration must be less than 100 years");
     unlockProtocol = msg.sender; // Make sure we link back to Unlock's smart contract.
     Ownable.initialize(_owner);
     ERC165.initialize();

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -52,7 +52,7 @@ exports.shouldCreateLock = function (accounts) {
             })
           assert.fail('Expected revert')
         } catch (error) {
-          assert.equal(error.message, 'VM Exception while processing transaction: revert Expiration duration must be less than 100 years')
+          assert.equal(error.message, 'VM Exception while processing transaction: revert Expiration duration exceeds 100 years')
         }
       })
     })

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -3,39 +3,58 @@ const PublicLock = artifacts.require('../../PublicLock.sol')
 
 exports.shouldCreateLock = function (accounts) {
   describe('createLock', function () {
-    let transaction
-    beforeEach(async function () {
-      transaction = await this.unlock.createLock(
-        60 * 60 * 24 * 30, // expirationDuration: 30 days
-        Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
-        100 // maxNumberOfKeys
-        , {
-          from: accounts[0]
-        })
-    })
-
-    it('should have kept track of the Lock inside Unlock with the right balances', async function () {
-      let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
-      // This is a bit of a dumb test because when the lock is missing, the value are 0 anyway...
-      let [deployed, totalSales, yieldedDiscountTokens] = await this.unlock.locks(publicLock.address)
-      assert(deployed)
-      assert(totalSales.eq(0))
-      assert(yieldedDiscountTokens.eq(0))
-    })
-
-    it('should trigger the NewLock event', function () {
-      const event = transaction.logs.find((log) => {
-        return log.event === 'NewLock'
+    describe('lock created successfully', function () {
+      let transaction
+      beforeEach(async function () {
+        transaction = await this.unlock.createLock(
+          60 * 60 * 24 * 30, // expirationDuration: 30 days
+          Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
+          100 // maxNumberOfKeys
+          , {
+            from: accounts[0]
+          })
       })
-      assert(event)
-      assert.equal(event.args.lockOwner, accounts[0])
-      assert(event.args.newLockAddress)
+
+      it('should have kept track of the Lock inside Unlock with the right balances', async function () {
+        let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
+        // This is a bit of a dumb test because when the lock is missing, the value are 0 anyway...
+        let [deployed, totalSales, yieldedDiscountTokens] = await this.unlock.locks(publicLock.address)
+        assert(deployed)
+        assert(totalSales.eq(0))
+        assert(yieldedDiscountTokens.eq(0))
+      })
+
+      it('should trigger the NewLock event', function () {
+        const event = transaction.logs.find((log) => {
+          return log.event === 'NewLock'
+        })
+        assert(event)
+        assert.equal(event.args.lockOwner, accounts[0])
+        assert(event.args.newLockAddress)
+      })
+
+      it('should have created the lock with the right address for unlock', async function () {
+        let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
+        let unlockProtocol = await publicLock.unlockProtocol()
+        assert.equal(unlockProtocol, this.unlock.address)
+      })
     })
 
-    it('should have created the lock with the right address for unlock', async function () {
-      let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
-      let unlockProtocol = await publicLock.unlockProtocol()
-      assert.equal(unlockProtocol, this.unlock.address)
+    describe('lock creation fails', function () {
+      it('should fail if expirationDuration is too large', async function () {
+        try {
+          await this.unlock.createLock(
+            60 * 60 * 24 * 365 * 101, // expirationDuration: 101 years
+            Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
+            100 // maxNumberOfKeys
+            , {
+              from: accounts[0]
+            })
+          assert.fail('Expected revert')
+        } catch (error) {
+          assert.equal(error.message, 'VM Exception while processing transaction: revert Expiration duration must be less than 100 years')
+        }
+      })
     })
   })
 }


### PR DESCRIPTION
# Description

When creating a lock, the expirationDuration must be < 100 years.

This PR addresses part of issue #1110.  It's a slight alternative to https://github.com/unlock-protocol/unlock/pull/1179 putting the require statement inside PublicLock instead. This is because:

 - Longer term I believe we should remove parameters from Unlock.sol and accept arbitrary data instead. This will free us up to define Lock types which require a completely different set of configuration information.
 - We may also want to add the ability for a Lock owner to change the expirationDuration, and if we did it's a little cleaner to have the requirement for creation and updates in the same place.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
