### PR TITLE
BigNumber and .call() usage fixes

### DIFF
--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -43,7 +43,7 @@ contract('Lock ERC721', (accounts) => {
     })
 
     it('should have the right number of keys', async () => {
-      const outstandingKeys = new BigNumber(await lock.outstandingKeys())
+      const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
       assert.equal(outstandingKeys.toFixed(), 4)
     })
 
@@ -76,7 +76,7 @@ contract('Lock ERC721', (accounts) => {
       })
 
       it('should have the right number of keys', async () => {
-        const outstandingKeys = await lock.outstandingKeys()
+        const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
         assert.equal(outstandingKeys.toFixed(), 4)
       })
 
@@ -100,7 +100,7 @@ contract('Lock ERC721', (accounts) => {
       })
 
       it('should have the right number of keys', async () => {
-        const outstandingKeys = await lock.outstandingKeys()
+        const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
         assert.equal(outstandingKeys.toFixed(), 4)
       })
 


### PR DESCRIPTION
# Description

Fixes BigNumber and .call usage.  I believe these were lost in a merge conflict.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
