### PR TITLE
Utilizing the personal signature method when available

### DIFF
--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -295,6 +295,10 @@ export default class WalletService extends EventEmitter {
    * Signs data for the given account
    */
   signData(account, data, callback) {
-    this.web3.eth.sign(data, account, callback)
+    if (this.web3.eth.personal) {
+      this.web3.eth.personal.sign(data, account, callback)
+    } else {
+      this.web3.eth.sign(data, account, callback)
+    }
   }
 }


### PR DESCRIPTION
The signature method change is to better support the staging and production environments that people will use.  This reflects the fact that their accounts will not be unlocked.

[https://ethereum.stackexchange.com/questions/25601/what-is-the-difference-between-web3-eth-sign-web3-eth-accounts-sign-web3-eth-p](https://ethereum.stackexchange.com/questions/25601/what-is-the-difference-between-web3-eth-sign-web3-eth-accounts-sign-web3-eth-p)

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
