### PR TITLE
Update pages constant mock so that there is no propType warning

### DIFF
--- a/unlock-app/src/__tests__/pages/pages.test.js
+++ b/unlock-app/src/__tests__/pages/pages.test.js
@@ -6,7 +6,7 @@ import { Home } from '../../pages/index'
 import { Jobs } from '../../pages/jobs'
 import { About } from '../../pages/about'
 import { Dashboard } from '../../pages/dashboard'
-import { pageTitle } from '../../constants'
+import { pageTitle, ETHEREUM_NETWORKS_NAMES } from '../../constants'
 import createUnlockStore from '../../createUnlockStore'
 
 jest.mock('../../constants')
@@ -45,8 +45,8 @@ describe('Pages', () => {
       const currency = {
         USD: 195.99,
       }
-
-      const store = createUnlockStore({ currency })
+      ETHEREUM_NETWORKS_NAMES[network.name] = ['A Name']
+      const store = createUnlockStore({ currency, network })
       const account = {
         address: '0xabc',
         privateKey: 'deadbeef',


### PR DESCRIPTION
# Description

This PR fixes #1285. It updates the `constants` mock in the pages test so that it actually contains the properties that dependent code tries to access.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
