### PR TITLE
Adjust iframe styling to avoid z-index issue

### DIFF
--- a/unlock-app/src/__tests__/paywall-builder/iframe.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/iframe.test.js
@@ -87,6 +87,12 @@ describe('iframe', () => {
   it('hide', () => {
     const iframe = {
       style: {},
+      contentDocument: {
+        body: {
+          style: {},
+        },
+      },
+      addEventListener: () => {},
     }
     const document = {
       body: {
@@ -98,7 +104,15 @@ describe('iframe', () => {
     expect(iframe.style).toEqual({
       backgroundColor: 'transparent',
       backgroundImage: 'none',
-      'z-index': '-2147483647',
+      overflow: 'hidden',
+      width: '134px',
+      height: '160px',
+      'margin-right': '-104px',
+      left: null,
+      top: null,
+      right: '0',
+      bottom: '105px',
+      transition: 'margin-right 0.4s ease-in',
     })
 
     expect(document.body.style).toEqual({

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -44485,48 +44485,6 @@ Object {
   fill: white;
 }
 
-.c2 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c3 {
-  padding: 0 20px 10px 20px;
-  border-color: lightgrey;
-  border-left: 1px solid;
-  border-right: 1px solid;
-  border-bottom: 1px solid;
-  border-radius: 0 0 20px 20px;
-  -webkit-transform: translateY(-21px);
-  -ms-transform: translateY(-21px);
-  transform: translateY(-21px);
-  -webkit-transition: -webkit-transform 0.5s,color 0.5s,background-color 0.5s;
-  -webkit-transition: transform 0.5s,color 0.5s,background-color 0.5s;
-  transition: transform 0.5s,color 0.5s,background-color 0.5s;
-  color: lightgrey;
-}
-
-.c3:hover {
-  -webkit-transform: translateY(0);
-  -ms-transform: translateY(0);
-  transform: translateY(0);
-  opacity: 100%;
-  color: white;
-  background-color: var(--green);
-  border-color: var(--green);
-  font-weight: bold;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -44552,16 +44510,12 @@ Object {
   width: 120px;
   height: 80px;
   margin-right: -33px;
-  box-shadow: 0px 0px 40px rgba(0,0,0,0.08);
+  float: right;
+  box-shadow: 14px 0px 40px rgba(0,0,0,0.08);
   background: var(--white);
-  position: fixed;
-  right: 0;
-  bottom: 105px;
-  margin-right: -106px;
   opacity: 0.5;
-  -webkit-transition: opacity 0.4s ease-in,margin-right 0.4s ease-in;
-  transition: opacity 0.4s ease-in,margin-right 0.4s ease-in;
-  opacity: 1;
+  -webkit-transition: opacity 0.4s ease-in;
+  transition: opacity 0.4s ease-in;
   margin-right: 0;
 }
 
@@ -44591,10 +44545,8 @@ Object {
 
 .c0:hover {
   opacity: 1;
-  margin-right: 0;
-  height: 80px;
-  -webkit-transition: opacity 0.4s ease-in,margin-right 0.4s ease-in;
-  transition: opacity 0.4s ease-in,margin-right 0.4s ease-in;
+  -webkit-transition: opacity 0.4s ease-in;
+  transition: opacity 0.4s ease-in;
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
@@ -44633,27 +44585,6 @@ Object {
           Subscribed with Unlock
         </p>
       </footer>
-      <div
-        class="c2"
-      >
-        <div
-          class="c3"
-        >
-          <select
-            id="changeProvider"
-            name="changeProvider"
-          >
-            <option
-              value="HTTP"
-            >
-              HTTP
-            </option>
-          </select>
-          <div>
-            Choose Provider
-          </div>
-        </div>
-      </div>
     </div>
   </body>,
   "container": <div>
@@ -44662,7 +44593,7 @@ Object {
       rel="stylesheet"
     />
     <footer
-      class="sc-1ws9jnj-8 sc-18dedc6-0 dZYAXI"
+      class="sc-1ws9jnj-8 sc-18dedc6-0 jeFBMt"
     >
       <div
         class="cenpj1-0 dhCRxc"
@@ -44680,27 +44611,6 @@ Object {
         Subscribed with Unlock
       </p>
     </footer>
-    <div
-      class="sc-1bbuge3-0 deeIGd"
-    >
-      <div
-        class="sc-1bbuge3-1 iBcmrA"
-      >
-        <select
-          id="changeProvider"
-          name="changeProvider"
-        >
-          <option
-            value="HTTP"
-          >
-            HTTP
-          </option>
-        </select>
-        <div>
-          Choose Provider
-        </div>
-      </div>
-    </div>
   </div>,
   "debug": [Function],
   "getAllByAltText": [Function],
@@ -46652,16 +46562,12 @@ Object {
   width: 120px;
   height: 80px;
   margin-right: -33px;
-  box-shadow: 0px 0px 40px rgba(0,0,0,0.08);
+  float: right;
+  box-shadow: 14px 0px 40px rgba(0,0,0,0.08);
   background: var(--white);
-  position: fixed;
-  right: 0;
-  bottom: 105px;
-  margin-right: -106px;
   opacity: 0.5;
-  -webkit-transition: opacity 0.4s ease-in,margin-right 0.4s ease-in;
-  transition: opacity 0.4s ease-in,margin-right 0.4s ease-in;
-  opacity: 1;
+  -webkit-transition: opacity 0.4s ease-in;
+  transition: opacity 0.4s ease-in;
   margin-right: 0;
 }
 
@@ -46691,10 +46597,8 @@ Object {
 
 .c0:hover {
   opacity: 1;
-  margin-right: 0;
-  height: 80px;
-  -webkit-transition: opacity 0.4s ease-in,margin-right 0.4s ease-in;
-  transition: opacity 0.4s ease-in,margin-right 0.4s ease-in;
+  -webkit-transition: opacity 0.4s ease-in;
+  transition: opacity 0.4s ease-in;
 }
 
 @media only screen and (min-device-width:0px) and (max-device-width:736px) {
@@ -46741,7 +46645,7 @@ Object {
       rel="stylesheet"
     />
     <footer
-      class="sc-1ws9jnj-8 sc-18dedc6-0 dZYAXI"
+      class="sc-1ws9jnj-8 sc-18dedc6-0 jeFBMt"
     >
       <div
         class="cenpj1-0 dhCRxc"

--- a/unlock-app/src/components/lock/UnlockFlag.js
+++ b/unlock-app/src/components/lock/UnlockFlag.js
@@ -4,7 +4,6 @@ import React from 'react'
 import { Colophon } from './LockStyles'
 import { RoundedLogo } from '../interface/Logo'
 import Media from '../../theme/media'
-import { SHOW_FLAG_FOR } from '../../constants'
 
 export function LockedFlag() {
   return (
@@ -15,49 +14,23 @@ export function LockedFlag() {
   )
 }
 
-export class UnlockedFlag extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      hidden: false,
-    }
-  }
-
-  componentDidMount() {
-    setTimeout(() => this.setState({ hidden: true }), SHOW_FLAG_FOR)
-  }
-
-  render() {
-    const { hidden } = this.state
-    return (
-      <Flag hidden={hidden}>
-        <RoundedLogo size="28px" />
-        <p>Subscribed with Unlock</p>
-      </Flag>
-    )
-  }
-}
+export const UnlockedFlag = () => (
+  <Flag>
+    <RoundedLogo size="28px" />
+    <p>Subscribed with Unlock</p>
+  </Flag>
+)
 
 const Flag = styled(Colophon)`
   float: right;
-  box-shadow: 0px 0px 40px rgba(0, 0, 0, 0.08);
+  box-shadow: 14px 0px 40px rgba(0, 0, 0, 0.08);
   background: var(--white);
   opacity: 0.5;
-  margin-right: -106px;
-  transition: opacity 0.4s ease-in, margin-right 0.4s ease-in;
-
-  ${props =>
-    props.hidden
-      ? ''
-      : `
-  opacity: 1;
+  transition: opacity 0.4s ease-in;
   margin-right: 0;
-`}
-
   &:hover {
     opacity: 1;
-    margin-right: 0;
-    transition: opacity 0.4s ease-in, margin-right 0.4s ease-in;
+    transition: opacity 0.4s ease-in;
   }
 
   ${Media.phone`

--- a/unlock-app/src/components/lock/UnlockFlag.js
+++ b/unlock-app/src/components/lock/UnlockFlag.js
@@ -39,13 +39,11 @@ export class UnlockedFlag extends React.Component {
 }
 
 const Flag = styled(Colophon)`
+  float: right;
   box-shadow: 0px 0px 40px rgba(0, 0, 0, 0.08);
   background: var(--white);
-  position: fixed;
-  right: 0;
-  bottom: 105px;
-  margin-right: -106px;
   opacity: 0.5;
+  margin-right: -106px;
   transition: opacity 0.4s ease-in, margin-right 0.4s ease-in;
 
   ${props =>
@@ -59,7 +57,6 @@ const Flag = styled(Colophon)`
   &:hover {
     opacity: 1;
     margin-right: 0;
-    height: 80px;
     transition: opacity 0.4s ease-in, margin-right 0.4s ease-in;
   }
 

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -43,7 +43,7 @@ class Paywall extends React.Component {
     if (locked) {
       lockPage()
     } else {
-      unlockPage() 
+      unlockPage()
     }
   }
   render() {

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -43,7 +43,7 @@ class Paywall extends React.Component {
     if (locked) {
       lockPage()
     } else {
-      unlockPage()
+      unlockPage() 
     }
   }
   render() {
@@ -58,7 +58,6 @@ class Paywall extends React.Component {
           </ShowWhenLocked>
           <ShowWhenUnlocked locked={locked}>
             <UnlockedFlag />
-            <DeveloperOverlay />
           </ShowWhenUnlocked>
         </GlobalErrorProvider>
       </BrowserOnly>

--- a/unlock-app/src/paywall-builder/iframe.js
+++ b/unlock-app/src/paywall-builder/iframe.js
@@ -34,25 +34,41 @@ export function show(iframe, document) {
 }
 
 export function hide(iframe, document) {
+  const expandedWidth = '256px'
+  const collapsedWidth = '30px'
+  const height = '80px'
+
+  // general settings
   document.body.style.overflow = ''
   iframe.style.backgroundColor = 'transparent'
   iframe.style.backgroundImage = 'none'
-  iframe.style.width = '134px'
-  iframe.style.height = '80px'
+  iframe.contentDocument.body.style.margin = '0'
+  iframe.contentDocument.body.style.height = height
+
+  // so that there's no scroll when it goes off the edge
+  iframe.style.overflow = 'hidden'
+  iframe.contentDocument.body.style.overflow = 'hidden'
+
+  // new dimensions
+  iframe.style.width = expandedWidth
+  iframe.style.height = height
+
+  // positioning
   iframe.style.left = null
   iframe.style.top = null
   iframe.style.right = '0'
   iframe.style.bottom = '105px'
-  iframe.style.overflow = 'hidden'
+
+  // Animation
   iframe.style.transition = 'width 0.4s ease-in'
-  iframe.contentDocument.body.style.margin = '0'
-  iframe.contentDocument.body.style.height = '80px'
-  iframe.contentDocument.body.style.overflow = 'hidden'
-  setTimeout(() => {iframe.style.width = '30px'}, SHOW_FLAG_FOR)
+
+  setTimeout(() => {
+    iframe.style.width = collapsedWidth
+  }, SHOW_FLAG_FOR)
   iframe.addEventListener('mouseenter', () => {
-    iframe.style.width = '134px'
+    iframe.style.width = expandedWidth
   })
   iframe.addEventListener('mouseleave', () => {
-    iframe.style.width = '30px'
+    iframe.style.width = collapsedWidth
   })
 }

--- a/unlock-app/src/paywall-builder/iframe.js
+++ b/unlock-app/src/paywall-builder/iframe.js
@@ -1,5 +1,3 @@
-import { SHOW_FLAG_FOR } from '../constants'
-
 export const iframeStyles = [
   'display:none',
   'position:fixed',
@@ -34,23 +32,27 @@ export function show(iframe, document) {
 }
 
 export function hide(iframe, document) {
-  const expandedWidth = '256px'
-  const collapsedWidth = '30px'
-  const height = '80px'
+  const width = '134px'
+  const height = '160px'
+  const collapsedMargin = '-104px'
 
   // general settings
   document.body.style.overflow = ''
   iframe.style.backgroundColor = 'transparent'
   iframe.style.backgroundImage = 'none'
+  iframe.style['margin-right'] = collapsedMargin
   iframe.contentDocument.body.style.margin = '0'
   iframe.contentDocument.body.style.height = height
+  iframe.contentDocument.body.style.display = 'flex'
+  iframe.contentDocument.body.style['flex-direction'] = 'column'
+  iframe.contentDocument.body.style['justify-content'] = 'center'
 
   // so that there's no scroll when it goes off the edge
   iframe.style.overflow = 'hidden'
   iframe.contentDocument.body.style.overflow = 'hidden'
 
   // new dimensions
-  iframe.style.width = expandedWidth
+  iframe.style.width = width
   iframe.style.height = height
 
   // positioning
@@ -60,15 +62,12 @@ export function hide(iframe, document) {
   iframe.style.bottom = '105px'
 
   // Animation
-  iframe.style.transition = 'width 0.4s ease-in'
+  iframe.style.transition = 'margin-right 0.4s ease-in'
 
-  setTimeout(() => {
-    iframe.style.width = collapsedWidth
-  }, SHOW_FLAG_FOR)
   iframe.addEventListener('mouseenter', () => {
-    iframe.style.width = expandedWidth
+    iframe.style['margin-right'] = '0'
   })
   iframe.addEventListener('mouseleave', () => {
-    iframe.style.width = collapsedWidth
+    iframe.style['margin-right'] = collapsedMargin
   })
 }

--- a/unlock-app/src/paywall-builder/iframe.js
+++ b/unlock-app/src/paywall-builder/iframe.js
@@ -1,3 +1,5 @@
+import { SHOW_FLAG_FOR } from '../constants'
+
 export const iframeStyles = [
   'display:none',
   'position:fixed',
@@ -35,5 +37,22 @@ export function hide(iframe, document) {
   document.body.style.overflow = ''
   iframe.style.backgroundColor = 'transparent'
   iframe.style.backgroundImage = 'none'
-  iframe.style['z-index'] = '-2147483647'
+  iframe.style.width = '134px'
+  iframe.style.height = '80px'
+  iframe.style.left = null
+  iframe.style.top = null
+  iframe.style.right = '0'
+  iframe.style.bottom = '105px'
+  iframe.style.overflow = 'hidden'
+  iframe.style.transition = 'width 0.4s ease-in'
+  iframe.contentDocument.body.style.margin = '0'
+  iframe.contentDocument.body.style.height = '80px'
+  iframe.contentDocument.body.style.overflow = 'hidden'
+  setTimeout(() => {iframe.style.width = '30px'}, SHOW_FLAG_FOR)
+  iframe.addEventListener('mouseenter', () => {
+    iframe.style.width = '134px'
+  })
+  iframe.addEventListener('mouseleave', () => {
+    iframe.style.width = '30px'
+  })
 }


### PR DESCRIPTION
# Description

This PR partially handles #1338. It resizes the iframe when we call the `hide` function to be the minimum necessary footprint to make the flag work. A side-effect of this change is that there is no developer overlay on unlocked pages until a new one is made that can live inside the flag. An additional side effect of this change, because now the iframe is responsible for all positioning, is that the stories which show the unlocked flag but do not have an iframe will not have the correct vertical positioning of the flag.

![animation](https://user-images.githubusercontent.com/9300702/52284150-d9757280-2931-11e9-8db8-42eb96e260f6.gif)

_The footprint of the iframe when collapsed_
<img width="104" alt="screen shot 2019-02-05 at 10 31 50 am" src="https://user-images.githubusercontent.com/9300702/52284201-f01bc980-2931-11e9-9c8b-e94342447c76.png">

_The footprint of the iframe when expanded_
<img width="180" alt="screen shot 2019-02-05 at 10 32 12 am" src="https://user-images.githubusercontent.com/9300702/52284243-045fc680-2932-11e9-9b8e-c836022cd2e4.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
