### PR TITLE
updated API on walletService

### DIFF
--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -265,9 +265,10 @@ describe('WalletService', () => {
         abi: [],
       }
       const mockSendTransaction = jest.fn()
-      const mockTransaction = new EventEmitter()
+      let mockTransaction
 
       beforeEach(() => {
+        mockTransaction = new EventEmitter()
         mockSendTransaction.mockReturnValue(mockTransaction)
         walletService.web3.eth.sendTransaction = mockSendTransaction
       })
@@ -300,6 +301,20 @@ describe('WalletService', () => {
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
           () => {}
+        )
+
+        mockTransaction.emit('transactionHash', transactionHash)
+      })
+
+      it('should callback with the hash', done => {
+        expect.assertions(1)
+        const transactionHash = '0x123'
+        walletService._sendTransaction(
+          { to, from, data, value, gas, privateKey, contract },
+          (error, hash) => {
+            expect(hash).toEqual(transactionHash)
+            done()
+          }
         )
 
         mockTransaction.emit('transactionHash', transactionHash)
@@ -403,6 +418,25 @@ describe('WalletService', () => {
           },
           expect.any(Function)
         )
+      })
+
+      it('should emit lock.updated with the transaction', done => {
+        expect.assertions(2)
+        const hash = '0x1213'
+
+        walletService._sendTransaction = jest.fn((args, cb) => {
+          return cb(null, hash)
+        })
+
+        walletService.on('lock.updated', (lockAddress, update) => {
+          expect(lockAddress).toBe(lock.address)
+          expect(update).toEqual({
+            transaction: hash,
+          })
+          done()
+        })
+
+        walletService.createLock(lock, owner)
       })
 
       it('should emit an error if the transaction could not be sent', done => {

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -142,6 +142,7 @@ export default class WalletService extends EventEmitter {
 
     return web3TransactionPromise
       .once('transactionHash', hash => {
+        callback(null, hash)
         this.emit('transaction.new', hash)
       })
       .on('error', error => {
@@ -198,14 +199,20 @@ export default class WalletService extends EventEmitter {
       {
         to: this.unlockContractAddress,
         from: owner,
-        data: data,
+        data,
         gas: 2000000,
         contract: UnlockContract,
       },
-      error => {
+      (error, hash) => {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_CREATE_LOCK))
         }
+        // Let's update the lock to reflect that it is linked to this
+        // This is an exception because, until we are able to determine the lock address
+        // before the transaction is mined, we need to link the lock and transaction.
+        return this.emit('lock.updated', lock.address, {
+          transaction: hash,
+        })
       }
     )
   }
@@ -259,7 +266,7 @@ export default class WalletService extends EventEmitter {
       {
         to: lock,
         from: account,
-        data: data,
+        data,
         gas: 1000000,
         contract: LockContract,
       },


### PR DESCRIPTION
When a transaction goes thrum(is mined) we can find which lock it is linked too by looking at the events
it triggered.
Since we use temporary lock ids we need a way to link a lock to its transaction because we would
not be able to find that lock back.


- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread