### PR TITLE
making the script which deploys to netlify independent of the platform

### DIFF
--- a/scripts/deploy-netlify.sh
+++ b/scripts/deploy-netlify.sh
@@ -2,29 +2,30 @@
 
 # This script deploys a static build to netlify.
 # It requires NETLIFY_AUTH_TOKEN to be set, as well as
-# TRAVIS_BRANCH to identify whether we deploy a 'draft' or a 'production' version (note that this
 # is production in the netlify sense, so it could be on staging.unlock-protocol.com).
 
 CURRENT_DIR=`pwd`;
 UNLOCK_APP_PATH="unlock-app";
 BUILD_PATH="$UNLOCK_APP_PATH/src/out/";
 DEPLOY_ENV=$1
+COMMIT=$2
+PUBLISH=$3
 
 if [ "$DEPLOY_ENV" = "staging" ]; then
-  if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  if [ "$PUBLISH" = "true" ]; then
     # This is a build on master, we deploy to staging as a published build
     PROD="--prod";
-    MESSAGE="Deploying $TRAVIS_COMMIT to staging. See logs below.";
+    MESSAGE="Deploying $COMMIT to staging. See logs below.";
   else
     # we deploy as a draft on staging
     PROD="";
-    MESSAGE="Deploying $TRAVIS_COMMIT to draft. See draft URL and logs below.";
+    MESSAGE="Deploying $COMMIT to draft. See draft URL and logs below.";
   fi
 fi
 
 if [ "$DEPLOY_ENV" = "prod" ]; then
   PROD="--prod";
-  MESSAGE="Deploying version $TRAVIS_TAG to production";
+  MESSAGE="Deploying version $COMMIT to production";
 fi
 
 if [ -n "$NETLIFY_SITE_ID" ] && [ -n "$NETLIFY_AUTH_TOKEN" ]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,4 +49,13 @@ if [ "$TARGET" = "netlify" ]; then
   ENV_VARS="$ENV_VARS -e NETLIFY_AUTH_TOKEN=$NETLIFY_AUTH_TOKEN"
 fi
 
-docker-compose -f $DOCKER_COMPOSE_FILE run $ENV_VARS $SERVICE $NPM_SCRIPT -- $ENV_TARGET
+# PUBLISH: whether to publish/promote the deployed version
+PUBLISH="false"
+if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  PUBLISH="true"
+fi
+
+# Deploy options
+OPTS="$ENV_TARGET $TRAVIS_COMMIT $PUBLISH"
+
+docker-compose -f $DOCKER_COMPOSE_FILE run $ENV_VARS $SERVICE $NPM_SCRIPT -- $OPTS


### PR DESCRIPTION
It is mostly about moving env variables around to avoid having code that is specific to the
platform on which it runs.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread