### PR TITLE
refactor displayError in GlobalErrorConsumer to use mapErrorToComponent

### DIFF
--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -5,17 +5,13 @@ import GlobalErrorConsumer, {
   displayError,
 } from '../../../components/interface/GlobalErrorConsumer'
 import { GlobalErrorContext } from '../../../utils/GlobalErrorProvider'
-import {
-  FATAL_NO_USER_ACCOUNT,
-  FATAL_MISSING_PROVIDER,
-  FATAL_WRONG_NETWORK,
-} from '../../../errors'
+import { FATAL_NO_USER_ACCOUNT, FATAL_MISSING_PROVIDER } from '../../../errors'
 
 const Provider = GlobalErrorContext.Provider
 
 describe('GlobalErrorConsumer', () => {
-  it('passes error initialized with metadata to displayError prop', () => {
-    expect.assertions(4)
+  it('passes error and errorMetadata to displayError prop', () => {
+    expect.assertions(5)
 
     const listen = jest.fn(() => <div>internal</div>)
     const wrapper = rtl.render(
@@ -29,16 +25,13 @@ describe('GlobalErrorConsumer', () => {
       </Provider>
     )
 
-    expect(wrapper.queryByText('internal')).not.toBeNull()
+    expect(wrapper.getByText('internal')).not.toBeNull()
     expect(listen).toHaveBeenCalledTimes(1)
 
+    expect(listen.mock.calls[0][0]).toBe(FATAL_NO_USER_ACCOUNT)
+    expect(listen.mock.calls[0][1]).toEqual({ thing: 'thingy' })
     // this next part tests to see if we got the error element and the children
-    const Error = listen.mock.calls[0][0]
-
-    const errorWrapper = rtl.render(Error)
-    expect(errorWrapper.queryByText('Need account')).not.toBeNull()
-
-    const children = listen.mock.calls[0][1]
+    const children = listen.mock.calls[0][2]
 
     const childrenWrapper = rtl.render(children)
     expect(childrenWrapper.queryByText('hi')).not.toBeNull()
@@ -63,176 +56,18 @@ describe('GlobalErrorConsumer', () => {
 
     expect(listen.mock.calls[0][0]).toBe(false)
   })
-  describe('error mappings', () => {
-    it('FATAL_MISSING_PROVIDER', () => {
-      expect.assertions(2)
-
-      const listen = jest.fn(() => <div>internal</div>)
-      rtl.render(
-        <Provider
-          value={{
-            error: FATAL_MISSING_PROVIDER,
-            errorMetadata: {},
-          }}
-        >
-          <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
-        </Provider>
-      )
-
-      expect(listen).toHaveBeenCalledTimes(1)
-
-      const Error = listen.mock.calls[0][0]
-      const errorWrapper = rtl.render(Error)
-      expect(errorWrapper.queryByText('Wallet missing')).not.toBeNull()
-    })
-    it('FATAL_WRONG_NETWORK', () => {
-      expect.assertions(2)
-
-      const listen = jest.fn(() => <div>internal</div>)
-      rtl.render(
-        <Provider
-          value={{
-            error: FATAL_WRONG_NETWORK,
-            errorMetadata: {
-              requiredNetworkId: 2,
-              currentNetwork: 'Fox News',
-            },
-          }}
-        >
-          <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
-        </Provider>
-      )
-
-      expect(listen).toHaveBeenCalledTimes(1)
-
-      const Error = listen.mock.calls[0][0]
-      const errorWrapper = rtl.render(Error)
-      expect(errorWrapper.queryByText('Network mismatch')).not.toBeNull()
-    })
-    it('FATAL_NO_USER_ACCOUNT', () => {
-      expect.assertions(2)
-
-      const listen = jest.fn(() => <div>internal</div>)
-      rtl.render(
-        <Provider
-          value={{
-            error: FATAL_NO_USER_ACCOUNT,
-            errorMetadata: {},
-          }}
-        >
-          <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
-        </Provider>
-      )
-
-      expect(listen).toHaveBeenCalledTimes(1)
-
-      const Error = listen.mock.calls[0][0]
-      const errorWrapper = rtl.render(Error)
-      expect(errorWrapper.queryByText('Need account')).not.toBeNull()
-    })
-    it('anything else (*)', () => {
-      expect.assertions(2)
-
-      const listen = jest.fn(() => <div>internal</div>)
-      rtl.render(
-        <Provider
-          value={{
-            error: 'GOBBLEDEGOOK_ERROR',
-            errorMetadata: {},
-          }}
-        >
-          <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
-        </Provider>
-      )
-
-      expect(listen).toHaveBeenCalledTimes(1)
-
-      const Error = listen.mock.calls[0][0]
-      const errorWrapper = rtl.render(Error)
-      expect(errorWrapper.queryByText('Fatal Error')).not.toBeNull()
-    })
-    describe('overrideMapping', () => {
-      it('overriding FATAL_NO_USER_ACCOUNT', () => {
-        expect.assertions(2)
-
-        const component = () => <div>overrode</div>
-
-        const mapping = {
-          FATAL_NO_USER_ACCOUNT: component,
-        }
-        const wrapper = rtl.render(
-          <Provider
-            value={{
-              error: FATAL_NO_USER_ACCOUNT,
-              errorMetadata: {},
-            }}
-          >
-            <GlobalErrorConsumer overrideMapping={mapping}>
-              hi
-            </GlobalErrorConsumer>
-          </Provider>
-        )
-
-        // verify that error was overridden
-        expect(wrapper.queryByText('overrode')).not.toBeNull()
-
-        const wrapper2 = rtl.render(
-          <Provider
-            value={{
-              error: FATAL_WRONG_NETWORK,
-              errorMetadata: {
-                requiredNetworkId: 1984,
-                currentNetwork: 'Fox News',
-              },
-            }}
-          >
-            <GlobalErrorConsumer overrideMapping={mapping}>
-              hi
-            </GlobalErrorConsumer>
-          </Provider>
-        )
-
-        // verify other errors are untouched
-        expect(wrapper2.queryByText('Network mismatch')).not.toBeNull()
-      })
-      it('overriding an unknown error', () => {
-        expect.assertions(1)
-
-        const component = () => <div>overrode</div>
-
-        const mapping = {
-          GOBBLEDEGOOK_ERROR: component,
-        }
-        const wrapper = rtl.render(
-          <Provider
-            value={{
-              error: 'GOBBLEDEGOOK_ERROR',
-              errorMetadata: {},
-            }}
-          >
-            <GlobalErrorConsumer overrideMapping={mapping}>
-              hi
-            </GlobalErrorConsumer>
-          </Provider>
-        )
-
-        expect(wrapper.queryByText('overrode')).not.toBeNull()
-      })
-    })
-  })
   describe('displayError', () => {
     it('displays the error if initialized', () => {
       const wrapper = rtl.render(
-        displayError(<div>Error Message</div>, <div>children</div>)
+        displayError(FATAL_MISSING_PROVIDER, {}, <div>children</div>)
       )
 
-      expect(wrapper.queryByText('Error Message')).not.toBeNull()
+      expect(wrapper.queryByText('Wallet missing')).not.toBeNull()
       expect(wrapper.queryByText('children')).toBeNull()
     })
     it('displays the children if no error is initialized', () => {
-      const wrapper = rtl.render(displayError(false, <div>children</div>))
+      const wrapper = rtl.render(displayError(false, {}, <div>children</div>))
 
-      expect(wrapper.queryByText('Error Message')).toBeNull()
       expect(wrapper.queryByText('children')).not.toBeNull()
     })
   })

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -10,7 +10,7 @@ import Overlay, {
   displayError,
 } from '../../../components/lock/Overlay'
 import { GlobalErrorContext } from '../../../utils/GlobalErrorProvider'
-import { FATAL_NO_USER_ACCOUNT } from '../../../errors'
+import { FATAL_NO_USER_ACCOUNT, FATAL_MISSING_PROVIDER } from '../../../errors'
 import createUnlockStore from '../../../createUnlockStore'
 import { ConfigContext } from '../../../utils/withConfig'
 
@@ -61,17 +61,17 @@ describe('Overlay', () => {
   describe('displayError', () => {
     it('should display children if there is no error', () => {
       expect.assertions(1)
-      const wrapper = rtl.render(displayError(false, <div>children</div>))
+      const wrapper = rtl.render(displayError(false, {}, <div>children</div>))
 
       expect(wrapper.getByText('children')).not.toBeNull()
     })
     it('should display error if present', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
-        displayError(<div>error</div>, <div>children</div>)
+        displayError(FATAL_MISSING_PROVIDER, {}, <div>children</div>)
       )
 
-      expect(wrapper.getByText('error')).not.toBeNull()
+      expect(wrapper.getByText('Wallet missing')).not.toBeNull()
     })
   })
   describe('error replacement', () => {

--- a/unlock-app/src/components/interface/GlobalErrorConsumer.js
+++ b/unlock-app/src/components/interface/GlobalErrorConsumer.js
@@ -2,35 +2,24 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { GlobalErrorContext } from '../../utils/GlobalErrorProvider'
-import { mapping } from '../creator/FatalError'
 import Layout from './Layout'
+import { mapErrorToComponent } from '../creator/FatalError'
 
 const Consumer = GlobalErrorContext.Consumer
 
-export const displayError = (error, children) => {
+export const displayError = (error, errorMetadata, children) => {
   if (error) {
-    return <Layout title="">{error}</Layout>
+    const Error = mapErrorToComponent(error, errorMetadata)
+    return <Layout title="">{Error}</Layout>
   }
   return <>{children}</>
 }
 
-export default function GlobalErrorConsumer({
-  displayError,
-  overrideMapping,
-  children,
-}) {
+export default function GlobalErrorConsumer({ displayError, children }) {
   return (
     <Consumer>
       {({ error, errorMetadata }) => {
-        // if the error condition exists, set it to the mapped fatal error component
-        // or to the fallback
-        // if no error exists, set it to false
-        const Error = error
-          ? overrideMapping[error] || mapping[error] || mapping['*']
-          : false
-
-        // call displayError with either false or the error element, and our child elements
-        return displayError(Error && <Error {...errorMetadata} />, children)
+        return displayError(error, errorMetadata, children)
       }}
     </Consumer>
   )
@@ -39,10 +28,8 @@ export default function GlobalErrorConsumer({
 GlobalErrorConsumer.propTypes = {
   children: PropTypes.node.isRequired,
   displayError: PropTypes.func,
-  overrideMapping: PropTypes.objectOf(PropTypes.func),
 }
 
 GlobalErrorConsumer.defaultProps = {
   displayError,
-  overrideMapping: {},
 }

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -8,10 +8,12 @@ import { hideModal, showModal } from '../../actions/modal'
 import { unlockPage } from '../../services/iframeService'
 import { LockedFlag } from './UnlockFlag'
 import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
+import { mapErrorToComponent } from '../creator/FatalError'
 
-export function displayError(error, children) {
+export function displayError(error, errorMetadata, children) {
   if (error) {
-    return <>{error}</>
+    const Error = mapErrorToComponent(error, errorMetadata)
+    return Error
   }
   return <>{children}</>
 }


### PR DESCRIPTION
# Description

Refactor `GlobalErrorConsumer` to simplify `displayError`. It removes all of the mapping logic and uses the new `mapErrorToComponent` function from `FatalError.js`. This also removes the need for the `overrideMapping` prop, as this is passed directly to `mapErrorToComponent` now.

The `displayError` in `Overlay` is refactored to match the new format and tests/stories affected are updated as well.

This is a step on the path to implementing #1287

Screenshot to verify behavior is not broken:

<img width="1636" alt="screen shot 2019-02-02 at 10 17 07 pm" src="https://user-images.githubusercontent.com/98250/52172209-d6fbf880-2738-11e9-80e0-9bf7b558df79.png">


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
