### PR TITLE
dispatch an action to open a new window if the paywall has been instructed to do so

### DIFF
--- a/unlock-app/src/__tests__/components/lock/Lock.test.js
+++ b/unlock-app/src/__tests__/components/lock/Lock.test.js
@@ -4,6 +4,7 @@ import {
 } from '../../../components/lock/Lock'
 import { purchaseKey } from '../../../actions/key'
 import { TRANSACTION_TYPES } from '../../../constants'
+import { openNewWindowModal } from '../../../actions/modal'
 
 describe('Lock', () => {
   describe('mapDispatchToProps', () => {
@@ -20,6 +21,22 @@ describe('Lock', () => {
       newProps.purchaseKey(key)
       expect(props.showModal).toHaveBeenCalledWith()
       expect(dispatch).toHaveBeenCalledWith(purchaseKey(key))
+    })
+
+    it('should dispatch openNewWindowModal if the openNewWindow prop is truthy', () => {
+      expect.assertions(2)
+      const dispatch = jest.fn()
+      const props = {
+        showModal: jest.fn(),
+        openInNewWindow: true,
+      }
+      const key = {}
+
+      const newProps = mapDispatchToProps(dispatch, props)
+
+      newProps.purchaseKey(key)
+      expect(props.showModal).not.toHaveBeenCalled()
+      expect(dispatch).toHaveBeenCalledWith(openNewWindowModal())
     })
   })
 

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -4,11 +4,10 @@ import { Provider } from 'react-redux'
 
 import { SHOW_MODAL, HIDE_MODAL } from '../../../actions/modal'
 
-import {
+import Overlay, {
   mapDispatchToProps,
   mapStateToProps,
   displayError,
-  Overlay,
 } from '../../../components/lock/Overlay'
 import { GlobalErrorContext } from '../../../utils/GlobalErrorProvider'
 import { FATAL_NO_USER_ACCOUNT } from '../../../errors'

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -6,6 +6,7 @@ import { SHOW_MODAL, HIDE_MODAL } from '../../../actions/modal'
 
 import {
   mapDispatchToProps,
+  mapStateToProps,
   displayError,
   Overlay,
 } from '../../../components/lock/Overlay'
@@ -33,6 +34,28 @@ describe('Overlay', () => {
       expect(dispatch).toHaveBeenCalledWith({
         modal: '0x123-0x456',
         type: SHOW_MODAL,
+      })
+    })
+  })
+  describe('mapStateToProps', () => {
+    it('should set openInNewWindow based on the value of account', () => {
+      expect.assertions(2)
+
+      const state1 = {
+        account: null,
+      }
+      const state2 = {
+        account: {
+          address: 'account',
+        },
+      }
+
+      expect(mapStateToProps(state1)).toEqual({
+        openInNewWindow: true,
+      })
+
+      expect(mapStateToProps(state2)).toEqual({
+        openInNewWindow: false,
       })
     })
   })

--- a/unlock-app/src/components/lock/Lock.js
+++ b/unlock-app/src/components/lock/Lock.js
@@ -63,6 +63,7 @@ Lock.propTypes = {
   purchaseKey: PropTypes.func.isRequired,
   config: UnlockPropTypes.configuration.isRequired,
   hideModal: PropTypes.func.isRequired,
+  openInNewWindow: PropTypes.bool.isRequired,
 }
 
 Lock.defaultProps = {
@@ -70,8 +71,14 @@ Lock.defaultProps = {
   transaction: null,
 }
 
-export const mapDispatchToProps = (dispatch, { showModal }) => ({
+export const mapDispatchToProps = (
+  dispatch,
+  { showModal, openInNewWindow }
+) => ({
   purchaseKey: key => {
+    if (openInNewWindow) {
+      //      return dispatch(openPaywallInNewWindow())
+    }
     showModal()
     dispatch(purchaseKey(key))
   },

--- a/unlock-app/src/components/lock/Lock.js
+++ b/unlock-app/src/components/lock/Lock.js
@@ -5,6 +5,7 @@ import UnlockPropTypes from '../../propTypes'
 import withConfig from '../../utils/withConfig'
 
 import { purchaseKey } from '../../actions/key'
+import { openNewWindowModal } from '../../actions/modal'
 
 import PendingKeyLock from './PendingKeyLock'
 import ConfirmingKeyLock from './ConfirmingKeyLock'
@@ -77,7 +78,7 @@ export const mapDispatchToProps = (
 ) => ({
   purchaseKey: key => {
     if (openInNewWindow) {
-      //      return dispatch(openPaywallInNewWindow())
+      return dispatch(openNewWindowModal())
     }
     showModal()
     dispatch(purchaseKey(key))

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -16,7 +16,13 @@ export function displayError(error, children) {
   return <>{children}</>
 }
 
-export const Overlay = ({ locks, hideModal, showModal, scrollPosition }) => (
+export const Overlay = ({
+  locks,
+  hideModal,
+  showModal,
+  scrollPosition,
+  openInNewWindow,
+}) => (
   <FullPage>
     <Banner scrollPosition={scrollPosition}>
       <Headline>
@@ -30,6 +36,7 @@ export const Overlay = ({ locks, hideModal, showModal, scrollPosition }) => (
               lock={lock}
               hideModal={hideModal}
               showModal={showModal}
+              openInNewWindow={openInNewWindow}
             />
           ))}
         </GlobalErrorConsumer>
@@ -44,7 +51,12 @@ Overlay.propTypes = {
   hideModal: PropTypes.func.isRequired,
   showModal: PropTypes.func.isRequired,
   scrollPosition: PropTypes.number.isRequired,
+  openInNewWindow: PropTypes.bool.isRequired,
 }
+
+export const mapStateToProps = ({ account }) => ({
+  openInNewWindow: !account,
+})
 
 export const mapDispatchToProps = (dispatch, { locks }) => ({
   hideModal: () => {
@@ -57,7 +69,7 @@ export const mapDispatchToProps = (dispatch, { locks }) => ({
 })
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(Overlay)
 

--- a/unlock-app/src/stories/lock/Lock.stories.js
+++ b/unlock-app/src/stories/lock/Lock.stories.js
@@ -51,6 +51,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        openInNewWindow={false}
       />
     )
   })
@@ -64,6 +65,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        openInNewWindow={false}
       />
     )
   })
@@ -76,6 +78,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        openInNewWindow={false}
       />
     )
   })
@@ -94,6 +97,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        openInNewWindow={false}
       />
     )
   })
