### PR TITLE
Watching transactions

### DIFF
--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -277,13 +277,20 @@ describe('Lock middleware', () => {
   })
 
   it('it should handle transaction.new events triggered by the web3Service', () => {
+    expect.assertions(2)
+
     const { store } = create()
+    mockWeb3Service.getTransaction = jest.fn()
+
     mockWeb3Service.emit('transaction.new', transaction)
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: ADD_TRANSACTION,
         transaction,
       })
+    )
+    expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
+      transaction.hash
     )
   })
 

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -63,12 +63,14 @@ export default function configure(
   let unlockAddress = ''
   let services = {}
   let supportedProviders = []
+  let blockTime = 8000 // in mseconds.
 
   if (env === 'test') {
     // In test, we fake the HTTP provider
     providers['HTTP'] = new Web3.providers.HttpProvider(
       `http://${runtimeConfig.httpProvider}:8545`
     )
+    blockTime = 10 // in mseconds.
     supportedProviders = ['HTTP']
     services['storage'] = { host: 'http://127.0.0.1:8080' }
     isRequiredNetwork = networkId => networkId === 1337
@@ -95,6 +97,9 @@ export default function configure(
 
     // In dev, we only require 6 confirmation because we only mine when there are pending transactions
     requiredConfirmations = 6
+
+    // we start ganache locally with a block time of 3
+    blockTime = 3000
   }
 
   if (env === 'staging') {
@@ -111,6 +116,9 @@ export default function configure(
 
     // Address for the Unlock smart contract
     unlockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+
+    // rinkeby block time is roughly same as main net
+    blockTime = 8000
   }
 
   if (env === 'prod') {
@@ -128,6 +136,9 @@ export default function configure(
 
     // Address for the Unlock smart contract
     unlockAddress = '0x3d5409cce1d45233de1d4ebdee74b8e004abdd13'
+
+    // See https://www.reddit.com/r/ethereum/comments/3c8v2i/what_is_the_expected_block_time/
+    blockTime = 8000
   }
 
   if (env === 'prod' || env === 'staging') {
@@ -135,6 +146,7 @@ export default function configure(
   }
 
   return {
+    blockTime,
     isServer,
     env,
     providers,

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -110,6 +110,8 @@ export default function web3Middleware({ getState, dispatch }) {
 
   web3Service.on('transaction.new', transaction => {
     dispatch(addTransaction(transaction))
+    // Let's fetch the transaction. This will also "watch" it for updates
+    web3Service.getTransaction(transaction.hash)
   })
 
   web3Service.on('transaction.updated', (transactionHash, update) => {


### PR DESCRIPTION
Since the piece triggering transactions and the piece actually loading data from the chain will be
distinct, we should not rely on the `sendTransaction` flow to "watch" on-going transaction.
Most of the web3 providers do not support using `filters`, so we implement a lightweight version
of this using `setTimeout` on transactions which are pulled from the chain but for which we
want to get updates.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread