### PR TITLE
extract dependency on global config variable from services, extract unused config from LockIconBar

### DIFF
--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -60,8 +60,9 @@ let providers
 describe('WalletService', () => {
   beforeEach(() => {
     nock.cleanAll()
-    providers = configure().providers
-    walletService = new WalletService(providers)
+    const config = configure()
+    walletService = new WalletService(config)
+    providers = config.providers
   })
 
   describe('connect', () => {

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -90,12 +90,17 @@ const unlockSmartContractAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
 
 let web3Service
 
-const { blockTime } = configure()
+let blockTime
 
 describe('Web3Service', () => {
   beforeEach(() => {
     nock.cleanAll()
-    web3Service = new Web3Service(unlockSmartContractAddress)
+    const config = configure()
+    web3Service = new Web3Service({
+      ...config,
+      lockAddress: unlockSmartContractAddress,
+    })
+    blockTime = config.blockTime
   })
 
   const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -10,10 +10,6 @@ import Media from '../../../theme/media'
 import withConfig from '../../../utils/withConfig'
 import { TRANSACTION_TYPES } from '../../../constants'
 
-import configure from '../../../config'
-
-const config = configure()
-
 export function LockIconBar({
   lock,
   priceUpdateTransaction,
@@ -98,7 +94,7 @@ LockIconBar.defaultProps = {
   edit: () => {},
 }
 
-const mapStateToProps = ({ transactions }, { lock }) => {
+const mapStateToProps = ({ transactions }, { lock, config }) => {
   let withdrawalTransaction = null
 
   Object.values(transactions).forEach(transaction => {

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -30,7 +30,7 @@ export default function walletMiddleware({ getState, dispatch }) {
   // Buffer of actions waiting for connection
   const actions = []
 
-  const walletService = new WalletService()
+  const walletService = new WalletService(config)
 
   /**
    * When an account was changed, we dispatch the corresponding action

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -3,7 +3,6 @@ import Web3 from 'web3'
 import Web3Utils from 'web3-utils'
 import LockContract from '../artifacts/contracts/PublicLock.json'
 import UnlockContract from '../artifacts/contracts/Unlock.json'
-import configure from '../config'
 import {
   MISSING_PROVIDER,
   NON_DEPLOYED_CONTRACT,
@@ -14,8 +13,6 @@ import {
   FAILED_TO_WITHDRAW_FROM_LOCK,
 } from '../errors'
 
-const { providers, unlockAddress } = configure()
-
 export const keyId = (lock, owner) => [lock, owner].join('-')
 
 /**
@@ -25,9 +22,10 @@ export const keyId = (lock, owner) => [lock, owner].join('-')
  * actually retrieving the data from the chain/smart contracts
  */
 export default class WalletService extends EventEmitter {
-  constructor(availableProviders = providers) {
+  constructor({ providers, unlockAddress }) {
     super()
-    this.providers = availableProviders
+    this.providers = providers
+    this.unlockAddress = unlockAddress
     this.ready = false
     this.providerName = null
     this.web3 = null
@@ -73,8 +71,10 @@ export default class WalletService extends EventEmitter {
     this.web3 = new Web3(provider)
 
     const networkId = await this.web3.eth.net.getId()
-    if (unlockAddress) {
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(unlockAddress)
+    if (this.unlockAddress) {
+      this.unlockContractAddress = Web3Utils.toChecksumAddress(
+        this.unlockAddress
+      )
     } else if (UnlockContract.networks[networkId]) {
       // If we do not have an address from config let's use the artifact files
       this.unlockContractAddress = Web3Utils.toChecksumAddress(


### PR DESCRIPTION
# Description

This PR extracts the global variable configuration from the `web3Service` and `walletService` in order to make them closer to pure, and make testing less brittle as a result. It also removes dead code in `LockIconBar` (it already uses withConfig, the call to `configure` was unnecessary as we can just use the currently unused `config` prop. Linting missed this because of the name collision)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
