### PR TITLE
Updates greenkeeper configuration, removing emoji characters

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -4,9 +4,7 @@
       "packages": [
         "package.json",
         "smart-contracts/package.json",
-        "unlock-app/package.json",
-        "unlock-branding/package.json",
-        "unlock-protocol.com/package.json"
+        "unlock-app/package.json"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,12 @@
     "type": "git",
     "url": "git+https://github.com/unlock-protocol/unlock.git"
   },
+  "greenkeeper" : {
+    "prTitles" : {
+      "basicPR": "Update ${dependency} to the latest version",
+      "groupPR": "Update ${dependency} in group ${group} to the latest version"
+    }
+  },
   "author": "",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
On Feb 6, 2019 we encountered an issue of a master build failing at the deployment step.  After some light investigation, this was attributed to an emoji character being used in the commit message 

This appears to be a somewhat known issue:
* https://forums.aws.amazon.com/thread.jspa?messageID=830285&tstart=0
* https://twitter.com/wesbos/status/834440991352434688

Greenkeeper provided the functionality to address this here: https://github.com/greenkeeperio/greenkeeper/issues/834

This Pull request utilizes the functionality to help ensure that pull request with emoji characters utilized as commit messages will not break out builds.

* Removes configuration for directories that no longer exist
* Updating pull request messages to no longer include emoji characters



# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
