### PR TITLE
Pull requests should be connected to filed issues

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Please include a summary of the change and which issue is fixed -include its num
 
 # Issues
 
-<!-- This PR should fix or ref at least one existing issue ID. Add or delete as appropriate. -->
+<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
 Fixes #
 Refs #
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,12 @@
 Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
 -->
 
+# Issues
+
+<!-- This PR should fix or ref at least one existing issue ID. Add or delete as appropriate. -->
+Fixes #
+Refs #
+
 # Checklist:
 
 - [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@ Refs #
 # Checklist:
 
 - [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
-  - [ ] It references and cleanly addresses an existing, filed issue ID
   - [ ] This PR only contains configuration changes (package.json, etc.)
   - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
 - [ ] My code follows the style guidelines of this project, including naming conventions

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,13 @@
 # Description
 
 <!--
-Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
+Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
 -->
 
 # Checklist:
 
 - [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
+  - [ ] It references and cleanly addresses an existing, filed issue
   - [ ] This PR only contains configuration changes (package.json, etc.)
   - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
 - [ ] My code follows the style guidelines of this project, including naming conventions

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Please include a summary of the change and which issue is fixed -include its num
 # Checklist:
 
 - [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
-  - [ ] It references and cleanly addresses an existing, filed issue
+  - [ ] It references and cleanly addresses an existing, filed issue ID
   - [ ] This PR only contains configuration changes (package.json, etc.)
   - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
 - [ ] My code follows the style guidelines of this project, including naming conventions


### PR DESCRIPTION
This way we can ensure a PR has a single purpose. There's no obvious way to _require_ that a PR is attached to an existing issue - so we should include it in the template instead.

Fixes #1699

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
