### PR TITLE
Passing the transaction values to the web3Service when the transaction has been submitted

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -149,7 +149,8 @@ describe('Wallet middleware', () => {
     const { store } = create()
     const from = '0xjulien'
     const to = '0xunlock'
-    mockWalletService.emit('transaction.new', transaction.hash, from, to)
+    const input = 'input'
+    mockWalletService.emit('transaction.new', transaction.hash, from, to, input)
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: GOT_WALLET })
     )
@@ -160,6 +161,7 @@ describe('Wallet middleware', () => {
           hash: transaction.hash,
           to,
           from,
+          input,
         }),
       })
     )

--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -458,7 +458,8 @@ describe('Lock middleware', () => {
     invoke(action)
     expect(next).toHaveBeenCalled()
     expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
-      transaction.hash
+      transaction.hash,
+      transaction
     )
   })
 

--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -304,15 +304,19 @@ describe('WalletService', () => {
       })
 
       it('should trigger the transaction.new event', done => {
-        expect.assertions(3)
+        expect.assertions(4)
         const transactionHash = '0x123'
 
-        walletService.on('transaction.new', (hash, sender, recipient) => {
-          expect(hash).toEqual(transactionHash)
-          expect(sender).toEqual(from)
-          expect(recipient).toEqual(to)
-          done()
-        })
+        walletService.on(
+          'transaction.new',
+          (hash, sender, recipient, input) => {
+            expect(hash).toEqual(transactionHash)
+            expect(sender).toEqual(from)
+            expect(recipient).toEqual(to)
+            expect(input).toEqual(data)
+            done()
+          }
+        )
 
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -53,7 +53,7 @@ export default function walletMiddleware({ getState, dispatch }) {
     )
   })
 
-  walletService.on('transaction.new', (transactionHash, from, to) => {
+  walletService.on('transaction.new', (transactionHash, from, to, input) => {
     // At this point we know that a wallet was found, because a new transaction
     // cannot be created without it
     dispatch(gotWallet())
@@ -62,6 +62,7 @@ export default function walletMiddleware({ getState, dispatch }) {
         hash: transactionHash,
         to,
         from,
+        input,
       })
     )
   })

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -121,7 +121,7 @@ export default function web3Middleware({ getState, dispatch }) {
       }
 
       if (action.type === NEW_TRANSACTION) {
-        web3Service.getTransaction(action.transaction.hash)
+        web3Service.getTransaction(action.transaction.hash, action.transaction)
       }
 
       if (action.type === CREATE_LOCK && !action.lock.address) {

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -144,7 +144,7 @@ export default class WalletService extends EventEmitter {
     return web3TransactionPromise
       .once('transactionHash', hash => {
         callback(null, hash)
-        this.emit('transaction.new', hash, from, to)
+        this.emit('transaction.new', hash, from, to, data)
       })
       .on('error', error => {
         callback(error)


### PR DESCRIPTION
This is the follow up of https://github.com/unlock-protocol/unlock/pull/1465


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread