### PR TITLE
Specify gas when using TestHelper

### DIFF
--- a/smart-contracts/test/Unlock/UnlockProxy.js
+++ b/smart-contracts/test/Unlock/UnlockProxy.js
@@ -61,7 +61,8 @@ contract('Unlock', function (accounts) {
         Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
         100, // maxNumberOfKeys
         {
-          from: accounts[0]
+          from: accounts[0],
+          gas: 4000000
         }
       )
       const newLockAddress = transaction.logs[0].args.newLockAddress

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -14,7 +14,8 @@ exports.shouldCreateLock = function (accounts) {
           Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
           100 // maxNumberOfKeys
           , {
-            from: accounts[0]
+            from: accounts[0],
+            gas: 4000000
           })
       })
 
@@ -52,7 +53,8 @@ exports.shouldCreateLock = function (accounts) {
           Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
           100 // maxNumberOfKeys
           , {
-            from: accounts[0]
+            from: accounts[0],
+            gas: 4000000
           }), 'MAX_EXPIRATION_100_YEARS')
       })
     })

--- a/smart-contracts/test/Unlock/behaviors/createLockWithInfiniteKeys.js
+++ b/smart-contracts/test/Unlock/behaviors/createLockWithInfiniteKeys.js
@@ -25,7 +25,8 @@ contract('PublicLock', accounts => {
           Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
           -1 // maxNumberOfKeys
           , {
-            from: accounts[0]
+            from: accounts[0],
+            gas: 4000000
           })
       })
 
@@ -44,7 +45,8 @@ contract('PublicLock', accounts => {
           Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
           0 // maxNumberOfKeys
           , {
-            from: accounts[0]
+            from: accounts[0],
+            gas: 4000000
           })
       })
 


### PR DESCRIPTION
# Description

Adding an (large) explicit gas limit to send calls when using the TestHelper.  This should have no impact now, but with the ZOS update this will prevent a fail since the new default has been lowered.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
