### PR TITLE
PublicLock SafeMath

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -559,7 +559,8 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
         // support this will change to a sequenceId assigned at purchase.
         keyByOwner[_recipient].tokenId = uint(_recipient);
       }
-      // SafeAdd is not required here since expirationDuration is capped to a tiny value (relative to the size of a uint)
+      // SafeAdd is not required here since expirationDuration is capped to a tiny value 
+      // (relative to the size of a uint)
       keyByOwner[_recipient].expirationTimestamp = now + expirationDuration;
     } else {
       // This is an existing owner trying to extend their key


### PR DESCRIPTION
# Description

Adds SafeMath from OpenZeppelin and uses it where appropriate inside PublicLock.sol.

All math in the contract should either use SafeMath or include a comment as to why SafeMath is not required.

I cannot write a unit test to confirm SafeMath guards against overflows here unless we implement some sort of mock test.  The issue is with an expirationDuration capped to 100 years, a unit test would need almost as long to trigger an overflow.

This PR addresses part of issue #1110.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
