### PR TITLE
Using an environment variable to set the readonly provider

### DIFF
--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -9,6 +9,7 @@ module.exports = withSourceMaps({
   publicRuntimeConfig: {
     unlockEnv: process.env.UNLOCK_ENV || 'dev',
     httpProvider: process.env.HTTP_PROVIDER || '127.0.0.1',
+    readOnlyProvider: process.env.READ_ONLY_PROVIDER,
   },
   webpack(config) {
     return config

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -64,6 +64,7 @@ export default function configure(
   let services = {}
   let supportedProviders = []
   let blockTime = 8000 // in mseconds.
+  const readOnlyProviderUrl = runtimeConfig.readOnlyProviderUrl
 
   if (env === 'test') {
     // In test, we fake the HTTP provider
@@ -145,12 +146,18 @@ export default function configure(
     requiredNetwork = ETHEREUM_NETWORKS_NAMES[requiredNetworkId][0]
   }
 
+  let readOnlyProvider
+  if (readOnlyProviderUrl) {
+    readOnlyProvider = new Web3.providers.HttpProvider(readOnlyProviderUrl)
+  }
+
   return {
     blockTime,
     isServer,
     env,
     providers,
     isRequiredNetwork,
+    readOnlyProvider,
     requiredNetworkId,
     requiredNetwork,
     requiredConfirmations,

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -9,6 +9,7 @@ import { TRANSACTION_TYPES, MAX_UINT } from '../constants'
 import { NON_DEPLOYED_CONTRACT } from '../errors'
 
 const {
+  readOnlyProvider,
   providers,
   unlockAddress,
   blockTime,
@@ -26,7 +27,13 @@ export default class Web3Service extends EventEmitter {
   constructor(unlockContractAddress = unlockAddress) {
     super()
 
-    this.web3 = new Web3(Object.values(providers)[0]) // Defaulting to the first provider...
+    if (readOnlyProvider) {
+      this.web3 = new Web3(readOnlyProvider)
+    } else {
+      this.web3 = new Web3(Object.values(providers)[0]) // Defaulting to the first provider.
+    }
+
+    // TODO: detect discrepancy in providers
 
     // Transactions create events which we use here to build the state.
     this.eventsHandlers = {


### PR DESCRIPTION
Using an environment variable to set the readonly provider.
The environment variable is set on the deploy script.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread