### PR TITLE
Using a string of eth as the only format for all kinds of prices and balances

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorAccount.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorAccount.test.js
@@ -7,7 +7,7 @@ import createUnlockStore from '../../../createUnlockStore'
 
 const account = {
   address: '0x3ca206264762caf81a8f0a843bbb850987b41e16',
-  balance: '200000000000000000',
+  balance: '0.2',
 }
 const network = {
   name: 4,

--- a/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
@@ -15,7 +15,7 @@ jest.mock('next/link', () => {
 const lock = {
   address: '0x1234567890',
   transaction: 'transactionid',
-  keyPrice: '100000000000000000',
+  keyPrice: '0.1',
   balance: '1',
   expirationDuration: 100,
 }

--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -261,7 +261,7 @@ describe('CreatorLockForm', () => {
       expect(wrapper.getByValue(INFINITY).dataset.valid).toBe('true')
     })
     it('key price is a positive number', () => {
-      const wrapper = makeLockForm({ keyPrice: '10000000000000000' })
+      const wrapper = makeLockForm({ keyPrice: '0.01' })
 
       expect(wrapper.getByValue('0.01').dataset.valid).toBe('true')
     })
@@ -276,7 +276,7 @@ describe('CreatorLockForm', () => {
       expect(createLock).toHaveBeenCalledWith(
         expect.objectContaining({
           expirationDuration: 2592000,
-          keyPrice: '10000000000000000',
+          keyPrice: '0.01',
           maxNumberOfKeys: 10,
           name: 'New Lock',
           owner: 'hi',

--- a/unlock-app/src/__tests__/components/helpers/Balance.test.js
+++ b/unlock-app/src/__tests__/components/helpers/Balance.test.js
@@ -6,16 +6,14 @@ import { Balance } from '../../../components/helpers/Balance'
 import createUnlockStore from '../../../createUnlockStore'
 
 describe('Balance Component', () => {
-  const unit = 'szabo'
-
   const store = createUnlockStore({
     currency: { USD: 195.99 },
   })
 
-  function renderIt(amount, u = unit, convertCurrency = true) {
+  function renderIt(amount, convertCurrency = true) {
     return rtl.render(
       <Provider store={store}>
-        <Balance amount={amount} unit={u} convertCurrency={convertCurrency} />
+        <Balance amount={amount} convertCurrency={convertCurrency} />
       </Provider>
     )
   }
@@ -31,7 +29,7 @@ describe('Balance Component', () => {
   })
 
   describe('when the balance is < 0.0001 Eth', () => {
-    const amount = '70'
+    const amount = '0.000070'
 
     it('shows the default minimum value of 三 < 0.0001', () => {
       const wrapper = renderIt(amount)
@@ -41,7 +39,7 @@ describe('Balance Component', () => {
   })
 
   describe('when the balance is > 0.0001 Eth and less than 1 Eth', () => {
-    const amount = '75800'
+    const amount = '0.075800'
 
     it('shows the balance in Eth to two decimal places', () => {
       const wrapper = renderIt(amount)
@@ -51,7 +49,7 @@ describe('Balance Component', () => {
   })
 
   describe('when the balance is > 1 Eth ', () => {
-    const amount = '2000000'
+    const amount = '2'
 
     it('shows the balance in Eth to two decimal places', () => {
       const wrapper = renderIt(amount)
@@ -61,7 +59,7 @@ describe('Balance Component', () => {
   })
 
   describe('when the balance converts to > $1000 ', () => {
-    const amount = '20000000'
+    const amount = '20'
 
     it('shows the balance in dollars in locale format without decimal', () => {
       const wrapper = renderIt(amount)
@@ -71,7 +69,7 @@ describe('Balance Component', () => {
   })
 
   describe('when the balance converts to > $100k ', () => {
-    const amount = '2000000000'
+    const amount = '2000'
 
     it('shows the balance in thousands of dollars postfixed with k', () => {
       const wrapper = renderIt(amount)
@@ -81,7 +79,7 @@ describe('Balance Component', () => {
   })
 
   describe('when the balance converts to > $1m ', () => {
-    const amount = '20000000000'
+    const amount = '20000'
 
     it('shows the balance in millions of dollars postfixed with m', () => {
       const wrapper = renderIt(amount)
@@ -91,22 +89,12 @@ describe('Balance Component', () => {
   })
 
   describe('when the balance converts to > $1b ', () => {
-    const amount = '20000000000000'
+    const amount = '20000000'
 
     it('shows the balance in billions of dollars postfixed with b', () => {
       const wrapper = renderIt(amount)
       expect(wrapper.queryByText('20000000.00')).not.toBeNull()
       expect(wrapper.queryByText('3.9b')).not.toBeNull()
-    })
-  })
-
-  describe('when the balance converts to > $1b, unit is eth (used in lock form)', () => {
-    const amount = '9999999'
-
-    it('shows the balance in billions of dollars postfixed with b', () => {
-      const wrapper = renderIt(amount, 'eth')
-      expect(wrapper.queryByText('9999999.00')).not.toBeNull()
-      expect(wrapper.queryByText('2b')).not.toBeNull()
     })
   })
 })

--- a/unlock-app/src/__tests__/components/helpers/BalanceProvider.test.js
+++ b/unlock-app/src/__tests__/components/helpers/BalanceProvider.test.js
@@ -4,16 +4,10 @@ import * as rtl from 'react-testing-library'
 import { BalanceProvider } from '../../../components/helpers/BalanceProvider'
 
 describe('BalanceProvider Component', () => {
-  function renderIt({
-    amount,
-    unit = 'szabo',
-    conversion = { USD: 195.99 },
-    render,
-  }) {
+  function renderIt({ amount, conversion = { USD: 195.99 }, render }) {
     return rtl.render(
       <BalanceProvider
         amount={amount}
-        unit={unit}
         conversion={conversion}
         render={render}
       />
@@ -22,7 +16,6 @@ describe('BalanceProvider Component', () => {
   it('renders with - when amount is null (probably unset)', () => {
     renderIt({
       amount: null,
-      unit: 'eth',
       conversion: {},
       render: (ethValue, fiatValue) => {
         expect(ethValue).toEqual(' - ')
@@ -34,7 +27,6 @@ describe('BalanceProvider Component', () => {
   it('renders with - when amount is undefined (probably loading)', () => {
     renderIt({
       amount: undefined,
-      unit: 'eth',
       conversion: {},
       render: (ethValue, fiatValue) => {
         expect(ethValue).toEqual(' - ')
@@ -46,7 +38,6 @@ describe('BalanceProvider Component', () => {
   it('USD conversion data is not available', () => {
     renderIt({
       amount: '100',
-      unit: 'eth',
       conversion: {},
       render: (ethValue, fiatValue) => {
         expect(ethValue).toEqual('100.00')
@@ -58,7 +49,6 @@ describe('BalanceProvider Component', () => {
   it('USD conversion data is available', () => {
     renderIt({
       amount: '100',
-      unit: 'eth',
       render: (ethValue, fiatValue) => {
         expect(ethValue).toEqual('100.00')
         expect(fiatValue).toEqual('19,599')
@@ -79,7 +69,7 @@ describe('BalanceProvider Component', () => {
   })
 
   describe('when the balance is < 0.0001 Eth', () => {
-    const amount = '70'
+    const amount = '0.000070'
 
     it('shows the default minimum value of 三 < 0.0001', () => {
       renderIt({
@@ -93,21 +83,21 @@ describe('BalanceProvider Component', () => {
   })
 
   describe('when the balance is > 0.0001 Eth and less than 1 Eth', () => {
-    const amount = '75800'
+    const amount = '0.0002'
 
     it('shows the balance in Eth to two decimal places', () => {
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
-          expect(ethValue).toEqual('0.076')
-          expect(fiatValue).toEqual('14.86')
+          expect(ethValue).toEqual('0.0002')
+          expect(fiatValue).toEqual('0.039')
         },
       })
     })
   })
 
   describe('when the balance is > 1 Eth ', () => {
-    const amount = '2000000'
+    const amount = '2.0'
 
     it('shows the balance in Eth to two decimal places', () => {
       renderIt({
@@ -121,7 +111,7 @@ describe('BalanceProvider Component', () => {
   })
 
   describe('when the balance would round up', () => {
-    const amount = '1998887'
+    const amount = '1.9989816877'
 
     it('shows the balance in Eth without rounding up', () => {
       renderIt({
@@ -134,7 +124,7 @@ describe('BalanceProvider Component', () => {
   })
 
   describe('when the balance converts to > $1000 ', () => {
-    const amount = '20000000'
+    const amount = '20'
 
     it('shows the balance in dollars in locale format without decimal', () => {
       renderIt({
@@ -148,7 +138,7 @@ describe('BalanceProvider Component', () => {
   })
 
   describe('when the balance converts to > $100k ', () => {
-    const amount = '2000000000'
+    const amount = '2000'
 
     it('shows the balance in thousands of dollars postfixed with k', () => {
       renderIt({
@@ -162,7 +152,7 @@ describe('BalanceProvider Component', () => {
   })
 
   describe('when the balance converts to > $1m ', () => {
-    const amount = '20000000000'
+    const amount = '20000'
 
     it('shows the balance in millions of dollars postfixed with m', () => {
       renderIt({
@@ -176,7 +166,7 @@ describe('BalanceProvider Component', () => {
   })
 
   describe('when the balance converts to > $1b ', () => {
-    const amount = '20000000000000'
+    const amount = '20000000'
 
     it('shows the balance in billions of dollars postfixed with b', () => {
       renderIt({

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -56,7 +56,7 @@ describe('Overlay', () => {
     const lock = {
       name: 'Monthly',
       address: '0xdeadbeef',
-      keyPrice: '100000000000000000000000',
+      keyPrice: '100000',
       expirationDuration: 123456789,
     }
     let store

--- a/unlock-app/src/__tests__/pages/pages.test.js
+++ b/unlock-app/src/__tests__/pages/pages.test.js
@@ -50,7 +50,7 @@ describe('Pages', () => {
       const account = {
         address: '0xabc',
         privateKey: 'deadbeef',
-        balance: '200000000000000000',
+        balance: '200',
       }
       rtl.render(
         <Provider store={store}>

--- a/unlock-app/src/__tests__/reducers/accountReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/accountReducer.test.js
@@ -6,7 +6,7 @@ import { SET_NETWORK } from '../../actions/network'
 describe('account reducer', () => {
   const account = {
     address: '0xdeadbeaf',
-    balance: 0,
+    balance: '0',
   }
 
   it('should return the initial state', () => {
@@ -39,7 +39,7 @@ describe('account reducer', () => {
 
   it('should update an account accordingly when receiving UPDATE_ACCOUNT', () => {
     const update = {
-      balance: 1337,
+      balance: '1337',
     }
     expect(
       reducer(account, {
@@ -48,7 +48,7 @@ describe('account reducer', () => {
       })
     ).toEqual({
       address: account.address,
-      balance: 1337,
+      balance: '1337',
     })
   })
 })

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -316,10 +316,12 @@ describe('Web3Service', () => {
             done()
           })
 
+          const inWei = Web3Utils.hexToNumberString('0xdeadbeef')
+
           web3Service.on('account.changed', account => {
             expect(account).toEqual({
               address: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
-              balance: '3735928559',
+              balance: Web3Utils.fromWei(inWei, 'ether'),
             })
           })
 
@@ -365,7 +367,7 @@ describe('Web3Service', () => {
             balance: '123',
           }
           getBalanceForAccountAndYieldBalance(account.address, '0xdeadbeef')
-
+          const inWei = Web3Utils.hexToNumberString('0xdeadbeef')
           web3Service.once('ready', () => {
             expect(web3Service.ready).toBe(true)
             done()
@@ -374,7 +376,7 @@ describe('Web3Service', () => {
           web3Service.on('account.changed', account => {
             expect(account).toEqual({
               address: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
-              balance: '3735928559',
+              balance: Web3Utils.fromWei(inWei, 'ether'),
             })
           })
 
@@ -649,10 +651,12 @@ describe('Web3Service', () => {
     describe('getAddressBalance', () => {
       it('should return the balance of the address', () => {
         expect.assertions(1)
+        const balance = '0xdeadbeef'
+        const inWei = Web3Utils.hexToNumberString(balance)
         const address = '0x1df62f291b2e969fb0849d99d9ce41e2f137006e'
         getBalanceForAccountAndYieldBalance(address, '0xdeadbeef')
         return web3Service.getAddressBalance(address).then(balance => {
-          expect(balance).toEqual(Web3Utils.hexToNumberString('0xdeadbeef'))
+          expect(balance).toEqual(Web3Utils.fromWei(inWei, 'ether'))
         })
       })
     })
@@ -691,8 +695,8 @@ describe('Web3Service', () => {
         web3Service.on('lock.updated', (address, update) => {
           expect(address).toBe(lockAddress)
           expect(update).toMatchObject({
-            balance: '3735944941',
-            keyPrice: '10000000000000000',
+            balance: Web3Utils.fromWei('3735944941', 'ether'),
+            keyPrice: Web3Utils.fromWei('10000000000000000', 'ether'),
             expirationDuration: 2592000,
             maxNumberOfKeys: 10,
             owner: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
@@ -1023,12 +1027,12 @@ describe('Web3Service', () => {
 
         getBalanceForAccountAndYieldBalance(
           '0x07748403082b29a45abD6C124A37E6B14e6B1803',
-          '0x1000'
+          '0x0'
         )
 
         return web3Service.createAccount().then(account => {
           expect(account).toMatchObject({
-            balance: '4096',
+            balance: '0',
             address: '0x07748403082b29a45abD6C124A37E6B14e6B1803',
           })
           web3Service.web3.eth.accounts.create = previousCreate
@@ -1044,7 +1048,7 @@ describe('Web3Service', () => {
         lock = {
           address: '0xadd',
           expirationDuration: 86400, // 1 day
-          keyPrice: '100000000000000000', // 0.1 Eth
+          keyPrice: '0.1', // 0.1 Eth
           maxNumberOfKeys: 100,
         }
         owner = {
@@ -1106,7 +1110,7 @@ describe('Web3Service', () => {
         lock = {
           address: '0x3ca206264762caf81a8f0a843bbb850987b41e16',
           expirationDuration: 86400, // 1 day
-          keyPrice: '100000000000000000', // 0.1 Eth
+          keyPrice: '0.1', // 0.1 Eth
           maxNumberOfKeys: 100,
         }
         owner = {
@@ -1151,7 +1155,7 @@ describe('Web3Service', () => {
             from: owner.address,
             data: expect.any(String), // encoded purchaseKey data
             gas: 1000000,
-            value: lock.keyPrice,
+            value: Web3Utils.toWei(lock.keyPrice, 'ether'),
             contractAbi: expect.any(Array), // abi...
           },
           expect.any(Function)
@@ -1193,7 +1197,7 @@ describe('Web3Service', () => {
         lock = {
           address: '0xbE9437f7D6A119c81609A93B724507156E62a84d',
           expirationDuration: 86400, // 1 day
-          keyPrice: '100000000000000000', // 0.1 Eth
+          keyPrice: '0.1', // 0.1 Eth
           maxNumberOfKeys: 100,
         }
         account = {
@@ -1246,7 +1250,7 @@ describe('Web3Service', () => {
         lock = {
           address: '0x3ca206264762caf81a8f0a843bbb850987b41e16',
           expirationDuration: 86400, // 1 day
-          keyPrice: '100000000000000000', // 0.1 Eth
+          keyPrice: '0.1', // 0.1 Eth
           maxNumberOfKeys: 100,
         }
         account = {

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -4133,14 +4133,14 @@ Object {
             <div
               class="c4"
             >
-              1.20
+              1203120301203013120.00
                ETH
             </div>
             <div
               class="c5"
             >
               $
-              235.80
+              235,799,547,832.8b
             </div>
           </div>
           <div
@@ -4183,14 +4183,14 @@ Object {
           <div
             class="sc-1ws9jnj-4 fAXDZN"
           >
-            1.20
+            1203120301203013120.00
              ETH
           </div>
           <div
             class="sc-1ws9jnj-4 gjtfkI"
           >
             $
-            235.80
+            235,799,547,832.8b
           </div>
         </div>
         <div
@@ -13462,7 +13462,7 @@ Object {
                 <span
                   class="c10"
                 >
-                  0.2
+                  200.00
                 </span>
               </span>
               
@@ -13605,7 +13605,7 @@ Object {
               <span
                 class="buwkmd-5 dKpFcq"
               >
-                0.2
+                200.00
               </span>
             </span>
             
@@ -14405,7 +14405,7 @@ Object {
             <span
               class="c7"
             >
-              10.00
+              10000000000000000000.00
             </span>
           </span>
           <div
@@ -14420,7 +14420,7 @@ Object {
               <span
                 class="c7"
               >
-                1,960
+                1,959,900,000,000b
               </span>
             </span>
           </div>
@@ -14623,7 +14623,7 @@ Object {
           <span
             class="buwkmd-5 dKpFcq"
           >
-            10.00
+            10000000000000000000.00
           </span>
         </span>
         <div
@@ -14638,7 +14638,7 @@ Object {
             <span
               class="buwkmd-5 dKpFcq"
             >
-              1,960
+              1,959,900,000,000b
             </span>
           </span>
         </div>
@@ -15091,7 +15091,7 @@ Object {
             <span
               class="c7"
             >
-              10.00
+              10000000000000000000.00
             </span>
           </span>
           <div
@@ -15106,7 +15106,7 @@ Object {
               <span
                 class="c7"
               >
-                1,960
+                1,959,900,000,000b
               </span>
             </span>
           </div>
@@ -15374,7 +15374,7 @@ Object {
           <span
             class="buwkmd-5 dKpFcq"
           >
-            10.00
+            10000000000000000000.00
           </span>
         </span>
         <div
@@ -15389,7 +15389,7 @@ Object {
             <span
               class="buwkmd-5 dKpFcq"
             >
-              1,960
+              1,959,900,000,000b
             </span>
           </span>
         </div>
@@ -15907,7 +15907,7 @@ Object {
             <span
               class="c7"
             >
-              10.00
+              10000000000000000000.00
             </span>
           </span>
           <div
@@ -15922,7 +15922,7 @@ Object {
               <span
                 class="c7"
               >
-                1,960
+                1,959,900,000,000b
               </span>
             </span>
           </div>
@@ -16190,7 +16190,7 @@ Object {
           <span
             class="buwkmd-5 dKpFcq"
           >
-            10.00
+            10000000000000000000.00
           </span>
         </span>
         <div
@@ -16205,7 +16205,7 @@ Object {
             <span
               class="buwkmd-5 dKpFcq"
             >
-              1,960
+              1,959,900,000,000b
             </span>
           </span>
         </div>
@@ -16691,7 +16691,7 @@ Object {
             <span
               class="c7"
             >
-              10.00
+              10000000000000000000.00
             </span>
           </span>
           <div
@@ -16706,7 +16706,7 @@ Object {
               <span
                 class="c7"
               >
-                1,960
+                1,959,900,000,000b
               </span>
             </span>
           </div>
@@ -16905,7 +16905,7 @@ Object {
           <span
             class="buwkmd-5 dKpFcq"
           >
-            10.00
+            10000000000000000000.00
           </span>
         </span>
         <div
@@ -16920,7 +16920,7 @@ Object {
             <span
               class="buwkmd-5 dKpFcq"
             >
-              1,960
+              1,959,900,000,000b
             </span>
           </span>
         </div>
@@ -17369,7 +17369,7 @@ Object {
             <span
               class="c7"
             >
-              10.00
+              10000000000000000000.00
             </span>
           </span>
           <div
@@ -17384,7 +17384,7 @@ Object {
               <span
                 class="c7"
               >
-                1,960
+                1,959,900,000,000b
               </span>
             </span>
           </div>
@@ -17652,7 +17652,7 @@ Object {
           <span
             class="buwkmd-5 dKpFcq"
           >
-            10.00
+            10000000000000000000.00
           </span>
         </span>
         <div
@@ -17667,7 +17667,7 @@ Object {
             <span
               class="buwkmd-5 dKpFcq"
             >
-              1,960
+              1,959,900,000,000b
             </span>
           </span>
         </div>
@@ -18211,7 +18211,7 @@ Object {
             <span
               class="c7"
             >
-              10.00
+              10000000000000000000.00
             </span>
           </span>
           <div
@@ -18226,7 +18226,7 @@ Object {
               <span
                 class="c7"
               >
-                1,960
+                1,959,900,000,000b
               </span>
             </span>
           </div>
@@ -18491,7 +18491,7 @@ Object {
           <span
             class="buwkmd-5 dKpFcq"
           >
-            10.00
+            10000000000000000000.00
           </span>
         </span>
         <div
@@ -18506,7 +18506,7 @@ Object {
             <span
               class="buwkmd-5 dKpFcq"
             >
-              1,960
+              1,959,900,000,000b
             </span>
           </span>
         </div>
@@ -19021,7 +19021,7 @@ Object {
             <span
               class="c7"
             >
-              10.00
+              10000000000000000000.00
             </span>
           </span>
           <div
@@ -19036,7 +19036,7 @@ Object {
               <span
                 class="c7"
               >
-                1,960
+                1,959,900,000,000b
               </span>
             </span>
           </div>
@@ -19309,7 +19309,7 @@ Object {
           <span
             class="buwkmd-5 dKpFcq"
           >
-            10.00
+            10000000000000000000.00
           </span>
         </span>
         <div
@@ -19324,7 +19324,7 @@ Object {
             <span
               class="buwkmd-5 dKpFcq"
             >
-              1,960
+              1,959,900,000,000b
             </span>
           </span>
         </div>
@@ -20362,7 +20362,7 @@ Object {
             required=""
             step="0.00001"
             type="number"
-            value="10"
+            value="10000000000000000000"
           />
         </span>
         <div>
@@ -20515,7 +20515,7 @@ Object {
           required=""
           step="0.00001"
           type="number"
-          value="10"
+          value="10000000000000000000"
         />
       </span>
       <div>
@@ -25313,7 +25313,7 @@ Object {
                   <span
                     class="c23"
                   >
-                    0.027
+                    27000000000000000.00
                   </span>
                 </span>
                 <div
@@ -25524,7 +25524,7 @@ Object {
                   <span
                     class="c23"
                   >
-                    10.00
+                    10000000000000000000.00
                   </span>
                 </span>
                 <div
@@ -25735,7 +25735,7 @@ Object {
                   <span
                     class="c23"
                   >
-                    0.027
+                    27000000000000000.00
                   </span>
                 </span>
                 <div
@@ -26376,7 +26376,7 @@ Object {
                 <span
                   class="buwkmd-5 dKpFcq"
                 >
-                  0.027
+                  27000000000000000.00
                 </span>
               </span>
               <div
@@ -26587,7 +26587,7 @@ Object {
                 <span
                   class="buwkmd-5 dKpFcq"
                 >
-                  10.00
+                  10000000000000000000.00
                 </span>
               </span>
               <div
@@ -26798,7 +26798,7 @@ Object {
                 <span
                   class="buwkmd-5 dKpFcq"
                 >
-                  0.027
+                  27000000000000000.00
                 </span>
               </span>
               <div
@@ -36289,7 +36289,7 @@ Object {
             <div
               class="c3"
             >
-              1.20
+              1203120301203013120.00
                Eth
             </div>
             <div>
@@ -36297,7 +36297,7 @@ Object {
                 class="c4"
               >
                 $
-                235.80
+                235,799,547,832.8b
               </span>
               <span
                 class="c5"
@@ -36343,7 +36343,7 @@ Object {
           <div
             class="yqqxp4-3 kxjMda"
           >
-            1.20
+            1203120301203013120.00
              Eth
           </div>
           <div>
@@ -36351,7 +36351,7 @@ Object {
               class="yqqxp4-4 fcTWoc"
             >
               $
-              235.80
+              235,799,547,832.8b
             </span>
             <span
               class="yqqxp4-6 gEUJdZ"
@@ -36554,7 +36554,7 @@ Object {
             <div
               class="c3"
             >
-              1.20
+              1203120301203013120.00
                Eth
             </div>
             <div>
@@ -36562,7 +36562,7 @@ Object {
                 class="c4"
               >
                 $
-                235.80
+                235,799,547,832.8b
               </span>
               <span
                 class="c5"
@@ -36608,7 +36608,7 @@ Object {
           <div
             class="yqqxp4-3 kxjMda"
           >
-            1.20
+            1203120301203013120.00
              Eth
           </div>
           <div>
@@ -36616,7 +36616,7 @@ Object {
               class="yqqxp4-4 fcTWoc"
             >
               $
-              235.80
+              235,799,547,832.8b
             </span>
             <span
               class="yqqxp4-6 gEUJdZ"
@@ -36818,7 +36818,7 @@ Object {
             <div
               class="c3"
             >
-              1.20
+              1203120301203013120.00
                Eth
             </div>
             <div>
@@ -36826,7 +36826,7 @@ Object {
                 class="c4"
               >
                 $
-                235.80
+                235,799,547,832.8b
               </span>
               <span
                 class="c5"
@@ -36871,7 +36871,7 @@ Object {
           <div
             class="yqqxp4-3 kxjMda"
           >
-            1.20
+            1203120301203013120.00
              Eth
           </div>
           <div>
@@ -36879,7 +36879,7 @@ Object {
               class="yqqxp4-4 fcTWoc"
             >
               $
-              235.80
+              235,799,547,832.8b
             </span>
             <span
               class="yqqxp4-6 gEUJdZ"
@@ -37114,14 +37114,14 @@ Object {
             <div
               class="c4"
             >
-              1.20
+              1203120301203013120.00
                ETH
             </div>
             <div
               class="c5"
             >
               $
-              235.80
+              235,799,547,832.8b
             </div>
           </div>
           <div
@@ -37164,14 +37164,14 @@ Object {
           <div
             class="sc-1ws9jnj-4 fAXDZN"
           >
-            1.20
+            1203120301203013120.00
              ETH
           </div>
           <div
             class="sc-1ws9jnj-4 gjtfkI"
           >
             $
-            235.80
+            235,799,547,832.8b
           </div>
         </div>
         <div
@@ -37509,14 +37509,14 @@ Object {
             <div
               class="c4"
             >
-              1.20
+              1203120301203013120.00
                ETH
             </div>
             <div
               class="c5"
             >
               $
-              235.80
+              235,799,547,832.8b
             </div>
           </div>
           <a
@@ -37582,14 +37582,14 @@ Object {
           <div
             class="sc-1ws9jnj-4 fAXDZN"
           >
-            1.20
+            1203120301203013120.00
              ETH
           </div>
           <div
             class="sc-1ws9jnj-4 gjtfkI"
           >
             $
-            235.80
+            235,799,547,832.8b
           </div>
         </div>
         <a
@@ -37843,14 +37843,14 @@ Object {
             <div
               class="c4"
             >
-              1.20
+              1203120301203013120.00
                ETH
             </div>
             <div
               class="c5"
             >
               $
-              235.80
+              235,799,547,832.8b
             </div>
           </div>
           <div
@@ -37889,14 +37889,14 @@ Object {
           <div
             class="sc-1ws9jnj-4 fAXDZN"
           >
-            1.20
+            1203120301203013120.00
              ETH
           </div>
           <div
             class="sc-1ws9jnj-4 gjtfkI"
           >
             $
-            235.80
+            235,799,547,832.8b
           </div>
         </div>
         <div
@@ -38090,7 +38090,7 @@ Object {
             <div
               class="c3"
             >
-              1.20
+              1203120301203013120.00
                Eth
             </div>
             <div>
@@ -38098,7 +38098,7 @@ Object {
                 class="c4"
               >
                 $
-                235.80
+                235,799,547,832.8b
               </span>
               <span
                 class="c5"
@@ -38143,7 +38143,7 @@ Object {
           <div
             class="yqqxp4-3 kxjMda"
           >
-            1.20
+            1203120301203013120.00
              Eth
           </div>
           <div>
@@ -38151,7 +38151,7 @@ Object {
               class="yqqxp4-4 fcTWoc"
             >
               $
-              235.80
+              235,799,547,832.8b
             </span>
             <span
               class="yqqxp4-6 gEUJdZ"
@@ -38353,7 +38353,7 @@ Object {
             <div
               class="c3"
             >
-              1.20
+              1203120301203013120.00
                Eth
             </div>
             <div>
@@ -38361,7 +38361,7 @@ Object {
                 class="c4"
               >
                 $
-                235.80
+                235,799,547,832.8b
               </span>
               <span
                 class="c5"
@@ -38406,7 +38406,7 @@ Object {
           <div
             class="yqqxp4-3 kxjMda"
           >
-            1.20
+            1203120301203013120.00
              Eth
           </div>
           <div>
@@ -38414,7 +38414,7 @@ Object {
               class="yqqxp4-4 fcTWoc"
             >
               $
-              235.80
+              235,799,547,832.8b
             </span>
             <span
               class="yqqxp4-6 gEUJdZ"
@@ -39761,7 +39761,7 @@ Object {
                     <div
                       class="c7"
                     >
-                      0.12
+                      123400000000000000.00
                        Eth
                     </div>
                     <div>
@@ -39769,7 +39769,7 @@ Object {
                         class="c8"
                       >
                         $
-                        24.19
+                        24,185,166,000b
                       </span>
                       <span
                         class="c9"
@@ -39902,7 +39902,7 @@ Object {
                   <div
                     class="yqqxp4-3 kxjMda"
                   >
-                    0.12
+                    123400000000000000.00
                      Eth
                   </div>
                   <div>
@@ -39910,7 +39910,7 @@ Object {
                       class="yqqxp4-4 fcTWoc"
                     >
                       $
-                      24.19
+                      24,185,166,000b
                     </span>
                     <span
                       class="yqqxp4-6 gEUJdZ"
@@ -40755,7 +40755,7 @@ Object {
                     <div
                       class="c7"
                     >
-                      0.01
+                      10000000000000000.00
                        Eth
                     </div>
                     <div>
@@ -40763,7 +40763,7 @@ Object {
                         class="c8"
                       >
                         $
-                        1.96
+                        1,959,900,000b
                       </span>
                       <span
                         class="c9"
@@ -40801,7 +40801,7 @@ Object {
                     <div
                       class="c7"
                     >
-                      0.1
+                      100000000000000000.00
                        Eth
                     </div>
                     <div>
@@ -40809,7 +40809,7 @@ Object {
                         class="c8"
                       >
                         $
-                        19.60
+                        19,599,000,000b
                       </span>
                       <span
                         class="c9"
@@ -40942,7 +40942,7 @@ Object {
                   <div
                     class="yqqxp4-3 kxjMda"
                   >
-                    0.01
+                    10000000000000000.00
                      Eth
                   </div>
                   <div>
@@ -40950,7 +40950,7 @@ Object {
                       class="yqqxp4-4 fcTWoc"
                     >
                       $
-                      1.96
+                      1,959,900,000b
                     </span>
                     <span
                       class="yqqxp4-6 gEUJdZ"
@@ -40988,7 +40988,7 @@ Object {
                   <div
                     class="yqqxp4-3 kxjMda"
                   >
-                    0.1
+                    100000000000000000.00
                      Eth
                   </div>
                   <div>
@@ -40996,7 +40996,7 @@ Object {
                       class="yqqxp4-4 fcTWoc"
                     >
                       $
-                      19.60
+                      19,599,000,000b
                     </span>
                     <span
                       class="yqqxp4-6 gEUJdZ"
@@ -43345,14 +43345,14 @@ Object {
             <div
               class="c4"
             >
-              1.20
+              1203120301203013120.00
                ETH
             </div>
             <div
               class="c5"
             >
               $
-              235.80
+              235,799,547,832.8b
             </div>
           </div>
           <div
@@ -43391,14 +43391,14 @@ Object {
           <div
             class="sc-1ws9jnj-4 fAXDZN"
           >
-            1.20
+            1203120301203013120.00
              ETH
           </div>
           <div
             class="sc-1ws9jnj-4 gjtfkI"
           >
             $
-            235.80
+            235,799,547,832.8b
           </div>
         </div>
         <div

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
-import Web3Utils from 'web3-utils'
 import { connect } from 'react-redux'
 import uniqid from 'uniqid'
 import UnlockPropTypes from '../../propTypes'
@@ -45,8 +44,6 @@ export class CreatorLockForm extends React.Component {
     try {
       if (!keyPrice.match(/^[0-9]+$/)) {
         keyPrice = props.keyPrice
-      } else {
-        keyPrice = Web3Utils.fromWei(keyPrice, props.keyPriceCurrency)
       }
     } catch (e) {
       // silently ignore invalid value, leave as what the original was
@@ -72,7 +69,6 @@ export class CreatorLockForm extends React.Component {
       expirationDuration: expirationDuration,
       expirationDurationUnit: props.expirationDurationUnit, // Days
       keyPrice: keyPrice,
-      keyPriceCurrency: props.keyPriceCurrency,
       maxNumberOfKeys,
       unlimitedKeys: maxNumberOfKeys === INFINITY,
       name: props.name,
@@ -104,7 +100,6 @@ export class CreatorLockForm extends React.Component {
       'expirationDuration',
       //'expirationDurationUnit',
       'keyPrice',
-      //'keyPriceCurrency',
       'maxNumberOfKeys',
       'name',
     ].reduce((fieldValidity, field) => {
@@ -155,7 +150,6 @@ export class CreatorLockForm extends React.Component {
     const {
       expirationDuration,
       expirationDurationUnit,
-      keyPriceCurrency,
       maxNumberOfKeys,
       unlimitedKeys,
       keyPrice,
@@ -167,7 +161,7 @@ export class CreatorLockForm extends React.Component {
       address: address,
       name: name,
       expirationDuration: expirationDuration * expirationDurationUnit,
-      keyPrice: Web3Utils.toWei(keyPrice.toString(10), keyPriceCurrency),
+      keyPrice: keyPrice.toString(10), // In Eth
       maxNumberOfKeys: unlimitedKeys ? UNLIMITED_KEYS_COUNT : maxNumberOfKeys,
       owner: account.address,
     }
@@ -320,7 +314,6 @@ CreatorLockForm.propTypes = {
   expirationDuration: PropTypes.number,
   expirationDurationUnit: PropTypes.number,
   keyPrice: PropTypes.string,
-  keyPriceCurrency: PropTypes.string,
   maxNumberOfKeys: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), // string is for '∞'
   name: PropTypes.string,
   address: PropTypes.string,
@@ -330,8 +323,7 @@ CreatorLockForm.propTypes = {
 CreatorLockForm.defaultProps = {
   expirationDuration: 30 * 86400,
   expirationDurationUnit: 86400, // Days
-  keyPrice: '10000000000000000',
-  keyPriceCurrency: 'ether',
+  keyPrice: '0.01',
   maxNumberOfKeys: 10,
   name: 'New Lock',
   address: uniqid(), // for new locks, we don't have an address, so use a temporary one

--- a/unlock-app/src/components/helpers/Balance.js
+++ b/unlock-app/src/components/helpers/Balance.js
@@ -8,13 +8,11 @@ import BalanceProvider from './BalanceProvider'
  * Component which shows a balance in Eth using default styles.
  * use the BalanceProvider
  * @param {*} amount: the amount to convert to Eth
- * @param {string} unit: the unit of the amount to convert to Eth
  * @param {boolean} convertCurrency: show the converted value
  */
-export const Balance = ({ amount, unit, convertCurrency }) => (
+export const Balance = ({ amount, convertCurrency }) => (
   <BalanceProvider
     amount={amount}
-    unit={unit}
     render={(ethWithPresentation, convertedUSDValue) => (
       <BalanceWithConversion>
         <Currency>
@@ -38,13 +36,11 @@ export const Balance = ({ amount, unit, convertCurrency }) => (
 
 Balance.propTypes = {
   amount: PropTypes.string,
-  unit: PropTypes.string,
   convertCurrency: PropTypes.bool,
 }
 
 Balance.defaultProps = {
   amount: null,
-  unit: 'wei',
   convertCurrency: true,
 }
 

--- a/unlock-app/src/components/helpers/BalanceProvider.js
+++ b/unlock-app/src/components/helpers/BalanceProvider.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import Web3Utils from 'web3-utils'
 import { connect } from 'react-redux'
 
 import UnlockPropTypes from '../../propTypes'
@@ -8,18 +7,13 @@ import { formatEth, formatCurrency } from '../../selectors/currency'
 /**
  * Render props component which computes the data required to display balance.
  * This is useful to display balance in different ways.
+ * amount is always in eth
  */
-export const BalanceProvider = ({ amount, unit, conversion, render }) => {
+export const BalanceProvider = ({ amount, conversion, render }) => {
   if (typeof amount === 'undefined' || amount === null) {
     return render(' - ', ' - ') || null
   }
-  let currency
-  if (unit !== 'dollars' && unit !== 'eth') {
-    const inWei = Web3Utils.toWei(amount || '0', unit)
-    currency = Web3Utils.fromWei(inWei, 'ether')
-  } else {
-    currency = +amount
-  }
+  let currency = parseFloat(amount)
   const ethWithPresentation = formatEth(currency)
   let convertedUSDValue
   if (!conversion.USD) {
@@ -32,14 +26,12 @@ export const BalanceProvider = ({ amount, unit, conversion, render }) => {
 
 BalanceProvider.propTypes = {
   amount: PropTypes.string,
-  unit: PropTypes.string,
   conversion: UnlockPropTypes.conversion,
   convertCurrency: PropTypes.bool,
 }
 
 BalanceProvider.defaultProps = {
   amount: null,
-  unit: 'wei',
   conversion: { USD: undefined },
   convertCurrency: true,
 }

--- a/unlock-app/src/propTypes.js
+++ b/unlock-app/src/propTypes.js
@@ -6,17 +6,18 @@ export const address = PropTypes.string
 export const account = PropTypes.shape({
   address: address,
   privateKey: PropTypes.string,
-  balance: PropTypes.string, // Too big to be a number
+  balance: PropTypes.string, // Must be expressed in Eth!
 })
 
 export const lock = PropTypes.shape({
   address,
   name: PropTypes.string,
   expirationDuration: PropTypes.number,
-  keyPrice: PropTypes.string,
+  keyPrice: PropTypes.string, // Must be expressed in Eth!
   maxNumberOfKeys: PropTypes.number,
   owner: PropTypes.string,
   outstandingKeys: PropTypes.number,
+  balance: PropTypes.string, // Must be expressed in Eth!
 })
 
 export const transaction = PropTypes.shape({

--- a/unlock-app/src/stories/creator/CreatorAccount.stories.js
+++ b/unlock-app/src/stories/creator/CreatorAccount.stories.js
@@ -25,7 +25,7 @@ storiesOf('CreatorAccount', module)
   .add('With balance', () => {
     const account = {
       address: '0x3ca206264762caf81a8f0a843bbb850987b41e16',
-      balance: '200000000000000000',
+      balance: '200',
     }
     const network = {
       name: 4,

--- a/unlock-app/src/stories/interface/Buttons.stories.js
+++ b/unlock-app/src/stories/interface/Buttons.stories.js
@@ -18,7 +18,7 @@ storiesOf('Buttons/Lock Buttons', module)
   .add('Withdraw, positive balance', () => {
     const lock = {
       address: '0xabc',
-      balance: 1,
+      balance: '1',
     }
     return <Buttons.Withdraw lock={lock} />
   })

--- a/unlock-app/src/stories/lock/Lock.stories.js
+++ b/unlock-app/src/stories/lock/Lock.stories.js
@@ -141,7 +141,7 @@ storiesOf('Lock', module)
       name: 'Monthly',
       keyPrice: '1203120301203013000',
       fiatPrice: 240.38,
-      balance: 5,
+      balance: '5',
     }
     return (
       <Lock


### PR DESCRIPTION
We are now using eth as the way to represent prices and balances. We use Eth as a string for now.
All conversions to wei are done *inside* the web3 provider.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread