### PR TITLE
Experiment: Refactor mixins and add approveForAll (ERC721 standard)

### DIFF
--- a/smart-contracts/contracts/interfaces/IERC721.sol
+++ b/smart-contracts/contracts/interfaces/IERC721.sol
@@ -44,20 +44,6 @@ interface IERC721 {
   /// @param _tokenId The NFT to approve
   function approve(address _approved, uint _tokenId) external payable;
 
-  /// @notice Count all NFTs assigned to an owner
-  /// @dev NFTs assigned to the zero address are considered invalid, and this
-  ///  function throws for queries about the zero address.
-  /// @param _owner An address for whom to query the balance
-  /// @return The number of NFTs owned by `_owner`, possibly zero
-  function balanceOf(address _owner) external view returns (uint);
-
-  /// @notice Find the owner of an NFT
-  /// @dev NFTs assigned to zero address are considered invalid, and queries
-  ///  about them do throw.
-  /// @param _tokenId The identifier for an NFT
-  /// @return The address of the owner of the NFT
-  function ownerOf(uint _tokenId) external view returns (address);
-
   /// @notice Transfers the ownership of an NFT from one address to another address
   /// @dev Throws unless `msg.sender` is the current owner, an authorized
   ///  operator, or the approved address for this NFT. Throws if `_from` is
@@ -86,7 +72,21 @@ interface IERC721 {
   ///  multiple operators per owner.
   /// @param _operator Address to add to the set of authorized operators.
   /// @param _approved True if the operator is approved, false to revoke approval
-  // function setApprovalForAll(address _operator, bool _approved) external;
+  function setApprovalForAll(address _operator, bool _approved) external;
+
+  /// @notice Count all NFTs assigned to an owner
+  /// @dev NFTs assigned to the zero address are considered invalid, and this
+  ///  function throws for queries about the zero address.
+  /// @param _owner An address for whom to query the balance
+  /// @return The number of NFTs owned by `_owner`, possibly zero
+  function balanceOf(address _owner) external view returns (uint);
+
+  /// @notice Find the owner of an NFT
+  /// @dev NFTs assigned to zero address are considered invalid, and queries
+  ///  about them do throw.
+  /// @param _tokenId The identifier for an NFT
+  /// @return The address of the owner of the NFT
+  function ownerOf(uint _tokenId) external view returns (address);
 
   /// @notice Get the approved address for a single NFT
   /// @dev Throws if `_tokenId` is not a valid NFT
@@ -98,7 +98,7 @@ interface IERC721 {
   /// @param _owner The address that owns the NFTs
   /// @param _operator The address that acts on behalf of the owner
   /// @return True if `_operator` is an approved operator for `_owner`, false otherwise
-  // function isApprovedForAll(address _owner, address _operator) external view returns (bool);
+  function isApprovedForAll(address _owner, address _operator) external view returns (bool);
 }
 
 // interface ERC721TokenReceiver {

--- a/smart-contracts/contracts/mixins/MixinDeprecateAndDestroy.sol
+++ b/smart-contracts/contracts/mixins/MixinDeprecateAndDestroy.sol
@@ -1,0 +1,63 @@
+pragma solidity 0.4.25;
+
+import "../interfaces/IERC721.sol";
+import "openzeppelin-eth/contracts/ownership/Ownable.sol";
+
+
+/**
+ * @title Mixin allowing the Lock owner to deprecate a Lock
+ * (preventing new purchases) and then destroy it.
+ * @author HardlyDifficult
+ * @dev `Mixins` are a design pattern seen in the 0x contracts.  It simply 
+ * separates logically groupings of code to ease readability. 
+ */
+contract MixinDeprecateAndDestroy is Ownable {
+
+  event Destroy(
+    uint balance,
+    address indexed owner
+  );
+
+  event Disable();
+
+  // Used to disable payable functions when deprecating an old lock
+  bool public isAlive;
+
+  // Only allow usage when contract is Alive
+  modifier onlyIfAlive() {
+    require(isAlive, "No access after contract has been disabled");
+    _;
+  }
+
+  constructor(
+  ) internal {
+    isAlive = true;
+  }
+
+  /**
+  * @dev Used to disable lock before migrating keys and/or destroying contract
+   */
+  function disableLock(
+  ) external
+    onlyOwner
+    onlyIfAlive
+  {
+    emit Disable();
+    isAlive = false;
+  }
+
+  /**
+  * @dev Used to clean up old lock contracts from the blockchain
+  * TODO: add a check to ensure all keys are INVALID!
+   */
+  function destroyLock(
+  ) external
+    onlyOwner
+  {
+    require(isAlive == false, "Not allowed to delete an active lock");
+    emit Destroy(address(this).balance, msg.sender);
+    selfdestruct(msg.sender);
+    // Note we don't clean up the `locks` data in Unlock.sol as it should not be necessary
+    // and leaves some data behind ("Unlock.LockBalances") which may be helpful.
+  }
+}

--- a/smart-contracts/contracts/mixins/MixinERC721Approval.sol
+++ b/smart-contracts/contracts/mixins/MixinERC721Approval.sol
@@ -1,0 +1,151 @@
+pragma solidity 0.4.25;
+
+import "../interfaces/IERC721.sol";
+import "./MixinKeyOwner.sol";
+import "./MixinDeprecateAndDestroy.sol";
+
+
+/**
+ * @title Mixin for the Approval related functions needed to meet the ERC721 
+ * standard
+ * @author HardlyDifficult
+ * @dev `Mixins` are a design pattern seen in the 0x contracts.  It simply 
+ * separates logically groupings of code to ease readability. 
+ */
+contract MixinERC721Approval is IERC721, MixinKeyOwner, MixinDeprecateAndDestroy {
+
+  // Keeping track of approved transfers
+  // This is a mapping of addresses which have approved
+  // the transfer of a key to another address where their key can be transfered
+  // Note: the approver may actually NOT have a key... and there can only
+  // be a single approved beneficiary
+  // Note 2: for transfer, both addresses will be different
+  // Note 3: for sales (new keys on restricted locks), both addresses will be the same
+  mapping (uint => address) internal approved;
+
+  // Keeping track of approved operators for a Lock owner.
+  // Since an owner can have up to 1 Key, this is similiar to above 
+  // but the approval does not reset when a transfer occurs.
+  mapping (address => mapping (address => bool)) private ownerToOperatorApproved;
+
+  // Ensure that the caller has a key
+  // or that the caller has been approved
+  // for ownership of that key
+  modifier onlyKeyOwnerOrApproved(
+    uint _tokenId
+  ) {
+    require(
+      isKeyOwner(_tokenId, msg.sender)
+      || isApproved(_tokenId, msg.sender)
+      || isApprovedForAll(ownerOf(_tokenId), msg.sender),
+      "Only key owner or approved");
+    _;
+  }
+
+  /**
+   * @dev Approves another address to transfer the given token ID
+   * The zero address indicates there is no approved address.
+   * There can only be one approved address per token at a given time.
+   * Can only be called by the token owner or an approved operator.
+   * Note: that since this is used for both purchase and transfer approvals
+   * the approved token may not exist.
+   */
+  function approve(
+    address _approved,
+    uint _tokenId
+  ) external
+    payable
+    onlyIfAlive
+    onlyKeyOwnerOrApproved(_tokenId)
+  {
+    require(_approved != address(0));
+    require(msg.sender != _approved, "You can't approve yourself");
+
+    approved[_tokenId] = _approved;
+    emit Approval(ownerByTokenId[_tokenId], _approved, _tokenId);
+  }
+
+  /**
+   * @dev Sets or unsets the approval of a given operator
+   * An operator is allowed to transfer all tokens of the sender on their behalf
+   * @param _to operator address to set the approval
+   * @param _approved representing the status of the approval to be set
+   */
+  function setApprovalForAll(
+    address _to,
+    bool _approved
+  ) external
+  {
+    require(_to != msg.sender, "You can't approve yourself");
+    ownerToOperatorApproved[msg.sender][_to] = _approved;
+    emit ApprovalForAll(msg.sender, _to, _approved);
+  }
+
+  /**
+   * external version
+   * Will return the approved recipient for a key, if any.
+   */
+  function getApproved(
+    uint _tokenId
+  ) external view
+    isKey(_tokenId)
+    returns (address)
+  {
+    return _getApproved(_tokenId);
+  }
+
+  /**
+   * @dev Tells whether an operator is approved by a given owner
+   * @param _owner owner address which you want to query the approval of
+   * @param _operator operator address which you want to query the approval of
+   * @return bool whether the given operator is approved by the given owner
+   */
+  function isApprovedForAll(
+    address _owner, 
+    address _operator
+  ) public view 
+    returns (bool) 
+  {
+    return ownerToOperatorApproved[_owner][_operator];
+  }
+
+  /**
+   * @dev Checks if the given user is approved to transfer the tokenId.
+   */
+  function isApproved(
+    uint _tokenId,
+    address _user
+  ) public 
+    returns (bool)
+  {
+    return approved[_tokenId] == _user;
+  }
+
+  /**
+   * Will return the approved recipient for a key transfer or ownership.
+   * Note: this does not check that a corresponding key
+   * actually exists.
+   */
+  function _getApproved(
+    uint _tokenId
+  ) internal view
+    returns (address)
+  {
+    address approvedRecipient = approved[_tokenId];
+    require(approvedRecipient != address(0), "No approved recipient exists");
+    return approvedRecipient;
+  }
+
+  /**
+   * @dev Function to clear current approval of a given token ID
+   * @param _tokenId uint256 ID of the token to be transferred
+   */
+  function _clearApproval(
+    uint256 _tokenId
+  ) internal
+  {
+    if (approved[_tokenId] != address(0)) {
+      approved[_tokenId] = address(0);
+    }
+  }
+}

--- a/smart-contracts/contracts/mixins/MixinKeyOwner.sol
+++ b/smart-contracts/contracts/mixins/MixinKeyOwner.sol
@@ -1,0 +1,80 @@
+pragma solidity 0.4.25;
+
+import "../interfaces/IERC721.sol";
+
+
+/**
+ * @title Mixin for Key ownership related functions needed to meet the ERC721 
+ * standard
+ * @author HardlyDifficult
+ * @dev `Mixins` are a design pattern seen in the 0x contracts.  It simply 
+ * separates logically groupings of code to ease readability. 
+ */
+contract MixinKeyOwner is IERC721 {
+
+  // Each tokenId can have at most exactly one owner at a time.
+  // Returns 0 if the token does not exist
+  // TODO: once we decouple tokenId from owner address (incl in js), then we can consider
+  // merging this with numberOfKeysSold into an array instead.
+  mapping (uint => address) internal ownerByTokenId;
+  
+  // Addresses of owners are also stored in an array.
+  // Addresses are never removed by design to avoid abuses around referals
+  address[] public owners;
+
+  // Ensure that the caller owns the key
+  modifier onlyKeyOwner(
+    uint _tokenId
+  ) {
+    require(
+      ownerByTokenId[_tokenId] == msg.sender, "Not the key owner"
+    );
+    _;
+  }
+
+  // Ensures that a key has an owner
+  modifier isKey(
+    uint _tokenId
+  ) {
+    require(
+      ownerByTokenId[_tokenId] != address(0), "No such key"
+    );
+    _;
+  }
+
+  /**
+   * Public function which returns the total number of unique owners (both expired
+   * and valid).  This may be larger than outstandingKeys.
+   */
+  function numberOfOwners(
+  ) external view
+    returns (uint)
+  {
+    return owners.length;
+  }
+
+  /**
+   * @notice ERC721: Find the owner of an NFT
+   * @return The address of the owner of the NFT, if applicable
+  */
+  function ownerOf(
+    uint _tokenId
+  ) public view
+    isKey(_tokenId)
+    returns (address)
+  {
+    return ownerByTokenId[_tokenId];
+  }
+
+  /**
+   * Checks if the given address owns the given tokenId.
+   */
+  function isKeyOwner(
+    uint _tokenId,
+    address _owner
+  ) public view 
+    returns (bool)
+  {
+    return ownerByTokenId[_tokenId] == _owner;
+  }
+}

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -19,7 +19,7 @@ contract('Lock ERC721', accounts => {
           locks['FIRST'].approve(accounts[2], 42, {
             from: accounts[1]
           }),
-          'Not the key owner'
+          'No such key'
         )
       })
     })
