### PR TITLE
Convert strings to hex

### DIFF
--- a/smart-contracts/test/Lock/Non_Public_purchaseFor.js
+++ b/smart-contracts/test/Lock/Non_Public_purchaseFor.js
@@ -23,7 +23,7 @@ contract('Lock', (accounts) => {
       it('should fail', () => {
         const lock = locks['PRIVATE']
         return lock
-          .purchaseFor(accounts[0], 'Julien')
+          .purchaseFor(accounts[0], Web3Utils.toHex('Julien'))
           .catch((error) => {
             assert.equal(error.message, 'VM Exception while processing transaction: revert')
             // Making sure we do not have a key set!
@@ -47,7 +47,7 @@ contract('Lock', (accounts) => {
 
     it('should fail if the sending account was not pre-approved', () => {
       return locks['RESTRICTED']
-        .purchaseFor(accounts[1], 'Satoshi', {
+        .purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
           value: Units.convert('0.01', 'eth', 'wei')
         })
         .then(() => {
@@ -65,7 +65,7 @@ contract('Lock', (accounts) => {
           from: owner
         })
         .then(() => {
-          locks['RESTRICTED'].purchaseFor(accounts[3], 'Szabo', {
+          locks['RESTRICTED'].purchaseFor(accounts[3], Web3Utils.toHex('Szabo'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
         })

--- a/smart-contracts/test/Lock/erc721/Non_Public_approve.js
+++ b/smart-contracts/test/Lock/erc721/Non_Public_approve.js
@@ -1,4 +1,3 @@
-
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
 
@@ -62,7 +61,7 @@ contract('Lock ERC721', (accounts) => {
           })
           .then(() => {
             // accounts[2] purchases a key
-            return locks['RESTRICTED'].purchaseFor(accounts[2], 'Julien', {
+            return locks['RESTRICTED'].purchaseFor(accounts[2], Web3Utils.toHex('Julien'), {
               value: locks['RESTRICTED'].params.keyPrice,
               from: accounts[2]
             })
@@ -108,7 +107,7 @@ contract('Lock ERC721', (accounts) => {
           })
           .then(() => {
             // accounts[5] purchases a key
-            return locks['RESTRICTED'].purchaseFor(accounts[5], 'Julien', {
+            return locks['RESTRICTED'].purchaseFor(accounts[5], Web3Utils.toHex('Julien'), {
               value: locks['RESTRICTED'].params.keyPrice,
               from: accounts[5]
             })
@@ -135,7 +134,7 @@ contract('Lock ERC721', (accounts) => {
           })
           .then(() => {
             // accounts[5] purchases a key
-            return locks['RESTRICTED'].purchaseFor(accounts[5], 'Julien', {
+            return locks['RESTRICTED'].purchaseFor(accounts[5], Web3Utils.toHex('Julien'), {
               value: locks['RESTRICTED'].params.keyPrice,
               from: accounts[5]
             })

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -34,7 +34,7 @@ contract('Lock ERC721', (accounts) => {
 
     describe('when the key exists', () => {
       before(() => {
-        return locks['FIRST'].purchaseFor(accounts[1], 'Satoshi', {
+        return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
           value: Units.convert('0.01', 'eth', 'wei'),
           from: accounts[1]
         })

--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -1,4 +1,6 @@
 const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+
 const deployLocks = require('../../helpers/deployLocks')
 const Unlock = artifacts.require('../../Unlock.sol')
 
@@ -37,7 +39,7 @@ contract('Lock ERC721', (accounts) => {
     })
 
     it('should return 1 if the user has a non expired key', () => {
-      return locks['FIRST'].purchaseFor(accounts[1], 'Satoshi', {
+      return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[1]
       }).then(() => {
@@ -48,7 +50,7 @@ contract('Lock ERC721', (accounts) => {
     })
 
     it('should return 1 if the user has an expired key', () => {
-      return locks['FIRST'].purchaseFor(accounts[5], 'Satoshi', {
+      return locks['FIRST'].purchaseFor(accounts[5], Web3Utils.toHex('Satoshi'), {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[5]
       }).then(() => {

--- a/smart-contracts/test/Lock/erc721/getTokenIdFor.js
+++ b/smart-contracts/test/Lock/erc721/getTokenIdFor.js
@@ -1,5 +1,5 @@
-
 const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
 const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../../helpers/deployLocks')
@@ -24,7 +24,7 @@ contract('Lock ERC721', (accounts) => {
     })
 
     it('should return the tokenId for the owner\'s key', async () => {
-      await locks['FIRST'].purchaseFor(accounts[1], 'Satoshi', {
+      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[1]
       })

--- a/smart-contracts/test/Lock/erc721/ownerOf.js
+++ b/smart-contracts/test/Lock/erc721/ownerOf.js
@@ -1,5 +1,5 @@
-
 const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
 
 const deployLocks = require('../../helpers/deployLocks')
 const Unlock = artifacts.require('../../Unlock.sol')
@@ -31,7 +31,7 @@ contract('Lock ERC721', (accounts) => {
     })
 
     it('should return the owner of the key', () => {
-      return locks['FIRST'].purchaseFor(accounts[1], 'Satoshi', {
+      return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[1]
       }).then(() => {

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -1,4 +1,3 @@
-
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
 
@@ -33,19 +32,19 @@ contract('Lock ERC721', (accounts) => {
 
     before(() => {
       return Promise.all([
-        locks['FIRST'].purchaseFor(accountWithKey, 'Satoshi', {
+        locks['FIRST'].purchaseFor(accountWithKey, Web3Utils.toHex('Satoshi'), {
           value: Units.convert('0.01', 'eth', 'wei'),
           from: accountWithKey
         }),
-        locks['FIRST'].purchaseFor(from, 'Julien', {
+        locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
           value: Units.convert('0.01', 'eth', 'wei'),
           from
         }),
-        locks['FIRST'].purchaseFor(accountWithExpiredKey, 'Finley', {
+        locks['FIRST'].purchaseFor(accountWithExpiredKey, Web3Utils.toHex('Finley'), {
           value: Units.convert('0.01', 'eth', 'wei'),
           from: accountWithExpiredKey
         }),
-        locks['FIRST'].purchaseFor(accountWithKeyApproved, 'Ben', {
+        locks['FIRST'].purchaseFor(accountWithKeyApproved, Web3Utils.toHex('Ben'), {
           value: Units.convert('0.01', 'eth', 'wei'),
           from: accountWithKeyApproved
         })
@@ -96,7 +95,7 @@ contract('Lock ERC721', (accounts) => {
         it('should transfer the key validity without extending it', () => {
           // First let's make sure from has a key!
           let fromExpirationTimestamp
-          return locks['FIRST'].purchaseFor(from, 'Julien', {
+          return locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
             value: Units.convert('0.01', 'eth', 'wei'),
             from
           }).then(() => {
@@ -120,7 +119,7 @@ contract('Lock ERC721', (accounts) => {
 
       describe('when the recipient already has a non expired key', () => {
         before(() => {
-          return locks['FIRST'].purchaseFor(from, 'Julien', {
+          return locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
             value: Units.convert('0.01', 'eth', 'wei'),
             from
           }).then(() => {
@@ -204,7 +203,7 @@ contract('Lock ERC721', (accounts) => {
       describe('when the key owner is the sender', () => {
         before(() => {
           // first, let's purchase a brand new key that we can transfer
-          return locks['FIRST'].purchaseFor(from, 'Julien', {
+          return locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
             value: Units.convert('0.01', 'eth', 'wei'),
             from
           }).then(() => {

--- a/smart-contracts/test/Lock/expireKeyFor.js
+++ b/smart-contracts/test/Lock/expireKeyFor.js
@@ -1,3 +1,5 @@
+const Web3Utils = require('web3-utils')
+
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
 
@@ -41,7 +43,7 @@ contract('Lock', (accounts) => {
     })
 
     it('should fail if the key has already expired', () => {
-      return locks['FIRST'].purchaseFor(accounts[2], 'Julien', {
+      return locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('Julien'), {
         value: locks['FIRST'].params.keyPrice,
         from: accounts[0]
       }).then(() => {
@@ -65,7 +67,7 @@ contract('Lock', (accounts) => {
     })
 
     it('should expire a valid key', () => {
-      return locks['FIRST'].purchaseFor(accounts[1], 'Julien', {
+      return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
         value: locks['FIRST'].params.keyPrice,
         from: accounts[0]
       }).then(() => {

--- a/smart-contracts/test/Lock/getOwnersByPage.js
+++ b/smart-contracts/test/Lock/getOwnersByPage.js
@@ -1,5 +1,6 @@
-
 const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
 
@@ -29,7 +30,7 @@ contract('Lock', (accounts) => {
 
     describe('when there are less owners than the page size', () => {
       it('should return all of the key owners', async () => {
-        await locks['FIRST'].purchaseFor(accounts[1], 'alpha', { value: Units.convert('0.01', 'eth', 'wei') })
+        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('alpha'), { value: Units.convert('0.01', 'eth', 'wei') })
         let result = await locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
         assert.equal(result.length, 1)
         assert.include(result, accounts[1])
@@ -38,15 +39,15 @@ contract('Lock', (accounts) => {
 
     describe('when there are more owners than the page size', () => {
       it('return page size number of key owners', async () => {
-        await locks['FIRST'].purchaseFor(accounts[1], 'alpha', {
+        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('alpha'), {
           value: Units.convert('0.01', 'eth', 'wei')
         })
 
-        await locks['FIRST'].purchaseFor(accounts[2], 'beta', {
+        await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('beta'), {
           value: Units.convert('0.01', 'eth', 'wei')
         })
 
-        await locks['FIRST'].purchaseFor(accounts[3], 'gamma', {
+        await locks['FIRST'].purchaseFor(accounts[3], Web3Utils.toHex('gamma'), {
           value: Units.convert('0.01', 'eth', 'wei')
         })
 
@@ -59,15 +60,15 @@ contract('Lock', (accounts) => {
 
     describe('when requesting a secondary page', () => {
       it('return page size number of key owners', async () => {
-        await locks['FIRST'].purchaseFor(accounts[1], 'alpha', {
+        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('alpha'), {
           value: Units.convert('0.01', 'eth', 'wei')
         })
 
-        await locks['FIRST'].purchaseFor(accounts[2], 'beta', {
+        await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('beta'), {
           value: Units.convert('0.01', 'eth', 'wei')
         })
 
-        await locks['FIRST'].purchaseFor(accounts[3], 'gamma', {
+        await locks['FIRST'].purchaseFor(accounts[3], Web3Utils.toHex('gamma'), {
           value: Units.convert('0.01', 'eth', 'wei')
         })
 

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -1,4 +1,3 @@
-
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
 
@@ -22,19 +21,19 @@ contract('Lock ERC721', (accounts) => {
     before(() => {
       // Purchase keys!
       return Promise.all([
-        lock.purchaseFor(accounts[1], 'Julien', {
+        lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
           value: lock.params.keyPrice,
           from: accounts[0]
         }),
-        lock.purchaseFor(accounts[2], 'Ben', {
+        lock.purchaseFor(accounts[2], Web3Utils.toHex('Ben'), {
           value: lock.params.keyPrice,
           from: accounts[0]
         }),
-        lock.purchaseFor(accounts[3], 'Satoshi', {
+        lock.purchaseFor(accounts[3], Web3Utils.toHex('Satoshi'), {
           value: lock.params.keyPrice,
           from: accounts[0]
         }),
-        lock.purchaseFor(accounts[4], 'Vitalik', {
+        lock.purchaseFor(accounts[4], Web3Utils.toHex('Vitalik'), {
           value: lock.params.keyPrice,
           from: accounts[0]
         })

--- a/smart-contracts/test/Lock/partialWithdraw.js
+++ b/smart-contracts/test/Lock/partialWithdraw.js
@@ -1,5 +1,5 @@
-
 const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
 
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
@@ -18,7 +18,7 @@ contract('Lock', (accounts) => {
 
     before(() => {
       const purchases = [accounts[1], accounts[2]].map((account) => {
-        return locks['OWNED'].purchaseFor(account, '', {
+        return locks['OWNED'].purchaseFor(account, Web3Utils.toHex(''), {
           value: price,
           from: account
         })

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -1,4 +1,3 @@
-
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
 
@@ -23,7 +22,7 @@ contract('Lock', (accounts) => {
     describe('when the contract has a public key release', () => {
       it('should fail if the price is not enough', () => {
         return locks['FIRST']
-          .purchaseFor(accounts[0], 'Julien', {
+          .purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
             value: Units.convert('0.0001', 'eth', 'wei')
           })
           .catch(error => {
@@ -38,7 +37,7 @@ contract('Lock', (accounts) => {
 
       it('should fail if we reached the max number of keys', () => {
         return locks['SINGLE KEY']
-          .purchaseFor(accounts[0], 'Julien', {
+          .purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
           .then(keyData => {
@@ -46,7 +45,7 @@ contract('Lock', (accounts) => {
           })
           .then(keyData => {
             assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
-            return locks['SINGLE KEY'].purchaseFor(accounts[1], 'Satoshi', {
+            return locks['SINGLE KEY'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
               value: Units.convert('0.01', 'eth', 'wei'),
               from: accounts[1]
             })
@@ -69,21 +68,21 @@ contract('Lock', (accounts) => {
           filter.stopWatching()
         })
         return locks['FIRST']
-          .purchaseFor(accounts[2], 'Vitalik', {
+          .purchaseFor(accounts[2], Web3Utils.toHex('Vitalik'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
       })
 
       describe('when the user already owns an expired key', () => {
         it('should expand the validity by the default key duration', () => {
-          return locks['SECOND'].purchaseFor(accounts[4], 'Satoshi', {
+          return locks['SECOND'].purchaseFor(accounts[4], Web3Utils.toHex('Satoshi'), {
             value: Units.convert('0.01', 'eth', 'wei')
           }).then(() => {
             // let's now expire the key
             return locks['SECOND'].expireKeyFor(accounts[4])
           }).then(() => {
             // Purchase a new one
-            return locks['SECOND'].purchaseFor(accounts[4], 'Satoshi', {
+            return locks['SECOND'].purchaseFor(accounts[4], Web3Utils.toHex('Satoshi'), {
               value: Units.convert('0.01', 'eth', 'wei')
             })
           }).then(() => {
@@ -101,7 +100,7 @@ contract('Lock', (accounts) => {
       describe('when the user already owns a non expired key', () => {
         it('should expand the validity by the default key duration', () => {
           let firstExpiration
-          return locks['FIRST'].purchaseFor(accounts[1], 'Satoshi', {
+          return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
             .then(() => {
@@ -114,7 +113,7 @@ contract('Lock', (accounts) => {
               assert.equal(Web3Utils.toUtf8(keyData), 'Satoshi')
               firstExpiration = expirationTimestamp
               assert(firstExpiration.gt(0))
-              return locks['FIRST'].purchaseFor(accounts[1], 'Szabo', {
+              return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Szabo'), {
                 value: Units.convert('0.01', 'eth', 'wei')
               })
             })
@@ -143,7 +142,7 @@ contract('Lock', (accounts) => {
               return locks['FIRST'].numberOfOwners()
                 .then(_numberOfOwners => {
                   numberOfOwners = parseInt(_numberOfOwners)
-                  return locks['FIRST'].purchaseFor(accounts[0], 'Julien', {
+                  return locks['FIRST'].purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
                     value: Units.convert('0.01', 'eth', 'wei')
                   })
                 })

--- a/smart-contracts/test/Lock/purchaseForFrom.js
+++ b/smart-contracts/test/Lock/purchaseForFrom.js
@@ -1,4 +1,3 @@
-
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
 
@@ -24,7 +23,7 @@ contract('Lock', (accounts) => {
       it('should fail', () => {
         const lock = locks['FIRST']
         return lock
-          .purchaseForFrom(accounts[0], accounts[1], 'Julien')
+          .purchaseForFrom(accounts[0], accounts[1], Web3Utils.toHex('Julien'))
           .catch((error) => {
             assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
             // Making sure we do not have a key set!
@@ -39,13 +38,13 @@ contract('Lock', (accounts) => {
     describe('if the referrer has a key', () => {
       it('should succeed', () => {
         const lock = locks['FIRST']
-        return lock.purchaseFor(accounts[0], 'Julien', {
+        return lock.purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
           value: Units.convert('0.01', 'eth', 'wei')
         }).then(() => {
           return lock.keyDataFor(accounts[0])
         }).then((keyData) => {
           assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
-          return lock.purchaseForFrom(accounts[1], accounts[0], 'Vitalik', {
+          return lock.purchaseForFrom(accounts[1], accounts[0], Web3Utils.toHex('Vitalik'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
         }).then(() => {

--- a/smart-contracts/test/Lock/withdraw.js
+++ b/smart-contracts/test/Lock/withdraw.js
@@ -1,5 +1,5 @@
-
 const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
 
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
@@ -24,7 +24,7 @@ contract('Lock', (accounts) => {
 
     before(() => {
       const purchases = [accounts[1], accounts[2]].map((account) => {
-        return locks['OWNED'].purchaseFor(account, '', {
+        return locks['OWNED'].purchaseFor(account, Web3Utils.toHex(''), {
           value: price,
           from: account
         })


### PR DESCRIPTION
# Description

Converting strings to hex before making a smart contract call.

With older versions (like we are on now) of Truffle, using either string, hex, or bytes here worked. Once we upgrade, this will require hex or bytes so this is a pre-req for #1078

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
