### PR TITLE
Add wallet status to state

### DIFF
--- a/unlock-app/src/__tests__/actions/walletStatus.test.js
+++ b/unlock-app/src/__tests__/actions/walletStatus.test.js
@@ -1,0 +1,17 @@
+import {
+  waitForWallet,
+  gotWallet,
+  WAIT_FOR_WALLET,
+  GOT_WALLET,
+} from '../../actions/walletStatus'
+
+describe('wallet status actions', () => {
+  it('should create an action to wait for the wallet', () => {
+    const expectedAction = { type: WAIT_FOR_WALLET }
+    expect(waitForWallet()).toEqual(expectedAction)
+  })
+  it('should create an action to indicate that the wallet is available', () => {
+    const expectedAction = { type: GOT_WALLET }
+    expect(gotWallet()).toEqual(expectedAction)
+  })
+})

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -135,6 +135,15 @@ describe('Wallet middleware', () => {
     )
   })
 
+  it('should handle transaction.pending events triggered by the walletService', () => {
+    expect.assertions(1)
+    const { store } = create()
+    mockWalletService.emit('transaction.pending')
+    expect(store.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: WAIT_FOR_WALLET })
+    )
+  })
+
   it('it should handle transaction.new events triggered by the walletService', () => {
     expect.assertions(2)
     const { store } = create()

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -7,6 +7,7 @@ import {
   UPDATE_LOCK_KEY_PRICE,
   UPDATE_LOCK,
 } from '../../actions/lock'
+import { WAIT_FOR_WALLET, GOT_WALLET } from '../../actions/walletStatus'
 import { PURCHASE_KEY } from '../../actions/key'
 import { SET_ACCOUNT } from '../../actions/accounts'
 import { SET_NETWORK } from '../../actions/network'
@@ -110,6 +111,9 @@ beforeEach(() => {
     },
     transactions: {},
     keys: {},
+    walletStatus: {
+      waiting: true,
+    },
   }
 })
 
@@ -132,9 +136,12 @@ describe('Wallet middleware', () => {
   })
 
   it('it should handle transaction.new events triggered by the walletService', () => {
-    expect.assertions(1)
+    expect.assertions(2)
     const { store } = create()
     mockWalletService.emit('transaction.new', transaction.hash)
+    expect(store.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: GOT_WALLET })
+    )
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: ADD_TRANSACTION,

--- a/unlock-app/src/__tests__/reducers/walletStatusReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/walletStatusReducer.test.js
@@ -1,0 +1,18 @@
+import reducer from '../../reducers/walletStatusReducer'
+import { WAIT_FOR_WALLET, GOT_WALLET } from '../../actions/walletStatus'
+
+describe('walletStatus reducer', () => {
+  const notWaiting = { waiting: false }
+  const waiting = { waiting: true }
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual(notWaiting)
+  })
+
+  it('should set waiting to true when receiving WAIT_FOR_WALLET', () => {
+    expect(reducer(notWaiting, { type: WAIT_FOR_WALLET })).toEqual(waiting)
+  })
+
+  it('should set waiting to false when receiving GOT_WALLET', () => {
+    expect(reducer(waiting, { type: GOT_WALLET })).toEqual(notWaiting)
+  })
+})

--- a/unlock-app/src/actions/walletStatus.js
+++ b/unlock-app/src/actions/walletStatus.js
@@ -1,0 +1,6 @@
+export const WAIT_FOR_WALLET = 'walletStatus/WAIT_FOR_WALLET'
+export const GOT_WALLET = 'walletStatus/GOT_WALLET'
+
+export const waitForWallet = () => ({ type: WAIT_FOR_WALLET })
+
+export const gotWallet = () => ({ type: GOT_WALLET })

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -35,6 +35,9 @@ import accountReducer, {
 import modalReducer, {
   initialState as defaultModals,
 } from './reducers/modalsReducer'
+import walletStatusReducer, {
+  initialState as defaultWalletStatus,
+} from './reducers/walletStatusReducer'
 
 const config = configure()
 
@@ -55,6 +58,7 @@ export const createUnlockStore = (
     transactions: transactionsReducer,
     currency: currencyReducer,
     errors: errorsReducer,
+    walletStatus: walletStatusReducer,
   }
 
   // Cleanup the defaultState to remove all null values so that we do not overwrite existing
@@ -77,6 +81,7 @@ export const createUnlockStore = (
       transactions: defaultTransactions,
       currency: defaultCurrency,
       errors: defaultError,
+      walletStatus: defaultWalletStatus,
     },
     {
       provider: Object.keys(config.providers)[0],

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -11,6 +11,7 @@ import { setNetwork } from '../actions/network'
 import { setError } from '../actions/error'
 import { SET_PROVIDER } from '../actions/provider'
 import { addTransaction } from '../actions/transaction'
+import { waitForWallet, gotWallet } from '../actions/walletStatus'
 import { TRANSACTION_TYPES } from '../constants'
 
 import generateJWTToken from '../utils/signature'
@@ -58,6 +59,14 @@ export default function walletMiddleware({ getState, dispatch }) {
         hash: transactionHash,
       })
     )
