### PR TITLE
new useLockFromService hook for the paywall

### DIFF
--- a/paywall/src/__tests__/hooks/useLockFromService.test.js
+++ b/paywall/src/__tests__/hooks/useLockFromService.test.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+
+import { Web3ServiceContext } from '../../hooks/components/Web3Service'
+import useLockFromService from '../../hooks/useLockFromService'
+
+describe('useLockFromService hook', () => {
+  let web3
+  let addEventListener
+  let removeEventListener
+
+  function MockLockFromService() {
+    const lock = useLockFromService('0x123')
+    return <div title="lock">{JSON.stringify(lock)}</div>
+  }
+  function Wrapper() {
+    return (
+      <Web3ServiceContext.Provider value={web3}>
+        <MockLockFromService />
+      </Web3ServiceContext.Provider>
+    )
+  }
+
+  beforeEach(() => {
+    addEventListener = jest.fn()
+    removeEventListener = jest.fn()
+    web3 = {
+      addEventListener,
+      removeEventListener,
+    }
+  })
+
+  it('listens for lock updates', () => {
+    rtl.render(<Wrapper />)
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      'lock.updated',
+      expect.any(Function)
+    )
+  })
+
+  it('stops listening for lock updates on unmount', () => {
+    const { unmount } = rtl.render(<Wrapper />)
+
+    unmount()
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'lock.updated',
+      expect.any(Function)
+    )
+  })
+
+  it('sets lock on update', () => {
+    const wrapper = rtl.render(<Wrapper />)
+
+    const update = addEventListener.mock.calls[0][1]
+
+    rtl.act(() => {
+      update('account', { address: 'hi', stuff: 'thing' })
+    })
+
+    expect(wrapper.getByTitle('lock')).toHaveTextContent(
+      JSON.stringify({ address: 'hi', stuff: 'thing' })
+    )
+  })
+})

--- a/paywall/src/__tests__/hooks/useLockFromService.test.js
+++ b/paywall/src/__tests__/hooks/useLockFromService.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
 
-import { Web3ServiceContext } from '../../hooks/components/Web3Service'
+import { Web3ServiceContext } from '../../hooks/components/Web3ServiceProvider'
 import useLockFromService from '../../hooks/useLockFromService'
 
 describe('useLockFromService hook', () => {

--- a/paywall/src/hooks/components/Web3Service.js
+++ b/paywall/src/hooks/components/Web3Service.js
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types'
+import React, { createContext } from 'react'
+
+import web3Service from '../../services/web3Service'
+
+export const Web3ServiceContext = createContext()
+
+export default function Web3Service({ children }) {
+  const { Provider } = Web3ServiceContext
+  const web3 = new web3Service()
+  return <Provider value={web3}>{children}</Provider>
+}
+
+Web3Service.propTypes = {
+  children: PropTypes.node.isRequired,
+}

--- a/paywall/src/hooks/components/Web3ServiceProvider.js
+++ b/paywall/src/hooks/components/Web3ServiceProvider.js
@@ -1,16 +1,18 @@
 import PropTypes from 'prop-types'
 import React, { createContext } from 'react'
 
+import useConfig from '../utils/useConfig'
 import web3Service from '../../services/web3Service'
 
 export const Web3ServiceContext = createContext()
 
-export default function Web3Service({ children }) {
+export default function Web3ServiceProvider({ children }) {
   const { Provider } = Web3ServiceContext
-  const web3 = new web3Service()
+  const { unlockAddress } = useConfig()
+  const web3 = new web3Service(unlockAddress)
   return <Provider value={web3}>{children}</Provider>
 }
 
-Web3Service.propTypes = {
+Web3ServiceProvider.propTypes = {
   children: PropTypes.node.isRequired,
 }

--- a/paywall/src/hooks/useLockFromService.js
+++ b/paywall/src/hooks/useLockFromService.js
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react'
+
+import useWeb3 from './web3/useWeb3Service'
+
+export default function useLockFromService(lockAddress) {
+  const [lock, setLock] = useState({ address: lockAddress })
+  const web3 = useWeb3()
+
+  const listenForLocks = (address, update) => {
+    setLock(update)
+  }
+  useEffect(
+    () => {
+      if (!web3) return
+      web3.addEventListener('lock.updated', listenForLocks)
+      return () => web3.removeEventListener('lock.updated', listenForLocks)
+    },
+    [web3, lockAddress]
+  )
+  return lock
+}

--- a/paywall/src/hooks/web3/useWeb3Service.js
+++ b/paywall/src/hooks/web3/useWeb3Service.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import { Web3ServiceContext } from '../components/Web3Service'
+
+export default function useWeb3Service() {
+  return useContext(Web3ServiceContext)
+}

--- a/paywall/src/hooks/web3/useWeb3Service.js
+++ b/paywall/src/hooks/web3/useWeb3Service.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { Web3ServiceContext } from '../components/Web3Service'
+import { Web3ServiceContext } from '../components/Web3ServiceProvider'
 
 export default function useWeb3Service() {
   return useContext(Web3ServiceContext)


### PR DESCRIPTION
# Description

fixes #1572, requires #1577 and #1583 to be merged first

new `useLockFromService` hook. The public-facing API is identical to the `useLock` hook, except it uses the `web3Service` internally

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
