### PR TITLE
Add builders for chain explorer URLs to config

### DIFF
--- a/unlock-app/src/__tests__/config.test.js
+++ b/unlock-app/src/__tests__/config.test.js
@@ -118,6 +118,13 @@ describe('config', () => {
         },
       })
     })
+
+    it('should contain the right URLs for chain explorers', () => {
+      expect.assertions(2)
+
+      expect(Object.keys(config.chainExplorerUrlBuilders)).toHaveLength(1)
+      expect(config.chainExplorerUrlBuilders.etherScan('0x0')).toEqual(false)
+    })
   })
 
   describe('staging', () => {
@@ -150,6 +157,15 @@ describe('config', () => {
         },
       })
     })
+
+    it('should contain the right URLs for chain explorers', () => {
+      expect.assertions(2)
+
+      expect(Object.keys(config.chainExplorerUrlBuilders)).toHaveLength(1)
+      expect(config.chainExplorerUrlBuilders.etherScan('0x0')).toEqual(
+        'https://rinkeby.etherscan.io/address/0x0'
+      )
+    })
   })
 
   describe('production', () => {
@@ -168,6 +184,15 @@ describe('config', () => {
     it('should have the right keys in production', () => {
       expect(config.requiredNetwork).toEqual('Mainnet')
       expect(config.providers).toEqual({}) // We miss a web3 provider!
+    })
+
+    it('should contain the right URLs for chain explorers', () => {
+      expect.assertions(2)
+
+      expect(Object.keys(config.chainExplorerUrlBuilders)).toHaveLength(1)
+      expect(config.chainExplorerUrlBuilders.etherScan('0x0')).toEqual(
+        'https://etherscan.io/address/0x0'
+      )
     })
   })
 })

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -75,6 +75,9 @@ export default function configure(
   let services = {}
   let supportedProviders = []
   let blockTime = 8000 // in mseconds.
+  let chainExplorerUrlBuilders = {
+    etherScan: () => false,
+  }
   const readOnlyProviderUrl = runtimeConfig.readOnlyProvider
 
   if (env === 'test') {
@@ -121,6 +124,8 @@ export default function configure(
 
     // In staging, the network can only be rinkeby
     isRequiredNetwork = networkId => networkId === 4
+    chainExplorerUrlBuilders.etherScan = address =>
+      `https://rinkeby.etherscan.io/address/${address}`
     requiredNetworkId = 4
     supportedProviders = ['Metamask', 'Opera']
     services['storage'] = { host: runtimeConfig.locksmithHost }
@@ -141,6 +146,8 @@ export default function configure(
 
     // In prod, the network can only be mainnet
     isRequiredNetwork = networkId => networkId === 1
+    chainExplorerUrlBuilders.etherScan = address =>
+      `https://etherscan.io/address/${address}`
     requiredNetworkId = 1
 
     supportedProviders = ['Metamask', 'Opera']
@@ -176,5 +183,6 @@ export default function configure(
     unlockAddress,
     services,
     supportedProviders,
+    chainExplorerUrlBuilders,
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

This PR adds a property `chainExplorerUrlBuilders` to the config. Since the chains are different between dev, staging, and prod, this allows us to set which URL to use to point to the explorers. Right now only EtherScan is in there, but it's possible that we'll add more in the future.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
