### PR TITLE
implement redirecting basics

### DIFF
--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -35,6 +35,19 @@ describe('Overlay', () => {
         type: SHOW_MODAL,
       })
     })
+    it('should yield a prop function which redirects if instructed', () => {
+      expect.assertions(1)
+      const locks = [{ address: '0x123' }, { address: '0x456' }]
+      const dispatch = jest.fn()
+      const props = mapDispatchToProps(dispatch, {
+        locks,
+        redirect: 'http://example.com',
+      })
+      props.hideModal()
+      // we can't actually test the redirect, in the test environment it doesn't work
+      // but we can verify that dispatch was not called for the normal behavior
+      expect(dispatch).not.toHaveBeenCalled()
+    })
   })
   describe('mapStateToProps', () => {
     it('should set openInNewWindow based on the value of account', () => {

--- a/unlock-app/src/__tests__/pages/paywall.test.js
+++ b/unlock-app/src/__tests__/pages/paywall.test.js
@@ -133,7 +133,7 @@ describe('Paywall', () => {
           pathname: `/paywall/${lock.address}/http%3A%2F%2Fexample.com`,
         },
       }
-      const props = mapStateToProps({ locks, router })
+      const props = mapStateToProps({ locks, router, keys, modals })
       expect(props.redirect).toBe('http://example.com')
     })
   })

--- a/unlock-app/src/__tests__/pages/paywall.test.js
+++ b/unlock-app/src/__tests__/pages/paywall.test.js
@@ -101,5 +101,19 @@ describe('Paywall', () => {
       const flagText = queryByText('Subscribed with Unlock')
       expect(flagText).toBeNull()
     })
+
+    it('should pull the redirect parameter from the page', () => {
+      const lock = { address: '0x4983D5ECDc5cc0E499c2D23BF4Ac32B982bAe53a' }
+      const locks = {
+        [lock.address]: lock,
+      }
+      const router = {
+        location: {
+          pathname: `/paywall/${lock.address}/http%3A%2F%2Fexample.com`,
+        },
+      }
+      const props = mapStateToProps({ locks, router })
+      expect(props.redirect).toBe('http://example.com')
+    })
   })
 })

--- a/unlock-app/src/__tests__/pages/paywall.test.js
+++ b/unlock-app/src/__tests__/pages/paywall.test.js
@@ -14,6 +14,14 @@ const locks = {
 }
 const router = {
   location: {
+    pathname: `/paywall/${lock.address}/http%3a%2f%2fexample.com`,
+    search: '',
+    hash: '',
+  },
+}
+
+const noRedirectRouter = {
+  location: {
     pathname: `/paywall/${lock.address}`,
     search: '',
     hash: '',
@@ -52,6 +60,19 @@ describe('Paywall', () => {
     it('should not be locked when there is a matching key', () => {
       const props = mapStateToProps({ locks, keys, modals, router })
       expect(props.locked).toBe(false)
+    })
+    it('should pass redirect if present in the URI', () => {
+      const props = mapStateToProps({ locks, keys, modals, router })
+      expect(props.redirect).toBe('http://example.com')
+    })
+    it('should not pass redirect if not present in the URI', () => {
+      const props = mapStateToProps({
+        locks,
+        keys,
+        modals,
+        router: noRedirectRouter,
+      })
+      expect(props.redirect).toBeFalsy()
     })
   })
   describe('handleIframe', () => {

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -60,8 +60,12 @@ export const mapStateToProps = ({ account }) => ({
   openInNewWindow: !account,
 })
 
-export const mapDispatchToProps = (dispatch, { locks }) => ({
+export const mapDispatchToProps = (dispatch, { locks, redirect }) => ({
   hideModal: () => {
+    if (redirect) {
+      window.location.href = redirect
+      return
+    }
     unlockPage()
     return dispatch(hideModal(locks.map(l => l.address).join('-')))
   },

--- a/unlock-app/src/pages/paywall.js
+++ b/unlock-app/src/pages/paywall.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import PropTypes from 'prop-types'
 import UnlockPropTypes from '../propTypes'
 import Overlay from '../components/lock/Overlay'
 import DeveloperOverlay from '../components/developer/DeveloperOverlay'
@@ -49,7 +48,7 @@ class Paywall extends React.Component {
   }
   render() {
     const { scrollPosition } = this.state
-    const { locks, locked } = this.props
+    const { locks, locked, redirect } = this.props
     return (
       <BrowserOnly>
         <GlobalErrorProvider>
@@ -81,37 +80,28 @@ Paywall.defaultProps = {
 }
 
 export const mapStateToProps = ({ locks, keys, modals, router }) => {
-  const { lockAddress } = lockRoute(router.location.pathname)
+  const { lockAddress, redirect } = lockRoute(router.location.pathname)
 
-  if (match) {
-    const lockFromUri = Object.values(locks).find(
-      lock => lock.address === lockAddress
-    )
+  const lockFromUri = Object.values(locks).find(
+    lock => lock.address === lockAddress
+  )
 
-    let validKeys = []
-    const locksFromUri = lockFromUri ? [lockFromUri] : []
-    locksFromUri.forEach(lock => {
-      for (let k of Object.values(keys)) {
-        if (
-          k.lock === lock.address &&
-          k.expiration > new Date().getTime() / 1000
-        ) {
-          validKeys.push(k)
-        }
+  let validKeys = []
+  const locksFromUri = lockFromUri ? [lockFromUri] : []
+  locksFromUri.forEach(lock => {
+    for (let k of Object.values(keys)) {
+      if (
+        k.lock === lock.address &&
+        k.expiration > new Date().getTime() / 1000
+      ) {
+        validKeys.push(k)
       }
-    })
+    }
+  })
 
-    const modalShown = !!modals[locksFromUri.map(l => l.address).join('-')]
-    const locked = validKeys.length === 0 || modalShown
-    const redirect = decodeURIComponent(match[3])
-    return { locked, locks: locksFromUri, redirect }
-  }
-
-  return {
-    locks: [],
-    redirect: false,
-    locked: false,
-  }
+  const modalShown = !!modals[locksFromUri.map(l => l.address).join('-')]
+  const locked = validKeys.length === 0 || modalShown
+  return { locked, locks: locksFromUri, redirect }
 }
 
 export default connect(mapStateToProps)(Paywall)


### PR DESCRIPTION
# Description

This PR is a step on the path to #1314 and #1287. It implements pulling the redirect URL from the paywall URL, and uses it to redirect after a key is purchased.

Next steps not present in this PR:
- redirect from the paywall if a key has already been purchased
- pass the account for a purchased key to the paywall client-side using a hash so we can set a cookie/localStorage/whatever

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
