### PR TITLE
new action for opening paywall modal in a new window

### DIFF
--- a/unlock-app/src/__tests__/actions/modal.test.js
+++ b/unlock-app/src/__tests__/actions/modal.test.js
@@ -3,6 +3,8 @@ import {
   SHOW_MODAL,
   hideModal,
   HIDE_MODAL,
+  openNewWindowModal,
+  OPEN_MODAL_IN_NEW_WINDOW,
 } from '../../actions/modal'
 
 describe('modal actions', () => {
@@ -22,5 +24,11 @@ describe('modal actions', () => {
       modal,
     }
     expect(hideModal(modal)).toEqual(expectedAction)
+  })
+
+  it('should create an action to open the modal in a new window', () => {
+    expect(openNewWindowModal()).toEqual({
+      type: OPEN_MODAL_IN_NEW_WINDOW,
+    })
   })
 })

--- a/unlock-app/src/actions/modal.js
+++ b/unlock-app/src/actions/modal.js
@@ -1,5 +1,6 @@
 export const SHOW_MODAL = 'modal/SHOW_MODAL'
 export const HIDE_MODAL = 'modal/HIDE_MODAL'
+export const OPEN_MODAL_IN_NEW_WINDOW = 'modal/OPEN_MODAL_IN_NEW_WINDOW'
 
 export const showModal = modal => ({
   type: SHOW_MODAL,
@@ -9,4 +10,9 @@ export const showModal = modal => ({
 export const hideModal = modal => ({
   type: HIDE_MODAL,
   modal,
+})
+
+// TODO: this is to be used in a new middleware to open paywall modal in a new window
+export const openNewWindowModal = () => ({
+  type: OPEN_MODAL_IN_NEW_WINDOW,
 })


### PR DESCRIPTION
# Description

New action that will be called as the callback for `purchaseKey` on a lock when it should be opened in a new window.

This is for #1315 and is a step on the path to #1287

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
