### PR TITLE
account polling is happening at the middleware level, not inside the service

### DIFF
--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -8,7 +8,6 @@ import UnlockContract from '../../artifacts/contracts/Unlock.json'
 import LockContract from '../../artifacts/contracts/PublicLock.json'
 /* eslint-enable import/no-unresolved */
 import configure from '../../config'
-import { delayPromise } from '../../utils/promises'
 import WalletService from '../../services/walletService'
 import {
   NOT_ENABLED_IN_PROVIDER,
@@ -19,7 +18,6 @@ import {
   FAILED_TO_UPDATE_KEY_PRICE,
   FAILED_TO_WITHDRAW_FROM_LOCK,
 } from '../../errors'
-import { POLLING_INTERVAL } from '../../constants'
 
 jest.mock('../../utils/promises')
 
@@ -69,42 +67,9 @@ describe('WalletService', () => {
     nock.cleanAll()
     config = configure()
     providers = config.providers
-    // the second argument is designed to stop the polling loop in the majority of tests
-    walletService = new WalletService(config, false)
+    walletService = new WalletService(config)
   })
-  describe('pollAccount', () => {
-    it('constructor calls timeout with pollAccount when ready', () => {
-      walletService = new WalletService(config)
-      expect.assertions(2)
-      walletService.checkForAccountChange = jest.fn(() =>
-        Promise.resolve('account')
-      )
 
-      walletService.emit('ready')
-      expect(walletService.ready).toBe(true)
-
-      // delayPromise is a jest.fn() in the mock file
-      expect(delayPromise).toHaveBeenCalledWith(POLLING_INTERVAL)
-    })
-
-    it('pollAccount calls checkForAccountChange and timeout', async () => {
-      walletService.account = 'old account'
-
-      walletService.checkForAccountChange = jest.fn(() =>
-        Promise.resolve('thank u, next')
-      )
-
-      await walletService.pollForAccountChange(false)
-
-      // delayPromise is a jest.fn() in the mock file
-      expect(delayPromise).toHaveBeenCalledWith(POLLING_INTERVAL)
-      expect(walletService.checkForAccountChange).toHaveBeenCalledWith(
-        'old account'
-      )
-
-      expect(walletService.account).toBe('thank u, next')
-    })
-  })
   describe('connect', () => {
     it('should get the network id', done => {
       expect.assertions(1)
@@ -144,7 +109,7 @@ describe('WalletService', () => {
       it('should not emit an error event when we have a contract address from config', done => {
         expect.assertions(3)
         config.unlockAddress = '0x1234567890123456789012345678901234567890'
-        const walletService2 = new WalletService(config, false)
+        const walletService2 = new WalletService(config)
 
         expect(walletService2.ready).toBe(false)
 
@@ -275,44 +240,8 @@ describe('WalletService', () => {
       return walletService.connect('HTTP')
     })
 
-    describe('checkForAccountChange', () => {
-      it('should emit account.changed if the account does not match the local account', async () => {
-        expect.assertions(1)
-        const unlockAccountsOnNode = [
-          '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-        ]
-
-        accountsAndYield(unlockAccountsOnNode)
-
-        walletService.emit = jest.fn()
-
-        await walletService.checkForAccountChange('prior')
-
-        expect(walletService.emit).toHaveBeenCalledWith(
-          'account.changed',
-          '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
-        )
-      })
-
-      it('should not emit account.changed if the account does match the local account', async () => {
-        expect.assertions(1)
-        const unlockAccountsOnNode = [
-          '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-        ]
-
-        accountsAndYield(unlockAccountsOnNode)
-
-        walletService.emit = jest.fn()
-
-        await walletService.checkForAccountChange(
-          '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
-        )
-
-        expect(walletService.emit).not.toHaveBeenCalled()
-      })
-    })
     describe('getAccount', () => {
-      describe('when no account was passed but the node has an unlocked account', () => {
+      describe('when the node has an unlocked account', () => {
         it('should load a local account and emit the ready event', done => {
           expect.assertions(2)
           const unlockAccountsOnNode = [
@@ -336,13 +265,15 @@ describe('WalletService', () => {
         })
       })
 
-      describe('when no account was passed and the node has no unlocked account', () => {
+      describe('when the node has no unlocked account', () => {
         it('should create an account and emit the ready event', done => {
           expect.assertions(2)
           const newAccount = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
 
-          walletService._createAccount = jest.fn(() => {
-            return Promise.resolve(newAccount)
+          walletService.web3.eth.accounts.create = jest.fn(() => {
+            return Promise.resolve({
+              address: newAccount,
+            })
           })
 
           accountsAndYield([])
@@ -356,7 +287,17 @@ describe('WalletService', () => {
             expect(account).toBe('0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1')
           })
 
-          return walletService.getAccount()
+          return walletService.getAccount(true)
+        })
+      })
+
+      describe('when the node has no unlocked account and when preventing from creating one', () => {
+        it('should fail and mark the walletService is not ready', async () => {
+          expect.assertions(1)
+          walletService.ready = true
+          accountsAndYield([])
+          await walletService.getAccount(false)
+          expect(walletService.ready).toBe(false)
         })
       })
     })
@@ -459,24 +400,6 @@ describe('WalletService', () => {
         )
 
         mockTransaction.emit('error', error)
-      })
-    })
-
-    describe('_createAccount', () => {
-      it('should yield a new account', async () => {
-        expect.assertions(1)
-        const address = '0x07748403082b29a45abD6C124A37E6B14e6B1803'
-        // mock web3's create
-        const mock = jest.fn()
-        mock.mockReturnValue({
-          address,
-        })
-        const previousCreate = walletService.web3.eth.accounts.create
-        walletService.web3.eth.accounts.create = mock
-
-        let account = await walletService._createAccount()
-        expect(account).toEqual(address)
-        walletService.web3.eth.accounts.create = previousCreate
       })
     })
 

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -15,8 +15,6 @@ import {
   FAILED_TO_UPDATE_KEY_PRICE,
   FAILED_TO_WITHDRAW_FROM_LOCK,
 } from '../errors'
-import { POLLING_INTERVAL } from '../constants'
-import { delayPromise } from '../utils/promises'
 
 export const keyId = (lock, owner) => [lock, owner].join('-')
 
@@ -27,10 +25,7 @@ export const keyId = (lock, owner) => [lock, owner].join('-')
  * actually retrieving the data from the chain/smart contracts
  */
 export default class WalletService extends EventEmitter {
-  constructor(
-    { providers, runningOnServer, unlockAddress } = configure(),
-    pollForAccountChanges = true
-  ) {
+  constructor({ providers, unlockAddress } = configure()) {
     super()
     if (unlockAddress) {
       this.unlockContractAddress = Web3Utils.toChecksumAddress(unlockAddress)
@@ -42,9 +37,6 @@ export default class WalletService extends EventEmitter {
 
     this.on('ready', () => {
       this.ready = true
-      if (pollForAccountChanges && !runningOnServer) {
-        this.pollForAccountChange(pollForAccountChanges)
-      }
     })
   }
 
@@ -118,74 +110,28 @@ export default class WalletService extends EventEmitter {
   }
 
   /**
-   * Poll to see if account has changed
-   */
-  async pollForAccountChange(pollForNextChange = true) {
-    await delayPromise(POLLING_INTERVAL)
-    try {
-      this.account = await this.checkForAccountChange(this.account)
-    } catch (e) {
-      // if the account poll fails, silently ignore it
-      // TODO: log the error when full-app logging is implemented (#1301)
-    }
-    // because this is async, the call stack is not affected, and does not grow
-    // for a non-async function this would quickly fill all available memory
-    if (pollForNextChange) {
-      this.pollForAccountChange(pollForNextChange /* always true */)
-    }
-  }
-
-  /**
-   * given the prior account address, determine if the account has changed and return the
-   * current address regardless of any change
-   */
-  async checkForAccountChange(currentAccount) {
-    const nextAccount = await this._getAccountAddressOrFallbackAddress(
-      // When retrieving the current account address, there is an
-      // option to fallback to another method when the account is null.
-      // In our case, we do not want to do anything, so our fallback
-      // is simply a promise that resolves to a missing account
-      Promise.resolve(null)
-    )
-
-    if (currentAccount !== nextAccount) {
-      this.emit('account.changed', nextAccount)
-    }
-    return nextAccount
-  }
-
-  /**
    * Function which yields the address of the account on the provider or creates a key pair.
    */
-  async getAccount() {
-    const address = await this._getAccountAddressOrFallbackAddress(
-      this._createAccount
-    )
+  async getAccount(createIfNone = false) {
+    const accounts = await this.web3.eth.getAccounts()
+    let address
+
+    if (!accounts.length && !createIfNone) {
+      // We do not have an account and were not asked to create one!
+      // Not sure how that could happen?
+      return (this.ready = false)
+    }
+
+    if (accounts.length) {
+      address = accounts[0] // We have an account.
+    } else if (createIfNone) {
+      let newAccount = await this.web3.eth.accounts.create()
+      address = newAccount.address
+    }
+
     this.emit('account.changed', address)
     this.emit('ready')
     return Promise.resolve(address)
-  }
-
-  /**
-   * Get the current user account address, calling a fallback if there is none
-   * @param fallback async function that returns an account address
-   * @return string
-   */
-  async _getAccountAddressOrFallbackAddress(fallback) {
-    const accounts = await this.web3.eth.getAccounts()
-    const address = accounts.length ? accounts[0] : await fallback()
-    return address
-  }
-
-  /**
-   * This creates an account on the current network and yields its address.
-   * TODO: is this actually used?
-   * @return Promise<string>
-   * @private
-   */
-  async _createAccount() {
-    const account = await this.web3.eth.accounts.create()
-    return account.address
   }
 
   /**


### PR DESCRIPTION
Polling for account changes is more app logic then business logic... so we are moving this
away from walletService!


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread