### PR TITLE
WIP: Refactor paywall to handle showing/hiding content based on lock status

### DIFF
--- a/unlock-app/src/__tests__/pages/paywall.test.js
+++ b/unlock-app/src/__tests__/pages/paywall.test.js
@@ -12,8 +12,10 @@ describe('Paywall', () => {
           pathname: `/paywall/${lock.address}`,
         },
       }
-      const props = mapStateToProps({ locks, router })
-      expect(props.lock).toBe(lock)
+      const keys = {}
+      const modals = []
+      const props = mapStateToProps({ locks, keys, modals, router })
+      expect(props.locks[0]).toBe(lock)
     })
   })
 })

--- a/unlock-app/src/__tests__/pages/paywall.test.js
+++ b/unlock-app/src/__tests__/pages/paywall.test.js
@@ -1,21 +1,81 @@
-import { mapStateToProps } from '../../pages/paywall'
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { Provider } from 'react-redux'
+import createUnlockStore from '../../createUnlockStore'
+import Paywall, { mapStateToProps } from '../../pages/paywall'
+import { lockPage, unlockPage } from '../../services/iframeService'
+import { ConfigContext } from '../../utils/withConfig'
 
+jest.mock('../../services/iframeService.js')
+
+const lock = { address: '0x4983D5ECDc5cc0E499c2D23BF4Ac32B982bAe53a' }
+const locks = {
+  [lock.address]: lock,
+}
+const router = {
+  location: {
+    pathname: `/paywall/${lock.address}`,
+    search: '',
+    hash: '',
+  },
+}
+
+let futureDate = new Date()
+futureDate.setYear(futureDate.getFullYear() + 1)
+futureDate = futureDate.getTime() / 1000
+
+const keys = {
+  aKey: {
+    lock: lock.address,
+    expiration: futureDate,
+  },
+}
+const modals = []
+
+const store = createUnlockStore({ locks, keys, modals, router })
+const noKeyStore = createUnlockStore({ locks, keys: {}, modals, router })
+
+afterEach(() => {
+  rtl.cleanup()
+  jest.clearAllMocks()
+})
 describe('Paywall', () => {
   describe('mapStateToProps', () => {
     it('should yield the lock which matches the address of the demo page', () => {
-      const lock = { address: '0x4983D5ECDc5cc0E499c2D23BF4Ac32B982bAe53a' }
-      const locks = {
-        [lock.address]: lock,
-      }
-      const router = {
-        location: {
-          pathname: `/paywall/${lock.address}`,
-        },
-      }
-      const keys = {}
-      const modals = []
       const props = mapStateToProps({ locks, keys, modals, router })
       expect(props.locks[0]).toBe(lock)
+    })
+    it('should be locked when no keys are available', () => {
+      const props = mapStateToProps({ locks, keys: {}, modals, router })
+      expect(props.locked).toBe(true)
+    })
+    it('should not be locked when there is a matching key', () => {
+      const props = mapStateToProps({ locks, keys, modals, router })
+      expect(props.locked).toBe(false)
+    })
+  })
+  describe('handleIframe', () => {
+    it('should call lockPage when it is locked', () => {
+      expect.assertions(2)
+      rtl.render(
+        <Provider store={noKeyStore}>
+          <Paywall />
+        </Provider>
+      )
+      expect(lockPage).toHaveBeenCalled()
+      expect(unlockPage).not.toHaveBeenCalled()
+    })
+    it('should call unlockPage when it is not locked', () => {
+      expect.assertions(2)
+      rtl.render(
+        <ConfigContext.Provider value={{ providers: [] }}>
+          <Provider store={store}>
+            <Paywall />
+          </Provider>
+        </ConfigContext.Provider>
+      )
+      expect(lockPage).not.toHaveBeenCalled()
+      expect(unlockPage).toHaveBeenCalled()
     })
   })
 })

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -17,6 +17,12 @@ class Paywall extends React.Component {
     this.isLocked = this.isLocked.bind(this)
     this.handleIframe = this.handleIframe.bind(this)
   }
