### PR TITLE
web3Service now passes the transaction hash rather than the transaction object for consistency and to make sure we stay immutable

### DIFF
--- a/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/lockMiddleware.test.js
@@ -110,6 +110,7 @@ beforeEach(() => {
     locks: {
       [lock.address]: lock,
     },
+    transactions: {},
     keys: {},
   }
 })
@@ -289,7 +290,7 @@ describe('Lock middleware', () => {
   it('it should handle transaction.updated events triggered by the web3Service', () => {
     const { store } = create()
     const update = {}
-    mockWeb3Service.emit('transaction.updated', transaction, update)
+    mockWeb3Service.emit('transaction.updated', transaction.hash, update)
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: UPDATE_TRANSACTION,
@@ -372,10 +373,18 @@ describe('Lock middleware', () => {
       expect.assertions(2)
       const { store } = create()
       const transaction = {
+        hash: '123',
         type: TRANSACTION_TYPES.LOCK_CREATION,
         lock: '0x123',
       }
-      mockWeb3Service.emit('error', { message: 'this was broken' }, transaction)
+      state.transactions = {
+        [transaction.hash]: transaction,
+      }
+      mockWeb3Service.emit(
+        'error',
+        { message: 'this was broken' },
+        transaction.hash
+      )
       expect(store.dispatch).toHaveBeenNthCalledWith(1, {
         type: DELETE_LOCK,
         address: transaction.lock,

--- a/unlock-app/src/middlewares/lockMiddleware.js
+++ b/unlock-app/src/middlewares/lockMiddleware.js
@@ -113,11 +113,12 @@ export default function lockMiddleware({ getState, dispatch }) {
     dispatch(addTransaction(transaction))
   })
 
-  web3Service.on('transaction.updated', (transaction, update) => {
-    dispatch(updateTransaction(transaction.hash, update))
+  web3Service.on('transaction.updated', (transactionHash, update) => {
+    dispatch(updateTransaction(transactionHash, update))
   })
 
-  web3Service.on('error', (error, transaction) => {
+  web3Service.on('error', (error, transactionHash) => {
+    const transaction = getState().transactions[transactionHash]
     if (transaction && transaction.type === TRANSACTION_TYPES.LOCK_CREATION) {
       // delete the lock
       dispatch(deleteLock(transaction.lock))


### PR DESCRIPTION
This is a part of a large refactor of web3Service which brings better consistency in the API and eventually
a break-down as explained in #1225


- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)