### PR TITLE
disable user account error in the paywall iframe

### DIFF
--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -27,6 +27,7 @@ describe('GlobalErrorConsumer', () => {
 
     expect(wrapper.getByText('internal')).not.toBeNull()
     expect(listen).toHaveBeenCalledTimes(1)
+    expect(listen.mock.calls[0][2]).toBe(FATAL_NO_USER_ACCOUNT)
 
     expect(listen.mock.calls[0][0]).toBe(FATAL_NO_USER_ACCOUNT)
     expect(listen.mock.calls[0][1]).toEqual({ thing: 'thingy' })

--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -27,7 +27,6 @@ describe('GlobalErrorConsumer', () => {
 
     expect(wrapper.getByText('internal')).not.toBeNull()
     expect(listen).toHaveBeenCalledTimes(1)
-    expect(listen.mock.calls[0][2]).toBe(FATAL_NO_USER_ACCOUNT)
 
     expect(listen.mock.calls[0][0]).toBe(FATAL_NO_USER_ACCOUNT)
     expect(listen.mock.calls[0][1]).toEqual({ thing: 'thingy' })

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -61,7 +61,9 @@ describe('Overlay', () => {
   describe('displayError', () => {
     it('should display children if there is no error', () => {
       expect.assertions(1)
-      const wrapper = rtl.render(displayError(true)(false, {}, <div>children</div>))
+      const wrapper = rtl.render(
+        displayError(true)(false, {}, <div>children</div>)
+      )
 
       expect(wrapper.getByText('children')).not.toBeNull()
     })
@@ -71,15 +73,12 @@ describe('Overlay', () => {
         displayError(true)(FATAL_MISSING_PROVIDER, {}, <div>children</div>)
       )
 
-      expect(wrapper.getByText('error')).not.toBeNull()
+      expect(wrapper.getByText('Wallet missing')).not.toBeNull()
     })
     it('should display children if account is missing and in the iframe', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
-        displayError(false)(
-          FATAL_NO_USER_ACCOUNT, {}
-          <div>children</div>,
-        )
+        displayError(false)(FATAL_NO_USER_ACCOUNT, {}, <div>children</div>)
       )
 
       expect(wrapper.queryByText('error')).toBeNull()
@@ -87,13 +86,10 @@ describe('Overlay', () => {
     it('should display error if account is missing and in the main window', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
-        displayError(true)(
-          FATAL_NO_USER_ACCOUNT, {},
-          <div>children</div>,
-        )
+        displayError(true)(FATAL_NO_USER_ACCOUNT, {}, <div>children</div>)
       )
 
-      expect(wrapper.getByText('Wallet missing')).not.toBeNull()
+      expect(wrapper.getByText('Need account')).not.toBeNull()
     })
   })
   describe('error replacement', () => {

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -138,12 +138,15 @@ describe('Overlay', () => {
           <ErrorProvider
             value={{ error: FATAL_NO_USER_ACCOUNT, errorMetadata: {} }}
           >
-            <Overlay
-              scrollPosition={0}
-              hideModal={() => {}}
-              showModal={() => {}}
-              locks={[lock]}
-            />
+            <ConfigContext.Provider value={{ requiredConfirmations: 12 }}>
+              <Overlay
+                scrollPosition={0}
+                hideModal={() => {}}
+                showModal={() => {}}
+                locks={[lock]}
+                openInNewWindow={false}
+              />
+            </ConfigContext.Provider>
           </ErrorProvider>
         </Provider>
       )

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -112,7 +112,7 @@ describe('Overlay', () => {
       const wrapper = rtl.render(
         <Provider store={store}>
           <ErrorProvider
-            value={{ error: FATAL_NO_USER_ACCOUNT, errorMetadata: {} }}
+            value={{ error: FATAL_MISSING_PROVIDER, errorMetadata: {} }}
           >
             <Overlay
               scrollPosition={0}
@@ -125,6 +125,30 @@ describe('Overlay', () => {
       )
 
       expect(wrapper.queryByText('100000.00 Eth')).toBeNull()
+      expect(wrapper.queryByText('Powered by Unlock')).not.toBeNull()
+      expect(
+        wrapper.queryByText(
+          'You have reached your limit of free articles. Please purchase access'
+        )
+      ).not.toBeNull()
+    })
+    it('displays lock when the error is missing account', () => {
+      const wrapper = rtl.render(
+        <Provider store={store}>
+          <ErrorProvider
+            value={{ error: FATAL_NO_USER_ACCOUNT, errorMetadata: {} }}
+          >
+            <Overlay
+              scrollPosition={0}
+              hideModal={() => {}}
+              showModal={() => {}}
+              locks={[lock]}
+            />
+          </ErrorProvider>
+        </Provider>
+      )
+
+      expect(wrapper.queryByText('100000.00 Eth')).not.toBeNull()
       expect(wrapper.queryByText('Powered by Unlock')).not.toBeNull()
       expect(
         wrapper.queryByText(

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -61,14 +61,36 @@ describe('Overlay', () => {
   describe('displayError', () => {
     it('should display children if there is no error', () => {
       expect.assertions(1)
-      const wrapper = rtl.render(displayError(false, {}, <div>children</div>))
+      const wrapper = rtl.render(displayError(true)(false, {}, <div>children</div>))
 
       expect(wrapper.getByText('children')).not.toBeNull()
     })
     it('should display error if present', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
-        displayError(FATAL_MISSING_PROVIDER, {}, <div>children</div>)
+        displayError(true)(FATAL_MISSING_PROVIDER, {}, <div>children</div>)
+      )
+
+      expect(wrapper.getByText('error')).not.toBeNull()
+    })
+    it('should display children if account is missing and in the iframe', () => {
+      expect.assertions(1)
+      const wrapper = rtl.render(
+        displayError(false)(
+          FATAL_NO_USER_ACCOUNT, {}
+          <div>children</div>,
+        )
+      )
+
+      expect(wrapper.queryByText('error')).toBeNull()
+    })
+    it('should display error if account is missing and in the main window', () => {
+      expect.assertions(1)
+      const wrapper = rtl.render(
+        displayError(true)(
+          FATAL_NO_USER_ACCOUNT, {},
+          <div>children</div>,
+        )
       )
 
       expect(wrapper.getByText('Wallet missing')).not.toBeNull()
@@ -87,7 +109,9 @@ describe('Overlay', () => {
       expect.assertions(3)
       const wrapper = rtl.render(
         <Provider store={store}>
-          <ConfigProvider value={{}}>
+          <ConfigProvider
+            value={{ requiredConfirmations: 12, isInIframe: true }}
+          >
             <ErrorProvider value={{ error: false, errorMetadata: {} }}>
               <Overlay
                 scrollPosition={0}
@@ -111,16 +135,20 @@ describe('Overlay', () => {
     it('displays error, headline, and flag when there is an error', () => {
       const wrapper = rtl.render(
         <Provider store={store}>
-          <ErrorProvider
-            value={{ error: FATAL_MISSING_PROVIDER, errorMetadata: {} }}
+          <ConfigProvider
+            value={{ requiredConfirmations: 12, isInIframe: true }}
           >
-            <Overlay
-              scrollPosition={0}
-              hideModal={() => {}}
-              showModal={() => {}}
-              locks={[lock]}
-            />
-          </ErrorProvider>
+            <ErrorProvider
+              value={{ error: FATAL_MISSING_PROVIDER, errorMetadata: {} }}
+            >
+              <Overlay
+                scrollPosition={0}
+                hideModal={() => {}}
+                showModal={() => {}}
+                locks={[lock]}
+              />
+            </ErrorProvider>
+          </ConfigProvider>
         </Provider>
       )
 
@@ -138,7 +166,9 @@ describe('Overlay', () => {
           <ErrorProvider
             value={{ error: FATAL_NO_USER_ACCOUNT, errorMetadata: {} }}
           >
-            <ConfigContext.Provider value={{ requiredConfirmations: 12 }}>
+            <ConfigProvider
+              value={{ requiredConfirmations: 12, isInIframe: true }}
+            >
               <Overlay
                 scrollPosition={0}
                 hideModal={() => {}}
@@ -146,7 +176,7 @@ describe('Overlay', () => {
                 locks={[lock]}
                 openInNewWindow={false}
               />
-            </ConfigContext.Provider>
+            </ConfigProvider>
           </ErrorProvider>
         </Provider>
       )

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -62,7 +62,7 @@ describe('Overlay', () => {
     it('should display children if there is no error', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
-        displayError(true)(false, {}, <div>children</div>)
+displayError(true /* isMainWindow */)(false, {}, <div>children</div>)
       )
 
       expect(wrapper.getByText('children')).not.toBeNull()

--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -62,7 +62,7 @@ describe('Overlay', () => {
     it('should display children if there is no error', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
-displayError(true /* isMainWindow */)(false, {}, <div>children</div>)
+        displayError(true /* isMainWindow */)(false, {}, <div>children</div>)
       )
 
       expect(wrapper.getByText('children')).not.toBeNull()
@@ -70,7 +70,11 @@ displayError(true /* isMainWindow */)(false, {}, <div>children</div>)
     it('should display error if present', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
-        displayError(true)(FATAL_MISSING_PROVIDER, {}, <div>children</div>)
+        displayError(true /* isMainWindow */)(
+          FATAL_MISSING_PROVIDER,
+          {},
+          <div>children</div>
+        )
       )
 
       expect(wrapper.getByText('Wallet missing')).not.toBeNull()
@@ -78,7 +82,11 @@ displayError(true /* isMainWindow */)(false, {}, <div>children</div>)
     it('should display children if account is missing and in the iframe', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
-        displayError(false)(FATAL_NO_USER_ACCOUNT, {}, <div>children</div>)
+        displayError(false /* iframe */)(
+          FATAL_NO_USER_ACCOUNT,
+          {},
+          <div>children</div>
+        )
       )
 
       expect(wrapper.queryByText('error')).toBeNull()
@@ -86,7 +94,11 @@ displayError(true /* isMainWindow */)(false, {}, <div>children</div>)
     it('should display error if account is missing and in the main window', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
-        displayError(true)(FATAL_NO_USER_ACCOUNT, {}, <div>children</div>)
+        displayError(true /* isMainWindow */)(
+          FATAL_NO_USER_ACCOUNT,
+          {},
+          <div>children</div>
+        )
       )
 
       expect(wrapper.getByText('Need account')).not.toBeNull()

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -42347,16 +42347,16 @@ Object {
               >
                 <img
                   class="c5"
-                  src="/static/images/illustrations/error.svg"
+                  src="/static/images/illustrations/network.svg"
                 />
                 <div
                   class="c6"
                 >
                   <h1>
-                    Need account
+                    Network mismatch
                   </h1>
                   <p>
-                    In order to display this content, you need to connect a crypto-wallet to your browser.
+                    You’re currently on the Foobar network but you need to be on the Rinkeby network. Please switch to Rinkeby.
                   </p>
                 </div>
               </section>
@@ -42461,16 +42461,16 @@ Object {
             >
               <img
                 class="sc-1g6piw8-1 fcKGMu"
-                src="/static/images/illustrations/error.svg"
+                src="/static/images/illustrations/network.svg"
               />
               <div
                 class="sc-1g6piw8-2 gCvXha"
               >
                 <h1>
-                  Need account
+                  Network mismatch
                 </h1>
                 <p>
-                  In order to display this content, you need to connect a crypto-wallet to your browser.
+                  You’re currently on the Foobar network but you need to be on the Rinkeby network. Please switch to Rinkeby.
                 </p>
               </div>
             </section>

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -41548,6 +41548,1002 @@ Object {
 }
 `;
 
+exports[`Storyshots Overlay iframe, account error is ignored 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c14 {
+  background-color: var(--brand);
+  height: 28px;
+  width: 28px;
+  border-radius: 50%;
+}
+
+.c14 > svg {
+  fill: white;
+}
+
+.c5 {
+  display: grid;
+  font-weight: 300;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-size: 20px;
+  line-height: 20px;
+  height: 40px;
+  border-radius: 4px 4px 0px 0px;
+  padding: 0px;
+  color: var(--grey);
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-family: 'Roboto',sans-serif;
+  font-weight: 300;
+  font-size: 12px;
+  color: var(--darkgrey);
+  background-color: var(--white);
+  justify-self: right;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  grid-row: 2;
+  grid-column: 1;
+  width: 120px;
+  height: 80px;
+  margin-right: -33px;
+}
+
+.c13 > * {
+  justify-self: left;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin-left: -14px;
+}
+
+.c13 > p {
+  margin-left: auto;
+  margin-right: auto;
+  width: 63px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  justify-self: center;
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: normal;
+  line-height: normal;
+  font-size: 12px;
+  color: var(--darkgrey);
+}
+
+.c4 {
+  display: grid;
+  justify-items: stretch;
+  margin: 0px;
+  padding: 0px;
+  font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
+  width: 200px;
+  height: 180px;
+  grid-gap: 0px;
+  background-clip: padding-box;
+  grid-template-rows: 40px 140px;
+  opacity: 1;
+  cursor: pointer;
+}
+
+.c12 {
+  display: grid;
+  font-weight: 300;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-size: 20px;
+  line-height: 20px;
+  height: 40px;
+  border-radius: 0px 0px 4px 4px;
+  padding: 0px;
+  width: 200px;
+  background-color: var(--green);
+  color: var(--white);
+}
+
+.c6 {
+  display: grid;
+  height: 140px;
+  width: 200px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
+  text-align: center;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  padding: 0px;
+  grid-template-rows: 40px 30px;
+  grid-gap: 8px;
+  padding-top: 0px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background-color: var(--white);
+  padding-top: 13px;
+}
+
+.c6:hover {
+  border: 1px solid var(--activegreen);
+}
+
+.c6:hover .c11 {
+  background-color: var(--activegreen);
+}
+
+.c7 {
+  font-size: 30px;
+  text-transform: uppercase;
+  color: var(--slate);
+  font-weight: bold;
+}
+
+.c8 {
+  font-size: 20px;
+  font-weight: 300;
+  color: var(--grey);
+}
+
+.c10 {
+  font-size: 20px;
+  font-weight: 300;
+  color: var(--grey);
+}
+
+.c9 {
+  color: var(--lightgrey);
+}
+
+.c0 {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient( rgba(255,255,255,0) 18%,rgba(255,255,255,0) 29%,var(--offwhite) 48% );
+}
+
+.c1 {
+  position: fixed;
+  display: grid;
+  min-height: 375px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--offwhite);
+  justify-items: center;
+  padding: 32px;
+  padding-bottom: 100px;
+  grid-gap: 24px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c2 {
+  font-size: 20px;
+  font-family: 'Roboto',sans-serif;
+  font-weight: bold;
+  color: var(--slate);
+  text-align: center;
+}
+
+.c3 {
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: 32px;
+  list-style: none;
+  margin: 0px;
+  padding: 0px;
+  grid-row: 2;
+  grid-column: 1;
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c13 {
+    display: none;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <section>
+        <h1>
+          HTML Ipsum Presents
+        </h1>
+        <p>
+          <strong>
+            Pellentesque habitant morbi tristique
+          </strong>
+           senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
+          <em>
+            Aenean ultricies mi vitae est.
+          </em>
+           Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+          <code>
+            commodo vitae
+          </code>
+          , ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui.
+          <a
+            href="."
+          >
+            Donec non enim
+          </a>
+           in turpis pulvinar facilisis. Ut felis.
+        </p>
+        <h2>
+          Header Level 2
+        </h2>
+        <ol>
+          <li>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+          </li>
+          <li>
+            Aliquam tincidunt mauris eu risus.
+          </li>
+        </ol>
+        <blockquote>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.
+          </p>
+        </blockquote>
+        <h3>
+          Header Level 3
+        </h3>
+        <ul>
+          <li>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+          </li>
+          <li>
+            Aliquam tincidunt mauris eu risus.
+          </li>
+        </ul>
+        <div
+          class="c0"
+        >
+          <div
+            class="c1"
+            style="height: 0%;"
+          >
+            <h1
+              class="c2"
+            >
+              You have reached your limit of free articles. Please purchase access
+            </h1>
+            <ul
+              class="c3"
+            >
+              <li
+                class="c4"
+              >
+                <header
+                  class="c5"
+                >
+                  One Month
+                </header>
+                <div>
+                  <div
+                    class="c6"
+                  >
+                    <div
+                      class="c7"
+                    >
+                      123400000000000000.00
+                       Eth
+                    </div>
+                    <div>
+                      <span
+                        class="c8"
+                      >
+                        $
+                        24,185,166,000b
+                      </span>
+                      <span
+                        class="c9"
+                      >
+                         | 
+                      </span>
+                      <span
+                        class="c10"
+                      >
+                        <span>
+                           - 
+                        </span>
+                      </span>
+                    </div>
+                    <footer
+                      class="c11 c12"
+                    >
+                      Purchase
+                    </footer>
+                  </div>
+                </div>
+              </li>
+            </ul>
+            <footer
+              class="c13"
+            >
+              <div
+                class="c14"
+              >
+                <svg
+                  viewBox="0 0 56 56"
+                >
+                  <title />
+                  <path
+                    d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                  />
+                </svg>
+              </div>
+              <p>
+                Powered by Unlock
+              </p>
+            </footer>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <section>
+      <h1>
+        HTML Ipsum Presents
+      </h1>
+      <p>
+        <strong>
+          Pellentesque habitant morbi tristique
+        </strong>
+         senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
+        <em>
+          Aenean ultricies mi vitae est.
+        </em>
+         Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+        <code>
+          commodo vitae
+        </code>
+        , ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui.
+        <a
+          href="."
+        >
+          Donec non enim
+        </a>
+         in turpis pulvinar facilisis. Ut felis.
+      </p>
+      <h2>
+        Header Level 2
+      </h2>
+      <ol>
+        <li>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </li>
+        <li>
+          Aliquam tincidunt mauris eu risus.
+        </li>
+      </ol>
+      <blockquote>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.
+        </p>
+      </blockquote>
+      <h3>
+        Header Level 3
+      </h3>
+      <ul>
+        <li>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </li>
+        <li>
+          Aliquam tincidunt mauris eu risus.
+        </li>
+      </ul>
+      <div
+        class="vaayz9-0 bexHxF"
+      >
+        <div
+          class="vaayz9-1 oVtjh"
+          style="height: 0%;"
+        >
+          <h1
+            class="vaayz9-2 fLUsTY"
+          >
+            You have reached your limit of free articles. Please purchase access
+          </h1>
+          <ul
+            class="vaayz9-3 bANiLD"
+          >
+            <li
+              class="sc-1ws9jnj-0 yqqxp4-0 jbcRkc"
+            >
+              <header
+                class="sc-1ws9jnj-1 kgNRxZ"
+              >
+                One Month
+              </header>
+              <div>
+                <div
+                  class="sc-1ws9jnj-3 yqqxp4-2 dzEKTb"
+                >
+                  <div
+                    class="yqqxp4-3 kxjMda"
+                  >
+                    123400000000000000.00
+                     Eth
+                  </div>
+                  <div>
+                    <span
+                      class="yqqxp4-4 fcTWoc"
+                    >
+                      $
+                      24,185,166,000b
+                    </span>
+                    <span
+                      class="yqqxp4-6 gEUJdZ"
+                    >
+                       | 
+                    </span>
+                    <span
+                      class="yqqxp4-4 yqqxp4-5 djpTSh"
+                    >
+                      <span>
+                         - 
+                      </span>
+                    </span>
+                  </div>
+                  <footer
+                    class="sc-1ws9jnj-2 yqqxp4-1 ghSrYu"
+                  >
+                    Purchase
+                  </footer>
+                </div>
+              </div>
+            </li>
+          </ul>
+          <footer
+            class="sc-1ws9jnj-8 qRrum"
+          >
+            <div
+              class="cenpj1-0 dhCRxc"
+            >
+              <svg
+                viewBox="0 0 56 56"
+              >
+                <title />
+                <path
+                  d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                />
+              </svg>
+            </div>
+            <p>
+              Powered by Unlock
+            </p>
+          </footer>
+        </div>
+      </div>
+    </section>
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Overlay main window, account error is displayed 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c8 {
+  background-color: var(--brand);
+  height: 28px;
+  width: 28px;
+  border-radius: 50%;
+}
+
+.c8 > svg {
+  fill: white;
+}
+
+.c4 {
+  display: grid;
+  row-gap: 16px;
+  -webkit-column-gap: 32px;
+  column-gap: 32px;
+  border: solid 1px var(--lightgrey);
+  grid-template-columns: 72px;
+  grid-auto-flow: column;
+  border-radius: 4px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 32px;
+  padding-bottom: 40px;
+}
+
+.c5 {
+  width: 72px;
+}
+
+.c6 {
+  display: grid;
+  grid-gap: 16px;
+}
+
+.c6 > h1 {
+  font-weight: bold;
+  color: var(--red);
+  margin: 0px;
+  padding: 0px;
+}
+
+.c6 > p {
+  margin: 0px;
+  padding: 0px;
+  font-size: 16px;
+  color: var(--dimgrey);
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-family: 'Roboto',sans-serif;
+  font-weight: 300;
+  font-size: 12px;
+  color: var(--darkgrey);
+  background-color: var(--white);
+  justify-self: right;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  grid-row: 2;
+  grid-column: 1;
+  width: 120px;
+  height: 80px;
+  margin-right: -33px;
+}
+
+.c7 > * {
+  justify-self: left;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin-left: -14px;
+}
+
+.c7 > p {
+  margin-left: auto;
+  margin-right: auto;
+  width: 63px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  justify-self: center;
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: normal;
+  line-height: normal;
+  font-size: 12px;
+  color: var(--darkgrey);
+}
+
+.c0 {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient( rgba(255,255,255,0) 18%,rgba(255,255,255,0) 29%,var(--offwhite) 48% );
+}
+
+.c1 {
+  position: fixed;
+  display: grid;
+  min-height: 375px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--offwhite);
+  justify-items: center;
+  padding: 32px;
+  padding-bottom: 100px;
+  grid-gap: 24px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c2 {
+  font-size: 20px;
+  font-family: 'Roboto',sans-serif;
+  font-weight: bold;
+  color: var(--slate);
+  text-align: center;
+}
+
+.c3 {
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: 32px;
+  list-style: none;
+  margin: 0px;
+  padding: 0px;
+  grid-row: 2;
+  grid-column: 1;
+}
+
+@media (max-width:500px) {
+  .c4 {
+    grid-template-columns: 1fr;
+    grid-auto-flow: row;
+    padding: 16px;
+  }
+}
+
+@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+  .c7 {
+    display: none;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <section>
+        <h1>
+          HTML Ipsum Presents
+        </h1>
+        <p>
+          <strong>
+            Pellentesque habitant morbi tristique
+          </strong>
+           senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
+          <em>
+            Aenean ultricies mi vitae est.
+          </em>
+           Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+          <code>
+            commodo vitae
+          </code>
+          , ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui.
+          <a
+            href="."
+          >
+            Donec non enim
+          </a>
+           in turpis pulvinar facilisis. Ut felis.
+        </p>
+        <h2>
+          Header Level 2
+        </h2>
+        <ol>
+          <li>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+          </li>
+          <li>
+            Aliquam tincidunt mauris eu risus.
+          </li>
+        </ol>
+        <blockquote>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.
+          </p>
+        </blockquote>
+        <h3>
+          Header Level 3
+        </h3>
+        <ul>
+          <li>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+          </li>
+          <li>
+            Aliquam tincidunt mauris eu risus.
+          </li>
+        </ul>
+        <div
+          class="c0"
+        >
+          <div
+            class="c1"
+            style="height: 0%;"
+          >
+            <h1
+              class="c2"
+            >
+              You have reached your limit of free articles. Please purchase access
+            </h1>
+            <ul
+              class="c3"
+            >
+              <section
+                class="c4"
+              >
+                <img
+                  class="c5"
+                  src="/static/images/illustrations/error.svg"
+                />
+                <div
+                  class="c6"
+                >
+                  <h1>
+                    Need account
+                  </h1>
+                  <p>
+                    In order to display this content, you need to connect a crypto-wallet to your browser.
+                  </p>
+                </div>
+              </section>
+            </ul>
+            <footer
+              class="c7"
+            >
+              <div
+                class="c8"
+              >
+                <svg
+                  viewBox="0 0 56 56"
+                >
+                  <title />
+                  <path
+                    d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                  />
+                </svg>
+              </div>
+              <p>
+                Powered by Unlock
+              </p>
+            </footer>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <section>
+      <h1>
+        HTML Ipsum Presents
+      </h1>
+      <p>
+        <strong>
+          Pellentesque habitant morbi tristique
+        </strong>
+         senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.
+        <em>
+          Aenean ultricies mi vitae est.
+        </em>
+         Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed,
+        <code>
+          commodo vitae
+        </code>
+        , ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui.
+        <a
+          href="."
+        >
+          Donec non enim
+        </a>
+         in turpis pulvinar facilisis. Ut felis.
+      </p>
+      <h2>
+        Header Level 2
+      </h2>
+      <ol>
+        <li>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </li>
+        <li>
+          Aliquam tincidunt mauris eu risus.
+        </li>
+      </ol>
+      <blockquote>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.
+        </p>
+      </blockquote>
+      <h3>
+        Header Level 3
+      </h3>
+      <ul>
+        <li>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        </li>
+        <li>
+          Aliquam tincidunt mauris eu risus.
+        </li>
+      </ul>
+      <div
+        class="vaayz9-0 bexHxF"
+      >
+        <div
+          class="vaayz9-1 oVtjh"
+          style="height: 0%;"
+        >
+          <h1
+            class="vaayz9-2 fLUsTY"
+          >
+            You have reached your limit of free articles. Please purchase access
+          </h1>
+          <ul
+            class="vaayz9-3 bANiLD"
+          >
+            <section
+              class="sc-1g6piw8-0 jXGMmL"
+            >
+              <img
+                class="sc-1g6piw8-1 fcKGMu"
+                src="/static/images/illustrations/error.svg"
+              />
+              <div
+                class="sc-1g6piw8-2 gCvXha"
+              >
+                <h1>
+                  Need account
+                </h1>
+                <p>
+                  In order to display this content, you need to connect a crypto-wallet to your browser.
+                </p>
+              </div>
+            </section>
+          </ul>
+          <footer
+            class="sc-1ws9jnj-8 qRrum"
+          >
+            <div
+              class="cenpj1-0 dhCRxc"
+            >
+              <svg
+                viewBox="0 0 56 56"
+              >
+                <title />
+                <path
+                  d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                />
+              </svg>
+            </div>
+            <p>
+              Powered by Unlock
+            </p>
+          </footer>
+        </div>
+      </div>
+    </section>
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots Overlay with a single Lock 1`] = `
 Object {
   "asFragment": [Function],

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -9,9 +9,10 @@ import { unlockPage } from '../../services/iframeService'
 import { LockedFlag } from './UnlockFlag'
 import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import { mapErrorToComponent } from '../creator/FatalError'
+import { FATAL_NO_USER_ACCOUNT } from '../../errors'
 
 export function displayError(error, errorMetadata, children) {
-  if (error) {
+  if (error && code !== FATAL_NO_USER_ACCOUNT) {
     const Error = mapErrorToComponent(error, errorMetadata)
     return Error
   }

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -16,11 +16,14 @@ export const displayError = isMainWindow =>
   function overlayDisplayError(error, errorMetadata, children) {
     const Error = mapErrorToComponent(error, errorMetadata)
 
-    if (isMainWindow && error) {
-      return Error
-    }
-    if (!isMainWindow && error && error !== FATAL_NO_USER_ACCOUNT) {
-      return Error
+    if (isMainWindow) {
+      if (error) {
+        return Error
+      }
+    } else {
+      if (error && error !== FATAL_NO_USER_ACCOUNT) {
+        return Error
+      }
     }
     return <>{children}</>
   }

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -17,6 +17,7 @@ export const displayError = isMainWindow =>
     const Error = mapErrorToComponent(error, errorMetadata)
 
     if (isMainWindow) {
+      // TODO: don't show fatal error until user clicks the lock
       if (error) {
         return Error
       }

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -16,6 +16,13 @@ export const displayError = isMainWindow =>
   function overlayDisplayError(error, errorMetadata, children) {
     const Error = mapErrorToComponent(error, errorMetadata)
 
+    /*
+     This next section provides an escape hatch for the paywall if a global error condition exists.
+     Only the MISSING_PROVIDER and WRONG_NETWORK error conditions (and not NO_USER_ACCOUNT)
+     cause an error to be displayed instead of the lock when the paywall is in an iframe. This
+     allows us to show a lock that will open a new window if we are in a wallet browser such
+     as coinbase that does not inject the provider account into iframes.
+    */
     if (isMainWindow) {
       // TODO: don't show fatal error until user clicks the lock
       if (error) {

--- a/unlock-app/src/stories/lock/Overlay.stories.js
+++ b/unlock-app/src/stories/lock/Overlay.stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react'
 import { Overlay } from '../../components/lock/Overlay'
 import createUnlockStore from '../../createUnlockStore'
 import { GlobalErrorContext } from '../../utils/GlobalErrorProvider'
-import { FATAL_NO_USER_ACCOUNT } from '../../errors'
+import { FATAL_WRONG_NETWORK } from '../../errors'
 import { ConfigContext } from '../../utils/withConfig'
 
 const ErrorProvider = GlobalErrorContext.Provider
@@ -113,7 +113,10 @@ storiesOf('Overlay', module)
       },
     ]
     return render(locks, {
-      error: FATAL_NO_USER_ACCOUNT,
-      errorMetadata: {},
+      error: FATAL_WRONG_NETWORK,
+      errorMetadata: {
+        currentNetwork: 'Foobar',
+        requiredNetworkId: 4,
+      },
     })
   })

--- a/unlock-app/src/stories/lock/Overlay.stories.js
+++ b/unlock-app/src/stories/lock/Overlay.stories.js
@@ -1,7 +1,7 @@
 import { Provider } from 'react-redux'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Overlay } from '../../components/lock/Overlay'
+import Overlay from '../../components/lock/Overlay'
 import createUnlockStore from '../../createUnlockStore'
 import { GlobalErrorContext } from '../../utils/GlobalErrorProvider'
 import { FATAL_WRONG_NETWORK } from '../../errors'
@@ -10,7 +10,10 @@ import { ConfigContext } from '../../utils/withConfig'
 const ErrorProvider = GlobalErrorContext.Provider
 const ConfigProvider = ConfigContext.Provider
 
-const config = {}
+const config = {
+  isInIframe: true,
+  requiredConfirmations: 12,
+}
 
 const store = createUnlockStore({
   currency: {

--- a/unlock-app/src/stories/lock/Overlay.stories.js
+++ b/unlock-app/src/stories/lock/Overlay.stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react'
 import Overlay from '../../components/lock/Overlay'
 import createUnlockStore from '../../createUnlockStore'
 import { GlobalErrorContext } from '../../utils/GlobalErrorProvider'
-import { FATAL_WRONG_NETWORK } from '../../errors'
+import { FATAL_WRONG_NETWORK, FATAL_NO_USER_ACCOUNT } from '../../errors'
 import { ConfigContext } from '../../utils/withConfig'
 
 const ErrorProvider = GlobalErrorContext.Provider
@@ -21,7 +21,11 @@ const store = createUnlockStore({
   },
 })
 
-const render = (locks, errors = { error: false, errorMetadata: {} }) => (
+const render = (
+  locks,
+  errors = { error: false, errorMetadata: {} },
+  thisConfig = config
+) => (
   <section>
     <h1>HTML Ipsum Presents</h1>
 
@@ -63,7 +67,7 @@ const render = (locks, errors = { error: false, errorMetadata: {} }) => (
       <li>Aliquam tincidunt mauris eu risus.</li>
     </ul>
 
-    <ConfigProvider value={config}>
+    <ConfigProvider value={thisConfig}>
       <ErrorProvider value={errors}>
         <Overlay
           scrollPosition={0}
@@ -122,4 +126,37 @@ storiesOf('Overlay', module)
         requiredNetworkId: 4,
       },
     })
+  })
+  .add('iframe, account error is ignored', () => {
+    const locks = [
+      {
+        name: 'One Month',
+        keyPrice: '123400000000000000',
+        fiatPrice: '20',
+      },
+    ]
+    return render(locks, {
+      error: FATAL_NO_USER_ACCOUNT,
+      errorMetadata: {},
+    })
+  })
+  .add('main window, account error is displayed', () => {
+    const locks = [
+      {
+        name: 'One Month',
+        keyPrice: '123400000000000000',
+        fiatPrice: '20',
+      },
+    ]
+    return render(
+      locks,
+      {
+        error: FATAL_NO_USER_ACCOUNT,
+        errorMetadata: {},
+      },
+      {
+        ...config,
+        isInIframe: false,
+      }
+    )
   })


### PR DESCRIPTION
# Description

This is the last UI step in implementing #1287. It disables the missing wallet error in the iframe of the paywall, so that we can see the lock. Then, the lock, when clicked, will open a new window if there is no user account present, which was implemented in previous PRs. This PR also ensures that if the paywall is opened directly, the missing wallet error displays.

The PR adds 2 new stories, to show the intended behavior, screenshots below.

The last step in implementing #1287 is not UI, but fixing #1368, and then it will be complete!

<img width="1636" alt="screen shot 2019-02-02 at 11 24 15 pm" src="https://user-images.githubusercontent.com/98250/52172648-0a8f5080-2742-11e9-865b-54094be28153.png">
<img width="1636" alt="screen shot 2019-02-02 at 11 24 11 pm" src="https://user-images.githubusercontent.com/98250/52172649-0b27e700-2742-11e9-9349-ae0876cc1558.png">


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread
