### PR TITLE
add getRouteFromWindow helper

### DIFF
--- a/paywall/src/__tests__/utils/routes.test.js
+++ b/paywall/src/__tests__/utils/routes.test.js
@@ -1,0 +1,129 @@
+import { lockRoute, getRouteFromWindow } from '../../utils/routes'
+
+describe('route utilities', () => {
+  describe('lockRoute', () => {
+    it('should return null value when it does not match', () => {
+      expect(lockRoute('/dashboard')).toEqual({
+        lockAddress: null,
+        prefix: null,
+        redirect: null,
+        account: null,
+      })
+      expect(lockRoute('/lock')).toEqual({
+        lockAddress: null,
+        prefix: null,
+        redirect: null,
+        account: null,
+      })
+      expect(lockRoute('/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')).toEqual({
+        lockAddress: null,
+        prefix: null,
+        redirect: null,
+        account: null,
+      })
+    })
+
+    it('should return the right prefix and lockAddress value when it matches', () => {
+      expect(
+        lockRoute('/lock/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/')
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'lock',
+        redirect: undefined,
+        account: undefined,
+      })
+
+      expect(
+        lockRoute('/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'paywall',
+        redirect: undefined,
+        account: undefined,
+      })
+      expect(
+        lockRoute('/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: undefined,
+        account: undefined,
+      })
+    })
+    it('should return the correct redirect parameter when it matches', () => {
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+      })
+    })
+    it('should return the correct account parameter when it matches', () => {
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      })
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: undefined,
+        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      })
+    })
+    it('should ignore malformed account parameter', () => {
+      expect(
+        lockRoute(
+          // address is too short
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+        account: undefined,
+      })
+    })
+    it('should return account parameter if redirect is not present', () => {
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: undefined,
+        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      })
+    })
+  })
+  describe('getRouteFromWindow', () => {
+    it('should parse route from window.location', () => {
+      const fakeWindow = {
+        location: {
+          pathname:
+            '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
+          hash: '#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        },
+      }
+      expect(getRouteFromWindow(fakeWindow)).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      })
+    })
+  })
+})

--- a/paywall/src/utils/routes.js
+++ b/paywall/src/utils/routes.js
@@ -24,6 +24,9 @@ export const lockRoute = path => {
   }
 }
 
-export default {
-  lockRoute,
+export function getRouteFromWindow(window) {
+  if (!window) {
+    return lockRoute('')
+  }
+  return lockRoute(window.location.pathname + window.location.hash)
 }


### PR DESCRIPTION
# Description

This PR is a step to #1533

This adds a new route parsing helper for the paywall that uses `window.location` to parse out route variables.

It is designed for hooks in that if it is invoked server-side, where window does not exist, it does not error, but returns no matches.

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
