### PR TITLE
pass the hash on to the paywall

### DIFF
--- a/unlock-app/src/__tests__/paywall-builder/build.test.js
+++ b/unlock-app/src/__tests__/paywall-builder/build.test.js
@@ -57,6 +57,9 @@ describe('buildPaywall', () => {
           expect(listener).not.toBe(null)
         },
         requestAnimationFrame() {},
+        location: {
+          hash: '',
+        },
       }
     })
     it('no lockAddress, give up', () => {
@@ -72,6 +75,21 @@ describe('buildPaywall', () => {
       expect(mockIframe).toHaveBeenCalledWith(
         document,
         '/url/paywall/lockaddress/'
+      )
+    })
+
+    it('passes the hash to the iframe, if present', () => {
+      // when the content is loaded from the paywall in a new window,
+      // it appends the user account as a hash. This is then passed on
+      // as-is. Note that it passes any hash on, without validation,
+      // because the lockRoute function properly validates the incoming hash
+      window.location.hash = '#hithere'
+      buildPaywall(window, document, fakeLockAddress)
+
+      expect(mockScript).toHaveBeenCalledWith(document)
+      expect(mockIframe).toHaveBeenCalledWith(
+        document,
+        '/url/paywall/lockaddress/#hithere'
       )
     })
 
@@ -102,6 +120,7 @@ describe('buildPaywall', () => {
           requestAnimationFrame() {},
           location: {
             href: 'href',
+            hash: '',
           },
         }
         blocker = {

--- a/unlock-app/src/paywall-builder/build.js
+++ b/unlock-app/src/paywall-builder/build.js
@@ -24,7 +24,8 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
     return
   }
 
-  const paywallUrl = findPaywallUrl(document) + `/paywall/${lockAddress}/`
+  const paywallUrl =
+    findPaywallUrl(document) + `/paywall/${lockAddress}/` + window.location.hash
   const iframe = getIframe(document, paywallUrl)
   add(document, iframe)
 


### PR DESCRIPTION
# Description

This is a step on the path to #1314 and #1287 

This PR causes the paywall to pass any hash from its content window to the paywall, so that if we were redirected from the paywall in a new window, we can pass that marker to the paywall to quickly retrieve the user's keys, as well as slowly retrieve them (part of separate PRs)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
