### PR TITLE
Now detecting pending transaction as ones which are not in a block yet

### DIFF
--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -235,7 +235,7 @@ describe('Web3Service', () => {
             '0x83f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
           nonce: '0x04',
           blockHash: 'null',
-          transactionIndex: null, // Not mined
+          blockNumber: null, // Not mined
           from: '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1',
           to: '0xcfeb869f69431e42cdb54a4f4f105c19c080a601',
           value: '0x0',

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -325,7 +325,7 @@ export default class Web3Service extends EventEmitter {
         blockTransaction.input
       )
 
-      if (blockTransaction.transactionIndex === null) {
+      if (blockTransaction.blockNumber === null) {
         // This means the transaction is not in a block yet (ie. not mined), but has been propagated
         this._watchTransaction(transactionHash)
         return this.emit('transaction.updated', transactionHash, {
@@ -352,21 +352,23 @@ export default class Web3Service extends EventEmitter {
       return this.web3.eth
         .getTransactionReceipt(transactionHash)
         .then(transactionReceipt => {
-          // NOTE: old version of web3.js (pre 1.0.0-beta.34) are not parsing 0x0 into a falsy value
-          if (
-            !transactionReceipt.status ||
-            transactionReceipt.status == '0x0'
-          ) {
-            return this.emit('transaction.updated', transactionHash, {
-              status: 'failed',
-            })
-          }
+          if (transactionReceipt) {
+            // NOTE: old version of web3.js (pre 1.0.0-beta.34) are not parsing 0x0 into a falsy value
+            if (
+              !transactionReceipt.status ||
+              transactionReceipt.status == '0x0'
+            ) {
+              return this.emit('transaction.updated', transactionHash, {
+                status: 'failed',
+              })
+            }
 
-          return this.parseTransactionLogsFromReceipt(
-            transactionHash,
-            contract,
-            transactionReceipt
-          )
+            return this.parseTransactionLogsFromReceipt(
+              transactionHash,
+              contract,
+              transactionReceipt
+            )
+          }
         })
     })
   }


### PR DESCRIPTION
Now detecting pending transaction as ones which are not in a block yet


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread