### PR TITLE
remove that pesky dirty node_modules in wiki when running npm ci

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -29,4 +29,6 @@ if [ "$SKIP_SERVICES" != "true" ]; then
 
   # Copy the parent binaries into the sub projects
   npm run link-parent-bin
+  # remove node_modules from wiki, we don't wants it
+  rm -rf wiki/node_modules
 fi


### PR DESCRIPTION
# Description

This PR remove node_modules from wiki/ after running npm ci, as this is not something we need and we always end up doing it manually anyways prior to a commit.

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
