### PR TITLE
use the React context for config in the app

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
@@ -6,6 +6,7 @@ import { CreatorLock } from '../../../components/creator/CreatorLock'
 import configure from '../../../config'
 import createUnlockStore from '../../../createUnlockStore'
 import { UNLIMITED_KEYS_COUNT } from '../../../constants'
+import { ConfigContext } from '../../../utils/withConfig'
 
 jest.mock('next/link', () => {
   return ({ children }) => children
@@ -44,6 +45,8 @@ const transaction = {
   lock: 'lockid',
 }
 
+const ConfigProvider = ConfigContext.Provider
+
 describe('CreatorLock', () => {
   it('should show embed code when the button is clicked', () => {
     const config = configure()
@@ -51,13 +54,15 @@ describe('CreatorLock', () => {
     const store = createUnlockStore()
 
     let wrapper = rtl.render(
-      <Provider store={store} config={config}>
-        <CreatorLock
-          lock={lock}
-          transaction={transaction}
-          updateKeyPrice={() => {}}
-        />
-      </Provider>
+      <ConfigProvider value={config}>
+        <Provider store={store}>
+          <CreatorLock
+            lock={lock}
+            transaction={transaction}
+            updateKeyPrice={() => {}}
+          />
+        </Provider>
+      </ConfigProvider>
     )
 
     expect(
@@ -85,13 +90,15 @@ describe('CreatorLock', () => {
     })
 
     let wrapper = rtl.render(
-      <Provider store={store} config={config}>
-        <CreatorLock
-          lock={lock}
-          transaction={transaction}
-          updateKeyPrice={() => {}}
-        />
-      </Provider>
+      <ConfigProvider value={config}>
+        <Provider store={store}>
+          <CreatorLock
+            lock={lock}
+            transaction={transaction}
+            updateKeyPrice={() => {}}
+          />
+        </Provider>
+      </ConfigProvider>
     )
 
     let editButton = wrapper.getByTitle('Edit')
@@ -112,13 +119,15 @@ describe('CreatorLock', () => {
     })
 
     let wrapper = rtl.render(
-      <Provider store={store} config={config}>
-        <CreatorLock
-          lock={keylock}
-          transaction={transaction}
-          updateKeyPrice={() => {}}
-        />
-      </Provider>
+      <ConfigProvider value={config}>
+        <Provider store={store}>
+          <CreatorLock
+            lock={keylock}
+            transaction={transaction}
+            updateKeyPrice={() => {}}
+          />
+        </Provider>
+      </ConfigProvider>
     )
 
     expect(wrapper.queryByText('1/10')).not.toBeNull()
@@ -136,13 +145,15 @@ describe('CreatorLock', () => {
     })
 
     let wrapper = rtl.render(
-      <Provider store={store} config={config}>
-        <CreatorLock
-          lock={unlimitedlock}
-          transaction={transaction}
-          updateKeyPrice={() => {}}
-        />
-      </Provider>
+      <ConfigProvider value={config}>
+        <Provider store={store}>
+          <CreatorLock
+            lock={unlimitedlock}
+            transaction={transaction}
+            updateKeyPrice={() => {}}
+          />
+        </Provider>
+      </ConfigProvider>
     )
 
     expect(wrapper.queryByText('1/∞')).not.toBeNull()

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -12,8 +12,10 @@ import {
 import { GlobalErrorContext } from '../../../utils/GlobalErrorProvider'
 import { FATAL_NO_USER_ACCOUNT } from '../../../errors'
 import createUnlockStore from '../../../createUnlockStore'
+import { ConfigContext } from '../../../utils/withConfig'
 
 const ErrorProvider = GlobalErrorContext.Provider
+const ConfigProvider = ConfigContext.Provider
 
 describe('Overlay', () => {
   describe('mapDispatchToProps', () => {
@@ -63,9 +65,15 @@ describe('Overlay', () => {
       expect.assertions(3)
       const wrapper = rtl.render(
         <Provider store={store}>
-          <ErrorProvider value={{ error: false, errorMetadata: {} }}>
-            <Overlay hideModal={() => {}} showModal={() => {}} locks={[lock]} />
-          </ErrorProvider>
+          <ConfigProvider value={{}}>
+            <ErrorProvider value={{ error: false, errorMetadata: {} }}>
+              <Overlay
+                hideModal={() => {}}
+                showModal={() => {}}
+                locks={[lock]}
+              />
+            </ErrorProvider>
+          </ConfigProvider>
         </Provider>
       )
 

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -7,6 +7,7 @@ import configure from '../config'
 import { createUnlockStore } from '../createUnlockStore'
 
 import GlobalStyle from '../theme/globalStyle'
+import { ConfigContext } from '../utils/withConfig'
 
 const config = configure()
 
@@ -25,7 +26,7 @@ function getOrCreateStore(initialState, history) {
   return window[__NEXT_REDUX_STORE__]
 }
 
-const ConfigContext = React.createContext()
+const ConfigProvider = ConfigContext.Provider
 
 class UnlockApp extends App {
   static async getInitialProps({ Component, ctx }) {
@@ -81,9 +82,9 @@ The Unlock team
         <GlobalStyle />
         <Provider store={store}>
           <ConnectedRouter history={history}>
-            <ConfigContext.Provider value={config}>
+            <ConfigProvider value={config}>
               <Component {...pageProps} router={router} />
-            </ConfigContext.Provider>
+            </ConfigProvider>
           </ConnectedRouter>
         </Provider>
       </Container>

--- a/unlock-app/src/stories/creator/CreatorLock.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLock.stories.js
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import CreatorLock from '../../components/creator/CreatorLock'
 import createUnlockStore from '../../createUnlockStore'
+import { ConfigContext } from '../../utils/withConfig'
 
 const withdrawalConfirmingAddress = '0xAAAAAAAAAAAAAAAAAAAAAAAAAA73289473298'
 const withdrawalSubmittedAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbb73289473298'
@@ -45,8 +46,17 @@ const store = createUnlockStore({
   },
 })
 
+const config = {
+  requiredConfirmations: 12,
+}
+
+const ConfigProvider = ConfigContext.Provider
+
 storiesOf('CreatorLock', module)
   .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
+  .addDecorator(getStory => (
+    <ConfigProvider value={config}>{getStory()}</ConfigProvider>
+  ))
   .add('Deployed', () => {
     const lock = {
       keyPrice: '10000000000000000000',

--- a/unlock-app/src/stories/creator/Dashboard.stories.js
+++ b/unlock-app/src/stories/creator/Dashboard.stories.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Dashboard } from '../../pages/dashboard'
 import createUnlockStore from '../../createUnlockStore'
+import { ConfigContext } from '../../utils/withConfig'
 
 const account = {
   address: '0x3ca206264762caf81a8f0a843bbb850987b41e16',
@@ -80,7 +81,18 @@ const noUserStore = createUnlockStore({
   router,
 })
 
+const ConfigProvider = ConfigContext.Provider
+
+const config = {
+  providers: [],
+  env: 'production',
+  requiredConfirmations: 12,
+}
+
 storiesOf('Dashboard', module)
+  .addDecorator(getStory => (
+    <ConfigProvider value={config}>{getStory()}</ConfigProvider>
+  ))
   .add('the dashboard', () => {
     return (
       <Provider store={store}>

--- a/unlock-app/src/stories/creator/LockIconBar.stories.js
+++ b/unlock-app/src/stories/creator/LockIconBar.stories.js
@@ -5,10 +5,18 @@ import { action } from '@storybook/addon-actions'
 import { Provider } from 'react-redux'
 import LockIconBar from '../../components/creator/lock/LockIconBar'
 import createUnlockStore from '../../createUnlockStore'
+import { ConfigContext } from '../../utils/withConfig'
 
 const store = createUnlockStore({})
 
+const ConfigProvider = ConfigContext.Provider
+
+const config = {}
+
 storiesOf('LockIconBar', module)
+  .addDecorator(getStory => (
+    <ConfigProvider value={config}>{getStory()}</ConfigProvider>
+  ))
   .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('LockIconBar', () => {
     const lock = {

--- a/unlock-app/src/stories/lock/Lock.stories.js
+++ b/unlock-app/src/stories/lock/Lock.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react'
 import { Provider } from 'react-redux'
 import { Lock } from '../../components/lock/Lock'
 import createUnlockStore from '../../createUnlockStore'
+import { ConfigContext } from '../../utils/withConfig'
 
 // lock, account, keys, purchaseKey
 const purchaseKey = () => {}
@@ -29,7 +30,16 @@ const store = createUnlockStore({
   },
 })
 
+const ConfigProvider = ConfigContext.Provider
+
+const storyConfig = {
+  requiredConfirmations: 12,
+}
+
 storiesOf('Lock', module)
+  .addDecorator(getStory => (
+    <ConfigProvider value={storyConfig}>{getStory()}</ConfigProvider>
+  ))
   .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('with no key (check hover state too)', () => {
     return (

--- a/unlock-app/src/stories/lock/Overlay.stories.js
+++ b/unlock-app/src/stories/lock/Overlay.stories.js
@@ -5,8 +5,12 @@ import { Overlay } from '../../components/lock/Overlay'
 import createUnlockStore from '../../createUnlockStore'
 import { GlobalErrorContext } from '../../utils/GlobalErrorProvider'
 import { FATAL_NO_USER_ACCOUNT } from '../../errors'
+import { ConfigContext } from '../../utils/withConfig'
 
 const ErrorProvider = GlobalErrorContext.Provider
+const ConfigProvider = ConfigContext.Provider
+
+const config = {}
 
 const store = createUnlockStore({
   currency: {
@@ -56,9 +60,11 @@ const render = (locks, errors = { error: false, errorMetadata: {} }) => (
       <li>Aliquam tincidunt mauris eu risus.</li>
     </ul>
 
-    <ErrorProvider value={errors}>
-      <Overlay locks={locks} hideModal={() => {}} showModal={() => {}} />
-    </ErrorProvider>
+    <ConfigProvider value={config}>
+      <ErrorProvider value={errors}>
+        <Overlay locks={locks} hideModal={() => {}} showModal={() => {}} />
+      </ErrorProvider>
+    </ConfigProvider>
   </section>
 )
 

--- a/unlock-app/src/stories/pages.stories.js
+++ b/unlock-app/src/stories/pages.stories.js
@@ -8,6 +8,7 @@ import Jobs from '../pages/jobs'
 import Terms from '../pages/terms'
 import Privacy from '../pages/privacy'
 import createUnlockStore from '../createUnlockStore'
+import { ConfigContext } from '../utils/withConfig'
 
 const store = createUnlockStore({
   currency: {
@@ -15,7 +16,16 @@ const store = createUnlockStore({
   },
 })
 
+const ConfigProvider = ConfigContext.Provider
+
+const config = {
+  env: 'production',
+}
+
 storiesOf('Content pages', module)
+  .addDecorator(getStory => (
+    <ConfigProvider value={config}>{getStory()}</ConfigProvider>
+  ))
   .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('the Home page', () => {
     return <Home />

--- a/unlock-app/src/utils/withConfig.js
+++ b/unlock-app/src/utils/withConfig.js
@@ -7,8 +7,7 @@ import configure from '../config'
  * Taken from https://reactjs.org/docs/context.html#consuming-context-with-a-hoc
  */
 
-const config = configure()
-export const ConfigContext = React.createContext(config)
+export const ConfigContext = React.createContext()
 
 /**
  * This creates an HOC from a component and injects the configuration.

--- a/unlock-app/src/utils/withConfig.js
+++ b/unlock-app/src/utils/withConfig.js
@@ -8,7 +8,7 @@ import configure from '../config'
  */
 
 const config = configure()
-const ConfigContext = React.createContext(config)
+export const ConfigContext = React.createContext(config)
 
 /**
  * This creates an HOC from a component and injects the configuration.

--- a/unlock-app/src/utils/withConfig.js
+++ b/unlock-app/src/utils/withConfig.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import configure from '../config'
 
 /**
  * Function which creates higher order component with the config


### PR DESCRIPTION
# Description

Currently, the `withConfig` helper uses its own version of the config. The `_app.js` file creates a new context, whose `Consumer` is not used anywhere. This PR links up the two, so that `withConfig` uses the configuration set in the Provider.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
