### PR TITLE
Removes our test chain id from our Typed Data

### DIFF
--- a/unlock-app/src/__tests__/utils/signature.test.js
+++ b/unlock-app/src/__tests__/utils/signature.test.js
@@ -72,7 +72,7 @@ describe('generateSignature', () => {
             { name: 'address', type: 'address' },
           ],
         },
-        domain: { name: 'Unlock Dashboard', version: '1', chainId: 1984 },
+        domain: { name: 'Unlock Dashboard', version: '1' },
         primaryType: 'Lock',
         message: {
           lock: {

--- a/unlock-app/src/structured_data/unlockLock.js
+++ b/unlock-app/src/structured_data/unlockLock.js
@@ -17,7 +17,6 @@ export default class UnlockLock {
     let domainData = {
       name: 'Unlock Dashboard',
       version: '1',
-      chainId: 1984,
     }
 
     let message = {


### PR DESCRIPTION
The EIP 712 Specification states the following: "The user-agent should refuse signing if it does not match the currently active chain."

Removing the chainId should allow us to request signature on all chains. We can tighten this a bit later

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
