### PR TITLE
Add blockNumber to each transaction

### DIFF
--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -1063,6 +1063,7 @@ describe('Web3Service', () => {
             confirmations: 0,
             createdAt: expect.any(Number),
             lock: lock.address,
+            blockNumber: Number.MAX_SAFE_INTEGER,
           }),
           {
             to: expect.any(String),

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -472,7 +472,7 @@ describe('Web3Service', () => {
 
     describe('getTransaction', () => {
       it('should update the number of confirmation based on number of blocks since the transaction', done => {
-        expect.assertions(2)
+        expect.assertions(3)
         ethBlockNumber(`0x${(29).toString('16')}`)
         ethGetTransactionByHash(transaction.hash, {
           hash:
@@ -500,6 +500,7 @@ describe('Web3Service', () => {
         web3Service.once('transaction.updated', (transaction, update) => {
           expect(update.confirmations).toEqual(15) //29-14
           expect(update.type).toEqual('TYPE') //29-14
+          expect(update.blockNumber).toEqual(14)
           done()
         })
 
@@ -545,7 +546,7 @@ describe('Web3Service', () => {
         })
 
         it('should mark the transaction as failed if the transaction receipt status is false', done => {
-          expect.assertions(3)
+          expect.assertions(4)
           ethGetTransactionReceipt(transaction.hash, {
             transactionIndex: '0x3',
             blockHash:
@@ -561,6 +562,7 @@ describe('Web3Service', () => {
           web3Service.once('transaction.updated', (transaction, update) => {
             expect(update.confirmations).toEqual(15) //29-14
             expect(update.type).toEqual('TYPE')
+            expect(update.blockNumber).toEqual(14)
             web3Service.once('transaction.updated', (transaction, update) => {
               expect(update.status).toBe('failed')
               done()
@@ -1063,7 +1065,6 @@ describe('Web3Service', () => {
             confirmations: 0,
             createdAt: expect.any(Number),
             lock: lock.address,
-            blockNumber: Number.MAX_SAFE_INTEGER,
           }),
           {
             to: expect.any(String),

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -384,6 +384,7 @@ export default class Web3Service extends EventEmitter {
       confirmations: 0,
       createdAt: new Date().getTime(),
       lock: lock.address, // This is likely a temporary address
+      blockNumber: Number.MAX_SAFE_INTEGER,
     }
 
     return this.sendTransaction(
@@ -513,6 +514,7 @@ export default class Web3Service extends EventEmitter {
           status: 'pending',
           type: transactionType,
           confirmations: 0,
+          blockNumber: Number.MAX_SAFE_INTEGER,
         })
       }
 
@@ -521,6 +523,7 @@ export default class Web3Service extends EventEmitter {
         status: 'mined',
         type: transactionType,
         confirmations: blockNumber - blockTransaction.blockNumber,
+        blockNumber: blockTransaction.blockNumber,
       })
 
       // Let's check its receipt to see if it triggered any event!

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -219,6 +219,7 @@ export default class Web3Service extends EventEmitter {
     })
 
     transaction.type = this.getTransactionType(contractAbi, data)
+    transaction.blockNumber = Number.MAX_SAFE_INTEGER
 
     return this.handleTransaction(
       transaction,
@@ -384,7 +385,6 @@ export default class Web3Service extends EventEmitter {
       confirmations: 0,
       createdAt: new Date().getTime(),
       lock: lock.address, // This is likely a temporary address
-      blockNumber: Number.MAX_SAFE_INTEGER,
     }
 
     return this.sendTransaction(


### PR DESCRIPTION
# Description

This PR adds a blockNumber property to each transaction in the Redux store. This will allow us to consistently sort locks on the dashboard by block number.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
