### PR TITLE
fix the lock path regexp to allow running from / as well as /paywall

### DIFF
--- a/paywall/src/__tests__/utils/routes.test.js
+++ b/paywall/src/__tests__/utils/routes.test.js
@@ -15,12 +15,6 @@ describe('route utilities', () => {
         redirect: null,
         account: null,
       })
-      expect(lockRoute('/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')).toEqual({
-        lockAddress: null,
-        prefix: null,
-        redirect: null,
-        account: null,
-      })
     })
 
     it('should return the right prefix and lockAddress value when it matches', () => {
@@ -46,6 +40,12 @@ describe('route utilities', () => {
       ).toEqual({
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'demo',
+        redirect: undefined,
+        account: undefined,
+      })
+      expect(lockRoute('/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: undefined,
         redirect: undefined,
         account: undefined,
       })

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -61,7 +61,7 @@ const lockAddress = accountRegex
  * You should not use this directly, instead use the utils/routes.js lockRoute function
  */
 export const LOCK_PATH_NAME_REGEXP = new RegExp(
-  `/(${prefix})/(${lockAddress})` +
+  `(?:/(${prefix}))?/(${lockAddress})` +
     // either "/urlEncodedRedirectUrl/#account" or just "#account" and these are all optional
     // note that "/#account" as in "/paywall/<lockaddress>/#<useraccount>" is also matched
     `(?:/(${urlEncodedRedirectUrl}))?(?:/?#(${userAccount}))?`


### PR DESCRIPTION
# Description

In order to support paths for the paywall such as `https://paywall.unlock-protocol.com/0x....` the regexp needs to make the prefix portion optional. This PR adds that functionality.

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
