### PR TITLE
Updates token middleware to reflect new state of Locks

### DIFF
--- a/locksmith/src/token_middleware.js
+++ b/locksmith/src/token_middleware.js
@@ -46,7 +46,7 @@ const validatePayloadBodyMatch = (payload, body) => {
   ;['iat', 'exp', 'iss'].forEach(reservedField => {
     delete evaluatingPayload[reservedField]
   })
-  ;['pending'].forEach(prune => {
+  ;['pending', 'transaction'].forEach(prune => {
     delete evaluatingBody[prune]
   })
 


### PR DESCRIPTION
The initial iteration of Locksmith included values to be exclude from comparison when checking the content of the request body vs. the associated header. With a shift from Lock with temporary addresses to those with  fetched from the valid sequence of Lock addresses we have also included the id of the transaction.

This information was not included in the initial release.

This is a stop gap to ensure that Locksmith continues to function as expected, after the addition of the erc712 work, we can evaluate reducing the amount of information compared between the body and the header.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
