### PR TITLE
working blocker while paywall is loading

### DIFF
--- a/unlock-app/src/__tests__/paywall-builder/blocker.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/blocker.test.js
@@ -1,0 +1,62 @@
+import * as blockerManager from '../../paywall-builder/blocker'
+
+describe('paywall builder', () => {
+  describe('blocker', () => {
+    it('getBlocker', () => {
+      const document = {
+        createElement() {
+          return { style: {}, appendChild: jest.fn() }
+        },
+      }
+
+      const blocker = blockerManager.getBlocker(document)
+
+      expect(blocker).toEqual(
+        expect.objectContaining({
+          id: '_unlock_blocker',
+          style: {
+            alignItems: 'center',
+            background: 'white',
+            display: 'flex',
+            fontSize: '30px',
+            height: '100vh',
+            justifyContent: 'center',
+            left: 0,
+            position: 'fixed',
+            top: 0,
+            width: '100vw',
+            zIndex: 222222222222222,
+          },
+        })
+      )
+
+      expect(blocker.appendChild).toHaveBeenCalledWith(
+        expect.objectContaining({
+          innerText: 'Loading access rights...',
+        })
+      )
+    })
+
+    it('addBlocker', () => {
+      const document = {
+        body: {
+          appendChild: jest.fn(),
+        },
+      }
+
+      blockerManager.addBlocker(document, 'blocker')
+
+      expect(document.body.appendChild).toHaveBeenCalledWith('blocker')
+    })
+
+    it('removeBlocker', () => {
+      const blocker = {
+        remove: jest.fn(),
+      }
+
+      blockerManager.removeBlocker(blocker)
+
+      expect(blocker.remove).toHaveBeenCalled()
+    })
+  })
+})

