### PR TITLE
Convert strings to hex

### DIFF
--- a/smart-contracts/test/Lock/erc721/onERC721Received.js
+++ b/smart-contracts/test/Lock/erc721/onERC721Received.js
@@ -1,4 +1,6 @@
 // const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+
 const deployLocks = require('../../helpers/deployLocks')
 const Unlock = artifacts.require('../../Unlock.sol')
 
@@ -8,7 +10,7 @@ contract('Lock Receiver', (accounts) => {
   operator = accounts[5]
   from = accounts[5]
   tokenId = 11
-  data = ''
+  data = Web3Utils.toHex('')
 
   before(() => {
     return Unlock.deployed()


### PR DESCRIPTION
# Description

Converting strings to hex before making a smart contract call.

With older versions (like we are on now) of Truffle, using either string, hex, or bytes here worked. Once we upgrade, this will require hex or bytes so this is a pre-req for #1078

This is an instance I missed like https://github.com/unlock-protocol/unlock/pull/1256

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
