### PR TITLE
set the network in web3service so walletMiddleware won't swallow all actions

### DIFF
--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -18,6 +18,7 @@ import {
   setKeysOnPageForLock,
 } from '../actions/keysPages'
 import { lockRoute } from '../utils/routes'
+import { setNetwork } from '../actions/network'
 
 // This middleware listen to redux events and invokes the web3Service API.
 // It also listen to events from web3Service and dispatches corresponding actions
@@ -52,6 +53,16 @@ export default function web3Middleware({ getState, dispatch }) {
     } else {
       dispatch(addLock(address, update))
     }
+  })
+
+  /**
+   * When the network has changed, we need to get a new account
+   * as well as reset all the reducers
+   */
+  web3Service.on('network.changed', networkId => {
+    // Set the new network, which should also clean up all reducers
+    // And we need a new account!
+    dispatch(setNetwork(networkId))
   })
 
   /**

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -91,6 +91,9 @@ export default class Web3Service extends EventEmitter {
     } else {
       return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
     }
+    this.web3.eth.net
+      .getId()
+      .then(networkId => this.emit('network.changed', networkId))
   }
 
   /**


### PR DESCRIPTION
# Description

Currently, `walletService` stores all actions until it receives one of `SET_NETWORK` `SET_PROVIDER` or `SET_ACCOUNT`. None of these happen if the user is logged out. This PR adds a `SET_NETWORK` at the end of the constructor of the `web3Service` so that we wake up the `walletMiddleware`, allowing all actions to propagate down to the reducers.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