+  })
+
+  walletService.on('wallet.waitForWallet', () => {
+    dispatch(waitForWallet())
+  })
+
+  walletService.on('wallet.gotWallet', () => {
+    dispatch(gotWallet())
   })
 
   walletService.on('lock.updated', (address, update) => {

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -54,6 +54,8 @@ export default function walletMiddleware({ getState, dispatch }) {
   })
 
   walletService.on('transaction.new', transactionHash => {
+    // If we're waiting (full-screen wallet notification overlay is active), we
+    // can safely dismiss it now
     const { waiting } = getState().walletStatus
     if (waiting) {
       dispatch(gotWallet())
@@ -65,6 +67,8 @@ export default function walletMiddleware({ getState, dispatch }) {
     )
   })
 
+  // A transaction has started, now we need to signal that we're waiting for
+  // interaction with the wallet
   walletService.on('transaction.pending', () => {
     dispatch(waitForWallet())
   })

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -69,10 +69,6 @@ export default function walletMiddleware({ getState, dispatch }) {
     dispatch(waitForWallet())
   })
 
-  walletService.on('wallet.gotWallet', () => {
-    dispatch(gotWallet())
-  })
-
   walletService.on('lock.updated', (address, update) => {
     dispatch(updateLock(address, update))
   })

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -54,6 +54,10 @@ export default function walletMiddleware({ getState, dispatch }) {
   })
 
   walletService.on('transaction.new', transactionHash => {
+    const { waiting } = getState().walletStatus
+    if (waiting) {
+      dispatch(gotWallet())
+    }
     dispatch(
       addTransaction({
         hash: transactionHash,
@@ -61,7 +65,7 @@ export default function walletMiddleware({ getState, dispatch }) {
     )
   })
 
-  walletService.on('wallet.waitForWallet', () => {
+  walletService.on('transaction.pending', () => {
     dispatch(waitForWallet())
   })
 

--- a/unlock-app/src/reducers/walletStatusReducer.js
+++ b/unlock-app/src/reducers/walletStatusReducer.js
@@ -1,0 +1,25 @@
+import { WAIT_FOR_WALLET, GOT_WALLET } from '../actions/walletStatus.js'
+
+import { SET_PROVIDER } from '../actions/provider'
+import { SET_NETWORK } from '../actions/network'
+import { SET_ACCOUNT } from '../actions/accounts'
+
+export const initialState = { waiting: false }
+
+const walletStatusReducer = (walletStatus = initialState, action) => {
+  if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
+    return initialState
+  }
+
+  if (action.type === WAIT_FOR_WALLET) {
+    return { waiting: true }
+  }
+
+  if (action.type === GOT_WALLET) {
+    return initialState
+  }
+
+  return walletStatus
+}
+
+export default walletStatusReducer

--- a/unlock-app/src/reducers/walletStatusReducer.js
+++ b/unlock-app/src/reducers/walletStatusReducer.js
@@ -1,4 +1,4 @@
-import { WAIT_FOR_WALLET, GOT_WALLET } from '../actions/walletStatus.js'
+import { WAIT_FOR_WALLET, GOT_WALLET } from '../actions/walletStatus'
 
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -139,9 +139,12 @@ export default class WalletService extends EventEmitter {
       gas,
     })
 
+    this.emit('wallet.waitForWallet')
+
     return web3TransactionPromise
       .once('transactionHash', hash => {
         callback(null, hash)
+        this.emit('wallet.gotWallet')
         this.emit('transaction.new', hash)
       })
       .on('error', error => {

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -139,12 +139,11 @@ export default class WalletService extends EventEmitter {
       gas,
     })
 
-    this.emit('wallet.waitForWallet')
+    this.emit('transaction.pending')
 
     return web3TransactionPromise
       .once('transactionHash', hash => {
         callback(null, hash)
-        this.emit('wallet.gotWallet')
         this.emit('transaction.new', hash)
       })
       .on('error', error => {


### PR DESCRIPTION
# Description

This PR introduces some scaffolding that will allow me to tackle #1080. With the introduction of a `walletStatus` in the state, it will be simple to trigger a full-screen modal as needed.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
