### PR TITLE
Change use of `requiredNetwork` to `requiredNetworkId`

### DIFF
--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -94,7 +94,7 @@ describe('GlobalErrorConsumer', () => {
           value={{
             error: FATAL_WRONG_NETWORK,
             errorMetadata: {
-              requiredNetwork: 'CBS',
+              requiredNetworkId: 2,
               currentNetwork: 'Fox News',
             },
           }}
@@ -181,7 +181,7 @@ describe('GlobalErrorConsumer', () => {
             value={{
               error: FATAL_WRONG_NETWORK,
               errorMetadata: {
-                requiredNetwork: 'CBS',
+                requiredNetworkId: 1984,
                 currentNetwork: 'Fox News',
               },
             }}

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -25274,7 +25274,7 @@ Object {
                 Network mismatch
               </h1>
               <p>
-                You’re currently on the Rinkeby network but you need to be on the Dev network. Please switch to Dev.
+                You’re currently on the Rinkeby network but you need to be on the Winston network. Please switch to Winston.
               </p>
             </div>
           </section>
@@ -25467,7 +25467,7 @@ Object {
               Network mismatch
             </h1>
             <p>
-              You’re currently on the Rinkeby network but you need to be on the Dev network. Please switch to Dev.
+              You’re currently on the Rinkeby network but you need to be on the Winston network. Please switch to Winston.
             </p>
           </div>
         </section>
@@ -29620,7 +29620,7 @@ Object {
             Network mismatch
           </h1>
           <p>
-            You’re currently on the main network but you need to be on the rinkeby network. Please switch to rinkeby.
+            You’re currently on the Mainnet network but you need to be on the Rinkeby network. Please switch to Rinkeby.
           </p>
         </div>
       </section>
@@ -29645,7 +29645,7 @@ Object {
           Network mismatch
         </h1>
         <p>
-          You’re currently on the main network but you need to be on the rinkeby network. Please switch to rinkeby.
+          You’re currently on the Mainnet network but you need to be on the Rinkeby network. Please switch to Rinkeby.
         </p>
       </div>
     </section>

--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
@@ -80,7 +80,7 @@ describe('GlobalErrorProvider', () => {
       expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent(
         JSON.stringify({
           currentNetwork: 'Mainnet',
-          requiredNetwork: 'Dev',
+          requiredNetworkId: 1984,
         })
       )
     })
@@ -106,7 +106,7 @@ describe('GlobalErrorProvider', () => {
       expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent(
         JSON.stringify({
           currentNetwork: 'Rinkeby',
-          requiredNetwork: 'Dev',
+          requiredNetworkId: 1984,
         })
       )
     })
@@ -132,7 +132,7 @@ describe('GlobalErrorProvider', () => {
       expect(wrapper.getByTestId('errorMetadata')).toHaveTextContent(
         JSON.stringify({
           currentNetwork: 'Unknown Network',
-          requiredNetwork: 'Dev',
+          requiredNetworkId: 1984,
         })
       )
     })

--- a/unlock-app/src/components/creator/FatalError.js
+++ b/unlock-app/src/components/creator/FatalError.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 
 import React from 'react'
 import styled from 'styled-components'
+import { ETHEREUM_NETWORKS_NAMES } from '../../constants'
 
 const defaultError = (
   <p>
@@ -76,20 +77,24 @@ const Message = styled.div`
   }
 `
 
-export const WrongNetwork = ({ currentNetwork, requiredNetwork }) => (
+export const WrongNetwork = ({ currentNetwork, requiredNetworkId }) => (
   <DefaultError
     title="Network mismatch"
     illustration="/static/images/illustrations/network.svg"
   >
     <p>
-      {`You’re currently on the ${currentNetwork} network but you need to be on the ${requiredNetwork} network. Please switch to ${requiredNetwork}.`}
+      {`You’re currently on the ${currentNetwork} network but you need to be on the ${
+        ETHEREUM_NETWORKS_NAMES[requiredNetworkId][0]
+      } network. Please switch to ${
+        ETHEREUM_NETWORKS_NAMES[requiredNetworkId][0]
+      }.`}
     </p>
   </DefaultError>
 )
 
 WrongNetwork.propTypes = {
   currentNetwork: PropTypes.string.isRequired,
-  requiredNetwork: PropTypes.string.isRequired,
+  requiredNetworkId: PropTypes.number.isRequired,
 }
 
 export const MissingProvider = () => (

--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -10,6 +10,7 @@ export const ETHEREUM_NETWORKS_NAMES = {
   2: ['Morden', 'staging'],
   3: ['Ropsten', 'staging'],
   4: ['Rinkeby', 'staging'],
+  1984: ['Winston', 'test'],
 }
 
 /**

--- a/unlock-app/src/stories/creator/FatalError.stories.js
+++ b/unlock-app/src/stories/creator/FatalError.stories.js
@@ -8,10 +8,7 @@ storiesOf('FatalError', module)
   })
   .add('Network mismatch', () => {
     return (
-      <FatalError.WrongNetwork
-        currentNetwork="main"
-        requiredNetwork="rinkeby"
-      />
+      <FatalError.WrongNetwork currentNetwork="Mainnet" requiredNetworkId={4} />
     )
   })
   .add('Wallet missing', () => {

--- a/unlock-app/src/utils/GlobalErrorProvider.js
+++ b/unlock-app/src/utils/GlobalErrorProvider.js
@@ -90,7 +90,7 @@ export class GlobalErrorProvider extends Component {
         error: FATAL_WRONG_NETWORK,
         errorMetadata: {
           currentNetwork: currentNetwork,
-          requiredNetwork: config.requiredNetwork,
+          requiredNetworkId: config.requiredNetworkId,
         },
       }
     }


### PR DESCRIPTION
# Description

This PR fixes #1239. Usage of the `requiredNetwork` property of `config` has been replaced with the use of `requiredNetworkId`

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
