### PR TITLE
fixing syntax for IS_PULL_REQUEST en variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,22 +106,30 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Set IS_PULL_REQUEST
+          command: scripts/circleci/set-is-pull-request.sh >> $BASH_ENV
+      - run:
           name: Pull Unlock Image
           command: scripts/pull-image.sh unlock "$CIRCLE_SHA1"
       - run:
           name: Deploy to Netlify
-          command: scripts/deploy.sh netlify $CIRCLE_SHA1 $CIRCLE_TAG $CIRCLE_BRANCH ($CIRCLE_PULL_REQUEST || "false")
+          command: scripts/deploy.sh netlify $CIRCLE_SHA1 $CIRCLE_TAG $CIRCLE_BRANCH $IS_PULL_REQUEST
 
   deploy-locksmith-beanstalk:
     machine: true
     environment:
       DOCKER_REPOSITORY: unlockprotocol
-      GIT_COMMIT_DESC: git log --format=%B -n 1 $CIRCLE_SHA1
     steps:
       - checkout
       - run:
+          name: Set GIT_COMMIT_DESC
+          command: echo 'export GIT_COMMIT_DESC=$(git log --format=%B -n 1 $CIRCLE_SHA1)' >> $BASH_ENV
+      - run:
+          name: Set IS_PULL_REQUEST
+          command: ./scripts/circleci/set-is-pull-request.sh >> $BASH_ENV
+      - run:
           name: Deploy to to Beanstalk
-          command: scripts/deploy-elasticbeanstalk.sh $CIRCLE_SHA1 $CIRCLE_BRANCH ($CIRCLE_PULL_REQUEST || "false") "$GIT_COMMIT_DESC"
+          command: scripts/deploy-elasticbeanstalk.sh $CIRCLE_SHA1 $CIRCLE_BRANCH $IS_PULL_REQUEST "$GIT_COMMIT_DESC"
 
   promote-unlock-image:
     machine: true

--- a/scripts/circleci/set-is-pull-request.sh
+++ b/scripts/circleci/set-is-pull-request.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# This script sets the variable IS_PULL_REQUEST which is used for deployments.
+# CirclCi uses the BASH_ENV variable to set values https://circleci.com/docs/2.0/env-vars/#using-bash_env-to-set-environment-variables
+
+
+if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+  echo "export IS_PULL_REQUEST='false'"
+else
+  echo "export IS_PULL_REQUEST='true'"
+fi;
+


### PR DESCRIPTION
The approach I took to set up env variables for CircleCI was not right.
This fixes it.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread