### PR TITLE
Adding a test case for clearing approval after transfer

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -600,7 +600,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     returns (address)
   {
     address approvedRecipient = approved[_tokenId];
-    require(approvedRecipient != address(0));
+    require(approvedRecipient != address(0), "No approved recipient exists");
     return approvedRecipient;
   }
 

--- a/smart-contracts/test/Lock/erc721/getApproved.js
+++ b/smart-contracts/test/Lock/erc721/getApproved.js
@@ -27,7 +27,7 @@ contract('Lock ERC721', (accounts) => {
     })
 
     it('should fail if no one was approved for a key', async () => {
-      await shouldFail(locks['FIRST'].getApproved(accounts[1]), '')
+      await shouldFail(locks['FIRST'].getApproved(accounts[1]), 'No approved recipient exists')
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -170,7 +170,7 @@ contract('Lock ERC721', (accounts) => {
             .transferFrom(accountWithKeyApproved, accountApproved, accountWithKeyApproved, {
               from: accountApproved
             })
-          await shouldFail(locks['FIRST'].getApproved(accountWithKeyApproved), '')
+          await shouldFail(locks['FIRST'].getApproved(accountApproved), '')
         })
       })
 

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -162,14 +162,6 @@ contract('Lock ERC721', (accounts) => {
         })
 
         it('approval should be cleared after a transfer', async () => {
-          await locks['FIRST']
-            .approve(accountApproved, accountWithKeyApproved, {
-              from: accountWithKeyApproved
-            })
-          await locks['FIRST']
-            .transferFrom(accountWithKeyApproved, accountApproved, accountWithKeyApproved, {
-              from: accountApproved
-            })
           await shouldFail(locks['FIRST'].getApproved(accountApproved), 'No approved recipient exists')
         })
       })

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -170,7 +170,7 @@ contract('Lock ERC721', (accounts) => {
             .transferFrom(accountWithKeyApproved, accountApproved, accountWithKeyApproved, {
               from: accountApproved
             })
-          await shouldFail(locks['FIRST'].getApproved(accountApproved), '')
+          await shouldFail(locks['FIRST'].getApproved(accountApproved), 'No approved recipient exists')
         })
       })
 

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -160,6 +160,18 @@ contract('Lock ERC721', (accounts) => {
                 })
             })
         })
+
+        it('approval should be cleared after a transfer', async () => {
+          await locks['FIRST']
+            .approve(accountApproved, accountWithKeyApproved, {
+              from: accountWithKeyApproved
+            })
+          await locks['FIRST']
+            .transferFrom(accountWithKeyApproved, accountApproved, accountWithKeyApproved, {
+              from: accountApproved
+            })
+          await shouldFail(locks['FIRST'].getApproved(accountWithKeyApproved), '')
+        })
       })
 
       describe('when the key owner is the sender', () => {


### PR DESCRIPTION
# Description

Adding a test case confirming that after a transfer the approval is cleared.  This prevents the approval from persisting to the new owner's asset.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
