### PR TITLE
Getting transactions from web3Service when they're added

### DIFF
--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -4,7 +4,11 @@ import web3Middleware from '../../middlewares/web3Middleware'
 import { ADD_LOCK, UPDATE_LOCK, CREATE_LOCK } from '../../actions/lock'
 import { UPDATE_KEY } from '../../actions/key'
 import { UPDATE_ACCOUNT } from '../../actions/accounts'
-import { ADD_TRANSACTION, UPDATE_TRANSACTION } from '../../actions/transaction'
+import {
+  ADD_TRANSACTION,
+  UPDATE_TRANSACTION,
+  NEW_TRANSACTION,
+} from '../../actions/transaction'
 import { SET_ERROR } from '../../actions/error'
 import { SET_KEYS_ON_PAGE_FOR_LOCK } from '../../actions/keysPages'
 import { PGN_ITEMS_PER_PAGE } from '../../constants'
@@ -376,6 +380,30 @@ describe('Lock middleware', () => {
       expect(mockWeb3Service.getKeyByLockForOwner).not.toHaveBeenCalled()
       expect(next).toHaveBeenCalledWith(action)
     })
+  })
+
+  it('should handle ADD_TRANSACTION', () => {
+    const { next, invoke } = create()
+    const action = { type: ADD_TRANSACTION, transaction }
+    mockWeb3Service.getTransaction = jest.fn()
+
+    invoke(action)
+    expect(next).toHaveBeenCalled()
+    expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
+      transaction.hash
+    )
+  })
+
+  it('should handle NEW_TRANSACTION', () => {
+    const { next, invoke } = create()
+    const action = { type: NEW_TRANSACTION, transaction }
+    mockWeb3Service.getTransaction = jest.fn()
+
+    invoke(action)
+    expect(next).toHaveBeenCalled()
+    expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
+      transaction.hash
+    )
   })
 
   describe('CREATE_LOCK', () => {

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -16,6 +16,7 @@ import {
   addTransaction,
   updateTransaction,
   ADD_TRANSACTION,
+  NEW_TRANSACTION,
 } from '../actions/transaction'
 import { PGN_ITEMS_PER_PAGE } from '../constants'
 
@@ -125,6 +126,10 @@ export default function web3Middleware({ getState, dispatch }) {
       }
 
       if (action.type === ADD_TRANSACTION) {
+        web3Service.getTransaction(action.transaction.hash)
+      }
+
+      if (action.type === NEW_TRANSACTION) {
         web3Service.getTransaction(action.transaction.hash)
       }
 


### PR DESCRIPTION
Getting transactions from web3Service when they're added


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread