### PR TITLE
use the config context from withConfig instead of rolling a new one in useConfig.js

### DIFF
--- a/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
@@ -1,7 +1,7 @@
 import * as rtl from 'react-testing-library'
 import React from 'react'
 
-import { ConfigContext } from '../../../hooks/utils/useConfig'
+import { ConfigContext } from '../../../utils/withConfig'
 import useListenForPostMessage from '../../../hooks/browser/useListenForPostMessage'
 
 describe('useListenForPostMessage hook', () => {

--- a/paywall/src/__tests__/hooks/browser/usePostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/usePostMessage.test.js
@@ -1,7 +1,7 @@
 import * as rtl from 'react-testing-library'
 import React from 'react'
 
-import { ConfigContext } from '../../../hooks/utils/useConfig'
+import { ConfigContext } from '../../../utils/withConfig'
 import usePostMessage from '../../../hooks/browser/usePostMessage'
 
 describe('usePostMessage hook', () => {

--- a/paywall/src/__tests__/hooks/helpers.js
+++ b/paywall/src/__tests__/hooks/helpers.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { ConfigContext } from '../../hooks/utils/useConfig'
+import { ConfigContext } from '../../utils/withConfig'
 
 const { Provider } = ConfigContext
 

--- a/paywall/src/__tests__/hooks/utils/useConfig.test.js
+++ b/paywall/src/__tests__/hooks/utils/useConfig.test.js
@@ -2,7 +2,8 @@ import React from 'react'
 import * as rtl from 'react-testing-library'
 
 import configuration from '../../../config'
-import useConfig, { ConfigContext } from '../../../hooks/utils/useConfig'
+import useConfig from '../../../hooks/utils/useConfig'
+import { ConfigContext } from '../../../utils/withConfig'
 
 describe('useConfig hook', () => {
   const { Provider } = ConfigContext

--- a/paywall/src/hooks/utils/useConfig.js
+++ b/paywall/src/hooks/utils/useConfig.js
@@ -1,6 +1,5 @@
-import { createContext, useContext } from 'react'
-
-export const ConfigContext = createContext()
+import { useContext } from 'react'
+import { ConfigContext } from '../../utils/withConfig'
 
 export default function useConfig() {
   return useContext(ConfigContext)


### PR DESCRIPTION
# Description

fixes #1742 by importing ConfigContext from withConfig.js

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
