### PR TITLE
use the parent window, not the iframe, in postMessageMiddleware

### DIFF
--- a/unlock-app/src/__tests__/middlewares/postMessageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/postMessageMiddleware.test.js
@@ -11,10 +11,8 @@ describe('postMessageMiddleware', () => {
 
       const window = {
         parent: {
-          contentWindow: {
-            postMessage: jest.fn(),
-            origin: 'origin',
-          },
+          postMessage: jest.fn(),
+          origin: 'origin',
         },
       }
       window.self = window
@@ -25,7 +23,7 @@ describe('postMessageMiddleware', () => {
       middleware()(next)(action)
 
       expect(next).toHaveBeenCalledWith(action)
-      expect(window.parent.contentWindow.postMessage).toHaveBeenCalledWith(
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
         'redirect',
         'origin'
       )

--- a/unlock-app/src/middlewares/postMessageMiddleware.js
+++ b/unlock-app/src/middlewares/postMessageMiddleware.js
@@ -4,12 +4,12 @@ import { inIframe } from '../config'
 // store is unused in this middleware, it is only for listening for actions
 // and converting them into postMessage
 const postMessageMiddleware = window => () => {
-  const iframe = window.parent
+  const parent = window.parent
   const enabled = inIframe(window)
   return next => action => {
     if (!enabled) return next(action)
     if (action.type === OPEN_MODAL_IN_NEW_WINDOW) {
-      iframe.contentWindow.postMessage('redirect', iframe.contentWindow.origin)
+      parent.postMessage('redirect', parent.origin)
     }
     return next(action)
   }


### PR DESCRIPTION
# Description

This corrects a logical error in the `postMessageMiddleware`. It was intended to be a middleware run only in the iframe, and to pass messages to the parent window. However, it is erroneously assuming at the point of `postMessage` that it is the parent window. This throws an exception when running in real code.

fixes #1373 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
