### PR TITLE
make sure we open a new window when retrieving account from localStorage

### DIFF
--- a/unlock-app/src/__tests__/components/lock/Overlay.test.js
+++ b/unlock-app/src/__tests__/components/lock/Overlay.test.js
@@ -38,7 +38,7 @@ describe('Overlay', () => {
   })
   describe('mapStateToProps', () => {
     it('should set openInNewWindow based on the value of account', () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       const state1 = {
         account: null,
@@ -48,13 +48,23 @@ describe('Overlay', () => {
           address: 'account',
         },
       }
+      const state3 = {
+        account: {
+          address: 'account',
+          fromLocalStorage: true,
+        },
+      }
 
       expect(mapStateToProps(state1)).toEqual({
         openInNewWindow: true,
       })
 
       expect(mapStateToProps(state2)).toEqual({
-        openInNewWindow: false,
+        openInNewWindow: undefined,
+      })
+
+      expect(mapStateToProps(state3)).toEqual({
+        openInNewWindow: true,
       })
     })
   })

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -77,7 +77,7 @@ Overlay.propTypes = {
 }
 
 export const mapStateToProps = ({ account }) => ({
-  openInNewWindow: !account,
+  openInNewWindow: !account || account.fromLocalStorage,
 })
 
 export const mapDispatchToProps = (dispatch, { locks }) => ({


### PR DESCRIPTION
# Description

Add support for checking whether the account came from localStorage when deciding whether to pop open a new window for the paywall (spoiler alert: we have to)

This is a step on the final path to #1287

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
