### PR TITLE
When we set the account, also get all the transactions for the locks...

### DIFF
--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -299,11 +299,18 @@ describe('Lock middleware', () => {
   })
 
   describe('not on the paywall', () => {
-    it('should handle SET_ACCOUNT by refreshing balance and retrieving historical unlock transactions', () => {
-      expect.assertions(3)
+    it('should handle SET_ACCOUNT by refreshing balance and retrieving historical unlock transactions', async () => {
+      expect.assertions(4)
+      const mockTx = {
+        returnValues: {
+          newLockAddress: '0x0',
+        },
+      }
+      const p = Promise.resolve([mockTx])
       mockWeb3Service.refreshAccountBalance = jest.fn()
-      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn()
+      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn(() => p)
       mockWeb3Service.getKeyByLockForOwner = jest.fn()
+      mockWeb3Service.getPastLockTransactions = jest.fn()
 
       const { invoke } = create()
 
@@ -318,15 +325,24 @@ describe('Lock middleware', () => {
       expect(
         mockWeb3Service.getPastLockCreationsTransactionsForUser
       ).toHaveBeenCalledWith(newAccount.address)
+      await p
+      expect(mockWeb3Service.getPastLockTransactions).toHaveBeenCalled()
       expect(mockWeb3Service.getKeyByLockForOwner).not.toHaveBeenCalled()
     })
   })
 
   describe('on the paywall', () => {
-    it('should handle SET_ACCOUNT by getting all keys for the owner of that account', () => {
+    it('should handle SET_ACCOUNT by getting all keys for the owner of that account', async () => {
+      const mockTx = {
+        returnValues: {
+          newLockAddress: '0x0',
+        },
+      }
+      const p = Promise.resolve([mockTx])
       mockWeb3Service.refreshAccountBalance = jest.fn()
-      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn()
+      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn(() => p)
       mockWeb3Service.getKeyByLockForOwner = jest.fn()
+      mockWeb3Service.getPastLockTransactions = jest.fn()
 
       const lock = '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9'
       state.router.location.pathname = `/paywall/${lock}/`
@@ -342,6 +358,8 @@ describe('Lock middleware', () => {
       expect(
         mockWeb3Service.getPastLockCreationsTransactionsForUser
       ).toHaveBeenCalled()
+      await p
+      expect(mockWeb3Service.getPastLockTransactions).toHaveBeenCalled()
       expect(mockWeb3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
         lock,
         '0x345'

--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -306,9 +306,11 @@ describe('Lock middleware', () => {
           newLockAddress: '0x0',
         },
       }
-      const p = Promise.resolve([mockTx])
+      const lockCreationTransaction = Promise.resolve([mockTx])
       mockWeb3Service.refreshAccountBalance = jest.fn()
-      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn(() => p)
+      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn(
+        () => lockCreationTransaction
+      )
       mockWeb3Service.getKeyByLockForOwner = jest.fn()
       mockWeb3Service.getPastLockTransactions = jest.fn()
 
@@ -325,7 +327,8 @@ describe('Lock middleware', () => {
       expect(
         mockWeb3Service.getPastLockCreationsTransactionsForUser
       ).toHaveBeenCalledWith(newAccount.address)
-      await p
+      await lockCreationTransaction
+      // We need to await this for the next assertion to work
       expect(mockWeb3Service.getPastLockTransactions).toHaveBeenCalled()
       expect(mockWeb3Service.getKeyByLockForOwner).not.toHaveBeenCalled()
     })
@@ -338,9 +341,11 @@ describe('Lock middleware', () => {
           newLockAddress: '0x0',
         },
       }
-      const p = Promise.resolve([mockTx])
+      const lockCreationTransaction = Promise.resolve([mockTx])
       mockWeb3Service.refreshAccountBalance = jest.fn()
-      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn(() => p)
+      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn(
+        () => lockCreationTransaction
+      )
       mockWeb3Service.getKeyByLockForOwner = jest.fn()
       mockWeb3Service.getPastLockTransactions = jest.fn()
 
@@ -358,7 +363,8 @@ describe('Lock middleware', () => {
       expect(
         mockWeb3Service.getPastLockCreationsTransactionsForUser
       ).toHaveBeenCalled()
-      await p
+      // We need to await this for the next assertion to work
+      await lockCreationTransaction
       expect(mockWeb3Service.getPastLockTransactions).toHaveBeenCalled()
       expect(mockWeb3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
         lock,

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -144,7 +144,11 @@ export default function web3Middleware({ getState, dispatch }) {
         web3Service
           .getPastLockCreationsTransactionsForUser(action.account.address)
           .then(lockCreations => {
-            // For each lock this user created, go get the history of interactions with that lock.
+            // For each lock this user created, go get the history of
+            // interactions with that lock. TODO: Only get the lock interactions
+            // (such as key price update, withdrawals) done by the user. Very
+            // popular locks in the future may have thousands of key purchases,
+            // and we almost certainly don't want to pull them all down here.
             lockCreations.forEach(lockCreation => {
               web3Service.getPastLockTransactions(
                 lockCreation.returnValues.newLockAddress

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -141,9 +141,16 @@ export default function web3Middleware({ getState, dispatch }) {
         // TODO: when the account has been updated we should reset web3Service and remove all listeners
         // So that pending API calls do not interract with our "new" state.
         web3Service.refreshAccountBalance(action.account)
-        web3Service.getPastLockCreationsTransactionsForUser(
-          action.account.address
-        )
+        web3Service
+          .getPastLockCreationsTransactionsForUser(action.account.address)
+          .then(lockCreations => {
+            // For each lock this user created, go get the history of interactions with that lock.
+            lockCreations.forEach(lockCreation => {
+              web3Service.getPastLockTransactions(
+                lockCreation.returnValues.newLockAddress
+              )
+            })
+          })
         const {
           router: {
             location: { pathname },


### PR DESCRIPTION
…associated with that account

# Description

This PR establishes the state needed for #1596 to proceed without hooks. Now, when the account is set and the locks created by that account are added to the state, we also get all the transactions on those locks and add them to the state. For example, now key price updates and key purchases are present in Redux.

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
