### PR TITLE
Add duration to Overlay stories

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -39479,7 +39479,7 @@ Object {
                         class="c10"
                       >
                         <span>
-                           - 
+                          142 days, 21 hours, 21 minutes and 18 seconds
                         </span>
                       </span>
                     </div>
@@ -39620,7 +39620,7 @@ Object {
                       class="yqqxp4-4 yqqxp4-5 djpTSh"
                     >
                       <span>
-                         - 
+                        142 days, 21 hours, 21 minutes and 18 seconds
                       </span>
                     </span>
                   </div>
@@ -40029,7 +40029,7 @@ Object {
                         class="c10"
                       >
                         <span>
-                           - 
+                          142 days, 21 hours, 21 minutes and 18 seconds
                         </span>
                       </span>
                     </div>
@@ -40075,7 +40075,7 @@ Object {
                         class="c10"
                       >
                         <span>
-                           - 
+                          142 days, 21 hours, 21 minutes and 18 seconds
                         </span>
                       </span>
                     </div>
@@ -40216,7 +40216,7 @@ Object {
                       class="yqqxp4-4 yqqxp4-5 djpTSh"
                     >
                       <span>
-                         - 
+                        142 days, 21 hours, 21 minutes and 18 seconds
                       </span>
                     </span>
                   </div>
@@ -40262,7 +40262,7 @@ Object {
                       class="yqqxp4-4 yqqxp4-5 djpTSh"
                     >
                       <span>
-                         - 
+                        142 days, 21 hours, 21 minutes and 18 seconds
                       </span>
                     </span>
                   </div>

--- a/unlock-app/src/stories/lock/Overlay.stories.js
+++ b/unlock-app/src/stories/lock/Overlay.stories.js
@@ -63,6 +63,7 @@ storiesOf('Overlay', module)
       {
         name: 'One Month',
         keyPrice: '123400000000000000',
+        expirationDuration: 12345678,
         fiatPrice: '20',
       },
     ]
@@ -73,11 +74,13 @@ storiesOf('Overlay', module)
       {
         name: 'One Month',
         keyPrice: '10000000000000000',
+        expirationDuration: 12345678,
         fiatPrice: '20.54',
       },
       {
         name: 'One Year',
         keyPrice: '100000000000000000',
+        expirationDuration: 12345678,
         fiatPrice: '200.27',
       },
     ]


### PR DESCRIPTION
# Description

The Overlay stories do not currently have a duration, this adds them.

Note: The odd time display is captured in #1185 and is not caused by this PR

<img width="1670" alt="screen shot 2019-01-23 at 3 25 40 pm" src="https://user-images.githubusercontent.com/98250/51634848-43018400-1f23-11e9-9933-258a73937ac4.png">
<img width="1670" alt="screen shot 2019-01-23 at 3 19 40 pm" src="https://user-images.githubusercontent.com/98250/51634849-43018400-1f23-11e9-93cb-8958481d4694.png">


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
