### PR TITLE
Adding missing `await` and converting to BigNumber

### DIFF
--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -101,8 +101,8 @@ contract('Lock', (accounts) => {
       describe('when the key was successfuly purchased', () => {
         let outstandingKeys, numberOfOwners, balance, now
 
-        before(() => {
-          balance = web3.eth.getBalance(locks['FIRST'].address)
+        before(async () => {
+          balance = new BigNumber(await web3.eth.getBalance(locks['FIRST'].address))
           return locks['FIRST'].outstandingKeys()
             .then(_outstandingKeys => {
               outstandingKeys = parseInt(_outstandingKeys)
@@ -131,8 +131,8 @@ contract('Lock', (accounts) => {
           assert(expirationTimestamp.gte(expirationDuration.plus(now)))
         })
 
-        it('should have added the funds to the contract', () => {
-          let newBalance = web3.eth.getBalance(locks['FIRST'].address)
+        it('should have added the funds to the contract', async () => {
+          let newBalance = new BigNumber(await web3.eth.getBalance(locks['FIRST'].address))
           assert.equal(parseFloat(Units.convert(newBalance, 'wei', 'eth')), parseFloat(Units.convert(balance, 'wei', 'eth')) + 0.01)
         })
 


### PR DESCRIPTION
# Description

`getBalance` is a promise but did not previously include an await.  With older versions of Truffle, await was optional but in future versions it will be required.

I also added BigNumber, this is an instance I missed in our previous PR.

This is a pre-req for #1078

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
