### PR TITLE
Cast address to payable address

### DIFF
--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -130,7 +130,7 @@ contract MixinLockCore is
   function _withdraw(uint _amount)
     private
   {
-    Ownable.owner().transfer(_amount);
+    address(uint160(Ownable.owner())).transfer(_amount);
     emit Withdrawal(msg.sender, _amount);
   }
 }


### PR DESCRIPTION
# Description

This syntax looks a little strange, but is required with solc5.  There are two distinct types - `address` and `address payable`, only the latter has `transfer` and similar functions.  

The challenge is with this update Solidity did not provide a way to cast to `address payable` directly.  From the docs: `the only way to perform such a conversion is by using an intermediate conversion to uint160`.

This should have 0 impact today, but will be required when we upgrade to solc5.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
