### PR TITLE
making the deploy-elasticbeanstalk.sh decoupled from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - scripts/integration-tests.sh
 after_success:
   - scripts/deploy.sh netlify $TRAVIS_COMMIT $TRAVIS_TAG $TRAVIS_BRANCH $TRAVIS_PULL_REQUEST
-  - scripts/deploy-elasticbeanstalk.sh
+  - scripts/deploy-elasticbeanstalk.sh $TRAVIS_BUILD_ID $TRAVIS_BRANCH $TRAVIS_PULL_REQUEST "$TRAVIS_COMMIT_MESSAGE"
   - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && scripts/push-image.sh unlock $TRAVIS_BRANCH
   - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && scripts/push-image.sh unlock-integration $TRAVIS_BRANCH
 after_failure:


### PR DESCRIPTION
In order to move to other CI platforms we need to decouple our scripts from travis.
This PR make the deploy-elasticbeanstalk.sh decoupled.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread