### PR TITLE
Add test for blockNumber value in sendTransaction

### DIFF
--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -963,7 +963,7 @@ describe('Web3Service', () => {
 
     describe('sendTransaction', () => {
       it('should handle cases where the transaction is sent via a provider', () => {
-        expect.assertions(4)
+        expect.assertions(5)
 
         web3Service.handleTransaction = jest.fn()
 
@@ -992,6 +992,7 @@ describe('Web3Service', () => {
           data
         )
         expect(transaction.type).toBe('TYPE')
+        expect(transaction.blockNumber).toEqual(Number.MAX_SAFE_INTEGER)
         expect(mockSendTransaction).toHaveBeenCalledWith({
           data,
           from,


### PR DESCRIPTION
# Description

This PR fixes my mistaken merge before adding the last test in https://github.com/unlock-protocol/unlock/pull/1189

It adds a test for `sendTransaction` ensuring that `blockNumber` was set to the right default value.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
