### PR TITLE
Duration now has a `round` property to handle rounding to next day

### DIFF
--- a/unlock-app/src/__tests__/components/helpers/Duration.test.js
+++ b/unlock-app/src/__tests__/components/helpers/Duration.test.js
@@ -20,4 +20,9 @@ describe('Duration Component', () => {
       wrapper.queryByText('115 days, 17 hours, 46 minutes and 40 seconds')
     ).not.toBe(null)
   })
+
+  it('unless we want to round', () => {
+    const wrapper = rtl.render(<Duration seconds={seconds} round />)
+    expect(wrapper.queryByText('116 days')).not.toBe(null)
+  })
 })

--- a/unlock-app/src/components/helpers/Duration.js
+++ b/unlock-app/src/components/helpers/Duration.js
@@ -1,24 +1,35 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { durationsAsTextFromSeconds } from '../../utils/durations'
+import {
+  durationsAsTextFromSeconds,
+  secondsAsDays,
+} from '../../utils/durations'
 
 /**
- * Component which shows a duration
+ * Component which shows a duration in days
  * @param {*} seconds: time in seconds
  */
-export function Duration({ seconds }) {
+export function Duration({ seconds, round }) {
   if (seconds === null) {
     return <span> - </span>
   }
-  return <span>{durationsAsTextFromSeconds(seconds)}</span>
+  const days = secondsAsDays(seconds)
+  const roundedSeconds = days * secondsInADay
+  return (
+    <span>{durationsAsTextFromSeconds(round ? roundedSeconds : seconds)}</span>
+  )
 }
 
 Duration.propTypes = {
   seconds: PropTypes.number,
+  round: PropTypes.bool,
 }
 
 Duration.defaultProps = {
   seconds: null,
+  round: false,
 }
 
 export default Duration
+
+const secondsInADay = 86400

--- a/unlock-app/src/components/helpers/Duration.js
+++ b/unlock-app/src/components/helpers/Duration.js
@@ -6,7 +6,7 @@ import {
 } from '../../utils/durations'
 
 /**
- * Component which shows a duration in days
+ * Component which shows a duration, rounded to next day if `round` is `true`
  * @param {*} seconds: time in seconds
  */
 export function Duration({ seconds, round }) {


### PR DESCRIPTION
# Description

This PR is step 1 in handling #1185. It adds a `round` property to the `Duration` component. When this property is `true`, `Duration` rounds the number of seconds passed to it to the next full day.

Once this is merged, I will make a PR setting this property on the various locks, which will resolve everything.

Question: would it be wise to create a story specifically for durations, and have examples of it with and without the `round` property?

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
