### PR TITLE
Merge in recent changes from unlock-app to paywall

### DIFF
--- a/paywall/package-lock.json
+++ b/paywall/package-lock.json
@@ -1053,8 +1053,7 @@
     "aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-      "dev": true
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
     },
     "ajv": {
       "version": "6.9.1",
@@ -2384,6 +2383,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -3181,6 +3185,22 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eth-ens-namehash": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "requires": {
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
     "eth-lib": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
@@ -3225,7 +3245,6 @@
       "version": "4.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.1.tgz",
       "integrity": "sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==",
-      "dev": true,
       "requires": {
         "@types/node": "^10.3.2",
         "aes-js": "3.0.0",
@@ -3243,7 +3262,6 @@
           "version": "6.3.3",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
           "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -3255,7 +3273,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
@@ -3264,20 +3281,17 @@
         "js-sha3": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
         },
         "setimmediate": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-          "dev": true
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "dev": true
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },
@@ -3310,6 +3324,11 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-0.0.12.tgz",
       "integrity": "sha1-5TnNZ/3vJ2ChaqUmL6mBNN9S468="
+    },
+    "eventemitter3": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+      "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
     },
     "events": {
       "version": "3.0.0",
@@ -3984,6 +4003,15 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
+    "fs-extra": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0"
+      }
+    },
     "fs-promise": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
@@ -3993,25 +4021,6 @@
         "fs-extra": "^2.0.0",
         "mz": "^2.6.0",
         "thenify-all": "^1.6.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        }
       }
     },
     "fs-write-stream-atomic": {
@@ -4882,6 +4891,21 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
       }
     },
     "ieee754": {
@@ -6318,6 +6342,14 @@
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -9178,8 +9210,7 @@
     "scrypt-js": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-      "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
-      "dev": true
+      "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
     },
     "scrypt.js": {
       "version": "0.2.0",
@@ -10019,23 +10050,6 @@
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
           }
-        },
-        "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
         }
       }
     },
@@ -10842,23 +10856,23 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.33.tgz",
-      "integrity": "sha1-xgIbV2mSdyY3HBhLhoRFMRsTkpU=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+      "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
       "requires": {
-        "web3-bzz": "1.0.0-beta.33",
-        "web3-core": "1.0.0-beta.33",
-        "web3-eth": "1.0.0-beta.33",
-        "web3-eth-personal": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33",
-        "web3-shh": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "web3-bzz": "1.0.0-beta.37",
+        "web3-core": "1.0.0-beta.37",
+        "web3-eth": "1.0.0-beta.37",
+        "web3-eth-personal": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37",
+        "web3-shh": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-bzz": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.33.tgz",
-      "integrity": "sha1-MVAPaZt+cO31FJDFXv+0J7+7OwE=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.37.tgz",
+      "integrity": "sha512-E+dho49Nsm/QpQvYWOF35YDsQrMvLB19AApENxhlQsu6HpWQt534DQul0t3Y/aAh8rlKD6Kanxt8LhHDG3vejQ==",
       "requires": {
         "got": "7.1.0",
         "swarm-js": "0.1.37",
@@ -10866,125 +10880,93 @@
       }
     },
     "web3-core": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.33.tgz",
