### PR TITLE
Add metadata to lock embed code form

### DIFF
--- a/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
+++ b/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
@@ -49,15 +49,18 @@ const Metadata = () => {
       </MetadataHeader>
       <MetadataBody>
         <div>
-          <input id="metering" type="number" />
-          <label htmlFor="metering">Free Articles</label>
+          <label htmlFor="metering">
+            <input id="metering" type="number" /> Free Articles
+          </label>
         </div>
         <div>
-          <input placeholder="Public Name" />
+          <input />
         </div>
         <div>
-          <input type="checkbox" />
-          <span>Allow unlocking before transaction is confirmed</span>
+          <label htmlFor="trustedUnlocking">
+            <input id="trustedUnlocking" type="checkbox" /> Allow unlocking
+            before transaction is confirmed
+          </label>
         </div>
       </MetadataBody>
     </div>
@@ -122,15 +125,13 @@ const MetadataBody = styled.div`
   }
 
   div:nth-child(3) {
-    display: grid;
-    grid-template-columns: min-content 1fr;
-    align-items: center;
     input {
       height: 26px;
       width: 26px;
-      border: none;
     }
-    span {
+    label {
+      display: flex;
+      align-items: center;
       font-size: 10px;
     }
   }

--- a/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
+++ b/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
@@ -49,8 +49,8 @@ const Metadata = () => {
       </MetadataHeader>
       <MetadataBody>
         <div>
-          <input type="number" />
-          <span>Free Articles</span>
+          <input id="metering" type="number" />
+          <label htmlFor="metering">Free Articles</label>
         </div>
         <div>
           <input placeholder="Public Name" />
@@ -98,6 +98,7 @@ const MetadataBody = styled.div`
     font-family: 'IBM Plex Mono', sans serif;
     font-size: 14px;
     font-weight: 200;
+    margin: 0 0.5em 0 0;
   }
 
   input:focus {
@@ -117,19 +118,16 @@ const MetadataBody = styled.div`
   div:nth-child(1) {
     input {
       width: 3em;
-      margin-right: 0.5em;
     }
   }
 
   div:nth-child(3) {
     display: grid;
-    grid-template-columns: 33px 1fr;
+    grid-template-columns: min-content 1fr;
     align-items: center;
     input {
       height: 26px;
       width: 26px;
-      margin: 0;
-      margin-right: 0.5em;
       border: none;
     }
     span {

--- a/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
+++ b/unlock-app/src/components/creator/lock/EmbedCodeSnippet.js
@@ -22,6 +22,7 @@ export function EmbedCodeSnippet({ lock }) {
   // TODO: add visual confirmation of code having been copied
   return (
     <CodeControls>
+      <Metadata />
       <Label>Code snippet</Label>
       <CodeSnippet value={embedCode(lock)} onClick={selectAll} readOnly />
       <Actions>
@@ -38,7 +39,104 @@ EmbedCodeSnippet.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
 }
 
+const Metadata = () => {
+  return (
+    <div>
+      <MetadataHeader>
+        <span>Metering</span>
+        <span>Public Name</span>
+        <span>Trusted Unlocking</span>
+      </MetadataHeader>
+      <MetadataBody>
+        <div>
+          <input type="number" />
+          <span>Free Articles</span>
+        </div>
+        <div>
+          <input placeholder="Public Name" />
+        </div>
+        <div>
+          <input type="checkbox" />
+          <span>Allow unlocking before transaction is confirmed</span>
+        </div>
+      </MetadataBody>
+    </div>
+  )
+}
+
 export default EmbedCodeSnippet
+
+const MetadataHeader = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  text-transform: uppercase;
+  font-size: 9px;
+  color: var(--4a4a4a);
+  margin-bottom: 7px;
+`
+
+const MetadataBody = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+
+  input[type='number'] {
+    -moz-appearance: textfield;
+  }
+
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  input {
+    background: var(--lightgrey);
+    border: 1px solid var(--lightgrey);
+    border-radius: 4px;
+    height: 26px;
+    padding: 0 8px;
+    font-family: 'IBM Plex Mono', sans serif;
+    font-size: 14px;
+    font-weight: 200;
+  }
+
+  input:focus {
+    outline: none;
+    border: 1px solid var(--grey);
+    transition: border 100ms ease;
+  }
+
+  input[data-valid='false'] {
+    border: 1px solid var(--red);
+  }
+
+  input:disabled {
+    color: var(--silver);
+  }
+
+  div:nth-child(1) {
+    input {
+      width: 3em;
+      margin-right: 0.5em;
+    }
+  }
+
+  div:nth-child(3) {
+    display: grid;
+    grid-template-columns: 33px 1fr;
+    align-items: center;
+    input {
+      height: 26px;
+      width: 26px;
+      margin: 0;
+      margin-right: 0.5em;
+      border: none;
+    }
+    span {
+      font-size: 10px;
+    }
+  }
+`
 
 const Actions = styled.div`
   display: grid;


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->
This PR resolves #1443. It adds the metadata fields to the embed form. Note that it doesn't actually do anything with these fields—hooking it up and putting the metadata onto the embed code, and then acting on that metadata, comes later.

I'll update this with stories soon.

<img width="1233" alt="image" src="https://user-images.githubusercontent.com/9300702/53031450-e074a880-343a-11e9-8dd8-8b0af7afa933.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
