### PR TITLE
Disable purchasing when sold out

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -36640,6 +36640,271 @@ Object {
 }
 `;
 
+exports[`Storyshots Lock disabled - no keys left to sell 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c1 {
+  display: grid;
+  font-weight: 300;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-size: 20px;
+  line-height: 20px;
+  height: 40px;
+  border-radius: 4px 4px 0px 0px;
+  padding: 0px;
+  color: var(--grey);
+}
+
+.c0 {
+  display: grid;
+  justify-items: stretch;
+  margin: 0px;
+  padding: 0px;
+  font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
+  width: 200px;
+  height: 180px;
+  grid-gap: 0px;
+  background-clip: padding-box;
+  grid-template-rows: 40px 140px;
+  opacity: 0.5;
+  cursor: pointer;
+}
+
+.c8 {
+  display: grid;
+  font-weight: 300;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-size: 20px;
+  line-height: 20px;
+  height: 40px;
+  border-radius: 0px 0px 4px 4px;
+  padding: 0px;
+  width: 200px;
+  background-color: var(--green);
+  color: var(--white);
+}
+
+.c2 {
+  display: grid;
+  height: 140px;
+  width: 200px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
+  text-align: center;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  padding: 0px;
+  grid-template-rows: 40px 30px;
+  grid-gap: 8px;
+  padding-top: 0px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background-color: var(--white);
+  padding-top: 13px;
+}
+
+.c2:hover {
+  border: 1px solid var(--activegreen);
+}
+
+.c2:hover .c7 {
+  background-color: var(--activegreen);
+}
+
+.c3 {
+  font-size: 30px;
+  text-transform: uppercase;
+  color: var(--slate);
+  font-weight: bold;
+}
+
+.c4 {
+  font-size: 20px;
+  font-weight: 300;
+  color: var(--grey);
+}
+
+.c6 {
+  font-size: 20px;
+  font-weight: 300;
+  color: var(--grey);
+}
+
+.c5 {
+  color: var(--lightgrey);
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <li
+        class="c0"
+        disabled=""
+      >
+        <header
+          class="c1"
+        >
+          Monthly
+        </header>
+        <div>
+          <div
+            class="c2"
+          >
+            <div
+              class="c3"
+            >
+              1.20
+               Eth
+            </div>
+            <div>
+              <span
+                class="c4"
+              >
+                $
+                235.80
+              </span>
+              <span
+                class="c5"
+              >
+                 | 
+              </span>
+              <span
+                class="c6"
+              >
+                <span>
+                  30 days
+                </span>
+              </span>
+            </div>
+            <footer
+              class="c7 c8"
+            >
+              Sold Out
+            </footer>
+          </div>
+        </div>
+      </li>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <li
+      class="sc-1ws9jnj-0 yqqxp4-0 gTmtWU"
+      disabled=""
+    >
+      <header
+        class="sc-1ws9jnj-1 kgNRxZ"
+      >
+        Monthly
+      </header>
+      <div>
+        <div
+          class="sc-1ws9jnj-3 yqqxp4-2 dzEKTb"
+        >
+          <div
+            class="yqqxp4-3 kxjMda"
+          >
+            1.20
+             Eth
+          </div>
+          <div>
+            <span
+              class="yqqxp4-4 fcTWoc"
+            >
+              $
+              235.80
+            </span>
+            <span
+              class="yqqxp4-6 gEUJdZ"
+            >
+               | 
+            </span>
+            <span
+              class="yqqxp4-4 yqqxp4-5 djpTSh"
+            >
+              <span>
+                30 days
+              </span>
+            </span>
+          </div>
+          <footer
+            class="sc-1ws9jnj-2 yqqxp4-1 ghSrYu"
+          >
+            Sold Out
+          </footer>
+        </div>
+      </div>
+    </li>
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots Lock with a balance 1`] = `
 Object {
   "asFragment": [Function],

--- a/unlock-app/src/components/lock/Lock.js
+++ b/unlock-app/src/components/lock/Lock.js
@@ -34,11 +34,19 @@ export const Lock = ({
   } else if (transaction && transaction.status == 'mined') {
     return <ConfirmedKeyLock lock={lock} hideModal={hideModal} />
   } else {
+    const soldOut = lock.outstandingKeys >= lock.maxNumberOfKeys
+    // When the lock is not disabled for other reasons (pending key on
+    // other lock...), we need to ensure that the lock is disabled
+    // when the lock is sold out
+    if (!disabled) {
+      disabled = soldOut
+    }
     return (
       <NoKeyLock
         lock={lock}
         disabled={disabled}
         purchaseKey={purchaseKey}
+        soldOut={soldOut}
         lockKey={lockKey}
       />
     )

--- a/unlock-app/src/components/lock/NoKeyLock.js
+++ b/unlock-app/src/components/lock/NoKeyLock.js
@@ -6,7 +6,13 @@ import { LockWrapper, LockHeader, LockBody, LockFooter } from './LockStyles'
 import BalanceProvider from '../helpers/BalanceProvider'
 import Duration from '../helpers/Duration'
 
-export const NoKeyLock = ({ lock, disabled, purchaseKey, lockKey }) => (
+export const NoKeyLock = ({
+  lock,
+  disabled,
+  purchaseKey,
+  lockKey,
+  soldOut,
+}) => (
   <Wrapper
     disabled={disabled}
     onClick={() => {
@@ -27,7 +33,7 @@ export const NoKeyLock = ({ lock, disabled, purchaseKey, lockKey }) => (
                 <Duration seconds={lock.expirationDuration} round />
               </ExpirationDuration>
             </div>
-            <Footer>Purchase</Footer>
+            <Footer>{soldOut ? 'Sold Out' : 'Purchase'}</Footer>
           </Body>
         </div>
       )}
@@ -39,12 +45,14 @@ NoKeyLock.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
   purchaseKey: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  soldOut: PropTypes.bool,
   lockKey: UnlockPropTypes.key,
 }
 
 NoKeyLock.defaultProps = {
   disabled: false,
   lockKey: null,
+  soldOut: false,
 }
 
 export default NoKeyLock

--- a/unlock-app/src/stories/lock/Lock.stories.js
+++ b/unlock-app/src/stories/lock/Lock.stories.js
@@ -18,6 +18,11 @@ const lock = {
   expirationDuration: 2592000,
 }
 
+const soldOutLock = Object.assign(
+  { maxNumberOfKeys: 1, outstandingKeys: 1 },
+  lock
+)
+
 const store = createUnlockStore({
   currency: {
     USD: 195.99,
@@ -43,6 +48,18 @@ storiesOf('Lock', module)
       <Lock
         disabled
         lock={lock}
+        transaction={null}
+        lockKey={null}
+        purchaseKey={purchaseKey}
+        config={config}
+        hideModal={() => {}}
+      />
+    )
+  })
+  .add('disabled - no keys left to sell', () => {
+    return (
+      <Lock
+        lock={soldOutLock}
         transaction={null}
         lockKey={null}
         purchaseKey={purchaseKey}


### PR DESCRIPTION
# Description

This PR fixes #1191. `Lock`s now check if they are sold out or not; if they are then `NoKeyLock` is disabled and shows that it is sold out. No impact on the other forms of the lock.

<img width="207" alt="screen shot 2019-01-24 at 10 58 25 am" src="https://user-images.githubusercontent.com/9300702/51690594-06876400-1fc7-11e9-8d28-9563d73f61ca.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
