### PR TITLE
new useListenForPostMessage hook

### DIFF
--- a/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
@@ -38,6 +38,39 @@ describe('useListenForPostMessage hook', () => {
     )
   })
 
+  it('only subscribes on mount, and not on update', () => {
+    expect.assertions(1)
+
+    const { rerender } = rtl.testHook(
+      () => useListenForPostMessage(fakeWindow),
+      {
+        wrapper,
+      }
+    )
+
+    rerender()
+
+    expect(fakeWindow.addEventListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsubscribes on unmount', () => {
+    expect.assertions(1)
+
+    const { unmount } = rtl.testHook(
+      () => useListenForPostMessage(fakeWindow),
+      {
+        wrapper,
+      }
+    )
+
+    unmount()
+
+    expect(fakeWindow.removeEventListener).toHaveBeenCalledWith(
+      'message',
+      expect.any(Function)
+    )
+  })
+
   it('ignores calls on the server', () => {
     expect.assertions(1)
 

--- a/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
@@ -1,0 +1,154 @@
+import * as rtl from 'react-testing-library'
+import React from 'react'
+
+import { ConfigContext } from '../../../hooks/utils/useConfig'
+import useListenForPostMessage from '../../../hooks/browser/useListenForPostMessage'
+
+describe('useListenForPostMessage hook', () => {
+  const { Provider } = ConfigContext
+
+  let fakeWindow
+  let config
+
+  function wrapper(props) {
+    return <Provider value={config} {...props} />
+  }
+
+  beforeEach(() => {
+    fakeWindow = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      parent: {
+        origin: 'origin',
+      },
+    }
+    config = { isServer: false, isInIframe: true }
+  })
+
+  it('sets up the event listener', () => {
+    expect.assertions(1)
+
+    rtl.testHook(() => useListenForPostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    expect(fakeWindow.addEventListener).toHaveBeenCalledWith(
+      'message',
+      expect.any(Function)
+    )
+  })
+
+  it('ignores calls on the server', () => {
+    expect.assertions(1)
+
+    config.isServer = true
+
+    rtl.testHook(() => useListenForPostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    expect(fakeWindow.addEventListener).not.toHaveBeenCalled()
+  })
+
+  it('ignores calls in the main window', () => {
+    expect.assertions(1)
+
+    config.isInIframe = false
+
+    rtl.testHook(() => useListenForPostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    expect(fakeWindow.addEventListener).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when window is not set', () => {
+    rtl.testHook(() => useListenForPostMessage(false), {
+      wrapper,
+    })
+  })
+
+  it('sets data when event is received', () => {
+    expect.assertions(2)
+
+    const { result } = rtl.testHook(() => useListenForPostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    const eventCallback = fakeWindow.addEventListener.mock.calls[0][1]
+
+    expect(result.current).toBe(undefined)
+    rtl.act(() =>
+      eventCallback({
+        source: fakeWindow.parent,
+        origin: fakeWindow.parent.origin,
+        data: 'data',
+      })
+    )
+
+    expect(result.current).toBe('data')
+  })
+
+  describe('insecure postMessage events', () => {
+    it('ignores source that is not the parent', () => {
+      expect.assertions(2)
+
+      const { result } = rtl.testHook(
+        () => useListenForPostMessage(fakeWindow),
+        {
+          wrapper,
+        }
+      )
+
+      const eventCallback = fakeWindow.addEventListener.mock.calls[0][1]
+
+      expect(result.current).toBe(undefined)
+      rtl.act(() =>
+        eventCallback({
+          source: fakeWindow.parent,
+          origin: fakeWindow.parent.origin,
+          data: 'data',
+        })
+      )
+      rtl.act(() =>
+        eventCallback({
+          source: 'nope',
+          origin: fakeWindow.parent.origin,
+          data: 'next',
+        })
+      )
+
+      expect(result.current).toBe('data')
+    })
+    it('ignores origin that is not the parent', () => {
+      expect.assertions(2)
+
+      const { result } = rtl.testHook(
+        () => useListenForPostMessage(fakeWindow),
+        {
+          wrapper,
+        }
+      )
+
+      const eventCallback = fakeWindow.addEventListener.mock.calls[0][1]
+
+      expect(result.current).toBe(undefined)
+      rtl.act(() =>
+        eventCallback({
+          source: fakeWindow.parent,
+          origin: fakeWindow.parent.origin,
+          data: 'data',
+        })
+      )
+      rtl.act(() =>
+        eventCallback({
+          source: fakeWindow.parent,
+          origin: 'nope',
+          data: 'next',
+        })
+      )
+
+      expect(result.current).toBe('data')
+    })
+  })
+})

--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+import useConfig from '../utils/useConfig'
+
+export default function useListenForPostmessage(window) {
+  const { isInIframe, isServer } = useConfig()
+  const parent = window && window.parent
+  const [data, setData] = useState()
+  const saveData = event => {
+    if (event.source !== parent || event.origin !== parent.origin) return
+    setData(event.data)
+  }
+
+  useEffect(() => {
+    if (isServer || !isInIframe || !window) return
+    window.addEventListener('message', saveData)
+    return () => {
+      window.removeEventListener('message', saveData)
+    }
+  })
+
+  return data
+}

--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -6,17 +6,20 @@ export default function useListenForPostmessage(window) {
   const parent = window && window.parent
   const [data, setData] = useState()
   const saveData = event => {
+    // ignore messages that do not come from our parent window
     if (event.source !== parent || event.origin !== parent.origin) return
     setData(event.data)
   }
 
+  // this hook subscribes to messages on mount, and unsubscribes on unmount
+  // it does not do it on update (component re-render)
   useEffect(() => {
     if (isServer || !isInIframe || !window) return
     window.addEventListener('message', saveData)
     return () => {
       window.removeEventListener('message', saveData)
     }
-  })
+  }, [])
 
   return data
 }


### PR DESCRIPTION
# Description

This PR is a step to #1533 and depends on #1536 to go green, and #1535 to remove `useConfig.js` from the diff

The `useListenForPostMessage` hook is a read-only abstraction of listening for messages passed from the parent window to the iframe. In the paywall, this is used to listen to the `scrollPosition` of the content in order to obscure it with the paywall.

It is used like this:

```js
const data = useListenForPostmessage(window)
const scrollPosition = data ? data.scrollPosition : 0
```

Prior to receiving a message, data will be `undefined`, afterwards it will update to the most recent value received and trigger a re-render.
<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
