### PR TITLE
new useLocalStorage hook

### DIFF
--- a/paywall/src/__tests__/hooks/browser/useLocalStorage-no-localStorage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useLocalStorage-no-localStorage.test.js
@@ -1,0 +1,37 @@
+import * as rtl from 'react-testing-library'
+import useLocalStorage from '../../../hooks/browser/useLocalStorage'
+
+jest.mock('../../../utils/localStorage', () => () => false)
+
+describe('no localStorage', () => {
+  let fakeWindow
+
+  beforeEach(() => {
+    jest.resetModules()
+    fakeWindow = {
+      storage: {},
+      localStorage: {
+        setItem: jest.fn((x, y) => (fakeWindow.storage[x] = y)),
+        getItem: jest.fn(x => fakeWindow.storage[x]),
+        removeItem: () => {},
+      },
+    }
+  })
+  it('does nothing', () => {
+    fakeWindow.localStorage.removeItem = () => {
+      throw new Error('nope')
+    }
+
+    const {
+      result: {
+        current: [, setValue],
+      },
+    } = rtl.testHook(() => useLocalStorage(fakeWindow, 'hi'))
+
+    expect(fakeWindow.localStorage.setItem).not.toHaveBeenCalled()
+
+    rtl.act(() => setValue('nope'))
+
+    expect(fakeWindow.localStorage.setItem).not.toHaveBeenCalled()
+  })
+})

--- a/paywall/src/__tests__/hooks/browser/useLocalStorage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useLocalStorage.test.js
@@ -1,0 +1,72 @@
+import * as rtl from 'react-testing-library'
+import useLocalStorage from '../../../hooks/browser/useLocalStorage'
+
+jest.mock('../../../utils/localStorage')
+
+describe('useLocalStorage hook', () => {
+  let fakeWindow
+
+  beforeEach(() => {
+    jest.resetModules()
+    fakeWindow = {
+      storage: {},
+      localStorage: {
+        setItem: jest.fn((x, y) => (fakeWindow.storage[x] = y)),
+        getItem: jest.fn(x => fakeWindow.storage[x]),
+        removeItem: () => {},
+      },
+    }
+  })
+  it('returns existing value of localStorage key and a setter', () => {
+    fakeWindow.storage.hi = 'there'
+
+    expect.assertions(2)
+
+    rtl.act(() => {})
+    const { result } = rtl.testHook(() => useLocalStorage(fakeWindow, 'hi'))
+
+    const [value, setter] = result.current
+
+    expect(value).toBe('there')
+    expect(typeof setter).toBe('function')
+  })
+  it('sets the value of the localStorage key when the setter is called', () => {
+    fakeWindow.storage['hi'] = 'there'
+
+    expect.assertions(1)
+
+    const {
+      result: {
+        current: [, setValue],
+      },
+    } = rtl.testHook(() => useLocalStorage(fakeWindow, 'hi'))
+
+    rtl.act(() => setValue('wow'))
+
+    expect(fakeWindow.localStorage.setItem).toHaveBeenCalledWith('hi', 'wow')
+  })
+  it('only sets the value when changed', () => {
+    fakeWindow.storage['hi'] = 'there'
+
+    expect.assertions(5)
+
+    const {
+      result: {
+        current: [, setValue],
+      },
+    } = rtl.testHook(() => useLocalStorage(fakeWindow, 'hi'))
+    expect(fakeWindow.localStorage.setItem).toHaveBeenCalledTimes(1)
+
+    rtl.act(() => setValue('wow'))
+    expect(fakeWindow.localStorage.setItem).toHaveBeenCalledTimes(2)
+
+    rtl.act(() => setValue('wow'))
+    expect(fakeWindow.localStorage.setItem).toHaveBeenCalledTimes(2)
+
+    rtl.act(() => setValue('wow'))
+    expect(fakeWindow.localStorage.setItem).toHaveBeenCalledTimes(2)
+
+    rtl.act(() => setValue('wheee'))
+    expect(fakeWindow.localStorage.setItem).toHaveBeenCalledTimes(3)
+  })
+})

--- a/paywall/src/hooks/browser/useLocalStorage.js
+++ b/paywall/src/hooks/browser/useLocalStorage.js
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react'
+import localStorageAvailable from '../../utils/localStorage'
+
+export default function useLocalStorage(window, key) {
+  const available = localStorageAvailable(window)
+
+  let startVal
+  if (available) {
+    startVal = window.localStorage.getItem(key)
+  }
+  const [value, setValue] = useState(startVal)
+  useEffect(
+    () => {
+      if (!available) return
+      window.localStorage.setItem(key, value)
+    },
+    [value]
+  )
+  return [value, setValue]
+}

--- a/paywall/src/hooks/browser/useLocalStorage.js
+++ b/paywall/src/hooks/browser/useLocalStorage.js
@@ -8,13 +8,18 @@ export default function useLocalStorage(window, key) {
   if (available) {
     startVal = window.localStorage.getItem(key)
   }
+  // this hook uses state as a proxy for the actual values in localStorage
+  // in order to trigger re-renders on any change to the localStorage
   const [value, setValue] = useState(startVal)
   useEffect(
     () => {
-      if (!available) return
+      if (!available) return // do nothing if localStorage can't be used
       window.localStorage.setItem(key, value)
     },
+    // this effect only runs when the value changes
+    // and not on every update to the component containing the hook
     [value]
   )
+
   return [value, setValue]
 }


### PR DESCRIPTION
# Description

This PR is a step to #1533 and depends on #1536 to go green

The `useLocalStorage` hook abstracts the process of querying and changing a single keyed value from `localStorage` in a way that guarantees success in any environment. It is used like this:

```js
// 'element' is the key for the value we will retrieve
// value is always whatever localStorage.getItem('element') returns
// setValue accepts a new value for the local storage. This must be a safe value for setItem()
const [value, setValue] = useLocalStorage(window, 'element')
```

`setValue` is safe to call in any part of the render phase, and will trigger an asynchronous update to the localStorage value, and a re-render.

The hook is inert if `localStorage` is not available, and always returns undefined for the value requested.
<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X]  My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
