### PR TITLE
add redirection support to paywall

### DIFF
--- a/unlock-app/src/__tests__/paywall-builder/build.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/build.test.js
@@ -100,6 +100,9 @@ describe('buildPaywall', () => {
             callbacks[type] = listener
           },
           requestAnimationFrame() {},
+          location: {
+            href: 'href',
+          },
         }
         blocker = {
           remove: jest.fn(),
@@ -143,7 +146,11 @@ describe('buildPaywall', () => {
         expect(mockHide).toHaveBeenCalledTimes(1)
         expect(mockShow).toHaveBeenCalledTimes(1)
       })
-      it('calls redirect on redirect event', () => {})
+      it('calls redirect on redirect event', () => {
+        callbacks.message({ data: 'redirect' })
+
+        expect(window.location.href).toBe('/url/paywall/lockaddress/href')
+      })
     })
   })
 })

--- a/unlock-app/src/__tests__/paywall-builder/build.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/build.test.js
@@ -1,4 +1,4 @@
-import buildPaywall from '../../paywall-builder/build'
+import buildPaywall, { redirect } from '../../paywall-builder/build'
 import * as script from '../../paywall-builder/script'
 import * as iframeManager from '../../paywall-builder/iframe'
 
@@ -22,6 +22,17 @@ describe('buildPaywall', () => {
 
   afterEach(() => jest.restoreAllMocks())
 
+  it('redirect', () => {
+    const window = {
+      location: {
+        href: 'href/',
+      },
+    }
+
+    redirect(window, 'hi')
+
+    expect((window.location.href = 'hi/href%2F'))
+  })
   describe('sets up the iframe on load', () => {
     let mockScript
     let mockIframe
@@ -132,6 +143,7 @@ describe('buildPaywall', () => {
         expect(mockHide).toHaveBeenCalledTimes(1)
         expect(mockShow).toHaveBeenCalledTimes(1)
       })
+      it('calls redirect on redirect event', () => {})
     })
   })
 })

--- a/unlock-app/src/paywall-builder/build.js
+++ b/unlock-app/src/paywall-builder/build.js
@@ -12,6 +12,12 @@ const baseBannerHeight = () => {
   return minHeightPct > 30 ? minHeightPct : 30
 }
 
+export function redirect(window, paywallUrl) {
+  const redirectTo = encodeURIComponent(window.location.href)
+
+  window.location.href = paywallUrl + '/' + redirectTo
+}
+
 export default function buildPaywall(window, document, lockAddress, blocker) {
   // If there is no lock, do nothing!
   if (!lockAddress) {
@@ -57,6 +63,9 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
         locked = false
         hide(iframe, document)
         blocker.remove()
+      }
+      if (event.data === 'redirect') {
+        redirect(window, paywallUrl)
       }
     },
     false

--- a/unlock-app/src/paywall-builder/build.js
+++ b/unlock-app/src/paywall-builder/build.js
@@ -15,7 +15,7 @@ const baseBannerHeight = () => {
 export function redirect(window, paywallUrl) {
   const redirectTo = encodeURIComponent(window.location.href)
 
-  window.location.href = paywallUrl + '/' + redirectTo
+  window.location.href = paywallUrl + redirectTo
 }
 
 export default function buildPaywall(window, document, lockAddress, blocker) {


### PR DESCRIPTION
# Description

This PR implements one of 2 possible solutions to the challenge of redirecting from the iframe paywall to a new window. This one assumes that the paywall iframe will use `postMessage` to tell the main window that the user has clicked on the lock to attempt to purchase a key. Then, it changes the current url to to paywall, appending a url-encoded return path so that the paywall will know how to redirect back to the content after the user purchases a key. This has the advantage that it will never be blocked by a pop-up blocker, and the drawback that it requires inter-window communication. However, the communication is pretty simple, so I elected to code this possible solution first.

A follow-up PR will link the paywall action dispatched to posting a message to the main window using a middleware. This middleware will become the new hub of all postMessage communication.

This PR implements #1313 and is a step on the path to #1287 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
