### PR TITLE
BigNumber to bignumber.js

### DIFF
--- a/smart-contracts/test/Lock/Lock.js
+++ b/smart-contracts/test/Lock/Lock.js
@@ -1,5 +1,5 @@
-
 const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
@@ -36,15 +36,20 @@ contract('Lock', (accounts) => {
         outstandingKeys,
         numberOfOwners
       ]) => {
+        expirationDuration = new BigNumber(expirationDuration)
+        keyPrice = new BigNumber(keyPrice)
+        maxNumberOfKeys = new BigNumber(maxNumberOfKeys)
+        outstandingKeys = new BigNumber(outstandingKeys)
+        numberOfOwners = new BigNumber(numberOfOwners)
         assert.strictEqual(owner, accounts[0])
-        assert(expirationDuration.eq(60 * 60 * 24 * 30))
+        assert.equal(expirationDuration.toFixed(), 60 * 60 * 24 * 30)
         assert.strictEqual(
           Units.convert(keyPrice, 'wei', 'eth'),
           '0.01'
         )
-        assert(maxNumberOfKeys.eq(10))
-        assert(outstandingKeys.eq(0))
-        assert(numberOfOwners.eq(0))
+        assert.equal(maxNumberOfKeys.toFixed(), 10)
+        assert.equal(outstandingKeys.toFixed(), 0)
+        assert.equal(numberOfOwners.toFixed(), 0)
       }
     )
   })

--- a/smart-contracts/test/Lock/erc721/Non_Public_approve.js
+++ b/smart-contracts/test/Lock/erc721/Non_Public_approve.js
@@ -62,7 +62,7 @@ contract('Lock ERC721', (accounts) => {
           .then(() => {
             // accounts[2] purchases a key
             return locks['RESTRICTED'].purchaseFor(accounts[2], Web3Utils.toHex('Julien'), {
-              value: locks['RESTRICTED'].params.keyPrice,
+              value: locks['RESTRICTED'].params.keyPrice.toFixed(),
               from: accounts[2]
             })
           })
@@ -108,7 +108,7 @@ contract('Lock ERC721', (accounts) => {
           .then(() => {
             // accounts[5] purchases a key
             return locks['RESTRICTED'].purchaseFor(accounts[5], Web3Utils.toHex('Julien'), {
-              value: locks['RESTRICTED'].params.keyPrice,
+              value: locks['RESTRICTED'].params.keyPrice.toFixed(),
               from: accounts[5]
             })
           })
@@ -135,7 +135,7 @@ contract('Lock ERC721', (accounts) => {
           .then(() => {
             // accounts[5] purchases a key
             return locks['RESTRICTED'].purchaseFor(accounts[5], Web3Utils.toHex('Julien'), {
-              value: locks['RESTRICTED'].params.keyPrice,
+              value: locks['RESTRICTED'].params.keyPrice.toFixed(),
               from: accounts[5]
             })
           })

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -87,7 +87,7 @@ contract('Lock ERC721', (accounts) => {
           assert.equal(event.event, 'Approval')
           assert.equal(event.args._owner, accounts[1])
           assert.equal(event.args._approved, accounts[2])
-          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.numberToHex(event.args._tokenId)), accounts[1])
+          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.numberToHex(event.args._tokenId)), Web3Utils.toChecksumAddress(accounts[1]))
         })
       })
     })

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -87,7 +87,7 @@ contract('Lock ERC721', (accounts) => {
           assert.equal(event.event, 'Approval')
           assert.equal(event.args._owner, accounts[1])
           assert.equal(event.args._approved, accounts[2])
-          assert.equal(Web3Utils.numberToHex(event.args._tokenId), accounts[1])
+          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.numberToHex(event.args._tokenId)), accounts[1])
         })
       })
     })

--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -1,5 +1,6 @@
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
+const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../../helpers/deployLocks')
 const shouldFail = require('../../helpers/shouldFail')
@@ -24,38 +25,30 @@ contract('Lock ERC721', (accounts) => {
       await shouldFail(locks['FIRST'].balanceOf(Web3Utils.padLeft(0, 40)), 'Invalid address')
     })
 
