### PR TITLE
new mapErrorToComponent function

### DIFF
--- a/unlock-app/src/__tests__/components/creator/FatalError.test.js
+++ b/unlock-app/src/__tests__/components/creator/FatalError.test.js
@@ -1,0 +1,60 @@
+import * as rtl from 'react-testing-library'
+import React from 'react'
+
+import { mapErrorToComponent } from '../../../components/creator/FatalError'
+import {
+  FATAL_MISSING_PROVIDER,
+  FATAL_NO_USER_ACCOUNT,
+  FATAL_WRONG_NETWORK,
+} from '../../../errors'
+
+describe('FatalError', () => {
+  describe('mapErrorToComponent', () => {
+    describe('maps errors to default components', () => {
+      it('FATAL_MISSING_PROVIDER', () => {
+        const component = mapErrorToComponent(FATAL_MISSING_PROVIDER, {})
+
+        const wrapper = rtl.render(component)
+        expect(wrapper.queryByText('Wallet missing')).not.toBeNull()
+      })
+      it('FATAL_NO_USER_ACCOUNT', () => {
+        const component = mapErrorToComponent(FATAL_NO_USER_ACCOUNT, {})
+
+        const wrapper = rtl.render(component)
+        expect(wrapper.queryByText('Need account')).not.toBeNull()
+      })
+      it('FATAL_WRONG_NETWORK', () => {
+        const component = mapErrorToComponent(FATAL_WRONG_NETWORK, {
+          currentNetwork: 'foo',
+          requiredNetworkId: 1,
+        })
+
+        const wrapper = rtl.render(component)
+        expect(wrapper.queryByText('Network mismatch')).not.toBeNull()
+      })
+      it('*', () => {
+        const component = mapErrorToComponent('whatever', {
+          title: 'some error',
+        })
+
+        const wrapper = rtl.render(component)
+        expect(wrapper.queryByText('some error')).not.toBeNull()
+      })
+      it('override', () => {
+        function Component() {
+          return <div>My error</div>
+        }
+        const component = mapErrorToComponent(
+          FATAL_NO_USER_ACCOUNT,
+          {},
+          {
+            FATAL_NO_USER_ACCOUNT: Component,
+          }
+        )
+
+        const wrapper = rtl.render(component)
+        expect(wrapper.queryByText('My error')).not.toBeNull()
+      })
+    })
+  })
+})

--- a/unlock-app/src/components/creator/FatalError.js
+++ b/unlock-app/src/components/creator/FatalError.js
@@ -126,6 +126,21 @@ export const mapping = {
   '*': DefaultError,
 }
 
+export function mapErrorToComponent(
+  error,
+  errorMetadata,
+  overrideMapping = {}
+) {
+  // if the error condition exists, set it to the mapped fatal error component
+  // or to the fallback
+  // if no error exists, set it to false
+  const Error = error
+    ? overrideMapping[error] || mapping[error] || mapping['*']
+    : false
+
+  return Error && <Error {...errorMetadata} />
+}
+
 export default {
   DefaultError,
   WrongNetwork,


### PR DESCRIPTION
# Description

Extract the mapping of fatal error to component from `GlobalErrorConsumer`, and put it in `FatalError.js`. A follow-up PR will refactor `GlobalErrorConsumer` to use this instead. It allows passing `error` and `errorMetadata` to the `displayError` function, and also removes the need for `overrideMapping` as a prop.

A small step on the path to #1287

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
