### PR TITLE
Adding a Lock name field

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -12,6 +12,7 @@ import './mixins/MixinDisableAndDestroy.sol';
 import './mixins/MixinKeys.sol';
 import './mixins/MixinLockCore.sol';
 import './mixins/MixinRefunds.sol';
+import './mixins/MixinLockMetadata.sol';
 import './mixins/MixinNoFallback.sol';
 import './mixins/MixinTransfer.sol';
 
@@ -34,6 +35,7 @@ contract PublicLock is
   MixinKeys,
   MixinApproval,
   MixinLockCore,
+  MixinLockMetadata
   MixinRefunds,
   MixinTransfer
 {

--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -35,7 +35,7 @@ contract PublicLock is
   MixinKeys,
   MixinApproval,
   MixinLockCore,
-  MixinLockMetadata
+  MixinLockMetadata,
   MixinRefunds,
   MixinTransfer
 {

--- a/smart-contracts/contracts/interfaces/IERC721.sol
+++ b/smart-contracts/contracts/interfaces/IERC721.sol
@@ -99,4 +99,7 @@ interface IERC721 {
   /// @param _operator The address that acts on behalf of the owner
   /// @return True if `_operator` is an approved operator for `_owner`, false otherwise
   function isApprovedForAll(address _owner, address _operator) external view returns (bool);
+
+  /// @notice A descriptive name for a collection of NFTs in this contract
+  function name() external view returns (string memory _name); 
 }

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -1,0 +1,41 @@
+pragma solidity 0.4.25;
+
+import 'openzeppelin-eth/contracts/ownership/Ownable.sol';
+import '../interfaces/IERC721.sol';
+
+
+/**
+ * @title Mixin for metadata about the Lock.
+ * @author HardlyDifficult
+ * @dev `Mixins` are a design pattern seen in the 0x contracts.  It simply 
+ * separates logically groupings of code to ease readability. 
+ */
+contract MixinLockMetadata is
+  IERC721,
+  Ownable
+{
+  /// A descriptive name for a collection of NFTs in this contract
+  string private lockName;
+
+  /**
+   * Allows the Lock owner to assign a descriptive name for this Lock.
+   */
+  function updateLockName(
+    string _lockName
+  ) external
+    onlyOwner
+  {
+    lockName = _lockName;
+  }
+
+  /**
+    * @dev Gets the token name
+    * @return string representing the token name
+    */
+  function name(
+  ) external view 
+    returns (string memory)
+  {
+    return lockName;
+  }
+}

--- a/smart-contracts/test/Lock/erc721/name.js
+++ b/smart-contracts/test/Lock/erc721/name.js
@@ -1,0 +1,79 @@
+const deployLocks = require('../../helpers/deployLocks')
+const shouldFail = require('../../helpers/shouldFail')
+const Unlock = artifacts.require('../../Unlock.sol')
+
+let unlock, lock
+
+contract('Lock ERC721', accounts => {
+  before(async () => {
+    unlock = await Unlock.deployed()
+    const locks = await deployLocks(unlock)
+    lock = locks['FIRST']
+  })
+
+  describe('name', () => {
+    describe('when there is no name', () => {
+      it('should return nothing when attempting to read the name', async () => {
+        assert.equal(await lock.name.call(), '')
+      })
+
+      it('should fail if someone other than the owner tries to set the name', async () => {
+        await shouldFail(
+          lock.updateLockName('Hardly', {
+            from: accounts[1]
+          })
+        )
+      })
+
+      it('should allow the owner to set a name', async () => {
+        await lock.updateLockName('Hardly', {
+          from: accounts[0]
+        })
+      })
+    })
+
+    describe('when the Lock has a name', () => {
+      before(async () => {
+        await lock.updateLockName('Hardly', {
+          from: accounts[0]
+        })
+      })
+
+      it('should return return the expected name', async () => {
+        assert.equal(await lock.name.call(), 'Hardly')
+      })
+
+      it('should fail if someone other than the owner tries to change the name', async () => {
+        await shouldFail(
+          lock.updateLockName('Difficult', {
+            from: accounts[1]
+          })
+        )
+      })
+
+      describe('should allow the owner to set a name', () => {
+        before(async () => {
+          await lock.updateLockName('Difficult', {
+            from: accounts[0]
+          })
+        })
+
+        it('should return return the expected name', async () => {
+          assert.equal(await lock.name.call(), 'Difficult')
+        })
+      })
+
+      describe('should allow the owner to unset the name', () => {
+        before(async () => {
+          await lock.updateLockName('', {
+            from: accounts[0]
+          })
+        })
+
+        it('should return return the expected name', async () => {
+          assert.equal(await lock.name.call(), '')
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Description

Adding a `name` field for the Lock.  This field follows the IERC721 optional metadata standard: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md

The name defaults to empty string and may be set anytime by the Lock owner.

I put this in a new `MixinMetadata` file since 1) it's completely independent logic and 2) we are likely to add more Lock metadata in the future.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
