### PR TITLE
simplify and fix the usePoll hook based on real-world testing

### DIFF
--- a/paywall/src/__tests__/hooks/utils/usePoll.test.js
+++ b/paywall/src/__tests__/hooks/utils/usePoll.test.js
@@ -13,7 +13,7 @@ describe('usePoll hook', () => {
 
     expect(setTimeout).toHaveBeenCalledTimes(2)
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 100)
-    expect(pollingFunction).not.toHaveBeenCalled()
+    expect(pollingFunction).toHaveBeenCalled()
   })
 
   it('calls effect only on mount, and not on update', () => {
@@ -35,16 +35,16 @@ describe('usePoll hook', () => {
 
     rtl.testHook(() => usePoll(pollingFunction, 100))
 
-    expect(pollingFunction).not.toHaveBeenCalled()
+    expect(pollingFunction).toHaveBeenCalled()
 
     jest.advanceTimersByTime(100)
-    expect(pollingFunction).toHaveBeenCalledTimes(1)
+    expect(pollingFunction).toHaveBeenCalledTimes(2)
 
     jest.advanceTimersByTime(99)
-    expect(pollingFunction).toHaveBeenCalledTimes(1)
+    expect(pollingFunction).toHaveBeenCalledTimes(2)
 
     jest.advanceTimersByTime(1)
-    expect(pollingFunction).toHaveBeenCalledTimes(2)
+    expect(pollingFunction).toHaveBeenCalledTimes(3)
   })
 
   it('clears the timeout when unmounted', () => {
@@ -57,7 +57,7 @@ describe('usePoll hook', () => {
     unmount()
 
     jest.advanceTimersByTime(2)
-    expect(pollingFunction).not.toHaveBeenCalled()
+    expect(pollingFunction).toHaveBeenCalled()
     expect(clearTimeout).toHaveBeenCalled()
   })
 })

--- a/paywall/src/hooks/utils/usePoll.js
+++ b/paywall/src/hooks/utils/usePoll.js
@@ -5,19 +5,23 @@ import { useEffect, useRef } from 'react'
  * that will automatically start the polling when the component mounts, and remove it when it
  * umounts
  */
-export default function usePoll(cb, delay) {
+export default function usePoll(cb, delay, noPoll = false) {
   // we use a ref to avoid re-render on change
   // refs act like class properties and are not to be confused with
   // the old React concept of ref
   const cancel = useRef()
   // this hook only runs on mount and cancels on umount
-  useEffect(() => {
-    let poll = f => {
-      cb()
-      cancel.current = setTimeout(f, delay)
-    }
-    poll = poll.bind(null, poll)
-    cancel.current = setTimeout(poll, delay)
-    return () => clearTimeout(cancel.current)
-  }, [])
+  useEffect(
+    () => {
+      if (noPoll) return
+      if (cancel.current) clearTimeout(cancel.current)
+      function poll() {
+        cb()
+        cancel.current = setTimeout(poll, delay)
+      }
+      poll()
+      return () => clearTimeout(cancel.current)
+    },
+    [cb]
+  )
 }

--- a/paywall/src/hooks/utils/usePoll.js
+++ b/paywall/src/hooks/utils/usePoll.js
@@ -5,23 +5,20 @@ import { useEffect, useRef } from 'react'
  * that will automatically start the polling when the component mounts, and remove it when it
  * umounts
  */
-export default function usePoll(cb, delay, noPoll = false) {
+export default function usePoll(cb, delay, vars = [cb], noPoll = false) {
   // we use a ref to avoid re-render on change
   // refs act like class properties and are not to be confused with
   // the old React concept of ref
   const cancel = useRef()
   // this hook only runs on mount and cancels on umount
-  useEffect(
-    () => {
-      if (noPoll) return
-      if (cancel.current) clearTimeout(cancel.current)
-      function poll() {
-        cb()
-        cancel.current = setTimeout(poll, delay)
-      }
-      poll()
-      return () => clearTimeout(cancel.current)
-    },
-    [cb]
-  )
+  useEffect(() => {
+    if (noPoll) return
+    if (cancel.current) clearTimeout(cancel.current)
+    function poll() {
+      cb()
+      cancel.current = setTimeout(poll, delay)
+    }
+    poll()
+    return () => clearTimeout(cancel.current)
+  }, vars)
 }


### PR DESCRIPTION
# Description

A step on the path to #1533 

This PR fixes some subtle bugs in the `usePoll` hook, and updates the tests accordingly

First, the hook needed to update when the callback changed, and cancel the polling with the previous callback.
Next, it adds a `noPoll` debugging option which can be used to turn off polling for debugging locally (all those `eth_accounts` calls @cnasc pointed out would be fixed by this as long as you're debugging the paywall. Once dashboard moved to hooks this benefit will also accrue)

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
