### PR TITLE
Switch event filter to use .logs instead

### DIFF
--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -45,7 +45,7 @@ contract('Lock', (accounts) => {
         await shouldFail(locks['SINGLE KEY'].keyDataFor(accounts[1]), 'No such key')
       })
 
-      it('should trigger an event when successful', () => {
+      it('should trigger an event when successful', async () => {
         const tx = await locks['FIRST']
           .purchaseFor(accounts[2], Web3Utils.toHex('Vitalik'), {
             value: Units.convert('0.01', 'eth', 'wei')

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -46,17 +46,13 @@ contract('Lock', (accounts) => {
       })
 
       it('should trigger an event when successful', () => {
-        let filter = locks['FIRST'].Transfer((error, { args }) => {
-          if (error) {
-            assert(false, error)
-          }
-          assert.equal(args._to, accounts[2])
-          filter.stopWatching()
-        })
-        return locks['FIRST']
+        const tx = await locks['FIRST']
           .purchaseFor(accounts[2], Web3Utils.toHex('Vitalik'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
+        assert.equal(tx.logs[0].event, 'Transfer')
+        assert.equal(tx.logs[0].args._from, 0)
+        assert.equal(tx.logs[0].args._to, accounts[2])
       })
 
       describe('when the user already owns an expired key', () => {


### PR DESCRIPTION
# Description

One test was using an event filter, however this approach does not work when we update Truffle.  I don't believe there was any need to use a filter here so went ahead and changed the test to use logs instead, which also simplifies the test a bit.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
