### PR TITLE
new Wallet component based on hooks for paywall

### DIFF
--- a/paywall/src/__tests__/hooks/components/Wallet.test.js
+++ b/paywall/src/__tests__/hooks/components/Wallet.test.js
@@ -99,12 +99,13 @@ describe('Wallet component', () => {
           <Wallet>
             <WalletContext.Consumer>
               {wallet => {
-                switch (render++) {
-                  case 0:
-                    expect(wallet).toBe(undefined)
-                    break
-                  case 1:
-                    expect(wallet).toBe(fakeWeb3)
+                if (render++) {
+                  // note, on initial render, the wallet is not ready, and is undefined
+                  // During the reconciliation process, the useEffect call in useCreateWallet
+                  // sets the wallet state to the new web3 object. This triggers a 2nd
+                  // render pass, which is why this test only checks the result on renders
+                  // past the first render
+                  expect(wallet).toBe(fakeWeb3)
                 }
               }}
             </WalletContext.Consumer>

--- a/paywall/src/__tests__/hooks/components/Wallet.test.js
+++ b/paywall/src/__tests__/hooks/components/Wallet.test.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import * as rtl from 'react-testing-library'
 import MockWeb3 from 'web3'
 
@@ -7,63 +6,19 @@ import Wallet, {
   useCreateWallet,
   WalletContext,
 } from '../../../hooks/components/Wallet'
-import { ConfigContext } from '../../../hooks/utils/useConfig'
 import { MISSING_PROVIDER, NOT_ENABLED_IN_PROVIDER } from '../../../errors'
+import { wrapperMaker, expectError } from '../helpers'
 
 jest.mock('web3')
 
 describe('Wallet component', () => {
-  const { Provider } = ConfigContext
-
   let config
-
-  class Catcher extends React.Component {
-    static propTypes = {
-      children: PropTypes.node.isRequired,
-    }
-    state = {
-      error: '',
-    }
-    componentDidCatch(error) {
-      this.setState({ error: error.message })
-    }
-
-    render() {
-      const { children } = this.props
-      const { error } = this.state
-      if (error) return <div>{error}</div>
-      return <>{children}</>
-    }
-  }
-
-  function wrapper(props) {
-    return (
-      <Catcher>
-        <Provider value={config} {...props} />
-      </Catcher>
-    )
-  }
+  let wrapper
 
   describe('useCreateWallet', () => {
-    function expectError(cb, err) {
-      // Record all errors.
-      let topLevelErrors = []
-      function handleTopLevelError(event) {
-        topLevelErrors.push(event.error)
-        // Prevent logging
-        event.preventDefault()
-      }
-      window.addEventListener('error', handleTopLevelError)
-      try {
-        cb()
-        expect(topLevelErrors).toHaveLength(1)
-        expect(topLevelErrors[0].message).toBe(err)
-      } finally {
-        window.removeEventListener('error', handleTopLevelError)
-      }
-    }
     beforeEach(() => {
       config = { providers: ['first'] }
+      wrapper = wrapperMaker(config)
     })
 
     it('throws if there are no providers', () => {

--- a/paywall/src/__tests__/hooks/components/Wallet.test.js
+++ b/paywall/src/__tests__/hooks/components/Wallet.test.js
@@ -1,0 +1,161 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import * as rtl from 'react-testing-library'
+import MockWeb3 from 'web3'
+
+import Wallet, {
+  useCreateWallet,
+  WalletContext,
+} from '../../../hooks/components/Wallet'
+import { ConfigContext } from '../../../hooks/utils/useConfig'
+import { MISSING_PROVIDER, NOT_ENABLED_IN_PROVIDER } from '../../../errors'
+
+jest.mock('web3')
+
+describe('Wallet component', () => {
+  const { Provider } = ConfigContext
+
+  let config
+
+  class Catcher extends React.Component {
+    static propTypes = {
+      children: PropTypes.node.isRequired,
+    }
+    state = {
+      error: '',
+    }
+    componentDidCatch(error) {
+      this.setState({ error: error.message })
+    }
+
+    render() {
+      const { children } = this.props
+      const { error } = this.state
+      if (error) return <div>{error}</div>
+      return <>{children}</>
+    }
+  }
+
+  function wrapper(props) {
+    return (
+      <Catcher>
+        <Provider value={config} {...props} />
+      </Catcher>
+    )
+  }
+
+  describe('useCreateWallet', () => {
+    function expectError(cb, err) {
+      // Record all errors.
+      let topLevelErrors = []
+      function handleTopLevelError(event) {
+        topLevelErrors.push(event.error)
+        // Prevent logging
+        event.preventDefault()
+      }
+      window.addEventListener('error', handleTopLevelError)
+      try {
+        cb()
+        expect(topLevelErrors).toHaveLength(1)
+        expect(topLevelErrors[0].message).toBe(err)
+      } finally {
+        window.removeEventListener('error', handleTopLevelError)
+      }
+    }
+    beforeEach(() => {
+      config = { providers: ['first'] }
+    })
+
+    it('throws if there are no providers', () => {
+      config.providers = []
+
+      expectError(() => {
+        rtl.testHook(() => useCreateWallet(), { wrapper })
+      }, MISSING_PROVIDER)
+    })
+
+    it('throws if the provider enable fails', () => {
+      config.providers = [
+        {
+          enable: () => {
+            throw 'nope'
+          },
+        },
+      ]
+
+      expectError(() => {
+        rtl.testHook(() => useCreateWallet(), { wrapper })
+      }, NOT_ENABLED_IN_PROVIDER)
+    })
+
+    it('throws if Web3 throws in constructor', () => {
+      config.providers = ['hi']
+      MockWeb3.mockImplementationOnce(() => {
+        throw new Error('nope')
+      })
+      expectError(() => {
+        rtl.act(() => {
+          rtl.testHook(() => useCreateWallet(), { wrapper })
+        })
+      }, MISSING_PROVIDER)
+    })
+
+    it('returns a new Web3 object if success occurs', () => {
+      // note: we can't test a provider with enable working because the asynchronous call to
+      // enable results in 2 scheduler cycles. rtl.act() is unable to capture this condition
+      // so the next best is just to show that we do in fact return a Web3 object when
+      // setup() is called. Coupled with the test above that proves
+      // enable is called if it is present on the provider and we are covered
+      config.providers = ['hi']
+      const fakeWeb3 = {
+        I: 'am a web3 with a spout and a handle',
+      }
+      MockWeb3.mockImplementationOnce(() => {
+        return fakeWeb3
+      })
+
+      const {
+        result: { current: web3 },
+      } = rtl.testHook(() => useCreateWallet(), { wrapper })
+
+      expect(web3).toBe(fakeWeb3)
+    })
+  })
+  describe('Wallet', () => {
+    it('passes down the wallet instance', () => {
+      config.providers = ['hi']
+      const fakeWeb3 = {
+        I: 'am a web3 with a spout and a handle',
+      }
+      MockWeb3.mockImplementationOnce(() => {
+        return fakeWeb3
+      })
+
+      const Wrapper = wrapper
+
+      let render = 0
+
+      // there are 2 valid states for the wallet:
+      // 1. Prior to initialization, it will be undefined
+      // 2. After initialization it will be the wallet object
+      // 3. (I lied) any errors that occur will be thrown (tested above)
+      rtl.render(
+        <Wrapper>
+          <Wallet>
+            <WalletContext.Consumer>
+              {wallet => {
+                switch (render++) {
+                  case 0:
+                    expect(wallet).toBe(undefined)
+                    break
+                  case 1:
+                    expect(wallet).toBe(fakeWeb3)
+                }
+              }}
+            </WalletContext.Consumer>
+          </Wallet>
+        </Wrapper>
+      )
+    })
+  })
+})

--- a/paywall/src/hooks/components/Wallet.js
+++ b/paywall/src/hooks/components/Wallet.js
@@ -44,6 +44,9 @@ export function useCreateWallet() {
         prepare()
       }
     },
+    // this effect will only re-run if the provider given to us by configuration changes
+    // currently, that's never, but leaves open the possibility of future changes.
+    // It will not, however, re-run on any other component update, which is a good thing
     [provider]
   )
 


### PR DESCRIPTION
# Description

This PR is a step on the path to #1533, requires #1549 be merged prior to merging

The `Wallet` component supplants what used to be the constructor and `connect` methods of `walletService`. It creates a new `Web3` instance based on the available provider, and passes it down through context. In future PRs, this will be used by the `useWallet` hook, and then further in the `useKey` to enable the `purchase` function

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
