### PR TITLE
Adding approve for all to meet ERC721 standard

### DIFF
--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -26,6 +26,11 @@ contract MixinApproval is
   // Note 3: for sales (new keys on restricted locks), both addresses will be the same
   mapping (uint => address) private approved;
 
+  // Keeping track of approved operators for a Lock owner.
+  // Since an owner can have up to 1 Key, this is similiar to above 
+  // but the approval does not reset when a transfer occurs.
+  mapping (address => mapping (address => bool)) private ownerToOperatorApproved;
+
   // Ensure that the caller has a key
   // or that the caller has been approved
   // for ownership of that key
@@ -34,7 +39,8 @@ contract MixinApproval is
   ) {
     require(
       isKeyOwner(_tokenId, msg.sender) ||
-      _getApproved(_tokenId) == msg.sender,
+        _isApproved(_tokenId, msg.sender) ||
+        isApprovedForAll(ownerOf(_tokenId), msg.sender),
       'ONLY_KEY_OWNER_OR_APPROVED');
     _;
   }
@@ -61,6 +67,22 @@ contract MixinApproval is
   }
 
   /**
+   * @dev Sets or unsets the approval of a given operator
+   * An operator is allowed to transfer all tokens of the sender on their behalf
+   * @param _to operator address to set the approval
+   * @param _approved representing the status of the approval to be set
+   */
+  function setApprovalForAll(
+    address _to,
+    bool _approved
+  ) external
+  {
+    require(_to != msg.sender, 'APPROVE_SELF');
+    ownerToOperatorApproved[msg.sender][_to] = _approved;
+    emit ApprovalForAll(msg.sender, _to, _approved);
+  }
+
+  /**
    * external version
    * Will return the approved recipient for a key, if any.
    */
@@ -72,6 +94,33 @@ contract MixinApproval is
     returns (address)
   {
     return _getApproved(_tokenId);
+  }
+
+  /**
+   * @dev Tells whether an operator is approved by a given owner
+   * @param _owner owner address which you want to query the approval of
+   * @param _operator operator address which you want to query the approval of
+   * @return bool whether the given operator is approved by the given owner
+   */
+  function isApprovedForAll(
+    address _owner, 
+    address _operator
+  ) public view 
+    returns (bool) 
+  {
+    return ownerToOperatorApproved[_owner][_operator];
+  }
+
+  /**
+   * @dev Checks if the given user is approved to transfer the tokenId.
+   */
+  function _isApproved(
+    uint _tokenId,
+    address _user
+  ) internal
+    returns (bool)
+  {
+    return approved[_tokenId] == _user;
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -26,7 +26,7 @@ contract MixinApproval is
   // Note 3: for sales (new keys on restricted locks), both addresses will be the same
   mapping (uint => address) private approved;
 
-  // Keeping track of approved operators for a Lock owner.
+  // Keeping track of approved operators for a Key owner.
   // Since an owner can have up to 1 Key, this is similiar to above 
   // but the approval does not reset when a transfer occurs.
   mapping (address => mapping (address => bool)) private ownerToOperatorApproved;

--- a/smart-contracts/test/Lock/erc721/approveForAll.js
+++ b/smart-contracts/test/Lock/erc721/approveForAll.js
@@ -27,12 +27,12 @@ contract('Lock ERC721', accounts => {
             from: owner
           }
         )
-        ID = await lock.getTokenIdFor(owner)
+        ID = await lock.getTokenIdFor.call(owner)
       })
 
       it('isApprovedForAll defaults to false', async () => {
         assert.equal(
-          await lock.isApprovedForAll(owner, approvedUser),
+          await lock.isApprovedForAll.call(owner, approvedUser),
           false
         )
       })
