### PR TITLE
using account address when calling walletService

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -119,7 +119,7 @@ describe('Wallet middleware', () => {
       address,
     }
 
-    mockWalletService.emit('account.changed', account)
+    mockWalletService.emit('account.changed', address)
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: SET_ACCOUNT,
@@ -302,7 +302,7 @@ describe('Wallet middleware', () => {
     invoke(action)
     expect(mockWalletService.createLock).toHaveBeenCalledWith(
       lock,
-      store.getState().account
+      store.getState().account.address
     )
     expect(mockGenerateJWTToken).toHaveBeenCalled()
     expect(next).toHaveBeenCalledWith(action)
@@ -319,7 +319,7 @@ describe('Wallet middleware', () => {
       key.lock,
       key.owner,
       lock.keyPrice,
-      account,
+      account.address,
       key.data
     )
     expect(next).toHaveBeenCalledWith(action)
@@ -333,8 +333,8 @@ describe('Wallet middleware', () => {
     invoke(action)
 
     expect(mockWalletService.withdrawFromLock).toHaveBeenCalledWith(
-      lock,
-      store.getState().account
+      lock.address,
+      store.getState().account.address
     )
     expect(next).toHaveBeenCalledWith(action)
   })
@@ -353,7 +353,7 @@ describe('Wallet middleware', () => {
 
       expect(mockWalletService.updateKeyPrice).toHaveBeenCalledWith(
         lock.address,
-        store.getState().account,
+        store.getState().account.address,
         '0.03'
       )
       expect(next).toHaveBeenCalledWith(action)

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -37,7 +37,11 @@ export default function walletMiddleware({ getState, dispatch }) {
    * The setAccount action will reset other relevant redux state
    */
   walletService.on('account.changed', account => {
-    dispatch(setAccount(account))
+    dispatch(
+      setAccount({
+        address: account,
+      })
+    )
   })
 
   walletService.on('transaction.new', transaction => {
@@ -91,8 +95,7 @@ export default function walletMiddleware({ getState, dispatch }) {
         walletService.connect(action.provider)
       } else if (action.type === CREATE_LOCK) {
         // Create the lock
-        walletService.createLock(action.lock, getState().account)
-
+        walletService.createLock(action.lock, getState().account.address)
         // And sign its name
         if (config.services.storage) {
           generateJWTToken(walletService, getState().account.address, {
@@ -121,15 +124,19 @@ export default function walletMiddleware({ getState, dispatch }) {
           action.key.lock,
           action.key.owner,
           lock.keyPrice,
-          account,
+          account.address,
           action.key.data
         )
       } else if (action.type === WITHDRAW_FROM_LOCK) {
         const account = getState().account
-        walletService.withdrawFromLock(action.lock, account)
+        walletService.withdrawFromLock(action.lock.address, account.address)
       } else if (action.type === UPDATE_LOCK_KEY_PRICE) {
         const account = getState().account
-        walletService.updateKeyPrice(action.address, account, action.price)
+        walletService.updateKeyPrice(
+          action.address,
+          account.address,
+          action.price
+        )
       } else if (action.type === LOCK_DEPLOYED) {
         // When a lock has been deployed, we need to sign its name again
         if (config.services.storage) {


### PR DESCRIPTION
The walletService only takes addresses for locks and accounts... fixed this (one more thing
that typcechking would have caught earlier!)


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread