### PR TITLE
Sets z-index on paywall iframe when hiding

### DIFF
--- a/unlock-app/src/__tests__/paywall-builder/iframe.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/iframe.test.js
@@ -98,6 +98,7 @@ describe('iframe', () => {
     expect(iframe.style).toEqual({
       backgroundColor: 'transparent',
       backgroundImage: 'none',
+      'z-index': '-2147483647',
     })
 
     expect(document.body.style).toEqual({

--- a/unlock-app/src/paywall-builder/iframe.js
+++ b/unlock-app/src/paywall-builder/iframe.js
@@ -35,4 +35,5 @@ export function hide(iframe, document) {
   document.body.style.overflow = ''
   iframe.style.backgroundColor = 'transparent'
   iframe.style.backgroundImage = 'none'
+  iframe.style['z-index'] = '-2147483647'
 }


### PR DESCRIPTION
# Description

When the paywall iframe is hidden, it's also pushed down the z-index so the protected site can be navigated.

Fixes #1278 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread