### PR TITLE
Re-ordering docker image to install dependncies less often

### DIFF
--- a/docker/unlock.dockerfile
+++ b/docker/unlock.dockerfile
@@ -20,43 +20,63 @@ RUN SKIP_SERVICES=true npm ci --production
 
 # Note: we do not build the test directory because it is built in its own image
 
+# Dependencies for smart contracts
 RUN mkdir /home/unlock/smart-contracts
 COPY --chown=node smart-contracts/package-lock.json /home/unlock/smart-contracts/.
 COPY --chown=node smart-contracts/package.json /home/unlock/smart-contracts/.
 WORKDIR /home/unlock/smart-contracts
 RUN npm ci --production
-COPY --chown=node smart-contracts/ /home/unlock/smart-contracts/.
-RUN npm run build
 
+# Dependencies for locksmith
 RUN mkdir /home/unlock/locksmith
 COPY --chown=node locksmith/package-lock.json /home/unlock/locksmith/.
 COPY --chown=node locksmith/package.json /home/unlock/locksmith/.
 WORKDIR /home/unlock/locksmith
 RUN npm ci --production
-COPY --chown=node locksmith/ /home/unlock/locksmith/.
-RUN npm run build
 
+# Dependencies for Unlock app
 RUN mkdir /home/unlock/unlock-app
 COPY --chown=node unlock-app/package-lock.json /home/unlock/unlock-app/.
 COPY --chown=node unlock-app/package.json /home/unlock/unlock-app/.
 WORKDIR /home/unlock/unlock-app
 RUN npm ci --production
-COPY --chown=node unlock-app/ /home/unlock/unlock-app/.
-RUN npm run build
 
+# Dependencies for Paywall
 RUN mkdir /home/unlock/paywall
 COPY --chown=node paywall/package-lock.json /home/unlock/paywall/.
 COPY --chown=node paywall/package.json /home/unlock/paywall/.
 WORKDIR /home/unlock/paywall
 RUN npm ci --production
+
+WORKDIR /home/unlock/
+# Copy the scripts which are used for builds
+COPY --chown=node ./scripts /home/unlock/scripts
+
+# Copy the parent binaries into the children
+WORKDIR /home/unlock/
+RUN npm run link-parent-bin
+
+# Build smart contract
+WORKDIR /home/unlock/smart-contracts
+COPY --chown=node smart-contracts/ /home/unlock/smart-contracts/.
+RUN npm run build
+
+# Build locksmith
+WORKDIR /home/unlock/locksmith
+COPY --chown=node locksmith/ /home/unlock/locksmith/.
+RUN npm run build
+
+# Build Unlock app
+WORKDIR /home/unlock/unlock-app
+COPY --chown=node unlock-app/ /home/unlock/unlock-app/.
+RUN npm run build
+
+# Build paywall
+WORKDIR /home/unlock/paywall
 COPY --chown=node paywall/ /home/unlock/paywall/.
 RUN npm run build
 
 WORKDIR /home/unlock/
-
-# Copy the parent binaries into the children
-RUN npm run link-parent-bin
-
-# Copy the rest
-COPY --chown=node . /home/unlock
+# # Copy the rest # Can we be smarter here since a lot has been copied already?
+# COPY --chown=node . /home/unlock
 


### PR DESCRIPTION
I think we can optimize things a bit further because istalling dependenies is what takes the most time but also happens fairly rarely.
This change should make builds faster because we benefit from more caching.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread