### PR TITLE
Use an explicit address 0

### DIFF
--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -76,7 +76,7 @@ contract('Lock ERC721', (accounts) => {
 
       it('should abort if the recipient is 0x', () => {
         return locks['FIRST']
-          .transferFrom(from, 0, from, {
+          .transferFrom(from, Web3Utils.padLeft(0, 40), from, {
             from
           })
           .then(() => {


### PR DESCRIPTION
# Description

Changing 0 to a valid address using Web3Utils.

With older versions (like we are on now) of Truffle, using either number or hex here worked. Once we upgrade, this will be required so this is a pre-req for #1078

This is another instance like https://github.com/unlock-protocol/unlock/pull/1254 (and I hope the last example like it)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
