### PR TITLE
add new account regex and also account hash in lock path regexp

### DIFF
--- a/unlock-app/src/__tests__/utils/routes.test.js
+++ b/unlock-app/src/__tests__/utils/routes.test.js
@@ -6,16 +6,19 @@ describe('lockRoute', () => {
       lockAddress: null,
       prefix: null,
       redirect: null,
+      account: null,
     })
     expect(lockRoute('/lock')).toEqual({
       lockAddress: null,
       prefix: null,
       redirect: null,
+      account: null,
     })
     expect(lockRoute('/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')).toEqual({
       lockAddress: null,
       prefix: null,
       redirect: null,
+      account: null,
     })
   })
 
@@ -52,6 +55,43 @@ describe('lockRoute', () => {
       lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
       prefix: 'demo',
       redirect: 'http://hithere',
+    })
+  })
+  it('should return the correct account parameter when it matches', () => {
+    expect(
+      lockRoute(
+        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+      )
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: 'http://hithere',
+      account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+    })
+  })
+  it('should ignore malformed account parameter', () => {
+    expect(
+      lockRoute(
+        // address is too short
+        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb'
+      )
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: 'http://hithere',
+      account: undefined,
+    })
+  })
+  it('should ignore account parameter if redirect is not present', () => {
+    expect(
+      lockRoute(
+        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+      )
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: undefined,
+      account: undefined,
     })
   })
 })

--- a/unlock-app/src/__tests__/utils/routes.test.js
+++ b/unlock-app/src/__tests__/utils/routes.test.js
@@ -82,7 +82,7 @@ describe('lockRoute', () => {
       account: undefined,
     })
   })
-  it('should ignore account parameter if redirect is not present', () => {
+  it('should return account parameter if redirect is not present', () => {
     expect(
       lockRoute(
         '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
@@ -91,7 +91,7 @@ describe('lockRoute', () => {
       lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
       prefix: 'demo',
       redirect: undefined,
-      account: undefined,
+      account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
     })
   })
 })

--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -37,7 +37,11 @@ export const TRANSACTION_TYPES = {
 /**
  * Matches /lock /demo or /paywall
  */
-export const LOCK_PATH_NAME_REGEXP = /\/([a-z0-9]+)\/(0x[a-fA-F0-9]{40})(\/(.+))?/
+export const LOCK_PATH_NAME_REGEXP = /\/([a-z0-9]+)\/(0x[a-fA-F0-9]{40})(\/([^#]+)(#(0x[a-fA-F0-9]{40}))?)?/
+/**
+ * Matches any valid ethereum account address
+ */
+export const ACCOUNT_REGEXP = /0x[a-fA-F0-9]{40}/
 
 export const PAGE_DESCRIPTION =
   'Unlock is a protocol which enables creators to monetize their content with a few lines of code in a fully decentralized way.'

--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -35,7 +35,16 @@ export const TRANSACTION_TYPES = {
 }
 
 /**
- * Matches /lock /demo or /paywall
+ * This regexp matches several important parameters passed in the url for the demo and paywall pages.
+ *
+ * '/demo/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9/'
+ *   will extract 'demo' and the lock address as match 1 and 2
+ * '/demo/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9/http%3A%2F%2Fexample.com'
+ *   will extract the same variables, and also the url-encoded redirect URL 'http://example.com' as match 4
+ * '/paywall/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9/#0xabcddc4CdBda8dc99c82D66d97B264386E41c0E9'
+ *   will extract the 'paywall' and lock address as match 1 and 2 and the account address as match 6
+ *
+ * You should not use this directly, instead use the utils/routes.js lockRoute function
  */
 export const LOCK_PATH_NAME_REGEXP = /\/([a-z0-9]+)\/(0x[a-fA-F0-9]{40})(\/([^#]+))?(#(0x[a-fA-F0-9]{40}))?/
 /**

--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -37,7 +37,7 @@ export const TRANSACTION_TYPES = {
 /**
  * Matches /lock /demo or /paywall
  */
-export const LOCK_PATH_NAME_REGEXP = /\/([a-z0-9]+)\/(0x[a-fA-F0-9]{40})(\/([^#]+)(#(0x[a-fA-F0-9]{40}))?)?/
+export const LOCK_PATH_NAME_REGEXP = /\/([a-z0-9]+)\/(0x[a-fA-F0-9]{40})(\/([^#]+))?(#(0x[a-fA-F0-9]{40}))?/
 /**
  * Matches any valid ethereum account address
  */

--- a/unlock-app/src/utils/routes.js
+++ b/unlock-app/src/utils/routes.js
@@ -12,6 +12,7 @@ export const lockRoute = path => {
       lockAddress: null,
       prefix: null,
       redirect: null,
+      account: null,
     }
   }
 
@@ -19,6 +20,7 @@ export const lockRoute = path => {
     lockAddress: match[2],
     prefix: match[1],
     redirect: match[4] && decodeURIComponent(match[4]),
+    account: match[6],
   }
 }
 


### PR DESCRIPTION
# Description

This is a step on the path to #1314 and #1287 

It adds the ability to parse an account off of the hash on a URL like `/demo/0x..../#0x....` where `0x....` is a valid address. It returns the parsed address from `lockRoute` as `address`

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
