### PR TITLE
not storing locks in the redux store if it does not have an address

### DIFF
--- a/unlock-app/src/__tests__/reducers/locksReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/locksReducer.test.js
@@ -58,6 +58,17 @@ describe('locks reducer', () => {
     })
   })
 
+  it('should not add the lock when receiving CREATE_LOCK if the lock has no address', () => {
+    expect(
+      reducer(initialState, {
+        type: CREATE_LOCK,
+        lock: {
+          name: 'no address lock',
+        },
+      })
+    ).toEqual(initialState)
+  })
+
   it('should delete a lock when DELETE_TRANSACTION is called for a transaction which created that lock', () => {
     const transaction = {
       lock: lock.address,

--- a/unlock-app/src/reducers/locksReducer.js
+++ b/unlock-app/src/reducers/locksReducer.js
@@ -39,9 +39,11 @@ const locksReducer = (state = initialState, action) => {
   }
 
   if (action.type === CREATE_LOCK) {
-    return {
-      ...state,
-      [action.lock.address]: action.lock,
+    if (action.lock.address) {
+      return {
+        ...state,
+        [action.lock.address]: action.lock,
+      }
     }
   }
 


### PR DESCRIPTION
This fixes the problem where the same lock would appear as many time as there are confirmations!


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread