### PR TITLE
Add walletStatus action to dismiss overlay

### DIFF
--- a/unlock-app/src/__tests__/actions/walletStatus.test.js
+++ b/unlock-app/src/__tests__/actions/walletStatus.test.js
@@ -1,8 +1,10 @@
 import {
   waitForWallet,
   gotWallet,
+  dismissWalletCheck,
   WAIT_FOR_WALLET,
   GOT_WALLET,
+  DISMISS_CHECK,
 } from '../../actions/walletStatus'
 
 describe('walletStatus actions', () => {
@@ -13,5 +15,9 @@ describe('walletStatus actions', () => {
   it('should create and action to indicate that the wallet is available', () => {
     const expectedAction = { type: GOT_WALLET }
     expect(gotWallet()).toEqual(expectedAction)
+  })
+  it('should create an action to indicate that the wallet check overlay should be dismissed', () => {
+    const expectedAction = { type: DISMISS_CHECK }
+    expect(dismissWalletCheck()).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/__tests__/reducers/walletStatusReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/walletStatusReducer.test.js
@@ -1,5 +1,9 @@
 import reducer, { initialState } from '../../reducers/walletStatusReducer'
-import { WAIT_FOR_WALLET, GOT_WALLET } from '../../actions/walletStatus'
+import {
+  WAIT_FOR_WALLET,
+  GOT_WALLET,
+  DISMISS_CHECK,
+} from '../../actions/walletStatus'
 
 describe('walletStatusReducer', () => {
   const waiting = { waiting: true }
@@ -13,5 +17,9 @@ describe('walletStatusReducer', () => {
 
   it('should set waiting to false when receiving GOT_WALLET', () => {
     expect(reducer(waiting, { type: GOT_WALLET })).toEqual(initialState)
+  })
+
+  it('should set waiting to false when receiving DISMISS_CHECK', () => {
+    expect(reducer(waiting, { type: DISMISS_CHECK })).toEqual(initialState)
   })
 })

--- a/unlock-app/src/actions/walletStatus.js
+++ b/unlock-app/src/actions/walletStatus.js
@@ -1,6 +1,9 @@
 export const WAIT_FOR_WALLET = 'walletStatus/WAIT_FOR_WALLET'
 export const GOT_WALLET = 'walletStatus/GOT_WALLET'
+export const DISMISS_CHECK = 'walletStatus/DISMISS_CHECK'
 
 export const waitForWallet = () => ({ type: WAIT_FOR_WALLET })
 
 export const gotWallet = () => ({ type: GOT_WALLET })
+
+export const dismissWalletCheck = () => ({ type: DISMISS_CHECK })

--- a/unlock-app/src/reducers/walletStatusReducer.js
+++ b/unlock-app/src/reducers/walletStatusReducer.js
@@ -1,4 +1,8 @@
-import { WAIT_FOR_WALLET, GOT_WALLET } from '../actions/walletStatus'
+import {
+  WAIT_FOR_WALLET,
+  GOT_WALLET,
+  DISMISS_CHECK,
+} from '../actions/walletStatus'
 
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
@@ -16,6 +20,10 @@ const walletStatusReducer = (walletStatus = initialState, action) => {
   }
 
   if (action.type === GOT_WALLET) {
+    return initialState
+  }
+
+  if (action.type === DISMISS_CHECK) {
     return initialState
   }
 

--- a/unlock-app/src/reducers/walletStatusReducer.js
+++ b/unlock-app/src/reducers/walletStatusReducer.js
@@ -11,20 +11,16 @@ import { SET_ACCOUNT } from '../actions/accounts'
 export const initialState = { waiting: false }
 
 const walletStatusReducer = (walletStatus = initialState, action) => {
-  if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
+  if (
+    [SET_PROVIDER, SET_NETWORK, SET_ACCOUNT, GOT_WALLET, DISMISS_CHECK].indexOf(
+      action.type
+    ) > -1
+  ) {
     return initialState
   }
 
   if (action.type === WAIT_FOR_WALLET) {
     return { waiting: true }
-  }
-
-  if (action.type === GOT_WALLET) {
-    return initialState
-  }
-
-  if (action.type === DISMISS_CHECK) {
-    return initialState
   }
 
   return walletStatus


### PR DESCRIPTION
# Description

To finish up #1080, we need something to happen when the dismiss button is clicked, which has identical results to the `GOT_WALLET` action, but which is semantically different so it justifies the addition of a new action `DISMISS_CHECK`. This PR adds that action and hooks it up to the reducer.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
