### PR TITLE
remove unused functionality from web3service

### DIFF
--- a/paywall/src/__tests__/services/web3Service.test.js
+++ b/paywall/src/__tests__/services/web3Service.test.js
@@ -73,12 +73,6 @@ const ethCallAndFail = (data, to, error) => {
   return jsonRpcRequest('eth_call', [{ data, to }, 'latest'], undefined, error)
 }
 
-const pad64 = data => {
-  return `${data.toString().padStart(64, '0')}`
-}
-
-const abiPaddedString = parameters => parameters.map(pad64).join('')
-
 nock.emitter.on('no match', function(clientRequestObject, options, body) {
   if (debug) {
     console.log(`NO HTTP MOCK EXISTS FOR THAT REQUEST\n${body}`)
@@ -171,33 +165,6 @@ describe('Web3Service', () => {
       })
 
       web3Service._getPastTransactionsForContract(contract, events, filter)
-    })
-  })
-
-  describe('getPastLockCreationsTransactionsForUser', () => {
-    it('should getPastEvents for the Unlock contract', () => {
-      expect.assertions(3)
-
-      class MockContract {
-        constructor(abi, address) {
-          expect(abi).toBe(UnlockContract.abi)
-          expect(address).toEqual(web3Service.unlockContractAddress)
-        }
-      }
-
-      web3Service.web3.eth.Contract = MockContract
-
-      const userAddress = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
-      web3Service._getPastTransactionsForContract = jest.fn()
-
-      web3Service.getPastLockCreationsTransactionsForUser(userAddress)
-      expect(web3Service._getPastTransactionsForContract).toHaveBeenCalledWith(
-        expect.any(MockContract),
-        'NewLock',
-        {
-          lockOwner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-        }
-      )
     })
   })
 
@@ -925,80 +892,6 @@ describe('Web3Service', () => {
         'PriceChanged',
         params
       )
-    })
-  })
-
-  describe('getKeysForLockOnPage', () => {
-    it('should get as many owners as there are per page, starting at the right index', done => {
-      const onPage = 0
-      const byPage = 5
-      const keyHolder = [
-        '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
-        '0xC66Ef2E0D0eDCce723b3fdd4307db6c5F0Dda1b8',
-      ]
-
-      expect.assertions(9)
-
-      web3Service._getKeyByLockForOwner = jest.fn(() => {
-        return new Promise(resolve => {
-          return resolve([100, 'hello'])
-        })
-      })
-
-      ethCallAndYield(
-        `0x10803b72${abiPaddedString([onPage, byPage])}`,
-        lockAddress,
-        `0x${abiPaddedString(['20', '2', keyHolder[0], keyHolder[1]])}`
-      )
-
-      web3Service.getKeysForLockOnPage(lockAddress, onPage, byPage)
-
-      web3Service.on('keys.page', (lock, page, keys) => {
-        expect(lockAddress).toEqual(lock)
-        expect(page).toEqual(onPage)
-        expect(keys.length).toEqual(2)
-        expect(keys[0].id).toEqual(`${lockAddress}-${keyHolder[0]}`)
-        expect(keys[0].owner).toEqual(keyHolder[0])
-        expect(keys[0].lock).toEqual(lockAddress)
-        expect(keys[0].expiration).toEqual(100)
-        expect(keys[0].data).toEqual('hello')
-        expect(keys[1].owner).toEqual(keyHolder[1])
-        done()
-      })
-    })
-
-    describe('when the on contract method does not exist', () => {
-      it('should use the iterative method of providing keyholder', done => {
-        const onPage = 0
-        const byPage = 2
-
-        for (let i = 0; i < byPage; i++) {
-          const start = onPage * byPage + i
-          ethCallAndYield(
-            `0x025e7c27${start.toString(16).padStart(64, 0)}`,
-            lockAddress,
-            '0x'
-          )
-        }
-
-        jest
-          .spyOn(web3Service, '_genKeyOwnersFromLockContract')
-          .mockImplementation(() => {
-            return Promise.resolve([])
-          })
-        jest.spyOn(web3Service, '_genKeyOwnersFromLockContractIterative')
-
-        web3Service.getKeysForLockOnPage(lockAddress, onPage, byPage)
-
-        web3Service.on('keys.page', (lock, page) => {
-          expect(lockAddress).toEqual(lock)
-          expect(page).toEqual(onPage)
-          expect(
-            web3Service._genKeyOwnersFromLockContractIterative
-          ).toHaveBeenCalledTimes(1)
-          done()
-        })
-      })
     })
   })
 

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -1,7 +1,7 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import { LOCATION_CHANGE } from 'connected-react-router'
-import { UPDATE_LOCK, addLock, updateLock } from '../actions/lock'
+import { UPDATE_LOCK, addLock, updateLock, ADD_LOCK } from '../actions/lock'
 import { updateKey, addKey } from '../actions/key'
 import { updateAccount, SET_ACCOUNT } from '../actions/accounts'
 import { setError } from '../actions/error'
@@ -112,7 +112,7 @@ export default function web3Middleware({ getState, dispatch }) {
         }
       }
 
-      if (action.type === UPDATE_LOCK) {
+      if (action.type === ADD_LOCK || action.type === UPDATE_LOCK) {
         const lock = getState().locks[action.address]
         if (getState().account) {
           web3Service.getKeyByLockForOwner(

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -1,14 +1,7 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import { LOCATION_CHANGE } from 'connected-react-router'
-import {
-  ADD_LOCK,
-  CREATE_LOCK,
-  UPDATE_LOCK,
-  addLock,
-  updateLock,
-  createLock,
-} from '../actions/lock'
+import { UPDATE_LOCK, addLock, updateLock } from '../actions/lock'
 import { updateKey, addKey } from '../actions/key'
 import { updateAccount, SET_ACCOUNT } from '../actions/accounts'
 import { setError } from '../actions/error'
@@ -18,13 +11,8 @@ import {
   ADD_TRANSACTION,
   NEW_TRANSACTION,
 } from '../actions/transaction'
-import { PGN_ITEMS_PER_PAGE } from '../constants'
 
 import Web3Service from '../services/web3Service'
-import {
-  SET_KEYS_ON_PAGE_FOR_LOCK,
-  setKeysOnPageForLock,
-} from '../actions/keysPages'
 import { lockRoute } from '../utils/routes'
 
 // This middleware listen to redux events and invokes the web3Service API.
@@ -34,16 +22,6 @@ export default function web3Middleware({ getState, dispatch }) {
 
   web3Service.on('account.updated', (account, update) => {
     dispatch(updateAccount(update))
-  })
-
-  /**
-   * When a lock was saved, we update it, as well as its transaction and
-   * refresh the balance of its owner and refresh its content
-   */
-  web3Service.on('lock.saved', (lock, address) => {
-    web3Service.refreshAccountBalance(getState().account)
-    web3Service.getLock(address)
-    web3Service.getPastLockTransactions(address) // This is costly and not useful for the paywall app...
   })
 
   /**
@@ -99,36 +77,14 @@ export default function web3Middleware({ getState, dispatch }) {
     dispatch(setError(error.message))
   })
 
-  web3Service.on('keys.page', (lock, page, keys) => {
-    dispatch(setKeysOnPageForLock(page, lock, keys))
-  })
-
   return function(next) {
     return function(action) {
-      // When the keys for a lock are loaded on the dashboard
-      if (action.type === SET_KEYS_ON_PAGE_FOR_LOCK) {
-        if (!action.keys) {
-          web3Service.getKeysForLockOnPage(
-            action.lock,
-            action.page,
-            PGN_ITEMS_PER_PAGE
-          )
-        }
-      }
-
       if (action.type === ADD_TRANSACTION) {
         web3Service.getTransaction(action.transaction.hash)
       }
 
       if (action.type === NEW_TRANSACTION) {
         web3Service.getTransaction(action.transaction.hash, action.transaction)
-      }
-
-      if (action.type === CREATE_LOCK && !action.lock.address) {
-        web3Service.generateLockAddress().then(address => {
-          action.lock.address = address
-          dispatch(createLock(action.lock))
-        })
       }
 
       next(action)
@@ -156,7 +112,7 @@ export default function web3Middleware({ getState, dispatch }) {
         }
       }
 
-      if (action.type === ADD_LOCK || action.type === UPDATE_LOCK) {
+      if (action.type === UPDATE_LOCK) {
         const lock = getState().locks[action.address]
         if (getState().account) {
           web3Service.getKeyByLockForOwner(
@@ -170,12 +126,8 @@ export default function web3Middleware({ getState, dispatch }) {
         action.payload.location.pathname
       ) {
         // Location was changed, get the matching lock, if we are on a paywall page
-        const { lockAddress, prefix } = lockRoute(
-          action.payload.location.pathname
-        )
-        if (lockAddress && prefix === 'paywall') {
-          web3Service.getLock(lockAddress)
-        }
+        const { lockAddress } = lockRoute(action.payload.location.pathname)
+        web3Service.getLock(lockAddress)
       }
     }
   }

--- a/paywall/src/services/web3Service.js
+++ b/paywall/src/services/web3Service.js
@@ -1,7 +1,6 @@
 import EventEmitter from 'events'
 import Web3 from 'web3'
 import Web3Utils from 'web3-utils'
-import ethJsUtil from 'ethereumjs-util'
 
 import LockContract from '../artifacts/contracts/PublicLock.json'
 import UnlockContract from '../artifacts/contracts/Unlock.json'


### PR DESCRIPTION
# Description

This removes lock creation, key pagination, retrieving past lock creation transactions for a specific user, lock withdrawal from the web3 service and middleware in the paywall

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
