### PR TITLE
Redirect back to content from paywall in new window

### DIFF
--- a/unlock-app/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
@@ -1,312 +1,427 @@
 import { openNewWindowModal, hideModal } from '../../actions/modal'
 import { setAccount } from '../../actions/accounts'
+import interWindowCommunicationMiddleware from '../../middlewares/interWindowCommunicationMiddleware'
+import { updateKey } from '../../actions/key'
 
 jest.mock('../../utils/localStorage')
-const interWindowCommunicationMiddleware = require('../../middlewares/interWindowCommunicationMiddleware')
-  .default
 
 describe('interWindowCommunicationMiddleware', () => {
+  const lock = '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+  const account = '0xaaaaa25a3e7Fb15263D0DD455B8aAfc08503bb54'
+
   describe('middleware functionality', () => {
-    it('does respond to OPEN_MODAL_IN_NEW_WINDOW if in an iframe', () => {
-      expect.assertions(2)
-      const next = jest.fn()
-
-      const action = openNewWindowModal()
-
-      const store = {
-        getState() {
-          return {
-            account: {
-              address: '0xabc',
-            },
-            router: {
-              location: {
-                pathname: '/paywall/',
+    describe('not in an iframe, running at /paywall in main window', () => {
+      it('does not respond to OPEN_MODAL_IN_NEW_WINDOW', () => {
+        expect.assertions(2)
+        const store = {
+          getState() {
+            return {
+              router: {
+                location: {
+                  pathname:
+                    '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
+                },
               },
+              account: {},
+              modals: {},
+            }
+          },
+        }
+
+        const next = jest.fn()
+
+        const action = openNewWindowModal()
+
+        const window = {
+          parent: {
+            contentWindow: {
+              postMessage: jest.fn(),
+              origin: 'origin',
             },
-          }
-        },
-        dispatch: jest.fn(),
-      }
+          },
+        }
+        window.self = window
+        window.top = window
 
-      const window = {
-        parent: {
-          postMessage: jest.fn(),
-          origin: 'origin',
-        },
-        addEventListener() {},
-      }
-      window.self = window
-      window.top = 'not window'
+        const middleware = interWindowCommunicationMiddleware(window)
 
-      const middleware = interWindowCommunicationMiddleware(window)
+        middleware(store)(next)(action)
 
-      middleware(store)(next)(action)
+        expect(next).toHaveBeenCalledWith(action)
+        expect(window.parent.contentWindow.postMessage).not.toHaveBeenCalled()
+      })
+      it('responds to HIDE_MODAL and redirects if present in the route url', () => {
+        expect.assertions(2)
+        const store = {
+          getState() {
+            return {
+              account: {
+                address: 'address',
+              },
+              router: {
+                location: {
+                  pathname:
+                    '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
+                },
+              },
+            }
+          },
+        }
 
-      expect(next).toHaveBeenCalledWith(action)
-      expect(window.parent.postMessage).toHaveBeenCalledWith(
-        'redirect',
-        'origin'
-      )
+        const next = jest.fn()
+
+        const action = hideModal()
+
+        const window = {
+          location: {
+            href: 'href',
+          },
+        }
+        window.self = window
+        window.top = window
+
+        const middleware = interWindowCommunicationMiddleware(window)
+
+        middleware(store)(next)(action)
+
+        expect(next).toHaveBeenCalledWith(action)
+        expect(window.location.href).toBe('http://hithere#address')
+      })
+      it('ignores HIDE_MODAL if redirect is not present in the route url', () => {
+        expect.assertions(2)
+        const store = {
+          getState() {
+            return {
+              account: {
+                address: '',
+              },
+              router: {
+                location: {
+                  pathname:
+                    '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+                },
+              },
+            }
+          },
+        }
+
+        const next = jest.fn()
+
+        const action = hideModal()
+
+        const window = {
+          location: {
+            href: 'href',
+          },
+          addEventListener() {},
+        }
+        window.self = window
+        window.top = window
+
+        const middleware = interWindowCommunicationMiddleware(window)
+
+        middleware(store)(next)(action)
+
+        expect(next).toHaveBeenCalledWith(action)
+        expect(window.location.href).toBe('href')
+      })
+      it('responds to UPDATE_KEY when not showing the modal, and redirects if present in the route url', () => {
+        expect.assertions(2)
+
+        const key = {
+          id: `${lock}-${account}`,
+          lock,
+          owner: account,
+          expiration: new Date().getTime() / 1000 + 10000,
+          data: null,
+        }
+
+        const store = {
+          getState() {
+            return {
+              account: {
+                address: account,
+              },
+              router: {
+                location: {
+                  pathname: `/paywall/${lock}/http%3a%2f%2fhithere`,
+                },
+              },
+              keys: {
+                [key.id]: key,
+              },
+              modals: {},
+            }
+          },
+        }
+
+        const next = jest.fn()
+
+        const action = updateKey(key.id, key)
+
+        const window = {
+          location: {
+            href: 'href',
+          },
+        }
+        window.self = window
+        window.top = window
+
+        const middleware = interWindowCommunicationMiddleware(window)
+
+        middleware(store)(next)(action)
+
+        expect(next).toHaveBeenCalledWith(action)
+        expect(window.location.href).toBe(`http://hithere#${account}`)
+      })
+      it('ignores UPDATE_KEY if redirect is not present in the route url', () => {
+        expect.assertions(2)
+        const store = {
+          getState() {
+            return {
+              account: {
+                address: '',
+              },
+              router: {
+                location: {
+                  pathname:
+                    '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+                },
+              },
+            }
+          },
+        }
+
+        const next = jest.fn()
+
+        const action = hideModal()
+
+        const window = {
+          location: {
+            href: 'href',
+          },
+          addEventListener() {},
+        }
+        window.self = window
+        window.top = window
+
+        const middleware = interWindowCommunicationMiddleware(window)
+
+        middleware(store)(next)(action)
+
+        expect(next).toHaveBeenCalledWith(action)
+        expect(window.location.href).toBe('href')
+      })
     })
-    it('does not respond to OPEN_MODAL_IN_NEW_WINDOW if not in an iframe', () => {
-      expect.assertions(2)
-      const store = {
-        getState() {},
-      }
+    describe("running in the iframe inside the publisher's content window", () => {
+      it('does respond to OPEN_MODAL_IN_NEW_WINDOW if in an iframe', () => {
+        expect.assertions(2)
+        const next = jest.fn()
 
-      const next = jest.fn()
+        const action = openNewWindowModal()
 
-      const action = openNewWindowModal()
+        const store = {
+          getState() {
+            return {
+              account: {
+                address: '0xabc',
+              },
+              router: {
+                location: {
+                  pathname:
+                    '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
+                },
+              },
+            }
+          },
+          dispatch: jest.fn(),
+        }
 
-      const window = {
-        parent: {
-          contentWindow: {
+        const window = {
+          parent: {
             postMessage: jest.fn(),
             origin: 'origin',
           },
-        },
-      }
-      window.self = window
-      window.top = window
+          addEventListener() {},
+        }
+        window.self = window
+        window.top = 'not window'
 
-      const middleware = interWindowCommunicationMiddleware(window)
+        const middleware = interWindowCommunicationMiddleware(window)
 
-      middleware(store)(next)(action)
+        middleware(store)(next)(action)
 
-      expect(next).toHaveBeenCalledWith(action)
-      expect(window.parent.contentWindow.postMessage).not.toHaveBeenCalled()
-    })
-    it('responds to HIDE_MODAL and redirects if present in the route url and in the main window', () => {
-      expect.assertions(2)
-      const store = {
-        getState() {
-          return {
-            account: {
-              address: 'address',
-            },
-            router: {
-              location: {
-                pathname:
-                  '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
+        expect(next).toHaveBeenCalledWith(action)
+        expect(window.parent.postMessage).toHaveBeenCalledWith(
+          'redirect',
+          'origin'
+        )
+      })
+      it('ignores HIDE_MODAL', () => {
+        expect.assertions(2)
+        const store = {
+          getState() {
+            return {
+              account: {
+                address: '0xabc',
               },
+              router: {
+                location: {
+                  pathname:
+                    '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
+                },
+              },
+            }
+          },
+        }
+
+        const next = jest.fn()
+
+        const action = hideModal()
+
+        const window = {
+          location: {
+            href: 'href',
+          },
+          addEventListener() {},
+        }
+        window.self = window
+        window.top = {}
+
+        const middleware = interWindowCommunicationMiddleware(window)
+
+        middleware(store)(next)(action)
+
+        expect(next).toHaveBeenCalledWith(action)
+        expect(window.location.href).toBe('href')
+      })
+      describe('no account present', () => {
+        describe('if account passed in URL hash', () => {
+          let store
+          let window
+          beforeEach(() => {
+            store = {
+              getState() {
+                return {
+                  account: null,
+                  router: {
+                    location: {
+                      pathname: `/paywall/${lock}#${account}`,
+                    },
+                  },
+                }
+              },
+              dispatch: jest.fn(),
+            }
+            window = {
+              localStorage: {
+                setItem: jest.fn(),
+                getItem: jest.fn(() => null),
+              },
+            }
+            window.self = window
+            window.top = {}
+          })
+          it('should dispatch SET_ACCOUNT', () => {
+            expect.assertions(1)
+            const middleware = interWindowCommunicationMiddleware(window)
+            middleware(store)(() => {})({})
+
+            expect(store.dispatch).toHaveBeenCalledWith(
+              setAccount({ address: account })
+            )
+          })
+          it('should save the account in localStorage', () => {
+            expect.assertions(1)
+            const middleware = interWindowCommunicationMiddleware(window)
+            middleware(store)(() => {})({})
+
+            expect(window.localStorage.setItem).toHaveBeenCalledWith(
+              '__unlock__account__',
+              account
+            )
+          })
+        })
+      })
+      describe('normal usage post-key purchase', () => {
+        let store
+        let window
+        beforeEach(() => {
+          store = {
+            getState() {
+              return {
+                account: null,
+                router: {
+                  location: {
+                    pathname: `/paywall/${lock}`,
+                  },
+                },
+              }
+            },
+            dispatch: jest.fn(),
+          }
+          window = {
+            localStorage: {
+              setItem: jest.fn(),
+              getItem: jest.fn(() => null),
             },
           }
-        },
-      }
+          window.self = window
+          window.top = {}
+        })
+        it('should dispatch SET_ACCOUNT if account is stored in localStorage', () => {
+          window.localStorage.getItem = jest.fn(() => account)
+          expect.assertions(2)
+          const middleware = interWindowCommunicationMiddleware(window)
+          middleware(store)(() => {})({})
 
-      const next = jest.fn()
+          expect(window.localStorage.getItem).toHaveBeenCalledWith(
+            '__unlock__account__'
+          )
+          expect(store.dispatch).toHaveBeenCalledWith(
+            setAccount({ address: account, fromLocalStorage: true })
+          )
+        })
+        it('should not dispatch SET_ACCOUNT if localStorage does not have an account', () => {
+          expect.assertions(2)
+          const middleware = interWindowCommunicationMiddleware(window)
+          middleware(store)(() => {})({})
 
-      const action = hideModal()
-
-      const window = {
-        location: {
-          href: 'href',
-        },
-      }
-      window.self = window
-      window.top = window
-
-      const middleware = interWindowCommunicationMiddleware(window)
-
-      middleware(store)(next)(action)
-
-      expect(next).toHaveBeenCalledWith(action)
-      expect(window.location.href).toBe('http://hithere#address')
-    })
-    it('ignores HIDE_MODAL in the iframe', () => {
-      expect.assertions(2)
-      const store = {
-        getState() {
-          return {
-            account: {
-              address: '0xabc',
-            },
-            router: {
-              location: {
-                pathname:
-                  '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
-              },
-            },
-          }
-        },
-      }
-
-      const next = jest.fn()
-
-      const action = hideModal()
-
-      const window = {
-        location: {
-          href: 'href',
-        },
-        addEventListener() {},
-      }
-      window.self = window
-      window.top = {}
-
-      const middleware = interWindowCommunicationMiddleware(window)
-
-      middleware(store)(next)(action)
-
-      expect(next).toHaveBeenCalledWith(action)
-      expect(window.location.href).toBe('href')
-    })
-    it('ignores HIDE_MODAL if redirect is not present in the route url and in the main window', () => {
-      expect.assertions(2)
-      const store = {
-        getState() {
-          return {
-            account: {
-              address: '',
-            },
-            router: {
-              location: {
-                pathname: '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-              },
-            },
-          }
-        },
-      }
-
-      const next = jest.fn()
-
-      const action = hideModal()
-
-      const window = {
-        location: {
-          href: 'href',
-        },
-        addEventListener() {},
-      }
-      window.self = window
-      window.top = window
-
-      const middleware = interWindowCommunicationMiddleware(window)
-
-      middleware(store)(next)(action)
-
-      expect(next).toHaveBeenCalledWith(action)
-      expect(window.location.href).toBe('href')
-    })
-    it('passes actions to the next middleware', () => {
-      expect.assertions(1)
-      const store = {
-        getState() {},
-      }
-
-      const next = jest.fn()
-
-      const action = {
-        type: 'boo',
-      }
-
-      const window = {}
-
-      const middleware = interWindowCommunicationMiddleware(window)
-
-      middleware(store)(next)(action)
-      expect(next).toHaveBeenCalledWith(action)
+          expect(window.localStorage.getItem).toHaveBeenCalledWith(
+            '__unlock__account__'
+          )
+          expect(store.dispatch).not.toHaveBeenCalled()
+        })
+      })
     })
   })
-  describe('if in the iframe with no account', () => {
-    const lock = '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54'
-    const account = '0xaaaaa25a3e7Fb15263D0DD455B8aAfc08503bb54'
-    describe('if account passed in URL hash', () => {
-      let store
-      let window
-      beforeEach(() => {
-        store = {
-          getState() {
-            return {
-              account: null,
-              router: {
-                location: {
-                  pathname: `/paywall/${lock}#${account}`,
-                },
-              },
-            }
+  it('passes actions to the next middleware', () => {
+    expect.assertions(1)
+    const store = {
+      getState() {
+        return {
+          router: {
+            location: {
+              pathname: '',
+            },
           },
-          dispatch: jest.fn(),
+          account: {},
+          modals: {},
         }
-        window = {
-          localStorage: {
-            setItem: jest.fn(),
-            getItem: jest.fn(() => null),
-          },
-        }
-        window.self = window
-        window.top = {}
-      })
-      it('should dispatch SET_ACCOUNT', () => {
-        expect.assertions(1)
-        const middleware = interWindowCommunicationMiddleware(window)
-        middleware(store)(() => {})({})
+      },
+    }
 
-        expect(store.dispatch).toHaveBeenCalledWith(
-          setAccount({ address: account })
-        )
-      })
-      it('should save the account in localStorage', () => {
-        expect.assertions(1)
-        const middleware = interWindowCommunicationMiddleware(window)
-        middleware(store)(() => {})({})
+    const next = jest.fn()
 
-        expect(window.localStorage.setItem).toHaveBeenCalledWith(
-          '__unlock__account__',
-          account
-        )
-      })
-    })
-    describe('normal usage post-key purchase', () => {
-      let store
-      let window
-      beforeEach(() => {
-        store = {
-          getState() {
-            return {
-              account: null,
-              router: {
-                location: {
-                  pathname: `/paywall/${lock}`,
-                },
-              },
-            }
-          },
-          dispatch: jest.fn(),
-        }
-        window = {
-          localStorage: {
-            setItem: jest.fn(),
-            getItem: jest.fn(() => null),
-          },
-        }
-        window.self = window
-        window.top = {}
-      })
-      it('should dispatch SET_ACCOUNT if account is stored in localStorage', () => {
-        window.localStorage.getItem = jest.fn(() => account)
-        expect.assertions(2)
-        const middleware = interWindowCommunicationMiddleware(window)
-        middleware(store)(() => {})({})
+    const action = {
+      type: 'boo',
+    }
 
-        expect(window.localStorage.getItem).toHaveBeenCalledWith(
-          '__unlock__account__'
-        )
-        expect(store.dispatch).toHaveBeenCalledWith(
-          setAccount({ address: account })
-        )
-      })
-      it('should not dispatch SET_ACCOUNT if localStorage does not have an account', () => {
-        expect.assertions(2)
-        const middleware = interWindowCommunicationMiddleware(window)
-        middleware(store)(() => {})({})
+    const window = {}
 
-        expect(window.localStorage.getItem).toHaveBeenCalledWith(
-          '__unlock__account__'
-        )
-        expect(store.dispatch).not.toHaveBeenCalled()
-      })
-    })
+    const middleware = interWindowCommunicationMiddleware(window)
+
+    middleware(store)(next)(action)
+    expect(next).toHaveBeenCalledWith(action)
   })
 })

--- a/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
+++ b/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
@@ -1,7 +1,7 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import { OPEN_MODAL_IN_NEW_WINDOW, HIDE_MODAL } from '../actions/modal'
-import { ADD_KEY, UPDATE_KEY } from '../actions/key'
+import { UPDATE_KEY } from '../actions/key'
 import { inIframe } from '../config'
 import { lockRoute } from '../utils/routes'
 import { setAccount } from '../actions/accounts'
@@ -13,8 +13,7 @@ function redirectToContentFromPaywall(window, getState) {
     account: { address },
   } = getState()
 
-  const { prefix, redirect } = lockRoute(router.location.pathname)
-  if (prefix !== 'paywall') return
+  const { redirect } = lockRoute(router.location.pathname)
   if (redirect) {
     window.location.href = redirect + '#' + address
   }
@@ -26,68 +25,79 @@ const interWindowCommunicationMiddleware = window => ({
   getState,
   dispatch,
 }) => {
+  let accountChecked = false
   const parent = window.parent
   const isInIframe = inIframe(window)
   return next => {
-    if (isInIframe) {
-      // if we are in the paywall on an iframe, account is not defined
-      // for coinbase wallet or trust wallet, and probably others.
-      // this checks the hash for a valid account and if found,
-      // sets our account to this account. This triggers retrieval
-      // of keys for that account, allowing the paywall to function
-      const { router, account } = getState()
-      if (!account) {
-        const { account: address } = lockRoute(router.location.pathname)
-        if (address) {
-          dispatch(setAccount({ address }))
-          // for subsequent accesses to paywalls, we save the user account in localStorage
-          // this is ONLY a stopgap until we can implement our own paywall-specific provider
-          if (localStorageAvailable(window)) {
-            window.localStorage.setItem('__unlock__account__', address)
-          }
-        } else if (localStorageAvailable(window)) {
-          // retrieve the stored account saved when the user purchased a key in the past
-          const storedAddress = window.localStorage.getItem(
-            '__unlock__account__'
+    return action => {
+      const { router, account, modals } = getState()
+      if (isInIframe && !accountChecked) {
+        accountChecked = true
+        // if we are in the paywall on an iframe, account is not defined
+        // for coinbase wallet or trust wallet, and probably others.
+        // this checks the hash for a valid account and if found,
+        // sets our account to this account. This triggers retrieval
+        // of keys for that account, allowing the paywall to function
+        if (!account) {
+          const { account: address } = lockRoute(
+            // we need the hash in order to retrieve the account from the iframe URL
+            router.location.pathname + router.location.hash
           )
-          if (storedAddress) {
-            dispatch(setAccount({ address: storedAddress }))
+          if (address) {
+            dispatch(setAccount({ address }))
+            // for subsequent accesses to paywalls, we save the user account in localStorage
+            // this is ONLY a stopgap until we can implement our own paywall-specific provider
+            if (localStorageAvailable(window)) {
+              window.localStorage.setItem('__unlock__account__', address)
+            }
+          } else {
+            if (localStorageAvailable(window)) {
+              // retrieve the stored account saved when the user purchased a key in the past
+              const storedAddress = window.localStorage.getItem(
+                '__unlock__account__'
+              )
+              if (storedAddress) {
+                dispatch(
+                  // the fromLocalStorage flag is needed for the overlay to know
+                  // that it should open a new window, even though the account
+                  // is set.
+                  setAccount({ address: storedAddress, fromLocalStorage: true })
+                )
+              }
+            }
           }
         }
       }
-    }
-    return action => {
-      const { router, account } = getState()
-      const { lockAddress } = lockRoute(router.location.pathname)
-      if (isInIframe && action.type === OPEN_MODAL_IN_NEW_WINDOW) {
-        parent.postMessage('redirect', parent.origin)
-      } else if (!isInIframe && action.type === HIDE_MODAL) {
-        // if the user clicks the button to go to content,
-        // we redirect back to the content, appending as a hash
-        // the user account. This is not sent to the server.
-        // then, the paywall.min.js script detects the hash
-        // and forwards it to the paywall in the iframe.
-        // the code at the top of this file handles that case
-        redirectToContentFromPaywall(window, getState)
-      } else if (
-        (!isInIframe && action.type === ADD_KEY) ||
-        action.type === UPDATE_KEY
-      ) {
-        next(action)
-        const state = getState()
-        const key = state.keys[action.id]
-        const modalsShowing = Object.keys(state.modals).length
-        if (
-          account &&
-          key.lock === lockAddress &&
-          key.owner === account.address &&
-          key.expiration &&
-          !modalsShowing
-        ) {
-          console.log(JSON.stringify(key), JSON.stringify(account), lockAddress)
+      const { lockAddress, prefix } = lockRoute(router.location.pathname)
+      if (prefix !== 'paywall') return next(action)
+      if (isInIframe) {
+        if (action.type === OPEN_MODAL_IN_NEW_WINDOW) {
+          parent.postMessage('redirect', parent.origin)
+        }
+      } else {
+        if (action.type === HIDE_MODAL) {
+          // if the user clicks the button to go to content,
+          // we redirect back to the content, appending as a hash
+          // the user account. This is not sent to the server.
+          // then, the paywall.min.js script detects the hash
+          // and forwards it to the paywall in the iframe.
+          // the code at the top of this file handles that case
           redirectToContentFromPaywall(window, getState)
         }
-        return
+        if (action.type === UPDATE_KEY) {
+          const {
+            update: { lock, expiration, owner },
+          } = action
+          if (
+            account &&
+            !modals[lockAddress] &&
+            owner === account.address &&
+            lock === lockAddress &&
+            expiration > new Date().getTime() / 1000
+          ) {
+            redirectToContentFromPaywall(window, getState)
+          }
+        }
       }
       next(action)
     }


### PR DESCRIPTION
# Description

This is probably the last step on the path to #1287, pending testing in coinbase wallet

This PR adds the missing redirect from the paywall in a new window back to the main window, both when the user dismisses the modal, and when returning to the paywall after a key has been purchased. In the latter case, it only redirects if it finds a non-expired key.

*brief description of the screencast:*
In this screencast, you will observe me changing the default demo URL to instead go directly to the paywall. Then, using a handy-dandy url encoding website, I encoded the demo URL that the paywall should return to, and popped it on the end of the url. This is how the return-to URL is passed to the paywall.  Then, I purchase a key, and click "go to content" and it redirects. Afterwards, I return to the paywall URL with the url-encoded redirect pasted on the end, and you can see that it returns to the content as well. In addition, you can see that it successfully appended the user account to the content url as a hash, which will trigger passing it to the paywall in the iframe, and then trigger retrieval of keys in wallet browsers that do not have the wallet available in the iframe.

![out](https://user-images.githubusercontent.com/98250/52499578-be149c80-2ba9-11e9-94c3-1a2a652019aa.gif)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