@@ -43,7 +43,7 @@ contract('Lock ERC721', accounts => {
             locks['FIRST'].approve(accounts[2], ID, {
               from: accounts[2]
             }),
-            'Not the key owner'
+            'Only key owner or approved'
           )
         })
       })

--- a/smart-contracts/test/Lock/erc721/approveForAll.js
+++ b/smart-contracts/test/Lock/erc721/approveForAll.js
@@ -1,0 +1,101 @@
+const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+const deployLocks = require('../../helpers/deployLocks')
+const shouldFail = require('../../helpers/shouldFail')
+const Unlock = artifacts.require('../../Unlock.sol')
+
+let unlock, lock, ID
+
+contract('Lock ERC721', accounts => {
+  before(async () => {
+    unlock = await Unlock.deployed()
+    locks = await deployLocks(unlock)
+    lock = locks['FIRST']
+  })
+
+  describe('approveForAll', () => {
+    let owner = accounts[1]
+    let approvedUser = accounts[2]
+
+    describe('when the key exists', () => {
+
+      before(async () => {
+        await lock.purchaseFor(
+          owner,
+          Web3Utils.toHex('Satoshi'),
+          {
+            value: Units.convert('0.01', 'eth', 'wei'),
+            from: owner
+          }
+        )
+        ID = await lock.getTokenIdFor(owner)
+      })
+
+      it('isApprovedForAll defaults to false', async () => {
+        assert.equal(
+          await lock.isApprovedForAll(owner, approvedUser),
+          false
+        )
+      })
+
+      describe('when the sender is self approving', () => {
+        it('should fail', async () => {
+          await shouldFail(
+            lock.setApprovalForAll(owner, true, {
+              from: owner
+            }),
+            "You can't approve yourself"
+          )
+        })
+      })
+
+      describe('when the approval succeeds', () => {
+        let event
+        before(async () => {
+          let result = await lock.setApprovalForAll(approvedUser, true, {
+            from: owner
+          })
+          event = result.logs[0]
+        })
+
+        it('isApprovedForAll is true', async () => {
+          assert.equal(
+            await lock.isApprovedForAll(owner, approvedUser),
+            true
+          )
+        })
+
+        it('should trigger the ApprovalForAll event', () => {
+          assert.equal(event.event, 'ApprovalForAll')
+          assert.equal(event.args._owner, owner)
+          assert.equal(event.args._operator, approvedUser)
+          assert.equal(event.args._approved, true)
+        })
+
+        it('should allow the approved user to transferFrom', async () => {
+          await lock.transferFrom(owner, accounts[2], ID, {
+            from: approvedUser
+          })
+        })
+      })
+
+      describe('can cancel an outstanding approval', () => {
+        before(async () => {
+          await lock.setApprovalForAll(approvedUser, true, {
+            from: owner
+          })
+          await lock.setApprovalForAll(approvedUser, false, {
+            from: owner
+          })
+        })
+
+        it('isApprovedForAll is false again', async () => {
+          assert.equal(
+            await lock.isApprovedForAll(owner, approvedUser),
+            false
+          )
+        })
+      })
+    })
+  })
+})

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -76,10 +76,11 @@ contract('Lock ERC721', accounts => {
 
       it('should abort if the recipient is 0x', async () => {
         await shouldFail(
-          locks['FIRST'].transferFrom(from, Web3Utils.padLeft(0, 40), from, {
+          locks['FIRST'].transferFrom(from, Web3Utils.padLeft(0, 40),
+            await locks['FIRST'].getTokenIdFor.call(from), {
             from
           }),
-          'No approved recipient exists'
+          'Can\'t Transfer to 0x Address'
         )
         // Ensuring that ownership of the key did not change
         const expirationTimestamp = new BigNumber(
@@ -213,7 +214,7 @@ contract('Lock ERC721', accounts => {
 
         it('approval should be cleared after a transfer', async () => {
           await shouldFail(
-            locks['FIRST'].getApproved(accountApproved),
+            locks['FIRST'].getApproved.call(ID),
             'No approved recipient exists'
           )
         })


### PR DESCRIPTION
# Description

Adding approveForAll, which is required to meet the ERC721 standard.  Since an owner can have up to 1 Key, the impact of this method is very similar to the standard approve - the difference being the approval is not lost when a transfer occurs.

This change only adds a few functions to the contract.  However I have included a refactor with these changes for consideration.  

The goal of this refactor is to simplify our large PublicLock contract.  I have separated a few distinct capabilities into their own file.  e.g. all approval related data and functions are in `MixinERC721Approval.sol`.  I find this makes it easier to read/review functionality (and may encourage re-use as we implement new types of Locks).

Inheritance in Solidity is effectively a copy/paste then compile process - so the impact of this refactor is 100% non-functional (i.e. the bytecode diff from the refactor alone should be null). 

This approach was inspired by 0x, see https://github.com/0xProject/0x-monorepo/tree/development/contracts/exchange/contracts/src

If you are not onboard with this "mixin" approach, I can roll that back while keeping the new approveForAll implementation.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
