### PR TITLE
pass the error code to displayError

### DIFF
--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -15,7 +15,7 @@ const Provider = GlobalErrorContext.Provider
 
 describe('GlobalErrorConsumer', () => {
   it('passes error initialized with metadata to displayError prop', () => {
-    expect.assertions(4)
+    expect.assertions(5)
 
     const listen = jest.fn(() => <div>internal</div>)
     const wrapper = rtl.render(
@@ -31,6 +31,7 @@ describe('GlobalErrorConsumer', () => {
 
     expect(wrapper.queryByText('internal')).not.toBeNull()
     expect(listen).toHaveBeenCalledTimes(1)
+    expect(listen.mock.calls[0][2]).toBe(FATAL_NO_USER_ACCOUNT)
 
     // this next part tests to see if we got the error element and the children
     const Error = listen.mock.calls[0][0]

--- a/unlock-app/src/components/interface/GlobalErrorConsumer.js
+++ b/unlock-app/src/components/interface/GlobalErrorConsumer.js
@@ -30,7 +30,11 @@ export default function GlobalErrorConsumer({
           : false
 
         // call displayError with either false or the error element, and our child elements
-        return displayError(Error && <Error {...errorMetadata} />, children)
+        return displayError(
+          Error && <Error {...errorMetadata} />,
+          children,
+          error
+        )
       }}
     </Consumer>
   )


### PR DESCRIPTION
# Description

This adds the error code as a third parameter to `displayError` for the `GlobalErrorConsumer`. We can use this information to not display an error in the paywall if the error is user account missing.

This is a step on the path to implementing #1287 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
