### PR TITLE
Adds additional basic test to cover the homepage

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -41,6 +41,7 @@ services:
     user: node
     environment:
       - UNLOCK_HOST=unlock
+      - CI=true
     depends_on:
       - ganache
       - unlock

--- a/tests/helpers/environment.js
+++ b/tests/helpers/environment.js
@@ -2,6 +2,7 @@ const net = require('net')
 const PuppeteerEnvironment = require('jest-environment-puppeteer')
 
 const port = process.env.UNLOCK_PORT || 3000
+const ci = process.env.CI
 
 /**
  * This is a helper function to ensure that we start the test suite only when the server is up
@@ -36,7 +37,9 @@ const serverIsUp = (delay, maxAttempts) => new Promise((resolve, reject) => {
 class UnlockEnvironment extends PuppeteerEnvironment {
   async setup() {
     await super.setup()
-    await serverIsUp(1000 /* every second */, 120 /* up to 2 minutes */)
+    if (ci) {
+      await serverIsUp(1000 /* every second */, 120 /* up to 2 minutes */)
+    }
   }
 
   async teardown() {

--- a/tests/test/home.test.js
+++ b/tests/test/home.test.js
@@ -1,11 +1,25 @@
 const url = require('../helpers/url')
 
 describe('Unlock', () => {
-
   it('should display "unlock" text on page', async () => {
-    jest.setTimeout(100000)
     const page = await browser.newPage()
     await page.goto(url('/'))
     await expect(page).toMatch('Unlock')
+  })
+
+  it('should display a go to dashboard button on the page', async () => {
+    const page = await browser.newPage()
+    await page.goto(url('/'))
+    const button = await page.waitFor('button')
+    await expect(button).toMatch('Go to Your Dashboard')
+  })
+
+  it('should display the Terms of Service and Privacy Policy links when tapping through to the dashboard', async () => {
+    const page = await browser.newPage()
+    await page.goto(url('/'))
+    const button = await page.waitFor('button')
+    await button.click()
+    await expect(page).toMatch('Terms of Service')
+    await expect(page).toMatch('Privacy Policy')
   })
 })


### PR DESCRIPTION
This pull request adds two integration test, getting the ball rolling on our coverage. These tests are simple but provide coverage to home page.

In addition this pull request makes a slight adjustment to the configuration of integration tests setup to ensure that test can be run locally.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
