### PR TITLE
fix regexp for detecting account

### DIFF
--- a/unlock-app/src/__tests__/utils/routes.test.js
+++ b/unlock-app/src/__tests__/utils/routes.test.js
@@ -68,6 +68,16 @@ describe('lockRoute', () => {
       redirect: 'http://hithere',
       account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
     })
+    expect(
+      lockRoute(
+        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+      )
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: undefined,
+      account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+    })
   })
   it('should ignore malformed account parameter', () => {
     expect(

--- a/unlock-app/src/__tests__/utils/routes.test.js
+++ b/unlock-app/src/__tests__/utils/routes.test.js
@@ -29,6 +29,7 @@ describe('lockRoute', () => {
       lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
       prefix: 'lock',
       redirect: undefined,
+      account: undefined,
     })
 
     expect(
@@ -37,6 +38,7 @@ describe('lockRoute', () => {
       lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
       prefix: 'paywall',
       redirect: undefined,
+      account: undefined,
     })
     expect(
       lockRoute('/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
@@ -44,6 +46,7 @@ describe('lockRoute', () => {
       lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
       prefix: 'demo',
       redirect: undefined,
+      account: undefined,
     })
   })
   it('should return the correct redirect parameter when it matches', () => {

--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -46,7 +46,7 @@ export const TRANSACTION_TYPES = {
  *
  * You should not use this directly, instead use the utils/routes.js lockRoute function
  */
-export const LOCK_PATH_NAME_REGEXP = /\/([a-z0-9]+)\/(0x[a-fA-F0-9]{40})(\/([^#]+))?(#(0x[a-fA-F0-9]{40}))?/
+export const LOCK_PATH_NAME_REGEXP = /\/([a-z0-9]+)\/(0x[a-fA-F0-9]{40})(\/([^#]+))?(\/?#(0x[a-fA-F0-9]{40}))?/
 /**
  * Matches any valid ethereum account address
  */

--- a/unlock-app/src/constants.js
+++ b/unlock-app/src/constants.js
@@ -34,6 +34,20 @@ export const TRANSACTION_TYPES = {
   UPDATE_KEY_PRICE: 'UPDATE_KEY_PRICE',
 }
 
+// used in defining the helpers for LOCK_PATH_NAME_REGEXP and ACCOUNT_REGEXP
+const accountRegex = '0x[a-fA-F0-9]{40}'
+
+/**
+ * Matches any valid ethereum account address
+ */
+export const ACCOUNT_REGEXP = new RegExp(accountRegex)
+
+// helpers for the LOCK_PATH_NAME_REGEXP
+const prefix = '[a-z0-9]+'
+const urlEncodedRedirectUrl = '[^#?]+'
+const userAccount = accountRegex
+const lockAddress = accountRegex
+
 /**
  * This regexp matches several important parameters passed in the url for the demo and paywall pages.
  *
@@ -46,11 +60,12 @@ export const TRANSACTION_TYPES = {
  *
  * You should not use this directly, instead use the utils/routes.js lockRoute function
  */
-export const LOCK_PATH_NAME_REGEXP = /\/([a-z0-9]+)\/(0x[a-fA-F0-9]{40})(\/([^#]+))?(\/?#(0x[a-fA-F0-9]{40}))?/
-/**
- * Matches any valid ethereum account address
- */
-export const ACCOUNT_REGEXP = /0x[a-fA-F0-9]{40}/
+export const LOCK_PATH_NAME_REGEXP = new RegExp(
+  `/(${prefix})/(${lockAddress})` +
+    // either "/urlEncodedRedirectUrl/#account" or just "#account" and these are all optional
+    // note that "/#account" as in "/paywall/<lockaddress>/#<useraccount>" is also matched
+    `(?:/(${urlEncodedRedirectUrl}))?(?:/?#(${userAccount}))?`
+)
 
 export const PAGE_DESCRIPTION =
   'Unlock is a protocol which enables creators to monetize their content with a few lines of code in a fully decentralized way.'

--- a/unlock-app/src/utils/routes.js
+++ b/unlock-app/src/utils/routes.js
@@ -19,8 +19,8 @@ export const lockRoute = path => {
   return {
     lockAddress: match[2],
     prefix: match[1],
-    redirect: match[4] && decodeURIComponent(match[4]),
-    account: match[6],
+    redirect: match[3] && decodeURIComponent(match[3]),
+    account: match[4],
   }
 }
 


### PR DESCRIPTION
# Description

The lock regexp did not allow a trailing slash before the `#` and so was failing to detect the hash in the paywall. This fixes that and adds a regression test

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
