### PR TITLE
save account in localStorage, and use it on subsequent requests

### DIFF
--- a/unlock-app/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
@@ -1,5 +1,9 @@
-import interWindowCommunicationMiddleware from '../../middlewares/interWindowCommunicationMiddleware'
 import { openNewWindowModal, hideModal } from '../../actions/modal'
+import { setAccount } from '../../actions/accounts'
+
+jest.mock('../../utils/localStorage')
+const interWindowCommunicationMiddleware = require('../../middlewares/interWindowCommunicationMiddleware')
+  .default
 
 describe('interWindowCommunicationMiddleware', () => {
   describe('middleware functionality', () => {
@@ -12,6 +16,9 @@ describe('interWindowCommunicationMiddleware', () => {
       const store = {
         getState() {
           return {
+            account: {
+              address: '0xabc',
+            },
             router: {
               location: {
                 pathname: '/paywall/',
@@ -112,6 +119,9 @@ describe('interWindowCommunicationMiddleware', () => {
       const store = {
         getState() {
           return {
+            account: {
+              address: '0xabc',
+            },
             router: {
               location: {
                 pathname:
@@ -197,6 +207,106 @@ describe('interWindowCommunicationMiddleware', () => {
 
       middleware(store)(next)(action)
       expect(next).toHaveBeenCalledWith(action)
+    })
+  })
+  describe('if in the iframe with no account', () => {
+    const lock = '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+    const account = '0xaaaaa25a3e7Fb15263D0DD455B8aAfc08503bb54'
+    describe('if account passed in URL hash', () => {
+      let store
+      let window
+      beforeEach(() => {
+        store = {
+          getState() {
+            return {
+              account: null,
+              router: {
+                location: {
+                  pathname: `/paywall/${lock}#${account}`,
+                },
+              },
+            }
+          },
+          dispatch: jest.fn(),
+        }
+        window = {
+          localStorage: {
+            setItem: jest.fn(),
+            getItem: jest.fn(() => null),
+          },
+        }
+        window.self = window
+        window.top = {}
+      })
+      it('should dispatch SET_ACCOUNT', () => {
+        expect.assertions(1)
+        const middleware = interWindowCommunicationMiddleware(window)
+        middleware(store)(() => {})({})
+
+        expect(store.dispatch).toHaveBeenCalledWith(
+          setAccount({ address: account })
+        )
+      })
+      it('should save the account in localStorage', () => {
+        expect.assertions(1)
+        const middleware = interWindowCommunicationMiddleware(window)
+        middleware(store)(() => {})({})
+
+        expect(window.localStorage.setItem).toHaveBeenCalledWith(
+          '__unlock__account__',
+          account
+        )
+      })
+    })
+    describe('normal usage post-key purchase', () => {
+      let store
+      let window
+      beforeEach(() => {
+        store = {
+          getState() {
+            return {
+              account: null,
+              router: {
+                location: {
+                  pathname: `/paywall/${lock}`,
+                },
+              },
+            }
+          },
+          dispatch: jest.fn(),
+        }
+        window = {
+          localStorage: {
+            setItem: jest.fn(),
+            getItem: jest.fn(() => null),
+          },
+        }
+        window.self = window
+        window.top = {}
+      })
+      it('should dispatch SET_ACCOUNT if account is stored in localStorage', () => {
+        window.localStorage.getItem = jest.fn(() => account)
+        expect.assertions(2)
+        const middleware = interWindowCommunicationMiddleware(window)
+        middleware(store)(() => {})({})
+
+        expect(window.localStorage.getItem).toHaveBeenCalledWith(
+          '__unlock__account__'
+        )
+        expect(store.dispatch).toHaveBeenCalledWith(
+          setAccount({ address: account })
+        )
+      })
+      it('should not dispatch SET_ACCOUNT if localStorage does not have an account', () => {
+        expect.assertions(2)
+        const middleware = interWindowCommunicationMiddleware(window)
+        middleware(store)(() => {})({})
+
+        expect(window.localStorage.getItem).toHaveBeenCalledWith(
+          '__unlock__account__'
+        )
+        expect(store.dispatch).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/unlock-app/src/utils/__mocks__/localStorage.js
+++ b/unlock-app/src/utils/__mocks__/localStorage.js
@@ -1,0 +1,3 @@
+export default function localStorageAvailable() {
+  return true
+}


### PR DESCRIPTION
# Description

This is probably the last PR needed to implement #1287 and #1314 

This PR adds the capability to save the user account to localStorage when redirecting from a successful key purchase. On subsequent accesses to any paywall, the account is retrieved from localStorage.

There are several conditions required to trigger this behavior:

1. the user must be in an iframe
2. the user must not have an account detected in their provider

Storage of the account *only* occurs when the user is redirected from a successful key purchase, and the account is in the hash of the URL.

Note: this PR adds a mock for `localStorageAvailable`, if you want that in a separate PR first, I can do that.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
