### PR TITLE
Adding a shouldFail helper

### DIFF
--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -2,6 +2,7 @@ const Units = require('ethereumjs-units')
 const Web3Utils = require('web3-utils')
 
 const deployLocks = require('../../helpers/deployLocks')
+const shouldFail = require('../../helpers/shouldFail')
 const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
@@ -19,15 +20,8 @@ contract('Lock ERC721', (accounts) => {
   })
 
   describe('balanceOf', () => {
-    it('should fail if the user address is 0', () => {
-      return locks['FIRST']
-        .balanceOf(Web3Utils.padLeft(0, 40))
-        .then(balance => {
-          assert(false)
-        })
-        .catch(error => {
-          assert.equal(error.message, 'VM Exception while processing transaction: revert Invalid address')
-        })
+    it('should fail if the user address is 0', async () => {
+      await shouldFail(locks['FIRST'].balanceOf(Web3Utils.padLeft(0, 40)), 'Invalid address')
     })
 
     it('should return 0 if the user has no key', () => {

--- a/smart-contracts/test/helpers/shouldFail.js
+++ b/smart-contracts/test/helpers/shouldFail.js
@@ -1,0 +1,12 @@
+module.exports = async function shouldFail (promise, expectedRevertReason) {
+  const expectedMessage = `VM Exception while processing transaction: revert ${expectedRevertReason}`
+  try {
+    await promise
+  } catch (error) {
+    if (error.message !== expectedMessage) {
+      throw new Error(`shouldFail reason for revert does not match. Got ${error.message}; expected ${expectedMessage}`)
+    }
+    return
+  }
+  throw new Error(`Call should have failed but did not. Expected ${expectedMessage}`)
+}


### PR DESCRIPTION
# Description

Creating a shouldFail helper method and applying it in just one example use case.  This way we can agree on the approach, then follow up migrating all other test cases to use the helper in a future PR.

I confirmed shouldFail does fail as expected in the two possible fail conditions (no revert or revert for the wrong reason).  However I don't have explicit tests for this helper method.  

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
