### PR TITLE
`await` when getting a contract with Truffle `at`

### DIFF
--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -19,7 +19,7 @@ exports.shouldCreateLock = function (accounts) {
       })
 
       it('should have kept track of the Lock inside Unlock with the right balances', async function () {
-        let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
+        let publicLock = await PublicLock.at(transaction.logs[0].args.newLockAddress)
         // This is a bit of a dumb test because when the lock is missing, the value are 0 anyway...
         let [deployed, totalSales, yieldedDiscountTokens] = await this.unlock.locks(publicLock.address)
         totalSales = new BigNumber(totalSales)
@@ -39,7 +39,7 @@ exports.shouldCreateLock = function (accounts) {
       })
 
       it('should have created the lock with the right address for unlock', async function () {
-        let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
+        let publicLock = await PublicLock.at(transaction.logs[0].args.newLockAddress)
         let unlockProtocol = await publicLock.unlockProtocol()
         assert.equal(unlockProtocol, this.unlock.address)
       })

--- a/smart-contracts/test/Unlock/behaviors/createLockWithInfiniteKeys.js
+++ b/smart-contracts/test/Unlock/behaviors/createLockWithInfiniteKeys.js
@@ -30,7 +30,7 @@ contract('PublicLock', accounts => {
       })
 
       it('should have created the lock with an infinite number of keys', async function () {
-        let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
+        let publicLock = await PublicLock.at(transaction.logs[0].args.newLockAddress)
         const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())
         assert.equal(maxNumberOfKeys.toFixed(), new BigNumber(2).pow(256).minus(1).toFixed())
       })
@@ -49,7 +49,7 @@ contract('PublicLock', accounts => {
       })
 
       it('should have created the lock with 0 keys', async function () {
-        let publicLock = PublicLock.at(transaction.logs[0].args.newLockAddress)
+        let publicLock = await PublicLock.at(transaction.logs[0].args.newLockAddress)
         const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())
         assert.equal(maxNumberOfKeys.toFixed(), 0)
       })


### PR DESCRIPTION
# Description

Getting a contract via Truffle uses a promise: https://truffleframework.com/docs/truffle/getting-started/interacting-with-your-contracts#use-a-contract-at-a-specific-address

With older versions (like we are on now) of Truffle, await here was optional. Once we upgrade, this will be required so this is a pre-req for #1078

This is another instance like https://github.com/unlock-protocol/unlock/pull/1253

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
