### PR TITLE
Recompile contracts on `npm run dev`

### DIFF
--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -32,7 +32,7 @@
     "remix": "remixd -s contracts --remix-ide http://localhost:8080 --read-only",
     "test": "truffle test --network test",
     "lint": "solhint \"contracts/**/*.sol\"",
-    "ci": "npm run lint && npm run deploy && npm run test",
+    "ci": "npm run lint && npm run build && npm run test",
     "build": "truffle compile --all",
     "deploy": "truffle deploy",
     "zos": "zos"

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -32,8 +32,8 @@
     "remix": "remixd -s contracts --remix-ide http://localhost:8080 --read-only",
     "test": "truffle test --network test",
     "lint": "solhint \"contracts/**/*.sol\"",
-    "ci": "npm run lint && npm run test",
-    "build": "truffle compile --reset",
+    "ci": "npm run lint && npm run deploy && npm run test",
+    "build": "truffle compile --all",
     "deploy": "truffle deploy",
     "zos": "zos"
   },

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -32,7 +32,8 @@
     "remix": "remixd -s contracts --remix-ide http://localhost:8080 --read-only",
     "test": "truffle test --network test",
     "lint": "solhint \"contracts/**/*.sol\"",
-    "ci": "npm run lint && npm run build && npm run test",
+    "dev": "npm run lint && npm run build && npm run test",
+    "ci": "npm run lint && npm run test",
     "build": "truffle compile --all",
     "deploy": "truffle deploy",
     "zos": "zos"


### PR DESCRIPTION
# Description

Changing the `ci` command to first build the contracts.  This should not have any real impact to the Travis CI environment, since it always works from a clean environment and when `truffle test` is run it uses the artifacts from `truffle compile` instead of compiling again.

Also updating `truffle compile --reset` to `truffle compile --all`.  The reset param is used for deploy only.

The benefit of this change is when testing locally.  Today both Nick and I hit an unexpected issue which was caused by a stale artifact.  

...alternatively we could make a `npm run dev` command

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
