### PR TITLE
KEY_PURCHASE transactions now have lock address metadata on transaction log page

### DIFF
--- a/unlock-app/src/__tests__/pages/log.test.js
+++ b/unlock-app/src/__tests__/pages/log.test.js
@@ -27,6 +27,14 @@ const transactions = {
     blockNumber: 3,
     type: TRANSACTION_TYPES.LOCK_CREATION,
   },
+  '0x31337': {
+    hash: '0x73313',
+    confirmations: 5,
+    status: 'mined',
+    type: TRANSACTION_TYPES.KEY_PURCHASE,
+    key: '0x12345678a-0xfeeded',
+    blockNumber: 5,
+  },
 }
 
 describe('Transaction Log', () => {
@@ -50,11 +58,12 @@ describe('Transaction Log', () => {
     const config = configure()
     const { transactionFeed, metadata } = mapStateToProps(state, { config })
     it('Should provide a feed of transactions sorted by blockNumber, descending', () => {
-      expect.assertions(4)
-      expect(transactionFeed).toHaveLength(3)
-      expect(transactionFeed[0].blockNumber).toEqual(3)
-      expect(transactionFeed[1].blockNumber).toEqual(2)
-      expect(transactionFeed[2].blockNumber).toEqual(1)
+      expect.assertions(5)
+      expect(transactionFeed).toHaveLength(4)
+      expect(transactionFeed[0].blockNumber).toEqual(5)
+      expect(transactionFeed[1].blockNumber).toEqual(3)
+      expect(transactionFeed[2].blockNumber).toEqual(2)
+      expect(transactionFeed[3].blockNumber).toEqual(1)
     })
     it('should include href to explorer, lock address, and readable name in the metadata', () => {
       expect.assertions(3)
@@ -62,6 +71,11 @@ describe('Transaction Log', () => {
       expect(md).toHaveProperty('href')
       expect(md).toHaveProperty('readableName')
       expect(md).toHaveProperty('lock')
+    })
+    it('should grab the lock address for the key creation transaction', () => {
+      expect.assertions(1)
+      const md = metadata['0x73313']
+      expect(md.lock).toEqual('0x12345678a')
     })
   })
 })

--- a/unlock-app/src/__tests__/pages/log.test.js
+++ b/unlock-app/src/__tests__/pages/log.test.js
@@ -48,7 +48,7 @@ describe('Transaction Log', () => {
       transactions,
     }
     const config = configure()
-    const { transactionFeed } = mapStateToProps(state, { config })
+    const { transactionFeed, metadata } = mapStateToProps(state, { config })
     it('Should provide a feed of transactions sorted by blockNumber, descending', () => {
       expect.assertions(4)
       expect(transactionFeed).toHaveLength(3)
@@ -56,11 +56,12 @@ describe('Transaction Log', () => {
       expect(transactionFeed[1].blockNumber).toEqual(2)
       expect(transactionFeed[2].blockNumber).toEqual(1)
     })
-    it('should include href to explorer and readable name in the feed', () => {
-      expect.assertions(2)
-      const tx = transactionFeed[0]
-      expect(tx).toHaveProperty('href')
-      expect(tx).toHaveProperty('readableName')
+    it('should include href to explorer, lock address, and readable name in the metadata', () => {
+      expect.assertions(3)
+      const md = metadata['0x9abcdef0']
+      expect(md).toHaveProperty('href')
+      expect(md).toHaveProperty('readableName')
+      expect(md).toHaveProperty('lock')
     })
   })
 })

--- a/unlock-app/src/pages/log.js
+++ b/unlock-app/src/pages/log.js
@@ -58,7 +58,15 @@ Log.propTypes = {
   account: UnlockPropTypes.account.isRequired,
   network: UnlockPropTypes.network.isRequired,
   transactionFeed: PropTypes.arrayOf(UnlockPropTypes.transaction).isRequired,
-  metadata: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)).isRequired,
+  metadata: PropTypes.objectOf(
+    PropTypes.objectOf(
+      PropTypes.shape({
+        href: PropTypes.string,
+        readableName: PropTypes.string,
+        lock: PropTypes.string,
+      })
+    )
+  ).isRequired,
 }
 
 const Content = styled.div`

--- a/unlock-app/src/pages/log.js
+++ b/unlock-app/src/pages/log.js
@@ -58,7 +58,7 @@ Log.propTypes = {
   account: UnlockPropTypes.account.isRequired,
   network: UnlockPropTypes.network.isRequired,
   transactionFeed: PropTypes.arrayOf(UnlockPropTypes.transaction).isRequired,
-  metadata: PropTypes.object.isRequired,
+  metadata: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)).isRequired,
 }
 
 const Content = styled.div`


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. Please also include relevant motivation and context.
-->
This PR fixes #1704. It refactors the `mapStateToProps` of the transaction log page to create a metadata object that holds the calculated values associated with each transaction, now including a lock address for key purchases.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
