### PR TITLE
Use .call consistently

### DIFF
--- a/smart-contracts/test/Lock/Non_Public_purchaseFor.js
+++ b/smart-contracts/test/Lock/Non_Public_purchaseFor.js
@@ -27,7 +27,7 @@ contract('Lock', (accounts) => {
         await shouldFail(lock
           .purchaseFor(accounts[0], Web3Utils.toHex('Julien')), '')
         // Making sure we do not have a key set!
-        await shouldFail(lock.keyExpirationTimestampFor(accounts[0]), '')
+        await shouldFail(lock.keyExpirationTimestampFor.call(accounts[0]), '')
       })
     })
   })
@@ -37,7 +37,7 @@ contract('Lock', (accounts) => {
     let owner
 
     before(() => {
-      return locks['RESTRICTED'].owner().then((_owner) => {
+      return locks['RESTRICTED'].owner.call().then((_owner) => {
         owner = _owner
       })
     })
@@ -61,7 +61,7 @@ contract('Lock', (accounts) => {
           })
         })
         .then(() => {
-          return locks['RESTRICTED'].keyDataFor(accounts[3])
+          return locks['RESTRICTED'].keyDataFor.call(accounts[3])
         })
         .then(keyData => {
           assert.equal(Web3Utils.toUtf8(keyData), 'Szabo')

--- a/smart-contracts/test/Lock/erc721/Non_Public_approve.js
+++ b/smart-contracts/test/Lock/erc721/Non_Public_approve.js
@@ -33,7 +33,7 @@ contract('Lock ERC721', (accounts) => {
     let owner
 
     before(() => {
-      return locks['RESTRICTED'].owner().then((_owner) => {
+      return locks['RESTRICTED'].owner.call().then((_owner) => {
         owner = _owner
       })
     })
@@ -45,7 +45,7 @@ contract('Lock ERC721', (accounts) => {
             from: owner
           })
           .then(() => {
-            return locks['RESTRICTED'].getApproved(accounts[1])
+            return locks['RESTRICTED'].getApproved.call(accounts[1])
           })
           .then((approved) => {
             assert.equal(approved, accounts[1])
@@ -73,7 +73,7 @@ contract('Lock ERC721', (accounts) => {
           })
           .then(() => {
             // Let's retrieve the approved key
-            return locks['RESTRICTED'].getApproved(accounts[2])
+            return locks['RESTRICTED'].getApproved.call(accounts[2])
           })
           .then((approved) => {
             // and make sure it is right
@@ -88,7 +88,7 @@ contract('Lock ERC721', (accounts) => {
           })
           .then(() => {
             // Let's retrieve the approved key
-            return locks['RESTRICTED'].getApproved(accounts[5])
+            return locks['RESTRICTED'].getApproved.call(accounts[5])
           })
           .then((approved) => {
             // and make sure it is right

--- a/smart-contracts/test/Lock/erc721/Non_Public_getApproved.js
+++ b/smart-contracts/test/Lock/erc721/Non_Public_getApproved.js
@@ -19,7 +19,7 @@ contract('Lock ERC721', (accounts) => {
     let lockOwner
 
     before(() => {
-      return locks['FIRST'].owner().then((_owner) => {
+      return locks['FIRST'].owner.call().then((_owner) => {
         lockOwner = _owner
       })
     })
@@ -28,7 +28,7 @@ contract('Lock ERC721', (accounts) => {
       return locks['FIRST'].approve(accounts[3], accounts[3], {
         from: lockOwner
       }).then(() => {
-        return locks['FIRST'].getApproved(accounts[3])
+        return locks['FIRST'].getApproved.call(accounts[3])
       }).then((approved) => {
         assert.equal(accounts[3], approved)
       })

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -68,7 +68,7 @@ contract('Lock ERC721', (accounts) => {
         })
 
         it('should assign the approvedForTransfer value', () => {
-          return locks['FIRST'].getApproved(accounts[1])
+          return locks['FIRST'].getApproved.call(accounts[1])
             .then((approved) => {
               assert.equal(approved, accounts[2])
             })

--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -22,11 +22,11 @@ contract('Lock ERC721', (accounts) => {
 
   describe('balanceOf', () => {
     it('should fail if the user address is 0', async () => {
-      await shouldFail(locks['FIRST'].balanceOf(Web3Utils.padLeft(0, 40)), 'Invalid address')
+      await shouldFail(locks['FIRST'].balanceOf.call(Web3Utils.padLeft(0, 40)), 'Invalid address')
     })
 
     it('should return 0 if the user has no key', async () => {
-      const balance = new BigNumber(await locks['FIRST'].balanceOf(accounts[3]))
+      const balance = new BigNumber(await locks['FIRST'].balanceOf.call(accounts[3]))
       assert.equal(balance.toFixed(), 0)
     })
 
@@ -35,7 +35,7 @@ contract('Lock ERC721', (accounts) => {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[1]
       })
-      const balance = new BigNumber(await locks['FIRST'].balanceOf(accounts[1]))
+      const balance = new BigNumber(await locks['FIRST'].balanceOf.call(accounts[1]))
       assert.equal(balance.toFixed(), 1)
     })
 
@@ -45,9 +45,9 @@ contract('Lock ERC721', (accounts) => {
         from: accounts[5]
       })
       await locks['FIRST'].expireKeyFor(accounts[5], {
-          from: accounts[0]
-        })
-      const balance = new BigNumber(await locks['FIRST'].balanceOf(accounts[5]))
+        from: accounts[0]
+      })
+      const balance = new BigNumber(await locks['FIRST'].balanceOf.call(accounts[5]))
       assert.equal(balance.toFixed(), 1)
     })
   })

--- a/smart-contracts/test/Lock/erc721/getApproved.js
+++ b/smart-contracts/test/Lock/erc721/getApproved.js
@@ -21,13 +21,13 @@ contract('Lock ERC721', (accounts) => {
     let lockOwner
 
     before(() => {
-      return locks['FIRST'].owner().then((_owner) => {
+      return locks['FIRST'].owner.call().then((_owner) => {
         lockOwner = _owner
       })
     })
 
     it('should fail if no one was approved for a key', async () => {
-      await shouldFail(locks['FIRST'].getApproved(accounts[1]), '')
+      await shouldFail(locks['FIRST'].getApproved.call(accounts[1]), '')
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/getTokenIdFor.js
+++ b/smart-contracts/test/Lock/erc721/getTokenIdFor.js
@@ -16,7 +16,7 @@ contract('Lock ERC721', (accounts) => {
 
   describe('getTokenIdFor', () => {
     it('should abort when the key has no owner', async () => {
-      await shouldFail(locks['FIRST'].getTokenIdFor(accounts[3]), 'No such key')
+      await shouldFail(locks['FIRST'].getTokenIdFor.call(accounts[3]), 'No such key')
     })
 
     it('should return the tokenId for the owner\'s key', async () => {
@@ -24,7 +24,7 @@ contract('Lock ERC721', (accounts) => {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[1]
       })
-      let address = new BigNumber(await locks['FIRST'].getTokenIdFor(accounts[1]))
+      let address = new BigNumber(await locks['FIRST'].getTokenIdFor.call(accounts[1]))
       // Note that as we implement ERC721 support, the tokenId will no longer
       // be the same as the user's address
       assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(address)), Web3Utils.toChecksumAddress(accounts[1]))

--- a/smart-contracts/test/Lock/erc721/ownerOf.js
+++ b/smart-contracts/test/Lock/erc721/ownerOf.js
@@ -22,7 +22,7 @@ contract('Lock ERC721', (accounts) => {
   describe('ownerOf', () => {
     it('should abort when the key has no owner', async () => {
       await shouldFail(locks['FIRST']
-        .ownerOf(accounts[3]), 'No such key')
+        .ownerOf.call(accounts[3]), 'No such key')
     })
 
     it('should return the owner of the key', () => {
@@ -30,7 +30,7 @@ contract('Lock ERC721', (accounts) => {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: accounts[1]
       }).then(() => {
-        return locks['FIRST'].ownerOf(accounts[1])
+        return locks['FIRST'].ownerOf.call(accounts[1])
       }).then(address => {
         assert.equal(address, accounts[1])
       })

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -51,7 +51,7 @@ contract('Lock ERC721', (accounts) => {
           from: accountWithKeyApproved
         })
       ]).then(async () => {
-        keyExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+        keyExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(from))
       })
     })
 
@@ -73,7 +73,7 @@ contract('Lock ERC721', (accounts) => {
           from
         }), '')
         // Ensuring that ownership of the key did not change
-        const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+        const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(from))
         assert.equal(keyExpiration.toFixed(), expirationTimestamp.toFixed())
       })
 
@@ -86,13 +86,13 @@ contract('Lock ERC721', (accounts) => {
             from
           })
           // Let's check the expiration date for that key
-          fromExpirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          fromExpirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(from))
           // Then let's expire the key for accountWithExpiredKey
           await locks['FIRST'].expireKeyFor(accountWithExpiredKey)
           await locks['FIRST'].transferFrom(from, accountWithExpiredKey, from, {
             from
           })
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accountWithExpiredKey))
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accountWithExpiredKey))
           assert.equal(expirationTimestamp.toFixed(), fromExpirationTimestamp.toFixed())
         })
       })
@@ -107,15 +107,15 @@ contract('Lock ERC721', (accounts) => {
             from
           })
           // First let's get the current expiration
-          transferedKeyTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
-          previousExpirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[1]))
+          transferedKeyTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(from))
+          previousExpirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
           await locks['FIRST'].transferFrom(from, accountWithKey, from, {
             from
           })
         })
 
         it('should expand the key\'s validity', async () => {
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accountWithKey))
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accountWithKey))
           const now = Math.floor(new Date().getTime() / 1000)
           // Check +/- 10 seconds
           assert(expirationTimestamp.gt(previousExpirationTimestamp.plus(transferedKeyTimestamp).minus(now + 10)))
@@ -123,7 +123,7 @@ contract('Lock ERC721', (accounts) => {
         })
 
         it('should expire the previous owner\'s key', async () => {
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(from))
           const now = Math.floor(new Date().getTime() / 1000)
           // Check only 10 seconds in the future to ensure deterministic test
           assert(expirationTimestamp.lt(now + 10))
@@ -132,13 +132,13 @@ contract('Lock ERC721', (accounts) => {
 
       describe('when the key owner is not the sender', () => {
         it('should fail if the sender has not been approved for that key', async () => {
-          const previousExpirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          const previousExpirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(from))
           await shouldFail(locks['FIRST']
             .transferFrom(from, accountNotApproved, from, {
               from: accountNotApproved
             }), 'Key is not valid')
           // Ensuring that ownership of the key did not change
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(from))
           assert.equal(previousExpirationTimestamp.toFixed(), expirationTimestamp.toFixed())
         })
 
@@ -153,7 +153,7 @@ contract('Lock ERC721', (accounts) => {
                 })
                 .then(() => {
                   return locks['FIRST']
-                    .balanceOf(accountApproved)
+                    .balanceOf.call(accountApproved)
                     .then(balance => {
                       assert.equal(balance, 1)
                     })
@@ -169,26 +169,26 @@ contract('Lock ERC721', (accounts) => {
             value: Units.convert('0.01', 'eth', 'wei'),
             from
           })
-          keyExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          keyExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(from))
           await locks['FIRST'].transferFrom(from, to, from, {
             from
           })
         })
 
         it('should mark the previous owner`s key as expired', async () => {
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(from))
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(from))
           assert(expirationTimestamp.gt(0))
           assert(expirationTimestamp.lt(keyExpiration))
         })
 
         it('should have assigned the key`s previous expiration to the new owner', async () => {
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(to))
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(to))
           assert.equal(expirationTimestamp.toFixed(), keyExpiration.toFixed())
         })
 
         it('should have assigned the key data field to the new owner', () => {
           return locks['FIRST']
-            .keyDataFor(to)
+            .keyDataFor.call(to)
             .then(keyData => {
               assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
             })

--- a/smart-contracts/test/Lock/expireKeyFor.js
+++ b/smart-contracts/test/Lock/expireKeyFor.js
@@ -37,7 +37,7 @@ contract('Lock', (accounts) => {
         value: locks['FIRST'].params.keyPrice.toFixed(),
         from: accounts[0]
       })
-      const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[2]))
+      const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[2]))
       const now = Math.floor(new Date().getTime() / 1000)
       assert(expirationTimestamp.gt(now))
       await locks['FIRST'].expireKeyFor(accounts[2], {
@@ -53,13 +53,13 @@ contract('Lock', (accounts) => {
         value: locks['FIRST'].params.keyPrice.toFixed(),
         from: accounts[0]
       })
-      let expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[1]))
+      let expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
       let now = Math.floor(new Date().getTime() / 1000)
       assert(expirationTimestamp.gt(now))
       await locks['FIRST'].expireKeyFor(accounts[1], {
         from: accounts[0]
       })
-      expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[1]))
+      expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
       now = Math.floor(new Date().getTime() / 1000)
       assert(expirationTimestamp.lte(now))
     })

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -49,7 +49,7 @@ contract('Lock ERC721', (accounts) => {
     })
 
     it('should have the right number of owners', () => {
-      return lock.numberOfOwners().then((numberOfOwners) => {
+      return lock.numberOfOwners.call().then((numberOfOwners) => {
         assert.equal(numberOfOwners, 4)
       })
     })
@@ -73,7 +73,7 @@ contract('Lock ERC721', (accounts) => {
       let numberOfOwners
 
       before(async () => {
-        numberOfOwners = new BigNumber(await lock.numberOfOwners())
+        numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
         await lock.transferFrom(accounts[1], accounts[5], accounts[1], { from: accounts[1] })
       })
 
@@ -84,7 +84,7 @@ contract('Lock ERC721', (accounts) => {
       })
 
       it('should have the right number of owners', async () => {
-        const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
+        const _numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
         assert.equal(_numberOfOwners.toFixed(), numberOfOwners.plus(1))
       })
 
@@ -98,7 +98,7 @@ contract('Lock ERC721', (accounts) => {
       let numberOfOwners
 
       before(async () => {
-        numberOfOwners = await lock.numberOfOwners()
+        numberOfOwners = await lock.numberOfOwners.call()
         await lock.transferFrom(accounts[2], accounts[3], accounts[2], { from: accounts[2] })
       })
 
@@ -109,7 +109,7 @@ contract('Lock ERC721', (accounts) => {
       })
 
       it('should have the right number of owners', async () => {
-        const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
+        const _numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
         assert.equal(_numberOfOwners.toFixed(), numberOfOwners)
       })
     })

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -28,7 +28,7 @@ contract('Lock', (accounts) => {
             value: Units.convert('0.0001', 'eth', 'wei')
           }), 'Insufficient funds')
         // Making sure we do not have a key set!
-        await shouldFail(locks['FIRST'].keyExpirationTimestampFor(accounts[0]), 'No such key')
+        await shouldFail(locks['FIRST'].keyExpirationTimestampFor.call(accounts[0]), 'No such key')
       })
 
       it('should fail if we reached the max number of keys', async () => {
@@ -36,13 +36,13 @@ contract('Lock', (accounts) => {
           .purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
-        const keyData = await locks['SINGLE KEY'].keyDataFor(accounts[0])
+        const keyData = await locks['SINGLE KEY'].keyDataFor.call(accounts[0])
         assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
         await shouldFail(locks['SINGLE KEY'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
           value: Units.convert('0.01', 'eth', 'wei'),
           from: accounts[1]
         }), 'Maximum number of keys already sold')
-        await shouldFail(locks['SINGLE KEY'].keyDataFor(accounts[1]), 'No such key')
+        await shouldFail(locks['SINGLE KEY'].keyDataFor.call(accounts[1]), 'No such key')
       })
 
       it('should trigger an event when successful', async () => {
@@ -67,7 +67,7 @@ contract('Lock', (accounts) => {
             value: Units.convert('0.01', 'eth', 'wei')
           })
           // And check the expiration which shiuld be exactly now + keyDuration
-          const expirationTimestamp = new BigNumber(await locks['SECOND'].keyExpirationTimestampFor(accounts[4]))
+          const expirationTimestamp = new BigNumber(await locks['SECOND'].keyExpirationTimestampFor.call(accounts[4]))
           const now = parseInt(new Date().getTime() / 1000)
           // we check +/- 10 seconds to fix for now being different inside the EVM and here... :(
           assert(expirationTimestamp.gt(locks['SECOND'].params.expirationDuration.plus(now - 10)))
@@ -80,16 +80,16 @@ contract('Lock', (accounts) => {
           await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
-          const firstKeyData = await locks['FIRST'].keyDataFor(accounts[1])
+          const firstKeyData = await locks['FIRST'].keyDataFor.call(accounts[1])
           assert.equal(Web3Utils.toUtf8(firstKeyData), 'Satoshi')
-          const firstExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[1]))
+          const firstExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
           assert(firstExpiration.gt(0))
           await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Szabo'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
-          const keyData = await locks['FIRST'].keyDataFor(accounts[1])
+          const keyData = await locks['FIRST'].keyDataFor.call(accounts[1])
           assert.equal(Web3Utils.toUtf8(keyData), 'Szabo')
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[1]))
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
           assert.equal(expirationTimestamp.toFixed(), firstExpiration.plus(locks['FIRST'].params.expirationDuration).toFixed())
         })
       })
