### PR TITLE
Not saving the locks when the price is not changed

### DIFF
--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -167,13 +167,14 @@ export class CreatorLockForm extends React.Component {
   }
 
   saveLock() {
-    const { account, createLock } = this.props
-    const lock = formValuesToLock(this.state)
-
-    createLock({
-      ...lock,
-      owner: account.address,
-    })
+    const { account, createLock, lock } = this.props
+    const newLock = formValuesToLock(this.state)
+    if (!lock.address || lock.keyPrice !== newLock.keyPrice) {
+      createLock({
+        ...newLock,
+        owner: account.address,
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
This is a very minor change to not issue a transaction when the user does not change the price!


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread