### PR TITLE
show server errors on localhost

### DIFF
--- a/unlock-app/src/pages/_error.js
+++ b/unlock-app/src/pages/_error.js
@@ -6,15 +6,19 @@ import UnlockPropTypes from '../propTypes'
 import withConfig from '../utils/withConfig'
 
 class Error extends React.Component {
-  static getInitialProps({ res, err }) {
+  static getInitialProps({ res, err, req }) {
     const statusCode = res ? res.statusCode : err ? err.statusCode : null
 
     // redirect to home now if not found
     if (statusCode) {
-      res.writeHead(301, {
-        Location: '/',
-      })
-      res.end()
+      if (req.headers.host.match(/^127.0.0.1|^localhost/)) {
+        console.log('Server-side error!', err) // eslint-disable-line
+      } else {
+        res.writeHead(301, {
+          Location: '/',
+        })
+        res.end()
+      }
     } else {
       Router.push('/')
     }

--- a/unlock-app/src/pages/_error.js
+++ b/unlock-app/src/pages/_error.js
@@ -11,7 +11,12 @@ class Error extends React.Component {
 
     // redirect to home now if not found
     if (statusCode) {
-      if (req.headers.host.match(/^127.0.0.1|^localhost/)) {
+      const configure = require('../config').default
+      const config = configure()
+      if (
+        config.env !== 'production' &&
+        req.connection.remoteAddress.match(/^127.0.0.1|^localhost/)
+      ) {
         console.log('Server-side error!', err) // eslint-disable-line
       } else {
         res.writeHead(301, {


### PR DESCRIPTION
# Description

When an error occurs server-side, the error handler redirects to the homepage. For production, this is acceptable (although we may choose to log the error in the future), but in development, this is a huge blocker to productivity. This PR detects which host we are running on, and if it is localhost, it displays the error instead of redirecting.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
