### PR TITLE
pulling remote branches before actually checking that this is a tag build

### DIFF
--- a/scripts/deploy-netlify.sh
+++ b/scripts/deploy-netlify.sh
@@ -18,8 +18,11 @@ echo ""
 if [ -n "$TRAVIS_TAG" ] &&
    [ -n "$TRAVIS_COMMIT" ] &&
    [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-  # Check that the TRAVIS_COMMIT is actually on the master branch [to avoid deploying tags which are not on master]
-  git branch --contains $TRAVIS_COMMIT | grep 'master' >> /dev/null
+  # Check that the TRAVIS_COMMIT is actually on the master branch in
+  # origin to avoid deploying tags which are not on master.
+  git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+  git fetch
+  git branch -r --contains $TRAVIS_COMMIT | grep 'master' >> /dev/null
   if [ $? -eq 0 ]; then
     # This is a tag build on master. We deploy to the main site!
     DEPLOY_ENV="prod";


### PR DESCRIPTION
After debugging further I found that travis does not actually checkout all of the branches, just the
commit that it needs to test.
So this fix will actually fetch all branches and will check that the commit is actually on master
before proceeding to a full deploy.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)