### PR TITLE
detect account changes

### DIFF
--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -3,7 +3,6 @@
 import EventEmitter from 'events'
 import nock from 'nock'
 import Web3Utils from 'web3-utils'
-import WalletService from '../../services/walletService'
 import UnlockContract from '../../artifacts/contracts/Unlock.json'
 import LockContract from '../../artifacts/contracts/PublicLock.json'
 import configure from '../../config'
@@ -16,6 +15,11 @@ import {
   FAILED_TO_UPDATE_KEY_PRICE,
   FAILED_TO_WITHDRAW_FROM_LOCK,
 } from '../../errors'
+import { POLLING_INTERVAL } from '../../constants'
+
+jest.mock('../../utils/promises')
+const WalletService = require('../../services/walletService').default
+const delay = require('../../utils/promises').delayPromise
 
 const nockScope = nock('http://127.0.0.1:8545', { encodedQueryParams: true })
 
@@ -55,15 +59,62 @@ nock.emitter.on('no match', function(clientRequestObject, options, body) {
 })
 
 let walletService
+let config
 let providers
 
 describe('WalletService', () => {
   beforeEach(() => {
     nock.cleanAll()
-    providers = configure().providers
-    walletService = new WalletService(providers)
+    config = configure()
+    providers = config.providers
+    // the second argument is designed to stop the polling loop in the majority of tests
+    walletService = new WalletService(config, false)
   })
+  describe('pollAccount', () => {
+    it('constructor calls timeout with pollAccount when ready', () => {
+      walletService = new WalletService(config)
+      expect.assertions(2)
+      walletService.checkForAccountChange = jest.fn(() =>
+        Promise.resolve('account')
+      )
 
+      walletService.emit('ready')
+      expect(walletService.ready).toBe(true)
+      expect(delay).toHaveBeenCalledWith(POLLING_INTERVAL)
+    })
+
+    it('pollAccount calls checkForAccountChange and timeout', async () => {
+      const isServer = false
+      walletService.account = 'old account'
+
+      walletService.checkForAccountChange = jest.fn(() =>
+        Promise.resolve('thank u, next')
+      )
+
+      await walletService.pollForAccountChange(isServer, false)
+
+      expect(delay).toHaveBeenCalledWith(POLLING_INTERVAL)
+      expect(walletService.checkForAccountChange).toHaveBeenCalledWith(
+        'old account'
+      )
+
+      expect(walletService.account).toBe('thank u, next')
+    })
+    it('pollAccount does not run on the server', async () => {
+      const isServer = true
+      walletService.account = 'old account'
+
+      walletService.checkForAccountChange = jest.fn(() =>
+        Promise.resolve('thank u, next')
+      )
+
+      await walletService.pollForAccountChange(isServer, false)
+
+      expect(walletService.checkForAccountChange).not.toHaveBeenCalled()
+
+      expect(walletService.account).toBe('old account')
+    })
+  })
   describe('connect', () => {
     it('should get the network id', done => {
       expect.assertions(1)
@@ -205,6 +256,42 @@ describe('WalletService', () => {
       return walletService.connect('HTTP')
     })
 
+    describe('checkForAccountChange', () => {
+      it('should emit account.changed if the account does not match the local account', async () => {
+        expect.assertions(1)
+        const unlockAccountsOnNode = [
+          '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+        ]
+
+        accountsAndYield(unlockAccountsOnNode)
+
+        walletService.emit = jest.fn()
+
+        await walletService.checkForAccountChange('prior')
+
+        expect(walletService.emit).toHaveBeenCalledWith(
+          'account.changed',
+          '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+        )
+      })
+
+      it('should not emit account.changed if the account does match the local account', async () => {
+        expect.assertions(1)
+        const unlockAccountsOnNode = [
+          '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+        ]
+
+        accountsAndYield(unlockAccountsOnNode)
+
+        walletService.emit = jest.fn()
+
+        await walletService.checkForAccountChange(
+          '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+        )
+
+        expect(walletService.emit).not.toHaveBeenCalled()
+      })
+    })
     describe('getAccount', () => {
       describe('when no account was passed but the node has an unlocked account', () => {
         it('should load a local account and emit the ready event', done => {

--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -153,22 +153,51 @@ describe('WalletService', () => {
       walletService.connect('AnotherProvider')
     })
 
-    it('should emit an error event when the smart contract has not been deployed on this network', done => {
-      expect.assertions(3)
+    describe('smart contract has not been deployed on this network', () => {
+      it('should not emit an error event when we have a contract address from config', done => {
+        expect.assertions(3)
+        config.unlockAddress = '0x1234567890123456789012345678901234567890'
+        const walletService2 = new WalletService(config, false)
 
-      expect(walletService.ready).toBe(false)
-      UnlockContract.networks = {}
+        expect(walletService2.ready).toBe(false)
 
-      const netVersion = Math.floor(Math.random() * 100000)
-      netVersionAndYield(netVersion)
+        const netVersion = Math.floor(Math.random() * 100000)
+        netVersionAndYield(netVersion)
 
-      expect(walletService.ready).toBe(false)
-      walletService.on('error', error => {
-        expect(error.message).toBe(NON_DEPLOYED_CONTRACT)
-        done()
+        expect(walletService2.ready).toBe(false)
+
+        expect(walletService2.unlockContractAddress).toBe(
+          '0x1234567890123456789012345678901234567890'
+        )
+
+        walletService2.on('error', error => {
+          expect(error).toBe('should not error')
+          done()
+        })
+        walletService2.on('network.changed', () => {
+          done()
+        })
+
+        walletService2.connect('HTTP')
       })
 
-      walletService.connect('HTTP')
+      it('should emit an error event when there is no config-provided contract address', done => {
+        expect.assertions(3)
+
+        expect(walletService.ready).toBe(false)
+        UnlockContract.networks = {}
+
+        const netVersion = Math.floor(Math.random() * 100000)
+        netVersionAndYield(netVersion)
+
+        expect(walletService.ready).toBe(false)
+        walletService.on('error', error => {
+          expect(error.message).toBe(NON_DEPLOYED_CONTRACT)
+          done()
+        })
+
+        walletService.connect('HTTP')
+      })
     })
 
     it('should silently ignore requests to connect again to the same provider', done => {

--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -6,6 +6,8 @@ import Web3Utils from 'web3-utils'
 import UnlockContract from '../../artifacts/contracts/Unlock.json'
 import LockContract from '../../artifacts/contracts/PublicLock.json'
 import configure from '../../config'
+import { delayPromise } from '../../utils/promises'
+import WalletService from '../../services/walletService'
 import {
   NOT_ENABLED_IN_PROVIDER,
   MISSING_PROVIDER,
@@ -18,8 +20,6 @@ import {
 import { POLLING_INTERVAL } from '../../constants'
 
 jest.mock('../../utils/promises')
-const WalletService = require('../../services/walletService').default
-const delay = require('../../utils/promises').delayPromise
 
 const nockScope = nock('http://127.0.0.1:8545', { encodedQueryParams: true })
 
@@ -80,7 +80,9 @@ describe('WalletService', () => {
 
       walletService.emit('ready')
       expect(walletService.ready).toBe(true)
-      expect(delay).toHaveBeenCalledWith(POLLING_INTERVAL)
+
+      // delayPromise is a jest.fn() in the mock file
+      expect(delayPromise).toHaveBeenCalledWith(POLLING_INTERVAL)
     })
 
     it('pollAccount calls checkForAccountChange and timeout', async () => {
@@ -93,7 +95,8 @@ describe('WalletService', () => {
 
       await walletService.pollForAccountChange(isServer, false)
 
-      expect(delay).toHaveBeenCalledWith(POLLING_INTERVAL)
+      // delayPromise is a jest.fn() in the mock file
+      expect(delayPromise).toHaveBeenCalledWith(POLLING_INTERVAL)
       expect(walletService.checkForAccountChange).toHaveBeenCalledWith(
         'old account'
       )

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -30,11 +30,8 @@ export default class WalletService extends EventEmitter {
     pollForAccountChanges = true
   ) {
     super()
-    if (unlockAddress.length) {
+    if (unlockAddress) {
       this.unlockContractAddress = Web3Utils.toChecksumAddress(unlockAddress)
-    } else {
-      // this will be set to the correct address in connect
-      this.unlockContractAddress = ''
     }
     this.providers = providers
     this.ready = false
@@ -87,16 +84,15 @@ export default class WalletService extends EventEmitter {
     const networkId = await this.web3.eth.net.getId()
     // unlockContractAddress is set in the constructor if config provides one in unlockAddress
     // this is set for staging and production
-    if (
-      !this.unlockContractAddress.length &&
-      UnlockContract.networks[networkId]
-    ) {
-      // If we do not have an address from config let's use the artifact files
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(
-        UnlockContract.networks[networkId].address
-      )
-    } else {
-      return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
+    if (!this.unlockContractAddress) {
+      if (UnlockContract.networks[networkId]) {
+        // If we do not have an address from config let's use the artifact files
+        this.unlockContractAddress = Web3Utils.toChecksumAddress(
+          UnlockContract.networks[networkId].address
+        )
+      } else {
+        return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
+      }
     }
 
     if (this.networkId !== networkId) {

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -13,8 +13,8 @@ import {
   FAILED_TO_UPDATE_KEY_PRICE,
   FAILED_TO_WITHDRAW_FROM_LOCK,
 } from '../errors'
-
-const { providers, unlockAddress } = configure()
+import { POLLING_INTERVAL } from '../constants'
+import { delayPromise } from '../utils/promises'
 
 export const keyId = (lock, owner) => [lock, owner].join('-')
 
@@ -25,15 +25,24 @@ export const keyId = (lock, owner) => [lock, owner].join('-')
  * actually retrieving the data from the chain/smart contracts
  */
 export default class WalletService extends EventEmitter {
-  constructor(availableProviders = providers) {
+  constructor(
+    { providers, runningOnServer, unlockAddress } = configure(),
+    pollForAccountChanges = true
+  ) {
     super()
-    this.providers = availableProviders
+    if (unlockAddress) {
+      this.unlockContractAddress = Web3Utils.toChecksumAddress(unlockAddress)
+    }
+    this.providers = providers
     this.ready = false
     this.providerName = null
     this.web3 = null
 
     this.on('ready', () => {
       this.ready = true
+      if (pollForAccountChanges) {
+        this.pollForAccountChange(runningOnServer)
+      }
     })
   }
 
@@ -73,9 +82,7 @@ export default class WalletService extends EventEmitter {
     this.web3 = new Web3(provider)
 
     const networkId = await this.web3.eth.net.getId()
-    if (unlockAddress) {
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(unlockAddress)
-    } else if (UnlockContract.networks[networkId]) {
+    if (!this.unlockContractAddress && UnlockContract.networks[networkId]) {
       // If we do not have an address from config let's use the artifact files
       this.unlockContractAddress = Web3Utils.toChecksumAddress(
         UnlockContract.networks[networkId].address
@@ -91,23 +98,65 @@ export default class WalletService extends EventEmitter {
   }
 
   /**
+   * Poll to see if account has changed
+   */
+  async pollForAccountChange(isServer, pollForNextChange = true) {
+    if (isServer) return
+    await delayPromise(POLLING_INTERVAL)
+    try {
+      this.account = await this.checkForAccountChange(this.account)
+    } catch (e) {
+      // if the account poll fails, silently ignore it
+      // TODO: log the error when full-app logging is implemented (#1301)
+    }
+    // because this is async, the call stack is not affected, and does not grow
+    // for a non-async function this would quickly fill all available memory
+    if (pollForNextChange) {
+      this.pollForAccountChange()
+    }
+  }
+
+  /**
+   * given the prior account address, determine if the account has changed and return the
+   * current address regardless of any change
+   */
+  async checkForAccountChange(currentAccount) {
+    const nextAccount = await this._getAccountAddressOrFallbackAddress(
+      // When retrieving the current account address, there is an
+      // option to fallback to another method when the account is null.
+      // In our case, we do not want to do anything, so our fallback
+      // is simply a promise that resolves to a missing account
+      Promise.resolve(null)
+    )
+
+    if (currentAccount !== nextAccount) {
+      this.emit('account.changed', nextAccount)
+    }
+    return nextAccount
+  }
+
+  /**
    * Function which yields the address of the account on the provider or creates a key pair.
    */
-  getAccount() {
-    const getOrCreateAccount = this.web3.eth.getAccounts().then(accounts => {
-      if (accounts.length === 0) {
-        return this._createAccount()
-      } else {
-        return Promise.resolve(accounts[0]) // defaults to the first account for now
-      }
-    })
-
+  async getAccount() {
     // Once we have the account, let's refresh it!
-    return getOrCreateAccount.then(address => {
-      this.emit('account.changed', address)
-      this.emit('ready')
-      return address
-    })
+    const address = await this._getAccountAddressOrFallbackAddress(
+      this._createAccount
+    )
+    this.emit('account.changed', address)
+    this.emit('ready')
+    return Promise.resolve(address)
+  }
+
+  /**
+   * Get the current user account address, calling a fallback if there is none
+   * @param fallback async function that returns an account address
+   * @return string
+   */
+  async _getAccountAddressOrFallbackAddress(fallback) {
+    const accounts = await this.web3.eth.getAccounts()
+    const address = accounts.length ? accounts[0] : await fallback()
+    return address
   }
 
   /**
@@ -116,12 +165,9 @@ export default class WalletService extends EventEmitter {
    * @return Promise<string>
    * @private
    */
-  _createAccount() {
-    return new Promise(resolve => {
-      return resolve(this.web3.eth.accounts.create())
-    }).then(account => {
-      return account.address
-    })
+  async _createAccount() {
+    const account = await this.web3.eth.accounts.create()
+    return account.address
   }
 
   /**

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -30,8 +30,11 @@ export default class WalletService extends EventEmitter {
     pollForAccountChanges = true
   ) {
     super()
-    if (unlockAddress) {
+    if (unlockAddress.length) {
       this.unlockContractAddress = Web3Utils.toChecksumAddress(unlockAddress)
+    } else {
+      // this will be set to the correct address in connect
+      this.unlockContractAddress = ''
     }
     this.providers = providers
     this.ready = false
@@ -82,7 +85,12 @@ export default class WalletService extends EventEmitter {
     this.web3 = new Web3(provider)
 
     const networkId = await this.web3.eth.net.getId()
-    if (!this.unlockContractAddress && UnlockContract.networks[networkId]) {
+    // unlockContractAddress is set in the constructor if config provides one in unlockAddress
+    // this is set for staging and production
+    if (
+      !this.unlockContractAddress.length &&
+      UnlockContract.networks[networkId]
+    ) {
       // If we do not have an address from config let's use the artifact files
       this.unlockContractAddress = Web3Utils.toChecksumAddress(
         UnlockContract.networks[networkId].address

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -139,7 +139,6 @@ export default class WalletService extends EventEmitter {
    * Function which yields the address of the account on the provider or creates a key pair.
    */
   async getAccount() {
-    // Once we have the account, let's refresh it!
     const address = await this._getAccountAddressOrFallbackAddress(
       this._createAccount
     )

--- a/unlock-app/src/utils/__mocks__/promises.js
+++ b/unlock-app/src/utils/__mocks__/promises.js
@@ -1,0 +1,12 @@
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * note: tried a few other ways of doing this.
+ * 1. importing the delayPromise from promises and using that (causes stack overflow in tests)
+ * 2. just mocking it out with ms => Promise.resolve(ms) (stack overflow)
+ *
+ * This is the only solution that works
+ */
+export const delayPromise = jest.fn(function delayPromise(ms) {
+  return new Promise(resolve => setTimeout(resolve.bind(null, ms), ms))
+})


### PR DESCRIPTION
# Description

This PR is almost the same as #1361 but this time without breaking staging or (presumably) production. It fixes #1242

The difference from #1361 is that this one does not emit an error if the `unlockAddress` was pulled from config and the `UnlockContract` artifact also does not have a contract address for the network. The code in question is line 87 in `walletService.js`:

```js
    if (!this.unlockContractAddress) {
      if (UnlockContract.networks[networkId]) {
        // If we do not have an address from config let's use the artifact files
        this.unlockContractAddress = Web3Utils.toChecksumAddress(
          UnlockContract.networks[networkId].address
        )
      } else {
        return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
      }
    }
```

The original code was:

```js
    if (!this.unlockContractAddress && UnlockContract.networks[networkId]) {
      // If we do not have an address from config let's use the artifact files
      this.unlockContractAddress = Web3Utils.toChecksumAddress(
        UnlockContract.networks[networkId].address
      )
    } else {
      return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
    }
```

This will immediately jump to the error if `this.unlockContractAddress` is set, which is not the intended behavior.

I added a test that replicated this failing behavior before coding the fix, which turned the test green.

Before submitting the PR, I verified that the branch netlify build worked. URL is pasted on the bottom of the checklist for you to click and verify prior to approving. Screenshot with URL visible:

<img width="1677" alt="screen shot 2019-02-08 at 9 46 04 pm" src="https://user-images.githubusercontent.com/98250/52515544-0607e380-2beb-11e9-85e3-817457d9fa5b.png">

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
- [X] if my code touches any service, I have verified that staging works. Link to the custom build is pasted here: [https://5c5e3eb60a805da1c93af658--unlock-staging.netlify.com/dashboard/](https://5c5e3eb60a805da1c93af658--unlock-staging.netlify.com/dashboard/)

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
