### PR TITLE
new useNetwork hook for the paywall

### DIFF
--- a/paywall/src/__tests__/hooks/web3/useNetwork.test.js
+++ b/paywall/src/__tests__/hooks/web3/useNetwork.test.js
@@ -1,0 +1,101 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import PropTypes from 'prop-types'
+
+import useNetwork from '../../../hooks/web3/useNetwork'
+import { wrapperMaker } from '../helpers'
+import { WalletContext } from '../../../hooks/components/Wallet'
+import getNetwork from '../../../hooks/asyncActions/network'
+
+jest.useFakeTimers()
+jest.mock('../../../hooks/asyncActions/network')
+
+describe('useNetwork hook', () => {
+  let config
+  let Wrapper
+  let networkId
+  const web3 = {
+    eth: {
+      net: {
+        getId: () => networkId,
+      },
+    },
+  }
+
+  function MockNetwork({ noPoll = true }) {
+    const network = useNetwork({ noPoll })
+    return <div>{network}</div>
+  }
+
+  MockNetwork.propTypes = {
+    noPoll: PropTypes.bool, // eslint-disable-line
+  }
+
+  beforeEach(() => {
+    getNetwork.mockImplementation((handle, web3) => {
+      handle(web3.eth.net.getId())
+    })
+    networkId = 4
+    config = {
+      requiredNetworkId: 4,
+    }
+    Wrapper = wrapperMaker(config)
+  })
+
+  it('returns default networkId', () => {
+    const wrapper = rtl.render(
+      <Wrapper>
+        <WalletContext.Provider value={web3}>
+          <MockNetwork />
+        </WalletContext.Provider>
+      </Wrapper>
+    )
+
+    expect(wrapper.getByText('4')).not.toBeNull()
+  })
+
+  it('updates networkId', () => {
+    let wrapper
+
+    networkId = 5
+    rtl.act(() => {
+      wrapper = rtl.render(
+        <Wrapper>
+          <WalletContext.Provider value={web3}>
+            <MockNetwork />
+          </WalletContext.Provider>
+        </Wrapper>
+      )
+    })
+
+    expect(wrapper.getByText('5')).not.toBeNull()
+  })
+
+  it('polls for changes to networkId', () => {
+    let wrapper
+
+    rtl.act(() => {
+      wrapper = rtl.render(
+        <Wrapper>
+          <WalletContext.Provider value={web3}>
+            <MockNetwork noPoll={false} />
+          </WalletContext.Provider>
+        </Wrapper>
+      )
+    })
+
+    expect(wrapper.getByText('4')).not.toBeNull()
+
+    rtl.act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    networkId = 6
+
+    rtl.act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(wrapper.getByText('6')).not.toBeNull()
+  })
+})

--- a/paywall/src/hooks/asyncActions/network.js
+++ b/paywall/src/hooks/asyncActions/network.js
@@ -1,0 +1,3 @@
+export default async (handle, wallet) => {
+  handle(await wallet.eth.net.getId())
+}

--- a/paywall/src/hooks/web3/useNetwork.js
+++ b/paywall/src/hooks/web3/useNetwork.js
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react'
+import useWallet from './useWallet'
+import usePoll from '../utils/usePoll'
+import { POLLING_INTERVAL } from '../../constants'
+import useConfig from '../utils/useConfig'
+import getNetworkId from '../asyncActions/network'
+
+export default function useNetwork({ noPoll = false } = {}) {
+  const wallet = useWallet()
+  const { requiredNetworkId } = useConfig()
+  const [currentNetwork, setCurrentNetwork] = useState(requiredNetworkId)
+
+  usePoll(
+    () => {
+      if (noPoll || !wallet) return
+      getNetworkId(networkId => {
+        if (networkId !== currentNetwork) setCurrentNetwork(networkId)
+      }, wallet)
+    },
+    POLLING_INTERVAL,
+    [wallet, noPoll]
+  )
+  useEffect(
+    () => {
+      if (!noPoll || !wallet) return
+      getNetworkId(networkId => setCurrentNetwork(networkId), wallet)
+    },
+    [wallet, noPoll]
+  ) // runs any time wallet changes
+  return currentNetwork
+}


### PR DESCRIPTION
# Description

A step on the path to #1533 

This is the new `useNetwork` hook for the paywall. It queries the user wallet to determine which network we are currently on. The output will be used in the paywall to trigger an error if the wallet is on a different network than the read-only web3. Unlike the old way, this one polls the network so that when the user changes the network, it will trigger an error as well. Note that metamask currently triggers a page refresh when the network changes, so that behavior is not currently necessary. However, it is possible that other wallets like coinbase wallet do not trigger this behavior, so this is a nice failsafe.

This PR perfectly exhibits the way to isolate async stuff while preserving most of the logic in the hook. This allows us to mock out the asynchronous stuff and still fully test the business logic using a component. This detail-hiding both allows us to test the user/dev experience and to ensure we aren't testing implementation details. Refactoring will be much easier in the future with this style of testing.

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
