### PR TITLE
Adding safeTransferFrom functions to Lock contract for erc721 compliance

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -35,7 +35,6 @@ contract PublicLock is
   MixinApproval,
   MixinLockCore,
   MixinRefunds,
-  MixinLockCore,
   MixinTransfer
 {
   using SafeMath for uint;
@@ -51,8 +50,8 @@ contract PublicLock is
     uint _version
   )
     public
+    MixinLockCore(_owner, _expirationDuration, _keyPrice, _maxNumberOfKeys, _version)
   {
-    MixinLockCore(_owner, _expirationDuration, _keyPrice, _maxNumberOfKeys, _version);
   }
 
   /**

--- a/smart-contracts/contracts/UnlockErrors.sol
+++ b/smart-contracts/contracts/UnlockErrors.sol
@@ -54,4 +54,7 @@ contract UnlockErrors {
 
   // This function may only be called once, and it already has been.
   string public constant ONLY_CALL_ONCE = 'ONLY_CALL_ONCE';
+
+  // This contract does NOT implement the IERC721Receiver interface.
+  string public constant NON_COMPLIANT_ERC721_RECEIVER = 'NON_COMPLIANT_ERC721_RECEIVER';
 }

--- a/smart-contracts/contracts/interfaces/IERC721.sol
+++ b/smart-contracts/contracts/interfaces/IERC721.sol
@@ -56,7 +56,7 @@ interface IERC721 {
   /// @param _to The new owner
   /// @param _tokenId The NFT to transfer
   /// @param data Additional data with no specified format, sent in call to `_to`
-  function safeTransferFrom(address _from, address _to, uint _tokenId, bytes data) external payable;
+  function safeTransferFrom(address _from, address _to, uint _tokenId, bytes data) public payable;
 
   /// @notice Transfers the ownership of an NFT from one address to another address
   /// @dev This works identically to the other function with an extra data parameter,

--- a/smart-contracts/contracts/interfaces/IERC721.sol
+++ b/smart-contracts/contracts/interfaces/IERC721.sol
@@ -56,7 +56,7 @@ interface IERC721 {
   /// @param _to The new owner
   /// @param _tokenId The NFT to transfer
   /// @param data Additional data with no specified format, sent in call to `_to`
-  // function safeTransferFrom(address _from, address _to, uint _tokenId, bytes data) external payable;
+  function safeTransferFrom(address _from, address _to, uint _tokenId, bytes data) external payable;
 
   /// @notice Transfers the ownership of an NFT from one address to another address
   /// @dev This works identically to the other function with an extra data parameter,
@@ -64,7 +64,7 @@ interface IERC721 {
   /// @param _from The current owner of the NFT
   /// @param _to The new owner
   /// @param _tokenId The NFT to transfer
-  // function safeTransferFrom(address _from, address _to, uint _tokenId) external payable;
+  function safeTransferFrom(address _from, address _to, uint _tokenId) external payable;
 
   /// @notice Enable or disable approval for a third party ('operator') to manage
   ///  all of `msg.sender`'s assets.

--- a/smart-contracts/contracts/mixins/MixinDisableAndDestroy.sol
+++ b/smart-contracts/contracts/mixins/MixinDisableAndDestroy.sol
@@ -8,15 +8,15 @@ import 'openzeppelin-eth/contracts/ownership/Ownable.sol';
  * @title Mixin allowing the Lock owner to disable a Lock (preventing new purchases)
  * and then destroy it.
  * @author HardlyDifficult
- * @dev `Mixins` are a design pattern seen in the 0x contracts.  It simply 
- * separates logically groupings of code to ease readability. 
+ * @dev `Mixins` are a design pattern seen in the 0x contracts.  It simply
+ * separates logically groupings of code to ease readability.
  */
 contract MixinDisableAndDestroy is
   IERC721,
   Ownable
 {
   // Used to disable payable functions when deprecating an old lock
-  bool public isAlive; 
+  bool public isAlive;
 
   event Destroy(
     uint balance,
@@ -58,7 +58,7 @@ contract MixinDisableAndDestroy is
     onlyOwner
   {
     require(isAlive == false, 'DISABLE_FIRST');
-    emit Destroy(this.balance, msg.sender);
+    emit Destroy(address(this).balance, msg.sender);
     selfdestruct(msg.sender);
     // Note we don't clean up the `locks` data in Unlock.sol as it should not be necessary
     // and leaves some data behind ('Unlock.LockBalances') which may be helpful.

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -17,8 +17,8 @@ import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
  */
 
 contract MixinTransfer is
-  MixinApproval,
   MixinKeys,
+  MixinApproval,
   MixinLockCore {
   using SafeMath for uint;
   using Address for address;

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -9,7 +9,7 @@ import 'openzeppelin-solidity/contracts/token/ERC721/IERC721Receiver.sol';
 import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
 /**
- * @title Mixin for the safe transfer related functions needed to meet the ERC721
+ * @title Mixin for the transfer-related functions needed to meet the ERC721
  * standard.
  * @author Nick Furfaro
  * @dev `Mixins` are a design pattern seen in the 0x contracts.  It simply
@@ -23,6 +23,7 @@ contract MixinTransfer is
   using SafeMath for uint;
   using Address for address;
 
+  // 0x150b7a02 == bytes4(keccak256('onERC721Received(address,address,uint256,bytes)'))
   bytes4 private constant _ERC721_RECEIVED = 0x150b7a02;
 
   /**

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -125,7 +125,7 @@ contract MixinTransfer is
     hasValidKey(ownerOf(_tokenId))
   {
     transferFrom(_from, _to, _tokenId);
-    require(_checkOnERC721Received(_from, _to, _tokenId, _data), 'NO_FALLBACK');
+    require(_checkOnERC721Received(_from, _to, _tokenId, _data), 'NON_COMPLIANT_ERC721_RECEIVER');
 
   }
 

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -1,0 +1,171 @@
+pragma solidity 0.4.25;
+
+import '../interfaces/IERC721.sol';
+import './mixins/MixinDisableAndDestroy.sol';
+import "../../AddressUtils.sol";
+
+/**
+ * @title Mixin for the safe transfer related functions needed to meet the ERC721
+ * standard.
+ * @author Nick Furfaro
+ * @dev `Mixins` are a design pattern seen in the 0x contracts.  It simply
+ * separates logically groupings of code to ease readability.
+ */
+
+contract MixinTransfer is IERC721 {
+  using AddressUtils for address;
+
+  /**
+   * This is payable because at some point we want to allow the LOCK to capture a fee on 2ndary
+   * market transactions...
+   */
+  function transferFrom(
+    address _from,
+    address _recipient,
+    uint _tokenId
+  )
+    external
+    payable
+    onlyIfAlive
+    notSoldOut()
+    hasValidKey(_from)
+    onlyKeyOwnerOrApproved(_tokenId)
+  {
+    require(_recipient != address(0), 'INVALID_ADDRESS');
+
+    Key storage fromKey = _getKeyFor(_from);
+    Key storage toKey = _getKeyFor(_recipient);
+
+    uint previousExpiration = toKey.expirationTimestamp;
+
+    if (previousExpiration == 0) {
+      // The recipient did not have a key previously
+      _addNewOwner(_recipient);
+      _setKeyOwner(_tokenId, _recipient);
+      toKey.tokenId = _tokenId;
+    }
+
+    if (previousExpiration <= block.timestamp) {
+      // The recipient did not have a key, or had a key but it expired. The new expiration is the
+      // sender's key expiration
+      toKey.expirationTimestamp = fromKey.expirationTimestamp;
+    } else {
+      // The recipient has a non expired key. We just add them the corresponding remaining time
+      // SafeSub is not required since the if confirms `previousExpiration - block.timestamp` cannot underflow
+      toKey.expirationTimestamp = fromKey
+        .expirationTimestamp.add(previousExpiration - block.timestamp);
+    }
+    // Overwite data in all cases
+    toKey.data = fromKey.data;
+
+    // Effectively expiring the key for the previous owner
+    fromKey.expirationTimestamp = block.timestamp;
+
+    // Clear any previous approvals
+    _clearApproval(_tokenId);
+
+    // trigger event
+    emit Transfer(
+      _from,
+      _recipient,
+      _tokenId
+    );
+  }
+
+  /**
+  * @notice Transfers the ownership of an NFT from one address to another address
+  * @dev This works identically to the other function with an extra data parameter,
+  *  except this function just sets data to ''
+  * @param _from The current owner of the NFT
+  * @param _to The new owner
+  * @param _tokenId The NFT to transfer
+  */
+  function safeTransferFrom(
+    address _from,
+    address _to,
+    uint _tokenId
+  )
+    external
+    payable
+    onlyIfAlive
+    onlyKeyOwnerOrApproved(_tokenId)
+  {
+
+  }
+
+  /**
+  * @notice Transfers the ownership of an NFT from one address to another address
+  * @param _from The current owner of the NFT
+  * @param _to The new owner
+  * @param _tokenId The NFT to transfer
+  * @param data Additional data with no specified format, sent in call to `_to`
+  */
+  function safeTransferFrom(
+    address _from,
+    address _to,
+    uint _tokenId,
+    bytes data
+  )
+    external
+    payable
+    onlyIfAlive
+    onlyKeyOwnerOrApproved(_tokenId)
+    hasValidKey(ownerOf(_tokenId))
+  {
+    require(isKeyOwner(_tokenId, _from), 'ONLY_KEY_OWNER');
+    require(_recipient != address(0), 'INVALID_ADDRESS');
+  }
+
+  /**
+  * @notice Handle the receipt of an NFT
+  * @dev The ERC721 smart contract calls this function on the recipient
+  * after a `safeTransfer`. This function MUST return the function selector,
+  * otherwise the caller will revert the transaction. The selector to be
+  * returned can be obtained as `this.onERC721Received.selector`. This
+  * function MAY throw to revert and reject the transfer.
+  * Note: the ERC721 contract address is always the message sender.
+  * @param operator The address which called `safeTransferFrom` function
+  * @param from The address which previously owned the token
+  * @param tokenId The NFT identifier which is being transferred
+  * @param data Additional data with no specified format
+  * @return `bytes4(keccak256('onERC721Received(address,address,uint,bytes)'))`
+  */
+  function onERC721Received(
+    address operator, // solhint-disable-line no-unused-vars
+    address from, // solhint-disable-line no-unused-vars
+    uint tokenId, // solhint-disable-line no-unused-vars
+    bytes memory data // solhint-disable-line no-unused-vars
+  )
+    public
+    returns(bytes4)
+  {
+    return this.onERC721Received.selector;
+  }
+
+  /**
+   * @dev Internal function to invoke `onERC721Received` on a target address
+   * @dev The call is not executed if the target address is not a contract
+   * @param _from address representing the previous owner of the given token ID
+   * @param _to target address that will receive the tokens
+   * @param _tokenId uint256 ID of the token to be transferred
+   * @param _data bytes optional data to send along with the call
+   * @return whether the call correctly returned the expected magic value
+   */
+  function checkAndCallSafeTransfer(
+    address _from,
+    address _to,
+    uint256 _tokenId,
+    bytes _data
+  )
+    internal
+    returns (bool)
+  {
+    if (!_to.isContract()) {
+      return true;
+    }
+    bytes4 retval = ERC721Receiver(_to).onERC721Received(
+      _from, _tokenId, _data);
+    return (retval == ERC721_RECEIVED);
+  }
+
+}

--- a/smart-contracts/test/Lock/erc721/onERC721Received.js
+++ b/smart-contracts/test/Lock/erc721/onERC721Received.js
@@ -6,7 +6,7 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks, operator, from, tokenId, data
 
-contract('Lock Receiver', (accounts) => {
+contract('Lock Receiver', accounts => {
   operator = accounts[5]
   from = accounts[5]
   tokenId = 11
@@ -26,8 +26,14 @@ contract('Lock Receiver', (accounts) => {
   describe('Implements IERC721Receiver interface', () => {
     it('should implement the onERC721Received() function', async function () {
       // PublicLock.onERC721Received.selector == 0x150b7a02`
-      const ERC721_RECEIVED = 0x150b7a02
-      const result = await locks['FIRST'].onERC721Received.call(operator, from, tokenId, data, {})
+      const ERC721_RECEIVED = Web3Utils.toHex(0x150b7a02)
+      const result = await locks['FIRST'].onERC721Received.call(
+        operator,
+        from,
+        tokenId,
+        data,
+        {}
+      )
       assert.equal(result, ERC721_RECEIVED)
     })
   })

--- a/smart-contracts/test/Lock/erc721/onERC721Received.js
+++ b/smart-contracts/test/Lock/erc721/onERC721Received.js
@@ -26,7 +26,7 @@ contract('Lock Receiver', accounts => {
   describe('Implements IERC721Receiver interface', () => {
     it('should implement the onERC721Received() function', async function () {
       // PublicLock.onERC721Received.selector == 0x150b7a02`
-      const ERC721_RECEIVED = Web3Utils.toHex(0x150b7a02)
+      const ERC721_RECEIVED = 0x150b7a02
       const result = await locks['FIRST'].onERC721Received.call(
         operator,
         from,

--- a/smart-contracts/test/Lock/erc721/safeTransferFrom.js
+++ b/smart-contracts/test/Lock/erc721/safeTransferFrom.js
@@ -1,14 +1,131 @@
+const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+const Web3Abi = require('web3-eth-abi')
+const abi = new Web3Abi.AbiCoder()
+
 const deployLocks = require('../../helpers/deployLocks')
+const shouldFail = require('../../helpers/shouldFail')
 const Unlock = artifacts.require('../../Unlock.sol')
 
-let unlock
+let unlock, locks
 
-contract('Lock ERC721', (accounts) => {
+contract('Lock ERC721', accounts => {
   before(async () => {
     unlock = await Unlock.deployed()
-    await deployLocks(unlock)
+    locks = await deployLocks(unlock)
   })
-
+  // function safeTransferFrom() still uses transferFrom() under the hood, but adds an additional check afterwards. transferFrom is already well-tested, so here we add a few checks to test only the new functionality.
   describe('safeTransferFrom', () => {
+    const from = accounts[1]
+    const to = accounts[2]
+    let ID
+
+    before(async () => {
+      // first, let's purchase a brand new key that we can transfer
+      await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from
+      })
+      ID = await locks['FIRST'].getTokenIdFor.call(from)
+    })
+
+    it('should work if no data is passed in', async () => {
+      await locks['FIRST'].safeTransferFrom(from, to, ID, {
+        from
+      })
+      let ownerOf = await locks['FIRST'].ownerOf.call(ID)
+      let data = await locks['FIRST'].keyDataFor.call(to)
+      assert.equal(ownerOf, to)
+      assert.equal(Web3Utils.toUtf8(data), 'Julien') // 'Julien' needs to be changed to '' after the data on a transferred key is 'reset' rather than preserved as is currently done.
+    })
+
+    // it('should work if some data is passed in ', async () => {
+    //   await locks['FIRST'].purchaseFor(accounts[7], Web3Utils.toHex('Julien'), {
+    //     value: Units.convert('0.01', 'eth', 'wei'),
+    //     from: accounts[7]
+    //   })
+    //   ID = await locks['FIRST'].getTokenIdFor.call(accounts[7])
+    //   await locks['FIRST'].safeTransferFromWithData(
+    //     accounts[7],
+    //     accounts[6],
+    //     ID,
+    //     'Julien',
+    //     {
+    //       from: accounts[7]
+    //     }
+    //   )
+    //   let ownerOf = await locks['FIRST'].ownerOf.call(ID)
+    //   assert.equal(ownerOf, accounts[6])
+    //   let data = await locks['FIRST'].keyDataFor.call(accounts[6])
+    //   assert.equal(Web3Utils.toUtf8(data), 'Julien') // 'Julien' needs to be changed to '' after the data on a transferred key is 'reset' rather than preserved as is currently done.
+    // })
+
+    it('should work if some data is passed in ', async () => {
+      await locks['FIRST'].purchaseFor(accounts[7], Web3Utils.toHex('Julien'), {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[7]
+      })
+      ID = await locks['FIRST'].getTokenIdFor.call(accounts[7])
+      let sender = Web3Utils.toChecksumAddress(accounts[7])
+      let receiver = Web3Utils.toChecksumAddress(accounts[6])
+
+      let encodedCall = abi.encodeFunctionCall(
+        {
+          name: 'safeTransferFrom',
+          type: 'function',
+          inputs: [
+            {
+              type: 'address',
+              name: '_from'
+            },
+            {
+              type: 'address',
+              name: '_to'
+            },
+            {
+              type: 'uint256',
+              name: '_tokenId'
+            },
+            {
+              type: 'bytes',
+              name: 'data'
+            }
+          ]
+        },
+        [sender, receiver, Web3Utils.toHex(ID), Web3Utils.toHex('Julien')] // TODO: replace hardcoded ID
+      )
+
+      await locks['FIRST'].sendTransaction({
+        from: accounts[7],
+        data: encodedCall
+      })
+      let ownerOf = await locks['FIRST'].ownerOf.call(ID)
+      assert.equal(ownerOf, accounts[6])
+      let data = await locks['FIRST'].keyDataFor.call(accounts[6])
+      assert.equal(Web3Utils.toUtf8(data), 'Julien') // 'Julien' needs to be changed to '' after the data on a transferred key is 'reset' rather than preserved as is currently done.
+    })
+
+    it('should fail if trying to transfer a key to a contract which does not implement onERC721Received', async () => {
+      await locks['FIRST'].purchaseFor(
+        accounts[5],
+        Web3Utils.toHex('Someone Else'),
+        {
+          value: Units.convert('0.01', 'eth', 'wei'),
+          from: accounts[5]
+        }
+      )
+      ID = await locks['FIRST'].getTokenIdFor.call(accounts[5])
+      // A contract which does NOT implement onERC721Received:
+      let nonCompliantContract = unlock.address
+      await shouldFail(
+        locks['FIRST'].safeTransferFrom(accounts[5], nonCompliantContract, ID, {
+          from: accounts[5]
+        }),
+        'NO_FALLBACK'
+      )
+      // make sure the key was not transferred
+      let ownerOf = await locks['FIRST'].ownerOf.call(ID)
+      assert.equal(ownerOf, accounts[5])
+    })
   })
 })

--- a/smart-contracts/test/Lock/erc721/safeTransferFrom.js
+++ b/smart-contracts/test/Lock/erc721/safeTransferFrom.js
@@ -36,29 +36,8 @@ contract('Lock ERC721', accounts => {
       let ownerOf = await locks['FIRST'].ownerOf.call(ID)
       let data = await locks['FIRST'].keyDataFor.call(to)
       assert.equal(ownerOf, to)
-      assert.equal(Web3Utils.toUtf8(data), 'Julien') // 'Julien' needs to be changed to '' after the data on a transferred key is 'reset' rather than preserved as is currently done.
+      assert.equal(Web3Utils.toUtf8(data), 'Julien')
     })
-
-    // it('should work if some data is passed in ', async () => {
-    //   await locks['FIRST'].purchaseFor(accounts[7], Web3Utils.toHex('Julien'), {
-    //     value: Units.convert('0.01', 'eth', 'wei'),
-    //     from: accounts[7]
-    //   })
-    //   ID = await locks['FIRST'].getTokenIdFor.call(accounts[7])
-    //   await locks['FIRST'].safeTransferFromWithData(
-    //     accounts[7],
-    //     accounts[6],
-    //     ID,
-    //     'Julien',
-    //     {
-    //       from: accounts[7]
-    //     }
-    //   )
-    //   let ownerOf = await locks['FIRST'].ownerOf.call(ID)
-    //   assert.equal(ownerOf, accounts[6])
-    //   let data = await locks['FIRST'].keyDataFor.call(accounts[6])
-    //   assert.equal(Web3Utils.toUtf8(data), 'Julien') // 'Julien' needs to be changed to '' after the data on a transferred key is 'reset' rather than preserved as is currently done.
-    // })
 
     it('should work if some data is passed in ', async () => {
       await locks['FIRST'].purchaseFor(accounts[7], Web3Utils.toHex('Julien'), {
@@ -68,7 +47,7 @@ contract('Lock ERC721', accounts => {
       ID = await locks['FIRST'].getTokenIdFor.call(accounts[7])
       let sender = Web3Utils.toChecksumAddress(accounts[7])
       let receiver = Web3Utils.toChecksumAddress(accounts[6])
-
+      // Using encodeFunctionCall as a workaround until the upgrade to Truffle v5.x. Can't call overloaded functions from js currently...
       let encodedCall = abi.encodeFunctionCall(
         {
           name: 'safeTransferFrom',
@@ -92,7 +71,7 @@ contract('Lock ERC721', accounts => {
             }
           ]
         },
-        [sender, receiver, Web3Utils.toHex(ID), Web3Utils.toHex('Julien')] // TODO: replace hardcoded ID
+        [sender, receiver, Web3Utils.toHex(ID), Web3Utils.toHex('Julien')]
       )
 
       await locks['FIRST'].sendTransaction({
@@ -102,7 +81,7 @@ contract('Lock ERC721', accounts => {
       let ownerOf = await locks['FIRST'].ownerOf.call(ID)
       assert.equal(ownerOf, accounts[6])
       let data = await locks['FIRST'].keyDataFor.call(accounts[6])
-      assert.equal(Web3Utils.toUtf8(data), 'Julien') // 'Julien' needs to be changed to '' after the data on a transferred key is 'reset' rather than preserved as is currently done.
+      assert.equal(Web3Utils.toUtf8(data), 'Julien')
     })
 
     it('should fail if trying to transfer a key to a contract which does not implement onERC721Received', async () => {


### PR DESCRIPTION
# Description

This PR implements the last required function(s) for our Lock contract to be erc721 compliant, and fixes #759. Tests have been added to ensure the additional safety provided by `safeTransferFrom` is working correctly, but `transferFrom` is still used under the hood to do the bulk of the work, and is already well tested.
- refactored transfer functionality into a new Mixin in keeping with the established pattern.
- added 2 `safeTransferFrom` functions (with different arity)
- I removed `notSoldOut` from `transferFrom` as it was not needed. Even if a Lock is sold out, keys can be transferred.
- I edited IERC721.sol temporarily as a workaround, line #59, external => public.
>"Solidity issue #2330: If a function is shown in this specification as external then a contract will be compliant if it uses public visibility. As a workaround for version 0.4.20, you can edit this interface to switch to public before inheriting from your contract."
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md#caveats 
- minor edit in `MixinDisableAndDestroy.sol` to silence a linter error regarding the way in which the address of the current contract is retrieved.
-note that I didn't change anything in `MixinKeyOwner.sol`...not sure why it shows changes.

- final action for ERC721 compliance is to complete #838 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
