### PR TITLE
listen for account in the hash of paywall url, and pass it when redirecting to content

### DIFF
--- a/unlock-app/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
@@ -34,7 +34,6 @@ describe('interWindowCommunicationMiddleware', () => {
 
       const middleware = interWindowCommunicationMiddleware(window)
 
-      const { getState } = store
       middleware(store)(next)(action)
 
       expect(next).toHaveBeenCalledWith(action)

--- a/unlock-app/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
@@ -3,14 +3,23 @@ import { openNewWindowModal, hideModal } from '../../actions/modal'
 
 describe('interWindowCommunicationMiddleware', () => {
   describe('middleware functionality', () => {
-    it('does responds to OPEN_MODAL_IN_NEW_WINDOW if in an iframe', () => {
+    it('does respond to OPEN_MODAL_IN_NEW_WINDOW if in an iframe', () => {
       expect.assertions(2)
       const next = jest.fn()
 
       const action = openNewWindowModal()
 
       const store = {
-        getState() {},
+        getState() {
+          return {
+            router: {
+              location: {
+                pathname: '/paywall/',
+              },
+            },
+          }
+        },
+        dispatch: jest.fn(),
       }
 
       const window = {
@@ -18,12 +27,14 @@ describe('interWindowCommunicationMiddleware', () => {
           postMessage: jest.fn(),
           origin: 'origin',
         },
+        addEventListener() {},
       }
       window.self = window
       window.top = 'not window'
 
       const middleware = interWindowCommunicationMiddleware(window)
 
+      const { getState } = store
       middleware(store)(next)(action)
 
       expect(next).toHaveBeenCalledWith(action)
@@ -65,6 +76,9 @@ describe('interWindowCommunicationMiddleware', () => {
       const store = {
         getState() {
           return {
+            account: {
+              address: 'address',
+            },
             router: {
               location: {
                 pathname:
@@ -92,7 +106,7 @@ describe('interWindowCommunicationMiddleware', () => {
       middleware(store)(next)(action)
 
       expect(next).toHaveBeenCalledWith(action)
-      expect(window.location.href).toBe('http://hithere')
+      expect(window.location.href).toBe('http://hithere#address')
     })
     it('ignores HIDE_MODAL in the iframe', () => {
       expect.assertions(2)
@@ -117,6 +131,7 @@ describe('interWindowCommunicationMiddleware', () => {
         location: {
           href: 'href',
         },
+        addEventListener() {},
       }
       window.self = window
       window.top = {}
@@ -133,6 +148,9 @@ describe('interWindowCommunicationMiddleware', () => {
       const store = {
         getState() {
           return {
+            account: {
+              address: '',
+            },
             router: {
               location: {
                 pathname: '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
@@ -150,6 +168,7 @@ describe('interWindowCommunicationMiddleware', () => {
         location: {
           href: 'href',
         },
+        addEventListener() {},
       }
       window.self = window
       window.top = window

--- a/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
+++ b/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
@@ -1,22 +1,50 @@
 import { OPEN_MODAL_IN_NEW_WINDOW, HIDE_MODAL } from '../actions/modal'
 import { inIframe } from '../config'
 import { lockRoute } from '../utils/routes'
+import { setAccount } from '../actions/accounts'
 
 // store is unused in this middleware, it is only for listening for actions
 // and converting them into postMessage
-const interWindowCommunicationMiddleware = window => ({ getState }) => {
+const interWindowCommunicationMiddleware = window => ({
+  getState,
+  dispatch,
+}) => {
   const parent = window.parent
   const isInIframe = inIframe(window)
-  return next => action => {
-    if (isInIframe && action.type === OPEN_MODAL_IN_NEW_WINDOW) {
-      parent.postMessage('redirect', parent.origin)
-    } else if (!isInIframe && action.type === HIDE_MODAL) {
-      const { redirect } = lockRoute(getState().router.location.pathname)
-      if (redirect) {
-        window.location.href = redirect
+  return next => {
+    if (isInIframe) {
+      // if we are in the paywall on an iframe, account is not defined
+      // for coinbase wallet or trust wallet, and probably others.
+      // this checks the hash for a valid account and if found,
+      // sets our account to this account. This triggers retrieval
+      // of keys for that account, allowing the paywall to function
+      const { router, account } = getState()
+      const { address } = lockRoute(router.location.pathname)
+      if (!account && address) {
+        dispatch(setAccount(address))
       }
     }
-    return next(action)
+    return action => {
+      if (isInIframe && action.type === OPEN_MODAL_IN_NEW_WINDOW) {
+        parent.postMessage('redirect', parent.origin)
+      } else if (!isInIframe && action.type === HIDE_MODAL) {
+        // if the user clicks the button to go to content,
+        // we redirect back to the content, appending as a hash
+        // the user account. This is not sent to the server.
+        // then, the paywall.min.js script detects the hash
+        // and forwards it to the paywall in the iframe.
+        // the code at the top of this file handles that case
+        const {
+          router,
+          account: { address },
+        } = getState()
+        const { redirect } = lockRoute(router.location.pathname)
+        if (redirect) {
+          window.location.href = redirect + '#' + address
+        }
+      }
+      return next(action)
+    }
   }
 }
 


### PR DESCRIPTION
# Description

This is a step on the path to #1314 and #1287 

This PR introduces a listener for the account hash in a url such as:

`/paywall/0x.../#0x...`

If detected, it will compare to the current account. If that account is not set, then it will use the account from the hash in order to retrieve keys.

In addition, if the paywall is loaded in a new window, it will listen for when the user clicks the "go to content" button or when a key is detected (in both cases, the `HIDE_MODAL` action is dispatched). Then, it will redirect back to the content, appending a hash containing the current user account.

This is then passed to the paywall in the iframe by the `paywall.min.js`, which triggers the code described in the first part of this PR description (whew!)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
