### PR TITLE
Adds new ShowWhenUnlocked component

### DIFF
--- a/unlock-app/src/__tests__/components/lock/ShowWhenUnlocked.test.js
+++ b/unlock-app/src/__tests__/components/lock/ShowWhenUnlocked.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+
+import ShowWhenUnlocked from '../../../components/lock/ShowWhenUnlocked'
+
+describe('ShowWhenUnlocked', () => {
+  describe('if the paywall state is unlocked', () => {
+    it('should show the children', () => {
+      expect.assertions(1)
+
+      const wrapper = rtl.render(
+        <ShowWhenUnlocked locked={false}>Show me</ShowWhenUnlocked>
+      )
+
+      expect(wrapper.queryByText('Show me')).not.toBeNull()
+    })
+  })
+
+  describe('if paywall state is locked', () => {
+    it('should not show the children', () => {
+      expect.assertions(1)
+
+      jest.useFakeTimers()
+      const wrapper = rtl.render(
+        <ShowWhenUnlocked locked>Show me</ShowWhenUnlocked>
+      )
+      jest.runAllTimers()
+
+      expect(wrapper.queryByText('Show me')).toBeNull()
+    })
+  })
+})

--- a/unlock-app/src/components/lock/ShowWhenUnlocked.js
+++ b/unlock-app/src/components/lock/ShowWhenUnlocked.js
@@ -2,12 +2,10 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 export default function ShowWhenUnlocked({ locked, children }) {
-  // We have at least one valid key and the modal was not shown
   if (locked) {
     return null
   }
 
-  // There is no valid key or we shown the modal previously
   return <>{children}</>
 }
 

--- a/unlock-app/src/components/lock/ShowWhenUnlocked.js
+++ b/unlock-app/src/components/lock/ShowWhenUnlocked.js
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export default function ShowWhenUnlocked({ locked, children }) {
+  // We have at least one valid key and the modal was not shown
+  if (locked) {
+    return null
+  }
+
+  // There is no valid key or we shown the modal previously
+  return <>{children}</>
+}
+
+ShowWhenUnlocked.propTypes = {
+  locked: PropTypes.bool,
+  children: PropTypes.node,
+}
+
+ShowWhenUnlocked.defaultProps = {
+  children: null,
+  locked: false,
+}


### PR DESCRIPTION
# Description

As a first step towards refactoring `ShowUnlessUserHasKeysToAnyLock` this extracts (new) behavior to show its children only when the paywall is unlocked.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