-      "integrity": "sha1-+C7VJfW2auzale7O08rSvWlfeDk=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.37.tgz",
+      "integrity": "sha512-cIwEqCj7OJyefQNauI0HOgW4sSaOQ98V99H2/HEIlnCZylsDzfw7gtQUdwnRFiIyIxjbWy3iWsjwDPoXNPZBYg==",
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-requestmanager": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-requestmanager": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-core-helpers": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.33.tgz",
-      "integrity": "sha1-Kvcz5QTbBefDZIwdrPV3sOwV3EM=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.37.tgz",
+      "integrity": "sha512-efaLOzN28RMnbugnyelgLwPWWaSwElQzcAJ/x3PZu+uPloM/lE5x0YuBKvIh7/PoSMlHqtRWj1B8CpuQOUQ5Ew==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "web3-eth-iban": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-core-method": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.33.tgz",
-      "integrity": "sha1-7Y7ExK+rIdwJid41g2hEZlIrboY=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.37.tgz",
+      "integrity": "sha512-pKWFUeqnVmzx3VrZg+CseSdrl/Yrk2ioid/HzolNXZE6zdoITZL0uRjnsbqXGEzgRRd1Oe/pFndpTlRsnxXloA==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-promievent": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-core-promievent": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.33.tgz",
-      "integrity": "sha1-0fXrtgFSfdSWViw2IXblWNly01g=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.37.tgz",
+      "integrity": "sha512-GTF2r1lP8nJBeA5Gxq5yZpJy9l8Fb9CXGZPfF8jHvaRdQHtm2Z+NDhqYmF833lcdkokRSyfPcXlz1mlWeClFpg==",
       "requires": {
         "any-promise": "1.3.0",
         "eventemitter3": "1.1.1"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
-        }
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.33.tgz",
-      "integrity": "sha1-ejbEA1QALfsXnKLb22pgEsn3Ges=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.37.tgz",
+      "integrity": "sha512-66VUqye5BGp1Zz1r8psCxdNH+GtTjaFwroum2Osx+wbC5oRjAiXkkadiitf6wRb+edodjEMPn49u7B6WGNuewQ==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-providers-http": "1.0.0-beta.33",
-        "web3-providers-ipc": "1.0.0-beta.33",
-        "web3-providers-ws": "1.0.0-beta.33"
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-providers-http": "1.0.0-beta.37",
+        "web3-providers-ipc": "1.0.0-beta.37",
+        "web3-providers-ws": "1.0.0-beta.37"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.33.tgz",
-      "integrity": "sha1-YCh1yfTV9NDhYhRitfwewZs1veM=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.37.tgz",
+      "integrity": "sha512-FdXl8so9kwkRRWziuCSpFsAuAdg9KvpXa1fQlT16uoGcYYfxwFO/nkwyBGQzkZt7emShI2IRugcazyPCZDwkOA==",
       "requires": {
         "eventemitter3": "1.1.1",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
-        }
+        "web3-core-helpers": "1.0.0-beta.37"
       }
     },
     "web3-eth": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.33.tgz",
-      "integrity": "sha1-hKn5TallUnyS2DitTlcN8CWJhJ8=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.37.tgz",
+      "integrity": "sha512-Eb3aGtkz3G9q+Z9DKgSQNbn/u8RtcZQQ0R4sW9hy5KK47GoT6vab5c6DiD3QWzI0BzitHzR5Ji+3VHf/hPUGgw==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-eth-abi": "1.0.0-beta.33",
-        "web3-eth-accounts": "1.0.0-beta.33",
-        "web3-eth-contract": "1.0.0-beta.33",
-        "web3-eth-iban": "1.0.0-beta.33",
-        "web3-eth-personal": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "web3-eth-abi": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.33.tgz",
-          "integrity": "sha1-IiH3FRZDZgAypN80D2EjSRaMgko=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.33",
-            "web3-utils": "1.0.0-beta.33"
-          }
-        }
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-eth-accounts": "1.0.0-beta.37",
+        "web3-eth-contract": "1.0.0-beta.37",
+        "web3-eth-ens": "1.0.0-beta.37",
+        "web3-eth-iban": "1.0.0-beta.37",
+        "web3-eth-personal": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-eth-abi": {
       "version": "1.0.0-beta.37",
       "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz",
       "integrity": "sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==",
-      "dev": true,
       "requires": {
         "ethers": "4.0.0-beta.1",
         "underscore": "1.8.3",
@@ -10994,14 +10976,12 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
         "web3-utils": {
           "version": "1.0.0-beta.37",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
           "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
-          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "eth-lib": "0.1.27",
@@ -11015,9 +10995,9 @@
       }
     },
     "web3-eth-accounts": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.33.tgz",
