### PR TITLE
Add openzeppelin-solidity package

### DIFF
--- a/smart-contracts/package-lock.json
+++ b/smart-contracts/package-lock.json
@@ -9780,9 +9780,9 @@
       "integrity": "sha512-gUdT24ozD5xXeB9tdTzHOYTpz7R1s0YVXhrYe5TSusiqP0YMqh97GB7Zugee2D6446cKxaE94BblgfgPNGaXRQ=="
     },
     "openzeppelin-solidity": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
-      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.0.0.tgz",
+      "integrity": "sha512-SolpxQFArtiYnlSNg3dZ9sz0WVlKtPqSOcJkXRllaZp4+Lpfqz3vxF0yoh7g75TszKPyadqoJmU7+GM/vwh9SA=="
     },
     "optimist": {
       "version": "0.6.1",
@@ -19166,6 +19166,11 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "openzeppelin-solidity": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
+          "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg=="
         },
         "semver": {
           "version": "5.6.0",

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -17,6 +17,7 @@
     "cross-env": "^5.2.0",
     "ethereumjs-units": "^0.2.0",
     "openzeppelin-eth": "^2.0.2",
+    "openzeppelin-solidity": "^2.0.0",
     "shelljs": "^0.8.3",
     "solhint": "^2.0.0",
     "solidity-coverage": "^0.5.11",


### PR DESCRIPTION
# Description

Adding the `openzeppelin-solidity` package.  

This is similar to `openzeppelin-eth`, however `-eth` contracts have been modified to support upgrading.  We need those for `Unlock` but not for the `PublicLock` contract.  One of the features used for upgrading is a "gap" variable (reserving space for future use) - which increases the gas cost.  

Using the version that's most similar to the version of `openzeppelin-eth` we are using.  Later versions require upgrading to Solidity 0.5

I'll follow up this PR with one switching some of our dependencies in PublicLock over.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
