### PR TITLE
Adds  disableLock and deleteLock functionality

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -54,12 +54,11 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   );
 
   event Destroy(
-    address lock,
     uint balance,
-    address owner
+    address indexed owner
   );
 
-  event Disable(address lock);
+  event Disable();
 
   // Fields
   // Unlock Protocol address
@@ -181,7 +180,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
 
   // Only allow usage when contract is Alive
   modifier onlyIfAlive() {
-    require(isAlive, "No access after contract has been deprecated");
+    require(isAlive, "No access after contract has been disabled");
     _;
   }
 
@@ -396,6 +395,33 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   }
 
   /**
+  * @dev Used to disable lock before migrating keys and/or destroying contract
+   */
+  function disableLock()
+    external
+    onlyOwner
+    onlyIfAlive
+  {
+    emit Disable();
+    isAlive = false;
+  }
+
+  /**
+  * @dev Used to clean up old lock contracts from the blockchain
+  * TODO: add a check to ensure all keys are INVALID!
+   */
+  function destroyLock()
+    external
+    onlyOwner
+  {
+    require(isAlive == false, "Not allowed to delete an active lock");
+    emit Destroy(this.balance, msg.sender);
+    selfdestruct(msg.sender);
+    // Note we don't clean up the `locks` data in Unlock.sol as it should not be necessary
+    // and leaves some data behind ("Unlock.LockBalances") which may be helpful.
+  }
+
+  /**
    * In the specific case of a Lock, each owner can own only at most 1 key.
    * @return The number of NFTs owned by `_owner`, either 0 or 1.
   */
@@ -468,30 +494,6 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
     returns (address)
   {
     return _getApproved(_tokenId);
-  }
-
-  function disableLock()
-    external
-    onlyOwner
-    onlyIfAlive
-  {
-    emit Disable(address(this));
-    isAlive = false;
-  }
-
-  /**
-  * @dev Used to clean up old lock contracts from the blockchain
-  * TODO: add a check to ensure all keys are INVALID!
-   */
-  function destroyLock()
-    external
-    onlyOwner
-  {
-    require(isAlive == false, "Not allowed to delete an active lock");
-    emit Destroy(address(this), this.balance, msg.sender);
-    selfdestruct(msg.sender);
-    // Note we don't clean up the `locks` data in Unlock.sol as it should not be necessary
-    // and leaves some data behind which may be helpful.
   }
 
   /**

--- a/smart-contracts/contracts/interfaces/ILockCore.sol
+++ b/smart-contracts/contracts/interfaces/ILockCore.sol
@@ -14,7 +14,7 @@ interface ILockCore {
   */
   function purchaseFor(
     address _recipient,
-    bytes _data
+    bytes  _data
   )
     external
     payable;
