### PR TITLE
new Web3 component for passing down the read-only web3 instance to children in the paywall

### DIFF
--- a/paywall/__mocks__/web3.js
+++ b/paywall/__mocks__/web3.js
@@ -1,0 +1,3 @@
+const web3 = jest.genMockFromModule('web3')
+
+module.exports = web3

--- a/paywall/src/__tests__/hooks/components/Web3.test.js
+++ b/paywall/src/__tests__/hooks/components/Web3.test.js
@@ -1,0 +1,70 @@
+import * as rtl from 'react-testing-library'
+import React from 'react'
+import MockWeb3 from 'web3'
+
+import Web3, { ReadOnlyContext } from '../../../hooks/components/Web3'
+import { ConfigContext } from '../../../hooks/utils/useConfig'
+
+jest.mock('web3')
+
+describe('Web3 component', () => {
+  const { Provider } = ConfigContext
+  const { Consumer } = ReadOnlyContext
+
+  let config
+  beforeEach(() => {
+    config = {
+      readOnlyProvider: false,
+      providers: [],
+    }
+    MockWeb3.mockClear()
+  })
+
+  it('uses readOnlyProvider if set', () => {
+    expect.assertions(1)
+    config.readOnlyProvider = 'read-only'
+
+    rtl.render(
+      <Provider value={config}>
+        <Web3>
+          <div>hi</div>
+        </Web3>
+      </Provider>
+    )
+
+    expect(MockWeb3).toHaveBeenCalledWith('read-only')
+  })
+
+  it('uses the first provider if read-only provider is not set', () => {
+    expect.assertions(1)
+    config.providers = ['first', 'second']
+
+    rtl.render(
+      <Provider value={config}>
+        <Web3>
+          <div>hi</div>
+        </Web3>
+      </Provider>
+    )
+
+    expect(MockWeb3).toHaveBeenCalledWith('first')
+  })
+
+  it('gets the web3 passed down from above', () => {
+    expect.assertions(1)
+
+    config.providers = ['first', 'second']
+
+    function get(web3) {
+      expect(web3).toEqual(expect.objectContaining({}))
+    }
+
+    rtl.render(
+      <Provider value={config}>
+        <Web3>
+          <Consumer>{get}</Consumer>
+        </Web3>
+      </Provider>
+    )
+  })
+})

--- a/paywall/src/__tests__/services/walletService.test.js
+++ b/paywall/src/__tests__/services/walletService.test.js
@@ -16,6 +16,7 @@ import {
 import { POLLING_INTERVAL } from '../../constants'
 
 jest.mock('../../utils/promises')
+jest.unmock('web3')
 
 const nockScope = nock('http://127.0.0.1:8545', { encodedQueryParams: true })
 

--- a/paywall/src/__tests__/services/web3Service.test.js
+++ b/paywall/src/__tests__/services/web3Service.test.js
@@ -8,6 +8,8 @@ import LockContract from '../../artifacts/contracts/PublicLock.json'
 import configure from '../../config'
 import { TRANSACTION_TYPES } from '../../constants'
 
+jest.unmock('web3')
+
 const nodeAccounts = [
   '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
   '0xaca94ef8bd5ffee41947b4585a84bda5a3d3da6e',

--- a/paywall/src/hooks/components/Web3.js
+++ b/paywall/src/hooks/components/Web3.js
@@ -1,0 +1,25 @@
+import React, { createContext } from 'react'
+import Web3Object from 'web3'
+import PropTypes from 'prop-types'
+import useConfig from '../utils/useConfig'
+
+export const ReadOnlyContext = createContext()
+
+export default function Web3({ children }) {
+  const { readOnlyProvider, providers } = useConfig()
+
+  let web3
+  if (readOnlyProvider) {
+    web3 = new Web3Object(readOnlyProvider)
+  } else {
+    web3 = new Web3Object(Object.values(providers)[0]) // Defaulting to the first provider.
+  }
+
+  return (
+    <ReadOnlyContext.Provider value={web3}>{children}</ReadOnlyContext.Provider>
+  )
+}
+
+Web3.propTypes = {
+  children: PropTypes.node.isRequired,
+}

--- a/paywall/src/hooks/utils/useConfig.js
+++ b/paywall/src/hooks/utils/useConfig.js
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react'
+
+export const ConfigContext = createContext()
+
+export default function useConfig() {
+  return useContext(ConfigContext)
+}


### PR DESCRIPTION
# Description

This PR is a step to #1533 and depends on #1536 to go green, and #1535 to remove `useConfig.js` from the diff

The component pulls in configuration and uses it to create a `Web3` object that can be used in any hook that needs to query the read-only provider. As an example, both the `useKeys` and `useLocks` hooks (in a future PR) depend on the `useWeb3` hook (also for a future PR), which pulls in the web3 instance from the context this component creates. This component requires the `ConfigContext` provider be initialized as a parent with the configuration, which it pulls in using the `useConfig` hook.

In order to simplify testing, it introduces a dead-simple automock for `web3`, which requires telling the existing `web3Service`/`walletService` tests not to mock using `jest.unmock('web3')`
<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
