### PR TITLE
new useAccount hook for the paywall

### DIFF
--- a/paywall/src/__tests__/hooks/asyncActions/accounts.test.js
+++ b/paywall/src/__tests__/hooks/asyncActions/accounts.test.js
@@ -19,6 +19,8 @@ describe('useAccount async account actions', () => {
       },
     }
 
+    // this helper function allows us to easily create a mock getAccount
+    // to test the code works as expected
     function testMockGetAccount() {
       return makeGetAccount({
         window: fakeWindow,
@@ -62,7 +64,7 @@ describe('useAccount async account actions', () => {
         }
       })
       describe('paywall in iframe', () => {
-        describe('account does not exist', () => {
+        describe('account does not exist (like in coinbase wallet)', () => {
           beforeEach(() => {
             accounts = []
           })
@@ -124,6 +126,7 @@ describe('useAccount async account actions', () => {
     let setAccount
     let setBalance
 
+    // easy mock pollForAccountChange creator for testing
     function testMockPollForAccount() {
       return makePollForAccountChange({
         web3,

--- a/paywall/src/__tests__/hooks/asyncActions/accounts.test.js
+++ b/paywall/src/__tests__/hooks/asyncActions/accounts.test.js
@@ -1,0 +1,237 @@
+import {
+  makeGetAccount,
+  makePollForAccountChange,
+} from '../../../hooks/asyncActions/accounts'
+
+describe('useAccount async account actions', () => {
+  describe('makeGetAccount', () => {
+    let setAccount
+    let setBalance
+    let saveLocalStorageAccount
+    let localStorageAccount
+    let isInIframe
+    let web3
+    let fakeWindow = {
+      location: {
+        pathname:
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
+        hash: '#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      },
+    }
+
+    function testMockGetAccount() {
+      return makeGetAccount({
+        window: fakeWindow,
+        web3,
+        isInIframe,
+        localStorageAccount,
+        saveLocalStorageAccount,
+        setAccount,
+        setBalance,
+      })
+    }
+    beforeEach(() => {
+      setAccount = jest.fn()
+      setBalance = jest.fn()
+      saveLocalStorageAccount = jest.fn()
+      isInIframe = true
+      localStorageAccount = undefined
+      web3 = undefined
+    })
+    it('does nothing if web3 is not defined', async () => {
+      web3 = false
+      const getAccount = testMockGetAccount()
+
+      await getAccount()
+
+      expect(setAccount).not.toHaveBeenCalled()
+    })
+    describe('web3 is set', () => {
+      let accounts = ['account']
+      let balance = '1000000000000000'
+      beforeEach(() => {
+        web3 = {
+          eth: {
+            getAccounts() {
+              return Promise.resolve(accounts)
+            },
+            getBalance() {
+              return Promise.resolve(balance)
+            },
+          },
+        }
+      })
+      describe('paywall in iframe', () => {
+        describe('account does not exist', () => {
+          beforeEach(() => {
+            accounts = []
+          })
+          it('sets the account from localStorage if possible', async () => {
+            localStorageAccount = 'local'
+
+            const getAccount = testMockGetAccount()
+
+            await getAccount()
+
+            expect(setAccount).toHaveBeenCalledWith('local')
+          })
+          it('sets the account from the URL if no localStorage account exists', async () => {
+            const getAccount = testMockGetAccount()
+
+            await getAccount()
+
+            expect(setAccount).toHaveBeenCalledWith(
+              '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+            )
+          })
+          it('saves the account in localStorage if provided in the URL', async () => {
+            const getAccount = testMockGetAccount()
+
+            await getAccount()
+
+            expect(saveLocalStorageAccount).toHaveBeenCalledWith(
+              '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+            )
+          })
+        })
+      })
+      describe('normal account flow', () => {
+        let getAccount
+        beforeEach(() => {
+          getAccount = testMockGetAccount()
+          accounts = ['account']
+        })
+        it('sets the account', async () => {
+          await getAccount()
+
+          expect(setAccount).toHaveBeenCalledWith('account')
+        })
+        it('retrieves and sets the balance', async () => {
+          await getAccount()
+
+          expect(setBalance).toHaveBeenCalledWith('0.001')
+        })
+      })
+    })
+  })
+  describe('makePollForAccount', () => {
+    let web3
+    let isInIframe
+    let localStorageAccount
+    let account
+    let nextAccount
+    let balance
+    let setAccount
+    let setBalance
+
+    function testMockPollForAccount() {
+      return makePollForAccountChange({
+        web3,
+        isInIframe,
+        localStorageAccount,
+        account,
+        setAccount,
+        setBalance,
+      })
+    }
+
+    beforeEach(() => {
+      account = 'account'
+      nextAccount = 'next'
+      balance = '10000000000000'
+      web3 = {
+        eth: {
+          getAccounts: jest.fn(() => {
+            return Promise.resolve([nextAccount])
+          }),
+          getBalance: jest.fn(() => {
+            return Promise.resolve(balance)
+          }),
+        },
+      }
+      isInIframe = true
+      localStorageAccount = undefined
+      setAccount = jest.fn()
+      setBalance = jest.fn()
+    })
+    describe('in iframe', () => {
+      it('does nothing if in the iframe and account was set via localStorage', async () => {
+        localStorageAccount = 'local'
+
+        const pollForAccountChange = testMockPollForAccount()
+
+        await pollForAccountChange()
+
+        expect(web3.eth.getAccounts).not.toHaveBeenCalled()
+      })
+      it('retrieves account if account was not retrieved from localStorage', async () => {
+        const pollForAccountChange = testMockPollForAccount()
+
+        await pollForAccountChange()
+
+        expect(web3.eth.getAccounts).toHaveBeenCalled()
+      })
+    })
+    describe('normal polling', () => {
+      it('does nothing if the new account matches the old', async () => {
+        expect.assertions(2)
+        nextAccount = account
+
+        const pollForAccountChange = testMockPollForAccount()
+
+        await pollForAccountChange()
+
+        expect(web3.eth.getAccounts).toHaveBeenCalled()
+        expect(setAccount).not.toHaveBeenCalled()
+      })
+      it('does nothing if the user was logged out and is still logged out', async () => {
+        expect.assertions(2)
+        nextAccount = account = null
+
+        const pollForAccountChange = testMockPollForAccount()
+
+        await pollForAccountChange()
+
+        expect(web3.eth.getAccounts).toHaveBeenCalled()
+        expect(setAccount).not.toHaveBeenCalled()
+      })
+      it('swallows exceptions', async () => {
+        web3.eth.getAccounts = () => Promise.reject(new Error('nope'))
+
+        const pollForAccountChange = testMockPollForAccount()
+
+        await pollForAccountChange()
+
+        expect(setAccount).not.toHaveBeenCalled()
+      })
+      describe('account change', () => {
+        beforeEach(() => {
+          balance = '3000000000000000'
+        })
+        it('sets the account if it is different', async () => {
+          const pollForAccountChange = testMockPollForAccount()
+
+          await pollForAccountChange()
+
+          expect(setAccount).toHaveBeenCalledWith('next')
+        })
+        it('retrieves and sets the balance if the account exists', async () => {
+          const pollForAccountChange = testMockPollForAccount()
+
+          await pollForAccountChange()
+
+          expect(setBalance).toHaveBeenCalledWith('0.003')
+        })
+        it('resets balance to 0 if the account was logged out', async () => {
+          nextAccount = null
+
+          const pollForAccountChange = testMockPollForAccount()
+
+          await pollForAccountChange()
+
+          expect(setBalance).toHaveBeenCalledWith('0')
+        })
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/hooks/useAccount.test.js
+++ b/paywall/src/__tests__/hooks/useAccount.test.js
@@ -12,6 +12,10 @@ import {
   makePollForAccountChange,
 } from '../../hooks/asyncActions/accounts'
 
+// we are going to mock out everything possible
+// in order to deal with asynchrony and hooks
+// React testing has not yet caught up with async functions in hooks
+// and this is the cleanest way to easily test them
 jest.mock('../../hooks/utils/usePoll')
 jest.mock('../../hooks/browser/useLocalStorage')
 jest.mock('../../hooks/asyncActions/accounts.js')
@@ -24,6 +28,11 @@ describe('useAccount hook', () => {
   let getAccount
   let pollForAccounts
 
+  // wrapper to use with rtl's testHook
+  // allows us to pass in the mock wallet
+  // the InnerWrapper is pulled from the test helpers file
+  // and includes passing in mock config and testing for errors
+  // thrown in hooks
   function wrapper(props) {
     return (
       <WalletContext.Provider value={wallet}>

--- a/paywall/src/__tests__/hooks/useAccount.test.js
+++ b/paywall/src/__tests__/hooks/useAccount.test.js
@@ -1,0 +1,116 @@
+import * as rtl from 'react-testing-library'
+import React from 'react'
+
+import { wrapperMaker } from './helpers'
+import useAccount from '../../hooks/useAccount'
+import usePoll from '../../hooks/utils/usePoll'
+import useLocalStorage from '../../hooks/browser/useLocalStorage'
+import { POLLING_INTERVAL } from '../../constants'
+import { WalletContext } from '../../hooks/components/Wallet'
+import {
+  makeGetAccount,
+  makePollForAccountChange,
+} from '../../hooks/asyncActions/accounts'
+
+jest.mock('../../hooks/utils/usePoll')
+jest.mock('../../hooks/browser/useLocalStorage')
+jest.mock('../../hooks/asyncActions/accounts.js')
+
+describe('useAccount hook', () => {
+  let config
+  let fakeWindow
+  let wallet
+  let InnerWrapper
+  let getAccount
+  let pollForAccounts
+
+  function wrapper(props) {
+    return (
+      <WalletContext.Provider value={wallet}>
+        <InnerWrapper {...props} />
+      </WalletContext.Provider>
+    )
+  }
+
+  beforeEach(() => {
+    getAccount = jest.fn()
+    pollForAccounts = jest.fn()
+    makeGetAccount.mockImplementation(() => getAccount)
+    makePollForAccountChange.mockImplementation(() => pollForAccounts)
+    useLocalStorage.mockImplementation(() => ['local', () => {}])
+    config = { isInIframe: true }
+    InnerWrapper = wrapperMaker(config)
+    wallet = 'wallet'
+    fakeWindow = {
+      fakeStorage: {
+        __unlock__account__: 'account',
+      },
+      location: {
+        pathname: '',
+        hash: '',
+      },
+      localStorage: {
+        setItem(name, value) {
+          fakeWindow.fakeStorage[name] = value
+        },
+        getItem(name) {
+          return fakeWindow.fakeStorage[name]
+        },
+      },
+    }
+  })
+
+  it('calls makeGetAccount', () => {
+    expect.assertions(1)
+
+    rtl.testHook(() => useAccount(fakeWindow), { wrapper })
+
+    expect(makeGetAccount).toHaveBeenCalledWith({
+      window: fakeWindow,
+      web3: 'wallet',
+      isInIframe: true,
+      localStorageAccount: 'local',
+      saveLocalStorageAccount: expect.any(Function),
+      setAccount: expect.any(Function),
+      setBalance: expect.any(Function),
+    })
+  })
+  it('calls useLocalStorage', () => {
+    expect.assertions(1)
+
+    rtl.testHook(() => useAccount(fakeWindow), { wrapper })
+
+    expect(useLocalStorage).toHaveBeenCalledWith(
+      fakeWindow,
+      '__unlock__account__'
+    )
+  })
+  it('calls makePollForAccount', () => {
+    expect.assertions(1)
+
+    rtl.testHook(() => useAccount(fakeWindow), { wrapper })
+
+    expect(makePollForAccountChange).toHaveBeenCalledWith({
+      web3: 'wallet',
+      isInIframe: true,
+      localStorageAccount: 'local',
+      account: null,
+      setAccount: expect.any(Function),
+      setBalance: expect.any(Function),
+    })
+  })
+  it('calls useEffect with getAccount', () => {
+    expect.assertions(1)
+
+    rtl.testHook(() => useAccount(fakeWindow), { wrapper })
+
+    expect(getAccount).toHaveBeenCalled()
+  })
+  it('calls usePoll with pollForAccounts', () => {
+    expect.assertions(1)
+
+    rtl.testHook(() => useAccount(fakeWindow), { wrapper })
+
+    expect(usePoll).toHaveBeenCalledWith(pollForAccounts, POLLING_INTERVAL)
+  })
+})

--- a/paywall/src/hooks/asyncActions/accounts.js
+++ b/paywall/src/hooks/asyncActions/accounts.js
@@ -1,0 +1,80 @@
+import Web3Utils from 'web3-utils'
+
+import { lockRoute } from '../../utils/routes'
+
+export function makeGetAccount({
+  window,
+  web3,
+  isInIframe,
+  localStorageAccount,
+  saveLocalStorageAccount,
+  setAccount,
+  setBalance,
+}) {
+  const getAccount = async () => {
+    if (!web3) return
+    let thisAccount = null
+    let balance = '0'
+    try {
+      const accounts = await web3.eth.getAccounts()
+      thisAccount = accounts[0]
+      if (!thisAccount) {
+        thisAccount = null
+        throw new Error('no account found')
+      }
+    } catch (e) {
+      if (isInIframe) {
+        if (localStorageAccount) {
+          thisAccount = localStorageAccount
+        } else {
+          const { account: address } = lockRoute(
+            // we need the hash in order to retrieve the account from the iframe URL
+            window.location.pathname + window.location.hash
+          )
+          if (address) {
+            thisAccount = address
+
+            saveLocalStorageAccount(address)
+          }
+        }
+      }
+    }
+    setAccount(thisAccount)
+
+    if (thisAccount) {
+      balance = await web3.eth.getBalance(thisAccount)
+    }
+    // see note above about this hack for testing
+    setBalance(Web3Utils.fromWei(balance, 'ether'))
+  }
+  return getAccount
+}
+
+export function makePollForAccountChange({
+  web3,
+  isInIframe,
+  localStorageAccount,
+  account,
+  setAccount,
+  setBalance,
+}) {
+  const pollForAccountChange = async () => {
+    if (isInIframe && localStorageAccount) return
+    try {
+      const nextAccounts = await web3.eth.getAccounts()
+      const next = nextAccounts && nextAccounts[0]
+      if (next !== account) {
+        setAccount(next)
+        if (next) {
+          const balance = await web3.eth.getBalance(next)
+          setBalance(Web3Utils.fromWei(balance, 'ether'))
+        } else {
+          setBalance('0')
+        }
+      }
+    } catch (e) {
+      // swallow
+    }
+  }
+  return pollForAccountChange
+}

--- a/paywall/src/hooks/useAccount.js
+++ b/paywall/src/hooks/useAccount.js
@@ -38,7 +38,7 @@ export default function useAccount(window) {
     () => {
       getAccount()
     },
-    [web3] // this effect only runs on mount and when (if) the wallet is ready
+    [web3, localStorageAccount, isInIframe] // this effect only runs on mount and when (if) the wallet is ready
   )
 
   // all polling for changes to account happens here

--- a/paywall/src/hooks/useAccount.js
+++ b/paywall/src/hooks/useAccount.js
@@ -24,6 +24,7 @@ export default function useAccount(window) {
     '__unlock__account__'
   )
 
+  // all account/balance retrieval and setting happens here
   const getAccount = makeGetAccount({
     window,
     web3,
@@ -37,9 +38,10 @@ export default function useAccount(window) {
     () => {
       getAccount()
     },
-    [web3]
+    [web3] // this effect only runs on mount and when (if) the wallet is ready
   )
 
+  // all polling for changes to account happens here
   const pollForAccountChange = makePollForAccountChange({
     web3,
     isInIframe,

--- a/paywall/src/hooks/useAccount.js
+++ b/paywall/src/hooks/useAccount.js
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+
+import useWallet from './web3/useWallet'
+import usePoll from './utils/usePoll'
+import { POLLING_INTERVAL } from '../constants'
+import useLocalStorage from './browser/useLocalStorage'
+import useConfig from './utils/useConfig'
+import {
+  makeGetAccount,
+  makePollForAccountChange,
+} from './asyncActions/accounts'
+
+/**
+ * window should be set to falsy if we cannot retrieve the account from localStorage, or store it there
+ */
+export default function useAccount(window) {
+  const web3 = useWallet()
+  const { isInIframe } = useConfig()
+
+  const [account, setAccount] = useState(null)
+  const [balance, setBalance] = useState(0)
+  const [localStorageAccount, saveLocalStorageAccount] = useLocalStorage(
+    window,
+    '__unlock__account__'
+  )
+
+  const getAccount = makeGetAccount({
+    window,
+    web3,
+    isInIframe,
+    localStorageAccount,
+    saveLocalStorageAccount,
+    setAccount,
+    setBalance,
+  })
+  useEffect(
+    () => {
+      getAccount()
+    },
+    [web3]
+  )
+
+  const pollForAccountChange = makePollForAccountChange({
+    web3,
+    isInIframe,
+    localStorageAccount,
+    account,
+    setAccount,
+    setBalance,
+  })
+  usePoll(pollForAccountChange, POLLING_INTERVAL)
+  return { account, localStorageAccount, balance }
+}


### PR DESCRIPTION
# Description

This is a step on the path to #1533 

**comparison to the current model**

The `useAccount` hook is a perfect example of the difference in state management strategies between hooks and redux. In redux, account state management was spread across several middleware and services:

- `walletService` handled retrieving the account, and polling for changes
- `interWindowCommunicationMiddleware` handled retrieving account information from `localStorage`, the URL on redirect from key purchase, and saving the account info back to `localStorage`

All of these account-related activities now happen in the same hook.

**how it is used**

```js
const { account, balance, localStorageAccount } = useAccount(window)
```

The implementation is hidden from users of the hook. All we need to act upon the account as an external user of the hook are the account address, the account balance, and whether it was set from localStorage or not. So, this is what the hook returns. Any change to any of the 3 values will trigger a re-render of the component using the hook.

**implementation detail: handling asyncrony and testing it in hooks**

Hooks are designed to replace side effects, and in particular asynchronous ones, although Suspense will probably be a better place for most of this once it is released.

There is one important logical separation in the `useAccount` hook. While researching the best way to test asynchrony in `useEffect`, I discovered that the React team [hasn't quite figured this out either](https://github.com/facebook/react/issues/14769#issuecomment-462528230).

Ultimately, it looks like using asynchrony directly inside the hook is probably an anti-pattern. It couples the implementation far too tightly, so prying it apart for testing is virtually impossible.

For this reason, the internals of `useAccount` are abstracted into `asyncActions/accounts.js`. In order to take advantage of the state changes, the async functions need to close over the values from the hook. If the function was declared directly in the hook, this would happen naturally, but makes testing impossibly complex. To achieve this same functionality, the 2 async functions are instead created using factory functions. The factories pass in the variables that the async functions need to close over.

With this change, testing is super simple, at the expense of arguably slightly less readability. However, it also yields much shorter functions, and clearer separation of concerns, so this may actually be an advantage. It does increase the surface area for bugs, as forgetting to pass in a variable or changing a signature can result in bugs. However, because this is simply a split of a single hook, the async actions are not called anywhere else, which reduces the chances for a bug.

After considering the above trade-offs, I chose the current design.

**improved polling using hooks**

One massive advantage over the old redux-based/*service design is apparent in the polling for account change. Because polling is abstracted out into a separate hook, the function that does the polling does not need to have any awareness that it is being called repeatedly. This vastly simplifies testing.

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
