### PR TITLE
EXPERIMENT: add polling utility and implement it for cancelable account polling

### DIFF
--- a/paywall/src/middlewares/currencyConversionMiddleware.js
+++ b/paywall/src/middlewares/currencyConversionMiddleware.js
@@ -4,6 +4,10 @@
 import axios from 'axios'
 
 import { setConversionRate } from '../actions/currencyConvert'
+import pollWithConditions from '../utils/polling'
+import configure from '../config'
+
+const config = configure()
 
 export default store => {
   axios
@@ -13,18 +17,28 @@ export default store => {
         setConversionRate(info.data.data.currency, info.data.data.amount)
       )
     )
-  setInterval(() => {
-    axios.get('https://api.coinbase.com/v2/prices/ETH-USD/buy').then(info => {
-      const {
-        data: {
-          data: { currency, amount },
-        },
-      } = info
-      const current = store.getState().currency[currency]
-      if (current === +amount) return
+  pollWithConditions(
+    () => {
+      axios.get('https://api.coinbase.com/v2/prices/ETH-USD/buy').then(info => {
+        const {
+          data: {
+            data: { currency, amount },
+          },
+        } = info
+        const current = store.getState().currency[currency]
+        if (current === +amount) return
 
-      store.dispatch(setConversionRate(currency, amount))
-    })
-  }, 10000)
+        store.dispatch(setConversionRate(currency, amount))
+      })
+    },
+    10000,
+    () => {
+      if (config.isServer) {
+        throw new Error('currency conversion polling is only on the client')
+      }
+      // temporarily stop polling when offline
+      return !window.navigator.isOnline
+    }
+  )
   return next => action => next(action)
 }

--- a/paywall/src/services/web3Service.js
+++ b/paywall/src/services/web3Service.js
@@ -16,9 +16,7 @@ const {
   readOnlyProvider,
   providers,
   unlockAddress,
-  blockTime,
   requiredNetworkId,
-  requiredConfirmations,
 } = configure()
 
 export const keyId = (lock, owner) => [lock, owner].join('-')
@@ -361,16 +359,6 @@ export default class Web3Service extends EventEmitter {
   }
 
   /**
-   * This will set a timeout to get a transaction after half a block time happened
-   * @param {string} transactionHash
-   */
-  _watchTransaction(transactionHash) {
-    setTimeout(() => {
-      this.getTransaction(transactionHash)
-    }, blockTime / 2)
-  }
-
-  /**
    * The transaction is still pending: it has been sent to the network but not
    * necessarily received by the node we're asking it (and not mined...)
    * TODO: This presents a UI challenge because we currently do not show anything to the
@@ -383,8 +371,6 @@ export default class Web3Service extends EventEmitter {
    * @private
    */
   _getSubmittedTransaction(transactionHash, blockNumber, defaults) {
-    this._watchTransaction(transactionHash)
-
     // If we have default values for the transaction (passed by the walletService)
     if (defaults) {
       const contract =
@@ -415,8 +401,6 @@ export default class Web3Service extends EventEmitter {
    * @private
    */
   _getPendingTransaction(blockTransaction) {
-    this._watchTransaction(blockTransaction.hash)
-
     const contract =
       this.unlockContractAddress ===
       Web3Utils.toChecksumAddress(blockTransaction.to)
@@ -470,11 +454,6 @@ export default class Web3Service extends EventEmitter {
         contract,
         blockTransaction.input
       )
-
-      // Let's watch for more confirmations if needed
-      if (blockNumber - blockTransaction.blockNumber < requiredConfirmations) {
-        this._watchTransaction(transactionHash)
-      }
 
       // The transaction was mined, so we should have a receipt for it
       this.emit('transaction.updated', transactionHash, {

--- a/paywall/src/utils/polling.js
+++ b/paywall/src/utils/polling.js
@@ -1,0 +1,22 @@
+/**
+ * poll at a regular interval, with the ability to pause polling or end it
+ */
+export default function pollWithConditions(
+  pollingCallback,
+  intervalMs,
+  disablePolling,
+  handleError = () => {}
+) {
+  async function poll() {
+    try {
+      if (disablePolling()) return
+      await pollingCallback()
+      setTimeout(poll, intervalMs)
+    } catch (e) {
+      // if the conditionsCallback throws, we stop the loop
+      // and pass the error out to an external handler, if any
+      handleError(e)
+    }
+  }
+  poll()
+}


### PR DESCRIPTION
This is an experiment to demonstrate the utility that a polling abstraction can provide. There are no new tests or changes to existing ones, so the build fails.

The `pollWithConditions` function allows declaring a function to poll and the interval to poll it at. Simple enough, but the difference from a regular setTimeout loop is the new features

Basically, the new features are:
- polling can be temporarily paused, and then resume
- polling can be permanently stopped

This can be used in a few helpful ways:

1. account polling can be stopped on the server or when we are in a coinbase wallet iframe
2. currency conversion polling can be paused when offline
3. transaction polling could start when a transaction is sent, and stop when it is confirmed or failed
4. we can finally detect network changes by using polling

Because the polling is independent from the thing being polled, the thing being polled need not be aware of its internal state, which simplifies implementation.

In addition, by thinking of middleware as redux-specific and hooks as React 16.8-specific, we can do polling in a hooks-native way, which differs subtly from a redux-specific way. This separation of side effects from the business logic makes it simpler to migrate code to novel environments.

It took about 50 minutes to design this, it's not complex, but it provides a lot more flexibility in the API usage.