### PR TITLE
remove convert from CreatorLockForm

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -33,6 +33,7 @@ describe('CreatorLockForm', () => {
     )
     return ret
   }
+  const secondsInADay = 86400
   const allFormErrors = [
     FORM_EXPIRATION_DURATION_INVALID,
     FORM_KEY_PRICE_INVALID,
@@ -93,7 +94,7 @@ describe('CreatorLockForm', () => {
       }
     })
     it('key expiration is a negative number', () => {
-      const wrapper = makeLockForm({ expirationDuration: -2 * 86400 })
+      const wrapper = makeLockForm({ expirationDuration: -2 * secondsInADay })
 
       expect(wrapper.getByValue('-2').dataset.valid).toBe('false')
     })
@@ -244,7 +245,7 @@ describe('CreatorLockForm', () => {
       )
     })
     it('key expiration is a positive number', () => {
-      const wrapper = makeLockForm({ expirationDuration: 35 * 86400 })
+      const wrapper = makeLockForm({ expirationDuration: 35 * secondsInADay })
 
       expect(wrapper.getByValue('35').dataset.valid).toBe('true')
     })

--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -9,7 +9,7 @@ import {
   FORM_KEY_PRICE_INVALID,
 } from '../../../errors'
 
-import { INFINITY } from '../../../constants'
+import { INFINITY, UNLIMITED_KEYS_COUNT } from '../../../constants'
 
 describe('CreatorLockForm', () => {
   let createLock
@@ -24,7 +24,6 @@ describe('CreatorLockForm', () => {
     const ret = rtl.render(
       <CreatorLockForm
         account={{ address: 'hi' }}
-        convert={false} // * see comment below
         createLock={createLock}
         hideAction={hideAction}
         setError={setError}
@@ -32,11 +31,6 @@ describe('CreatorLockForm', () => {
         {...values}
       />
     )
-    // * (regarding the convert prop)
-    // tests that do not explicitly pass "{ convert: true }" will instruct
-    // CreatorLockForm to accept all values "as is" and not convert keyPrice or expirationDuration
-    // from wei and seconds to eth and days, respectively.
-    // this will be removed when a way is found to test form field validation edge cases
     return ret
   }
   const allFormErrors = [
@@ -58,7 +52,7 @@ describe('CreatorLockForm', () => {
 
   describe('things that should not fail', () => {
     it('properly handle unlimited keys when editing', () => {
-      const wrapper = makeLockForm({ maxNumberOfKeys: 0, convert: true })
+      const wrapper = makeLockForm({ maxNumberOfKeys: UNLIMITED_KEYS_COUNT })
 
       const submit = wrapper.getByText('Submit')
       expect(submit).not.toBeNull()
@@ -99,9 +93,9 @@ describe('CreatorLockForm', () => {
       }
     })
     it('key expiration is a negative number', () => {
-      const wrapper = makeLockForm({ expirationDuration: -1 })
+      const wrapper = makeLockForm({ expirationDuration: -2 * 86400 })
 
-      expect(wrapper.getByValue('-1').dataset.valid).toBe('false')
+      expect(wrapper.getByValue('-2').dataset.valid).toBe('false')
     })
     it('max number of keys is missing', () => {
       const save = console.error // eslint-disable-line
@@ -126,9 +120,9 @@ describe('CreatorLockForm', () => {
       }
     })
     it('max number of keys is a negative number', () => {
-      const wrapper = makeLockForm({ maxNumberOfKeys: -1 })
+      const wrapper = makeLockForm({ maxNumberOfKeys: -2 })
 
-      expect(wrapper.getByValue('-1').dataset.valid).toBe('false')
+      expect(wrapper.getByValue('-2').dataset.valid).toBe('false')
     })
     it('key price is not a number', () => {
       const save = console.error // eslint-disable-line
@@ -196,7 +190,7 @@ describe('CreatorLockForm', () => {
         }
       })
       it('max number of keys is a negative number', () => {
-        const wrapper = makeLockForm({ maxNumberOfKeys: -1 })
+        const wrapper = makeLockForm({ maxNumberOfKeys: -2 })
 
         const submit = wrapper.getByText('Submit')
         expect(submit).not.toBeNull()
@@ -250,7 +244,7 @@ describe('CreatorLockForm', () => {
       )
     })
     it('key expiration is a positive number', () => {
-      const wrapper = makeLockForm({ expirationDuration: 35 })
+      const wrapper = makeLockForm({ expirationDuration: 35 * 86400 })
 
       expect(wrapper.getByValue('35').dataset.valid).toBe('true')
     })
@@ -260,13 +254,13 @@ describe('CreatorLockForm', () => {
       expect(wrapper.getByValue('35').dataset.valid).toBe('true')
     })
     it('max number of keys is infinity', () => {
-      const wrapper = makeLockForm({ maxNumberOfKeys: INFINITY })
+      const wrapper = makeLockForm({ maxNumberOfKeys: UNLIMITED_KEYS_COUNT })
 
       expect(wrapper.getByDisplayValue(INFINITY)).not.toBeNull()
       expect(wrapper.getByValue(INFINITY).dataset.valid).toBe('true')
     })
     it('key price is a positive number', () => {
-      const wrapper = makeLockForm({ keyPrice: '0.01' })
+      const wrapper = makeLockForm({ keyPrice: '10000000000000000' })
 
       expect(wrapper.getByValue('0.01').dataset.valid).toBe('true')
     })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -20854,7 +20854,7 @@ Object {
             name="expirationDuration"
             step="1"
             type="number"
-            value="-0.000011574074074074073"
+            value="-1"
           />
            
           days
@@ -21007,7 +21007,7 @@ Object {
           name="expirationDuration"
           step="1"
           type="number"
-          value="-0.000011574074074074073"
+          value="-1"
         />
          
         days
@@ -21404,7 +21404,7 @@ Object {
             required=""
             step="0.00001"
             type="number"
-            value="-0.000000000000000001"
+            value="-1"
           />
         </span>
         <div>
@@ -21557,7 +21557,7 @@ Object {
           required=""
           step="0.00001"
           type="number"
-          value="-0.000000000000000001"
+          value="-1"
         />
       </span>
       <div>
@@ -21905,11 +21905,11 @@ Object {
           class="c3"
         >
           <input
-            data-valid="true"
+            data-valid="false"
             disabled=""
             name="maxNumberOfKeys"
             type="text"
-            value="∞"
+            value="-2"
           />
         </div>
         <span
@@ -22058,11 +22058,11 @@ Object {
         class="mlglvd-7 sc-1u8ov25-5 hzTKUl"
       >
         <input
-          data-valid="true"
+          data-valid="false"
           disabled=""
           name="maxNumberOfKeys"
           type="text"
-          value="∞"
+          value="-2"
         />
       </div>
       <span

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -37,6 +37,11 @@ export class CreatorLockForm extends React.Component {
     let expirationDuration = props.expirationDuration
     let keyPrice = props.keyPrice
     let maxNumberOfKeys = props.maxNumberOfKeys
+    // these try/catch blocks are designed to allow us to accept
+    // a wide range of both valid and invalid input
+    // and use the form itself to display invalid values
+    // keeping with the principle of accepting as much as possible
+    // and being strict in what data we send out
     try {
       if (!keyPrice.match(/^[0-9]+$/)) {
         keyPrice = props.keyPrice

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -37,15 +37,31 @@ export class CreatorLockForm extends React.Component {
     let expirationDuration = props.expirationDuration
     let keyPrice = props.keyPrice
     let maxNumberOfKeys = props.maxNumberOfKeys
-    if (props.convert) {
-      keyPrice = Web3Utils.fromWei(keyPrice, props.keyPriceCurrency)
-      expirationDuration = expirationDuration / props.expirationDurationUnit
-      // unlimited keys is represented differently in the frontend and the backend,
-      // so when a lock has `maxNumberOfKeys` set to UNLIMITED_KEYS_COUNT,
-      // convert it to infinity symbol for frontend display
-      if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
-        maxNumberOfKeys = INFINITY
+    try {
+      if (!keyPrice.match(/^[0-9]+$/)) {
+        keyPrice = props.keyPrice
+      } else {
+        keyPrice = Web3Utils.fromWei(keyPrice, props.keyPriceCurrency)
       }
+    } catch (e) {
+      // silently ignore invalid value, leave as what the original was
+      keyPrice = props.keyPrice
+    }
+    try {
+      expirationDuration =
+        parseInt(expirationDuration) / props.expirationDurationUnit
+      if (isNaN(expirationDuration)) {
+        expirationDuration = props.expirationDuration
+      }
+    } catch (e) {
+      // silently ignore invalid value, leave as what the original was
+      expirationDuration = props.expirationDuration
+    }
+    // unlimited keys is represented differently in the frontend and the backend,
+    // so when a lock has `maxNumberOfKeys` set to UNLIMITED_KEYS_COUNT,
+    // convert it to infinity symbol for frontend display
+    if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
+      maxNumberOfKeys = INFINITY
     }
     this.state = {
       expirationDuration: expirationDuration,
@@ -304,7 +320,6 @@ CreatorLockForm.propTypes = {
   name: PropTypes.string,
   address: PropTypes.string,
   pending: PropTypes.bool,
-  convert: PropTypes.bool, // this prop is to allow form field validation tests to test edge cases
 }
 
 CreatorLockForm.defaultProps = {
@@ -315,7 +330,6 @@ CreatorLockForm.defaultProps = {
   maxNumberOfKeys: 10,
   name: 'New Lock',
   address: uniqid(), // for new locks, we don't have an address, so use a temporary one
-  convert: true,
   pending: false,
 }
 

--- a/unlock-app/src/stories/creator/CreatorLockForm-errors.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm-errors.stories.js
@@ -30,7 +30,7 @@ storiesOf('CreatorLockForm/invalid', module)
   .add('invalid duration', () => {
     return (
       <CreatorLockForm
-        expirationDuration={-1}
+        expirationDuration={-1 * 86400}
         valid={false}
         hideAction={action('hide')}
         setError={action('setError')}
@@ -41,7 +41,7 @@ storiesOf('CreatorLockForm/invalid', module)
   .add('invalid num keys', () => {
     return (
       <CreatorLockForm
-        maxNumberOfKeys={-1}
+        maxNumberOfKeys={-2}
         valid={false}
         hideAction={action('hide')}
         setError={action('setError')}


### PR DESCRIPTION
# Description

Fixes #1068 by removing convert. In order to make it possible to test against invalid values, we are extremely permissive on input. So, when invalid input is encountered, it is simply left untouched. This way, we leave the error conditions to the form itself to display. In other words, if passed a cockamamie lock, the edit form will simply refuse to allow you to save it until the errors are fixed. Screenshots to show I didn't break anything :)

<img width="1680" alt="screen shot 2019-01-23 at 11 50 39 pm" src="https://user-images.githubusercontent.com/98250/51655243-c34ad800-1f69-11e9-9b59-2a6ac926c6ef.png">
<img width="1680" alt="screen shot 2019-01-23 at 11 50 28 pm" src="https://user-images.githubusercontent.com/98250/51655244-c34ad800-1f69-11e9-980c-a9a4e286222d.png">
<img width="1680" alt="screen shot 2019-01-23 at 11 49 44 pm" src="https://user-images.githubusercontent.com/98250/51655245-c34ad800-1f69-11e9-87fd-07cfde7b2410.png">
<img width="1680" alt="screen shot 2019-01-23 at 11 49 37 pm" src="https://user-images.githubusercontent.com/98250/51655246-c34ad800-1f69-11e9-8eed-133f6c1c0770.png">
<img width="1680" alt="screen shot 2019-01-23 at 11 50 54 pm" src="https://user-images.githubusercontent.com/98250/51655241-c2b24180-1f69-11e9-934f-dcf0605517c3.png">


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
