### PR TITLE
prefix all redux actions

### DIFF
--- a/unlock-app/src/__tests__/actions/storage.test.js
+++ b/unlock-app/src/__tests__/actions/storage.test.js
@@ -5,6 +5,8 @@ import {
   STORAGE_ERROR,
   storeLockCreation,
   storeLockUpdate,
+  STORE_LOCK_CREATION,
+  STORE_LOCK_UPDATE,
 } from '../../actions/storage'
 
 describe('Storage action', () => {
@@ -41,7 +43,7 @@ describe('Store Lock Creation', () => {
     const token = 'An authorization token'
 
     const expectation = {
-      type: 'STORE_LOCK_CREATION',
+      type: STORE_LOCK_CREATION,
       owner: owner,
       lock: lock,
       token: token,
@@ -59,7 +61,7 @@ describe('Store Lock Update', () => {
     const update = 'A new lock address'
 
     const expectation = {
-      type: 'STORE_LOCK_UPDATE',
+      type: STORE_LOCK_UPDATE,
       owner: owner,
       lockAddress: currentLock,
       token: token,

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,4 +1,6 @@
 import storageMiddleware from '../../middlewares/storageMiddleware'
+import { UPDATE_LOCK } from '../../actions/lock'
+import { STORE_LOCK_UPDATE, STORE_LOCK_CREATION } from '../../actions/storage'
 
 /**
  * This is a "fake" middleware caller
@@ -58,7 +60,7 @@ describe('Storage middleware', () => {
   describe('handling STORE_LOCK_CREATION', () => {
     it('dispatches to the appropriate storage middleware handler', () => {
       const { next, invoke } = create()
-      const action = { type: 'STORE_LOCK_CREATION' }
+      const action = { type: STORE_LOCK_CREATION }
       invoke(action)
       expect(mockStoreLockDetails).toHaveBeenCalled()
       expect(next).toHaveBeenCalledTimes(1)
@@ -69,7 +71,7 @@ describe('Storage middleware', () => {
     describe('when the update is a transaction', () => {
       it('calls the next middleware', () => {
         const { next, invoke } = create()
-        const action = { type: 'UPDATE_LOCK', update: { transaction: 'foo' } }
+        const action = { type: UPDATE_LOCK, update: { transaction: 'foo' } }
         invoke(action)
         expect(mockLockLookUp).not.toBeCalled()
         expect(next).toHaveBeenCalledTimes(1)
@@ -78,7 +80,7 @@ describe('Storage middleware', () => {
     describe('when the update is not a transaction', () => {
       it('dispatches to the appropriate storage middleware handler', () => {
         const { next, invoke } = create()
-        const action = { type: 'UPDATE_LOCK', update: { foo: 'foo' } }
+        const action = { type: UPDATE_LOCK, update: { foo: 'foo' } }
         invoke(action)
         expect(mockLockLookUp).toBeCalled()
         expect(next).toHaveBeenCalledTimes(1)
@@ -91,7 +93,7 @@ describe('Storage middleware', () => {
       it('dispatches to the appropriate storage middleware handler', () => {
         const { next, invoke } = create()
         const action = {
-          type: 'STORE_LOCK_UPDATE',
+          type: STORE_LOCK_UPDATE,
           address: '0xfff',
           lock: { address: '0x3f3f3' },
         }

--- a/unlock-app/src/actions/accounts.js
+++ b/unlock-app/src/actions/accounts.js
@@ -1,5 +1,5 @@
-export const SET_ACCOUNT = 'SET_ACCOUNT'
-export const UPDATE_ACCOUNT = 'UPDATE_ACCOUNT'
+export const SET_ACCOUNT = 'accounts/SET_ACCOUNT'
+export const UPDATE_ACCOUNT = 'accounts/UPDATE_ACCOUNT'
 
 export const updateAccount = update => ({
   type: UPDATE_ACCOUNT,

--- a/unlock-app/src/actions/currencyconvert.js
+++ b/unlock-app/src/actions/currencyconvert.js
@@ -1,4 +1,5 @@
-export const SET_ETHER_CONVERSION_RATE = 'SET_ETHER_CONVERSION_RATE'
+export const SET_ETHER_CONVERSION_RATE =
+  'currencyconvert/SET_ETHER_CONVERSION_RATE'
 
 export function setConversionRate(currency, rateFor1Eth) {
   return {

--- a/unlock-app/src/actions/error.js
+++ b/unlock-app/src/actions/error.js
@@ -1,5 +1,5 @@
-export const SET_ERROR = 'SET_ERROR'
-export const RESET_ERROR = 'RESET_ERROR'
+export const SET_ERROR = 'error/SET_ERROR'
+export const RESET_ERROR = 'error/RESET_ERROR'
 
 export const setError = error => ({
   type: SET_ERROR,

--- a/unlock-app/src/actions/lock.js
+++ b/unlock-app/src/actions/lock.js
@@ -1,10 +1,10 @@
-export const ADD_LOCK = 'ADD_LOCK'
-export const CREATE_LOCK = 'CREATE_LOCK'
-export const DELETE_LOCK = 'DELETE_LOCK'
-export const LOCK_DEPLOYED = 'LOCK_DEPLOYED'
-export const UPDATE_LOCK = 'UPDATE_LOCK'
-export const UPDATE_LOCK_KEY_PRICE = 'UPDATE_LOCK_KEY_PRICE'
-export const WITHDRAW_FROM_LOCK = 'WITHDRAW_FROM_LOCK'
+export const ADD_LOCK = 'lock/ADD_LOCK'
+export const CREATE_LOCK = 'lock/CREATE_LOCK'
+export const DELETE_LOCK = 'lock/DELETE_LOCK'
+export const LOCK_DEPLOYED = 'lock/LOCK_DEPLOYED'
+export const UPDATE_LOCK = 'lock/UPDATE_LOCK'
+export const UPDATE_LOCK_KEY_PRICE = 'lock/UPDATE_LOCK_KEY_PRICE'
+export const WITHDRAW_FROM_LOCK = 'lock/WITHDRAW_FROM_LOCK'
 
 export const createLock = lock => ({
   type: CREATE_LOCK,

--- a/unlock-app/src/actions/modal.js
+++ b/unlock-app/src/actions/modal.js
@@ -1,5 +1,5 @@
-export const SHOW_MODAL = 'SHOW_MODAL'
-export const HIDE_MODAL = 'HIDE_MODAL'
+export const SHOW_MODAL = 'modal/SHOW_MODAL'
+export const HIDE_MODAL = 'modal/HIDE_MODAL'
 
 export const showModal = modal => ({
   type: SHOW_MODAL,

--- a/unlock-app/src/actions/network.js
+++ b/unlock-app/src/actions/network.js
@@ -1,4 +1,4 @@
-export const SET_NETWORK = 'SET_NETWORK'
+export const SET_NETWORK = 'network/SET_NETWORK'
 
 export const setNetwork = network => ({
   type: SET_NETWORK,

--- a/unlock-app/src/actions/provider.js
+++ b/unlock-app/src/actions/provider.js
@@ -1,4 +1,4 @@
-export const SET_PROVIDER = 'SET_PROVIDER'
+export const SET_PROVIDER = 'provider/SET_PROVIDER'
 
 export const setProvider = provider => ({
   type: SET_PROVIDER,

--- a/unlock-app/src/actions/signature.js
+++ b/unlock-app/src/actions/signature.js
@@ -1,4 +1,4 @@
-export const SIGNATURE_ERROR = 'SIGNATURE_ERROR'
+export const SIGNATURE_ERROR = 'signature/SIGNATURE_ERROR'
 
 export function signatureError(error) {
   return {

--- a/unlock-app/src/actions/storage.js
+++ b/unlock-app/src/actions/storage.js
@@ -1,11 +1,11 @@
-export const SET_LOCK_NAME = 'SET_LOCK_NAME'
-export const STORAGE_ERROR = 'STORAGE_ERROR'
-export const STORE_LOCK_CREATION = 'STORE_LOCK_CREATION'
-export const STORE_LOCK_UPDATE = 'STORE_LOCK_UPDATE'
+export const SET_LOCK_NAME = 'storage/SET_LOCK_NAME'
+export const STORAGE_ERROR = 'storage/STORAGE_ERROR'
+export const STORE_LOCK_CREATION = 'storage/STORE_LOCK_CREATION'
+export const STORE_LOCK_UPDATE = 'storage/STORE_LOCK_UPDATE'
 
 export function setLockName(address, name) {
   return {
-    type: 'SET_LOCK_NAME',
+    type: SET_LOCK_NAME,
     address: address,
     name: name,
   }
@@ -13,14 +13,14 @@ export function setLockName(address, name) {
 
 export function storageError(error) {
   return {
-    type: 'STORAGE_ERROR',
+    type: STORAGE_ERROR,
     error: error,
   }
 }
 
 export function storeLockCreation(owner, lock, token) {
   return {
-    type: 'STORE_LOCK_CREATION',
+    type: STORE_LOCK_CREATION,
     owner: owner,
     lock: lock,
     token: token,
@@ -29,7 +29,7 @@ export function storeLockCreation(owner, lock, token) {
 
 export function storeLockUpdate(owner, currentLock, token, update) {
   return {
-    type: 'STORE_LOCK_UPDATE',
+    type: STORE_LOCK_UPDATE,
     owner: owner,
     lockAddress: currentLock,
     token: token,

--- a/unlock-app/src/actions/transaction.js
+++ b/unlock-app/src/actions/transaction.js
@@ -1,6 +1,6 @@
-export const ADD_TRANSACTION = 'ADD_TRANSACTION'
-export const UPDATE_TRANSACTION = 'UPDATE_TRANSACTION'
-export const DELETE_TRANSACTION = 'DELETE_TRANSACTION'
+export const ADD_TRANSACTION = 'transaction/ADD_TRANSACTION'
+export const UPDATE_TRANSACTION = 'transaction/UPDATE_TRANSACTION'
+export const DELETE_TRANSACTION = 'transaction/DELETE_TRANSACTION'
 
 export const addTransaction = transaction => ({
   type: ADD_TRANSACTION,


### PR DESCRIPTION
# Description

Fixes #1052 by adding a prefix based on the file name to every redux action constant, and fixing the few locations where constants were not being used.

<img width="1680" alt="screen shot 2019-01-23 at 11 03 46 pm" src="https://user-images.githubusercontent.com/98250/51653923-91cf0e00-1f63-11e9-9ebd-9fba9e9c7fc4.png">


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
