### PR TITLE
Redirect to published content if requested

### DIFF
--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -35,6 +35,19 @@ describe('Overlay', () => {
         type: SHOW_MODAL,
       })
     })
+    it('should yield a prop function which redirects if instructed', () => {
+      expect.assertions(1)
+      const locks = [{ address: '0x123' }, { address: '0x456' }]
+      const dispatch = jest.fn()
+      const props = mapDispatchToProps(dispatch, {
+        locks,
+        redirect: 'http://example.com',
+      })
+      props.hideModal()
+      // we can't actually test the redirect, in the test environment it doesn't work
+      // but we can verify that dispatch was not called for the normal behavior
+      expect(dispatch).not.toHaveBeenCalled()
+    })
   })
   describe('displayError', () => {
     it('should display children if there is no error', () => {

--- a/unlock-app/src/__tests__/pages/paywall.test.js
+++ b/unlock-app/src/__tests__/pages/paywall.test.js
@@ -15,5 +15,19 @@ describe('Paywall', () => {
       const props = mapStateToProps({ locks, router })
       expect(props.lock).toBe(lock)
     })
+
+    it('should pull the redirect parameter from the page', () => {
+      const lock = { address: '0x4983D5ECDc5cc0E499c2D23BF4Ac32B982bAe53a' }
+      const locks = {
+        [lock.address]: lock,
+      }
+      const router = {
+        location: {
+          pathname: `/paywall/${lock.address}/http%3A%2F%2Fexample.com`,
+        },
+      }
+      const props = mapStateToProps({ locks, router })
+      expect(props.redirect).toBe('http://example.com')
+    })
   })
 })

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -45,8 +45,12 @@ Overlay.propTypes = {
   showModal: PropTypes.func.isRequired,
 }
 
-export const mapDispatchToProps = (dispatch, { locks }) => ({
+export const mapDispatchToProps = (dispatch, { locks, redirect }) => ({
   hideModal: () => {
+    if (redirect) {
+      window.location.href = redirect
+      return
+    }
     unlockPage()
     return dispatch(hideModal(locks.map(l => l.address).join('-')))
   },

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import UnlockPropTypes from '../propTypes'
 import Overlay from '../components/lock/Overlay'
@@ -8,12 +9,12 @@ import { LOCK_PATH_NAME_REGEXP } from '../constants'
 import BrowserOnly from '../components/helpers/BrowserOnly'
 import GlobalErrorProvider from '../utils/GlobalErrorProvider'
 
-const Paywall = ({ lock }) => {
+const Paywall = ({ lock, redirect }) => {
   return (
     <BrowserOnly>
       <GlobalErrorProvider>
         <ShowUnlessUserHasKeyToAnyLock locks={lock ? [lock] : []}>
-          <Overlay locks={lock ? [lock] : []} />
+          <Overlay locks={lock ? [lock] : []} redirect={redirect} />
           <DeveloperOverlay />
         </ShowUnlessUserHasKeyToAnyLock>
       </GlobalErrorProvider>
@@ -23,17 +24,25 @@ const Paywall = ({ lock }) => {
 
 Paywall.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
+  redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+}
+
+Paywall.defaultProps = {
+  redirect: false,
 }
 
 export const mapStateToProps = ({ locks, router }) => {
   const match = router.location.pathname.match(LOCK_PATH_NAME_REGEXP)
 
-  const lock = match
-    ? Object.values(locks).find(lock => lock.address === match[1])
-    : null
+  if (match) {
+    const lock = Object.values(locks).find(lock => lock.address === match[1])
+    const redirect = decodeURIComponent(match[3])
+    return { lock, redirect }
+  }
 
   return {
-    lock,
+    lock: null,
+    redirect: false,
   }
 }
 


### PR DESCRIPTION
# Description

If the URL for the paywall contains a URL to redirect to after finishing purchase, then it will redirect instead of dispatching the `hideModal` event

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
