### PR TITLE
Update to the canonical URL for ERC-721

### DIFF
--- a/smart-contracts/contracts/interfaces/IERC721.sol
+++ b/smart-contracts/contracts/interfaces/IERC721.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.4.25;
 
 /// @title ERC-721 Non-Fungible Token Standard
-/// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
+/// @dev See https://eips.ethereum.org/EIPS/eip-721
 ///  Note: the ERC-165 identifier for this interface is 0x80ac58cd
 
 interface IERC721 {


### PR DESCRIPTION
Please use the canonical URL for references to ERC-721.

Reference: https://github.com/ethereum/EIPs#preferred-citation-format