### PR TITLE
configuration helper for testing hooks (paywall)

### DIFF
--- a/paywall/package.json
+++ b/paywall/package.json
@@ -11,7 +11,7 @@
     "before": "npm run build-paywall",
     "build": "npm run before && next build",
     "start": "npm run before && next start",
-    "test": "cross-env UNLOCK_ENV=test jest --env=jsdom",
+    "test": "cross-env UNLOCK_ENV=test jest test.js --env=jsdom",
     "lint": "eslint .",
     "reformat": "prettier-eslint \"src/**/*.js\" --write",
     "fail-pending-changes": "../scripts/pending-changes.sh",

--- a/paywall/src/__tests__/hooks/helpers.js
+++ b/paywall/src/__tests__/hooks/helpers.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ConfigContext } from '../../hooks/utils/useConfig'
+
+const { Provider } = ConfigContext
+
+export class Catcher extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  }
+  state = {
+    error: '',
+  }
+  componentDidCatch(error) {
+    this.setState({ error: error.message })
+  }
+
+  render() {
+    const { children } = this.props
+    const { error } = this.state
+    if (error) return <div>{error}</div>
+    return <>{children}</>
+  }
+}
+
+export const wrapperMaker = config =>
+  function wrapper(props) {
+    return (
+      <Catcher>
+        <Provider value={config} {...props} />
+      </Catcher>
+    )
+  }
+
+export function expectError(cb, err) {
+  // Record all errors.
+  let topLevelErrors = []
+  function handleTopLevelError(event) {
+    topLevelErrors.push(event.error)
+    // Prevent logging
+    event.preventDefault()
+  }
+  window.addEventListener('error', handleTopLevelError)
+  try {
+    cb()
+    expect(topLevelErrors).toHaveLength(1)
+    expect(topLevelErrors[0].message).toBe(err)
+  } finally {
+    window.removeEventListener('error', handleTopLevelError)
+  }
+}


### PR DESCRIPTION
# Description

This PR extracts some common test functionality into a helpers file for use in testing hooks

It includes a wrapper used by rtl's `testHook` to pass configuration context to the hook being tested, and a method for testing thrown errors in hooks through `expectError`. It turns out that this is very complex, in that thrown errors will always trigger a `console.error` in jsdom, even if they are caught. The helper adds a global error listener on window, which is used to catch the errors. Then, using preventDefault, React uses that and the fact that the error was caught and handled by an error boundary to remove the other console.error, which is always sent by React when in development unless these conditions are met.

SUPER wtf, but that's how it works. `expectError` hides all that complexity and allows wrapping any React component in a callback, and then asserting on the exception we wanted to be thrown.

The package.json change is required because by default jest runs every .js file in`__tests__`. It turns out the convention of `.test.js` is supposed to be used directly alongside the file in src. Go figure. By passing `test.js` to jest, this ensures that we don't inadvertantly run `helpers.js` as a test file and get an error because it doesn't contain any tests

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
