### PR TITLE
Adding missing `view` keyword

### DIFF
--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -117,7 +117,7 @@ contract MixinApproval is
   function _isApproved(
     uint _tokenId,
     address _user
-  ) internal
+  ) internal view
     returns (bool)
   {
     return approved[_tokenId] == _user;

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -137,7 +137,7 @@ contract MixinKeys is
    */
   function _getKeyFor(
     address _owner
-  ) internal
+  ) internal view
     returns (Key storage)
   {
     return keyByOwner[_owner];


### PR DESCRIPTION
# Description

Adding a couple missing `view` keywords.  These produced warnings previously and become errors when we upgrade to solc5.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
