### PR TITLE
Adds new ShowWhenLocked component

### DIFF
--- a/unlock-app/src/__tests__/components/lock/ShowWhenLocked.test.js
+++ b/unlock-app/src/__tests__/components/lock/ShowWhenLocked.test.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+
+import ShowWhenLocked from '../../../components/lock/ShowWhenLocked'
+
+describe('ShowWhenLocked', () => {
+  describe('if there is a valid key', () => {
+    it('should not show the children if not locked', () => {
+      expect.assertions(1)
+
+      jest.useFakeTimers()
+
+      const wrapper = rtl.render(
+        <ShowWhenLocked locked={false}>Show me</ShowWhenLocked>
+      )
+
+      jest.runAllTimers()
+
+      expect(wrapper.queryByText('Show me')).toBeNull()
+    })
+
+    it('should show nothing if accounts are not loaded and 200ms has not elapsed (no flash)', () => {
+      expect.assertions(1)
+
+      jest.useFakeTimers()
+
+      const wrapper = rtl.render(
+        <ShowWhenLocked locked>Show me</ShowWhenLocked>
+      )
+      jest.advanceTimersByTime(199)
+
+      expect(wrapper.queryByText('Show me')).toBeNull()
+    })
+
+    it('should show the children if there is a modal', () => {
+      expect.assertions(1)
+
+      jest.useFakeTimers()
+
+      const wrapper = rtl.render(
+        <ShowWhenLocked locked>Show me</ShowWhenLocked>
+      )
+      jest.runAllTimers()
+
+      expect(wrapper.queryByText('Show me')).not.toBeNull()
+    })
+  })
+
+  describe('if paywall state is locked', () => {
+    it('should show the children', () => {
+      expect.assertions(1)
+
+      jest.useFakeTimers()
+      const wrapper = rtl.render(
+        <ShowWhenLocked locked>Show me</ShowWhenLocked>
+      )
+      jest.runAllTimers()
+
+      expect(wrapper.queryByText('Show me')).not.toBeNull()
+    })
+  })
+})

--- a/unlock-app/src/components/lock/ShowWhenLocked.js
+++ b/unlock-app/src/components/lock/ShowWhenLocked.js
@@ -4,12 +4,10 @@ import React from 'react'
 import SuspendedRender from '../helpers/SuspendedRender'
 
 export default function ShowWhenLocked({ locked, children }) {
-  // We have at least one valid key and the modal was not shown
   if (!locked) {
     return null
   }
 
-  // There is no valid key or we shown the modal previously
   return <SuspendedRender>{children}</SuspendedRender>
 }
 

--- a/unlock-app/src/components/lock/ShowWhenLocked.js
+++ b/unlock-app/src/components/lock/ShowWhenLocked.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import SuspendedRender from '../helpers/SuspendedRender'
+
+export default function ShowWhenLocked({ locked, children }) {
+  // We have at least one valid key and the modal was not shown
+  if (!locked) {
+    return null
+  }
+
+  // There is no valid key or we shown the modal previously
+  return <SuspendedRender>{children}</SuspendedRender>
+}
+
+ShowWhenLocked.propTypes = {
+  locked: PropTypes.bool,
+  children: PropTypes.node,
+}
+
+ShowWhenLocked.defaultProps = {
+  children: null,
+  locked: false,
+}


### PR DESCRIPTION
# Description

As a first step towards refactoring `ShowWhenUserHasKeysToAnyLock` this extracts behavior that shows children when the paywall is locked.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
