### PR TITLE
Downgrade lint errors regarding quotes / migrate to single quote

### DIFF
--- a/smart-contracts/.soliumrc.json
+++ b/smart-contracts/.soliumrc.json
@@ -5,8 +5,8 @@
   ],
   "rules": {
     "quotes": [
-      "error",
-      "double"
+      "warning",
+      "single"
     ],
     "indentation": [
       "warning",


### PR DESCRIPTION
# Description

Downgrading lint errors for quotes to warning and changing the preference to single quote.  
I'll follow up with a PR changing all the quotes to single, then to change the lint settings back to error.

The reason for this is simply to be consistent with our Javascript lint settings.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