@@ -113,6 +117,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        openInNewWindow={false}
       />
     )
   })
@@ -132,6 +137,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        openInNewWindow={false}
       />
     )
   })
@@ -151,6 +157,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        openInNewWindow={false}
       />
     )
   })
@@ -167,6 +174,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        openInNewWindow={false}
       />
     )
   })

--- a/unlock-app/src/stories/lock/Overlay.stories.js
+++ b/unlock-app/src/stories/lock/Overlay.stories.js
@@ -67,6 +67,7 @@ const render = (locks, errors = { error: false, errorMetadata: {} }) => (
           locks={locks}
           hideModal={() => {}}
           showModal={() => {}}
+          openInNewWindow={false}
         />
       </ErrorProvider>
     </ConfigProvider>


### PR DESCRIPTION
# Description

This PR modifies the `purchaseKey` callback to dispatch an `openNewWindowModal` action if the `Lock` is instructed to open a new window on key purchase attempt. The actual window opening is handled in a middleware, which will be in a separate PR.

It detects whether a new window needs to be opened by adding a `mapStateToProps` to the `Overlay` `connect`. This function adds a new prop `openInNewWindow` which is a simple test: do we have access to a user account? If not, we will open a new window when the user clicks the lock to purchase a key.

This PR is for #1315 and is a step along the path to #1287 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
