### PR TITLE
Propagating the lock changes when a transaction is attached to it

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -5,6 +5,7 @@ import {
   DELETE_LOCK,
   WITHDRAW_FROM_LOCK,
   UPDATE_LOCK_KEY_PRICE,
+  UPDATE_LOCK,
 } from '../../actions/lock'
 import { PURCHASE_KEY } from '../../actions/key'
 import { SET_ACCOUNT } from '../../actions/accounts'
@@ -131,11 +132,27 @@ describe('Wallet middleware', () => {
   it('it should handle transaction.new events triggered by the walletService', () => {
     expect.assertions(1)
     const { store } = create()
-    mockWalletService.emit('transaction.new', transaction)
+    mockWalletService.emit('transaction.new', transaction.hash)
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: ADD_TRANSACTION,
         transaction,
+      })
+    )
+  })
+
+  it('it should handle lock.updated events triggered by the walletService', () => {
+    expect.assertions(1)
+    const { store } = create()
+    const update = {
+      transaction: '0x123',
+    }
+    mockWalletService.emit('lock.updated', lock.address, update)
+    expect(store.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: UPDATE_LOCK,
+        address: lock.address,
+        update,
       })
     )
   })

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -4,6 +4,7 @@ import {
   deleteLock,
   UPDATE_LOCK_KEY_PRICE,
   LOCK_DEPLOYED,
+  updateLock,
 } from '../actions/lock'
 import { PURCHASE_KEY } from '../actions/key'
 import { setAccount, SET_ACCOUNT } from '../actions/accounts'
@@ -44,8 +45,16 @@ export default function walletMiddleware({ getState, dispatch }) {
     )
   })
 
-  walletService.on('transaction.new', transaction => {
-    dispatch(addTransaction(transaction))
+  walletService.on('transaction.new', transactionHash => {
+    dispatch(
+      addTransaction({
+        hash: transactionHash,
+      })
+    )
+  })
+
+  walletService.on('lock.updated', (address, update) => {
+    dispatch(updateLock(address, update))
   })
 
   walletService.on('error', (error, transactionHash) => {


### PR DESCRIPTION
Also fixing another bug when triggering the addTransaction action


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread