### PR TITLE
add postMessage middleware

### DIFF
--- a/unlock-app/src/__tests__/middlewares/postMessageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/postMessageMiddleware.test.js
@@ -1,45 +1,94 @@
-import postMessageMiddleware from '../../middlewares/postMessageMiddleware'
+import postMessageMiddleware, {
+  inIframe,
+} from '../../middlewares/postMessageMiddleware'
 import { openNewWindowModal } from '../../actions/modal'
 
 describe('postMessageMiddleware', () => {
-  it('does responds to OPEN_MODAL_IN_NEW_WINDOW if in an iframe', () => {
-    expect.assertions(2)
-    const next = jest.fn()
-
-    const action = openNewWindowModal()
-
-    const window = {
-      parent: {
-        contentWindow: {
-          postMessage: jest.fn(),
-          origin: 'origin',
-        },
-      },
-    }
-
-    const middleware = postMessageMiddleware(window)
-
-    middleware()(next)(action)
-
-    expect(next).toHaveBeenCalledWith(action)
-    expect(window.parent.contentWindow.postMessage).toHaveBeenCalledWith(
-      'redirect',
-      'origin'
-    )
+  describe('inIframe', () => {
+    it('should return false when self == top', () => {
+      const window = {}
+      window.self = window
+      window.top = window
+      expect(inIframe(window)).toBe(false)
+    })
+    it('should return true when self != top', () => {
+      const window = {
+        self: 'nope',
+        top: 'yes',
+      }
+      expect(inIframe(window)).toBe(true)
+    })
+    it('should return true when an exception is thrown', () => {
+      expect(inIframe()).toBe(true)
+    })
   })
-  it('passes actions to the next middleware', () => {
-    expect.assertions(1)
-    const next = jest.fn()
 
-    const action = {
-      type: 'boo',
-    }
+  describe('middleware functionality', () => {
+    it('does responds to OPEN_MODAL_IN_NEW_WINDOW if in an iframe', () => {
+      expect.assertions(2)
+      const next = jest.fn()
 
-    const window = {}
+      const action = openNewWindowModal()
 
-    const middleware = postMessageMiddleware(window)
+      const window = {
+        parent: {
+          contentWindow: {
+            postMessage: jest.fn(),
+            origin: 'origin',
+          },
+        },
+      }
+      window.self = window
+      window.top = 'not window'
 
-    middleware()(next)(action)
-    expect(next).toHaveBeenCalledWith(action)
+      const middleware = postMessageMiddleware(window)
+
+      middleware()(next)(action)
+
+      expect(next).toHaveBeenCalledWith(action)
+      expect(window.parent.contentWindow.postMessage).toHaveBeenCalledWith(
+        'redirect',
+        'origin'
+      )
+    })
+    it('does not respond to OPEN_MODAL_IN_NEW_WINDOW if not in an iframe', () => {
+      expect.assertions(2)
+      const next = jest.fn()
+
+      const action = openNewWindowModal()
+
+      const window = {
+        parent: {
+          contentWindow: {
+            postMessage: jest.fn(),
+            origin: 'origin',
+          },
+        },
+      }
+      window.self = window
+      window.top = window
+
+      const middleware = postMessageMiddleware(window)
+
+      middleware()(next)(action)
+
+      expect(next).toHaveBeenCalledWith(action)
+      expect(window.parent.contentWindow.postMessage).not.toHaveBeenCalled()
+    })
+    it('passes actions to the next middleware', () => {
+      expect.assertions(1)
+      const next = jest.fn()
+
+      const action = {
+        type: 'boo',
+      }
+
+      const window = {}
+
+      const middleware = postMessageMiddleware(window)
+
+      middleware()(next)(action)
+      expect(next).toHaveBeenCalledWith(action)
+    })
   })
 })

--- a/unlock-app/src/__tests__/middlewares/postMessageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/postMessageMiddleware.test.js
@@ -1,28 +1,7 @@
-import postMessageMiddleware, {
-  inIframe,
-} from '../../middlewares/postMessageMiddleware'
+import postMessageMiddleware from '../../middlewares/postMessageMiddleware'
 import { openNewWindowModal } from '../../actions/modal'
 
 describe('postMessageMiddleware', () => {
-  describe('inIframe', () => {
-    it('should return false when self == top', () => {
-      const window = {}
-      window.self = window
-      window.top = window
-      expect(inIframe(window)).toBe(false)
-    })
-    it('should return true when self != top', () => {
-      const window = {
-        self: 'nope',
-        top: 'yes',
-      }
-      expect(inIframe(window)).toBe(true)
-    })
-    it('should return true when an exception is thrown', () => {
-      expect(inIframe()).toBe(true)
-    })
-  })
-
   describe('middleware functionality', () => {
     it('does responds to OPEN_MODAL_IN_NEW_WINDOW if in an iframe', () => {
       expect.assertions(2)

--- a/unlock-app/src/__tests__/middlewares/postMessageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/postMessageMiddleware.test.js
@@ -1,0 +1,45 @@
+import postMessageMiddleware from '../../middlewares/postMessageMiddleware'
+import { openNewWindowModal } from '../../actions/modal'
+
+describe('postMessageMiddleware', () => {
+  it('does responds to OPEN_MODAL_IN_NEW_WINDOW if in an iframe', () => {
+    expect.assertions(2)
+    const next = jest.fn()
+
+    const action = openNewWindowModal()
+
+    const window = {
+      parent: {
+        contentWindow: {
+          postMessage: jest.fn(),
+          origin: 'origin',
+        },
+      },
+    }
+
+    const middleware = postMessageMiddleware(window)
+
+    middleware()(next)(action)
+
+    expect(next).toHaveBeenCalledWith(action)
+    expect(window.parent.contentWindow.postMessage).toHaveBeenCalledWith(
+      'redirect',
+      'origin'
+    )
+  })
+  it('passes actions to the next middleware', () => {
+    expect.assertions(1)
+    const next = jest.fn()
+
+    const action = {
+      type: 'boo',
+    }
+
+    const window = {}
+
+    const middleware = postMessageMiddleware(window)
+
+    middleware()(next)(action)
+    expect(next).toHaveBeenCalledWith(action)
+  })
+})

--- a/unlock-app/src/middlewares/postMessageMiddleware.js
+++ b/unlock-app/src/middlewares/postMessageMiddleware.js
@@ -1,11 +1,21 @@
 import { OPEN_MODAL_IN_NEW_WINDOW } from '../actions/modal'
 
+// cribbed from https://stackoverflow.com/questions/326069/how-to-identify-if-a-webpage-is-being-loaded-inside-an-iframe-or-directly-into-t
+export function inIframe(window) {
+  try {
+    return window.self !== window.top
+  } catch (e) {
+    return true
+  }
+}
+
 // store is unused in this middleware, it is only for listening for actions
 // and converting them into postMessage
 const postMessageMiddleware = window => () => {
-  let iframe = window.parent
+  const iframe = window.parent
+  const enabled = inIframe(window)
   return next => action => {
-    if (!iframe) return next(action)
+    if (!enabled) return next(action)
     if (action.type === OPEN_MODAL_IN_NEW_WINDOW) {
       iframe.contentWindow.postMessage('redirect', iframe.contentWindow.origin)
     }

--- a/unlock-app/src/middlewares/postMessageMiddleware.js
+++ b/unlock-app/src/middlewares/postMessageMiddleware.js
@@ -1,0 +1,16 @@
+import { OPEN_MODAL_IN_NEW_WINDOW } from '../actions/modal'
+
+// store is unused in this middleware, it is only for listening for actions
+// and converting them into postMessage
+const postMessageMiddleware = window => () => {
+  let iframe = window.parent
+  return next => action => {
+    if (!iframe) return next(action)
+    if (action.type === OPEN_MODAL_IN_NEW_WINDOW) {
+      iframe.contentWindow.postMessage('redirect', iframe.contentWindow.origin)
+    }
+    return next(action)
+  }
+}
+
+export default postMessageMiddleware

--- a/unlock-app/src/middlewares/postMessageMiddleware.js
+++ b/unlock-app/src/middlewares/postMessageMiddleware.js
@@ -1,13 +1,5 @@
 import { OPEN_MODAL_IN_NEW_WINDOW } from '../actions/modal'
-
-// cribbed from https://stackoverflow.com/questions/326069/how-to-identify-if-a-webpage-is-being-loaded-inside-an-iframe-or-directly-into-t
-export function inIframe(window) {
-  try {
-    return window.self !== window.top
-  } catch (e) {
-    return true
-  }
-}
+import { inIframe } from '../config'
 
 // store is unused in this middleware, it is only for listening for actions
 // and converting them into postMessage

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -14,6 +14,7 @@ import web3Middleware from '../middlewares/web3Middleware'
 import currencyConversionMiddleware from '../middlewares/currencyConversionMiddleware'
 import storageMiddleware from '../middlewares/storageMiddleware'
 import walletMiddleware from '../middlewares/walletMiddleware'
+import postMessageMiddleware from '../middlewares/postMessageMiddleware'
 
 const config = configure()
 
@@ -21,6 +22,7 @@ const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
 
 function getOrCreateStore(initialState, history) {
   const middlewares = [
+    postMessageMiddleware(global),
     web3Middleware,
     currencyConversionMiddleware,
     walletMiddleware,


### PR DESCRIPTION
# Description

This adds a new middleware, `postMessageMiddleware`. This middleware listens for redux actions, and then posts messages from the iframe to the parent window. In its first guise, it only listens for the `OPEN_MODAL_IN_NEW_WINDOW` action and posts a message to the parent window which will prompt it to redirect to the paywall in the main window. In subsequent PRs, this will extract the `showModal`/`hideModal` events and post those to the parent as well. This PR also enables the middleware in `_app.js`

One important feature of the middleware: if the current page is not executing in an iframe, it is disabled and just passes actions through to the next middleware in the chain. This will avoid exceptions when trying to post to a non-existent parent window.

This is the final step for implementing #1314 and a step on the path to #1287 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