+  componentDidMount() {
+    this.handleIframe()
+  }
+  componentDidUpdate() {
+    this.handleIframe()
+  }
   isLocked() {
     const { keys, modalShown } = this.props
     return !(keys.length > 0 && !modalShown)

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -14,7 +14,6 @@ import { lockPage, unlockPage } from '../services/iframeService'
 class Paywall extends React.Component {
   constructor(props) {
     super(props)
-    this.isLocked = this.isLocked.bind(this)
     this.handleIframe = this.handleIframe.bind(this)
   }
   componentDidMount() {

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -25,7 +25,7 @@ class Paywall extends React.Component {
   }
   isLocked() {
     const { keys, modalShown } = this.props
-    return !(keys.length > 0 && !modalShown)
+    return keys.length === 0 || modalShown
   }
   handleIframe() {
     if (this.isLocked()) {

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -23,20 +23,16 @@ class Paywall extends React.Component {
   componentDidUpdate() {
     this.handleIframe()
   }
-  isLocked() {
-    const { keys, modalShown } = this.props
-    return keys.length === 0 || modalShown
-  }
   handleIframe() {
-    if (this.isLocked()) {
+    const { locked } = this.props
+    if (locked) {
       lockPage()
     } else {
       unlockPage()
     }
   }
   render() {
-    const { locks } = this.props
-    const locked = this.isLocked()
+    const { locks, locked } = this.props
     return (
       <BrowserOnly>
         <GlobalErrorProvider>
@@ -55,13 +51,7 @@ class Paywall extends React.Component {
 
 Paywall.propTypes = {
   locks: PropTypes.arrayOf(UnlockPropTypes.lock).isRequired,
-  keys: PropTypes.arrayOf(UnlockPropTypes.key),
-  modalShown: PropTypes.bool,
-}
-
-Paywall.defaultProps = {
-  keys: [],
-  modalShown: false,
+  locked: PropTypes.bool.isRequired,
 }
 
 export const mapStateToProps = ({ locks, keys, modals, router }) => {
@@ -84,10 +74,12 @@ export const mapStateToProps = ({ locks, keys, modals, router }) => {
     }
   })
 
+  const modalShown = !!modals[locksFromUri.map(l => l.address).join('-')]
+  const locked = validKeys.length === 0 || modalShown
+
   return {
-    modalShown: !!modals[locksFromUri.map(l => l.address).join('-')],
-    keys: validKeys,
     locks: locksFromUri,
+    locked,
   }
 }
 

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -25,15 +25,30 @@ Paywall.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
 }
 
-export const mapStateToProps = ({ locks, router }) => {
+export const mapStateToProps = ({ locks, keys, modals, router }) => {
   const match = router.location.pathname.match(LOCK_PATH_NAME_REGEXP)
 
-  const lock = match
+  const lockFromUri = match
     ? Object.values(locks).find(lock => lock.address === match[1])
     : null
 
+  let validKeys = []
+  const locksFromUri = lockFromUri ? [lockFromUri] : []
+  locksFromUri.forEach(lock => {
+    for (let k of Object.values(keys)) {
+      if (
+        k.lock === lock.address &&
+        k.expiration > new Date().getTime() / 1000
+      ) {
+        validKeys.push(k)
+      }
+    }
+  })
+
   return {
-    lock,
+    modalShown: !!modals[locksFromUri.map(l => l.address).join('-')],
+    keys: validKeys,
+    locks: locksFromUri,
   }
 }
 

--- a/unlock-app/src/stories/creator/Paywall.stories.js
+++ b/unlock-app/src/stories/creator/Paywall.stories.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import Paywall from '../../pages/paywall'
 import createUnlockStore from '../../createUnlockStore'
+import { ConfigContext } from '../../utils/withConfig'
 
 const lock = {
   address: '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e',
@@ -80,8 +81,10 @@ storiesOf('Paywall', module)
   })
   .add('the paywall overlay, unlocked', () => {
     return (
-      <Provider store={unlockedStore}>
-        <Paywall />
-      </Provider>
+      <ConfigContext.Provider value={{ providers: [] }}>
+        <Provider store={unlockedStore}>
+          <Paywall />
+        </Provider>
+      </ConfigContext.Provider>
     )
   })


### PR DESCRIPTION
# Description
A step on the road to #980, based on @cellog's work. This refactors `Paywall` in such a way that it:

1. Handles the iframe without using `ShowUnlessUserHasKeyToAnyLock`
2. Delegates visibility of children to `ShowWhenLocked` and `ShowWhenUnlocked`

A future PR will include the subscription status flag on the unlocked page using the `ShowWhenUnlocked` component.

~~**We should hold off on merging this for now, the storybook is incorrect due to the value of the development `requiredNetwork` in `config`**~~ Resolved.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
