### PR TITLE
Adding isAlive variable & onlyIfAlive modifier

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -65,6 +65,9 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   // The version number for this lock contract,
   uint public publicLockVersion;
 
+  // Used to disable payable functions when deprecating an old lock
+  bool public isAlive;
+
   // Keys
   // Each owner can have at most exactly one key
   // TODO: could we use public here? (this could be confusing though because it getter will
@@ -153,6 +156,12 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     _;
   }
 
+  // Only allow usage when contract is Alive
+  modifier onlyIfAlive() {
+    require(isAlive, "No access after contract has been deprecated");
+    _;
+  }
+
   // Constructor
   constructor(
     address _owner,
@@ -170,6 +179,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     keyPrice = _keyPrice;
     maxNumberOfKeys = _maxNumberOfKeys;
     publicLockVersion = _version;
+    isAlive = true;
   }
 
   /**
@@ -183,6 +193,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   )
     external
     payable
+    onlyIfAlive
   {
     return _purchaseFor(_recipient, address(0), _data);
   }
@@ -200,6 +211,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   )
     external
     payable
+    onlyIfAlive
     hasValidKey(_referrer)
   {
     return _purchaseFor(_recipient, _referrer, _data);
@@ -216,6 +228,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   )
     external
     payable
+    onlyIfAlive
     notSoldOut()
     hasValidKey(_from)
     onlyKeyOwnerOrApproved(_tokenId)
@@ -298,6 +311,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   )
     external
     payable
+    onlyIfAlive
     onlyKeyOwner(_tokenId)
   {
     require(_approved != address(0));

--- a/smart-contracts/test/Lock/Lock.js
+++ b/smart-contracts/test/Lock/Lock.js
@@ -27,7 +27,8 @@ contract('Lock', accounts => {
       lock.maxNumberOfKeys.call(),
       lock.outstandingKeys.call(),
       lock.numberOfOwners.call(),
-      lock.publicLockVersion.call()
+      lock.publicLockVersion.call(),
+      lock.isAlive.call()
     ]).then(
       ([
         owner,
@@ -36,7 +37,8 @@ contract('Lock', accounts => {
         maxNumberOfKeys,
         outstandingKeys,
         numberOfOwners,
-        publicLockVersion
+        publicLockVersion,
+        isAlive
       ]) => {
         expirationDuration = new BigNumber(expirationDuration)
         keyPrice = new BigNumber(keyPrice)
@@ -50,6 +52,7 @@ contract('Lock', accounts => {
         assert.equal(outstandingKeys.toFixed(), 0)
         assert.equal(numberOfOwners.toFixed(), 0)
         assert.equal(publicLockVersion.toFixed(), 1) // needs updating each lock-version change
+        assert.equal(isAlive, true)
       }
     )
   })


### PR DESCRIPTION
# Description

This PR is a small step in preparing to implement the destruction of deprecated locks and the migration of keys, #1348 . I've added only 1 test so far to ensure that `isAlive` is set correctly in the constructor. More testing around this needs to be done as additional functionality is added.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
