### PR TITLE
add redirect capability to constants and server

### DIFF
--- a/unlock-app/src/_server.js
+++ b/unlock-app/src/_server.js
@@ -22,7 +22,7 @@ function _server(port, dev) {
           // get the query string passed to our application
           const path = pathname.split('/')[1]
           if (path === 'paywall') {
-            const params = route('/paywall/:lockAddress')(pathname)
+            const params = route('/paywall/:lockAddress/:redirect?')(pathname)
             app.render(req, res, '/paywall', Object.assign(params, query))
           } else if (path === 'demo') {
             const params = route('/demo/:lockaddress')(pathname)

--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -37,7 +37,7 @@ export const TRANSACTION_TYPES = {
 /**
  * Matches /lock /demo or /paywall
  */
-export const LOCK_PATH_NAME_REGEXP = /\/[a-z0-9]+\/(0x[a-fA-F0-9]{40}).*/
+export const LOCK_PATH_NAME_REGEXP = /\/[a-z0-9]+\/(0x[a-fA-F0-9]{40})(\/(.+))?/
 
 export const PAGE_DESCRIPTION =
   'Unlock is a protocol which enables creators to monetize their content with a few lines of code in a fully decentralized way.'


### PR DESCRIPTION
# Description

This modifies the `LOCK_PATH_NAME_REGEXP` constant and the allowed url for the paywall to add a URL that the paywall should use to redirect the browser towards after the user clicks the "continue to content button on the lock.

This is a step on the way of #1314 and #1287 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
