### PR TITLE
fixing env variable assignment for read only reader

### DIFF
--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -75,7 +75,7 @@ export default function configure(
   let services = {}
   let supportedProviders = []
   let blockTime = 8000 // in mseconds.
-  const readOnlyProviderUrl = runtimeConfig.readOnlyProviderUrl
+  const readOnlyProviderUrl = runtimeConfig.readOnlyProvider
 
   if (env === 'test') {
     // In test, we fake the HTTP provider


### PR DESCRIPTION
We were *not* using the fast readonly provider because of that :/


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread