### PR TITLE
Remove flash of MAX_UINT from unlimited key locks

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
@@ -35,6 +35,7 @@ const unlimitedlock = {
   balance: '1',
   outstandingKeys: 1,
   maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+  unlimitedKeys: true,
   expirationDuration: 100,
 }
 

--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -278,6 +278,7 @@ describe('CreatorLockForm', () => {
           expirationDuration: 2592000,
           keyPrice: '0.01',
           maxNumberOfKeys: 10,
+          unlimitedKeys: false,
           name: 'New Lock',
           owner: 'hi',
         })

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -686,6 +686,7 @@ describe('Web3Service', () => {
           keyPrice: Web3Utils.fromWei('10000000000000000', 'ether'),
           expirationDuration: 2592000,
           maxNumberOfKeys: 10,
+          unlimitedKeys: false,
           owner: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
           outstandingKeys: 17,
           asOf: 1337,
@@ -730,6 +731,7 @@ describe('Web3Service', () => {
         expect(address).toBe(lockAddress)
         expect(update).toMatchObject({
           maxNumberOfKeys: -1,
+          unlimitedKeys: true,
         })
         done()
       })

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -34,9 +34,7 @@ const LockKeysNumbers = ({ lock }) => (
     typeof lock.outstandingKeys !== 'undefined' &&
     typeof lock.maxNumberOfKeys !== 'undefined'
       ? `${lock.outstandingKeys}/${
-          lock.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
-            ? INFINITY
-            : lock.maxNumberOfKeys
+          lock.unlimitedKeys ? INFINITY : lock.maxNumberOfKeys
         }`
       : ' - '}
   </LockKeys>

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -25,7 +25,7 @@ import {
 } from './LockStyles'
 import { updateKeyPrice } from '../../actions/lock'
 
-import { INFINITY, UNLIMITED_KEYS_COUNT } from '../../constants'
+import { INFINITY } from '../../constants'
 
 const LockKeysNumbers = ({ lock }) => (
   <LockKeys>

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -163,6 +163,7 @@ export class CreatorLockForm extends React.Component {
       keyPrice: keyPrice.toString(10), // In Eth
       maxNumberOfKeys: unlimitedKeys ? UNLIMITED_KEYS_COUNT : maxNumberOfKeys,
       owner: account.address,
+      unlimitedKeys,
     }
 
     createLock(lock)

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -551,6 +551,7 @@ export default class Web3Service extends EventEmitter {
 
     // Once all lock attributes have been fetched
     return Promise.all(constantPromises).then(() => {
+      update.unlimitedKeys = update.maxNumberOfKeys === -1
       this.emit('lock.updated', address, update)
       return update
     })

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -6,7 +6,7 @@ import ethJsUtil from 'ethereumjs-util'
 import LockContract from '../artifacts/contracts/PublicLock.json'
 import UnlockContract from '../artifacts/contracts/Unlock.json'
 import configure from '../config'
-import { TRANSACTION_TYPES, MAX_UINT } from '../constants'
+import { TRANSACTION_TYPES, MAX_UINT, UNLIMITED_KEYS_COUNT } from '../constants'
 import { NON_DEPLOYED_CONTRACT } from '../errors'
 
 const {
@@ -517,7 +517,7 @@ export default class Web3Service extends EventEmitter {
       expirationDuration: parseInt,
       maxNumberOfKeys: value => {
         if (value === MAX_UINT) {
-          return -1
+          return UNLIMITED_KEYS_COUNT
         }
         return parseInt(value)
       },
@@ -551,7 +551,7 @@ export default class Web3Service extends EventEmitter {
 
     // Once all lock attributes have been fetched
     return Promise.all(constantPromises).then(() => {
-      update.unlimitedKeys = update.maxNumberOfKeys === -1
+      update.unlimitedKeys = update.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
       this.emit('lock.updated', address, update)
       return update
     })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

This PR fixes #1476. By adding an additional boolean property to the lock indicating whether or not it has unlimited keys, we sidestep some issues around handling different numerical representations of that concept.

I think a future PR should be to refactor `CreatorLockForm` (the way that unlimited keys are handled from a user perspective is kind of confusing, and by improving that we can also probably simplify what we pass around and validate) and the rest of the code involved in lock creation. 
# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