@@ -103,7 +103,7 @@ contract('Lock', (accounts) => {
             .then(_outstandingKeys => {
               outstandingKeys = parseInt(_outstandingKeys)
               now = parseInt(new Date().getTime() / 1000)
-              return locks['FIRST'].numberOfOwners()
+              return locks['FIRST'].numberOfOwners.call()
                 .then(_numberOfOwners => {
                   numberOfOwners = parseInt(_numberOfOwners)
                   return locks['FIRST'].purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
@@ -115,15 +115,15 @@ contract('Lock', (accounts) => {
 
         it('should have the right data for the key', () => {
           return locks['FIRST']
-            .keyDataFor(accounts[0])
+            .keyDataFor.call(accounts[0])
             .then(keyData => {
               assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
             })
         })
 
         it('should have the right expiration timestamp for the key', async () => {
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor(accounts[0]))
-          const expirationDuration = new BigNumber(await locks['FIRST'].expirationDuration())
+          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[0]))
+          const expirationDuration = new BigNumber(await locks['FIRST'].expirationDuration.call())
           assert(expirationTimestamp.gte(expirationDuration.plus(now)))
         })
 

--- a/smart-contracts/test/Lock/purchaseForFrom.js
+++ b/smart-contracts/test/Lock/purchaseForFrom.js
@@ -26,7 +26,7 @@ contract('Lock', (accounts) => {
         await shouldFail(lock
           .purchaseForFrom(accounts[0], accounts[1], Web3Utils.toHex('Julien')), 'Key is not valid')
         // Making sure we do not have a key set!
-        await shouldFail(lock.keyExpirationTimestampFor(accounts[0]), 'No such key')
+        await shouldFail(lock.keyExpirationTimestampFor.call(accounts[0]), 'No such key')
       })
     })
 
@@ -36,14 +36,14 @@ contract('Lock', (accounts) => {
         return lock.purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
           value: Units.convert('0.01', 'eth', 'wei')
         }).then(() => {
-          return lock.keyDataFor(accounts[0])
+          return lock.keyDataFor.call(accounts[0])
         }).then((keyData) => {
           assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
           return lock.purchaseForFrom(accounts[1], accounts[0], Web3Utils.toHex('Vitalik'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
         }).then(() => {
-          return lock.keyDataFor(accounts[1])
+          return lock.keyDataFor.call(accounts[1])
         }).then((keyData) => {
           assert.equal(Web3Utils.toUtf8(keyData), 'Vitalik')
         })

--- a/smart-contracts/test/Lock/updateKeyPrice.js
+++ b/smart-contracts/test/Lock/updateKeyPrice.js
@@ -12,13 +12,13 @@ contract('Lock', (accounts) => {
     before(async () => {
       unlock = await Unlock.deployed()
       locks = await deployLocks(unlock)
-      keyPriceBefore = new BigNumber(await locks['FIRST'].keyPrice())
+      keyPriceBefore = new BigNumber(await locks['FIRST'].keyPrice.call())
       assert.equal(keyPriceBefore.toFixed(), 10000000000000000)
       transaction = await locks['FIRST'].updateKeyPrice(Units.convert('0.3', 'eth', 'wei'))
     })
 
     it('should change the actual keyPrice', async () => {
-      const keyPriceAfter = new BigNumber(await locks['FIRST'].keyPrice())
+      const keyPriceAfter = new BigNumber(await locks['FIRST'].keyPrice.call())
       assert.equal(keyPriceAfter.toFixed(), 300000000000000000)
     })
 
@@ -34,7 +34,7 @@ contract('Lock', (accounts) => {
       let keyPrice
 
       before(async () => {
-        keyPrice = new BigNumber(await locks['FIRST'].keyPrice())
+        keyPrice = new BigNumber(await locks['FIRST'].keyPrice.call())
         await shouldFail(locks['FIRST'].updateKeyPrice(
           Units.convert('0.3', 'eth', 'wei'),
           {
@@ -44,7 +44,7 @@ contract('Lock', (accounts) => {
 
 
       it('should leave the price unchanged', async () => {
-        const keyPriceAfter = new BigNumber(await locks['FIRST'].keyPrice())
+        const keyPriceAfter = new BigNumber(await locks['FIRST'].keyPrice.call())
         assert.equal(keyPrice.toFixed(), keyPriceAfter.toFixed())
       })
     })

--- a/smart-contracts/test/Unlock/behaviors/initialization.js
+++ b/smart-contracts/test/Unlock/behaviors/initialization.js
@@ -3,7 +3,7 @@ const BigNumber = require('bignumber.js')
 exports.shouldHaveInitialized = function (unlockOwner) {
   describe('initialization', function () {
     it('should have an owner', async function () {
-      const owner = await this.unlock.owner()
+      const owner = await this.unlock.owner.call()
       assert.equal(owner, unlockOwner)
     })
 


### PR DESCRIPTION
# Description

In Truffle, `.call` is used to make a read-only call vs send a transaction to be mined.  The keyword is meant to be optional for constant methods (i.e. Truffle uses the ABI to automatically assume `call` vs `send`).

https://truffleframework.com/docs/truffle/reference/contract-abstractions#calling-getters

We were previously inconsistent about if `.call` was used or not.  For example: 
 - with: https://github.com/unlock-protocol/unlock/blob/b477ad17dc38f4f2bba990ba189691d9b0dac9f4/smart-contracts/test/Lock/erc165.js
 - without: https://github.com/unlock-protocol/unlock/blob/b477ad17dc38f4f2bba990ba189691d9b0dac9f4/smart-contracts/test/Lock/owners.js#L62

This is optional with Truffle, making it a style/consistency question.  

However I'm working towards supporting `solidity-coverage` and in that environment it seems using `.call` is not optional.  So this should get us a step closer to https://github.com/unlock-protocol/unlock/issues/38

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)