### PR TITLE
moving lock address generation to web3Service

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -360,31 +360,19 @@ describe('Wallet middleware', () => {
     })
 
     describe('when the lock does not have an address', () => {
-      it('will dispatch a new action with an update included the projected address', done => {
+      it('should not try to create a lock', () => {
         expect.assertions(2)
         let lock = {
           keyPrice: '100',
           owner: account,
         }
-        const { next, invoke, store } = create()
+        const { next, invoke } = create()
         const action = { type: CREATE_LOCK, lock }
+        mockWalletService.createLock = jest.fn()
 
-        mockWalletService.generateLockAddress = jest.fn()
-        mockWalletService.generateLockAddress.mockReturnValue(
-          Promise.resolve('0xcafecafecafecafe')
-        )
-        invoke(action).then(() => {
-          expect(store.dispatch).toHaveBeenCalledWith({
-            type: 'lock/CREATE_LOCK',
-            lock: {
-              keyPrice: '100',
-              owner: { address: '0xabc' },
-              address: '0xcafecafecafecafe',
-            },
-          })
-          expect(next).not.toHaveBeenCalled()
-        })
-        done()
+        invoke(action)
+        expect(next).toHaveBeenCalled()
+        expect(mockWalletService.createLock).not.toHaveBeenCalled()
       })
     })
   })

--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events'
 import { LOCATION_CHANGE } from 'react-router-redux'
 import web3Middleware from '../../middlewares/web3Middleware'
-import { ADD_LOCK, UPDATE_LOCK } from '../../actions/lock'
+import { ADD_LOCK, UPDATE_LOCK, CREATE_LOCK } from '../../actions/lock'
 import { UPDATE_KEY } from '../../actions/key'
 import { UPDATE_ACCOUNT } from '../../actions/accounts'
 import { ADD_TRANSACTION, UPDATE_TRANSACTION } from '../../actions/transaction'
@@ -375,6 +375,41 @@ describe('Lock middleware', () => {
 
       expect(mockWeb3Service.getKeyByLockForOwner).not.toHaveBeenCalled()
       expect(next).toHaveBeenCalledWith(action)
+    })
+  })
+
+  describe('CREATE_LOCK', () => {
+    it('should generateLockAddress if the address is missing', () => {
+      expect.assertions(2)
+      const { next, invoke } = create()
+      const lock = {
+        name: 'my lock',
+      }
+      const address = '0x123'
+      const action = { type: CREATE_LOCK, lock }
+      mockWeb3Service.generateLockAddress = jest.fn(() => {
+        return Promise.resolve(address)
+      })
+
+      invoke(action)
+      expect(mockWeb3Service.generateLockAddress).toHaveBeenCalledWith()
+      expect(next).toHaveBeenCalledWith(action)
+    })
+
+    it('should do nothing is the lock has an address', () => {
+      expect.assertions(2)
+      let lock = {
+        keyPrice: '100',
+        owner: account,
+        address: '0x123',
+      }
+      const { next, invoke } = create()
+      const action = { type: CREATE_LOCK, lock }
+      mockWeb3Service.generateLockAddress = jest.fn()
+
+      invoke(action)
+      expect(next).toHaveBeenCalled()
+      expect(mockWeb3Service.generateLockAddress).not.toHaveBeenCalled()
     })
   })
 

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -1,7 +1,14 @@
 /* eslint no-console: 0 */ // TODO: remove me when this is clean
 
 import { LOCATION_CHANGE } from 'react-router-redux'
-import { ADD_LOCK, UPDATE_LOCK, addLock, updateLock } from '../actions/lock'
+import {
+  ADD_LOCK,
+  CREATE_LOCK,
+  UPDATE_LOCK,
+  addLock,
+  updateLock,
+  createLock,
+} from '../actions/lock'
 import { updateKey, addKey } from '../actions/key'
 import { updateAccount, SET_ACCOUNT } from '../actions/accounts'
 import { setError } from '../actions/error'
@@ -119,6 +126,13 @@ export default function web3Middleware({ getState, dispatch }) {
 
       if (action.type === ADD_TRANSACTION) {
         web3Service.getTransaction(action.transaction.hash)
+      }
+
+      if (action.type === CREATE_LOCK && !action.lock.address) {
+        web3Service.generateLockAddress().then(address => {
+          action.lock.address = address
+          dispatch(createLock(action.lock))
+        })
       }
 
       next(action)

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -1,7 +1,6 @@
 import EventEmitter from 'events'
 import Web3 from 'web3'
 import Web3Utils from 'web3-utils'
-import ethJsUtil from 'ethereumjs-util'
 import LockContract from '../artifacts/contracts/PublicLock.json'
 import UnlockContract from '../artifacts/contracts/Unlock.json'
 import configure from '../config'
@@ -216,17 +215,6 @@ export default class WalletService extends EventEmitter {
           transaction: hash,
         })
       }
-    )
-  }
-
-  async generateLockAddress() {
-    let transactionCount = await this.web3.eth.getTransactionCount(
-      this.unlockContractAddress
-    )
-    return Web3Utils.toChecksumAddress(
-      ethJsUtil.bufferToHex(
-        ethJsUtil.generateAddress(this.unlockContractAddress, transactionCount)
-      )
     )
   }
 

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'events'
 import Web3 from 'web3'
 import Web3Utils from 'web3-utils'
+import ethJsUtil from 'ethereumjs-util'
 
 import LockContract from '../artifacts/contracts/PublicLock.json'
 import UnlockContract from '../artifacts/contracts/Unlock.json'
@@ -91,6 +92,20 @@ export default class Web3Service extends EventEmitter {
     } else {
       return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
     }
+  }
+
+  /**
+   * "Guesses" what the next Lock's address is going to be
+   */
+  async generateLockAddress() {
+    let transactionCount = await this.web3.eth.getTransactionCount(
+      this.unlockContractAddress
+    )
+    return Web3Utils.toChecksumAddress(
+      ethJsUtil.bufferToHex(
+        ethJsUtil.generateAddress(this.unlockContractAddress, transactionCount)
+      )
+    )
   }
 
   /**


### PR DESCRIPTION
Since this does not require the user's wallet information this should go thru the web3Service instead
of the walletService.
This also adds the added benefit of having both web3Middleware and walletMiddleware not breaking the middleware chain anymore.
They both act on the CREATE_LOCK action, but only if it respectively has no address or an address for the lock.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread