### PR TITLE
avoid outdated package

### DIFF
--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'events'
-import { LOCATION_CHANGE } from 'react-router-redux'
+import { LOCATION_CHANGE } from 'connected-react-router'
 import web3Middleware from '../../middlewares/web3Middleware'
 import { ADD_LOCK, UPDATE_LOCK, CREATE_LOCK } from '../../actions/lock'
 import { UPDATE_KEY } from '../../actions/key'


### PR DESCRIPTION
# Description

react-router-redux is not used any more. connected-react-router is its successor. A subsequent PR will remove the outdated dep in package.json
<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
