### PR TITLE
Updating gas amount associated with lock creation

### DIFF
--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -552,7 +552,7 @@ describe('WalletService', () => {
             to: walletService.unlockContractAddress,
             from: owner,
             data,
-            gas: 2000000,
+            gas: 2500000,
             contract: UnlockContract,
           },
           expect.any(Function)

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -48,7 +48,7 @@ export default function storageMiddleware({ getState, dispatch }) {
       if (action.type === UPDATE_LOCK) {
         // Only look up the name for a lock for which the name is empty/not-set
         const lock = getState().locks[action.address]
-        if (!lock.name) {
+        if (lock && !lock.name) {
           storageService.lockLookUp(action.address).then(name => {
             dispatch(updateLock(action.address, { name }))
           })

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -47,6 +47,20 @@ export default class WalletService extends EventEmitter {
   }
 
   /**
+   * Expooses gas amount constants to be utilzed when sending relevant transactions
+   * for the platform.
+   */
+
+  static gasAmountConstants() {
+    return {
+      createLock: 2500000,
+      updateKeyPrice: 1000000,
+      purchaseKey: 1000000,
+      withdrawFromLock: 1000000,
+    }
+  }
+
+  /**
    * This connects to the web3 service and listens to new blocks
    * @param {string} providerName
    * @return
@@ -217,7 +231,7 @@ export default class WalletService extends EventEmitter {
         to: lock,
         from: account,
         data,
-        gas: 1000000,
+        gas: WalletService.gasAmountConstants().updateKeyPrice,
         contract: LockContract,
       },
       error => {
@@ -252,7 +266,7 @@ export default class WalletService extends EventEmitter {
         to: this.unlockContractAddress,
         from: owner,
         data,
-        gas: 2000000,
+        gas: WalletService.gasAmountConstants().createLock,
         contract: UnlockContract,
       },
       (error, hash) => {
@@ -292,7 +306,7 @@ export default class WalletService extends EventEmitter {
         to: lock,
         from: account,
         data: abi,
-        gas: 1000000,
+        gas: WalletService.gasAmountConstants().purchaseKey,
         value: Web3Utils.toWei(keyPrice, 'ether'),
         contract: LockContract,
       },
@@ -319,7 +333,7 @@ export default class WalletService extends EventEmitter {
         to: lock,
         from: account,
         data,
-        gas: 1000000,
+        gas: WalletService.gasAmountConstants().withdrawFromLock,
         contract: LockContract,
       },
       error => {


### PR DESCRIPTION
As a resolution to #1509 we are increasing the amount of gas associated with lock creation. 

There was an adjustment to the contract increasing the amount of gas required. 

> createLock takes just over 2m gas (my tests show 2,062,266 - 2,084,111).  The v0 contract took about 1,645,188 to accomplish the same.  So if there's a cap on the call, it should be raised to maybe 2.5m

A small potential bug was snagged along the way.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
