### PR TITLE
Converting maxNumberOfKeys to BigNumber

### DIFF
--- a/smart-contracts/test/Unlock/behaviors/createLockWithInfiniteKeys.js
+++ b/smart-contracts/test/Unlock/behaviors/createLockWithInfiniteKeys.js
@@ -1,5 +1,6 @@
-
 const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
+
 const Unlock = artifacts.require('./Unlock.sol')
 const PublicLock = artifacts.require('../../PublicLock.sol')
 const Zos = require('zos')
@@ -30,8 +31,8 @@ contract('PublicLock', accounts => {
 
       it('should have created the lock with an infinite number of keys', async function () {
         let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
-        const maxNumberOfKeys = await publicLock.maxNumberOfKeys()
-        assert.equal(maxNumberOfKeys.toNumber(10), 1.157920892373162e+77)
+        const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())
+        assert.equal(maxNumberOfKeys.toFixed(), new BigNumber(2).pow(256).minus(1).toFixed())
       })
     })
 
@@ -49,8 +50,8 @@ contract('PublicLock', accounts => {
 
       it('should have created the lock with 0 keys', async function () {
         let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
-        const maxNumberOfKeys = await publicLock.maxNumberOfKeys()
-        assert.equal(maxNumberOfKeys.toNumber(10), 0)
+        const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())
+        assert.equal(maxNumberOfKeys.toFixed(), 0)
       })
     })
   })


### PR DESCRIPTION
# Description

Yet another instance of BigNumber I had missed.

With this change, I also changed the test to confirm the exact value instead of using the exponential notation.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
