### PR TITLE
new useLock hook for the paywall

### DIFF
--- a/paywall/src/__tests__/hooks/asyncActions/locks.test.js
+++ b/paywall/src/__tests__/hooks/asyncActions/locks.test.js
@@ -1,0 +1,92 @@
+import { makeGetLockAttributes } from '../../../hooks/asyncActions/locks'
+import { MAX_UINT, UNLIMITED_KEYS_COUNT } from '../../../constants'
+
+describe('useLock async lock actions', () => {
+  describe('makeGetLockAttributes', () => {
+    const defaultContract = {
+      keyPrice: '400000000000000000',
+      expirationDuration: 12345,
+      maxNumberOfKeys: 100,
+      owner: '0x123',
+      outstandingKeys: 2,
+    }
+    const web3 = {
+      eth: {
+        getBalance: () => Promise.resolve('123000000000000000'),
+        getBlockNumber: () => Promise.resolve(123),
+      },
+    }
+    const lockAddress = 'address'
+
+    function makeMockAttribute(val) {
+      return () => ({
+        call: () => Promise.resolve(val),
+      })
+    }
+    function getMockContract(changes = {}) {
+      const contract = {
+        ...defaultContract,
+        ...changes,
+      }
+      return {
+        methods: Object.keys(contract).reduce((coll, attribute) => {
+          coll[attribute] = makeMockAttribute(contract[attribute])
+          return coll
+        }, {}),
+      }
+    }
+
+    let setLock
+
+    beforeEach(() => {
+      setLock = jest.fn()
+    })
+
+    it('returns the contract', async () => {
+      const contract = getMockContract()
+
+      const getLockAttributes = makeGetLockAttributes({
+        web3,
+        lockAddress,
+        setLock,
+      })
+
+      await getLockAttributes(contract)
+
+      expect(setLock).toHaveBeenCalledWith({
+        address: lockAddress,
+        keyPrice: '0.4',
+        expirationDuration: 12345,
+        maxNumberOfKeys: 100,
+        unlimitedKeys: false,
+        owner: '0x123',
+        outstandingKeys: 2,
+        balance: '0.123',
+        asOf: 123,
+      })
+    })
+    it('sets unlimited keys when maxNumberOfKeys is unlimited', async () => {
+      const contract = getMockContract({ maxNumberOfKeys: MAX_UINT })
+
+      const getLockAttributes = makeGetLockAttributes({
+        web3,
+        lockAddress,
+        setLock,
+      })
+
+      await getLockAttributes(contract)
+
+      expect(setLock).toHaveBeenCalledWith({
+        address: lockAddress,
+        keyPrice: '0.4',
+        expirationDuration: 12345,
+        maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+        unlimitedKeys: true,
+        owner: '0x123',
+        outstandingKeys: 2,
+        balance: '0.123',
+        asOf: 123,
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/hooks/useLock.test.js
+++ b/paywall/src/__tests__/hooks/useLock.test.js
@@ -1,0 +1,81 @@
+import * as rtl from 'react-testing-library'
+import React from 'react'
+
+import useLock from '../../hooks/useLock'
+import LockContract from '../../artifacts/contracts/PublicLock.json'
+
+import { makeGetLockAttributes } from '../../hooks/asyncActions/locks'
+import { ReadOnlyContext } from '../../hooks/components/Web3'
+
+// we are going to mock out everything possible
+// in order to deal with asynchrony and hooks
+// React testing has not yet caught up with async functions in hooks
+// and this is the cleanest way to easily test them
+jest.mock('../../hooks/asyncActions/locks.js')
+
+describe('useLock hook', () => {
+  let web3
+  let getLockAttributes
+  const lockAddress = 'address'
+  const contract = { contract: 'contract' }
+
+  // wrapper to use with rtl's testHook
+  // allows us to pass in the mock wallet
+  // the InnerWrapper is pulled from the test helpers file
+  // and includes passing in mock config and testing for errors
+  // thrown in hooks
+  function wrapper(props) {
+    return <ReadOnlyContext.Provider value={web3} {...props} />
+  }
+
+  beforeEach(() => {
+    getLockAttributes = jest.fn()
+    makeGetLockAttributes.mockImplementation(() => getLockAttributes)
+    web3 = {
+      eth: {
+        Contract: jest.fn(() => contract),
+      },
+    }
+  })
+  it('calls makeGetLockAttributes', () => {
+    rtl.testHook(
+      () => {
+        useLock(lockAddress)
+      },
+      { wrapper }
+    )
+
+    expect(makeGetLockAttributes).toHaveBeenCalledWith({
+      web3,
+      lockAddress,
+      setLock: expect.any(Function),
+    })
+  })
+  it('calls getLockAttributes', () => {
+    rtl.testHook(
+      () => {
+        useLock(lockAddress)
+      },
+      { wrapper }
+    )
+
+    expect(getLockAttributes).toHaveBeenCalledWith(contract)
+  })
+  it('calls web3.eth.Contract with the LockContract abi', () => {
+    rtl.testHook(
+      () => {
+        useLock(lockAddress)
+      },
+      { wrapper }
+    )
+
+    expect(web3.eth.Contract).toHaveBeenCalledWith(LockContract.abi, 'address')
+  })
+  it('returns the lock', () => {
+    const {
+      result: { current: lock },
+    } = rtl.testHook(() => useLock(lockAddress), { wrapper })
+
+    expect(lock).toEqual({ address: lockAddress })
+  })
+})

--- a/paywall/src/__tests__/hooks/useLock.test.js
+++ b/paywall/src/__tests__/hooks/useLock.test.js
@@ -78,4 +78,16 @@ describe('useLock hook', () => {
 
     expect(lock).toEqual({ address: lockAddress })
   })
+  it('does not update unless web3 changes', () => {
+    const { rerender } = rtl.testHook(
+      () => {
+        useLock(lockAddress)
+      },
+      { wrapper }
+    )
+
+    rerender()
+
+    expect(web3.eth.Contract).toHaveBeenCalledTimes(1)
+  })
 })

--- a/paywall/src/hooks/asyncActions/locks.js
+++ b/paywall/src/hooks/asyncActions/locks.js
@@ -1,0 +1,59 @@
+import Web3Utils from 'web3-utils'
+import { MAX_UINT, UNLIMITED_KEYS_COUNT } from '../../constants'
+
+export const attributes = {
+  keyPrice: x => Web3Utils.fromWei(x, 'ether'),
+  expirationDuration: parseInt,
+  maxNumberOfKeys: value => {
+    if (value === MAX_UINT) {
+      return UNLIMITED_KEYS_COUNT
+    }
+    return parseInt(value)
+  },
+  owner: x => x,
+  outstandingKeys: parseInt,
+}
+
+export function makeGetLockAttributes({ web3, lockAddress, setLock }) {
+  const getLockAttributes = async contract => {
+    const constantPromises = Object.keys(attributes).map(async attribute => {
+      const result = await contract.methods[attribute]().call()
+      return attributes[attribute](result) // We cast the value
+    })
+
+    // Let's load its balance
+    const getBalance = async () => {
+      const balance = await web3.eth.getBalance(lockAddress)
+      return Web3Utils.fromWei(balance, 'ether')
+    }
+    constantPromises.push(getBalance())
+
+    // Let's load the current block to use to compare versions
+    constantPromises.push(web3.eth.getBlockNumber())
+
+    // Once all lock attributes have been fetched
+    const [
+      keyPrice,
+      expirationDuration,
+      maxNumberOfKeys,
+      owner,
+      outstandingKeys,
+      balance,
+      asOf,
+    ] = await Promise.all(constantPromises)
+    const update = {
+      address: lockAddress,
+      keyPrice,
+      expirationDuration,
+      maxNumberOfKeys,
+      unlimitedKeys: maxNumberOfKeys === UNLIMITED_KEYS_COUNT,
+      owner,
+      outstandingKeys,
+      balance,
+      asOf,
+    }
+    setLock(update)
+  }
+
+  return getLockAttributes
+}

--- a/paywall/src/hooks/useLock.js
+++ b/paywall/src/hooks/useLock.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react'
+
+import LockContract from '../artifacts/contracts/PublicLock.json'
+import useWeb3 from './web3/useWeb3'
+import { makeGetLockAttributes } from './asyncActions/locks'
+
+export default function useLock(lockAddress) {
+  const [lock, setLock] = useState({ address: lockAddress })
+  const web3 = useWeb3()
+
+  const getLockAttributes = makeGetLockAttributes({
+    web3,
+    lockAddress,
+    setLock,
+  })
+  useEffect(
+    () => {
+      const contract = new web3.eth.Contract(LockContract.abi, lockAddress)
+      getLockAttributes(contract)
+    },
+    [lockAddress]
+  )
+  return lock
+}

--- a/paywall/src/hooks/useLock.js
+++ b/paywall/src/hooks/useLock.js
@@ -15,10 +15,11 @@ export default function useLock(lockAddress) {
   })
   useEffect(
     () => {
+      if (!web3) return
       const contract = new web3.eth.Contract(LockContract.abi, lockAddress)
       getLockAttributes(contract)
     },
-    [lockAddress]
+    [web3, lockAddress]
   )
   return lock
 }


### PR DESCRIPTION
# Description

This is a step on the path to #1533 

the `useLock` hook retrieves lock data from the read-only web3 provider, and forces a re-render when it is done retrieving it.  It is used simply by:

```js
const lock = useLock(address)
```

Presumably the lock address will be parsed from the URL and passed in (that's how the paywall uses it).

Currently there is no polling, and the lock is only retrieved once. If desired, adding polling for price changes/key availability would be trivial to add, just would need to do a usePoll instead of useEffect

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
