### PR TITLE
Introduce walletStatus to state

### DIFF
--- a/unlock-app/src/__tests__/actions/walletStatus.test.js
+++ b/unlock-app/src/__tests__/actions/walletStatus.test.js
@@ -1,0 +1,17 @@
+import {
+  waitForWallet,
+  gotWallet,
+  WAIT_FOR_WALLET,
+  GOT_WALLET,
+} from '../../actions/walletStatus'
+
+describe('walletStatus actions', () => {
+  it('should create and action to wait for the wallet', () => {
+    const expectedAction = { type: WAIT_FOR_WALLET }
+    expect(waitForWallet()).toEqual(expectedAction)
+  })
+  it('should create and action to indicate that the wallet is available', () => {
+    const expectedAction = { type: GOT_WALLET }
+    expect(gotWallet()).toEqual(expectedAction)
+  })
+})

--- a/unlock-app/src/__tests__/reducers/walletStatusReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/walletStatusReducer.test.js
@@ -1,0 +1,18 @@
+import reducer from '../../reducers/walletStatusReducer'
+import { WAIT_FOR_WALLET, GOT_WALLET } from '../../actions/walletStatus'
+
+describe('walletStatusReducer', () => {
+  const notWaiting = { waiting: false }
+  const waiting = { waiting: true }
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual(notWaiting)
+  })
+
+  it('should set waiting to true when receiving WAIT_FOR_WALLET', () => {
+    expect(reducer(notWaiting, { type: WAIT_FOR_WALLET })).toEqual(waiting)
+  })
+
+  it('should set waiting to false when receiving GOT_WALLET', () => {
+    expect(reducer(waiting, { type: GOT_WALLET })).toEqual(notWaiting)
+  })
+})

--- a/unlock-app/src/__tests__/reducers/walletStatusReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/walletStatusReducer.test.js
@@ -1,18 +1,17 @@
-import reducer from '../../reducers/walletStatusReducer'
+import reducer, { initialState } from '../../reducers/walletStatusReducer'
 import { WAIT_FOR_WALLET, GOT_WALLET } from '../../actions/walletStatus'
 
 describe('walletStatusReducer', () => {
-  const notWaiting = { waiting: false }
   const waiting = { waiting: true }
   it('should return the initial state', () => {
-    expect(reducer(undefined, {})).toEqual(notWaiting)
+    expect(reducer(undefined, {})).toEqual(initialState)
   })
 
   it('should set waiting to true when receiving WAIT_FOR_WALLET', () => {
-    expect(reducer(notWaiting, { type: WAIT_FOR_WALLET })).toEqual(waiting)
+    expect(reducer(initialState, { type: WAIT_FOR_WALLET })).toEqual(waiting)
   })
 
   it('should set waiting to false when receiving GOT_WALLET', () => {
-    expect(reducer(waiting, { type: GOT_WALLET })).toEqual(notWaiting)
+    expect(reducer(waiting, { type: GOT_WALLET })).toEqual(initialState)
   })
 })

--- a/unlock-app/src/actions/walletStatus.js
+++ b/unlock-app/src/actions/walletStatus.js
@@ -1,0 +1,6 @@
+export const WAIT_FOR_WALLET = 'walletStatus/WAIT_FOR_WALLET'
+export const GOT_WALLET = 'walletStatus/GOT_WALLET'
+
+export const waitForWallet = () => ({ type: WAIT_FOR_WALLET })
+
+export const gotWallet = () => ({ type: GOT_WALLET })

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -35,6 +35,9 @@ import accountReducer, {
 import modalReducer, {
   initialState as defaultModals,
 } from './reducers/modalsReducer'
+import walletStatusReducer, {
+  initialState as defaultWalletStatus,
+} from './reducers/walletStatusReducer'
 
 const config = configure()
 
@@ -55,6 +58,7 @@ export const createUnlockStore = (
     transactions: transactionsReducer,
     currency: currencyReducer,
     errors: errorsReducer,
+    walletStatus: walletStatusReducer,
   }
 
   // Cleanup the defaultState to remove all null values so that we do not overwrite existing
@@ -77,6 +81,7 @@ export const createUnlockStore = (
       transactions: defaultTransactions,
       currency: defaultCurrency,
       errors: defaultError,
+      walletStatus: defaultWalletStatus,
     },
     {
       provider: Object.keys(config.providers)[0],

--- a/unlock-app/src/reducers/walletStatusReducer.js
+++ b/unlock-app/src/reducers/walletStatusReducer.js
@@ -1,0 +1,25 @@
+import { WAIT_FOR_WALLET, GOT_WALLET } from '../actions/walletStatus'
+
+import { SET_PROVIDER } from '../actions/provider'
+import { SET_NETWORK } from '../actions/network'
+import { SET_ACCOUNT } from '../actions/accounts'
+
+export const initialState = { waiting: false }
+
+const walletStatusReducer = (walletStatus = initialState, action) => {
+  if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
+    return initialState
+  }
+
+  if (action.type === WAIT_FOR_WALLET) {
+    return { waiting: true }
+  }
+
+  if (action.type === GOT_WALLET) {
+    return initialState
+  }
+
+  return walletStatus
+}
+
+export default walletStatusReducer


### PR DESCRIPTION
# Description

This PR introduces the concept of `walletStatus` to the state. It will enable us to track whether we are waiting for the user to interact with their wallet. #1409 depends on this, and will introduce event handling that actually dispatches these actions and updates the state.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
