### PR TITLE
Updates WalletMiddleware , no longer request signature on cancel of lock creation

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -86,16 +86,16 @@ jest.mock('../../services/walletService', () => {
   }
 })
 
-let mockGenerateJWTToken = jest.fn(() => Promise.resolve())
+let mockGenerateSignature = jest.fn(() => Promise.resolve())
 
 jest.mock('../../utils/signature', () => () => {
-  return mockGenerateJWTToken()
+  return mockGenerateSignature()
 })
 
 beforeEach(() => {
   // Reset the mock
   mockWalletService = new MockWalletService()
-  mockGenerateJWTToken = jest.fn(() => Promise.resolve())
+  mockGenerateSignature = jest.fn(() => Promise.resolve())
 
   // Reset state!
   account = {
@@ -370,10 +370,13 @@ describe('Wallet middleware', () => {
       })
 
       it("should handle CREATE_LOCK by calling walletService's createLock", () => {
-        expect.assertions(3)
+        expect.assertions(2)
         const { next, invoke, store } = create()
         const action = { type: CREATE_LOCK, lock }
-        mockWalletService.createLock = jest.fn()
+
+        mockWalletService.createLock = jest
+          .fn()
+          .mockImplementation(() => Promise.resolve())
         mockWalletService.ready = true
 
         invoke(action)
@@ -381,7 +384,7 @@ describe('Wallet middleware', () => {
           lock,
           store.getState().account.address
         )
-        expect(mockGenerateJWTToken).toHaveBeenCalled()
+
         expect(next).toHaveBeenCalledWith(action)
       })
     })

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -123,26 +123,29 @@ export default function walletMiddleware({ getState, dispatch }) {
         walletService.connect(action.provider)
       } else if (action.type === CREATE_LOCK && action.lock.address) {
         ensureReadyBefore(() => {
-          walletService.createLock(action.lock, getState().account.address)
-          if (config.services.storage) {
-            generateSignature(
-              walletService.web3,
-              getState().account.address,
-              action.lock
-            )
-              .then(token => {
-                dispatch(
-                  storeLockCreation(
-                    getState().account.address,
-                    token.data,
-                    token.result
-                  )
+          walletService
+            .createLock(action.lock, getState().account.address)
+            .then(() => {
+              if (config.services.storage) {
+                generateSignature(
+                  walletService.web3,
+                  getState().account.address,
+                  action.lock
                 )
-              })
-              .catch(error => {
-                dispatch(signatureError(error))
-              })
-          }
+                  .then(token => {
+                    dispatch(
+                      storeLockCreation(
+                        getState().account.address,
+                        token.data,
+                        token.result
+                      )
+                    )
+                  })
+                  .catch(error => {
+                    dispatch(signatureError(error))
+                  })
+              }
+            })
         })
       } else if (action.type === PURCHASE_KEY) {
         ensureReadyBefore(() => {

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -276,9 +276,7 @@ export default class WalletService extends EventEmitter {
         // Let's update the lock to reflect that it is linked to this
         // This is an exception because, until we are able to determine the lock address
         // before the transaction is mined, we need to link the lock and transaction.
-        return this.emit('lock.updated', lock.address, {
-          transaction: hash,
-        })
+        return this.emit('lock.updated', lock.address, { transaction: hash })
       }
     )
   }


### PR DESCRIPTION
This is effectively steering the code to react when there is a rejection of the transaction
via metamask or some other wallet

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
