### PR TITLE
New hooks for managing postMessage calls in paywall

### DIFF
--- a/paywall/src/__tests__/hooks/browser/usePostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/usePostMessage.test.js
@@ -1,0 +1,144 @@
+import * as rtl from 'react-testing-library'
+import React from 'react'
+
+import { ConfigContext } from '../../../hooks/utils/useConfig'
+import usePostMessage from '../../../hooks/browser/usePostMessage'
+
+describe('usePostMessage hook', () => {
+  const { Provider } = ConfigContext
+
+  let fakeWindow
+  let config
+
+  function wrapper(props) {
+    return <Provider value={config} {...props} />
+  }
+
+  beforeEach(() => {
+    fakeWindow = {
+      parent: {
+        postMessage: jest.fn(),
+        origin: 'origin',
+      },
+    }
+    config = { isServer: false, isInIframe: true }
+  })
+
+  it('posts a message to the window parent when postMessage is called', () => {
+    expect.assertions(2)
+
+    const {
+      result: {
+        current: { postMessage },
+      },
+    } = rtl.testHook(() => usePostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    expect(typeof postMessage).toBe('function')
+    rtl.act(() => {
+      postMessage('hi')
+    })
+    expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith('hi', 'origin')
+  })
+  it('ignores calls on the server', () => {
+    expect.assertions(1)
+
+    config.isServer = true
+
+    const {
+      result: {
+        current: { postMessage },
+      },
+    } = rtl.testHook(() => usePostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    rtl.act(() => {
+      postMessage('hi')
+    })
+    expect(fakeWindow.parent.postMessage).not.toHaveBeenCalled()
+  })
+  it('ignores calls in the main window', () => {
+    expect.assertions(1)
+
+    config.isInIframe = false
+
+    const {
+      result: {
+        current: { postMessage },
+      },
+    } = rtl.testHook(() => usePostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    rtl.act(() => {
+      postMessage('hi')
+    })
+    expect(fakeWindow.parent.postMessage).not.toHaveBeenCalled()
+  })
+  it('ignores calls with an empty message', () => {
+    expect.assertions(1)
+
+    const {
+      result: {
+        current: { postMessage },
+      },
+    } = rtl.testHook(() => usePostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    rtl.act(() => {
+      postMessage()
+    })
+    expect(fakeWindow.parent.postMessage).not.toHaveBeenCalled()
+  })
+  it('does not call postMessage twice with the same message', () => {
+    expect.assertions(1)
+
+    const {
+      result: {
+        current: { postMessage },
+      },
+    } = rtl.testHook(() => usePostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    rtl.act(() => {
+      postMessage('hi')
+    })
+    rtl.act(() => {
+      postMessage('hi')
+    })
+
+    expect(fakeWindow.parent.postMessage).toHaveBeenCalledTimes(1)
+  })
+  it('does call postMessage when the message changes', () => {
+    expect.assertions(2)
+
+    const {
+      result: {
+        current: { postMessage },
+      },
+    } = rtl.testHook(() => usePostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    rtl.act(() => {
+      postMessage('hi')
+    })
+
+    rtl.act(() => {
+      postMessage('hi')
+    })
+
+    rtl.act(() => {
+      postMessage('bye')
+    })
+    expect(fakeWindow.parent.postMessage).toHaveBeenCalledTimes(2)
+    expect(fakeWindow.parent.postMessage).toHaveBeenLastCalledWith(
+      'bye',
+      'origin'
+    )
+  })
+})

--- a/paywall/src/hooks/browser/usePostMessage.js
+++ b/paywall/src/hooks/browser/usePostMessage.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+import useConfig from '../utils/useConfig'
+
+export default function usePostmessage(window) {
+  const { isInIframe, isServer } = useConfig()
+  const [message, postMessage] = useState()
+  useEffect(
+    () => {
+      if (isServer || !isInIframe || !message) return
+      window.parent.postMessage(message, window.parent.origin)
+    },
+    // this next line tells React to only post the message if it has changed.
+    // This is important because the hook will be called on every render,
+    // not just when the postMessage call has changed the state to something else
+    // and we only want to post the message on the very first time it is requested
+    [message]
+  )
+  return { postMessage }
+}

--- a/paywall/src/hooks/utils/useConfig.js
+++ b/paywall/src/hooks/utils/useConfig.js
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react'
 
-export const ConfigContext = createContext(3)
+export const ConfigContext = createContext()
 
 export default function useConfig() {
   return useContext(ConfigContext)

--- a/paywall/src/hooks/utils/useConfig.js
+++ b/paywall/src/hooks/utils/useConfig.js
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react'
 
-export const ConfigContext = createContext()
+export const ConfigContext = createContext(3)
 
 export default function useConfig() {
   return useContext(ConfigContext)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

This PR is a step to #1533 and depends on #1536 to go green, and #1535 to remove `useConfig.js` from the diff

This PR contains the first simple React hooks for managing communication between the paywall and its parent window.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
