### PR TITLE
new localStorage util for managing key storage in the paywall

### DIFF
--- a/unlock-app/src/__tests__/utils/localStorage.test.js
+++ b/unlock-app/src/__tests__/utils/localStorage.test.js
@@ -1,0 +1,127 @@
+import {
+  getKeysFromStorage,
+  getUserStorageName,
+  getKeysForLockFromStorage,
+  resetAccountStorage,
+  saveKeyToStorage,
+} from '../../utils/localStorage'
+
+describe('localStorage utility', () => {
+  let window
+  let fakeStorage
+  const account = '0x123'
+  const network = 1
+  const user = getUserStorageName(account, network)
+  const lock1 = '0xdeadbeef'
+  const lock2 = '0xfadebeef'
+  const key1 = {
+    lock: lock1,
+    owner: account,
+    expiration: 0,
+    data: null,
+    id: `${lock1}-${account}`,
+  }
+  const key2 = {
+    lock: lock2,
+    owner: account,
+    expiration: 0,
+    data: null,
+    id: `${lock1}-${account}`,
+  }
+  beforeEach(() => {
+    fakeStorage = {}
+    window = {
+      localStorage: {
+        setItem: jest.fn((item, thing) => (fakeStorage[item] = thing)),
+        getItem: jest.fn(item => fakeStorage[item] || null),
+        removeItem: jest.fn(() => null),
+      },
+    }
+  })
+  describe('getKeysFromStorage', () => {
+    it("pulls the user's keys from storage", () => {
+      expect.assertions(1)
+      const info = {
+        [key1.id]: key1,
+      }
+      fakeStorage[user] = JSON.stringify(info)
+      expect(getKeysFromStorage(window, account, network)).toEqual(info)
+    })
+  })
+  describe('getKeysForLockFromStorage', () => {
+    it("pulls the specific lock's keys from storage", () => {
+      expect.assertions(2)
+      const info = {
+        [lock1]: {
+          [key1.id]: key1,
+        },
+        [lock2]: {
+          [key2.id]: key2,
+        },
+      }
+      fakeStorage[user] = JSON.stringify(info)
+      expect(
+        getKeysForLockFromStorage(window, lock1, account, network)
+      ).toEqual({
+        [key1.id]: key1,
+      })
+      expect(
+        getKeysForLockFromStorage(window, lock2, account, network)
+      ).toEqual({
+        [key2.id]: key2,
+      })
+    })
+  })
+  it('resetAccountStorage', () => {
+    expect.assertions(1)
+    resetAccountStorage(window, account, network)
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith(user)
+  })
+  describe('saveKeyToStorage', () => {
+    const expectedValue = {
+      [lock1]: {
+        [key1.id]: key1,
+      },
+    }
+    it('sets value correctly when localStorage is empty', () => {
+      expect.assertions(2)
+      saveKeyToStorage(window, key1, network)
+
+      expect(window.localStorage.getItem).toHaveBeenCalledWith(user)
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        user,
+        JSON.stringify(expectedValue)
+      )
+    })
+    it('sets value correctly when localStorage has other locks', () => {
+      const newValue = {
+        [lock2]: {
+          [key2.id]: key2,
+        },
+      }
+      fakeStorage[user] = JSON.stringify(newValue)
+      expect.assertions(2)
+      saveKeyToStorage(window, key1, network)
+
+      expect(window.localStorage.getItem).toHaveBeenCalledWith(user)
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        user,
+        JSON.stringify({
+          ...newValue,
+          ...expectedValue,
+        })
+      )
+    })
+    it('sets value correctly when localStorage has the same key already', () => {
+      fakeStorage[user] = JSON.stringify(expectedValue)
+      expect.assertions(2)
+      saveKeyToStorage(window, key1, network)
+
+      expect(window.localStorage.getItem).toHaveBeenCalledWith(user)
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        user,
+        JSON.stringify(expectedValue)
+      )
+    })
+  })
+})

--- a/unlock-app/src/utils/localStorage.js
+++ b/unlock-app/src/utils/localStorage.js
@@ -1,0 +1,58 @@
+// copied from the MDN docs as the best way to detect localStorage presence
+export function localStorageAvailable(window) {
+  try {
+    var storage = window.localStorage,
+      x = '__storage_test__'
+    storage.setItem(x, x)
+    storage.removeItem(x)
+    return true
+  } catch (e) {
+    return (
+      e instanceof DOMException &&
+      // everything except Firefox
+      (e.code === 22 ||
+        // Firefox
+        e.code === 1014 ||
+        // test name field too, because code might not be present
+        // everything except Firefox
+        e.name === 'QuotaExceededError' ||
+        // Firefox
+        e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+      // acknowledge QuotaExceededError only if there's something already stored
+      storage.length !== 0
+    )
+  }
+}
+
+export function getUserStorageName(account, network) {
+  return `unlock-${account}-${network}`
+}
+
+export function saveKeyToStorage(window, key, network) {
+  const storageKeys = getKeysFromStorage(window, key.owner, network)
+  const keys = storageKeys ? storageKeys : {}
+  keys[key.lock] = keys[key.lock] || {}
+  keys[key.lock][key.id] = key
+  window.localStorage.setItem(
+    getUserStorageName(key.owner, network),
+    JSON.stringify(keys)
+  )
+}
+
+export function getKeysFromStorage(window, account, network) {
+  const info = window.localStorage.getItem(getUserStorageName(account, network))
+  try {
+    return JSON.parse(info)
+  } catch (e) {
+    return {}
+  }
+}
+
+export function getKeysForLockFromStorage(window, lock, account, network) {
+  const allKeys = getKeysFromStorage(window, account, network)
+  return allKeys[lock] || {}
+}
+
+export function resetAccountStorage(window, account, network) {
+  window.localStorage.removeItem(getUserStorageName(account, network))
+}


### PR DESCRIPTION
# Description

This adds a new utility library for handling localStorage. Specific functionality is detecting the existence of localStorage and then storing keys.

Keys are indexed by user, network, and lock.

This is a step along the road to #1314 and #1287 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
