### PR TITLE
Updates Locksmith with the ability to utilize a user config to local development

### DIFF
--- a/locksmith/.gitignore
+++ b/locksmith/.gitignore
@@ -1,1 +1,2 @@
 development.sqlite3
+/config/config.user.js

--- a/locksmith/.sequelizerc
+++ b/locksmith/.sequelizerc
@@ -1,5 +1,17 @@
-const path = require('path');
+const fs = require('fs')
+const path = require('path')
+
+let configurationFile = () => {
+  let userFile  = path.resolve('config', 'config.user.js')
+  let generalFile = path.resolve('config', 'config.js')
+
+  if (fs.existsSync(userFile)) {
+    return userFile
+  } else {
+    return generalFile
+  }
+}
 
 module.exports = {
-  'config': path.resolve('config', 'config.js')
+  'config': path.resolve('config', configurationFile())
 }


### PR DESCRIPTION
Addressing #1034 

In order to help developers avoid accidentally committing code containing their credentials, the configuration will utilize `config.user.js` when the file is present.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
