### PR TITLE
move response to HIDE_MODAL to interWindowCommunicationMiddleware from Overlay

### DIFF
--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -35,19 +35,6 @@ describe('Overlay', () => {
         type: SHOW_MODAL,
       })
     })
-    it('should yield a prop function which redirects if instructed', () => {
-      expect.assertions(1)
-      const locks = [{ address: '0x123' }, { address: '0x456' }]
-      const dispatch = jest.fn()
-      const props = mapDispatchToProps(dispatch, {
-        locks,
-        redirect: 'http://example.com',
-      })
-      props.hideModal()
-      // we can't actually test the redirect, in the test environment it doesn't work
-      // but we can verify that dispatch was not called for the normal behavior
-      expect(dispatch).not.toHaveBeenCalled()
-    })
   })
   describe('mapStateToProps', () => {
     it('should set openInNewWindow based on the value of account', () => {

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -60,12 +60,8 @@ export const mapStateToProps = ({ account }) => ({
   openInNewWindow: !account,
 })
 
-export const mapDispatchToProps = (dispatch, { locks, redirect }) => ({
+export const mapDispatchToProps = (dispatch, { locks }) => ({
   hideModal: () => {
-    if (redirect) {
-      window.location.href = redirect
-      return
-    }
     unlockPage()
     return dispatch(hideModal(locks.map(l => l.address).join('-')))
   },

--- a/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
+++ b/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
@@ -1,15 +1,20 @@
-import { OPEN_MODAL_IN_NEW_WINDOW } from '../actions/modal'
+import { OPEN_MODAL_IN_NEW_WINDOW, HIDE_MODAL } from '../actions/modal'
 import { inIframe } from '../config'
+import { lockRoute } from '../utils/routes'
 
 // store is unused in this middleware, it is only for listening for actions
 // and converting them into postMessage
-const interWindowCommunicationMiddleware = window => () => {
+const interWindowCommunicationMiddleware = window => ({ getState }) => {
   const parent = window.parent
-  const enabled = inIframe(window)
+  const isInIframe = inIframe(window)
   return next => action => {
-    if (!enabled) return next(action)
-    if (action.type === OPEN_MODAL_IN_NEW_WINDOW) {
+    if (isInIframe && action.type === OPEN_MODAL_IN_NEW_WINDOW) {
       parent.postMessage('redirect', parent.origin)
+    } else if (!isInIframe && action.type === HIDE_MODAL) {
+      const { redirect } = lockRoute(getState().router.location.pathname)
+      if (redirect) {
+        window.location.href = redirect
+      }
     }
     return next(action)
   }


### PR DESCRIPTION
# Description

This moves the moment where we redirect from Overlay to the middleware, so that it will always happen when the modal is hidden, not just when the user clicks hide.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
