### PR TITLE
Add missing `memory` keyword

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -163,7 +163,7 @@ contract PublicLock is
     address operator, // solhint-disable-line no-unused-vars
     address from, // solhint-disable-line no-unused-vars
     uint tokenId, // solhint-disable-line no-unused-vars
-    bytes data // solhint-disable-line no-unused-vars
+    bytes memory data // solhint-disable-line no-unused-vars
   )
     public
     returns(bytes4)


### PR DESCRIPTION
# Description

Adding the `memory` keyword where it was previously assumed.  This is no longer optional when we upgrade to solc5

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
