### PR TITLE
Converting more numbers to BigNumber

### DIFF
--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -42,16 +42,14 @@ contract('Lock ERC721', (accounts) => {
       ])
     })
 
-    it('should have the right number of keys', () => {
-      return lock.outstandingKeys().then((outstandingKeys) => {
-        assert.equal(outstandingKeys, 4)
-      })
+    it('should have the right number of keys', async () => {
+      const outstandingKeys = new BigNumber(await lock.outstandingKeys())
+      assert.equal(outstandingKeys.toFixed(), 4)
     })
 
-    it('should have the right number of owners', () => {
-      return lock.numberOfOwners().then((numberOfOwners) => {
-        assert.equal(numberOfOwners, 4)
-      })
+    it('should have the right number of owners', async () => {
+      const numberOfOwners = new BigNumber(await lock.numberOfOwners())
+      assert.equal(numberOfOwners.toFixed(), 4)
     })
 
     it('should allow for access to an individual key owner', () => {
@@ -77,10 +75,9 @@ contract('Lock ERC721', (accounts) => {
         await lock.transferFrom(accounts[1], accounts[5], accounts[1], { from: accounts[1] })
       })
 
-      it('should have the right number of keys', () => {
-        return lock.outstandingKeys().then((outstandingKeys) => {
-          assert.equal(outstandingKeys, 4)
-        })
+      it('should have the right number of keys', async () => {
+        const outstandingKeys = await lock.outstandingKeys()
+        assert.equal(outstandingKeys.toFixed(), 4)
       })
 
       it('should have the right number of owners', async () => {
@@ -98,19 +95,18 @@ contract('Lock ERC721', (accounts) => {
       let numberOfOwners
 
       before(async () => {
-        numberOfOwners = await lock.numberOfOwners()
+        numberOfOwners = new BigNumber(await lock.numberOfOwners())
         await lock.transferFrom(accounts[2], accounts[3], accounts[2], { from: accounts[2] })
       })
 
-      it('should have the right number of keys', () => {
-        return lock.outstandingKeys().then((outstandingKeys) => {
-          assert.equal(outstandingKeys, 4)
-        })
+      it('should have the right number of keys', async () => {
+        const outstandingKeys = await lock.outstandingKeys()
+        assert.equal(outstandingKeys.toFixed(), 4)
       })
 
       it('should have the right number of owners', async () => {
         const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
-        assert.equal(_numberOfOwners.toFixed(), numberOfOwners)
+        assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed())
       })
     })
   })

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -99,18 +99,12 @@ contract('Lock', (accounts) => {
 
         before(async () => {
           balance = new BigNumber(await web3.eth.getBalance(locks['FIRST'].address))
-          return locks['FIRST'].outstandingKeys()
-            .then(_outstandingKeys => {
-              outstandingKeys = parseInt(_outstandingKeys)
-              now = parseInt(new Date().getTime() / 1000)
-              return locks['FIRST'].numberOfOwners()
-                .then(_numberOfOwners => {
-                  numberOfOwners = parseInt(_numberOfOwners)
-                  return locks['FIRST'].purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
-                    value: Units.convert('0.01', 'eth', 'wei')
-                  })
-                })
-            })
+          outstandingKeys = new BigNumber(await locks['FIRST'].outstandingKeys())
+          now = parseInt(new Date().getTime() / 1000)
+          numberOfOwners = new BigNumber(await locks['FIRST'].numberOfOwners())
+          return locks['FIRST'].purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
+            value: Units.convert('0.01', 'eth', 'wei')
+          })
         })
 
         it('should have the right data for the key', () => {
@@ -132,26 +126,20 @@ contract('Lock', (accounts) => {
           assert.equal(parseFloat(Units.convert(newBalance, 'wei', 'eth')), parseFloat(Units.convert(balance, 'wei', 'eth')) + 0.01)
         })
 
-        it('should have increased the number of outstanding keys', () => {
-          return locks['FIRST'].outstandingKeys
-            .call()
-            .then(_outstandingKeys => {
-              assert.equal(
-                parseInt(_outstandingKeys),
-                outstandingKeys + 1
-              )
-            })
+        it('should have increased the number of outstanding keys', async () => {
+          const _outstandingKeys = new BigNumber(await locks['FIRST'].outstandingKeys.call())
+          assert.equal(
+            _outstandingKeys.toFixed(),
+            outstandingKeys.plus(1).toFixed()
+          )
         })
 
-        it('should have increased the number of owners', () => {
-          return locks['FIRST'].numberOfOwners
-            .call()
-            .then(_numberOfOwners => {
-              assert.equal(
-                parseInt(_numberOfOwners),
-                numberOfOwners + 1
-              )
-            })
+        it('should have increased the number of owners', async () => {
+          const _numberOfOwners = new BigNumber(await locks['FIRST'].numberOfOwners.call())
+          assert.equal(
+            _numberOfOwners.toFixed(),
+            numberOfOwners.plus(1).toFixed()
+          )
         })
       })
     })


### PR DESCRIPTION
# Description

There are so many numbers in our tests!  Here are more that need converting to BigNumber.

This is another instance like https://github.com/unlock-protocol/unlock/pull/1264

It's required for `solidity-coverage`, getting us a step closer to enabling that.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