--- a/unlock-app/src/__tests__/paywall-builder/build.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/build.test.js
@@ -70,6 +70,7 @@ describe('buildPaywall', () => {
       let callbacks
       let mockShow
       let mockHide
+      let blocker
       beforeEach(() => {
         callbacks = {}
         window = {
@@ -77,17 +78,31 @@ describe('buildPaywall', () => {
             callbacks[type] = listener
           },
         }
+        blocker = {
+          remove: jest.fn(),
+        }
         mockShow = jest.spyOn(iframeManager, 'show')
         mockShow.mockImplementation(() => {})
         mockHide = jest.spyOn(iframeManager, 'hide')
         mockHide.mockImplementation(() => {})
-        buildPaywall(window, document, fakeLockAddress)
+        buildPaywall(window, document, fakeLockAddress, blocker)
       })
       it('triggers show on locked event', () => {
         callbacks.message({ data: 'locked' })
 
         expect(mockShow).toHaveBeenCalledWith('iframe', document)
         expect(mockHide).not.toHaveBeenCalled()
+      })
+      it('closes the blocker on locked event', () => {
+        callbacks.message({ data: 'locked' })
+
+        expect(blocker.remove).toHaveBeenCalled()
+      })
+      it('closes the blocker on unlocked event', () => {
+        callbacks.message({ data: 'locked' })
+        callbacks.message({ data: 'unlocked' })
+
+        expect(blocker.remove).toHaveBeenCalledTimes(2)
       })
       it('does not trigger show on locked event if already unlocked', () => {
         callbacks.message({ data: 'locked' })

--- a/unlock-app/src/__tests__/paywall-builder/index.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/index.test.js
@@ -1,9 +1,12 @@
 import * as mutations from '../../paywall-builder/mutationobserver'
 import * as buildManager from '../../paywall-builder/build'
+import * as blockerManager from '../../paywall-builder/blocker'
 
 describe('paywall builder integration', () => {
   let listenForNewLocks
   let buildPaywall
+  let getBlocker
+  let addBlocker
   beforeEach(() => {
     listenForNewLocks = jest
       .spyOn(mutations, 'listenForNewLocks')
@@ -11,6 +14,12 @@ describe('paywall builder integration', () => {
     buildPaywall = jest
       .spyOn(buildManager, 'default')
       .mockImplementation(() => 'paywall')
+    getBlocker = jest
+      .spyOn(blockerManager, 'getBlocker')
+      .mockImplementation(() => 'blocker')
+    addBlocker = jest
+      .spyOn(blockerManager, 'addBlocker')
+      .mockImplementation(() => 'addblocker')
   })
 
   afterEach(() => jest.restoreAllMocks())
@@ -27,6 +36,13 @@ describe('paywall builder integration', () => {
     expect(paywall).toBeInstanceOf(Function)
     paywall('lock')
 
-    expect(buildPaywall).toHaveBeenCalledWith(window, document, 'lock')
+    expect(buildPaywall).toHaveBeenCalledWith(
+      window,
+      document,
+      'lock',
+      'blocker'
+    )
+    expect(getBlocker).toHaveBeenCalled()
+    expect(addBlocker).toHaveBeenCalledWith(document, 'blocker')
   })
 })

--- a/unlock-app/src/paywall-builder/blocker.js
+++ b/unlock-app/src/paywall-builder/blocker.js
@@ -1,0 +1,32 @@
+export function getBlocker(document) {
+  const blocker = document.createElement('div')
+
+  blocker.id = '_unlock_blocker'
+
+  blocker.style.height = '100vh'
+  blocker.style.width = '100vw'
+  blocker.style.position = 'fixed'
+  blocker.style.top = 0
+  blocker.style.left = 0
+  blocker.style.background = 'white'
+  blocker.style.display = 'flex'
+  blocker.style.justifyContent = 'center'
+  blocker.style.alignItems = 'center'
+  blocker.style.fontSize = '30px'
+  blocker.style.zIndex = 222222222222222
+
+  const text = document.createElement('div')
+
+  text.innerText = 'Loading access rights...'
+  blocker.appendChild(text)
+
+  return blocker
+}
+
+export function addBlocker(document, blocker) {
+  document.body.appendChild(blocker)
+}
+
+export function removeBlocker(blocker) {
+  blocker.remove()
+}

--- a/unlock-app/src/paywall-builder/build.js
+++ b/unlock-app/src/paywall-builder/build.js
@@ -1,7 +1,7 @@
 import { getIframe, add, show, hide } from './iframe'
 import { findPaywallUrl } from './script'
 
-export default function buildPaywall(window, document, lockAddress) {
+export default function buildPaywall(window, document, lockAddress, blocker) {
   // If there is no lock, do nothing!
   if (!lockAddress) {
     return
@@ -19,10 +19,12 @@ export default function buildPaywall(window, document, lockAddress) {
       if (event.data === 'locked' && !locked) {
         locked = true
         show(iframe, document)
+        blocker.remove()
       }
       if (event.data === 'unlocked' && locked) {
         locked = false
         hide(iframe, document)
+        blocker.remove()
       }
     },
     false

--- a/unlock-app/src/paywall-builder/index.js
+++ b/unlock-app/src/paywall-builder/index.js
@@ -1,5 +1,12 @@
 import { listenForNewLocks } from './mutationobserver'
+import { getBlocker, addBlocker } from './blocker'
 import buildPaywall from './build'
 
-window.onload = () =>
-  listenForNewLocks(lock => buildPaywall(window, document, lock), document.head)
+window.onload = () => {
+  const blocker = getBlocker(document)
+  addBlocker(document, blocker)
+  listenForNewLocks(
+    lock => buildPaywall(window, document, lock, blocker),
+    document.head
+  )
+}


### PR DESCRIPTION
# Description

This is a crude fix for #1236 that hides the paywall content as soon as it is possible (at window.onload)

Locked paywall:
![out](https://user-images.githubusercontent.com/98250/52019081-ac9d0780-24ba-11e9-8763-6c06d4c1e015.gif)

Unlocked paywall:
![out](https://user-images.githubusercontent.com/98250/52019199-08679080-24bb-11e9-8dc1-c983337ac802.gif)


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
