### PR TITLE
Make NoKeyLock always round duration

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -39465,7 +39465,7 @@ Object {
                         class="c10"
                       >
                         <span>
-                          142 days, 21 hours, 21 minutes and 18 seconds
+                          143 days
                         </span>
                       </span>
                     </div>
@@ -39606,7 +39606,7 @@ Object {
                       class="yqqxp4-4 yqqxp4-5 djpTSh"
                     >
                       <span>
-                        142 days, 21 hours, 21 minutes and 18 seconds
+                        143 days
                       </span>
                     </span>
                   </div>
@@ -40447,7 +40447,7 @@ Object {
                         class="c10"
                       >
                         <span>
-                          142 days, 21 hours, 21 minutes and 18 seconds
+                          143 days
                         </span>
                       </span>
                     </div>
@@ -40493,7 +40493,7 @@ Object {
                         class="c10"
                       >
                         <span>
-                          142 days, 21 hours, 21 minutes and 18 seconds
+                          143 days
                         </span>
                       </span>
                     </div>
@@ -40634,7 +40634,7 @@ Object {
                       class="yqqxp4-4 yqqxp4-5 djpTSh"
                     >
                       <span>
-                        142 days, 21 hours, 21 minutes and 18 seconds
+                        143 days
                       </span>
                     </span>
                   </div>
@@ -40680,7 +40680,7 @@ Object {
                       class="yqqxp4-4 yqqxp4-5 djpTSh"
                     >
                       <span>
-                        142 days, 21 hours, 21 minutes and 18 seconds
+                        143 days
                       </span>
                     </span>
                   </div>

--- a/unlock-app/src/components/lock/NoKeyLock.js
+++ b/unlock-app/src/components/lock/NoKeyLock.js
@@ -24,7 +24,7 @@ export const NoKeyLock = ({ lock, disabled, purchaseKey, lockKey }) => (
               <FiatPrice>${fiatPrice}</FiatPrice>
               <Separator> | </Separator>
               <ExpirationDuration>
-                <Duration seconds={lock.expirationDuration} />
+                <Duration seconds={lock.expirationDuration} round />
               </ExpirationDuration>
             </div>
             <Footer>Purchase</Footer>


### PR DESCRIPTION
# Description

This PR fixes #1185. It sets the `round` property on the `Duration` within `NoKeyLock`, thus ensuring that the lock always displays a whole number of days.

<img width="682" alt="screen shot 2019-01-24 at 8 32 35 am" src="https://user-images.githubusercontent.com/9300702/51681634-3dec1580-1fb3-11e9-913c-8fb86e68c881.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
