### PR TITLE
Restoring logo to mobile view

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -22728,7 +22728,7 @@ exports[`Storyshots Dashboard dashboard, no locks 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c8 {
+    .c10 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -22740,21 +22740,21 @@ Object {
   line-height: 24px;
 }
 
-.c8 > svg {
+.c10 > svg {
   fill: white;
   height: 24px;
   width: 24px;
 }
 
-.c8:hover {
+.c10:hover {
   background-color: var(--link);
 }
 
-.c8:hover > svg {
+.c10:hover > svg {
   fill: white;
 }
 
-.c11 {
+.c13 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -22766,21 +22766,21 @@ Object {
   line-height: 48px;
 }
 
-.c11 > svg {
+.c13 > svg {
   fill: white;
   height: 48px;
   width: 48px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: var(--link);
 }
 
-.c11:hover > svg {
+.c13:hover > svg {
   fill: white;
 }
 
-.c9 {
+.c11 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -22795,11 +22795,11 @@ Object {
   color: var(--link);
 }
 
-.c7:hover .c9 {
+.c9:hover .c11 {
   display: inline-block;
 }
 
-.c20 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22809,7 +22809,7 @@ Object {
   flex-direction: column;
 }
 
-.c21 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22820,22 +22820,22 @@ Object {
   padding-bottom: 0.5em;
 }
 
-.c22 {
+.c24 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c22:before {
+.c24:before {
   content: '三';
 }
 
-.c23 {
+.c25 {
   white-space: nowrap;
   text-transform: uppercase;
 }
 
-.c13 {
+.c15 {
   display: grid;
   grid-template-columns: auto 1fr 1fr;
   -webkit-align-items: center;
@@ -22845,14 +22845,14 @@ Object {
   grid-gap: 8px;
 }
 
-.c14 {
+.c16 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   font-weight: 500;
   color: var(--red);
 }
 
-.c15 {
+.c17 {
   font-family: 'IBM Plex Mono',monospace;
   display: grid;
   row-gap: 8px;
@@ -22861,7 +22861,7 @@ Object {
   grid-template-columns: 40px 200px repeat(2,100px) repeat(3,24px) 1fr;
 }
 
-.c16 {
+.c18 {
   display: grid;
   height: 40px;
   grid-row: span 2;
@@ -22874,7 +22874,7 @@ Object {
   align-content: start;
 }
 
-.c17 {
+.c19 {
   font-weight: 100;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
@@ -22884,7 +22884,7 @@ Object {
   font-size: 8px;
 }
 
-.c18 {
+.c20 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   width: 128px;
@@ -22893,7 +22893,7 @@ Object {
   word-break: break-all;
 }
 
-.c19 {
+.c21 {
   font-size: 16px;
   font-weight: 500;
   color: var(--darkgrey);
@@ -22907,6 +22907,17 @@ Object {
 }
 
 .c2 > svg {
+  fill: white;
+}
+
+.c7 {
+  background-color: var(--brand);
+  height: 30px;
+  width: 30px;
+  border-radius: 50%;
+}
+
+.c7 > svg {
   fill: white;
 }
 
@@ -22926,7 +22937,7 @@ Object {
   color: var(--grey);
 }
 
-.c6 {
+.c8 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(4,24px);
@@ -22938,13 +22949,13 @@ Object {
   height: 100%;
 }
 
-.c10 {
+.c12 {
   display: none;
   height: auto;
   grid-column: second;
 }
 
-.c10 .c7 {
+.c12 .c9 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -22955,24 +22966,24 @@ Object {
   align-self: center;
 }
 
-.c10 .c7:nth-child(1) {
+.c12 .c9:nth-child(1) {
   pointer-events: none;
 }
 
-.c10 .c7:nth-child(2) {
+.c12 .c9:nth-child(2) {
   pointer-events: none;
   display: none;
 }
 
-.c10 .c7 > svg {
+.c12 .c9 > svg {
   fill: var(--grey);
 }
 
-.c10 .c7:hover > svg {
+.c12 .c9:hover > svg {
   fill: var(--grey);
 }
 
-.c12 {
+.c14 {
   background-color: var(--white);
   width: 100%;
   height: auto;
@@ -22999,17 +23010,23 @@ Object {
   top: 50px;
 }
 
-.c12 .c7 {
+.c14 .c9 {
   margin: 24px;
 }
 
-.c12 .c7 small {
+.c14 .c9 small {
   display: block;
   color: var(--grey);
   text-align: center;
   top: 5px;
   width: 100%;
   text-align: center;
+}
+
+.c6 {
+  float: left;
+  margin-right: 20px;
+  padding-top: 2px;
 }
 
 .c0 {
@@ -23033,7 +23050,7 @@ Object {
   width: 100%;
 }
 
-.c32 {
+.c34 {
   display: grid;
   row-gap: 16px;
   -webkit-column-gap: 32px;
@@ -23050,35 +23067,35 @@ Object {
   padding-bottom: 40px;
 }
 
-.c33 {
+.c35 {
   width: 72px;
 }
 
-.c34 {
+.c36 {
   display: grid;
   grid-gap: 16px;
 }
 
-.c34 > h1 {
+.c36 > h1 {
   font-weight: bold;
   color: var(--grey);
   margin: 0px;
   padding: 0px;
 }
 
-.c34 > p {
+.c36 > p {
   margin: 0px;
   padding: 0px;
   font-size: 16px;
   color: var(--dimgrey);
 }
 
-.c24 {
+.c26 {
   display: grid;
   grid-gap: 32px;
 }
 
-.c25 {
+.c27 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   padding-left: 8px;
@@ -23092,7 +23109,7 @@ Object {
   align-items: center;
 }
 
-.c26 {
+.c28 {
   font-family: 'IBM Plex Sans';
   font-size: 13px;
   font-weight: bold;
@@ -23106,7 +23123,7 @@ Object {
   color: var(--grey);
 }
 
-.c27 {
+.c29 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -23121,7 +23138,7 @@ Object {
   color: var(--darkgrey);
 }
 
-.c28 {
+.c30 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -23136,7 +23153,7 @@ Object {
   color: var(--darkgrey);
 }
 
-.c31 {
+.c33 {
   background-color: var(--green);
   border: none;
   font-size: 16px;
@@ -23151,19 +23168,19 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c29 {
+  .c31 {
     display: none;
   }
 }
 
 @media only screen and (min-device-width:736px) {
-  .c30 {
+  .c32 {
     display: none;
   }
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c15 {
+  .c17 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
     grid-template-columns: 45px 145px repeat(2,80px);
@@ -23171,7 +23188,7 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c16 {
+  .c18 {
     height: 0px;
   }
 }
@@ -23185,31 +23202,37 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c8 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c12 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c14 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c14 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
   .c6 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c10 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c10 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c12 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c12 {
     display: none;
   }
 }
@@ -23232,13 +23255,13 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c35 {
+  .c37 {
     display: none;
   }
 }
 
 @media (max-width:500px) {
-  .c32 {
+  .c34 {
     grid-template-columns: 1fr;
     grid-auto-flow: row;
     padding: 16px;
@@ -23246,7 +23269,7 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c25 {
+  .c27 {
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
     -webkit-align-items: start;
@@ -23258,19 +23281,19 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c26 {
-    grid-row: span 2;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c28 {
     grid-row: span 2;
   }
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c31 {
+  .c30 {
+    grid-row: span 2;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c33 {
     display: none;
   }
 }
@@ -23312,13 +23335,33 @@ Object {
             <h1
               class="c5"
             >
+              <div
+                class="c6"
+              >
+                <a
+                  href="/"
+                >
+                  <div
+                    class="c7"
+                  >
+                    <svg
+                      viewBox="0 0 56 56"
+                    >
+                      <title />
+                      <path
+                        d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                      />
+                    </svg>
+                  </div>
+                </a>
+              </div>
               Creator Dashboard
             </h1>
             <div
-              class="c6"
+              class="c8"
             >
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/about"
                 title="About"
               >
@@ -23335,13 +23378,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   About
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/jobs"
                 title="Join us"
               >
@@ -23357,13 +23400,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Join us
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://github.com/unlock-protocol/unlock"
                 title="Source Code"
               >
@@ -23377,13 +23420,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Source Code
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://t.me/unlockprotocol"
                 title="Telegram"
               >
@@ -23399,17 +23442,17 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Telegram
                 </small>
               </a>
             </div>
             <div
-              class="c10"
+              class="c12"
             >
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 56 42"
@@ -23424,7 +23467,7 @@ Object {
                 
               </a>
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 58 32"
@@ -23442,29 +23485,29 @@ Object {
               </a>
             </div>
             <div
-              class="c12"
+              class="c14"
             />
           </header>
           <section
             class=""
           >
             <header
-              class="c13"
+              class="c15"
             >
               <h2>
                 Account
               </h2>
               <span
-                class="c14"
+                class="c16"
               >
                 Winston
               </span>
             </header>
             <div
-              class="c15"
+              class="c17"
             >
               <div
-                class="c16"
+                class="c18"
               >
                 <div
                   class="paper"
@@ -23521,52 +23564,52 @@ Object {
                 </div>
               </div>
               <div
-                class="c17"
+                class="c19"
               >
                 Address
               </div>
               <div
-                class="c17"
+                class="c19"
               >
                 Balance
               </div>
               <div
-                class="c17"
+                class="c19"
               >
                 Earning
               </div>
               <div
-                class="c16"
+                class="c18"
               />
               <div
-                class="c16"
+                class="c18"
               />
               <div
-                class="c16"
+                class="c18"
               />
               <div
-                class="c16"
+                class="c18"
               />
                
               <div
-                class="c18"
+                class="c20"
               >
                 0x3ca206264762caf81a8f0a843bbb850987b41e16
               </div>
               <div
-                class="c19"
+                class="c21"
               >
                 <div
-                  class="c20"
+                  class="c22"
                 >
                   <span
-                    class="c21"
+                    class="c23"
                   >
                     <span
-                      class="c22"
+                      class="c24"
                     />
                     <span
-                      class="c23"
+                      class="c25"
                     >
                        - 
                     </span>
@@ -23575,72 +23618,72 @@ Object {
                 </div>
               </div>
               <div
-                class="c19"
+                class="c21"
               >
                 0.00
               </div>
             </div>
           </section>
           <section
-            class="c24"
+            class="c26"
           >
             <div
-              class="c25"
+              class="c27"
             >
               <div
-                class="c26"
+                class="c28"
               >
                 Locks
               </div>
               <div
-                class="c27"
+                class="c29"
               >
                 Name / Address
               </div>
               <div
-                class="c27"
+                class="c29"
               >
                 Duration
               </div>
               <div
-                class="c28"
+                class="c30"
               >
                 Quantity
               </div>
               <div
-                class="c27"
+                class="c29"
               >
                 Price
               </div>
               <div
-                class="c27"
+                class="c29"
               >
                 <div
-                  class="c29"
+                  class="c31"
                 >
                   Balance
                 </div>
                 <div
-                  class="c30"
+                  class="c32"
                 >
                   Balance
                 </div>
               </div>
               <button
-                class="c31"
+                class="c33"
               >
                 Create Lock
               </button>
             </div>
             <section
-              class="c32"
+              class="c34"
             >
               <img
-                class="c33"
+                class="c35"
                 src="/static/images/illustrations/lock.svg"
               />
               <div
-                class="c34"
+                class="c36"
               >
                 <h1>
                   Create a lock to get started
@@ -23651,7 +23694,7 @@ Object {
           </section>
         </div>
         <div
-          class="c35"
+          class="c37"
         />
       </div>
     </div>
@@ -23693,6 +23736,26 @@ Object {
           <h1
             class="sc-1glv5oz-1 jZepcb"
           >
+            <div
+              class="sc-1glv5oz-5 dCcmGu"
+            >
+              <a
+                href="/"
+              >
+                <div
+                  class="cenpj1-0 eCEwze"
+                >
+                  <svg
+                    viewBox="0 0 56 56"
+                  >
+                    <title />
+                    <path
+                      d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                    />
+                  </svg>
+                </div>
+              </a>
+            </div>
             Creator Dashboard
           </h1>
           <div
@@ -24086,7 +24149,7 @@ exports[`Storyshots Dashboard dashboard, no user account 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c8 {
+    .c10 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -24098,21 +24161,21 @@ Object {
   line-height: 24px;
 }
 
-.c8 > svg {
+.c10 > svg {
   fill: white;
   height: 24px;
   width: 24px;
 }
 
-.c8:hover {
+.c10:hover {
   background-color: var(--link);
 }
 
-.c8:hover > svg {
+.c10:hover > svg {
   fill: white;
 }
 
-.c11 {
+.c13 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -24124,21 +24187,21 @@ Object {
   line-height: 48px;
 }
 
-.c11 > svg {
+.c13 > svg {
   fill: white;
   height: 48px;
   width: 48px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: var(--link);
 }
 
-.c11:hover > svg {
+.c13:hover > svg {
   fill: white;
 }
 
-.c9 {
+.c11 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -24153,7 +24216,7 @@ Object {
   color: var(--link);
 }
 
-.c7:hover .c9 {
+.c9:hover .c11 {
   display: inline-block;
 }
 
@@ -24165,6 +24228,17 @@ Object {
 }
 
 .c2 > svg {
+  fill: white;
+}
+
+.c7 {
+  background-color: var(--brand);
+  height: 30px;
+  width: 30px;
+  border-radius: 50%;
+}
+
+.c7 > svg {
   fill: white;
 }
 
@@ -24184,7 +24258,7 @@ Object {
   color: var(--grey);
 }
 
-.c6 {
+.c8 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(4,24px);
@@ -24196,13 +24270,13 @@ Object {
   height: 100%;
 }
 
-.c10 {
+.c12 {
   display: none;
   height: auto;
   grid-column: second;
 }
 
-.c10 .c7 {
+.c12 .c9 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -24213,24 +24287,24 @@ Object {
   align-self: center;
 }
 
-.c10 .c7:nth-child(1) {
+.c12 .c9:nth-child(1) {
   pointer-events: none;
 }
 
-.c10 .c7:nth-child(2) {
+.c12 .c9:nth-child(2) {
   pointer-events: none;
   display: none;
 }
 
-.c10 .c7 > svg {
+.c12 .c9 > svg {
   fill: var(--grey);
 }
 
-.c10 .c7:hover > svg {
+.c12 .c9:hover > svg {
   fill: var(--grey);
 }
 
-.c12 {
+.c14 {
   background-color: var(--white);
   width: 100%;
   height: auto;
@@ -24257,17 +24331,23 @@ Object {
   top: 50px;
 }
 
-.c12 .c7 {
+.c14 .c9 {
   margin: 24px;
 }
 
-.c12 .c7 small {
+.c14 .c9 small {
   display: block;
   color: var(--grey);
   text-align: center;
   top: 5px;
   width: 100%;
   text-align: center;
+}
+
+.c6 {
+  float: left;
+  margin-right: 20px;
+  padding-top: 2px;
 }
 
 .c0 {
@@ -24291,7 +24371,7 @@ Object {
   width: 100%;
 }
 
-.c13 {
+.c15 {
   display: grid;
   row-gap: 16px;
   -webkit-column-gap: 32px;
@@ -24308,23 +24388,23 @@ Object {
   padding-bottom: 40px;
 }
 
-.c14 {
+.c16 {
   width: 72px;
 }
 
-.c15 {
+.c17 {
   display: grid;
   grid-gap: 16px;
 }
 
-.c15 > h1 {
+.c17 > h1 {
   font-weight: bold;
   color: var(--red);
   margin: 0px;
   padding: 0px;
 }
 
-.c15 > p {
+.c17 > p {
   margin: 0px;
   padding: 0px;
   font-size: 16px;
@@ -24340,31 +24420,37 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c8 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c12 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c14 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c14 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
   .c6 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c10 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c10 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c12 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c12 {
     display: none;
   }
 }
@@ -24387,13 +24473,13 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c16 {
+  .c18 {
     display: none;
   }
 }
 
 @media (max-width:500px) {
-  .c13 {
+  .c15 {
     grid-template-columns: 1fr;
     grid-auto-flow: row;
     padding: 16px;
@@ -24436,12 +24522,34 @@ Object {
           >
             <h1
               class="c5"
-            />
+            >
+              <div
+                class="c6"
+              >
+                <a
+                  href="/"
+                >
+                  <div
+                    class="c7"
+                  >
+                    <svg
+                      viewBox="0 0 56 56"
+                    >
+                      <title />
+                      <path
+                        d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                      />
+                    </svg>
+                  </div>
+                </a>
+              </div>
+              
+            </h1>
             <div
-              class="c6"
+              class="c8"
             >
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/about"
                 title="About"
               >
@@ -24458,13 +24566,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   About
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/jobs"
                 title="Join us"
               >
@@ -24480,13 +24588,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Join us
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://github.com/unlock-protocol/unlock"
                 title="Source Code"
               >
@@ -24500,13 +24608,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Source Code
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://t.me/unlockprotocol"
                 title="Telegram"
               >
@@ -24522,17 +24630,17 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Telegram
                 </small>
               </a>
             </div>
             <div
-              class="c10"
+              class="c12"
             >
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 56 42"
@@ -24547,7 +24655,7 @@ Object {
                 
               </a>
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 58 32"
@@ -24565,18 +24673,18 @@ Object {
               </a>
             </div>
             <div
-              class="c12"
+              class="c14"
             />
           </header>
           <section
-            class="c13"
+            class="c15"
           >
             <img
-              class="c14"
+              class="c16"
               src="/static/images/illustrations/error.svg"
             />
             <div
-              class="c15"
+              class="c17"
             >
               <h1>
                 Need account
@@ -24588,7 +24696,7 @@ Object {
           </section>
         </div>
         <div
-          class="c16"
+          class="c18"
         />
       </div>
     </div>
@@ -24629,7 +24737,29 @@ Object {
         >
           <h1
             class="sc-1glv5oz-1 jZepcb"
-          />
+          >
+            <div
+              class="sc-1glv5oz-5 dCcmGu"
+            >
+              <a
+                href="/"
+              >
+                <div
+                  class="cenpj1-0 eCEwze"
+                >
+                  <svg
+                    viewBox="0 0 56 56"
+                  >
+                    <title />
+                    <path
+                      d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                    />
+                  </svg>
+                </div>
+              </a>
+            </div>
+            
+          </h1>
           <div
             class="sc-1glv5oz-2 bijesQ"
           >
@@ -24835,7 +24965,7 @@ exports[`Storyshots Dashboard dashboard, wrong network 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c8 {
+    .c10 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -24847,21 +24977,21 @@ Object {
   line-height: 24px;
 }
 
-.c8 > svg {
+.c10 > svg {
   fill: white;
   height: 24px;
   width: 24px;
 }
 
-.c8:hover {
+.c10:hover {
   background-color: var(--link);
 }
 
-.c8:hover > svg {
+.c10:hover > svg {
   fill: white;
 }
 
-.c11 {
+.c13 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -24873,21 +25003,21 @@ Object {
   line-height: 48px;
 }
 
-.c11 > svg {
+.c13 > svg {
   fill: white;
   height: 48px;
   width: 48px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: var(--link);
 }
 
-.c11:hover > svg {
+.c13:hover > svg {
   fill: white;
 }
 
-.c9 {
+.c11 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -24902,7 +25032,7 @@ Object {
   color: var(--link);
 }
 
-.c7:hover .c9 {
+.c9:hover .c11 {
   display: inline-block;
 }
 
@@ -24914,6 +25044,17 @@ Object {
 }
 
 .c2 > svg {
+  fill: white;
+}
+
+.c7 {
+  background-color: var(--brand);
+  height: 30px;
+  width: 30px;
+  border-radius: 50%;
+}
+
+.c7 > svg {
   fill: white;
 }
 
@@ -24933,7 +25074,7 @@ Object {
   color: var(--grey);
 }
 
-.c6 {
+.c8 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(4,24px);
@@ -24945,13 +25086,13 @@ Object {
   height: 100%;
 }
 
-.c10 {
+.c12 {
   display: none;
   height: auto;
   grid-column: second;
 }
 
-.c10 .c7 {
+.c12 .c9 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -24962,24 +25103,24 @@ Object {
   align-self: center;
 }
 
-.c10 .c7:nth-child(1) {
+.c12 .c9:nth-child(1) {
   pointer-events: none;
 }
 
-.c10 .c7:nth-child(2) {
+.c12 .c9:nth-child(2) {
   pointer-events: none;
   display: none;
 }
 
-.c10 .c7 > svg {
+.c12 .c9 > svg {
   fill: var(--grey);
 }
 
-.c10 .c7:hover > svg {
+.c12 .c9:hover > svg {
   fill: var(--grey);
 }
 
-.c12 {
+.c14 {
   background-color: var(--white);
   width: 100%;
   height: auto;
@@ -25006,17 +25147,23 @@ Object {
   top: 50px;
 }
 
-.c12 .c7 {
+.c14 .c9 {
   margin: 24px;
 }
 
-.c12 .c7 small {
+.c14 .c9 small {
   display: block;
   color: var(--grey);
   text-align: center;
   top: 5px;
   width: 100%;
   text-align: center;
+}
+
+.c6 {
+  float: left;
+  margin-right: 20px;
+  padding-top: 2px;
 }
 
 .c0 {
@@ -25040,7 +25187,7 @@ Object {
   width: 100%;
 }
 
-.c13 {
+.c15 {
   display: grid;
   row-gap: 16px;
   -webkit-column-gap: 32px;
@@ -25057,23 +25204,23 @@ Object {
   padding-bottom: 40px;
 }
 
-.c14 {
+.c16 {
   width: 72px;
 }
 
-.c15 {
+.c17 {
   display: grid;
   grid-gap: 16px;
 }
 
-.c15 > h1 {
+.c17 > h1 {
   font-weight: bold;
   color: var(--red);
   margin: 0px;
   padding: 0px;
 }
 
-.c15 > p {
+.c17 > p {
   margin: 0px;
   padding: 0px;
   font-size: 16px;
@@ -25089,31 +25236,37 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c8 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c12 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c14 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c14 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
   .c6 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c10 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c10 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c12 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c12 {
     display: none;
   }
 }
@@ -25136,13 +25289,13 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c16 {
+  .c18 {
     display: none;
   }
 }
 
 @media (max-width:500px) {
-  .c13 {
+  .c15 {
     grid-template-columns: 1fr;
     grid-auto-flow: row;
     padding: 16px;
@@ -25185,12 +25338,34 @@ Object {
           >
             <h1
               class="c5"
-            />
+            >
+              <div
+                class="c6"
+              >
+                <a
+                  href="/"
+                >
+                  <div
+                    class="c7"
+                  >
+                    <svg
+                      viewBox="0 0 56 56"
+                    >
+                      <title />
+                      <path
+                        d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                      />
+                    </svg>
+                  </div>
+                </a>
+              </div>
+              
+            </h1>
             <div
-              class="c6"
+              class="c8"
             >
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/about"
                 title="About"
               >
@@ -25207,13 +25382,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   About
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/jobs"
                 title="Join us"
               >
@@ -25229,13 +25404,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Join us
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://github.com/unlock-protocol/unlock"
                 title="Source Code"
               >
@@ -25249,13 +25424,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Source Code
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://t.me/unlockprotocol"
                 title="Telegram"
               >
@@ -25271,17 +25446,17 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Telegram
                 </small>
               </a>
             </div>
             <div
-              class="c10"
+              class="c12"
             >
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 56 42"
@@ -25296,7 +25471,7 @@ Object {
                 
               </a>
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 58 32"
@@ -25314,18 +25489,18 @@ Object {
               </a>
             </div>
             <div
-              class="c12"
+              class="c14"
             />
           </header>
           <section
-            class="c13"
+            class="c15"
           >
             <img
-              class="c14"
+              class="c16"
               src="/static/images/illustrations/network.svg"
             />
             <div
-              class="c15"
+              class="c17"
             >
               <h1>
                 Network mismatch
@@ -25337,7 +25512,7 @@ Object {
           </section>
         </div>
         <div
-          class="c16"
+          class="c18"
         />
       </div>
     </div>
@@ -25378,7 +25553,29 @@ Object {
         >
           <h1
             class="sc-1glv5oz-1 jZepcb"
-          />
+          >
+            <div
+              class="sc-1glv5oz-5 dCcmGu"
+            >
+              <a
+                href="/"
+              >
+                <div
+                  class="cenpj1-0 eCEwze"
+                >
+                  <svg
+                    viewBox="0 0 56 56"
+                  >
+                    <title />
+                    <path
+                      d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                    />
+                  </svg>
+                </div>
+              </a>
+            </div>
+            
+          </h1>
           <div
             class="sc-1glv5oz-2 bijesQ"
           >
@@ -25584,7 +25781,7 @@ exports[`Storyshots Dashboard the dashboard 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c43 {
+    .c45 {
   background-color: white;
   cursor: pointer;
   border-radius: 50%;
@@ -25596,21 +25793,21 @@ Object {
   line-height: 24px;
 }
 
-.c43 > svg {
+.c45 > svg {
   fill: var(--lightgrey);
   height: 24px;
   width: 24px;
 }
 
-.c43:hover {
+.c45:hover {
   background-color: white;
 }
 
-.c43:hover > svg {
+.c45:hover > svg {
   fill: var(--lightgrey);
 }
 
-.c44 {
+.c46 {
   background-color: var(--lightgrey);
   cursor: pointer;
   border-radius: 50%;
@@ -25622,21 +25819,21 @@ Object {
   line-height: 24px;
 }
 
-.c44 > svg {
+.c46 > svg {
   fill: var(--grey);
   height: 24px;
   width: 24px;
 }
 
-.c44:hover {
+.c46:hover {
   background-color: var(--link);
 }
 
-.c44:hover > svg {
+.c46:hover > svg {
   fill: white;
 }
 
-.c8 {
+.c10 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -25648,21 +25845,21 @@ Object {
   line-height: 24px;
 }
 
-.c8 > svg {
+.c10 > svg {
   fill: white;
   height: 24px;
   width: 24px;
 }
 
-.c8:hover {
+.c10:hover {
   background-color: var(--link);
 }
 
-.c8:hover > svg {
+.c10:hover > svg {
   fill: white;
 }
 
-.c11 {
+.c13 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -25674,21 +25871,21 @@ Object {
   line-height: 48px;
 }
 
-.c11 > svg {
+.c13 > svg {
   fill: white;
   height: 48px;
   width: 48px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: var(--link);
 }
 
-.c11:hover > svg {
+.c13:hover > svg {
   fill: white;
 }
 
-.c9 {
+.c11 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -25703,11 +25900,11 @@ Object {
   color: var(--link);
 }
 
-.c7:hover .c9 {
+.c9:hover .c11 {
   display: inline-block;
 }
 
-.c20 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -25717,7 +25914,7 @@ Object {
   flex-direction: column;
 }
 
-.c21 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -25728,38 +25925,38 @@ Object {
   padding-bottom: 0.5em;
 }
 
-.c22 {
+.c24 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c22:before {
+.c24:before {
   content: '三';
 }
 
-.c37 {
+.c39 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c37:before {
+.c39:before {
   content: '$';
 }
 
-.c23 {
+.c25 {
   white-space: nowrap;
   text-transform: uppercase;
 }
 
-.c36 {
+.c38 {
   font-size: 10px;
   color: var(--darkgrey);
   margin-top: 5px;
 }
 
-.c13 {
+.c15 {
   display: grid;
   grid-template-columns: auto 1fr 1fr;
   -webkit-align-items: center;
@@ -25769,14 +25966,14 @@ Object {
   grid-gap: 8px;
 }
 
-.c14 {
+.c16 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   font-weight: 500;
   color: var(--red);
 }
 
-.c15 {
+.c17 {
   font-family: 'IBM Plex Mono',monospace;
   display: grid;
   row-gap: 8px;
@@ -25785,7 +25982,7 @@ Object {
   grid-template-columns: 40px 200px repeat(2,100px) repeat(3,24px) 1fr;
 }
 
-.c16 {
+.c18 {
   display: grid;
   height: 40px;
   grid-row: span 2;
@@ -25798,7 +25995,7 @@ Object {
   align-content: start;
 }
 
-.c17 {
+.c19 {
   font-weight: 100;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
@@ -25808,7 +26005,7 @@ Object {
   font-size: 8px;
 }
 
-.c18 {
+.c20 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   width: 128px;
@@ -25817,13 +26014,13 @@ Object {
   word-break: break-all;
 }
 
-.c19 {
+.c21 {
   font-size: 16px;
   font-weight: 500;
   color: var(--darkgrey);
 }
 
-.c38 {
+.c40 {
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
@@ -25839,7 +26036,7 @@ Object {
   color: var(--grey);
 }
 
-.c39 {
+.c41 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -25851,7 +26048,7 @@ Object {
   align-self: end;
 }
 
-.c40 {
+.c42 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -25864,19 +26061,19 @@ Object {
   margin-bottom: 15px;
 }
 
-.c41 {
+.c43 {
   display: grid;
   justify-items: end;
   padding-right: 24px;
 }
 
-.c42 {
+.c44 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(3,24px);
 }
 
-.c45 {
+.c47 {
   margin-top: 13px;
   font-size: 10px;
   font-family: 'IBM Plex Sans',sans-serif;
@@ -25886,7 +26083,7 @@ Object {
   padding-right: 24px;
 }
 
-.c32 {
+.c34 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   min-height: 48px;
@@ -25904,22 +26101,22 @@ Object {
   cursor: pointer;
 }
 
-.c32 > * {
+.c34 > * {
   padding-top: 16px;
 }
 
-.c33 {
+.c35 {
   grid-row: span 2;
 }
 
-.c34 {
+.c36 {
   color: var(--link);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c35 {
+.c37 {
   color: var(--grey);
   font-weight: 200;
   white-space: nowrap;
@@ -25939,6 +26136,17 @@ Object {
   fill: white;
 }
 
+.c7 {
+  background-color: var(--brand);
+  height: 30px;
+  width: 30px;
+  border-radius: 50%;
+}
+
+.c7 > svg {
+  fill: white;
+}
+
 .c4 {
   display: grid;
   grid-gap: 0;
@@ -25955,7 +26163,7 @@ Object {
   color: var(--grey);
 }
 
-.c6 {
+.c8 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(4,24px);
@@ -25967,13 +26175,13 @@ Object {
   height: 100%;
 }
 
-.c10 {
+.c12 {
   display: none;
   height: auto;
   grid-column: second;
 }
 
-.c10 .c7 {
+.c12 .c9 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -25984,24 +26192,24 @@ Object {
   align-self: center;
 }
 
-.c10 .c7:nth-child(1) {
+.c12 .c9:nth-child(1) {
   pointer-events: none;
 }
 
-.c10 .c7:nth-child(2) {
+.c12 .c9:nth-child(2) {
   pointer-events: none;
   display: none;
 }
 
-.c10 .c7 > svg {
+.c12 .c9 > svg {
   fill: var(--grey);
 }
 
-.c10 .c7:hover > svg {
+.c12 .c9:hover > svg {
   fill: var(--grey);
 }
 
-.c12 {
+.c14 {
   background-color: var(--white);
   width: 100%;
   height: auto;
@@ -26028,17 +26236,23 @@ Object {
   top: 50px;
 }
 
-.c12 .c7 {
+.c14 .c9 {
   margin: 24px;
 }
 
-.c12 .c7 small {
+.c14 .c9 small {
   display: block;
   color: var(--grey);
   text-align: center;
   top: 5px;
   width: 100%;
   text-align: center;
+}
+
+.c6 {
+  float: left;
+  margin-right: 20px;
+  padding-top: 2px;
 }
 
 .c0 {
@@ -26062,12 +26276,12 @@ Object {
   width: 100%;
 }
 
-.c24 {
+.c26 {
   display: grid;
   grid-gap: 32px;
 }
 
-.c25 {
+.c27 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   padding-left: 8px;
@@ -26081,7 +26295,7 @@ Object {
   align-items: center;
 }
 
-.c26 {
+.c28 {
   font-family: 'IBM Plex Sans';
   font-size: 13px;
   font-weight: bold;
@@ -26095,7 +26309,7 @@ Object {
   color: var(--grey);
 }
 
-.c27 {
+.c29 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -26110,7 +26324,7 @@ Object {
   color: var(--darkgrey);
 }
 
-.c28 {
+.c30 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -26125,7 +26339,7 @@ Object {
   color: var(--darkgrey);
 }
 
-.c31 {
+.c33 {
   background-color: var(--green);
   border: none;
   font-size: 16px;
@@ -26140,19 +26354,19 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c29 {
+  .c31 {
     display: none;
   }
 }
 
 @media only screen and (min-device-width:736px) {
-  .c30 {
+  .c32 {
     display: none;
   }
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c15 {
+  .c17 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
     grid-template-columns: 45px 145px repeat(2,80px);
@@ -26160,19 +26374,19 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c16 {
+  .c18 {
     height: 0px;
   }
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c41 {
+  .c43 {
     display: none;
   }
 }
 
 @media only screen and (min-device-width:736px) {
-  .c32 {
+  .c34 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
     grid-column-gap: 16px;
@@ -26180,7 +26394,7 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c32 {
+  .c34 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -26188,7 +26402,7 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c34 {
+  .c36 {
     grid-column: span 2;
   }
 }
@@ -26202,31 +26416,37 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c8 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c12 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c14 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c14 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
   .c6 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c10 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c10 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c12 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c12 {
     display: none;
   }
 }
@@ -26249,13 +26469,13 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c46 {
+  .c48 {
     display: none;
   }
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c25 {
+  .c27 {
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
     -webkit-align-items: start;
@@ -26267,19 +26487,19 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c26 {
-    grid-row: span 2;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
   .c28 {
     grid-row: span 2;
   }
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c31 {
+  .c30 {
+    grid-row: span 2;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c33 {
     display: none;
   }
 }
@@ -26321,13 +26541,33 @@ Object {
             <h1
               class="c5"
             >
+              <div
+                class="c6"
+              >
+                <a
+                  href="/"
+                >
+                  <div
+                    class="c7"
+                  >
+                    <svg
+                      viewBox="0 0 56 56"
+                    >
+                      <title />
+                      <path
+                        d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                      />
+                    </svg>
+                  </div>
+                </a>
+              </div>
               Creator Dashboard
             </h1>
             <div
-              class="c6"
+              class="c8"
             >
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/about"
                 title="About"
               >
@@ -26344,13 +26584,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   About
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/jobs"
                 title="Join us"
               >
@@ -26366,13 +26606,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Join us
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://github.com/unlock-protocol/unlock"
                 title="Source Code"
               >
@@ -26386,13 +26626,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Source Code
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://t.me/unlockprotocol"
                 title="Telegram"
               >
@@ -26408,17 +26648,17 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Telegram
                 </small>
               </a>
             </div>
             <div
-              class="c10"
+              class="c12"
             >
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 56 42"
@@ -26433,7 +26673,7 @@ Object {
                 
               </a>
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 58 32"
@@ -26451,29 +26691,29 @@ Object {
               </a>
             </div>
             <div
-              class="c12"
+              class="c14"
             />
           </header>
           <section
             class=""
           >
             <header
-              class="c13"
+              class="c15"
             >
               <h2>
                 Account
               </h2>
               <span
-                class="c14"
+                class="c16"
               >
                 Winston
               </span>
             </header>
             <div
-              class="c15"
+              class="c17"
             >
               <div
-                class="c16"
+                class="c18"
               >
                 <div
                   class="paper"
@@ -26530,52 +26770,52 @@ Object {
                 </div>
               </div>
               <div
-                class="c17"
+                class="c19"
               >
                 Address
               </div>
               <div
-                class="c17"
+                class="c19"
               >
                 Balance
               </div>
               <div
-                class="c17"
+                class="c19"
               >
                 Earning
               </div>
               <div
-                class="c16"
+                class="c18"
               />
               <div
-                class="c16"
+                class="c18"
               />
               <div
-                class="c16"
+                class="c18"
               />
               <div
-                class="c16"
+                class="c18"
               />
                
               <div
-                class="c18"
+                class="c20"
               >
                 0x3ca206264762caf81a8f0a843bbb850987b41e16
               </div>
               <div
-                class="c19"
+                class="c21"
               >
                 <div
-                  class="c20"
+                  class="c22"
                 >
                   <span
-                    class="c21"
+                    class="c23"
                   >
                     <span
-                      class="c22"
+                      class="c24"
                     />
                     <span
-                      class="c23"
+                      class="c25"
                     >
                        - 
                     </span>
@@ -26584,68 +26824,68 @@ Object {
                 </div>
               </div>
               <div
-                class="c19"
+                class="c21"
               >
                 0.00
               </div>
             </div>
           </section>
           <section
-            class="c24"
+            class="c26"
           >
             <div
-              class="c25"
+              class="c27"
             >
               <div
-                class="c26"
+                class="c28"
               >
                 Locks
               </div>
               <div
-                class="c27"
+                class="c29"
               >
                 Name / Address
               </div>
               <div
-                class="c27"
+                class="c29"
               >
                 Duration
               </div>
               <div
-                class="c28"
+                class="c30"
               >
                 Quantity
               </div>
               <div
-                class="c27"
+                class="c29"
               >
                 Price
               </div>
               <div
-                class="c27"
+                class="c29"
               >
                 <div
-                  class="c29"
+                  class="c31"
                 >
                   Balance
                 </div>
                 <div
-                  class="c30"
+                  class="c32"
                 >
                   Balance
                 </div>
               </div>
               <button
-                class="c31"
+                class="c33"
               >
                 Create Lock
               </button>
             </div>
             <div
-              class="c32"
+              class="c34"
             >
               <div
-                class="c33"
+                class="c35"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -26721,11 +26961,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c34"
+                class="c36"
               >
                 Infinite Lock
                 <div
-                  class="c35"
+                  class="c37"
                 >
                   0x9abcdef0
                 </div>
@@ -26743,31 +26983,31 @@ Object {
                 10/0
               </div>
               <div
-                class="c20"
+                class="c22"
               >
                 <span
-                  class="c21"
+                  class="c23"
                 >
                   <span
-                    class="c22"
+                    class="c24"
                   />
                   <span
-                    class="c23"
+                    class="c25"
                   >
                     27000000000000000.00
                   </span>
                 </span>
                 <div
-                  class="c36"
+                  class="c38"
                 >
                   <span
-                    class="c21"
+                    class="c23"
                   >
                     <span
-                      class="c37"
+                      class="c39"
                     />
                     <span
-                      class="c23"
+                      class="c25"
                     >
                       ---
                     </span>
@@ -26778,34 +27018,34 @@ Object {
                 class=""
               >
                 <div
-                  class="c29"
+                  class="c31"
                 >
                   <div
-                    class="c20"
+                    class="c22"
                   >
                     <span
-                      class="c21"
+                      class="c23"
                     >
                       <span
-                        class="c22"
+                        class="c24"
                       />
                       <span
-                        class="c23"
+                        class="c25"
                       >
                          - 
                       </span>
                     </span>
                     <div
-                      class="c36"
+                      class="c38"
                     >
                       <span
-                        class="c21"
+                        class="c23"
                       >
                         <span
-                          class="c37"
+                          class="c39"
                         />
                         <span
-                          class="c23"
+                          class="c25"
                         >
                            - 
                         </span>
@@ -26814,19 +27054,19 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c30"
+                  class="c32"
                 >
                   <div
-                    class="c20"
+                    class="c22"
                   >
                     <span
-                      class="c21"
+                      class="c23"
                     >
                       <span
-                        class="c22"
+                        class="c24"
                       />
                       <span
-                        class="c23"
+                        class="c25"
                       >
                          - 
                       </span>
@@ -26836,15 +27076,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c38"
+                class="c40"
               >
                 <div
-                  class="c39"
+                  class="c41"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c40"
+                  class="c42"
                 >
                   2
                    / 
@@ -26853,10 +27093,10 @@ Object {
               </div>
             </div>
             <div
-              class="c32"
+              class="c34"
             >
               <div
-                class="c33"
+                class="c35"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -26932,11 +27172,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c34"
+                class="c36"
               >
                 New Lock
                 <div
-                  class="c35"
+                  class="c37"
                 >
                   0x56781234a
                 </div>
@@ -26954,31 +27194,31 @@ Object {
                 32/800
               </div>
               <div
-                class="c20"
+                class="c22"
               >
                 <span
-                  class="c21"
+                  class="c23"
                 >
                   <span
-                    class="c22"
+                    class="c24"
                   />
                   <span
-                    class="c23"
+                    class="c25"
                   >
                     10000000000000000000.00
                   </span>
                 </span>
                 <div
-                  class="c36"
+                  class="c38"
                 >
                   <span
-                    class="c21"
+                    class="c23"
                   >
                     <span
-                      class="c37"
+                      class="c39"
                     />
                     <span
-                      class="c23"
+                      class="c25"
                     >
                       ---
                     </span>
@@ -26989,34 +27229,34 @@ Object {
                 class=""
               >
                 <div
-                  class="c29"
+                  class="c31"
                 >
                   <div
-                    class="c20"
+                    class="c22"
                   >
                     <span
-                      class="c21"
+                      class="c23"
                     >
                       <span
-                        class="c22"
+                        class="c24"
                       />
                       <span
-                        class="c23"
+                        class="c25"
                       >
                          - 
                       </span>
                     </span>
                     <div
-                      class="c36"
+                      class="c38"
                     >
                       <span
-                        class="c21"
+                        class="c23"
                       >
                         <span
-                          class="c37"
+                          class="c39"
                         />
                         <span
-                          class="c23"
+                          class="c25"
                         >
                            - 
                         </span>
@@ -27025,19 +27265,19 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c30"
+                  class="c32"
                 >
                   <div
-                    class="c20"
+                    class="c22"
                   >
                     <span
-                      class="c21"
+                      class="c23"
                     >
                       <span
-                        class="c22"
+                        class="c24"
                       />
                       <span
-                        class="c23"
+                        class="c25"
                       >
                          - 
                       </span>
@@ -27047,15 +27287,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c38"
+                class="c40"
               >
                 <div
-                  class="c39"
+                  class="c41"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c40"
+                  class="c42"
                 >
                   4
                    / 
@@ -27064,10 +27304,10 @@ Object {
               </div>
             </div>
             <div
-              class="c32"
+              class="c34"
             >
               <div
-                class="c33"
+                class="c35"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -27143,11 +27383,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c34"
+                class="c36"
               >
                 My Blog
                 <div
-                  class="c35"
+                  class="c37"
                 >
                   0x12345678a
                 </div>
@@ -27165,31 +27405,31 @@ Object {
                 3/240
               </div>
               <div
-                class="c20"
+                class="c22"
               >
                 <span
-                  class="c21"
+                  class="c23"
                 >
                   <span
-                    class="c22"
+                    class="c24"
                   />
                   <span
-                    class="c23"
+                    class="c25"
                   >
                     27000000000000000.00
                   </span>
                 </span>
                 <div
-                  class="c36"
+                  class="c38"
                 >
                   <span
-                    class="c21"
+                    class="c23"
                   >
                     <span
-                      class="c37"
+                      class="c39"
                     />
                     <span
-                      class="c23"
+                      class="c25"
                     >
                       ---
                     </span>
@@ -27200,34 +27440,34 @@ Object {
                 class=""
               >
                 <div
-                  class="c29"
+                  class="c31"
                 >
                   <div
-                    class="c20"
+                    class="c22"
                   >
                     <span
-                      class="c21"
+                      class="c23"
                     >
                       <span
-                        class="c22"
+                        class="c24"
                       />
                       <span
-                        class="c23"
+                        class="c25"
                       >
                          - 
                       </span>
                     </span>
                     <div
-                      class="c36"
+                      class="c38"
                     >
                       <span
-                        class="c21"
+                        class="c23"
                       >
                         <span
-                          class="c37"
+                          class="c39"
                         />
                         <span
-                          class="c23"
+                          class="c25"
                         >
                            - 
                         </span>
@@ -27236,19 +27476,19 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c30"
+                  class="c32"
                 >
                   <div
-                    class="c20"
+                    class="c22"
                   >
                     <span
-                      class="c21"
+                      class="c23"
                     >
                       <span
-                        class="c22"
+                        class="c24"
                       />
                       <span
-                        class="c23"
+                        class="c25"
                       >
                          - 
                       </span>
@@ -27261,13 +27501,13 @@ Object {
                 class=""
               >
                 <div
-                  class="c41"
+                  class="c43"
                 >
                   <div
-                    class="c42"
+                    class="c44"
                   >
                     <button
-                      class="c7 c43"
+                      class="c9 c45"
                     >
                       <svg
                         name="Withdraw"
@@ -27283,7 +27523,7 @@ Object {
                       
                     </button>
                     <button
-                      class="c7 c44"
+                      class="c9 c46"
                       title="Edit"
                     >
                       <svg
@@ -27301,13 +27541,13 @@ Object {
                         />
                       </svg>
                       <small
-                        class="c9"
+                        class="c11"
                       >
                         Edit
                       </small>
                     </button>
                     <button
-                      class="c7 c44"
+                      class="c9 c46"
                       title="Show embed code"
                     >
                       <svg
@@ -27322,7 +27562,7 @@ Object {
                         />
                       </svg>
                       <small
-                        class="c9"
+                        class="c11"
                       >
                         Show embed code
                       </small>
@@ -27330,14 +27570,14 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c45"
+                  class="c47"
                 />
               </div>
             </div>
           </section>
         </div>
         <div
-          class="c46"
+          class="c48"
         />
       </div>
     </div>
@@ -27379,6 +27619,26 @@ Object {
           <h1
             class="sc-1glv5oz-1 jZepcb"
           >
+            <div
+              class="sc-1glv5oz-5 dCcmGu"
+            >
+              <a
+                href="/"
+              >
+                <div
+                  class="cenpj1-0 eCEwze"
+                >
+                  <svg
+                    viewBox="0 0 56 56"
+                  >
+                    <title />
+                    <path
+                      d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                    />
+                  </svg>
+                </div>
+              </a>
+            </div>
             Creator Dashboard
           </h1>
           <div
@@ -30918,7 +31178,7 @@ exports[`Storyshots Header the header with a title 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c4 {
+    .c6 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -30930,21 +31190,21 @@ Object {
   line-height: 24px;
 }
 
-.c4 > svg {
+.c6 > svg {
   fill: white;
   height: 24px;
   width: 24px;
 }
 
-.c4:hover {
+.c6:hover {
   background-color: var(--link);
 }
 
-.c4:hover > svg {
+.c6:hover > svg {
   fill: white;
 }
 
-.c7 {
+.c9 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -30956,21 +31216,21 @@ Object {
   line-height: 48px;
 }
 
-.c7 > svg {
+.c9 > svg {
   fill: white;
   height: 48px;
   width: 48px;
 }
 
-.c7:hover {
+.c9:hover {
   background-color: var(--link);
 }
 
-.c7:hover > svg {
+.c9:hover > svg {
   fill: white;
 }
 
-.c5 {
+.c7 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -30985,8 +31245,19 @@ Object {
   color: var(--link);
 }
 
-.c3:hover .c5 {
+.c5:hover .c7 {
   display: inline-block;
+}
+
+.c3 {
+  background-color: var(--brand);
+  height: 30px;
+  width: 30px;
+  border-radius: 50%;
+}
+
+.c3 > svg {
+  fill: white;
 }
 
 .c0 {
@@ -31005,7 +31276,7 @@ Object {
   color: var(--grey);
 }
 
-.c2 {
+.c4 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(4,24px);
@@ -31017,13 +31288,13 @@ Object {
   height: 100%;
 }
 
-.c6 {
+.c8 {
   display: none;
   height: auto;
   grid-column: second;
 }
 
-.c6 .c3 {
+.c8 .c5 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -31034,24 +31305,24 @@ Object {
   align-self: center;
 }
 
-.c6 .c3:nth-child(1) {
+.c8 .c5:nth-child(1) {
   pointer-events: none;
 }
 
-.c6 .c3:nth-child(2) {
+.c8 .c5:nth-child(2) {
   pointer-events: none;
   display: none;
 }
 
-.c6 .c3 > svg {
+.c8 .c5 > svg {
   fill: var(--grey);
 }
 
-.c6 .c3:hover > svg {
+.c8 .c5:hover > svg {
   fill: var(--grey);
 }
 
-.c8 {
+.c10 {
   background-color: var(--white);
   width: 100%;
   height: auto;
@@ -31078,17 +31349,23 @@ Object {
   top: 50px;
 }
 
-.c8 .c3 {
+.c10 .c5 {
   margin: 24px;
 }
 
-.c8 .c3 small {
+.c10 .c5 small {
   display: block;
   color: var(--grey);
   text-align: center;
   top: 5px;
   width: 100%;
   text-align: center;
+}
+
+.c2 {
+  float: left;
+  margin-right: 20px;
+  padding-top: 2px;
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
@@ -31100,31 +31377,37 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c4 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c8 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c8 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c10 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c10 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
   .c2 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c6 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c6 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c8 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c8 {
     display: none;
   }
 }
@@ -31140,13 +31423,33 @@ Object {
         <h1
           class="c1"
         >
+          <div
+            class="c2"
+          >
+            <a
+              href="/"
+            >
+              <div
+                class="c3"
+              >
+                <svg
+                  viewBox="0 0 56 56"
+                >
+                  <title />
+                  <path
+                    d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                  />
+                </svg>
+              </div>
+            </a>
+          </div>
           Roses are red
         </h1>
         <div
-          class="c2"
+          class="c4"
         >
           <a
-            class="c3 c4"
+            class="c5 c6"
             href="/about"
             title="About"
           >
@@ -31163,13 +31466,13 @@ Object {
               />
             </svg>
             <small
-              class="c5"
+              class="c7"
             >
               About
             </small>
           </a>
           <a
-            class="c3 c4"
+            class="c5 c6"
             href="/jobs"
             title="Join us"
           >
@@ -31185,13 +31488,13 @@ Object {
               />
             </svg>
             <small
-              class="c5"
+              class="c7"
             >
               Join us
             </small>
           </a>
           <a
-            class="c3 c4"
+            class="c5 c6"
             href="https://github.com/unlock-protocol/unlock"
             title="Source Code"
           >
@@ -31205,13 +31508,13 @@ Object {
               />
             </svg>
             <small
-              class="c5"
+              class="c7"
             >
               Source Code
             </small>
           </a>
           <a
-            class="c3 c4"
+            class="c5 c6"
             href="https://t.me/unlockprotocol"
             title="Telegram"
           >
@@ -31227,17 +31530,17 @@ Object {
               />
             </svg>
             <small
-              class="c5"
+              class="c7"
             >
               Telegram
             </small>
           </a>
         </div>
         <div
-          class="c6"
+          class="c8"
         >
           <a
-            class="c3 c7"
+            class="c5 c9"
           >
             <svg
               viewBox="0 0 56 42"
@@ -31252,7 +31555,7 @@ Object {
             
           </a>
           <a
-            class="c3 c7"
+            class="c5 c9"
           >
             <svg
               viewBox="0 0 58 32"
@@ -31270,7 +31573,7 @@ Object {
           </a>
         </div>
         <div
-          class="c8"
+          class="c10"
         />
       </header>
     </div>
@@ -31286,6 +31589,26 @@ Object {
       <h1
         class="sc-1glv5oz-1 jZepcb"
       >
+        <div
+          class="sc-1glv5oz-5 dCcmGu"
+        >
+          <a
+            href="/"
+          >
+            <div
+              class="cenpj1-0 eCEwze"
+            >
+              <svg
+                viewBox="0 0 56 56"
+              >
+                <title />
+                <path
+                  d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                />
+              </svg>
+            </div>
+          </a>
+        </div>
         Roses are red
       </h1>
       <div
@@ -31470,7 +31793,7 @@ exports[`Storyshots Header the header without a title 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c4 {
+    .c6 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -31482,21 +31805,21 @@ Object {
   line-height: 24px;
 }
 
-.c4 > svg {
+.c6 > svg {
   fill: white;
   height: 24px;
   width: 24px;
 }
 
-.c4:hover {
+.c6:hover {
   background-color: var(--link);
 }
 
-.c4:hover > svg {
+.c6:hover > svg {
   fill: white;
 }
 
-.c7 {
+.c9 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -31508,21 +31831,21 @@ Object {
   line-height: 48px;
 }
 
-.c7 > svg {
+.c9 > svg {
   fill: white;
   height: 48px;
   width: 48px;
 }
 
-.c7:hover {
+.c9:hover {
   background-color: var(--link);
 }
 
-.c7:hover > svg {
+.c9:hover > svg {
   fill: white;
 }
 
-.c5 {
+.c7 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -31537,8 +31860,19 @@ Object {
   color: var(--link);
 }
 
-.c3:hover .c5 {
+.c5:hover .c7 {
   display: inline-block;
+}
+
+.c3 {
+  background-color: var(--brand);
+  height: 30px;
+  width: 30px;
+  border-radius: 50%;
+}
+
+.c3 > svg {
+  fill: white;
 }
 
 .c0 {
@@ -31557,7 +31891,7 @@ Object {
   color: var(--grey);
 }
 
-.c2 {
+.c4 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(4,24px);
@@ -31569,13 +31903,13 @@ Object {
   height: 100%;
 }
 
-.c6 {
+.c8 {
   display: none;
   height: auto;
   grid-column: second;
 }
 
-.c6 .c3 {
+.c8 .c5 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -31586,24 +31920,24 @@ Object {
   align-self: center;
 }
 
-.c6 .c3:nth-child(1) {
+.c8 .c5:nth-child(1) {
   pointer-events: none;
 }
 
-.c6 .c3:nth-child(2) {
+.c8 .c5:nth-child(2) {
   pointer-events: none;
   display: none;
 }
 
-.c6 .c3 > svg {
+.c8 .c5 > svg {
   fill: var(--grey);
 }
 
-.c6 .c3:hover > svg {
+.c8 .c5:hover > svg {
   fill: var(--grey);
 }
 
-.c8 {
+.c10 {
   background-color: var(--white);
   width: 100%;
   height: auto;
@@ -31630,17 +31964,23 @@ Object {
   top: 50px;
 }
 
-.c8 .c3 {
+.c10 .c5 {
   margin: 24px;
 }
 
-.c8 .c3 small {
+.c10 .c5 small {
   display: block;
   color: var(--grey);
   text-align: center;
   top: 5px;
   width: 100%;
   text-align: center;
+}
+
+.c2 {
+  float: left;
+  margin-right: 20px;
+  padding-top: 2px;
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
@@ -31652,31 +31992,37 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c4 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c8 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c8 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c10 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c10 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
   .c2 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c6 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c6 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c8 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c8 {
     display: none;
   }
 }
@@ -31692,13 +32038,33 @@ Object {
         <h1
           class="c1"
         >
+          <div
+            class="c2"
+          >
+            <a
+              href="/"
+            >
+              <div
+                class="c3"
+              >
+                <svg
+                  viewBox="0 0 56 56"
+                >
+                  <title />
+                  <path
+                    d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                  />
+                </svg>
+              </div>
+            </a>
+          </div>
           Unlock
         </h1>
         <div
-          class="c2"
+          class="c4"
         >
           <a
-            class="c3 c4"
+            class="c5 c6"
             href="/about"
             title="About"
           >
@@ -31715,13 +32081,13 @@ Object {
               />
             </svg>
             <small
-              class="c5"
+              class="c7"
             >
               About
             </small>
           </a>
           <a
-            class="c3 c4"
+            class="c5 c6"
             href="/jobs"
             title="Join us"
           >
@@ -31737,13 +32103,13 @@ Object {
               />
             </svg>
             <small
-              class="c5"
+              class="c7"
             >
               Join us
             </small>
           </a>
           <a
-            class="c3 c4"
+            class="c5 c6"
             href="https://github.com/unlock-protocol/unlock"
             title="Source Code"
           >
@@ -31757,13 +32123,13 @@ Object {
               />
             </svg>
             <small
-              class="c5"
+              class="c7"
             >
               Source Code
             </small>
           </a>
           <a
-            class="c3 c4"
+            class="c5 c6"
             href="https://t.me/unlockprotocol"
             title="Telegram"
           >
@@ -31779,17 +32145,17 @@ Object {
               />
             </svg>
             <small
-              class="c5"
+              class="c7"
             >
               Telegram
             </small>
           </a>
         </div>
         <div
-          class="c6"
+          class="c8"
         >
           <a
-            class="c3 c7"
+            class="c5 c9"
           >
             <svg
               viewBox="0 0 56 42"
@@ -31804,7 +32170,7 @@ Object {
             
           </a>
           <a
-            class="c3 c7"
+            class="c5 c9"
           >
             <svg
               viewBox="0 0 58 32"
@@ -31822,7 +32188,7 @@ Object {
           </a>
         </div>
         <div
-          class="c8"
+          class="c10"
         />
       </header>
     </div>
@@ -31838,6 +32204,26 @@ Object {
       <h1
         class="sc-1glv5oz-1 jZepcb"
       >
+        <div
+          class="sc-1glv5oz-5 dCcmGu"
+        >
+          <a
+            href="/"
+          >
+            <div
+              class="cenpj1-0 eCEwze"
+            >
+              <svg
+                viewBox="0 0 56 56"
+              >
+                <title />
+                <path
+                  d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                />
+              </svg>
+            </div>
+          </a>
+        </div>
         Unlock
       </h1>
       <div
@@ -36825,7 +37211,7 @@ exports[`Storyshots Layout the layout for the dashboard 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c8 {
+    .c10 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -36837,21 +37223,21 @@ Object {
   line-height: 24px;
 }
 
-.c8 > svg {
+.c10 > svg {
   fill: white;
   height: 24px;
   width: 24px;
 }
 
-.c8:hover {
+.c10:hover {
   background-color: var(--link);
 }
 
-.c8:hover > svg {
+.c10:hover > svg {
   fill: white;
 }
 
-.c11 {
+.c13 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -36863,21 +37249,21 @@ Object {
   line-height: 48px;
 }
 
-.c11 > svg {
+.c13 > svg {
   fill: white;
   height: 48px;
   width: 48px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: var(--link);
 }
 
-.c11:hover > svg {
+.c13:hover > svg {
   fill: white;
 }
 
-.c9 {
+.c11 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -36892,7 +37278,7 @@ Object {
   color: var(--link);
 }
 
-.c7:hover .c9 {
+.c9:hover .c11 {
   display: inline-block;
 }
 
@@ -36904,6 +37290,17 @@ Object {
 }
 
 .c2 > svg {
+  fill: white;
+}
+
+.c7 {
+  background-color: var(--brand);
+  height: 30px;
+  width: 30px;
+  border-radius: 50%;
+}
+
+.c7 > svg {
   fill: white;
 }
 
@@ -36923,7 +37320,7 @@ Object {
   color: var(--grey);
 }
 
-.c6 {
+.c8 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(4,24px);
@@ -36935,13 +37332,13 @@ Object {
   height: 100%;
 }
 
-.c10 {
+.c12 {
   display: none;
   height: auto;
   grid-column: second;
 }
 
-.c10 .c7 {
+.c12 .c9 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -36952,24 +37349,24 @@ Object {
   align-self: center;
 }
 
-.c10 .c7:nth-child(1) {
+.c12 .c9:nth-child(1) {
   pointer-events: none;
 }
 
-.c10 .c7:nth-child(2) {
+.c12 .c9:nth-child(2) {
   pointer-events: none;
   display: none;
 }
 
-.c10 .c7 > svg {
+.c12 .c9 > svg {
   fill: var(--grey);
 }
 
-.c10 .c7:hover > svg {
+.c12 .c9:hover > svg {
   fill: var(--grey);
 }
 
-.c12 {
+.c14 {
   background-color: var(--white);
   width: 100%;
   height: auto;
@@ -36996,17 +37393,23 @@ Object {
   top: 50px;
 }
 
-.c12 .c7 {
+.c14 .c9 {
   margin: 24px;
 }
 
-.c12 .c7 small {
+.c14 .c9 small {
   display: block;
   color: var(--grey);
   text-align: center;
   top: 5px;
   width: 100%;
   text-align: center;
+}
+
+.c6 {
+  float: left;
+  margin-right: 20px;
+  padding-top: 2px;
 }
 
 .c0 {
@@ -37039,31 +37442,37 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c8 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c12 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c12 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c14 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
+  .c14 {
+    display: none;
+  }
+}
+
+@media only screen and (min-device-width:736px) {
   .c6 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c10 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c10 {
-    display: none;
-  }
-}
-
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c12 {
-    display: grid;
-  }
-}
-
-@media only screen and (min-device-width:736px) {
-  .c12 {
     display: none;
   }
 }
@@ -37086,7 +37495,7 @@ Object {
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
-  .c13 {
+  .c15 {
     display: none;
   }
 }
@@ -37128,13 +37537,33 @@ Object {
             <h1
               class="c5"
             >
+              <div
+                class="c6"
+              >
+                <a
+                  href="/"
+                >
+                  <div
+                    class="c7"
+                  >
+                    <svg
+                      viewBox="0 0 56 56"
+                    >
+                      <title />
+                      <path
+                        d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                      />
+                    </svg>
+                  </div>
+                </a>
+              </div>
               Unlock Dashboard
             </h1>
             <div
-              class="c6"
+              class="c8"
             >
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/about"
                 title="About"
               >
@@ -37151,13 +37580,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   About
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="/jobs"
                 title="Join us"
               >
@@ -37173,13 +37602,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Join us
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://github.com/unlock-protocol/unlock"
                 title="Source Code"
               >
@@ -37193,13 +37622,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Source Code
                 </small>
               </a>
               <a
-                class="c7 c8"
+                class="c9 c10"
                 href="https://t.me/unlockprotocol"
                 title="Telegram"
               >
@@ -37215,17 +37644,17 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c9"
+                  class="c11"
                 >
                   Telegram
                 </small>
               </a>
             </div>
             <div
-              class="c10"
+              class="c12"
             >
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 56 42"
@@ -37240,7 +37669,7 @@ Object {
                 
               </a>
               <a
-                class="c7 c11"
+                class="c9 c13"
               >
                 <svg
                   viewBox="0 0 58 32"
@@ -37258,12 +37687,12 @@ Object {
               </a>
             </div>
             <div
-              class="c12"
+              class="c14"
             />
           </header>
         </div>
         <div
-          class="c13"
+          class="c15"
         />
       </div>
     </div>
@@ -37305,6 +37734,26 @@ Object {
           <h1
             class="sc-1glv5oz-1 jZepcb"
           >
+            <div
+              class="sc-1glv5oz-5 dCcmGu"
+            >
+              <a
+                href="/"
+              >
+                <div
+                  class="cenpj1-0 eCEwze"
+                >
+                  <svg
+                    viewBox="0 0 56 56"
+                  >
+                    <title />
+                    <path
+                      d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                    />
+                  </svg>
+                </div>
+              </a>
+            </div>
             Unlock Dashboard
           </h1>
           <div

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -23024,8 +23024,6 @@ Object {
 }
 
 .c6 {
-  float: left;
-  margin-right: 20px;
   padding-top: 2px;
 }
 
@@ -23198,6 +23196,14 @@ Object {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
     height: auto;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c5 {
+    display: grid;
+    grid-gap: 0;
+    grid-template-columns: 50px auto;
   }
 }
 
@@ -23734,10 +23740,10 @@ Object {
           class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
-            class="sc-1glv5oz-1 jZepcb"
+            class="sc-1glv5oz-1 eozQRg"
           >
             <div
-              class="sc-1glv5oz-5 dCcmGu"
+              class="sc-1glv5oz-5 bgXdkG"
             >
               <a
                 href="/"
@@ -24345,8 +24351,6 @@ Object {
 }
 
 .c6 {
-  float: left;
-  margin-right: 20px;
   padding-top: 2px;
 }
 
@@ -24416,6 +24420,14 @@ Object {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
     height: auto;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c5 {
+    display: grid;
+    grid-gap: 0;
+    grid-template-columns: 50px auto;
   }
 }
 
@@ -24736,10 +24748,10 @@ Object {
           class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
-            class="sc-1glv5oz-1 jZepcb"
+            class="sc-1glv5oz-1 eozQRg"
           >
             <div
-              class="sc-1glv5oz-5 dCcmGu"
+              class="sc-1glv5oz-5 bgXdkG"
             >
               <a
                 href="/"
@@ -25161,8 +25173,6 @@ Object {
 }
 
 .c6 {
-  float: left;
-  margin-right: 20px;
   padding-top: 2px;
 }
 
@@ -25232,6 +25242,14 @@ Object {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
     height: auto;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c5 {
+    display: grid;
+    grid-gap: 0;
+    grid-template-columns: 50px auto;
   }
 }
 
@@ -25552,10 +25570,10 @@ Object {
           class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
-            class="sc-1glv5oz-1 jZepcb"
+            class="sc-1glv5oz-1 eozQRg"
           >
             <div
-              class="sc-1glv5oz-5 dCcmGu"
+              class="sc-1glv5oz-5 bgXdkG"
             >
               <a
                 href="/"
@@ -26250,8 +26268,6 @@ Object {
 }
 
 .c6 {
-  float: left;
-  margin-right: 20px;
   padding-top: 2px;
 }
 
@@ -26412,6 +26428,14 @@ Object {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
     height: auto;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c5 {
+    display: grid;
+    grid-gap: 0;
+    grid-template-columns: 50px auto;
   }
 }
 
@@ -27617,10 +27641,10 @@ Object {
           class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
-            class="sc-1glv5oz-1 jZepcb"
+            class="sc-1glv5oz-1 eozQRg"
           >
             <div
-              class="sc-1glv5oz-5 dCcmGu"
+              class="sc-1glv5oz-5 bgXdkG"
             >
               <a
                 href="/"
@@ -31363,8 +31387,6 @@ Object {
 }
 
 .c2 {
-  float: left;
-  margin-right: 20px;
   padding-top: 2px;
 }
 
@@ -31373,6 +31395,14 @@ Object {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
     height: auto;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c1 {
+    display: grid;
+    grid-gap: 0;
+    grid-template-columns: 50px auto;
   }
 }
 
@@ -31587,10 +31617,10 @@ Object {
       class="sc-1glv5oz-0 cOQbpj"
     >
       <h1
-        class="sc-1glv5oz-1 jZepcb"
+        class="sc-1glv5oz-1 eozQRg"
       >
         <div
-          class="sc-1glv5oz-5 dCcmGu"
+          class="sc-1glv5oz-5 bgXdkG"
         >
           <a
             href="/"
@@ -31978,8 +32008,6 @@ Object {
 }
 
 .c2 {
-  float: left;
-  margin-right: 20px;
   padding-top: 2px;
 }
 
@@ -31988,6 +32016,14 @@ Object {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
     height: auto;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c1 {
+    display: grid;
+    grid-gap: 0;
+    grid-template-columns: 50px auto;
   }
 }
 
@@ -32202,10 +32238,10 @@ Object {
       class="sc-1glv5oz-0 cOQbpj"
     >
       <h1
-        class="sc-1glv5oz-1 jZepcb"
+        class="sc-1glv5oz-1 eozQRg"
       >
         <div
-          class="sc-1glv5oz-5 dCcmGu"
+          class="sc-1glv5oz-5 bgXdkG"
         >
           <a
             href="/"
@@ -37407,8 +37443,6 @@ Object {
 }
 
 .c6 {
-  float: left;
-  margin-right: 20px;
   padding-top: 2px;
 }
 
@@ -37438,6 +37472,14 @@ Object {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
     height: auto;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c5 {
+    display: grid;
+    grid-gap: 0;
+    grid-template-columns: 50px auto;
   }
 }
 
@@ -37732,10 +37774,10 @@ Object {
           class="sc-1glv5oz-0 cOQbpj"
         >
           <h1
-            class="sc-1glv5oz-1 jZepcb"
+            class="sc-1glv5oz-1 eozQRg"
           >
             <div
-              class="sc-1glv5oz-5 dCcmGu"
+              class="sc-1glv5oz-5 bgXdkG"
             >
               <a
                 href="/"

--- a/unlock-app/src/components/interface/Header.js
+++ b/unlock-app/src/components/interface/Header.js
@@ -107,6 +107,11 @@ const TopHeader = styled.header`
 
 const Title = styled.h1`
   color: var(--grey);
+  ${Media.phone`
+    display: grid;
+    grid-gap: 0;
+    grid-template-columns: 50px auto;
+  `};
 `
 
 const DesktopButtons = styled.div`
@@ -207,7 +212,5 @@ const LogoContainer = styled.div`
   ${Media.nophone`
     display: none;
   `};
-  float: left;
-  margin-right: 20px;
   padding-top: 2px;
 `

--- a/unlock-app/src/components/interface/Header.js
+++ b/unlock-app/src/components/interface/Header.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
-import { WordMarkLogo } from './Logo'
+import { RoundedLogo, WordMarkLogo } from './Logo'
 import Buttons from './buttons/layout'
 import { ButtonLink } from './buttons/Button'
 import Media from '../../theme/media'
@@ -43,7 +43,16 @@ export default class Header extends React.PureComponent {
             </a>
           </Link>
         ) : (
-          <Title>{title}</Title>
+          <Title>
+            <LogoContainer>
+              <Link href="/">
+                <a>
+                  <RoundedLogo size="30px" />
+                </a>
+              </Link>
+            </LogoContainer>
+            {title}
+          </Title>
         )}
         <DesktopButtons>
           {navigationButtons.map(NavButton => (
@@ -192,4 +201,13 @@ const MobilePopover = styled.div`
   ${Media.nophone`
     display: none;
   `};
+`
+
+const LogoContainer = styled.div`
+  ${Media.nophone`
+    display: none;
+  `};
+  float: left;
+  margin-right: 20px;
+  padding-top: 2px;
 `


### PR DESCRIPTION
# Description

The rounded logo was intended to be part of the header design on mobile layouts, but it was omitted. This PR restores the logo to view.

Fixes #806 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

Here's the logo in situ:

<img width="362" alt="screen shot 2019-02-02 at 11 14 29 am" src="https://user-images.githubusercontent.com/624104/52168214-3972db80-26dc-11e9-99bf-6b1cd740888e.png">

The non-mobile dashboard remains unchanged:

<img width="1431" alt="screen shot 2019-02-02 at 11 12 14 am" src="https://user-images.githubusercontent.com/624104/52168216-42fc4380-26dc-11e9-8902-0c95664c94be.png">

Ditto the mobile header for content pages:

<img width="368" alt="screen shot 2019-02-02 at 11 14 40 am" src="https://user-images.githubusercontent.com/624104/52168222-4a235180-26dc-11e9-8602-c052ccc3fce1.png">
