### PR TITLE
Refactor mixin for key owner related functions

### DIFF
--- a/smart-contracts/contracts/UnlockErrors.sol
+++ b/smart-contracts/contracts/UnlockErrors.sol
@@ -13,9 +13,6 @@ contract UnlockErrors {
   // The specified value must be greater than 0.
   string public constant GREATER_THAN_ZERO = 'GREATER_THAN_ZERO';
 
-  // Index must be in-bounds
-  string public constant INDEX_OUT_OF_BOUNDS = 'INDEX_OUT_OF_BOUNDS';
-
   // The specified address is not valid (i.e. must not be 0).
   string public constant INVALID_ADDRESS = 'INVALID_ADDRESS';
 

--- a/smart-contracts/contracts/mixins/MixinKeyOwner.sol
+++ b/smart-contracts/contracts/mixins/MixinKeyOwner.sol
@@ -19,7 +19,7 @@ contract MixinKeyOwner is IERC721 {
 
   // Addresses of owners are also stored in an array.
   // Addresses are never removed by design to avoid abuses around referals
-  address[] private owners; // TODO - switch back to public
+  address[] public owners;
 
   // Ensure that the caller owns the key
   modifier onlyKeyOwner(

--- a/smart-contracts/contracts/mixins/MixinKeyOwner.sol
+++ b/smart-contracts/contracts/mixins/MixinKeyOwner.sol
@@ -1,0 +1,138 @@
+pragma solidity 0.4.25;
+
+import '../interfaces/IERC721.sol';
+
+/**
+ * @title Mixin for Key ownership related functions needed to meet the ERC721 
+ * standard
+ * @author HardlyDifficult
+ * @dev `Mixins` are a design pattern seen in the 0x contracts.  It simply 
+ * separates logically groupings of code to ease readability. 
+ */
+contract MixinKeyOwner is IERC721 {
+   
+  // Each tokenId can have at most exactly one owner at a time.
+  // Returns 0 if the token does not exist
+  // TODO: once we decouple tokenId from owner address (incl in js), then we can consider
+  // merging this with numberOfKeysSold into an array instead.
+  mapping (uint => address) private ownerByTokenId;
+
+  // Addresses of owners are also stored in an array.
+  // Addresses are never removed by design to avoid abuses around referals
+  address[] private owners; // TODO - switch back to public
+
+  // Ensure that the caller owns the key
+  modifier onlyKeyOwner(
+    uint _tokenId
+  ) {
+    require(
+      isKeyOwner(_tokenId, msg.sender), 'ONLY_KEY_OWNER'
+    );
+    _;
+  }
+
+  // Ensures that a key has an owner
+  modifier isKey(
+    uint _tokenId
+  ) {
+    require(
+      ownerByTokenId[_tokenId] != address(0), 'NO_SUCH_KEY'
+    );
+    _;
+  }
+
+ /**
+  * A function which returns a subset of the keys for this Lock as an array
+  * @param _page the page of key owners requested when faceted by page size
+  * @param _pageSize the number of Key Owners requested per page
+  */
+  function getOwnersByPage(uint _page, uint _pageSize)
+    public
+    view
+    returns (address[] memory)
+  {
+    require(owners.length > 0, 'NO_OUTSTANDING_KEYS');
+    uint pageSize = _pageSize;
+    uint _startIndex = _page * pageSize;
+    uint endOfPageIndex;
+
+    if (_startIndex + pageSize > owners.length) {
+      endOfPageIndex = owners.length;
+      pageSize = owners.length - _startIndex;
+    } else {
+      endOfPageIndex = (_startIndex + pageSize);
+    }
+
+    // new temp in-memory array to hold pageSize number of requested owners:
+    address[] memory ownersByPage = new address[](pageSize);
+    uint pageIndex = 0;
+
+    // Build the requested set of owners into a new temporary array:
+    for (uint i = _startIndex; i < endOfPageIndex; i++) {
+      ownersByPage[pageIndex] = owners[i];
+      pageIndex++;
+    }
+
+    return ownersByPage;
+  }
+
+  /**
+   * Public function which returns the total number of unique owners (both expired
+   * and valid).  This may be larger than outstandingKeys.
+   */
+  function numberOfOwners()
+    public
+    view
+    returns (uint)
+  {
+    return owners.length;
+  }
+
+  /**
+   * @notice ERC721: Find the owner of an NFT
+   * @return The address of the owner of the NFT, if applicable
+  */
+  function ownerOf(
+    uint _tokenId
+  )
+    public
+    view
+    isKey(_tokenId)
+    returns (address)
+  {
+    return ownerByTokenId[_tokenId];
+  }
+
+  /**
+   * Checks if the given address owns the given tokenId.
+   */
+  function isKeyOwner(
+    uint _tokenId,
+    address _owner
+  ) public view 
+    returns (bool)
+  {
+    return ownerByTokenId[_tokenId] == _owner;
+  }
+
+  /**
+   * Adds a new (unique) Key owner.
+   */
+  function _addNewOwner(
+    address _owner
+  ) internal
+  {
+    owners.push(_owner);
+  }
+
+  /**
+   * Sets the Key owner for a given tokenId.
+   */
+  function _setKeyOwner(
+    uint _tokenId,
+    address _owner
+  ) internal
+  {
+    ownerByTokenId[_tokenId] = _owner;
+  } 
+}


### PR DESCRIPTION
# Description

Part of the refactor described in #1587

Specifically for key owner related functions.  With this I changed `ownerByTokenId` to private (vs internal) and added a couple internal functions with a goal of keeping data itself private to the Mixin -- to ease readability.

No functionality should change with this PR.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
