### PR TITLE
Switch address from number to hex

### DIFF
--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -1,4 +1,6 @@
 const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+
 const deployLocks = require('../../helpers/deployLocks')
 const Unlock = artifacts.require('../../Unlock.sol')
 
@@ -19,7 +21,7 @@ contract('Lock ERC721', (accounts) => {
   describe('balanceOf', () => {
     it('should fail if the user address is 0', () => {
       return locks['FIRST']
-        .balanceOf('0x0000000000000000000000000000000000000000')
+        .balanceOf(Web3Utils.padLeft(0, 40))
         .then(balance => {
           assert(false)
         })

--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -19,7 +19,7 @@ contract('Lock ERC721', (accounts) => {
   describe('balanceOf', () => {
     it('should fail if the user address is 0', () => {
       return locks['FIRST']
-        .balanceOf(0)
+        .balanceOf('0x0000000000000000000000000000000000000000')
         .then(balance => {
           assert(false)
         })


### PR DESCRIPTION
# Description

Changing `0` to a valid address using Web3Utils.

With older versions (like we are on now) of Truffle, using either number or hex here worked. Once we upgrade, this will be required so this is a pre-req for #1078

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
