### PR TITLE
fix setting up of redux dev tools extension

### DIFF
--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -86,8 +86,12 @@ export const createUnlockStore = (
 
   middlewares.push(routerMiddleware(history))
 
-  const composeEnhancers =
-    global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+  let composeEnhancers
+  if (config.isServer) {
+    composeEnhancers = compose
+  } else {
+    composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+  }
 
   return createStore(
     combineReducers(reducers),


### PR DESCRIPTION
# Description

For some reason, the existing setup code for redux dev tools extension doesn't like being referenced from `global` and must be from `window`. This PR uses the `isServer` config variable to make sure we don't reference `window` unless we are in the browser, and makes dev tools work for the paywall even when it's in an iframe!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
