### PR TITLE
passing middlewares when creating the store

### DIFF
--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider/missingProvider.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider/missingProvider.test.js
@@ -22,23 +22,19 @@ const {
 
 describe('GlobalErrorProvider', () => {
   function makeTestStore(newValues = {}) {
-    return createUnlockStore(
-      {
-        account: {
-          address: '0xdeadbeef',
-          balance: '1000',
-        },
-        network: {
-          name: 1337,
-        },
-        router: {
-          route: '/somewhere',
-        },
-        ...newValues,
+    return createUnlockStore({
+      account: {
+        address: '0xdeadbeef',
+        balance: '1000',
       },
-      undefined,
-      true
-    )
+      network: {
+        name: 1337,
+      },
+      router: {
+        route: '/somewhere',
+      },
+      ...newValues,
+    })
   }
 
   // eslint-disable-next-line

--- a/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
+++ b/unlock-app/src/__tests__/utils/GlobalErrorProvider/normal.test.js
@@ -9,23 +9,19 @@ import { FATAL_NO_USER_ACCOUNT, FATAL_WRONG_NETWORK } from '../../../errors'
 
 describe('GlobalErrorProvider', () => {
   function makeTestStore(newValues = {}) {
-    return createUnlockStore(
-      {
-        account: {
-          address: '0xdeadbeef',
-          balance: '1000',
-        },
-        network: {
-          name: 1337,
-        },
-        router: {
-          route: '/somewhere',
-        },
-        ...newValues,
+    return createUnlockStore({
+      account: {
+        address: '0xdeadbeef',
+        balance: '1000',
       },
-      undefined,
-      true
-    )
+      network: {
+        name: 1337,
+      },
+      router: {
+        route: '/somewhere',
+      },
+      ...newValues,
+    })
   }
   // eslint-disable-next-line
   function PeekAtContextConsumer() {

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -36,16 +36,12 @@ import modalReducer, {
   initialState as defaultModals,
 } from './reducers/modalsReducer'
 
-// Middlewares
-import web3Middleware from './middlewares/web3Middleware'
-import currencyConversionMiddleware from './middlewares/currencyConversionMiddleware'
-import storageMiddleware from './middlewares/storageMiddleware'
-
 const config = configure()
 
 export const createUnlockStore = (
   defaultState = {},
-  history = createMemoryHistory()
+  history = createMemoryHistory(),
+  middlewares = []
 ) => {
   const reducers = {
     router: connectRouter(history),
@@ -88,15 +84,7 @@ export const createUnlockStore = (
     defaultState
   )
 
-  const middlewares = [
-    web3Middleware,
-    currencyConversionMiddleware,
-    routerMiddleware(history),
-  ]
-
-  if (config.services.storage) {
-    middlewares.push(storageMiddleware)
-  }
+  middlewares.push(routerMiddleware(history))
 
   const composeEnhancers =
     global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -9,14 +9,25 @@ import { createUnlockStore } from '../createUnlockStore'
 import GlobalStyle from '../theme/globalStyle'
 import { ConfigContext } from '../utils/withConfig'
 
+// Middlewares
+import web3Middleware from '../middlewares/web3Middleware'
+import currencyConversionMiddleware from '../middlewares/currencyConversionMiddleware'
+import storageMiddleware from '../middlewares/storageMiddleware'
+
 const config = configure()
 
 const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
 
 function getOrCreateStore(initialState, history) {
+  const middlewares = [web3Middleware, currencyConversionMiddleware]
+
+  if (config.services.storage) {
+    middlewares.push(storageMiddleware)
+  }
+
   // Always make a new store if server, otherwise state is shared between requests
   if (config.isServer) {
-    return createUnlockStore(initialState, history)
+    return createUnlockStore(initialState, history, middlewares)
   }
 
   // Create store if unavailable on the client and set it on the window object


### PR DESCRIPTION
This will provider better isolation when doing tests and using the `createStore` function.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread