### PR TITLE
Infinite lock display fix

### DIFF
--- a/unlock-app/src/__tests__/reducers/locksReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/locksReducer.test.js
@@ -10,6 +10,7 @@ import { SET_ACCOUNT } from '../../actions/accounts'
 import { DELETE_TRANSACTION } from '../../actions/transaction'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
+import { MAX_UINT, UNLIMITED_KEYS_COUNT } from '../../constants'
 
 describe('locks reducer', () => {
   const lock = {
@@ -54,6 +55,24 @@ describe('locks reducer', () => {
       })
     ).toEqual({
       [lock.address]: lock,
+    })
+  })
+
+  it('should normalize MAX_UINT when receiving CREATE_LOCK', () => {
+    const maxUintLock = {
+      address: '123',
+      maxNumberOfKeys: MAX_UINT,
+    }
+    expect(
+      reducer(undefined, {
+        type: CREATE_LOCK,
+        lock: maxUintLock,
+      })
+    ).toEqual({
+      [maxUintLock.address]: {
+        ...maxUintLock,
+        maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+      },
     })
   })
 
@@ -263,6 +282,33 @@ describe('locks reducer', () => {
         name: 'hello',
         address: '0x123',
         keyPrice: '0.02',
+      },
+    })
+  })
+
+  it('should normalize MAX_UINT when updating a lock', () => {
+    const state = {
+      '0x123': {
+        name: 'hello',
+        address: '0x123',
+        maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+      },
+    }
+    const action = {
+      type: UPDATE_LOCK,
+      address: '0x123',
+      update: {
+        name: 'hello',
+        keyPrice: '1.001',
+        maxNumberOfKeys: MAX_UINT,
+      },
+    }
+    expect(reducer(state, action)).toEqual({
+      '0x123': {
+        name: 'hello',
+        address: '0x123',
+        keyPrice: '1.001',
+        maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
       },
     })
   })

--- a/unlock-app/src/reducers/locksReducer.js
+++ b/unlock-app/src/reducers/locksReducer.js
@@ -9,6 +9,7 @@ import { DELETE_TRANSACTION } from '../actions/transaction'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 import { SET_ACCOUNT } from '../actions/accounts'
+import { MAX_UINT, UNLIMITED_KEYS_COUNT } from '../constants'
 
 export const initialState = {}
 
@@ -38,10 +39,19 @@ const locksReducer = (state = initialState, action) => {
   }
 
   if (action.type === CREATE_LOCK) {
-    if (action.lock.address) {
+    // Smart contracts and the frontend app use a different representation for
+    // unlimited keys. Here we look to see if the value of maxNumberOfKeys is
+    // set to the smart contract representation. If it is, we replace it with
+    // the frontend representation.
+    let lock = {}
+    Object.assign(lock, action.lock)
+    if (lock.maxNumberOfKeys === MAX_UINT) {
+      lock.maxNumberOfKeys = UNLIMITED_KEYS_COUNT
+    }
+    if (lock.address) {
       return {
         ...state,
-        [action.lock.address]: action.lock,
+        [lock.address]: lock,
       }
     }
   }
@@ -59,9 +69,18 @@ const locksReducer = (state = initialState, action) => {
       return state
     }
 
+    // Smart contracts and the frontend app use a different representation for
+    // unlimited keys. Here we look to see if the value of maxNumberOfKeys is
+    // set to the smart contract representation. If it is, we replace it with
+    // the frontend representation.
+    let update = {}
+    Object.assign(update, action.update)
+    if (update.maxNumberOfKeys === MAX_UINT) {
+      update.maxNumberOfKeys = UNLIMITED_KEYS_COUNT
+    }
     return {
       ...state,
-      [action.address]: Object.assign(state[action.address], action.update),
+      [action.address]: Object.assign(state[action.address], update),
     }
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

This PR fixes #1476. This issue occurred because of the 2 different representations for unlimited keys. In the smart contracts we use an incredibly huge number, and in the frontend we use -1. There were 2 cases where the `MAX_UINT` value could sneak into the frontend:
1. when creating a lock
2. when updating a lock

Because `MAX_UINT` is not a valid state representation for the frontend, the solution implemented here is to ensure that it doesn't enter the Redux store at all by checking for it and replacing it with the equivalent representation.
# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