-      "integrity": "sha1-JajX9OWOHpk7kvBpVILMzckhL5E=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.37.tgz",
+      "integrity": "sha512-uvbHL62/zwo4GDmwKdqH9c/EgYd8QVnAfpVw8D3epSISpgbONNY7Hr4MRMSd/CqAP12l2Ls9JVQGLhhC83bW6g==",
       "requires": {
         "any-promise": "1.3.0",
         "crypto-browserify": "3.12.0",
@@ -11025,10 +11005,10 @@
         "scrypt.js": "0.2.0",
         "underscore": "1.8.3",
         "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       },
       "dependencies": {
         "eth-lib": {
@@ -11049,45 +11029,42 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.33.tgz",
-      "integrity": "sha1-nlkZ8pF6PGe0+2Vp1JxeMDiSW84=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.37.tgz",
+      "integrity": "sha512-h1B3A8Z/C7BlnTCHkrWbXZQTViDxfR12lKMeTkT8Sqj5phFmxrBlPE4ORy4lf1Dk5b23mZYE0r/IRACx4ThCrQ==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-promievent": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-eth-abi": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "web3-eth-abi": {
-          "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.33.tgz",
-          "integrity": "sha1-IiH3FRZDZgAypN80D2EjSRaMgko=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.33",
-            "web3-utils": "1.0.0-beta.33"
-          }
-        }
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
+      }
+    },
+    "web3-eth-ens": {
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.37.tgz",
+      "integrity": "sha512-dR3UkrVzdRrJhfP57xBPx0CMiVnCcYFvh+u2XMkGydrhHgupSUkjqGr89xry/j1T0BkuN9mikpbyhdCVMXqMbg==",
+      "requires": {
+        "eth-ens-namehash": "2.0.8",
+        "underscore": "1.8.3",
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-eth-contract": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-eth-iban": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.33.tgz",
-      "integrity": "sha1-HXPQxSiKRWWxdUp1tfs+oLd6Uy8=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.37.tgz",
+      "integrity": "sha512-WQRniGJFxH/XCbd7miO6+jnUG+6bvuzfeufPIiOtCbeIC1ypp1kSqER8YVBDrTyinU1xnf1U5v0KBZ2yiWBJxQ==",
       "requires": {
         "bn.js": "4.11.6",
-        "web3-utils": "1.0.0-beta.33"
+        "web3-utils": "1.0.0-beta.37"
       },
       "dependencies": {
         "bn.js": {
@@ -11098,71 +11075,71 @@
       }
     },
     "web3-eth-personal": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.33.tgz",
-      "integrity": "sha1-tOSFh8xOfrAY2ib947Tzul+bmO8=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.37.tgz",
+      "integrity": "sha512-B4dZpGbD+nGnn48i6nJBqrQ+HB7oDmd+Q3wGRKOsHSK5HRWO/KwYeA7wgwamMAElkut50lIsT9EJl4Apfk3G5Q==",
       "requires": {
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-net": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.33.tgz",
-      "integrity": "sha1-tskNGg4WJuquiz2SKsFTZy/VZEU=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.37.tgz",
+      "integrity": "sha512-xG/uBtMdDa1UMXw9KjDUgf3fXA/fDEJUYUS0TDn+U9PMgngA+UVECHNNvQTrVVDxEky38V3sahwIDiopNsQdsw==",
       "requires": {
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-providers-http": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.33.tgz",
-      "integrity": "sha1-OzWuAO599blrSTSWKtSobypVmcE=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.37.tgz",
+      "integrity": "sha512-FM/1YDB1jtZuTo78habFj7S9tNHoqt0UipdyoQV29b8LkGKZV9Vs3is8L24hzuj1j/tbwkcAH+ewIseHwu0DTg==",
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.33",
-        "xhr2": "0.1.4"
+        "web3-core-helpers": "1.0.0-beta.37",
+        "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.33.tgz",
-      "integrity": "sha1-Twrcmv6dEsBm5L5cPFNvUHPLB8Y=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.37.tgz",
+      "integrity": "sha512-NdRPRxYMIU0C3u18NI8u4bwbhI9pCg5nRgDGYcmSAx5uOBxiYcQy+hb0WkJRRhBoyIXJmy+s26FoH8904+UnPg==",
       "requires": {
         "oboe": "2.1.3",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33"
+        "web3-core-helpers": "1.0.0-beta.37"
       }
     },
     "web3-providers-ws": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.33.tgz",
-      "integrity": "sha1-j93qQuGbvyUh7IeVRkV6Yjqdye8=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.37.tgz",
+      "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
+        "web3-core-helpers": "1.0.0-beta.37",
         "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       }
     },
     "web3-shh": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.33.tgz",
-      "integrity": "sha1-+Z4mVz9uCZMhrw2fK/z+Pe01UKE=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.37.tgz",
+      "integrity": "sha512-h5STG/xqZNQWtCLYOu7NiMqwqPea8SfkKQUPUFxXKIPVCFVKpHuQEwW1qcPQRJMLhlQIv17xuoUe1A+RzDNbrw==",
       "requires": {
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37"
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-      "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+      "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
       "requires": {
         "bn.js": "4.11.6",
         "eth-lib": "0.1.27",
@@ -11498,10 +11475,13 @@
         "xhr-request": "^1.0.1"
       }
     },
-    "xhr2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
+    "xhr2-cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+      "requires": {
+        "cookiejar": "^2.1.1"
+      }
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -11511,8 +11491,7 @@
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-      "dev": true
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xtend": {
       "version": "4.0.1",

--- a/paywall/package.json
+++ b/paywall/package.json
@@ -54,9 +54,9 @@
     "run-script-os": "^1.0.5",
     "styled-components": "^4.1.3",
     "typescript": "^3.3.3",
-    "web3": "^1.0.0-beta.33",
-    "web3-eth-abi": "^1.0.0-beta.37",
-    "web3-utils": "^1.0.0-beta.33"
+    "web3": "1.0.0-beta.37",
+    "web3-eth-abi": "1.0.0-beta.37",
+    "web3-utils": "1.0.0-beta.37"
   },
   "lint-staged": {
     "linters": {

--- a/paywall/package.json
+++ b/paywall/package.json
@@ -55,6 +55,7 @@
     "styled-components": "^4.1.3",
     "typescript": "^3.3.3",
     "web3": "^1.0.0-beta.33",
+    "web3-eth-abi": "^1.0.0-beta.37",
     "web3-utils": "^1.0.0-beta.33"
   },
   "lint-staged": {
@@ -80,8 +81,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "nodemon": "^1.18.10",
-    "web3-eth-abi": "^1.0.0-beta.37"
+    "nodemon": "^1.18.10"
   },
   "engines": {
     "node": "=8.11.4"

--- a/paywall/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/walletMiddleware.test.js
@@ -1,6 +1,12 @@
 import EventEmitter from 'events'
 import walletMiddleware from '../../middlewares/walletMiddleware'
-import { UPDATE_LOCK } from '../../actions/lock'
+import {
+  CREATE_LOCK,
+  DELETE_LOCK,
+  WITHDRAW_FROM_LOCK,
+  UPDATE_LOCK_KEY_PRICE,
+  UPDATE_LOCK,
+} from '../../actions/lock'
 import {
   WAIT_FOR_WALLET,
   GOT_WALLET,
@@ -12,6 +18,7 @@ import { SET_NETWORK } from '../../actions/network'
 import { SET_PROVIDER } from '../../actions/provider'
 import { NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ERROR } from '../../actions/error'
+import { TRANSACTION_TYPES, POLLING_INTERVAL } from '../../constants'
 import { NO_USER_ACCOUNT } from '../../errors'
 
 /**
@@ -79,16 +86,18 @@ jest.mock('../../services/walletService', () => {
   }
 })
 
-let mockGenerateJWTToken = jest.fn(() => Promise.resolve())
+let mockGenerateSignature = jest.fn(() => Promise.resolve())
 
 jest.mock('../../utils/signature', () => () => {
-  return mockGenerateJWTToken()
+  return mockGenerateSignature()
 })
+
+jest.useFakeTimers()
 
 beforeEach(() => {
   // Reset the mock
   mockWalletService = new MockWalletService()
-  mockGenerateJWTToken = jest.fn(() => Promise.resolve())
+  mockGenerateSignature = jest.fn(() => Promise.resolve())
 
   // Reset state!
   account = {
@@ -115,20 +124,28 @@ beforeEach(() => {
 })
 
 describe('Wallet middleware', () => {
-  it('it should handle account.changed events triggered by the walletService', () => {
-    expect.assertions(1)
+  it('should handle account.changed events triggered by the walletService', () => {
+    expect.assertions(3)
     const { store } = create()
     const address = '0x123'
     const account = {
       address,
     }
+    mockWalletService.getAccount = jest.fn()
 
     mockWalletService.emit('account.changed', address)
+
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: SET_ACCOUNT,
         account,
       })
+    )
+
+    expect(setTimeout).toHaveBeenCalledTimes(1)
+    expect(setTimeout).toHaveBeenCalledWith(
+      expect.any(Function),
+      POLLING_INTERVAL
     )
   })
 
@@ -199,7 +216,7 @@ describe('Wallet middleware', () => {
         state.network.name = 1773
         mockWalletService.getAccount = jest.fn()
         mockWalletService.emit('network.changed', networkId)
-        expect(mockWalletService.getAccount).toHaveBeenCalledWith()
+        expect(mockWalletService.getAccount).toHaveBeenCalledWith(true) // create an account if none is set
       })
 
       it('should dispatch a SET_NETWORK action', () => {
@@ -221,6 +238,39 @@ describe('Wallet middleware', () => {
   })
 
   describe('error events triggered by the walletService', () => {
+    it('should handle error triggered when creating a lock', () => {
+      expect.assertions(3)
+      const { store } = create()
+      const transaction = {
+        hash: '123',
+        type: TRANSACTION_TYPES.LOCK_CREATION,
+        lock: '0x123',
+      }
+      state.transactions = {
+        [transaction.hash]: transaction,
+      }
+      mockWalletService.emit(
+        'error',
+        { message: 'this was broken' },
+        transaction.hash
+      )
+      expect(store.dispatch).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ type: DISMISS_CHECK })
+      )
+      expect(store.dispatch).toHaveBeenNthCalledWith(2, {
+        type: DELETE_LOCK,
+        address: transaction.lock,
+      })
+      expect(store.dispatch).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          type: SET_ERROR,
+          error: 'Failed to create lock. Did you decline the transaction?',
+        })
+      )
+    })
+
     it('it should handle error events triggered by the walletService', () => {
       expect.assertions(1)
       const { store } = create()
@@ -274,6 +324,132 @@ describe('Wallet middleware', () => {
         lock.keyPrice,
         account.address,
         key.data
+      )
+      expect(next).toHaveBeenCalledWith(action)
+    })
+  })
+
+  describe('WITHDRAW_FROM_LOCK', () => {
+    it('when the service is not ready it should set an error and not try to withdraw from the lock', () => {
+      expect.assertions(3)
+      const { next, invoke, store } = create()
+      const action = { type: WITHDRAW_FROM_LOCK, lock }
+      mockWalletService.withdrawFromLock = jest.fn()
+      mockWalletService.ready = false
+      invoke(action)
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: 'error/SET_ERROR',
+        error: NO_USER_ACCOUNT,
+      })
+
+      expect(mockWalletService.withdrawFromLock).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalledWith(action)
+    })
+
+    it('should handle WITHDRAW_FROM_LOCK by calling withdrawFromLock from walletService', () => {
+      expect.assertions(2)
+      const { next, invoke, store } = create()
+      const action = { type: WITHDRAW_FROM_LOCK, lock }
+      mockWalletService.withdrawFromLock = jest.fn()
+      mockWalletService.ready = true
+      invoke(action)
+      expect(mockWalletService.withdrawFromLock).toHaveBeenCalledWith(
+        lock.address,
+        store.getState().account.address
+      )
+      expect(next).toHaveBeenCalledWith(action)
+    })
+  })
+
+  describe('CREATE_LOCK', () => {
+    describe('when the lock has an address', () => {
+      it('when the service is not ready it should set an error and not try to create the lock', () => {
+        expect.assertions(3)
+        const { next, invoke, store } = create()
+        const action = { type: CREATE_LOCK, lock }
+        mockWalletService.createLock = jest.fn()
+        mockWalletService.ready = false
+        invoke(action)
+        expect(store.dispatch).toHaveBeenCalledWith({
+          type: 'error/SET_ERROR',
+          error: NO_USER_ACCOUNT,
+        })
+
+        expect(mockWalletService.createLock).not.toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith(action)
+      })
+
+      it("should handle CREATE_LOCK by calling walletService's createLock", () => {
+        expect.assertions(2)
+        const { next, invoke, store } = create()
+        const action = { type: CREATE_LOCK, lock }
+
+        mockWalletService.createLock = jest
+          .fn()
+          .mockImplementation(() => Promise.resolve())
+        mockWalletService.ready = true
+
+        invoke(action)
+        expect(mockWalletService.createLock).toHaveBeenCalledWith(
+          lock,
+          store.getState().account.address
+        )
+
+        expect(next).toHaveBeenCalledWith(action)
+      })
+    })
+
+    describe('when the lock does not have an address', () => {
+      it('should not try to createLock', () => {
+        expect.assertions(2)
+        let lock = {
+          keyPrice: '100',
+          owner: account,
+        }
+        mockWalletService.createLock = jest.fn()
+        const { next, invoke } = create()
+        const action = { type: CREATE_LOCK, lock }
+        mockWalletService.ready = true
+
+        invoke(action)
+        expect(next).toHaveBeenCalled()
+        expect(mockWalletService.createLock).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('UPDATE_LOCK_KEY_PRICE', () => {
+    it('when the service is not ready it should set an error and not try to update the ley price', () => {
+      expect.assertions(3)
+      const { next, invoke, store } = create()
+      const action = { type: UPDATE_LOCK_KEY_PRICE, lock }
+      mockWalletService.updateKeyPrice = jest.fn()
+      mockWalletService.ready = false
+      invoke(action)
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: 'error/SET_ERROR',
+        error: NO_USER_ACCOUNT,
+      })
+
+      expect(mockWalletService.updateKeyPrice).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalledWith(action)
+    })
+
+    it('should invoke updateKeyPrice on receiving an update request', () => {
+      expect.assertions(2)
+      const { next, invoke, store } = create()
+      const action = {
+        type: UPDATE_LOCK_KEY_PRICE,
+        address: lock.address,
+        price: '0.03',
+      }
+      mockWalletService.updateKeyPrice = jest.fn()
+      mockWalletService.ready = true
+      invoke(action)
+      expect(mockWalletService.updateKeyPrice).toHaveBeenCalledWith(
+        lock.address,
+        store.getState().account.address,
+        '0.03'
       )
       expect(next).toHaveBeenCalledWith(action)
     })

--- a/paywall/src/__tests__/services/web3Service.test.js
+++ b/paywall/src/__tests__/services/web3Service.test.js
@@ -1,6 +1,8 @@
 /* eslint no-console: 0 */
 
 import Web3Utils from 'web3-utils'
+import Web3EthAbi from 'web3-eth-abi'
+
 import nock from 'nock'
 import Web3Service from '../../services/web3Service'
 /* eslint-disable import/no-unresolved */
@@ -954,7 +956,7 @@ describe('Web3Service', () => {
       ethCallAndYield(
         `0x10803b72${abiPaddedString([onPage, byPage])}`,
         lockAddress,
-        `0x${abiPaddedString(['20', '2', keyHolder[0], keyHolder[1]])}`
+        Web3EthAbi.encodeParameter('uint256[]', keyHolder)
       )
 
       web3Service.getKeysForLockOnPage(lockAddress, onPage, byPage)

--- a/paywall/src/__tests__/services/web3Service.test.js
+++ b/paywall/src/__tests__/services/web3Service.test.js
@@ -641,15 +641,15 @@ describe('Web3Service', () => {
   })
 
   describe('getAddressBalance', () => {
-    it('should return the balance of the address', () => {
+    it('should return the balance of the address', async () => {
       expect.assertions(1)
       const balance = '0xdeadbeef'
       const inWei = Web3Utils.hexToNumberString(balance)
       const address = '0x1df62f291b2e969fb0849d99d9ce41e2f137006e'
       getBalanceForAccountAndYieldBalance(address, '0xdeadbeef')
-      return web3Service.getAddressBalance(address).then(balance => {
-        expect(balance).toEqual(Web3Utils.fromWei(inWei, 'ether'))
-      })
+
+      let addressBalance = await web3Service.getAddressBalance(address)
+      expect(addressBalance).toEqual(Web3Utils.fromWei(inWei, 'ether'))
     })
   })
 
@@ -747,7 +747,7 @@ describe('Web3Service', () => {
   })
 
   describe('_getKeyByLockForOwner', () => {
-    it('should update the data and expiration date', () => {
+    it('should update the data and expiration date', async () => {
       expect.assertions(2)
       ethCallAndYield(
         '0xabdf82ce00000000000000000000000090f8bf6a479f320ead074411a4b0e7944ea8c9c1',
@@ -765,15 +765,15 @@ describe('Web3Service', () => {
         lockAddress
       )
 
-      return web3Service
-        ._getKeyByLockForOwner(lockContract, nodeAccounts[0])
-        .then(([expiration, data]) => {
-          expect(expiration).toBe(1532557829)
-          expect(data).toBe(null)
-        })
+      let [expiration, data] = await web3Service._getKeyByLockForOwner(
+        lockContract,
+        nodeAccounts[0]
+      )
+      expect(expiration).toBe(1532557829)
+      expect(data).toBe(null)
     })
 
-    it('should handle missing key when the lock exists', () => {
+    it('should handle missing key when the lock exists', async () => {
       expect.assertions(2)
 
       ethCallAndFail(
@@ -792,12 +792,12 @@ describe('Web3Service', () => {
         lockAddress
       )
 
-      return web3Service
-        ._getKeyByLockForOwner(lockContract, nodeAccounts[0])
-        .then(([expiration, data]) => {
-          expect(expiration).toBe(0)
-          expect(data).toBe(null)
-        })
+      let [expiration, data] = await web3Service._getKeyByLockForOwner(
+        lockContract,
+        nodeAccounts[0]
+      )
+      expect(expiration).toBe(0)
+      expect(data).toBe(null)
     })
   })
 

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -1,7 +1,14 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import { LOCATION_CHANGE } from 'connected-react-router'
-import { UPDATE_LOCK, addLock, updateLock, ADD_LOCK } from '../actions/lock'
+import {
+  ADD_LOCK,
+  CREATE_LOCK,
+  UPDATE_LOCK,
+  addLock,
+  updateLock,
+  createLock,
+} from '../actions/lock'
 import { updateKey, addKey } from '../actions/key'
 import { updateAccount, SET_ACCOUNT } from '../actions/accounts'
 import { setError } from '../actions/error'
@@ -11,8 +18,13 @@ import {
   ADD_TRANSACTION,
   NEW_TRANSACTION,
 } from '../actions/transaction'
+import { PGN_ITEMS_PER_PAGE } from '../constants'
 
 import Web3Service from '../services/web3Service'
+import {
+  SET_KEYS_ON_PAGE_FOR_LOCK,
+  setKeysOnPageForLock,
+} from '../actions/keysPages'
 import { lockRoute } from '../utils/routes'
 
 // This middleware listen to redux events and invokes the web3Service API.
@@ -22,6 +34,16 @@ export default function web3Middleware({ getState, dispatch }) {
 
   web3Service.on('account.updated', (account, update) => {
     dispatch(updateAccount(update))
+  })
+
+  /**
+   * When a lock was saved, we update it, as well as its transaction and
+   * refresh the balance of its owner and refresh its content
+   */
+  web3Service.on('lock.saved', (lock, address) => {
+    web3Service.refreshAccountBalance(getState().account)
+    web3Service.getLock(address)
+    web3Service.getPastLockTransactions(address) // This is costly and not useful for the paywall app...
   })
 
   /**
@@ -77,14 +99,36 @@ export default function web3Middleware({ getState, dispatch }) {
     dispatch(setError(error.message))
   })
 
+  web3Service.on('keys.page', (lock, page, keys) => {
+    dispatch(setKeysOnPageForLock(page, lock, keys))
+  })
+
   return function(next) {
     return function(action) {
+      // When the keys for a lock are loaded on the dashboard
+      if (action.type === SET_KEYS_ON_PAGE_FOR_LOCK) {
+        if (!action.keys) {
+          web3Service.getKeysForLockOnPage(
+            action.lock,
+            action.page,
+            PGN_ITEMS_PER_PAGE
+          )
+        }
+      }
+
       if (action.type === ADD_TRANSACTION) {
         web3Service.getTransaction(action.transaction.hash)
       }
 
       if (action.type === NEW_TRANSACTION) {
         web3Service.getTransaction(action.transaction.hash, action.transaction)
+      }
+
+      if (action.type === CREATE_LOCK && !action.lock.address) {
+        web3Service.generateLockAddress().then(address => {
+          action.lock.address = address
+          dispatch(createLock(action.lock))
+        })
       }
 
       next(action)
@@ -97,9 +141,20 @@ export default function web3Middleware({ getState, dispatch }) {
         // TODO: when the account has been updated we should reset web3Service and remove all listeners
         // So that pending API calls do not interract with our "new" state.
         web3Service.refreshAccountBalance(action.account)
-        web3Service.getPastLockCreationsTransactionsForUser(
-          action.account.address
-        )
+        web3Service
+          .getPastLockCreationsTransactionsForUser(action.account.address)
+          .then(lockCreations => {
+            // For each lock this user created, go get the history of
+            // interactions with that lock. TODO: Only get the lock interactions
+            // (such as key price update, withdrawals) done by the user. Very
+            // popular locks in the future may have thousands of key purchases,
+            // and we almost certainly don't want to pull them all down here.
+            lockCreations.forEach(lockCreation => {
+              web3Service.getPastLockTransactions(
+                lockCreation.returnValues.newLockAddress
+              )
+            })
+          })
         const {
           router: {
             location: { pathname },
@@ -112,7 +167,7 @@ export default function web3Middleware({ getState, dispatch }) {
         }
       }
 
-      if (action.type === ADD_LOCK || action.type === UPDATE_LOCK) {
+      if (action.type === ADD_LOCK || action.type == UPDATE_LOCK) {
         const lock = getState().locks[action.address]
         if (getState().account) {
           web3Service.getKeyByLockForOwner(
@@ -126,8 +181,12 @@ export default function web3Middleware({ getState, dispatch }) {
         action.payload.location.pathname
       ) {
         // Location was changed, get the matching lock, if we are on a paywall page
-        const { lockAddress } = lockRoute(action.payload.location.pathname)
-        web3Service.getLock(lockAddress)
+        const { lockAddress, prefix } = lockRoute(
+          action.payload.location.pathname
+        )
+        if (lockAddress && prefix === 'paywall') {
+          web3Service.getLock(lockAddress)
+        }
       }
     }
   }


### PR DESCRIPTION
# Description

This PR synchronizes the changed files to match their cousins in unlock-app.

The paywall app split was long enough ago that the middlewares and services are out of date. This PR merges them back in. Note that all of the work extracting unneeded stuff for the paywall is put back in. I don't see any way around this because of our current design.

As a more pointed side note, if the web3Service, web3Middleware and walletService and walletMiddleware were more modular, such that features were grouped in different files, keeping the two directories in sync would not require copy/pasting.

Until then, expect regular PRs of this nature.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