@@ -28,11 +28,11 @@ interface ILockCore {
   function purchaseForFrom(
     address _recipient,
     address _referrer,
-    bytes _data
+    bytes  _data
   )
     external
     payable;
-    
+
   /**
    * @dev Destroys the user's key and sends a refund based on the amount of time remaining.
    */
@@ -71,10 +71,30 @@ interface ILockCore {
     external;
 
   /**
+  * @dev Used to disable lock before migrating keys and/or destroying contract.
+  * @dev Reverts if called by anyone but the owner.
+  * @dev Reverts if isAlive == false
+  * @dev Should emit Disable event.
+  */
+  function disableLock(
+  )
+    external;
+
+  /**
+  * @dev Used to clean up old lock contracts from the blockchain by using selfdestruct.
+  * @dev Reverts if called by anyone but the owner.
+  * @dev Reverts if isAlive == true
+  * @dev Should emit Destroy event.
+   */
+  function destroyLock(
+  )
+    external;
+
+  /**
    * @dev Determines how much of a refund a key owner would receive if they issued
-   * a cancelAndRefund now.  
+   * a cancelAndRefund now.
    * @param _owner The owner of the key check the refund value for.
-   * Note that due to the time required to mine a tx, the actual refund amount will be lower 
+   * Note that due to the time required to mine a tx, the actual refund amount will be lower
    * than what the user reads from this call.
    */
   function getCancelAndRefundValueFor(
@@ -120,7 +140,7 @@ interface ILockCore {
   )
     external
     view
-    returns (bytes data);
+    returns (bytes memory data);
 
   /**
   * @dev Returns the key's ExpirationTimestamp field for a given owner.
@@ -143,5 +163,5 @@ interface ILockCore {
   )
     external
     view
-    returns (address[]);
+    returns (address[] memory);
 }

--- a/smart-contracts/test/Lock/destroyLock.js
+++ b/smart-contracts/test/Lock/destroyLock.js
@@ -63,7 +63,7 @@ contract('Lock', accounts => {
       })
 
       it('previously valid key is no longer valid', async () => {
-        assert.equal(await lock.getHasValidKey(accounts[1]), false)
+        assert.equal(await lock.getHasValidKey.call(accounts[1]), false)
       })
 
       // After selfdestruct, a user can't buy a key, but if they try they loose their money.
@@ -84,7 +84,7 @@ contract('Lock', accounts => {
         assert.equal(finalLockBalance, 10000000000000000)
 
         // The user did not purchase a key, but still sent their eth to the contract.
-        assert.equal(await lock.getHasValidKey(accounts[1]), false)
+        assert.equal(await lock.getHasValidKey.call(accounts[1]), false)
       })
     })
   })

--- a/smart-contracts/test/Lock/destroyLock.js
+++ b/smart-contracts/test/Lock/destroyLock.js
@@ -1,0 +1,91 @@
+const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+const BigNumber = require('bignumber.js')
+
+const deployLocks = require('../helpers/deployLocks')
+const shouldFail = require('../helpers/shouldFail')
+const Unlock = artifacts.require('../Unlock.sol')
+
+let unlock, locks
+
+contract('Lock', accounts => {
+  let lock
+
+  before(async () => {
+    unlock = await Unlock.deployed()
+    locks = await deployLocks(unlock)
+    lock = locks['FIRST']
+  })
+
+  describe('destroyLock', () => {
+    it('should fail if called by the wrong account', async () => {
+      await shouldFail(lock.destroyLock({ from: accounts[1] }), '')
+    })
+
+    describe('when called by the owner', () => {
+      let initialLockBalance, initialOwnerBalance, txObj, event
+
+      before(async () => {
+        await lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+        assert.equal(await lock.getHasValidKey(accounts[1]), true) // pre-req
+
+        initialLockBalance = new BigNumber(
+          await web3.eth.getBalance(lock.address)
+        )
+        initialOwnerBalance = new BigNumber(
+          await web3.eth.getBalance(accounts[0])
+        )
+        await lock.disableLock() // We can't destroy a lock without first disabling it
+        txObj = await lock.destroyLock({ from: accounts[0] })
+        event = txObj.logs[0]
+      })
+
+      it('owner should have received funds from the contract', async () => {
+        const finalOwnerBalance = new BigNumber(
+          await web3.eth.getBalance(accounts[0])
+        )
+        assert(finalOwnerBalance.gt(initialOwnerBalance))
+      })
+
+      it('contract should no longer have any funds', async () => {
+        const finalLockBalance = new BigNumber(
+          await web3.eth.getBalance(lock.address)
+        )
+        assert.equal(finalLockBalance.toFixed(), 0)
+      })
+
+      it('should trigger the Destroy event', () => {
+        assert.equal(event.event, 'Destroy')
+        assert(event.args.balance.eq(initialLockBalance))
+        assert.equal(event.args.owner, accounts[0])
+      })
+
+      it('previously valid key is no longer valid', async () => {
+        assert.equal(await lock.getHasValidKey(accounts[1]), false)
+      })
+
+      // After selfdestruct, a user can't buy a key, but if they try they loose their money.
+      it('does not allow people to purchase new keys', async () => {
+        let initialLockBalance = new BigNumber(
+          await web3.eth.getBalance(lock.address)
+        ).toFixed()
+        assert.equal(initialLockBalance, 0)
+
+        // This line does not fail, but instead calls the fallback function and sends msg.value to the destroyed contract.
+        await lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+
+        let finalLockBalance = new BigNumber(
+          await web3.eth.getBalance(lock.address)
+        ).toFixed()
+        assert.equal(finalLockBalance, 10000000000000000)
+
+        // The user did not purchase a key, but still sent their eth to the contract.
+        assert.equal(await lock.getHasValidKey(accounts[1]), false)
+      })
+    })
+  })
+})

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -95,7 +95,7 @@ contract('Lock', accounts => {
       })
 
       it('should still allow access to non-payable contract functions', async () => {
-        let HasValidKey = await lock.getHasValidKey(accounts[1])
+        let HasValidKey = await lock.getHasValidKey.call(accounts[1])
         assert.equal(HasValidKey, true)
       })
     })

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -1,0 +1,103 @@
+const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+const BigNumber = require('bignumber.js')
+
+const deployLocks = require('../helpers/deployLocks')
+const shouldFail = require('../helpers/shouldFail')
+const Unlock = artifacts.require('../Unlock.sol')
+
+let unlock, locks, ID
+
+contract('Lock', accounts => {
+  let lock
+
+  before(async () => {
+    unlock = await Unlock.deployed()
+    locks = await deployLocks(unlock)
+    lock = locks['FIRST']
+    await lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
+      value: Units.convert('0.01', 'eth', 'wei')
+    })
+    ID = new BigNumber(await lock.getTokenIdFor(accounts[1])).toFixed()
+  })
+
+  describe('disableLock', () => {
+    it('should fail if called by the wrong account', async () => {
+      await shouldFail(lock.disableLock({ from: accounts[1] }), '')
+    })
+
+    it('should fail if called before the lock is disabled', async () => {
+      await shouldFail(
+        lock.destroyLock(),
+        'Not allowed to delete an active lock'
+      )
+    })
+
+    describe('when the lock has been disabled', () => {
+      let txObj, event
+      before(async () => {
+        txObj = await lock.disableLock({ from: accounts[0] })
+        event = txObj.logs[0]
+      })
+
+      it('should trigger the Disable event', () => {
+        console.log(event)
+        assert.equal(event.event, 'Disable')
+      })
+
+      it('should fail if called while lock is disabled', async () => {
+        await shouldFail(
+          lock.disableLock(),
+          'No access after contract has been disabled'
+        )
+      })
+
+      it('should fail if a user tries to purchase a key', async () => {
+        await shouldFail(
+          lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
+            value: Units.convert('0.01', 'eth', 'wei')
+          }),
+          'No access after contract has been disabled'
+        )
+      })
+
+      it('should fail if a user tries to purchase a key with a referral', async () => {
+        await shouldFail(
+          lock.purchaseForFrom(
+            accounts[1],
+            accounts[3],
+            Web3Utils.toHex('Julien'),
+            {
+              value: Units.convert('0.01', 'eth', 'wei')
+            }
+          ),
+          'No access after contract has been disabled'
+        )
+      })
+
+      it('should fail if a user tries to transfer a key', async () => {
+        await shouldFail(
+          lock.transferFrom(accounts[1], accounts[3], ID, {
+            from: accounts[1],
+            value: Units.convert('0.01', 'eth', 'wei')
+          }),
+          'No access after contract has been disabled'
+        )
+      })
+
+      it('should fail if a key owner tries to a approve an address', async () => {
+        await shouldFail(
+          lock.approve(accounts[3], ID, {
+            from: accounts[1]
+          }),
+          'No access after contract has been disabled'
+        )
+      })
+
+      it('should still allow access to non-payable contract functions', async () => {
+        let HasValidKey = await lock.getHasValidKey(accounts[1])
+        assert.equal(HasValidKey, true)
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Description

This PR fixes #1468 by allowing Lock contracts to be disabled and deleted (a 2-step process).
The rationale is to allow a lock to be disabled to prevent further key purchases or transfers, and then allow for the lock owner to ensure there are no longer any valid keys on the lock before deleting. The key migration functionality has not been implemented yet, but when it is, an additional check (TODO already added to contract) must be made in the `destroyLock` function to ensure there are no more valid keys.



# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
