### PR TITLE
retrieve keys for user if on the paywall when SET_ACCOUNT is triggered

### DIFF
--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -299,7 +299,7 @@ describe('Lock middleware', () => {
   })
 
   describe('not on the paywall', () => {
-    it('should handle SET_ACCOUNT by refreshing balance and retrieving historical lock transactions', () => {
+    it('should handle SET_ACCOUNT by refreshing balance and retrieving historical unlock transactions', () => {
       expect.assertions(3)
       mockWeb3Service.refreshAccountBalance = jest.fn()
       mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn()


### PR DESCRIPTION
# Description

This PR adds a listener for `SET_ACCOUNT` in `web3Middleware` that will prompt the `web3Service` to retrieve keys for that user if on the paywall page.

It also uncovered a race condition in `SET_ACCOUNT`/`UPDATE_ACCOUNT` order caused by placing the code block before reducers have had a chance to update state, and adds a test for that as well.

A step on the path to #1314 and #1287 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
