### PR TITLE
fixing the case of swallen action: never use async/await in reducers...

### DIFF
--- a/unlock-app/src/middlewares/currencyConversionMiddleware.js
+++ b/unlock-app/src/middlewares/currencyConversionMiddleware.js
@@ -1,4 +1,6 @@
 // TODO convert to fetch instead of using axios when it is supported well enough
+/* eslint promise/prefer-await-to-then: 0 */
+
 import axios from 'axios'
 
 import { setConversionRate } from '../actions/currencyconvert'

--- a/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
+++ b/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
@@ -1,3 +1,5 @@
+/* eslint promise/prefer-await-to-then: 0 */
+
 import { OPEN_MODAL_IN_NEW_WINDOW, HIDE_MODAL } from '../actions/modal'
 import { inIframe } from '../config'
 import { lockRoute } from '../utils/routes'

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -1,3 +1,4 @@
+/* eslint promise/prefer-await-to-then: 0 */
 import {
   CREATE_LOCK,
   WITHDRAW_FROM_LOCK,

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -1,4 +1,4 @@
-/* eslint no-console: 0 */ // TODO: remove me when this is clean
+/* eslint promise/prefer-await-to-then: 0 */
 
 import { LOCATION_CHANGE } from 'react-router-redux'
 import {


### PR DESCRIPTION
fixing the case of swallen action: never use async/await in reducers...


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread