### PR TITLE
Moving NODE_ENV to package.json

### DIFF
--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -35,14 +35,14 @@
   },
   "scripts": {
     "remix": "remixd -s contracts --remix-ide http://localhost:8080 --read-only",
-    "test": "truffle test --network development",
+    "test": "cross-env NODE_ENV=test truffle test --network development",
     "lint": "solhint \"contracts/**/*.sol\" && solium -d ./contracts/ && eslint .",
     "dev": "npm run lint && npm run build && npm run test",
     "ci": "npm run lint && npm run test && npm run coverage",
     "build": "truffle compile --all",
     "deploy": "truffle deploy",
     "zos": "zos",
-    "coverage": "cross-env TEST_COVERAGE=true solidity-coverage"
+    "coverage": "cross-env NODE_ENV=test cross-env TEST_COVERAGE=true solidity-coverage"
   },
   "author": "",
   "license": "ISC"

--- a/smart-contracts/test/Unlock/UnlockProxy.js
+++ b/smart-contracts/test/Unlock/UnlockProxy.js
@@ -1,5 +1,3 @@
-process.env.NODE_ENV = 'test'
-
 const Unlock = artifacts.require('Unlock')
 const UnlockTestV2 = artifacts.require('UnlockTestV2')
 const UnlockTestV3 = artifacts.require('UnlockTestV3')


### PR DESCRIPTION
# Description

The ZOS TestHelper requires an environment variable to be set.  Moving that configuration from code to package.json instead.

```
Important: for TestHelper to work correctly in your testing environment, you need to set the NODE_ENV environment variable to test when running your tests. For instance, if you are using truffle, run NODE_ENV=test truffle test.
```

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
