### PR TITLE
new usePoll hook

### DIFF
--- a/paywall/src/__tests__/hooks/utils/usePoll.test.js
+++ b/paywall/src/__tests__/hooks/utils/usePoll.test.js
@@ -1,0 +1,63 @@
+import * as rtl from 'react-testing-library'
+import usePoll from '../../../hooks/utils/usePoll'
+
+jest.useFakeTimers()
+
+describe('usePoll hook', () => {
+  beforeEach(() => setTimeout.mockClear())
+  it('calls setTimeout with the polling function and delay', () => {
+    expect.assertions(3)
+    const pollingFunction = jest.fn()
+
+    rtl.testHook(() => usePoll(pollingFunction, 100))
+
+    expect(setTimeout).toHaveBeenCalledTimes(2)
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 100)
+    expect(pollingFunction).not.toHaveBeenCalled()
+  })
+
+  it('calls effect only on mount, and not on update', () => {
+    expect.assertions(2)
+    const pollingFunction = jest.fn()
+
+    const { rerender } = rtl.testHook(() => usePoll(pollingFunction, 100))
+
+    expect(setTimeout).toHaveBeenCalledTimes(2)
+
+    rerender()
+
+    expect(setTimeout).toHaveBeenCalledTimes(2)
+  })
+
+  it('calls the polling function every interval', () => {
+    expect.assertions(4)
+    const pollingFunction = jest.fn()
+
+    rtl.testHook(() => usePoll(pollingFunction, 100))
+
+    expect(pollingFunction).not.toHaveBeenCalled()
+
+    jest.advanceTimersByTime(100)
+    expect(pollingFunction).toHaveBeenCalledTimes(1)
+
+    jest.advanceTimersByTime(99)
+    expect(pollingFunction).toHaveBeenCalledTimes(1)
+
+    jest.advanceTimersByTime(1)
+    expect(pollingFunction).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the timeout when unmounted', () => {
+    expect.assertions(2)
+    const pollingFunction = jest.fn()
+
+    const { unmount } = rtl.testHook(() => usePoll(pollingFunction, 100))
+    jest.advanceTimersByTime(99)
+
+    unmount()
+
+    jest.advanceTimersByTime(2)
+    expect(pollingFunction).not.toHaveBeenCalled()
+    expect(clearTimeout).toHaveBeenCalled()
+  })
+})

--- a/paywall/src/hooks/utils/usePoll.js
+++ b/paywall/src/hooks/utils/usePoll.js
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Run a function repeatedly with a delay. This is a mobile-safe version of setInterval
+ * that will automatically start the polling when the component mounts, and remove it when it
+ * umounts
+ */
+export default function usePoll(cb, delay) {
+  // we use a ref to avoid re-render on change
+  // refs act like class properties and are not to be confused with
+  // the old React concept of ref
+  const cancel = useRef()
+  // this hook only runs on mount and cancels on umount
+  useEffect(() => {
+    let poll = f => {
+      cb()
+      cancel.current = setTimeout(f, delay)
+    }
+    poll = poll.bind(null, poll)
+    cancel.current = setTimeout(poll, delay)
+    return () => clearTimeout(cancel.current)
+  }, [])
+}


### PR DESCRIPTION
# Description

This PR is a step to #1533 and depends on #1536 to go green

The usePoll hook implements a cancellable `setTimeout` polling. This is used in the (soon to be PRed) `useAccount` hook to implement polling for account changes. It has the same method signature as `setTimeout` except it only starts the polling on mount of the React element and cancels it when the 
component unmounts.

usage:
```js
usePoll(fn, 500)
```

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
