### PR TITLE
Change address 0 to 0x00..0

### DIFF
--- a/smart-contracts/test/Unlock/UnlockProxy.js
+++ b/smart-contracts/test/Unlock/UnlockProxy.js
@@ -1,3 +1,4 @@
+const Web3Utils = require('web3-utils')
 const Unlock = artifacts.require('Unlock')
 const UnlockTestV2 = artifacts.require('UnlockTestV2')
 const UnlockTestV3 = artifacts.require('UnlockTestV3')
@@ -49,7 +50,7 @@ contract('Unlock', function (accounts) {
       })
 
       it('should allow changing functions', async function () {
-        const results = await this.unlock.computeAvailableDiscountFor(0, 0)
+        const results = await this.unlock.computeAvailableDiscountFor(Web3Utils.padLeft(0, 40), 0)
         assert.equal(results[0].toString(), '42')
         assert.equal(results[1].toString(), '42')
       })


### PR DESCRIPTION
# Description

Changing the 0 address to the hex format instead.  With the truffle update there is a new type check which causes a simple `0` to fail.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
