### PR TITLE
enable overriding the display of specific errors

### DIFF
--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -155,8 +155,10 @@ describe('GlobalErrorConsumer', () => {
       it('overriding FATAL_NO_USER_ACCOUNT', () => {
         expect.assertions(2)
 
+        const component = () => <div>overrode</div>
+
         const mapping = {
-          FATAL_NO_USER_ACCOUNT: () => <div>overrode</div>, // eslint-disable-line react/display-name
+          FATAL_NO_USER_ACCOUNT: component,
         }
         const wrapper = rtl.render(
           <Provider
@@ -196,8 +198,10 @@ describe('GlobalErrorConsumer', () => {
       it('overriding an unknown error', () => {
         expect.assertions(1)
 
+        const component = () => <div>overrode</div>
+
         const mapping = {
-          GOBBLEDEGOOK_ERROR: () => <div>overrode</div>, // eslint-disable-line react/display-name
+          GOBBLEDEGOOK_ERROR: component,
         }
         const wrapper = rtl.render(
           <Provider

--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -151,6 +151,70 @@ describe('GlobalErrorConsumer', () => {
       const errorWrapper = rtl.render(Error)
       expect(errorWrapper.queryByText('Fatal Error')).not.toBeNull()
     })
+    describe('overrideMapping', () => {
+      it('overriding FATAL_NO_USER_ACCOUNT', () => {
+        expect.assertions(2)
+
+        const mapping = {
+          FATAL_NO_USER_ACCOUNT: () => <div>overrode</div>, // eslint-disable-line react/display-name
+        }
+        const wrapper = rtl.render(
+          <Provider
+            value={{
+              error: FATAL_NO_USER_ACCOUNT,
+              errorMetadata: {},
+            }}
+          >
+            <GlobalErrorConsumer overrideMapping={mapping}>
+              hi
+            </GlobalErrorConsumer>
+          </Provider>
+        )
+
+        // verify that error was overridden
+        expect(wrapper.queryByText('overrode')).not.toBeNull()
+
+        const wrapper2 = rtl.render(
+          <Provider
+            value={{
+              error: FATAL_WRONG_NETWORK,
+              errorMetadata: {
+                requiredNetwork: 'CBS',
+                currentNetwork: 'Fox News',
+              },
+            }}
+          >
+            <GlobalErrorConsumer overrideMapping={mapping}>
+              hi
+            </GlobalErrorConsumer>
+          </Provider>
+        )
+
+        // verify other errors are untouched
+        expect(wrapper2.queryByText('Network mismatch')).not.toBeNull()
+      })
+      it('overriding an unknown error', () => {
+        expect.assertions(1)
+
+        const mapping = {
+          GOBBLEDEGOOK_ERROR: () => <div>overrode</div>, // eslint-disable-line react/display-name
+        }
+        const wrapper = rtl.render(
+          <Provider
+            value={{
+              error: 'GOBBLEDEGOOK_ERROR',
+              errorMetadata: {},
+            }}
+          >
+            <GlobalErrorConsumer overrideMapping={mapping}>
+              hi
+            </GlobalErrorConsumer>
+          </Provider>
+        )
+
+        expect(wrapper.queryByText('overrode')).not.toBeNull()
+      })
+    })
   })
   describe('displayError', () => {
     it('displays the error if initialized', () => {

--- a/unlock-app/src/components/interface/GlobalErrorConsumer.js
+++ b/unlock-app/src/components/interface/GlobalErrorConsumer.js
@@ -14,14 +14,20 @@ export const displayError = (error, children) => {
   return <>{children}</>
 }
 
-export default function GlobalErrorConsumer({ displayError, children }) {
+export default function GlobalErrorConsumer({
+  displayError,
+  overrideMapping,
+  children,
+}) {
   return (
     <Consumer>
       {({ error, errorMetadata }) => {
         // if the error condition exists, set it to the mapped fatal error component
         // or to the fallback
         // if no error exists, set it to false
-        const Error = error ? mapping[error] || mapping['*'] : false
+        const Error = error
+          ? overrideMapping[error] || mapping[error] || mapping['*']
+          : false
 
         // call displayError with either false or the error element, and our child elements
         return displayError(Error && <Error {...errorMetadata} />, children)
@@ -33,8 +39,10 @@ export default function GlobalErrorConsumer({ displayError, children }) {
 GlobalErrorConsumer.propTypes = {
   children: PropTypes.node.isRequired,
   displayError: PropTypes.func,
+  overrideMapping: PropTypes.objectOf(PropTypes.func),
 }
 
 GlobalErrorConsumer.defaultProps = {
   displayError,
+  overrideMapping: {},
 }


### PR DESCRIPTION
# Description

In preparation for having more user-friendly errors on the paywall that are different from the dashboard errors, this makes it possible to override specific errors

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
