### PR TITLE
refactored lockLookUp

### DIFF
--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -157,11 +157,7 @@ describe('Storage middleware', () => {
         const action = { type: UPDATE_LOCK, address: lock.address, update: {} }
         delete state.locks[lock.address].name
         mockStorageService.lockLookUp = jest.fn(() => {
-          return Promise.resolve({
-            data: {
-              name: 'A lock has no name',
-            },
-          })
+          return Promise.resolve('A lock has no name')
         })
         await invoke(action)
         expect(mockStorageService.lockLookUp).toHaveBeenCalledWith(lock.address)

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -13,8 +13,12 @@ describe('StorageService', () => {
     describe('when the requested lock exists', () => {
       it('returns the details', () => {
         storageService.lockLookUp('0x42').then(successFn)
-        http.mockResponse()
-        expect(successFn).toHaveBeenCalled()
+        http.mockResponse({
+          data: {
+            name: 'hello',
+          },
+        })
+        expect(successFn).toHaveBeenCalledWith('hello')
         expect(http.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x42`)
       })
     })

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -49,9 +49,8 @@ export default function storageMiddleware({ getState, dispatch }) {
         // Only look up the name for a lock for which the name is empty/not-set
         const lock = getState().locks[action.address]
         if (!lock.name) {
-          // TODO: lockLookUp should probably return the data, not the HTTP response
-          storageService.lockLookUp(action.address).then(results => {
-            dispatch(updateLock(action.address, { name: results.data.name }))
+          storageService.lockLookUp(action.address).then(name => {
+            dispatch(updateLock(action.address, { name }))
           })
         }
       }

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -21,7 +21,8 @@ export default class StorageService {
   }
 
   /**
-   * Gets all the transactions sent by a given address
+   * Gets all the transactions sent by a given address.
+   * Returns an empty array by default
    * TODO: conider a more robust url building
    * @param {*} senderAddress
    */
@@ -29,7 +30,10 @@ export default class StorageService {
     return axios
       .get(`${this.host}/transactions?sender=${senderAddress}`)
       .then(response => {
-        return response.data.transactions.map(t => t.transactionHash)
+        if (response.data && response.data.transactions) {
+          return response.data.transactions.map(t => t.transactionHash)
+        }
+        return []
       })
   }
 
@@ -37,8 +41,17 @@ export default class StorageService {
     return { Authorization: ` Bearer ${token}` }
   }
 
+  /**
+   * Returns the name of undefined
+   * @param {*} address
+   */
   lockLookUp(address) {
-    return axios.get(`${this.host}/lock/${address}`)
+    return axios.get(`${this.host}/lock/${address}`).then(result => {
+      if (result.data && result.data.name) {
+        return result.data.name
+      }
+      return null
+    })
   }
 
   storeLockDetails(lock, token) {


### PR DESCRIPTION
We only return the name and making StorageService slightly more robust by only access data if it exists.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread