### PR TITLE
Fix shouldFail condition

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -281,6 +281,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     external
     onlyOwner
   {
+    require(_amount > 0, "Must request an amount greater than 0");
     uint256 balance = address(this).balance;
     require(balance > 0 && balance >= _amount, "Not enough funds");
     _withdraw(_amount);

--- a/smart-contracts/test/Lock/partialWithdraw.js
+++ b/smart-contracts/test/Lock/partialWithdraw.js
@@ -64,11 +64,10 @@ contract('Lock', (accounts) => {
         await locks['OWNED'].partialWithdraw(0, {
           from: owner
         })
-        return
+        assert.fail()
       } catch (error) {
-        assert.equal(error.message, 'VM Exception while processing transaction: revert Not enough funds')
+        assert.equal(error.message, 'VM Exception while processing transaction: revert Must request an amount greater than 0')
       }
-      assert.fail()
     })
 
     describe('when the owner withdraws some funds', () => {


### PR DESCRIPTION
# Description

Requesting a withdraw of amount `0` should fail per tests, but does not fail per the contract.  Fixing the contract to fail as expected, and updating the test to confirm the failure.

The test did not catch this as it was not crafted correctly.  This is an example of why we need: https://github.com/unlock-protocol/unlock/issues/1106

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
