### PR TITLE
await on Truffle Promise

### DIFF
--- a/smart-contracts/test/helpers/deployLocks.js
+++ b/smart-contracts/test/helpers/deployLocks.js
@@ -10,10 +10,10 @@ module.exports = function deployLocks (unlock) {
         Locks[name].expirationDuration,
         Locks[name].keyPrice,
         Locks[name].maxNumberOfKeys
-      ).then((tx) => {
+      ).then(async (tx) => {
         // THIS API IS LIKELY TO BREAK BECAUSE IT ASSUMES SO MUCH
         const evt = tx.logs[0]
-        locks[name] = PublicLock.at(evt.args.newLockAddress)
+        locks[name] = await PublicLock.at(evt.args.newLockAddress)
         locks[name].params = Locks[name]
       })
     })


### PR DESCRIPTION
# Description

Getting a contract via Truffle uses a promise: https://truffleframework.com/docs/truffle/getting-started/interacting-with-your-contracts#use-a-contract-at-a-specific-address

With older versions (like we are on now) of Truffle, `await` here was optional.  Once we upgrade, this will be required so this is a pre-req for https://github.com/unlock-protocol/unlock/issues/1078

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
