### PR TITLE
Updates failure scenarios for Storage service and associated tests

### DIFF
--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -25,9 +25,12 @@ describe('StorageService', () => {
     describe('when the requested lock doesnt exist', () => {
       it('raises an appropriate error', async () => {
         expect.assertions(2)
-        axios.get.mockRejectedValue()
-        const result = await storageService.lockLookUp('0x1234243')
-        expect(result).toEqual(null)
+        axios.get.mockRejectedValue('An Error')
+        try {
+          await storageService.lockLookUp('0x1234243')
+        } catch (error) {
+          expect(error).toEqual('An Error')
+        }
         expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x1234243`)
       })
     })
@@ -55,12 +58,17 @@ describe('StorageService', () => {
 
     describe('when attempting to store an existing lock', () => {
       it('returns a failure promise', async () => {
-        expect.assertions(1)
-        axios.post.mockRejectedValue()
-        await storageService.storeLockDetails({
-          name: 'lock_name',
-          address: 'existing_address',
-        })
+        expect.assertions(2)
+        axios.post.mockRejectedValue('An Error')
+        try {
+          await storageService.storeLockDetails({
+            name: 'lock_name',
+            address: 'existing_address',
+          })
+        } catch (error) {
+          expect(error).toEqual('An Error')
+        }
+
         expect(axios.post).toHaveBeenCalledWith(
           `${serviceHost}/lock`,
           {
@@ -94,10 +102,16 @@ describe('StorageService', () => {
     })
 
     describe('when a lock can not be updated', () => {
-      it('should not fail', async () => {
-        expect.assertions(1)
-        axios.put.mockRejectedValue()
-        await storageService.updateLockDetails('lock_address')
+      it('returns an rejected Promise', async () => {
+        expect.assertions(2)
+        axios.put.mockRejectedValue('An Error')
+
+        try {
+          await storageService.updateLockDetails('lock_address')
+        } catch (error) {
+          expect(error).toEqual('An Error')
+        }
+
         expect(axios.put).toHaveBeenCalledWith(
           `${serviceHost}/lock/lock_address`,
           undefined,

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -63,7 +63,6 @@ export default function storageMiddleware({ getState, dispatch }) {
           storageService
             .lockLookUp(action.address)
             .then(name => {
-              if (!name) return
               dispatch(updateLock(action.address, { name }))
             })
             .catch(error => {

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -41,8 +41,10 @@ export default class StorageService {
   }
 
   /**
-   * Returns the name of undefined
-   * Note that we swallow errors here for now...
+   * Returns the name of the request Lock,
+   * in a failure scenario a rejected promise is returned
+   * to the caller.
+   *
    * @param {*} address
    */
   async lockLookUp(address) {
@@ -51,14 +53,16 @@ export default class StorageService {
       if (result.data && result.data.name) {
         return result.data.name
       }
-      return null
-    } catch (err) {
-      return null
+      return Promise.reject(null)
+    } catch (error) {
+      return Promise.reject(error)
     }
   }
 
   /**
-   * Note that we swallow errors here for now...
+   * Store the details of the provide Lock. In the case of failure a rejected promise is
+   * returned to the caller.
+   *
    * @param {*} lock
    * @param {*} token
    */
@@ -70,13 +74,15 @@ export default class StorageService {
 
     try {
       return await axios.post(`${this.host}/lock`, lock, opts)
-    } catch (err) {
-      return null
+    } catch (error) {
+      return Promise.reject(error)
     }
   }
 
   /**
-   * Note that we swallow errors here for now...
+   *  Updates a lock with with details provided. In the case of failure a rejected promise is
+   * returned to the caller.
+   *
    * @param {*} address
    * @param {*} update
    * @param {*} token
@@ -88,8 +94,8 @@ export default class StorageService {
     }
     try {
       return await axios.put(`${this.host}/lock/${address}`, update, opts)
-    } catch (err) {
-      return null
+    } catch (error) {
+      return Promise.reject(error)
     }
   }
 }


### PR DESCRIPTION
This is a fast follow item from release of #1619

Addressing the faulty behavior, negative scenarios are no longer passed to consumers as resolved promises and are presented as rejections.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
