### PR TITLE
Parallelizing Travis for faster CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,16 @@
 # Both of these steps could be run in parallel
 language: generic
 env:
-  - TEST_SUITE=smart-contracts
-  - TEST_SUITE=unlock-app
-  - TEST_SUITE=locksmith
   global:
     - DB_USERNAME='locksmith_test'
     - DB_PASSWORD='password'
     - DB_NAME='locksmith_test'
     - DB_HOSTNAME='db'
+matrix:
+  include:
+    - env: TEST_SUITE=smart-contracts
+    - env: TEST_SUITE=unlock-app
+    - env: TEST_SUITE=locksmith
 services:
   - docker
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@
 # Both of these steps could be run in parallel
 language: generic
 env:
+  - TEST_SUITE=smart-contracts
+  - TEST_SUITE=unlock-app
+  - TEST_SUITE=locksmith
   global:
     - DB_USERNAME='locksmith_test'
     - DB_PASSWORD='password'
@@ -27,9 +30,7 @@ before_script:
   - scripts/build-image.sh unlock-integration
   - scripts/docker-compose-build.sh
 script:
-  - scripts/tests.sh smart-contracts
-  - scripts/tests.sh unlock-app
-  - scripts/tests.sh locksmith
+  - scripts/tests.sh $TEST_SUITE
 #  - scripts/integration-tests.sh
 after_success:
   - scripts/deploy.sh netlify


### PR DESCRIPTION
# Description

Reduces the build time to 8.5 minutes vs the usual 10.  I believe we can make this much faster if we run with this approach - at the moment each the the parallel runs do redundant steps.  For example, the longest at the moment is smart-contracts but it runs a lot of other Travis commands which are not related to smart contracts (and that suite is going to take another couple mins once solidity-coverage is working).

If we want to continue this direction, I believe the next step may be to add build stages: https://docs.travis-ci.com/user/build-stages/

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