-    it('should return 0 if the user has no key', () => {
-      return locks['FIRST']
-        .balanceOf(accounts[3])
-        .then(balance => {
-          assert(balance.eq(0))
-        })
+    it('should return 0 if the user has no key', async () => {
+      const balance = new BigNumber(await locks['FIRST'].balanceOf(accounts[3]))
+      assert.equal(balance.toFixed(), 0)
     })
 
-    it('should return 1 if the user has a non expired key', () => {
-      return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
+    it('should return 1 if the user has a non expired key', async () => {
+      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[1]
-      }).then(() => {
-        return locks['FIRST'].balanceOf(accounts[1])
-      }).then(balance => {
-        assert(balance.eq(1))
       })
+      const balance = new BigNumber(await locks['FIRST'].balanceOf(accounts[1]))
+      assert.equal(balance.toFixed(), 1)
     })
 
-    it('should return 1 if the user has an expired key', () => {
-      return locks['FIRST'].purchaseFor(accounts[5], Web3Utils.toHex('Satoshi'), {
+    it('should return 1 if the user has an expired key', async () => {
+      await locks['FIRST'].purchaseFor(accounts[5], Web3Utils.toHex('Satoshi'), {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[5]
-      }).then(() => {
-        return locks['FIRST'].expireKeyFor(accounts[5], {
+      })
+      await locks['FIRST'].expireKeyFor(accounts[5], {
           from: accounts[0]
         })
-      }).then(() => {
-        return locks['FIRST'].balanceOf(accounts[5])
-      }).then(balance => {
-        assert(balance.eq(1))
-      })
+      const balance = new BigNumber(await locks['FIRST'].balanceOf(accounts[5]))
+      assert.equal(balance.toFixed(), 1)
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/getTokenIdFor.js
+++ b/smart-contracts/test/Lock/erc721/getTokenIdFor.js
@@ -31,7 +31,7 @@ contract('Lock ERC721', (accounts) => {
       let address = new BigNumber(await locks['FIRST'].getTokenIdFor(accounts[1]))
       // Note that as we implement ERC721 support, the tokenId will no longer
       // be the same as the user's address
-      assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(address)), accounts[1])
+      assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(address)), Web3Utils.toChecksumAddress(accounts[1]))
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/getTokenIdFor.js
+++ b/smart-contracts/test/Lock/erc721/getTokenIdFor.js
@@ -31,7 +31,7 @@ contract('Lock ERC721', (accounts) => {
       let address = new BigNumber(await locks['FIRST'].getTokenIdFor(accounts[1]))
       // Note that as we implement ERC721 support, the tokenId will no longer
       // be the same as the user's address
-      assert.equal(address.toFixed(), new BigNumber(accounts[1]).toFixed())
+      assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(address)), accounts[1])
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/getTokenIdFor.js
+++ b/smart-contracts/test/Lock/erc721/getTokenIdFor.js
@@ -28,10 +28,10 @@ contract('Lock ERC721', (accounts) => {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[1]
       })
-      let address = await locks['FIRST'].getTokenIdFor(accounts[1])
+      let address = new BigNumber(await locks['FIRST'].getTokenIdFor(accounts[1]))
       // Note that as we implement ERC721 support, the tokenId will no longer
       // be the same as the user's address
-      assert(address.eq(new BigNumber(accounts[1])))
+      assert.equal(address.toFixed(), new BigNumber(accounts[1]).toFixed())
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -96,7 +96,7 @@ contract('Lock ERC721', (accounts) => {
             from
           })
           // Let's check the expiration date for that key
-          fromExpirationTimestamp = await locks['FIRST'].keyExpirationTimestampFor(from)
+          fromExpirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
             // Then let's expire the key for accountWithExpiredKey
           await locks['FIRST'].expireKeyFor(accountWithExpiredKey)
           await locks['FIRST'].transferFrom(from, accountWithExpiredKey, from, {
@@ -175,19 +175,15 @@ contract('Lock ERC721', (accounts) => {
       })
 
       describe('when the key owner is the sender', () => {
-        before(() => {
+        before(async () => {
           // first, let's purchase a brand new key that we can transfer
-          return locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+          await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
             value: Units.convert('0.01', 'eth', 'wei'),
             from
-          }).then(() => {
-            return locks['FIRST'].keyExpirationTimestampFor(from)
-              .then((expirationTimestamp) => {
-                keyExpiration = expirationTimestamp
-                return locks['FIRST'].transferFrom(from, to, from, {
-                  from
-                })
-              })
+          })
+          keyExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          await locks['FIRST'].transferFrom(from, to, from, {
+            from
           })
         })
 

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -1,5 +1,6 @@
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
+const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../../helpers/deployLocks')
 const Unlock = artifacts.require('../../Unlock.sol')
@@ -48,10 +49,8 @@ contract('Lock ERC721', (accounts) => {
           value: Units.convert('0.01', 'eth', 'wei'),
           from: accountWithKeyApproved
         })
-      ]).then(() => {
-        return locks['FIRST'].keyExpirationTimestampFor(from)
-      }).then((expirationTimestamp) => {
-        keyExpiration = expirationTimestamp
+      ]).then(async () => {
+        keyExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
       })
     })
 
@@ -74,110 +73,85 @@ contract('Lock ERC721', (accounts) => {
           })
       })
 
-      it('should abort if the recipient is 0x', () => {
-        return locks['FIRST']
-          .transferFrom(from, Web3Utils.padLeft(0, 40), from, {
+      it('should abort if the recipient is 0x', async () => {
+        try {
+          await locks['FIRST'].transferFrom(from, Web3Utils.padLeft(0, 40), from, {
             from
           })
-          .then(() => {
-            assert(false, 'This should not succeed')
-          })
-          .catch(error => {
+          assert(false, 'This should not succeed')
+        } catch(error) {
             assert.equal(error.message, 'VM Exception while processing transaction: revert')
             // Ensuring that ownership of the key did not change
-            return locks['FIRST'].keyExpirationTimestampFor(from)
-          }).then((expirationTimestamp) => {
-            assert(keyExpiration.eq(expirationTimestamp))
-          })
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          assert.equal(keyExpiration.toFixed(), expirationTimestamp.toFixed())
+        }
       })
 
       describe('when the recipient already has an expired key', () => {
-        it('should transfer the key validity without extending it', () => {
+        it('should transfer the key validity without extending it', async () => {
           // First let's make sure from has a key!
           let fromExpirationTimestamp
-          return locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+          await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
             value: Units.convert('0.01', 'eth', 'wei'),
             from
-          }).then(() => {
-            // Let's check the expiration date for that key
-            return locks['FIRST'].keyExpirationTimestampFor(from)
-          }).then((_fromExpirationTimestamp) => {
-            fromExpirationTimestamp = _fromExpirationTimestamp
-            // Then let's expire the key for accountWithExpiredKey
-            return locks['FIRST'].expireKeyFor(accountWithExpiredKey)
-          }).then(() => {
-            return locks['FIRST'].transferFrom(from, accountWithExpiredKey, from, {
-              from
-            })
-          }).then(() => {
-            return locks['FIRST'].keyExpirationTimestampFor(accountWithExpiredKey)
-          }).then((expirationTimestamp) => {
-            assert(expirationTimestamp.eq(fromExpirationTimestamp))
           })
+          // Let's check the expiration date for that key
+          fromExpirationTimestamp = await locks['FIRST'].keyExpirationTimestampFor(from)
+            // Then let's expire the key for accountWithExpiredKey
+          await locks['FIRST'].expireKeyFor(accountWithExpiredKey)
+          await locks['FIRST'].transferFrom(from, accountWithExpiredKey, from, {
+            from
+          })
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accountWithExpiredKey))
+          assert.equal(expirationTimestamp.toFixed(), fromExpirationTimestamp.toFixed())
         })
       })
 
       describe('when the recipient already has a non expired key', () => {
-        before(() => {
-          return locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+        before(async () => {
+          await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
             value: Units.convert('0.01', 'eth', 'wei'),
             from
-          }).then(() => {
-            // First let's get the current expiration
-            let previousExpirationTimestamp, transferedKeyTimestamp
-            return Promise.all([
-              locks['FIRST'].keyExpirationTimestampFor(from),
-              locks['FIRST'].keyExpirationTimestampFor(accounts[1])
-            ])
-          }).then(([_transferedKeyTimestamp, _previousExpirationTimestamp]) => {
-            transferedKeyTimestamp = _transferedKeyTimestamp
-            previousExpirationTimestamp = _previousExpirationTimestamp
-            return locks['FIRST'].transferFrom(from, accountWithKey, from, {
-              from
-            })
+          })
+          // First let's get the current expiration
+          transferedKeyTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          previousExpirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[1]))
+          await locks['FIRST'].transferFrom(from, accountWithKey, from, {
+            from
           })
         })
 
-        it('should expand the key\'s validity', () => {
-          return locks['FIRST'].keyExpirationTimestampFor(accountWithKey)
-            .then((expirationTimestamp) => {
-              const now = Math.floor(new Date().getTime() / 1000)
-              // Check +/- 10 seconds
-              assert(expirationTimestamp.gt(previousExpirationTimestamp.add(transferedKeyTimestamp).sub(now + 10)))
-              assert(expirationTimestamp.lt(previousExpirationTimestamp.add(transferedKeyTimestamp).sub(now - 10)))
-            })
+        it('should expand the key\'s validity', async () => {
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accountWithKey))
+          const now = Math.floor(new Date().getTime() / 1000)
+          // Check +/- 10 seconds
+          assert(expirationTimestamp.gt(previousExpirationTimestamp.plus(transferedKeyTimestamp).minus(now + 10)))
+          assert(expirationTimestamp.lt(previousExpirationTimestamp.plus(transferedKeyTimestamp).minus(now - 10)))
         })
 
-        it('should expire the previous owner\'s key', () => {
-          return locks['FIRST'].keyExpirationTimestampFor(from)
-            .then((expirationTimestamp) => {
-              const now = Math.floor(new Date().getTime() / 1000)
-              // Check only 10 seconds in the future to ensure deterministic test
-              assert(expirationTimestamp.lt(now + 10))
-            })
+        it('should expire the previous owner\'s key', async () => {
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          const now = Math.floor(new Date().getTime() / 1000)
+          // Check only 10 seconds in the future to ensure deterministic test
+          assert(expirationTimestamp.lt(now + 10))
         })
       })
 
       describe('when the key owner is not the sender', () => {
-        it('should fail if the sender has not been approved for that key', () => {
-          let previousExpirationTimestamp
-          return locks['FIRST'].keyExpirationTimestampFor(from)
-            .then((_expirationTimestamp) => {
-              previousExpirationTimestamp = _expirationTimestamp
-              return locks['FIRST']
-                .transferFrom(from, accountNotApproved, from, {
-                  from: accountNotApproved
-                })
-            }).then(() => {
-              assert(false, 'This should not succeed')
+        it('should fail if the sender has not been approved for that key', async () => {
+          const previousExpirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          try {
+            await locks['FIRST']
+            .transferFrom(from, accountNotApproved, from, {
+              from: accountNotApproved
             })
-            .catch(error => {
-              assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
-              // Ensuring that ownership of the key did not change
-              return locks['FIRST'].keyExpirationTimestampFor(from)
-            }).then((expirationTimestamp) => {
-              assert(previousExpirationTimestamp.eq(expirationTimestamp))
-            })
+            assert(false, 'This should not succeed')
+          } catch(error) {
+            assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
+            // Ensuring that ownership of the key did not change
+            const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+            assert.equal(previousExpirationTimestamp.toFixed(), expirationTimestamp.toFixed())
+          }
         })
 
         it('should succeed if the sender has been approved for that key', () => {
@@ -217,19 +191,15 @@ contract('Lock ERC721', (accounts) => {
           })
         })
 
-        it('should mark the previous owner`s key as expired', () => {
-          return locks['FIRST'].keyExpirationTimestampFor(from)
-            .then((expirationTimestamp) => {
-              assert(expirationTimestamp.gt(0))
-              assert(expirationTimestamp.lt(keyExpiration))
-            })
+        it('should mark the previous owner`s key as expired', async () => {
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          assert(expirationTimestamp.gt(0))
+          assert(expirationTimestamp.lt(keyExpiration))
         })
 
-        it('should have assigned the key`s previous expiration to the new owner', () => {
-          return locks['FIRST'].keyExpirationTimestampFor(to)
-            .then((expirationTimestamp) => {
-              assert(expirationTimestamp.eq(keyExpiration))
-            })
+        it('should have assigned the key`s previous expiration to the new owner', async () => {
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(to))
+          assert.equal(expirationTimestamp.toFixed(), keyExpiration.toFixed())
         })
 
         it('should have assigned the key data field to the new owner', () => {

--- a/smart-contracts/test/Lock/expireKeyFor.js
+++ b/smart-contracts/test/Lock/expireKeyFor.js
@@ -45,7 +45,7 @@ contract('Lock', (accounts) => {
 
     it('should fail if the key has already expired', async () => {
       await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('Julien'), {
-        value: locks['FIRST'].params.keyPrice,
+        value: locks['FIRST'].params.keyPrice.toFixed(),
         from: accounts[0]
       })
       const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[2]))
@@ -66,7 +66,7 @@ contract('Lock', (accounts) => {
 
     it('should expire a valid key', async () => {
       await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
-        value: locks['FIRST'].params.keyPrice,
+        value: locks['FIRST'].params.keyPrice.toFixed(),
         from: accounts[0]
       })
       let expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[1]))

--- a/smart-contracts/test/Lock/expireKeyFor.js
+++ b/smart-contracts/test/Lock/expireKeyFor.js
@@ -1,4 +1,5 @@
 const Web3Utils = require('web3-utils')
+const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
@@ -42,48 +43,41 @@ contract('Lock', (accounts) => {
         })
     })
 
-    it('should fail if the key has already expired', () => {
-      return locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('Julien'), {
+    it('should fail if the key has already expired', async () => {
+      await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('Julien'), {
         value: locks['FIRST'].params.keyPrice,
         from: accounts[0]
-      }).then(() => {
-        return locks['FIRST'].keyExpirationTimestampFor(accounts[2])
-      }).then((expirationTimestamp) => {
-        const now = Math.floor(new Date().getTime() / 1000)
-        assert(expirationTimestamp.gt(now))
-        return locks['FIRST'].expireKeyFor(accounts[2], {
-          from: accounts[0]
-        })
-      }).then(() => {
-        return locks['FIRST'].expireKeyFor(accounts[2], {
-          from: accounts[0]
-        })
-      }).then(() => {
-        assert(false, 'this should have failed')
       })
-        .catch(error => {
-          assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
+      const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[2]))
+      const now = Math.floor(new Date().getTime() / 1000)
+      assert(expirationTimestamp.gt(now))
+      await locks['FIRST'].expireKeyFor(accounts[2], {
+        from: accounts[0]
+      })
+      try {
+        await locks['FIRST'].expireKeyFor(accounts[2], {
+          from: accounts[0]
         })
+        assert(false, 'this should have failed')
+      } catch(error) {
+        assert.equal(error.message, 'VM Exception while processing transaction: revert Key is not valid')
+      }
     })
 
-    it('should expire a valid key', () => {
-      return locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
+    it('should expire a valid key', async () => {
+      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
         value: locks['FIRST'].params.keyPrice,
         from: accounts[0]
-      }).then(() => {
-        return locks['FIRST'].keyExpirationTimestampFor(accounts[1])
-      }).then((expirationTimestamp) => {
-        const now = Math.floor(new Date().getTime() / 1000)
-        assert(expirationTimestamp.gt(now))
-        return locks['FIRST'].expireKeyFor(accounts[1], {
-          from: accounts[0]
-        })
-      }).then(() => {
-        return locks['FIRST'].keyExpirationTimestampFor(accounts[1])
-      }).then((expirationTimestamp) => {
-        const now = Math.floor(new Date().getTime() / 1000)
-        assert(expirationTimestamp.lte(now))
       })
+      let expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[1]))
+      let now = Math.floor(new Date().getTime() / 1000)
+      assert(expirationTimestamp.gt(now))
+      await locks['FIRST'].expireKeyFor(accounts[1], {
+        from: accounts[0]
+      })
+      expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[1]))
+      now = Math.floor(new Date().getTime() / 1000)
+      assert(expirationTimestamp.lte(now))
     })
   })
 })

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -23,19 +23,19 @@ contract('Lock ERC721', (accounts) => {
       // Purchase keys!
       return Promise.all([
         lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
-          value: lock.params.keyPrice,
+          value: lock.params.keyPrice.toFixed(),
           from: accounts[0]
         }),
         lock.purchaseFor(accounts[2], Web3Utils.toHex('Ben'), {
-          value: lock.params.keyPrice,
+          value: lock.params.keyPrice.toFixed(),
           from: accounts[0]
         }),
         lock.purchaseFor(accounts[3], Web3Utils.toHex('Satoshi'), {
-          value: lock.params.keyPrice,
+          value: lock.params.keyPrice.toFixed(),
           from: accounts[0]
         }),
         lock.purchaseFor(accounts[4], Web3Utils.toHex('Vitalik'), {
-          value: lock.params.keyPrice,
+          value: lock.params.keyPrice.toFixed(),
           from: accounts[0]
         })
       ])

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -1,5 +1,6 @@
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
+const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
@@ -75,7 +76,7 @@ contract('Lock ERC721', (accounts) => {
       let numberOfOwners
 
       before(async () => {
-        numberOfOwners = await lock.numberOfOwners()
+        numberOfOwners = new BigNumber(await lock.numberOfOwners())
         await lock.transferFrom(accounts[1], accounts[5], accounts[1], { from: accounts[1] })
       })
   
@@ -85,10 +86,9 @@ contract('Lock ERC721', (accounts) => {
         })
       })
   
-      it('should have the right number of owners', () => {
-        return lock.numberOfOwners().then((_numberOfOwners) => {
-          assert(_numberOfOwners.eq(numberOfOwners.plus(1)))
-        })
+      it('should have the right number of owners', async () => {
+        const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
+        assert.equal(_numberOfOwners.toFixed(), numberOfOwners.plus(1))
       })
 
       it('should fail if I transfer from the same account again', async () => {
@@ -115,10 +115,9 @@ contract('Lock ERC721', (accounts) => {
         })
       })
   
-      it('should have the right number of owners', () => {
-        return lock.numberOfOwners().then((_numberOfOwners) => {
-          assert(_numberOfOwners.eq(numberOfOwners))
-        })
+      it('should have the right number of owners', async () => {
+        const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
+        assert.equal(_numberOfOwners.toFixed(), numberOfOwners)
       })
     })
   })

--- a/smart-contracts/test/Lock/partialWithdraw.js
+++ b/smart-contracts/test/Lock/partialWithdraw.js
@@ -86,12 +86,12 @@ contract('Lock', (accounts) => {
         gasUsed = new BigNumber(txObj.receipt.gasUsed)
         gasPrice = new BigNumber(txHash.gasPrice)
         txFee = gasPrice.times(gasUsed)
-        finalOwnerBalance = new BigNumber(web3.eth.getBalance(owner))
+        finalOwnerBalance = new BigNumber(await web3.eth.getBalance(owner))
         assert.equal(finalOwnerBalance.toFixed(), initialOwnerBalance.plus(withdrawalAmount).minus(txFee).toFixed())
       })
 
       it('should decrease the lock\'s balance by the amount of funds withdrawn from the lock', async () => {
-        finalLockBalance = new BigNumber(web3.eth.getBalance(locks['OWNED'].address))
+        finalLockBalance = new BigNumber(await web3.eth.getBalance(locks['OWNED'].address))
         assert.equal(finalLockBalance.toFixed(), expectedLockBalance.toFixed())
       })
     })

--- a/smart-contracts/test/Lock/partialWithdraw.js
+++ b/smart-contracts/test/Lock/partialWithdraw.js
@@ -36,7 +36,7 @@ contract('Lock', (accounts) => {
     it('should fail if called by address other than owner', async () => {
       try {
         assert.notEqual(owner, accounts[1]) // Making sure
-        await locks['OWNED'].partialWithdraw(withdrawalAmount, {
+        await locks['OWNED'].partialWithdraw(withdrawalAmount.toFixed(), {
           from: accounts[1]
         })
       } catch (error) {
@@ -48,8 +48,8 @@ contract('Lock', (accounts) => {
 
     it('should fail if too much is withdrawn', async () => {
       try {
-        initialLockBalance = new BigNumber(web3.eth.getBalance(locks['OWNED'].address))
-        await locks['OWNED'].partialWithdraw(initialLockBalance.plus(withdrawalAmount), {
+        initialLockBalance = new BigNumber(await web3.eth.getBalance(locks['OWNED'].address))
+        await locks['OWNED'].partialWithdraw(initialLockBalance.plus(withdrawalAmount).toFixed(), {
           from: owner
         })
       } catch (error) {
@@ -75,8 +75,8 @@ contract('Lock', (accounts) => {
 
       before(async () => {
         expectedLockBalance = initialLockBalance.minus(withdrawalAmount)
-        initialOwnerBalance = new BigNumber(web3.eth.getBalance(owner))
-        txObj = await locks['OWNED'].partialWithdraw(withdrawalAmount, {
+        initialOwnerBalance = new BigNumber(await web3.eth.getBalance(owner))
+        txObj = await locks['OWNED'].partialWithdraw(withdrawalAmount.toFixed(), {
           from: owner
         })
       })
@@ -85,14 +85,14 @@ contract('Lock', (accounts) => {
         txHash = await web3.eth.getTransaction(txObj.tx)
         gasUsed = new BigNumber(txObj.receipt.gasUsed)
         gasPrice = new BigNumber(txHash.gasPrice)
-        txFee = gasPrice.mul(gasUsed)
+        txFee = gasPrice.times(gasUsed)
         finalOwnerBalance = new BigNumber(web3.eth.getBalance(owner))
         assert.equal(finalOwnerBalance.toFixed(), initialOwnerBalance.plus(withdrawalAmount).minus(txFee).toFixed())
       })
 
       it('should decrease the lock\'s balance by the amount of funds withdrawn from the lock', async () => {
         finalLockBalance = new BigNumber(web3.eth.getBalance(locks['OWNED'].address))
-        assert.equal(finalLockBalance.toFixed(), expectedLockBalance)
+        assert.equal(finalLockBalance.toFixed(), expectedLockBalance.toFixed())
       })
     })
   })

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -89,8 +89,8 @@ contract('Lock', (accounts) => {
           const expirationTimestamp = new BigNumber(await locks['SECOND'].keyExpirationTimestampFor(accounts[4]))
           const now = parseInt(new Date().getTime() / 1000)
           // we check +/- 10 seconds to fix for now being different inside the EVM and here... :(
-          assert(expirationTimestamp.gt(locks['SECOND'].params.expirationDuration + now - 10))
-          assert(expirationTimestamp.lt(locks['SECOND'].params.expirationDuration + now + 10))
+          assert(expirationTimestamp.gt(locks['SECOND'].params.expirationDuration.plus(now - 10)))
+          assert(expirationTimestamp.lt(locks['SECOND'].params.expirationDuration.plus(now + 10)))
         })
       })
 

--- a/smart-contracts/test/Lock/updateKeyPrice.js
+++ b/smart-contracts/test/Lock/updateKeyPrice.js
@@ -32,7 +32,7 @@ contract('Lock', (accounts) => {
     describe('when the sender is not the lock owner', () => {
       let keyPrice, error
       before(async () => {
-        keyPrice = await locks['FIRST'].keyPrice()
+        keyPrice = new BigNumber(await locks['FIRST'].keyPrice())
         try {
           await locks['FIRST'].updateKeyPrice(
             Units.convert('0.3', 'eth', 'wei'),

--- a/smart-contracts/test/Lock/updateKeyPrice.js
+++ b/smart-contracts/test/Lock/updateKeyPrice.js
@@ -1,4 +1,5 @@
 const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
@@ -10,14 +11,14 @@ contract('Lock', (accounts) => {
     before(async () => {
       unlock = await Unlock.deployed()
       locks = await deployLocks(unlock)
-      keyPriceBefore = await locks['FIRST'].keyPrice()
-      assert(keyPriceBefore.eq(10000000000000000))
+      keyPriceBefore = new BigNumber(await locks['FIRST'].keyPrice())
+      assert.equal(keyPriceBefore.toFixed(), 10000000000000000)
       transaction = await locks['FIRST'].updateKeyPrice(Units.convert('0.3', 'eth', 'wei'))
     })
 
     it('should change the actual keyPrice', async () => {
-      const keyPriceAfter = await locks['FIRST'].keyPrice()
-      assert(keyPriceAfter.eq(300000000000000000))
+      const keyPriceAfter = new BigNumber(await locks['FIRST'].keyPrice())
+      assert.equal(keyPriceAfter.toFixed(), 300000000000000000)
     })
 
     it('should trigger an event', () => {
@@ -25,7 +26,7 @@ contract('Lock', (accounts) => {
         return log.event === 'PriceChanged'
       })
       assert(event)
-      assert(event.args.keyPrice.eq(300000000000000000))
+      assert.equal(new BigNumber(event.args.keyPrice).toFixed(), 300000000000000000)
     })
 
     describe('when the sender is not the lock owner', () => {
@@ -48,8 +49,8 @@ contract('Lock', (accounts) => {
       })
 
       it('should leave the price unchanged', async () => {
-        const keyPriceAfter = await locks['FIRST'].keyPrice()
-        assert(keyPrice.eq(keyPriceAfter))
+        const keyPriceAfter = new BigNumber(await locks['FIRST'].keyPrice())
+        assert.equal(keyPrice.toFixed(), keyPriceAfter.toFixed())
       })
     })
   })

--- a/smart-contracts/test/Lock/withdraw.js
+++ b/smart-contracts/test/Lock/withdraw.js
@@ -1,5 +1,6 @@
 const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
+const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
 const Unlock = artifacts.require('../Unlock.sol')
@@ -49,19 +50,20 @@ contract('Lock', (accounts) => {
 
     describe('when the owner withdraws funds', () => {
       let ownerBalance, lockBalance
-      before(() => {
-        lockBalance = web3.eth.getBalance(locks['OWNED'].address)
-        ownerBalance = web3.eth.getBalance(owner)
+      before(async () => {
+        lockBalance = new BigNumber(await web3.eth.getBalance(locks['OWNED'].address))
+        ownerBalance = new BigNumber(await web3.eth.getBalance(owner))
         return locks['OWNED'].withdraw({
           from: owner
         })
       })
-      it('should increase the owner\'s balance with the funds from the lock', () => {
-        assert(web3.eth.getBalance(owner) > ownerBalance)
+      it('should increase the owner\'s balance with the funds from the lock', async () => {
+        const balance = new BigNumber(await web3.eth.getBalance(owner))
+        assert(balance.gt(ownerBalance))
       })
 
-      it('should set the lock\'s balance to 0', () => {
-        assert.equal(web3.eth.getBalance(locks['OWNED'].address), 0)
+      it('should set the lock\'s balance to 0', async () => {
+        assert.equal(await web3.eth.getBalance(locks['OWNED'].address), 0)
       })
     })
   })

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -1,4 +1,6 @@
 const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
+
 const PublicLock = artifacts.require('../../PublicLock.sol')
 
 exports.shouldCreateLock = function (accounts) {
@@ -19,9 +21,11 @@ exports.shouldCreateLock = function (accounts) {
         let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
         // This is a bit of a dumb test because when the lock is missing, the value are 0 anyway...
         let [deployed, totalSales, yieldedDiscountTokens] = await this.unlock.locks(publicLock.address)
+        totalSales = new BigNumber(totalSales)
+        yieldedDiscountTokens = new BigNumber(yieldedDiscountTokens)
         assert(deployed)
-        assert(totalSales.eq(0))
-        assert(yieldedDiscountTokens.eq(0))
+        assert.equal(totalSales.toFixed(), 0)
+        assert.equal(yieldedDiscountTokens.toFixed(), 0)
       })
 
       it('should trigger the NewLock event', function () {

--- a/smart-contracts/test/Unlock/behaviors/initialization.js
+++ b/smart-contracts/test/Unlock/behaviors/initialization.js
@@ -1,3 +1,5 @@
+const BigNumber = require('bignumber.js')
+
 exports.shouldHaveInitialized = function (unlockOwner) {
   describe('initialization', function () {
     it('should have an owner', async function () {
@@ -6,13 +8,13 @@ exports.shouldHaveInitialized = function (unlockOwner) {
     })
 
     it('should have initialized grossNetworkProduct', async function () {
-      const grossNetworkProduct = await this.unlock.grossNetworkProduct()
-      assert(grossNetworkProduct.eq(0))
+      const grossNetworkProduct = new BigNumber(await this.unlock.grossNetworkProduct())
+      assert.equal(grossNetworkProduct.toFixed(), 0)
     })
 
     it('should have initialized totalDiscountGranted', async function () {
-      const totalDiscountGranted = await this.unlock.totalDiscountGranted()
-      assert(totalDiscountGranted.eq(0))
+      const totalDiscountGranted = new BigNumber(await this.unlock.totalDiscountGranted())
+      assert.equal(totalDiscountGranted.toFixed(), 0)
     })
   })
 }

--- a/smart-contracts/test/fixtures/locks.js
+++ b/smart-contracts/test/fixtures/locks.js
@@ -1,18 +1,19 @@
 const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
 
 let publicLock = {
-  expirationDuration: 60 * 60 * 24 * 30, // 30 days
-  expirationTimestamp: 0, // Not used
+  expirationDuration: new BigNumber(60 * 60 * 24 * 30), // 30 days
+  expirationTimestamp: new BigNumber(0), // Not used
   keyPriceCalculator: null, //
-  keyPrice: Units.convert(0.01, 'eth', 'wei'), // in wei
-  maxNumberOfKeys: 10
+  keyPrice: new BigNumber(Units.convert(0.01, 'eth', 'wei')), // in wei
+  maxNumberOfKeys: new BigNumber(10)
 }
 
 module.exports = {
   'FIRST': Object.assign({}, publicLock, {}),
   'SECOND': Object.assign({}, publicLock, {}),
   'SINGLE KEY': Object.assign({}, publicLock, {
-    maxNumberOfKeys: 1
+    maxNumberOfKeys: new BigNumber(1)
   }),
   'OWNED': Object.assign({}, publicLock, {})
 

--- a/smart-contracts/test/helpers/deployLocks.js
+++ b/smart-contracts/test/helpers/deployLocks.js
@@ -7,9 +7,9 @@ module.exports = function deployLocks (unlock) {
   return Promise.all(
     Object.keys(Locks).map(name => {
       return unlock.createLock(
-        Locks[name].expirationDuration,
-        Locks[name].keyPrice,
-        Locks[name].maxNumberOfKeys
+        Locks[name].expirationDuration.toFixed(),
+        Locks[name].keyPrice.toFixed(),
+        Locks[name].maxNumberOfKeys.toFixed()
       ).then(async (tx) => {
         // THIS API IS LIKELY TO BREAK BECAUSE IT ASSUMES SO MUCH
         const evt = tx.logs[0]


### PR DESCRIPTION
# Description

Switching to bignumber.js

There were changes to the BN implementation in a recent Truffle update, requiring we update all our BigNumbers.  Instead of working with their choices, this should explicitly use bignumber.js for all BigNumbers.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
