### PR TITLE
new useWeb3 and useWallet hooks for the paywall

### DIFF
--- a/paywall/src/__tests__/hooks/web3/useWallet.test.js
+++ b/paywall/src/__tests__/hooks/web3/useWallet.test.js
@@ -1,0 +1,21 @@
+import * as rtl from 'react-testing-library'
+import React from 'react'
+
+import { WalletContext } from '../../../hooks/components/Wallet'
+import useWallet from '../../../hooks/web3/useWallet'
+
+describe('useWeb3 hook', () => {
+  const { Provider } = WalletContext
+
+  function wrapper(props) {
+    return <Provider value="wallet" {...props} />
+  }
+
+  it('retrieves the wallet object from context', () => {
+    const {
+      result: { current: web3 },
+    } = rtl.testHook(() => useWallet(), { wrapper })
+
+    expect(web3).toBe('wallet')
+  })
+})

--- a/paywall/src/__tests__/hooks/web3/useWeb3.test.js
+++ b/paywall/src/__tests__/hooks/web3/useWeb3.test.js
@@ -1,0 +1,21 @@
+import * as rtl from 'react-testing-library'
+import React from 'react'
+
+import { ReadOnlyContext } from '../../../hooks/components/Web3'
+import useWeb3 from '../../../hooks/web3/useWeb3'
+
+describe('useWeb3 hook', () => {
+  const { Provider } = ReadOnlyContext
+
+  function wrapper(props) {
+    return <Provider value="web3" {...props} />
+  }
+
+  it('retrieves the read-only web3 object from context', () => {
+    const {
+      result: { current: web3 },
+    } = rtl.testHook(() => useWeb3(), { wrapper })
+
+    expect(web3).toBe('web3')
+  })
+})

--- a/paywall/src/hooks/components/Wallet.js
+++ b/paywall/src/hooks/components/Wallet.js
@@ -1,0 +1,65 @@
+import Web3 from 'web3'
+import React, { useState, useEffect, createContext } from 'react'
+import PropTypes from 'prop-types'
+import { MISSING_PROVIDER, NOT_ENABLED_IN_PROVIDER } from '../../errors'
+import useConfig from '../utils/useConfig'
+
+export const WalletContext = createContext()
+
+export function useCreateWallet() {
+  const { providers } = useConfig()
+  if (!providers.length) {
+    throw new Error(MISSING_PROVIDER)
+  }
+  const provider = providers[0]
+  const [web3, setWeb3] = useState()
+  const [error, setError] = useState(false)
+
+  const setup = () => {
+    try {
+      setWeb3(new Web3(provider))
+    } catch (e) {
+      setError(new Error(MISSING_PROVIDER))
+    }
+  }
+  const prepare = async () => {
+    try {
+      // this exists for metamask and other modern dapp wallets and must be called,
+      // see: https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8
+      await provider.enable()
+      setup()
+    } catch (error) {
+      // we use setError because we are not in the render phase, so this will not be caught
+      // by error boundaries
+      setError(new Error(NOT_ENABLED_IN_PROVIDER))
+    }
+  }
+  useEffect(
+    () => {
+      if (!provider.enable) {
+        setup()
+      } else {
+        // we can't call async functions directly because they return a promise,
+        // and useEffect assumes the return from an effect is a cleanup function
+        prepare()
+      }
+    },
+    [provider]
+  )
+
+  if (error) throw error
+
+  return web3
+}
+
+export default function Wallet({ children }) {
+  const wallet = useCreateWallet()
+
+  return (
+    <WalletContext.Provider value={wallet}>{children}</WalletContext.Provider>
+  )
+}
+
+Wallet.propTypes = {
+  children: PropTypes.node.isRequired,
+}

--- a/paywall/src/hooks/web3/useWallet.js
+++ b/paywall/src/hooks/web3/useWallet.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import { WalletContext } from '../components/Wallet'
+
+export default function useWallet() {
+  return useContext(WalletContext)
+}

--- a/paywall/src/hooks/web3/useWeb3.js
+++ b/paywall/src/hooks/web3/useWeb3.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import { ReadOnlyContext } from '../components/Web3'
+
+export default function useWeb3() {
+  return useContext(ReadOnlyContext)
+}


### PR DESCRIPTION
# Description

This is a step on the path to #1533, and requires #1545 to be merged prior to merging

This PR adds 2 new hooks, `useWeb3` and `useWallet`. Both are simple abstractions, wrapping `useContext` and pulling in their `Web3` objects for the read-only provider and the wallet provider, respectively.

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