@@ -59,7 +59,7 @@ contract('Lock ERC721', accounts => {
 
         it('isApprovedForAll is true', async () => {
           assert.equal(
-            await lock.isApprovedForAll(owner, approvedUser),
+            await lock.isApprovedForAll.call(owner, approvedUser),
             true
           )
         })
@@ -90,7 +90,7 @@ contract('Lock ERC721', accounts => {
 
         it('isApprovedForAll is false again', async () => {
           assert.equal(
-            await lock.isApprovedForAll(owner, approvedUser),
+            await lock.isApprovedForAll.call(owner, approvedUser),
             false
           )
         })

--- a/smart-contracts/test/Lock/erc721/approveForAll.js
+++ b/smart-contracts/test/Lock/erc721/approveForAll.js
@@ -1,0 +1,100 @@
+const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+const deployLocks = require('../../helpers/deployLocks')
+const shouldFail = require('../../helpers/shouldFail')
+const Unlock = artifacts.require('../../Unlock.sol')
+
+let unlock, lock, ID
+
+contract('Lock ERC721', accounts => {
+  before(async () => {
+    unlock = await Unlock.deployed()
+    const locks = await deployLocks(unlock)
+    lock = locks['FIRST']
+  })
+
+  describe('approveForAll', () => {
+    let owner = accounts[1]
+    let approvedUser = accounts[2]
+
+    describe('when the key exists', () => {
+      before(async () => {
+        await lock.purchaseFor(
+          owner,
+          Web3Utils.toHex('Satoshi'),
+          {
+            value: Units.convert('0.01', 'eth', 'wei'),
+            from: owner
+          }
+        )
+        ID = await lock.getTokenIdFor(owner)
+      })
+
+      it('isApprovedForAll defaults to false', async () => {
+        assert.equal(
+          await lock.isApprovedForAll(owner, approvedUser),
+          false
+        )
+      })
+
+      describe('when the sender is self approving', () => {
+        it('should fail', async () => {
+          await shouldFail(
+            lock.setApprovalForAll(owner, true, {
+              from: owner
+            }),
+            'APPROVE_SELF'
+          )
+        })
+      })
+
+      describe('when the approval succeeds', () => {
+        let event
+        before(async () => {
+          let result = await lock.setApprovalForAll(approvedUser, true, {
+            from: owner
+          })
+          event = result.logs[0]
+        })
+
+        it('isApprovedForAll is true', async () => {
+          assert.equal(
+            await lock.isApprovedForAll(owner, approvedUser),
+            true
+          )
+        })
+
+        it('should trigger the ApprovalForAll event', () => {
+          assert.equal(event.event, 'ApprovalForAll')
+          assert.equal(event.args._owner, owner)
+          assert.equal(event.args._operator, approvedUser)
+          assert.equal(event.args._approved, true)
+        })
+
+        it('should allow the approved user to transferFrom', async () => {
+          await lock.transferFrom(owner, accounts[2], ID, {
+            from: approvedUser
+          })
+        })
+      })
+
+      describe('can cancel an outstanding approval', () => {
+        before(async () => {
+          await lock.setApprovalForAll(approvedUser, true, {
+            from: owner
+          })
+          await lock.setApprovalForAll(approvedUser, false, {
+            from: owner
+          })
+        })
+
+        it('isApprovedForAll is false again', async () => {
+          assert.equal(
+            await lock.isApprovedForAll(owner, approvedUser),
+            false
+          )
+        })
+      })
+    })
+  })
+})

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -67,19 +67,21 @@ contract('Lock ERC721', accounts => {
     describe('when the lock is public', () => {
       it('should abort when there is no key to transfer', async () => {
         await shouldFail(
-          locks['FIRST'].transferFrom(accountWithNoKey, to, accountWithNoKey, {
-            from: accountWithNoKey
-          }),
+          locks['FIRST'].transferFrom(accountWithNoKey, to,
+            await locks['FIRST'].getTokenIdFor(accountWithNoKey), {
+              from: accountWithNoKey
+            }),
           'KEY_NOT_VALID'
         )
       })
 
       it('should abort if the recipient is 0x', async () => {
         await shouldFail(
-          locks['FIRST'].transferFrom(from, Web3Utils.padLeft(0, 40), from, {
-            from
-          }),
-          'NONE_APPROVED'
+          locks['FIRST'].transferFrom(from, Web3Utils.padLeft(0, 40),
+            await locks['FIRST'].getTokenIdFor(from), {
+              from
+            }),
+          'INVALID_ADDRESS'
         )
         // Ensuring that ownership of the key did not change
         const expirationTimestamp = new BigNumber(

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -75,7 +75,7 @@ contract('Lock ERC721', accounts => {
       it('should abort if the recipient is 0x', async () => {
         await shouldFail(
           locks['FIRST'].transferFrom(from, Web3Utils.padLeft(0, 40),
-            await locks['FIRST'].getTokenIdFor(from), {
+            await locks['FIRST'].getTokenIdFor.call(from), {
               from
             }),
           'INVALID_ADDRESS'

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -67,10 +67,7 @@ contract('Lock ERC721', accounts => {
     describe('when the lock is public', () => {
       it('should abort when there is no key to transfer', async () => {
         await shouldFail(
-          locks['FIRST'].transferFrom(accountWithNoKey, to,
-            await locks['FIRST'].getTokenIdFor(accountWithNoKey), {
-              from: accountWithNoKey
-            }),
+          locks['FIRST'].transferFrom(accountWithNoKey, to, 999),
           'KEY_NOT_VALID'
         )
       })


### PR DESCRIPTION
# Description

Adding approveForAll, which is required to meet the ERC721 standard. Since an owner can have up to 1 Key, the impact of this method is very similar to the standard approve - the difference being the approval is not lost when a transfer occurs.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
