### PR TITLE
Lock version numbers

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -32,7 +32,7 @@ import "./PublicLock.sol";
 import "./interfaces/IUnlock.sol";
 
 
-/// @dev Must list the direct base contracts in the order from “most base-like” to “most derived”. 
+/// @dev Must list the direct base contracts in the order from “most base-like” to “most derived”.
 /// https://solidity.readthedocs.io/en/latest/contracts.html#multiple-inheritance-and-linearization
 contract Unlock is IUnlock, Initializable, Ownable {
 
@@ -97,7 +97,8 @@ contract Unlock is IUnlock, Initializable, Ownable {
       msg.sender,
       _expirationDuration,
       _keyPrice,
-      _maxNumberOfKeys
+      _maxNumberOfKeys,
+      0 // set Lock version explicitly
     );
 
     // Assign the new Lock

--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -98,7 +98,7 @@ contract Unlock is IUnlock, Initializable, Ownable {
       _expirationDuration,
       _keyPrice,
       _maxNumberOfKeys,
-      0 // set Lock version explicitly
+      1 // set Lock version explicitly
     );
 
     // Assign the new Lock

--- a/smart-contracts/old_lock_versions/lockVersioning.md
+++ b/smart-contracts/old_lock_versions/lockVersioning.md
@@ -1,0 +1,13 @@
+### Lock Versions
+
+As the lock contract evolves, there will likely be some changes which break the front-end integration. When this occurs, we will bump the version number on the lock contract itself. For ease of reviewing changes, the process might look like this:
+
+#### PR 1/2
+
+- the old lock version (ie: `PublicLock.sol`) is copied & pasted into a new file (`oldPublicLock.sol`) in the `smart-contracts/old_lock_versions` directory so we keep it for reference.
+- the old lock version has its name changed to reflect the new version we're about to update to (ie: `PublicLockV1.sol`).
+
+#### PR 2/2
+
+- the version number for the new Lock contract is edited in `Unlock.sol.createLock()`.
+- Unlock is Upgraded using zos so that it will start to deploy the new lock version moving forward.

--- a/smart-contracts/test/Lock/Lock.js
+++ b/smart-contracts/test/Lock/Lock.js
@@ -6,7 +6,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock', (accounts) => {
+contract('Lock', accounts => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -26,7 +26,8 @@ contract('Lock', (accounts) => {
       lock.keyPrice.call(),
       lock.maxNumberOfKeys.call(),
       lock.outstandingKeys.call(),
-      lock.numberOfOwners.call()
+      lock.numberOfOwners.call(),
+      lock.publicLockVersion.call()
     ]).then(
       ([
         owner,
@@ -34,7 +35,8 @@ contract('Lock', (accounts) => {
         keyPrice,
         maxNumberOfKeys,
         outstandingKeys,
-        numberOfOwners
+        numberOfOwners,
+        publicLockVersion
       ]) => {
         expirationDuration = new BigNumber(expirationDuration)
         keyPrice = new BigNumber(keyPrice)
@@ -43,13 +45,11 @@ contract('Lock', (accounts) => {
         numberOfOwners = new BigNumber(numberOfOwners)
         assert.strictEqual(owner, accounts[0])
         assert.equal(expirationDuration.toFixed(), 60 * 60 * 24 * 30)
-        assert.strictEqual(
-          Units.convert(keyPrice, 'wei', 'eth'),
-          '0.01'
-        )
+        assert.strictEqual(Units.convert(keyPrice, 'wei', 'eth'), '0.01')
         assert.equal(maxNumberOfKeys.toFixed(), 10)
         assert.equal(outstandingKeys.toFixed(), 0)
         assert.equal(numberOfOwners.toFixed(), 0)
+        assert.equal(publicLockVersion.toFixed(), 1) // needs updating each lock-version change
       }
     )
   })


### PR DESCRIPTION
# Description
This PR supercedes #1261 which I've closed, as it was bumping the lock version in addition to laying the groundwork for version numbers. 
I've added a markdown doc in the new directory `smart-contracts/old_lock_versions` with details on bumping the lock version number.

###Still to do on Issue #1116:
- [ ] deal with burning/killing old locks
- [ ] deal with migrating old lock to new versions

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)

This is the `lockVersions.MD` file:
### Lock Versions

As the lock contract evolves, there will likely be some changes which break the front-end integration. When this occurs, we will bump the version number on the lock contract itself. For ease of reviewing changes, the process might look like this:

#### PR 1/2

- the old lock version (ie: `PublicLock.sol`) is copied & pasted into a new file (`oldPublicLock.sol`) in the `smart-contracts/old_lock_versions` directory so we keep it for reference.
- the old lock version has its name changed to reflect the new version we're about to update to (ie: `PublicLockV1.sol`).

#### PR 2/2

- the version number for the new Lock contract is edited in `Unlock.sol.createLock()`.
- Unlock is Upgraded using zos so that it will start to deploy the new lock version moving forward.
