### PR TITLE
Remove test network from truffle config js

### DIFF
--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "remix": "remixd -s contracts --remix-ide http://localhost:8080 --read-only",
-    "test": "truffle test --network test",
+    "test": "truffle test --network development",
     "lint": "solhint \"contracts/**/*.sol\"",
     "dev": "npm run lint && npm run build && npm run test",
     "ci": "npm run lint && npm run test",

--- a/smart-contracts/truffle-config.js
+++ b/smart-contracts/truffle-config.js
@@ -39,7 +39,7 @@ module.exports = {
     },
     development: {
       // used for solidity-coverage
-      host: '127.0.0.1',
+      host: testHost,
       port: 8545,
       network_id: '*' // Match any network id
     },

--- a/smart-contracts/truffle-config.js
+++ b/smart-contracts/truffle-config.js
@@ -49,12 +49,6 @@ module.exports = {
       port: 8546, // We use ganache-gui and this is its default port
       network_id: '*' // Match any network id
     },
-    test: {
-      // used to run tests in docker (ci)
-      host: testHost,
-      port: 8545,
-      network_id: '*' // Match any network id
-    },
     rinkeby: {
       provider: new Web3.providers.HttpProvider(rinkebyProviderUrl),
       network_id: '4' // Network Id for Rinkeby


### PR DESCRIPTION
# Description

This removes the 'test' network from `truffle-config.js`, as we now use 'local' and 'development' to be compatible with solidity-coverage.
A follow-up PR will remove the 'test' network from the migrations scripts.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
