### PR TITLE
Extracting the transaction based on its state and key on Locks

### DIFF
--- a/unlock-app/src/__tests__/components/lock/Lock.test.js
+++ b/unlock-app/src/__tests__/components/lock/Lock.test.js
@@ -3,6 +3,7 @@ import {
   mapDispatchToProps,
 } from '../../../components/lock/Lock'
 import { purchaseKey } from '../../../actions/key'
+import { TRANSACTION_TYPES } from '../../../constants'
 
 describe('Lock', () => {
   describe('mapDispatchToProps', () => {
@@ -42,7 +43,7 @@ describe('Lock', () => {
       expect(newProps.lockKey.owner).toEqual(state.account.address)
       expect(newProps.lockKey.data).toEqual(undefined)
       expect(newProps.lockKey.expiration).toEqual(undefined)
-      expect(newProps.transaction).toEqual(null)
+      expect(newProps.transaction).toEqual(undefined) // Array::find will return undefined if no item is matched
     })
 
     it('should return the lockKey and its transaction if applicable', () => {
@@ -57,19 +58,21 @@ describe('Lock', () => {
         account: {
           address: '0x123',
         },
-        keys: [
-          {
+        keys: {
+          '0x123-0x456': {
+            id: '0x123-0x456',
             lock: props.lock.address,
             owner: '0x123',
             expiration: 1000,
             data: 'hello',
-            transaction: '0x777',
           },
-        ],
+        },
         transactions: {
           '0x777': {
+            type: TRANSACTION_TYPES.KEY_PURCHASE,
             status: 'pending',
             hash: '0x777',
+            key: '0x123-0x456',
           },
         },
       }
@@ -78,10 +81,7 @@ describe('Lock', () => {
       expect(newProps.lockKey.owner).toEqual(state.account.address)
       expect(newProps.lockKey.data).toEqual('hello')
       expect(newProps.lockKey.expiration).toEqual(1000)
-      expect(newProps.transaction).toEqual({
-        status: 'pending',
-        hash: '0x777',
-      })
+      expect(newProps.transaction).toEqual(state.transactions['0x777'])
     })
   })
 })

--- a/unlock-app/src/components/lock/Lock.js
+++ b/unlock-app/src/components/lock/Lock.js
@@ -12,9 +12,7 @@ import ConfirmedKeyLock from './ConfirmedKeyLock'
 import NoKeyLock from './NoKeyLock'
 import { UNLIMITED_KEYS_COUNT, TRANSACTION_TYPES } from '../../constants'
 
-import configure from '../../config'
 
-const config = configure()
 
 export const Lock = ({
   lock,

--- a/unlock-app/src/components/lock/Lock.js
+++ b/unlock-app/src/components/lock/Lock.js
@@ -12,7 +12,6 @@ import ConfirmedKeyLock from './ConfirmedKeyLock'
 import NoKeyLock from './NoKeyLock'
 import { UNLIMITED_KEYS_COUNT, TRANSACTION_TYPES } from '../../constants'
 
-
 export const Lock = ({
   lock,
   lockKey,

--- a/unlock-app/src/components/lock/Lock.js
+++ b/unlock-app/src/components/lock/Lock.js
@@ -13,7 +13,6 @@ import NoKeyLock from './NoKeyLock'
 import { UNLIMITED_KEYS_COUNT, TRANSACTION_TYPES } from '../../constants'
 
 
-
 export const Lock = ({
   lock,
   lockKey,

--- a/unlock-app/src/components/lock/Lock.js
+++ b/unlock-app/src/components/lock/Lock.js
@@ -10,7 +10,11 @@ import PendingKeyLock from './PendingKeyLock'
 import ConfirmingKeyLock from './ConfirmingKeyLock'
 import ConfirmedKeyLock from './ConfirmedKeyLock'
 import NoKeyLock from './NoKeyLock'
-import { UNLIMITED_KEYS_COUNT } from '../../constants'
+import { UNLIMITED_KEYS_COUNT, TRANSACTION_TYPES } from '../../constants'
+
+import configure from '../../config'
+
+const config = configure()
 
 export const Lock = ({
   lock,
@@ -95,9 +99,15 @@ export const mapStateToProps = (state, { lock }) => {
       lock: lock.address,
       owner: account.address,
     }
-  } else {
-    transaction = state.transactions[lockKey.transaction]
   }
+
+  // Let's select the transaction corresponding to this key purchase, if it exists
+  // This transaction is of type KEY_PURCHASE
+  transaction = Object.values(state.transactions).find(
+    transaction =>
+      transaction.type === TRANSACTION_TYPES.KEY_PURCHASE &&
+      transaction.key === lockKey.id
+  )
 
   return {
     lockKey,


### PR DESCRIPTION
The key object does not know of its transaction


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread