### PR TITLE
Chosing between staging and production is not specific to Netlify anymore

### DIFF
--- a/scripts/deploy-netlify.sh
+++ b/scripts/deploy-netlify.sh
@@ -5,48 +5,26 @@
 # TRAVIS_BRANCH to identify whether we deploy a 'draft' or a 'production' version (note that this
 # is production in the netlify sense, so it could be on staging.unlock-protocol.com).
 
-
 CURRENT_DIR=`pwd`;
 UNLOCK_APP_PATH="unlock-app";
 BUILD_PATH="$UNLOCK_APP_PATH/src/out/";
+DEPLOY_ENV=$1
 
-echo "Starting to deploy"
-echo "Env variables:"
-env | grep "TRAVIS_"
-echo ""
-
-if [ -n "$TRAVIS_TAG" ] &&
-   [ -n "$TRAVIS_COMMIT" ] &&
-   [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-  # Check that the TRAVIS_COMMIT is actually on the master branch in
-  # origin to avoid deploying tags which are not on master.
-  git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-  git fetch
-  git branch -r --contains $TRAVIS_COMMIT | grep 'master' >> /dev/null
-  if [ $? -eq 0 ]; then
-    # This is a tag build on master. We deploy to the main site!
-    DEPLOY_ENV="prod";
-    NETLIFY_SITE_ID="$NETLIFY_PROD_SITE_ID"
-    PROD="--prod";
-    MESSAGE="Deploying version $TRAVIS_TAG to production";
-  else
-    echo "Skipping deployment on Netlify because commit $TRAVIS_COMMIT for tag $TRAVIS_TAG is not on master"
-    exit 0
-  fi
-else
-  # This is a branch build. We deploy to the staging site
-  DEPLOY_ENV="staging"
-  NETLIFY_SITE_ID="$NETLIFY_STAGING_SITE_ID"
-
+if [ "$DEPLOY_ENV" = "staging" ]; then
   if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     # This is a build on master, we deploy to staging as a published build
     PROD="--prod";
-    MESSAGE="Deploying $TRAVIS_COMMIT to production";
+    MESSAGE="Deploying $TRAVIS_COMMIT to staging. See logs below.";
   else
     # we deploy as a draft on staging
     PROD="";
-    MESSAGE="Deploying $TRAVIS_COMMIT to draft";
+    MESSAGE="Deploying $TRAVIS_COMMIT to draft. See draft URL and logs below.";
   fi
+fi
+
+if [ "$DEPLOY_ENV" = "prod" ]; then
+  PROD="--prod";
+  MESSAGE="Deploying version $TRAVIS_TAG to production";
 fi
 
 if [ -n "$NETLIFY_SITE_ID" ] && [ -n "$NETLIFY_AUTH_TOKEN" ]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,16 +2,43 @@
 
 # This script invokes the deployment script for the target (as first arg) inside the default docker
 # image by copying all the Travis env variables inside the docker image
+# The second argument indicates if the build is for staging or production
 
 TARGET=$1
+ENV_TARGET="staging"
 NPM_SCRIPT="npm run deploy-$TARGET"
 SERVICE="unlock"
 REPO_ROOT=`dirname "$0"`/..
 DOCKER_COMPOSE_FILE=$REPO_ROOT/docker/docker-compose.ci.yml
 ENV_VARS=`env | grep TRAVIS_ | awk '{print "-e ",$1}' ORS=' '`
 
-if [ "$TARGET" = "netlify" ]; then
-  ENV_VARS="$ENV_VARS -e NETLIFY_STAGING_SITE_ID=$NETLIFY_STAGING_SITE_ID -e NETLIFY_AUTH_TOKEN=$NETLIFY_AUTH_TOKEN"
+# Identify the environment for the target (production or staging)
+if [ -n "$TRAVIS_TAG" ] &&
+   [ -n "$TRAVIS_COMMIT" ] &&
+   [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  # Check that the TRAVIS_COMMIT is actually on the master branch to avoid deploying tags which are not on master
+  git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+  git fetch >> /dev/null
+  git branch -r --contains $TRAVIS_COMMIT | grep 'master' >> /dev/null
+  if [ $? -eq 0 ]; then
+    # This is a tag build on master. We deploy to the main site!
+    ENV_TARGET="prod"
+  else
+    echo "Skipping deployment because commit $TRAVIS_COMMIT for tag $TRAVIS_TAG is not on master"
+    exit 0
+  fi
+else
+  # This is a branch build. We deploy to the staging site
+  ENV_TARGET="staging"
 fi
 
-docker-compose -f $DOCKER_COMPOSE_FILE run $ENV_VARS $SERVICE $NPM_SCRIPT
+## Custom variables passed for netlify
+if [ "$TARGET" = "netlify" ]; then
+  NETLIFY_SITE_ID=$NETLIFY_STAGING_SITE_ID
+  if [ "$ENV_TARGET" = "prod" ]; then
+    NETLIFY_SITE_ID=$NETLIFY_PROD_SITE_ID
+  fi
+  ENV_VARS="$ENV_VARS -e NETLIFY_SITE_ID=$NETLIFY_SITE_ID -e NETLIFY_AUTH_TOKEN=$NETLIFY_AUTH_TOKEN"
+fi
+
+docker-compose -f $DOCKER_COMPOSE_FILE run $ENV_VARS $SERVICE $NPM_SCRIPT -- $ENV_TARGET


### PR DESCRIPTION
I believe we will have deployments between staging and production on any hosting provider we chose,
so I am pulling the logic to determnine which is which inside the main deploy.sh script.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread