### PR TITLE
Adds estimated lock address as temporary address

### DIFF
--- a/unlock-app/package-lock.json
+++ b/unlock-app/package-lock.json
@@ -17118,11 +17118,6 @@
         }
       }
     },
-    "uniqid": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.0.3.tgz",
-      "integrity": "sha512-R2qx3X/LYWSdGRaluio4dYrPXAJACTqyUjuyXHoJLBUOIfmMcnYOyY2d6Y4clZcIz5lK6ZaI0Zzmm0cPfsIqzQ=="
-    },
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -44,7 +44,6 @@
     "run-script-os": "^1.0.5",
     "storybook-react-router": "^1.0.2",
     "styled-components": "^4.1.3",
-    "uniqid": "^5.0.3",
     "web3": "1.0.0-beta.33",
     "web3-utils": "1.0.0-beta.33"
   },

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
-import uniqid from 'uniqid'
 import UnlockPropTypes from '../../propTypes'
 
 import Icon from '../lock/Icon'
@@ -326,8 +325,8 @@ CreatorLockForm.defaultProps = {
   keyPrice: '0.01',
   maxNumberOfKeys: 10,
   name: 'New Lock',
-  address: uniqid(), // for new locks, we don't have an address, so use a temporary one
   pending: false,
+  address: null,
 }
 
 const mapStateToProps = state => {

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events'
 import Web3 from 'web3'
 import Web3Utils from 'web3-utils'
-
+import ethJsUtil from 'ethereumjs-util'
 import LockContract from '../artifacts/contracts/PublicLock.json'
 import UnlockContract from '../artifacts/contracts/Unlock.json'
 import configure from '../config'
@@ -216,6 +216,17 @@ export default class WalletService extends EventEmitter {
           transaction: hash,
         })
       }
+    )
+  }
+
+  async generateLockAddress() {
+    let transactionCount = await this.web3.eth.getTransactionCount(
+      this.unlockContractAddress
+    )
+    return Web3Utils.toChecksumAddress(
+      ethJsUtil.bufferToHex(
+        ethJsUtil.generateAddress(this.unlockContractAddress, transactionCount)
+      )
     )
   }
 


### PR DESCRIPTION
This pull request replaces the temporary uuid assigned to newly created locks with
the next address of the lock created by the Lock Factory. 

Ideally, this will resolve the double lock/ghost lock scenario we are currently experiencing as well as unblock Locksmith from being made available on staging

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
