### PR TITLE
Add missing BigNumber

### DIFF
--- a/smart-contracts/test/Lock/Lock.js
+++ b/smart-contracts/test/Lock/Lock.js
@@ -45,6 +45,7 @@ contract('Lock', accounts => {
         maxNumberOfKeys = new BigNumber(maxNumberOfKeys)
         outstandingKeys = new BigNumber(outstandingKeys)
         numberOfOwners = new BigNumber(numberOfOwners)
+        publicLockVersion = new BigNumber(publicLockVersion)
         assert.strictEqual(owner, accounts[0])
         assert.equal(expirationDuration.toFixed(), 60 * 60 * 24 * 30)
         assert.strictEqual(Units.convert(keyPrice, 'wei', 'eth'), '0.01')

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -51,7 +51,7 @@ contract('Lock', (accounts) => {
         txObj = await lock.cancelAndRefund({
           from: keyOwners[0]
         })
-        withdrawalAmount = await web3.eth.getBalance(lock.address).minus(initialLockBalance)
+        withdrawalAmount = new BigNumber(await web3.eth.getBalance(lock.address)).minus(initialLockBalance)
       })
 
       it('should emit a CancelKey event', async () => {


### PR DESCRIPTION
# Description

Updating a couple instances of numbers to explicitly use bignumber.js.  The reason for this is depending on the environment we are in, numbers may be in a different bignumber format - this standardizes on bignumber.js

It's required with the solc5 upgrade due to a change in number handling.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
