### PR TITLE
fix all the eslint errors, and 2 bugs in paywall tests

### DIFF
--- a/paywall/src/__tests__/actions/accounts.test.js
+++ b/paywall/src/__tests__/actions/accounts.test.js
@@ -7,6 +7,7 @@ import {
 
 describe('accounts actions', () => {
   it('should create an action to set the account', () => {
+    expect.assertions(1)
     const account = {
       address: '0xabc',
       privateKey: 'deadbeef',
@@ -19,6 +20,7 @@ describe('accounts actions', () => {
   })
 
   it('should create an action to update an account', () => {
+    expect.assertions(1)
     const update = {
       balance: '1337',
     }

--- a/paywall/src/__tests__/actions/currencyConvert.test.js
+++ b/paywall/src/__tests__/actions/currencyConvert.test.js
@@ -5,6 +5,7 @@ import {
 
 describe('currency conversion actions', () => {
   it('should create an action to set a currency conversion rate for USD', () => {
+    expect.assertions(1)
     const rateFor1Eth = '195.99'
     const convertedRate = 195.99
     const currency = 'USD'
@@ -17,6 +18,7 @@ describe('currency conversion actions', () => {
   })
 
   it('should create an action to set a currency conversion rate for EUR', () => {
+    expect.assertions(1)
     const rateFor1Eth = '200.30'
     const convertedRate = 200.3
     const currency = 'EUR'

--- a/paywall/src/__tests__/actions/error.test.js
+++ b/paywall/src/__tests__/actions/error.test.js
@@ -9,6 +9,7 @@ const MY_ERROR = 'MY ERROR'
 
 describe('error actions', () => {
   it('should create an action to set the error', () => {
+    expect.assertions(1)
     const error = MY_ERROR
     const expectedAction = {
       type: SET_ERROR,
@@ -19,6 +20,7 @@ describe('error actions', () => {
   })
 
   it('should create an action to reset all errors', () => {
+    expect.assertions(1)
     const error = null
     const expectedAction = {
       type: SET_ERROR,
@@ -29,6 +31,7 @@ describe('error actions', () => {
   })
 
   it('should create an action to reset a single error', () => {
+    expect.assertions(1)
     const error = MY_ERROR
     const expectedAction = {
       type: RESET_ERROR,

--- a/paywall/src/__tests__/actions/key.test.js
+++ b/paywall/src/__tests__/actions/key.test.js
@@ -9,6 +9,7 @@ import {
 
 describe('key actions', () => {
   it('should create an action to purchase a key', () => {
+    expect.assertions(1)
     const key = {}
     const expectedAction = {
       type: PURCHASE_KEY,
@@ -18,6 +19,7 @@ describe('key actions', () => {
   })
 
   it('should create an action to add a key to the store', () => {
+    expect.assertions(1)
     const id = '123'
     const key = {
       expiration: 100,
@@ -33,6 +35,7 @@ describe('key actions', () => {
   })
 
   it('should create an action to update a key in the store', () => {
+    expect.assertions(1)
     const key = {
       expiration: 100,
       data: 'hello',

--- a/paywall/src/__tests__/actions/keysPages.test.js
+++ b/paywall/src/__tests__/actions/keysPages.test.js
@@ -5,6 +5,7 @@ import {
 
 describe('key actions', () => {
   it('should create an action to set the keys for lock on a given page', () => {
+    expect.assertions(1)
     const page = '10'
     const lock = '0x123'
     const keys = [{}, {}]

--- a/paywall/src/__tests__/actions/lock.test.js
+++ b/paywall/src/__tests__/actions/lock.test.js
@@ -15,6 +15,7 @@ import {
 
 describe('lock actions', () => {
   it('should create an action to create a lock', () => {
+    expect.assertions(1)
     const lock = {}
     const expectedAction = {
       type: CREATE_LOCK,
@@ -24,6 +25,7 @@ describe('lock actions', () => {
   })
 
   it('should create an action to update the lock', () => {
+    expect.assertions(1)
     const address = '0x1234'
     const update = {}
     const expectedAction = {
@@ -35,6 +37,7 @@ describe('lock actions', () => {
   })
 
   it('should create an action to add the lock', () => {
+    expect.assertions(1)
     const lock = {}
     const address = '0x123'
     const expectedAction = {
@@ -46,6 +49,7 @@ describe('lock actions', () => {
   })
 
   it('should create an action to delete a lock', () => {
+    expect.assertions(1)
     const address = '0x123'
     const expectedAction = {
       type: DELETE_LOCK,
@@ -55,6 +59,7 @@ describe('lock actions', () => {
   })
 
   it('should create an action to withdraw from the lock', () => {
+    expect.assertions(1)
     const lock = {}
     const expectedAction = {
       type: WITHDRAW_FROM_LOCK,
@@ -64,6 +69,7 @@ describe('lock actions', () => {
   })
 
   it('should create an action to update the key price', () => {
+    expect.assertions(1)
     const address = '0x123'
     const price = '0.02'
     const expectedAction = {

--- a/paywall/src/__tests__/actions/modal.test.js
+++ b/paywall/src/__tests__/actions/modal.test.js
@@ -9,6 +9,7 @@ import {
 
 describe('modal actions', () => {
   it('should create an action to show a modal', () => {
+    expect.assertions(1)
     const modal = ''
     const expectedAction = {
       type: SHOW_MODAL,
@@ -18,6 +19,7 @@ describe('modal actions', () => {
   })
 
   it('should create an action to hide a modal', () => {
+    expect.assertions(1)
     const modal = ''
     const expectedAction = {
       type: HIDE_MODAL,
@@ -27,6 +29,7 @@ describe('modal actions', () => {
   })
 
   it('should create an action to open the modal in a new window', () => {
+    expect.assertions(1)
     expect(openNewWindowModal()).toEqual({
       type: OPEN_MODAL_IN_NEW_WINDOW,
     })

--- a/paywall/src/__tests__/actions/network.test.js
+++ b/paywall/src/__tests__/actions/network.test.js
@@ -2,6 +2,7 @@ import { setNetwork, SET_NETWORK } from '../../actions/network'
 
 describe('network actions', () => {
   it('should create an action to set the network', () => {
+    expect.assertions(1)
     const network = 'dev'
     const expectedAction = {
       type: SET_NETWORK,

--- a/paywall/src/__tests__/actions/provider.test.js
+++ b/paywall/src/__tests__/actions/provider.test.js
@@ -2,6 +2,7 @@ import { setProvider, SET_PROVIDER } from '../../actions/provider'
 
 describe('provider actions', () => {
   it('should create an action to set the provider', () => {
+    expect.assertions(1)
     const provider = 'dev'
     const expectedAction = {
       type: SET_PROVIDER,

--- a/paywall/src/__tests__/actions/signature.test.js
+++ b/paywall/src/__tests__/actions/signature.test.js
@@ -2,6 +2,7 @@ import { signatureError } from '../../actions/signature'
 
 describe('signature error', () => {
   it('should return the signature error', () => {
+    expect.assertions(1)
     const error = new Error('An error')
     const expectation = {
       type: 'SIGNATURE_ERROR',

--- a/paywall/src/__tests__/actions/storage.test.js
+++ b/paywall/src/__tests__/actions/storage.test.js
@@ -1,12 +1,13 @@
 import {
   storageError,
   STORAGE_ERROR,
-  storeLockCreation,
-  STORE_LOCK_CREATION,
+  storeLockName,
+  STORE_LOCK_NAME,
 } from '../../actions/storage'
 
 describe('Storage error', () => {
   it('should create an action emitting a storage error', () => {
+    expect.assertions(1)
     const error = 'a fancy error'
 
     const expectation = {
@@ -20,17 +21,18 @@ describe('Storage error', () => {
 
 describe('Store Lock Creation', () => {
   it('should create an action indicating storage of a newly created lock', () => {
+    expect.assertions(1)
     const owner = "An owner's address"
     const lock = {}
     const token = 'An authorization token'
 
     const expectation = {
-      type: STORE_LOCK_CREATION,
+      type: STORE_LOCK_NAME,
       owner: owner,
       lock: lock,
       token: token,
     }
 
-    expect(storeLockCreation(owner, lock, token)).toEqual(expectation)
+    expect(storeLockName(owner, lock, token)).toEqual(expectation)
   })
 })

--- a/paywall/src/__tests__/actions/transaction.test.js
+++ b/paywall/src/__tests__/actions/transaction.test.js
@@ -11,6 +11,7 @@ import {
 
 describe('transaction actions', () => {
   it('should create an action to add a transaction', () => {
+    expect.assertions(1)
     const transaction = {}
     const expectedAction = {
       type: ADD_TRANSACTION,
@@ -20,6 +21,7 @@ describe('transaction actions', () => {
   })
 
   it('should create an action to update the transaction', () => {
+    expect.assertions(1)
     const hash = '0x123'
     const update = {}
     const expectedAction = {
@@ -31,6 +33,7 @@ describe('transaction actions', () => {
   })
 
   it('should create an action to delete a transaction', () => {
+    expect.assertions(1)
     const transaction = {}
     const expectedAction = {
       type: DELETE_TRANSACTION,
@@ -40,6 +43,7 @@ describe('transaction actions', () => {
   })
 
   it('should create an action to add a new transaction', () => {
+    expect.assertions(1)
     const transaction = {}
     const expectedAction = {
       type: NEW_TRANSACTION,

--- a/paywall/src/__tests__/actions/walletStatus.test.js
+++ b/paywall/src/__tests__/actions/walletStatus.test.js
@@ -9,14 +9,19 @@ import {
 
 describe('walletStatus actions', () => {
   it('should create and action to wait for the wallet', () => {
+    expect.assertions(1)
     const expectedAction = { type: WAIT_FOR_WALLET }
     expect(waitForWallet()).toEqual(expectedAction)
   })
+
   it('should create and action to indicate that the wallet is available', () => {
+    expect.assertions(1)
     const expectedAction = { type: GOT_WALLET }
     expect(gotWallet()).toEqual(expectedAction)
   })
+
   it('should create an action to indicate that the wallet check overlay should be dismissed', () => {
+    expect.assertions(1)
     const expectedAction = { type: DISMISS_CHECK }
     expect(dismissWalletCheck()).toEqual(expectedAction)
   })

--- a/paywall/src/__tests__/components/creator/FatalError.test.js
+++ b/paywall/src/__tests__/components/creator/FatalError.test.js
@@ -12,18 +12,21 @@ describe('FatalError', () => {
   describe('mapErrorToComponent', () => {
     describe('maps errors to default components', () => {
       it('FATAL_MISSING_PROVIDER', () => {
+        expect.assertions(1)
         const component = mapErrorToComponent(FATAL_MISSING_PROVIDER, {})
 
         const wrapper = rtl.render(component)
         expect(wrapper.queryByText('Wallet missing')).not.toBeNull()
       })
       it('FATAL_NO_USER_ACCOUNT', () => {
+        expect.assertions(1)
         const component = mapErrorToComponent(FATAL_NO_USER_ACCOUNT, {})
 
         const wrapper = rtl.render(component)
         expect(wrapper.queryByText('Need account')).not.toBeNull()
       })
       it('FATAL_WRONG_NETWORK', () => {
+        expect.assertions(1)
         const component = mapErrorToComponent(FATAL_WRONG_NETWORK, {
           currentNetwork: 'foo',
           requiredNetworkId: 1,
@@ -33,6 +36,7 @@ describe('FatalError', () => {
         expect(wrapper.queryByText('Network mismatch')).not.toBeNull()
       })
       it('*', () => {
+        expect.assertions(1)
         const component = mapErrorToComponent('whatever', {
           title: 'some error',
         })
@@ -41,6 +45,7 @@ describe('FatalError', () => {
         expect(wrapper.queryByText('some error')).not.toBeNull()
       })
       it('override', () => {
+        expect.assertions(1)
         function Component() {
           return <div>My error</div>
         }

--- a/paywall/src/__tests__/components/developer/DeveloperOverlay.test.js
+++ b/paywall/src/__tests__/components/developer/DeveloperOverlay.test.js
@@ -40,6 +40,7 @@ describe('DeveloperOverlay', () => {
   })
 
   it('has a dropdown that can be used to choose between providers', () => {
+    expect.assertions(2)
     const component = rtl.render(
       <DeveloperOverlay config={config} setProvider={callback} />
     )
@@ -49,6 +50,7 @@ describe('DeveloperOverlay', () => {
   })
 
   it('sets selected provider from prop', () => {
+    expect.assertions(1)
     const component = rtl.render(
       <DeveloperOverlay
         config={config}
@@ -61,6 +63,7 @@ describe('DeveloperOverlay', () => {
   })
 
   it('selects provider', () => {
+    expect.assertions(2)
     const component = rtl.render(
       <DeveloperOverlay
         config={config}
@@ -77,6 +80,7 @@ describe('DeveloperOverlay', () => {
   })
 
   it('mapStateToProps', () => {
+    expect.assertions(1)
     expect(
       mapStateToProps({
         provider: 'hi',

--- a/paywall/src/__tests__/components/helpers/BalanceProvider.test.js
+++ b/paywall/src/__tests__/components/helpers/BalanceProvider.test.js
@@ -14,6 +14,7 @@ describe('BalanceProvider Component', () => {
     )
   }
   it('renders with - when amount is null (probably unset)', () => {
+    expect.assertions(2)
     renderIt({
       amount: null,
       conversion: {},
@@ -25,6 +26,7 @@ describe('BalanceProvider Component', () => {
   })
 
   it('renders with - when amount is undefined (probably loading)', () => {
+    expect.assertions(2)
     renderIt({
       amount: undefined,
       conversion: {},
@@ -36,6 +38,7 @@ describe('BalanceProvider Component', () => {
   })
 
   it('USD conversion data is not available', () => {
+    expect.assertions(2)
     renderIt({
       amount: '100',
       conversion: {},
@@ -47,6 +50,7 @@ describe('BalanceProvider Component', () => {
   })
 
   it('USD conversion data is available', () => {
+    expect.assertions(2)
     renderIt({
       amount: '100',
       render: (ethValue, fiatValue) => {
@@ -58,6 +62,7 @@ describe('BalanceProvider Component', () => {
 
   describe('when the balance is 0 Eth', () => {
     it('should render 0 for both values', () => {
+      expect.assertions(2)
       renderIt({
         amount: '0',
         render: (ethValue, fiatValue) => {
@@ -72,6 +77,7 @@ describe('BalanceProvider Component', () => {
     const amount = '0.000070'
 
     it('shows the default minimum value of 三 < 0.0001', () => {
+      expect.assertions(2)
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
@@ -86,6 +92,7 @@ describe('BalanceProvider Component', () => {
     const amount = '0.0002'
 
     it('shows the balance in Eth to two decimal places', () => {
+      expect.assertions(2)
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
@@ -100,6 +107,7 @@ describe('BalanceProvider Component', () => {
     const amount = '2.0'
 
     it('shows the balance in Eth to two decimal places', () => {
+      expect.assertions(2)
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
@@ -114,6 +122,7 @@ describe('BalanceProvider Component', () => {
     const amount = '1.9989816877'
 
     it('shows the balance in Eth without rounding up', () => {
+      expect.assertions(1)
       renderIt({
         amount,
         render: ethValue => {
@@ -127,6 +136,7 @@ describe('BalanceProvider Component', () => {
     const amount = '20'
 
     it('shows the balance in dollars in locale format without decimal', () => {
+      expect.assertions(2)
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
@@ -141,6 +151,7 @@ describe('BalanceProvider Component', () => {
     const amount = '2000'
 
     it('shows the balance in thousands of dollars postfixed with k', () => {
+      expect.assertions(2)
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
@@ -155,6 +166,7 @@ describe('BalanceProvider Component', () => {
     const amount = '20000'
 
     it('shows the balance in millions of dollars postfixed with m', () => {
+      expect.assertions(2)
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
@@ -169,6 +181,7 @@ describe('BalanceProvider Component', () => {
     const amount = '20000000'
 
     it('shows the balance in billions of dollars postfixed with b', () => {
+      expect.assertions(2)
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {

--- a/paywall/src/__tests__/components/helpers/BrowserOnly.test.js
+++ b/paywall/src/__tests__/components/helpers/BrowserOnly.test.js
@@ -11,11 +11,13 @@ describe('BrowserOnly', () => {
     </BrowserOnly>
   )
   it('renders children in the browser', () => {
+    expect.assertions(2)
     const element = rtl.render(tester)
     expect(element.queryByText('first')).not.toBeNull()
     expect(element.queryByText('second')).not.toBeNull()
   })
   it('does not render children on the server', () => {
+    expect.assertions(1)
     const output = ReactDOMServer.renderToStaticMarkup(tester)
     expect(output).toBe('')
   })

--- a/paywall/src/__tests__/components/helpers/Duration.test.js
+++ b/paywall/src/__tests__/components/helpers/Duration.test.js
@@ -7,6 +7,7 @@ describe('Duration Component', () => {
   const seconds = 10000000
 
   it('shows - when the seconds are null or undefined', () => {
+    expect.assertions(2)
     let wrapper = rtl.render(<Duration seconds={null} />)
     expect(wrapper.queryByText('-')).not.toBe(null)
 
@@ -15,6 +16,7 @@ describe('Duration Component', () => {
   })
 
   it('shows the duration in seconds', () => {
+    expect.assertions(1)
     const wrapper = rtl.render(<Duration seconds={seconds} />)
     expect(
       wrapper.queryByText('115 days, 17 hours, 46 minutes and 40 seconds')
@@ -22,6 +24,7 @@ describe('Duration Component', () => {
   })
 
   it('unless we want to round', () => {
+    expect.assertions(1)
     const wrapper = rtl.render(<Duration seconds={seconds} round />)
     expect(wrapper.queryByText('116 days')).not.toBe(null)
   })

--- a/paywall/src/__tests__/components/helpers/SuspendedError.test.js
+++ b/paywall/src/__tests__/components/helpers/SuspendedError.test.js
@@ -8,6 +8,7 @@ jest.useFakeTimers()
 describe('SuspendedRender', () => {
   const Fallback = () => <div>hi</div>
   it('should not display anything during timeout', () => {
+    expect.assertions(1)
     const rendered = rtl.render(
       <SuspendedRender>
         <Fallback />
@@ -16,6 +17,7 @@ describe('SuspendedRender', () => {
     expect(rendered.queryByText('hi')).toBeNull()
   })
   it('should display fallback after timeout', () => {
+    expect.assertions(2)
     const rendered = rtl.render(
       <SuspendedRender>
         <Fallback />

--- a/paywall/src/__tests__/components/interface/Button.test.js
+++ b/paywall/src/__tests__/components/interface/Button.test.js
@@ -11,6 +11,7 @@ jest.mock('next/link', () => {
 afterEach(rtl.cleanup)
 describe('Button', () => {
   it('should activate the action function when clicked', () => {
+    expect.assertions(1)
     let buttonClicked = false
     const action = () => {
       buttonClicked = true
@@ -25,6 +26,7 @@ describe('Button', () => {
   })
 
   it('should not propagate click events', () => {
+    expect.assertions(2)
     let buttonClicked = false
     let wrapperClicked = false
 

--- a/paywall/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/paywall/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -58,6 +58,7 @@ describe('GlobalErrorConsumer', () => {
   })
   describe('displayError', () => {
     it('displays the error if initialized', () => {
+      expect.assertions(2)
       const wrapper = rtl.render(
         displayError(FATAL_MISSING_PROVIDER, {}, <div>children</div>)
       )
@@ -66,6 +67,7 @@ describe('GlobalErrorConsumer', () => {
       expect(wrapper.queryByText('children')).toBeNull()
     })
     it('displays the children if no error is initialized', () => {
+      expect.assertions(1)
       const wrapper = rtl.render(displayError(false, {}, <div>children</div>))
 
       expect(wrapper.queryByText('children')).not.toBeNull()

--- a/paywall/src/__tests__/components/lock/Lock.test.js
+++ b/paywall/src/__tests__/components/lock/Lock.test.js
@@ -42,6 +42,7 @@ describe('Lock', () => {
 
   describe('mapStateToProps', () => {
     it('should return a new lockKey and no transaction when there is no matching key', () => {
+      expect.assertions(5)
       const state = {
         network: {},
         account: {
@@ -64,6 +65,7 @@ describe('Lock', () => {
     })
 
     it('should return the lockKey and its transaction if applicable', () => {
+      expect.assertions(5)
       const props = {
         lock: {
           address: '0xdeadbeef',

--- a/paywall/src/__tests__/components/lock/Overlay.test.js
+++ b/paywall/src/__tests__/components/lock/Overlay.test.js
@@ -151,6 +151,7 @@ describe('Overlay', () => {
       ).not.toBeNull()
     })
     it('displays error, headline, and flag when there is an error', () => {
+      expect.assertions(3)
       const wrapper = rtl.render(
         <Provider store={store}>
           <ConfigProvider
@@ -179,6 +180,7 @@ describe('Overlay', () => {
       ).not.toBeNull()
     })
     it('displays lock when the error is missing account', () => {
+      expect.assertions(3)
       const wrapper = rtl.render(
         <Provider store={store}>
           <ErrorProvider

--- a/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
@@ -96,6 +96,7 @@ describe('useListenForPostMessage hook', () => {
   })
 
   it('does not throw when window is not set', () => {
+    expect.assertions(0)
     rtl.testHook(() => useListenForPostMessage(false), {
       wrapper,
     })

--- a/paywall/src/__tests__/hooks/browser/useLocalStorage-no-localStorage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useLocalStorage-no-localStorage.test.js
@@ -18,6 +18,7 @@ describe('no localStorage', () => {
     }
   })
   it('does nothing', () => {
+    expect.assertions(2)
     fakeWindow.localStorage.removeItem = () => {
       throw new Error('nope')
     }

--- a/paywall/src/__tests__/hooks/browser/useLocalStorage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useLocalStorage.test.js
@@ -18,6 +18,7 @@ describe('useLocalStorage hook', () => {
     }
   })
   it('returns existing value of localStorage key and a setter', () => {
+    expect.assertions(2)
     fakeWindow.storage.hi = 'there'
 
     expect.assertions(2)
@@ -31,6 +32,7 @@ describe('useLocalStorage hook', () => {
     expect(typeof setter).toBe('function')
   })
   it('sets the value of the localStorage key when the setter is called', () => {
+    expect.assertions(1)
     fakeWindow.storage['hi'] = 'there'
 
     expect.assertions(1)
@@ -46,9 +48,9 @@ describe('useLocalStorage hook', () => {
     expect(fakeWindow.localStorage.setItem).toHaveBeenCalledWith('hi', 'wow')
   })
   it('only sets the value when changed', () => {
-    fakeWindow.storage['hi'] = 'there'
-
     expect.assertions(5)
+
+    fakeWindow.storage['hi'] = 'there'
 
     const {
       result: {

--- a/paywall/src/__tests__/middlewares/currencyConversionMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/currencyConversionMiddleware.test.js
@@ -13,6 +13,7 @@ describe('Currency conversion service retrieval middleware', () => {
   const APIaddress = 'https://api.coinbase.com/v2/prices/ETH-USD/buy'
 
   it('service called, action dispatched to set currency conversion rate', () => {
+    expect.assertions(4)
     jest.useFakeTimers()
     const middleware = require('../../middlewares/currencyConversionMiddleware')
       .default
@@ -44,6 +45,7 @@ describe('Currency conversion service retrieval middleware', () => {
     )
   })
   it("service called, values are the same, so don't dispatch", () => {
+    expect.assertions(2)
     jest.useFakeTimers()
     const middleware = require('../../middlewares/currencyConversionMiddleware')
       .default

--- a/paywall/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
@@ -370,8 +370,8 @@ describe('interWindowCommunicationMiddleware', () => {
           window.top = {}
         })
         it('should dispatch SET_ACCOUNT if account is stored in localStorage', () => {
-          window.localStorage.getItem = jest.fn(() => account)
           expect.assertions(2)
+          window.localStorage.getItem = jest.fn(() => account)
           const middleware = interWindowCommunicationMiddleware(window)
           middleware(store)(() => {})({})
 

--- a/paywall/src/__tests__/paywall-builder/blocker.test.js
+++ b/paywall/src/__tests__/paywall-builder/blocker.test.js
@@ -3,6 +3,7 @@ import * as blockerManager from '../../../paywall-builder/blocker'
 describe('paywall builder', () => {
   describe('blocker', () => {
     it('getBlocker', () => {
+      expect.assertions(2)
       const document = {
         createElement() {
           return { style: {}, appendChild: jest.fn() }
@@ -38,6 +39,7 @@ describe('paywall builder', () => {
     })
 
     it('addBlocker', () => {
+      expect.assertions(1)
       const document = {
         body: {
           appendChild: jest.fn(),
@@ -50,6 +52,7 @@ describe('paywall builder', () => {
     })
 
     it('removeBlocker', () => {
+      expect.assertions(1)
       const blocker = {
         remove: jest.fn(),
       }

--- a/paywall/src/__tests__/paywall-builder/build.test.js
+++ b/paywall/src/__tests__/paywall-builder/build.test.js
@@ -23,15 +23,16 @@ describe('buildPaywall', () => {
   afterEach(() => jest.restoreAllMocks())
 
   it('redirect', () => {
-    const window = {
+    expect.assertions(1)
+    const fakeWindow = {
       location: {
         href: 'href/',
       },
     }
 
-    redirect(window, 'hi')
+    redirect(fakeWindow, 'hi/')
 
-    expect((window.location.href = 'hi/href%2F'))
+    expect(fakeWindow.location.href).toBe('hi/href%2F')
   })
   describe('sets up the iframe on load', () => {
     let mockScript
@@ -47,6 +48,7 @@ describe('buildPaywall', () => {
           postMessage: () => {},
         },
       }
+
       mockAdd = jest.spyOn(iframeManager, 'add')
       mockScript.mockImplementation(() => '/url')
       mockIframe.mockImplementation(() => mockIframeImpl)
@@ -62,13 +64,16 @@ describe('buildPaywall', () => {
         },
       }
     })
+
     it('no lockAddress, give up', () => {
+      expect.assertions(1)
       buildPaywall(window, document)
 
       expect(mockScript).not.toHaveBeenCalled()
     })
 
     it('sets up the iframe with correct url', () => {
+      expect.assertions(4) // 2 are in the addEventListener in the mock window (see beforeEach)
       buildPaywall(window, document, fakeLockAddress)
 
       expect(mockScript).toHaveBeenCalledWith(document)
@@ -76,6 +81,7 @@ describe('buildPaywall', () => {
     })
 
     it('passes the hash to the iframe, if present', () => {
+      expect.assertions(4) // 2 are in the addEventListener in the mock window (see beforeEach)
       // when the content is loaded from the paywall in a new window,
       // it appends the user account as a hash. This is then passed on
       // as-is. Note that it passes any hash on, without validation,
@@ -91,12 +97,14 @@ describe('buildPaywall', () => {
     })
 
     it('adds the iframe to the page', () => {
+      expect.assertions(3) // 2 are in the addEventListener in the mock window (see beforeEach)
       buildPaywall(window, document, fakeLockAddress)
 
       expect(mockAdd).toHaveBeenCalledWith(document, mockIframeImpl)
     })
 
     it('sets up the message event listeners', () => {
+      expect.assertions(3) // 2 are in the addEventListener in the mock window (see beforeEach)
       jest.spyOn(window, 'addEventListener')
       buildPaywall(window, document, fakeLockAddress)
 
@@ -130,23 +138,27 @@ describe('buildPaywall', () => {
         buildPaywall(window, document, fakeLockAddress, blocker)
       })
       it('triggers show on locked event', () => {
+        expect.assertions(2)
         callbacks.message({ data: 'locked' })
 
         expect(mockShow).toHaveBeenCalledWith(mockIframeImpl, document)
         expect(mockHide).not.toHaveBeenCalled()
       })
       it('closes the blocker on locked event', () => {
+        expect.assertions(1)
         callbacks.message({ data: 'locked' })
 
         expect(blocker.remove).toHaveBeenCalled()
       })
       it('closes the blocker on unlocked event', () => {
+        expect.assertions(1)
         callbacks.message({ data: 'locked' })
         callbacks.message({ data: 'unlocked' })
 
         expect(blocker.remove).toHaveBeenCalledTimes(2)
       })
       it('does not trigger show on locked event if already unlocked', () => {
+        expect.assertions(2)
         callbacks.message({ data: 'locked' })
         callbacks.message({ data: 'locked' })
 
@@ -154,6 +166,7 @@ describe('buildPaywall', () => {
         expect(mockHide).not.toHaveBeenCalled()
       })
       it('triggers hide on unlock event', () => {
+        expect.assertions(3)
         callbacks.message({ data: 'locked' })
         callbacks.message({ data: 'unlocked' })
         callbacks.message({ data: 'unlocked' })
@@ -163,6 +176,7 @@ describe('buildPaywall', () => {
         expect(mockShow).toHaveBeenCalledTimes(1)
       })
       it('calls redirect on redirect event', () => {
+        expect.assertions(1)
         callbacks.message({ data: 'redirect' })
 
         expect(window.location.href).toBe('/url/lockaddress/href')

--- a/paywall/src/__tests__/paywall-builder/iframe.test.js
+++ b/paywall/src/__tests__/paywall-builder/iframe.test.js
@@ -8,6 +8,7 @@ import {
 
 describe('iframe', () => {
   it('add appends the iframe to document.body', () => {
+    expect.assertions(5)
     const el = {
       setAttribute: jest.fn(),
     }
@@ -32,6 +33,7 @@ describe('iframe', () => {
 
   describe('add', () => {
     it('adds iframe if not present', () => {
+      expect.assertions(1)
       const document = {
         body: {
           insertAdjacentElement: jest.fn(),
@@ -49,6 +51,7 @@ describe('iframe', () => {
       )
     })
     it('ignores add if present', () => {
+      expect.assertions(1)
       const document = {
         body: {
           appendChild: jest.fn(),
@@ -64,6 +67,7 @@ describe('iframe', () => {
   })
 
   it('show', () => {
+    expect.assertions(2)
     const iframe = {
       style: {},
     }
@@ -85,6 +89,7 @@ describe('iframe', () => {
   })
 
   it('hide', () => {
+    expect.assertions(2)
     const iframe = {
       style: {},
       contentDocument: {

--- a/paywall/src/__tests__/paywall-builder/index.test.js
+++ b/paywall/src/__tests__/paywall-builder/index.test.js
@@ -25,6 +25,7 @@ describe('paywall builder integration', () => {
   afterEach(() => jest.restoreAllMocks())
 
   it('calls listenForLocks', () => {
+    expect.assertions(5)
     global.window = {}
 
     require('../../../paywall-builder')

--- a/paywall/src/__tests__/paywall-builder/mutationObserver.test.js
+++ b/paywall/src/__tests__/paywall-builder/mutationObserver.test.js
@@ -43,15 +43,18 @@ describe('mutationObserver', () => {
       callback = jest.fn()
     })
     it('bails if no nodes added', () => {
+      expect.assertions(1)
       changeListener(callback, [])
       expect(callback).not.toBeCalled()
     })
     it('bails if node is not a meta tag', () => {
+      expect.assertions(1)
       const mutations = makeMutation([tag('notmeta', 'hi', 'content')])
       changeListener(callback, mutations)
       expect(callback).not.toBeCalled()
     })
     it('bails if node is not a meta tag named "lock"', () => {
+      expect.assertions(1)
       const mutations = makeMutation([
         tag('notmeta', 'hi', 'content'),
         tag('meta', 'hi', 'content2'),
@@ -60,6 +63,7 @@ describe('mutationObserver', () => {
       expect(callback).not.toBeCalled()
     })
     it('calls callback with content attribute', () => {
+      expect.assertions(1)
       const mutations = makeMutation([
         tag('notmeta', 'hi', 'content'),
         tag('meta', 'hi', 'content2'),
@@ -80,10 +84,12 @@ describe('mutationObserver', () => {
       jest.restoreAllMocks()
     })
     it('immediately calls callback if a lock meta tag already exists in the page', () => {
+      expect.assertions(1)
       listenForNewLocks(callback, mockHead('hi'))
       expect(callback).toBeCalledWith('hi')
     })
     it('creates MutationObserver and calls observe', () => {
+      expect.assertions(3)
       global.MutationObserver = function() {
         this.observe = jest.fn()
         observer = this

--- a/paywall/src/__tests__/paywall-builder/script.test.js
+++ b/paywall/src/__tests__/paywall-builder/script.test.js
@@ -30,9 +30,11 @@ describe('script', () => {
     )
 
     it('finds the correct attribute', () => {
+      expect.assertions(1)
       expect(findPaywallUrl(fakeDoc)).toBe('hooby/booby')
     })
     it('returns the default url if nothing is found', () => {
+      expect.assertions(1)
       fakeDoc = {
         getElementsByTagName() {
           return [makeFakeScript('foobar'), makeFakeScript('nope')]
@@ -41,6 +43,7 @@ describe('script', () => {
       expect(findPaywallUrl(fakeDoc)).toBe(DEFAULT_URL)
     })
     it('returns data-unlock-src if present', () => {
+      expect.assertions(1)
       fakeDoc = {
         getElementsByTagName() {
           return [
@@ -54,6 +57,7 @@ describe('script', () => {
   })
 
   it('findLocks', () => {
+    expect.assertions(2)
     const el = {
       getAttribute() {
         return 'hi'

--- a/paywall/src/__tests__/reducers/accountReducer.test.js
+++ b/paywall/src/__tests__/reducers/accountReducer.test.js
@@ -10,17 +10,21 @@ describe('account reducer', () => {
   }
 
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(reducer(undefined, {})).toEqual(null)
   })
 
   it('should return the initial state when receveing SET_PROVIDER', () => {
+    expect.assertions(1)
     expect(
       reducer(account, {
         type: SET_PROVIDER,
       })
     ).toEqual(null)
   })
+
   it('should return the initial state when receveing SET_NETWORK', () => {
+    expect.assertions(1)
     expect(
       reducer(account, {
         type: SET_NETWORK,
@@ -29,6 +33,7 @@ describe('account reducer', () => {
   })
 
   it('should set the account accordingly when receiving SET_ACCOUNT', () => {
+    expect.assertions(1)
     expect(
       reducer(undefined, {
         type: SET_ACCOUNT,
@@ -38,6 +43,7 @@ describe('account reducer', () => {
   })
 
   it('should update an account accordingly when receiving UPDATE_ACCOUNT', () => {
+    expect.assertions(1)
     const update = {
       balance: '1337',
     }

--- a/paywall/src/__tests__/reducers/currencyReducer.test.js
+++ b/paywall/src/__tests__/reducers/currencyReducer.test.js
@@ -7,14 +7,17 @@ describe('currency conversion reducer', () => {
   }
 
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(reducer(undefined, {})).toBe(initialState)
   })
 
   it('should set the conversion rate for USD when receiving a rate for USD', () => {
+    expect.assertions(1)
     expect(reducer(undefined, setConversionRate('USD', '123'))).toEqual(USD123)
   })
 
   it('should set the conversion rate for EUR when receiving a rate for EUR', () => {
+    expect.assertions(1)
     expect(reducer(USD123, setConversionRate('EUR', '321'))).toEqual({
       USD: 123,
       EUR: 321,

--- a/paywall/src/__tests__/reducers/errorsReducer.test.js
+++ b/paywall/src/__tests__/reducers/errorsReducer.test.js
@@ -10,10 +10,12 @@ describe('errors reducer', () => {
   const error2 = action2.error
 
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(reducer(undefined, {})).toBe(initialState)
   })
 
   it('should return the initial state when receiving SET_PROVIDER', () => {
+    expect.assertions(1)
     expect(
       reducer([error], {
         type: SET_PROVIDER,
@@ -22,6 +24,7 @@ describe('errors reducer', () => {
   })
 
   it('should return the initial state when receiving SET_NETWORK', () => {
+    expect.assertions(1)
     expect(
       reducer([error], {
         type: SET_NETWORK,
@@ -30,27 +33,33 @@ describe('errors reducer', () => {
   })
 
   it('should set the error accordingly when receiving SET_ERROR', () => {
+    expect.assertions(1)
     expect(reducer(undefined, action)).toEqual([error])
   })
 
   it('should set add an error when receiving SET_ERROR again', () => {
+    expect.assertions(1)
     expect(reducer([error], action2)).toEqual([error, error2])
   })
 
   it('should not set the same error twice', () => {
+    expect.assertions(1)
     expect(reducer([error], action)).toEqual([error])
   })
 
   it('should not change state if RESET_ERROR with non-existing error is called', () => {
+    expect.assertions(1)
     const state = ['some other error']
     expect(reducer(state, resetError('non-existing'))).toBe(state)
   })
 
   it('should reset all errors if RESET_ERROR with no specific error received', () => {
+    expect.assertions(1)
     expect(reducer([1, 2], resetError())).toBe(initialState)
   })
 
   it('should reset a specific error if RESET_ERROR is called with a specific error', () => {
+    expect.assertions(3)
     expect(reducer([1, 2], resetError(1))).toEqual([2])
     expect(reducer([1, 2], resetError(2))).toEqual([1])
     expect(reducer([1, 2], resetError(3))).toEqual([1, 2])

--- a/paywall/src/__tests__/reducers/keysPagesReducer.test.js
+++ b/paywall/src/__tests__/reducers/keysPagesReducer.test.js
@@ -18,10 +18,12 @@ describe('keys page reducer', () => {
   }
 
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(reducer(undefined, {})).toEqual({})
   })
 
   it('should return the initial state when receveing SET_PROVIDER', () => {
+    expect.assertions(1)
     const state = {
       '0x123': {
         keys: [],
@@ -36,6 +38,7 @@ describe('keys page reducer', () => {
   })
 
   it('should return the initial state when receveing SET_NETWORK', () => {
+    expect.assertions(1)
     const state = {
       '0x123': {
         keys: [],
@@ -53,6 +56,7 @@ describe('keys page reducer', () => {
   // Upon changing account, we need to clear the existing keys on the page. The web3 middleware will
   // re-populate them
   it('should clear the keys on page when receiving SET_ACCOUNT', () => {
+    expect.assertions(1)
     const account = {}
     const state = {
       '0x123': {
@@ -70,6 +74,7 @@ describe('keys page reducer', () => {
 
   describe('SET_KEYS_ON_PAGE_FOR_LOCK', () => {
     it('should set the keys on that page accordingly', () => {
+      expect.assertions(1)
       const state = {}
       const action = {
         type: SET_KEYS_ON_PAGE_FOR_LOCK,
@@ -87,6 +92,7 @@ describe('keys page reducer', () => {
     })
 
     it('should set the keys on that page accordingly even when a value was previously set', () => {
+      expect.assertions(1)
       const state = {
         '0x123': {
           page: 1,

--- a/paywall/src/__tests__/reducers/keysReducer.test.js
+++ b/paywall/src/__tests__/reducers/keysReducer.test.js
@@ -12,10 +12,12 @@ describe('keys reducer', () => {
   }
 
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(reducer(undefined, {})).toEqual({})
   })
 
   it('should return the initial state when receveing SET_PROVIDER', () => {
+    expect.assertions(1)
     expect(
       reducer(
         {
@@ -29,6 +31,7 @@ describe('keys reducer', () => {
   })
 
   it('should return the initial state when receveing SET_NETWORK', () => {
+    expect.assertions(1)
     expect(
       reducer(
         {
@@ -44,6 +47,7 @@ describe('keys reducer', () => {
   // Upon changing account, we need to clear the existing keys. The web3 middleware will
   // re-populate them
   it('should clear the keys when receiving SET_ACCOUNT', () => {
+    expect.assertions(1)
     const account = {}
     const state = {
       [key.id]: key,
@@ -58,6 +62,7 @@ describe('keys reducer', () => {
 
   describe('ADD_KEY', () => {
     it('should refuse to add a key with the wrong id and keep state intact', () => {
+      expect.assertions(1)
       const id = '0x123'
 
       const state = {}
@@ -74,6 +79,8 @@ describe('keys reducer', () => {
     })
 
     it('should refuse to overwrite keys and keep state unchanged', () => {
+      expect.assertions(1)
+
       const id = '0x123'
 
       const state = {
@@ -94,6 +101,8 @@ describe('keys reducer', () => {
     })
 
     it('should add the key by its id accordingly when receiving ADD_KEY', () => {
+      expect.assertions(1)
+
       const id = '0x123'
       const key = {
         data: 'data',
@@ -120,6 +129,8 @@ describe('keys reducer', () => {
 
   describe('PURCHASE_KEY', () => {
     it('should add a key when receiving PURCHASE_KEY if the key has an id', () => {
+      expect.assertions(1)
+
       expect(
         reducer(
           {},
@@ -134,6 +145,8 @@ describe('keys reducer', () => {
     })
 
     it('should add a key when receiving PURCHASE_KEY and construct a key id if needed', () => {
+      expect.assertions(1)
+
       const newKey = {
         lock: '0x123',
         owner: '0x456',
@@ -158,6 +171,8 @@ describe('keys reducer', () => {
 
   describe('UPDATE_KEY', () => {
     it('should keep state unchanged if trying to update the key id', () => {
+      expect.assertions(1)
+
       const key = {
         id: 'keyId',
         expiration: 0,
@@ -178,6 +193,8 @@ describe('keys reducer', () => {
     })
 
     it('should keep state unchanged when the key being updated does not exist', () => {
+      expect.assertions(1)
+
       const key = {
         id: 'keyId',
         expiration: 0,
@@ -198,6 +215,7 @@ describe('keys reducer', () => {
     })
 
     it('should update the keys values', () => {
+      expect.assertions(1)
       const key = {
         id: 'keyId',
         expiration: 0,

--- a/paywall/src/__tests__/reducers/locksReducer.test.js
+++ b/paywall/src/__tests__/reducers/locksReducer.test.js
@@ -17,10 +17,12 @@ describe('locks reducer', () => {
   }
 
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(reducer(undefined, {})).toBe(initialState)
   })
 
   it('should return the initial state when receveing SET_PROVIDER', () => {
+    expect.assertions(1)
     expect(
       reducer(
         {
@@ -34,6 +36,7 @@ describe('locks reducer', () => {
   })
 
   it('should return the initial state when receveing SET_NETWORK', () => {
+    expect.assertions(1)
     expect(
       reducer(
         {
@@ -47,6 +50,7 @@ describe('locks reducer', () => {
   })
 
   it('should add the lock when receiving CREATE_LOCK and if it was not there yet', () => {
+    expect.assertions(1)
     expect(
       reducer(undefined, {
         type: CREATE_LOCK,
@@ -58,6 +62,7 @@ describe('locks reducer', () => {
   })
 
   it('should not add the lock when receiving CREATE_LOCK if the lock has no address', () => {
+    expect.assertions(1)
     expect(
       reducer(initialState, {
         type: CREATE_LOCK,
@@ -69,6 +74,7 @@ describe('locks reducer', () => {
   })
 
   it('should delete a lock when DELETE_TRANSACTION is called for a transaction which created that lock', () => {
+    expect.assertions(1)
     const transaction = {
       lock: lock.address,
     }
@@ -86,6 +92,7 @@ describe('locks reducer', () => {
   })
 
   it('should not delete a lock when DELETE_TRANSACTION is called for a transaction which created another lock', () => {
+    expect.assertions(1)
     const transaction = {
       lock: `${lock.address}x`,
     }
@@ -107,6 +114,7 @@ describe('locks reducer', () => {
   // Upon changing account, we need to clear the existing locks. The web3 middleware will
   // re-populate them
   it('should clear the locks when receiving SET_ACCOUNT', () => {
+    expect.assertions(1)
     const account = {}
     expect(
       reducer(
@@ -123,6 +131,7 @@ describe('locks reducer', () => {
 
   describe('DELETE_LOCK', () => {
     it('should delete a lock', () => {
+      expect.assertions(1)
       const state = {
         '0x123': {
           address: '0x123',
@@ -138,6 +147,7 @@ describe('locks reducer', () => {
 
   describe('ADD_LOCK', () => {
     it('should keep state unchanged if the address is a mismatch', () => {
+      expect.assertions(1)
       const state = {}
       const action = {
         type: ADD_LOCK,
@@ -150,6 +160,7 @@ describe('locks reducer', () => {
     })
 
     it('should keep state unchanged if the lock was previously added', () => {
+      expect.assertions(1)
       const state = {
         '0x123': {},
       }
@@ -164,6 +175,7 @@ describe('locks reducer', () => {
     })
 
     it('should add the lock and add its address', () => {
+      expect.assertions(1)
       const state = {
         '0x456': {},
       }
@@ -187,6 +199,7 @@ describe('locks reducer', () => {
 
   describe('UPDATE_LOCK', () => {
     it('should keep state unchanged if trying to update the lock address', () => {
+      expect.assertions(1)
       const state = {
         '0x123': {
           name: 'hello',
@@ -204,6 +217,7 @@ describe('locks reducer', () => {
     })
 
     it('should keep state unchanged when the lock being updated does not exist', () => {
+      expect.assertions(1)
       const state = {
         '0x123': {
           name: 'hello',
@@ -221,6 +235,7 @@ describe('locks reducer', () => {
     })
 
     it('should update the locks values', () => {
+      expect.assertions(1)
       const state = {
         '0x123': {
           name: 'hello',
@@ -246,6 +261,7 @@ describe('locks reducer', () => {
   })
 
   it("should update a lock's key price when UPDATE_LOCK_KEY_PRICE is called", () => {
+    expect.assertions(1)
     const state = {
       '0x123': {
         name: 'hello',

--- a/paywall/src/__tests__/reducers/modalsReducer.test.js
+++ b/paywall/src/__tests__/reducers/modalsReducer.test.js
@@ -5,10 +5,12 @@ import { SET_NETWORK } from '../../actions/network'
 
 describe('modal reducer', () => {
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(reducer(undefined, {})).toEqual({})
   })
 
   it('should return the initial state when receveing SET_PROVIDER', () => {
+    expect.assertions(1)
     expect(
       reducer(
         {
@@ -23,6 +25,7 @@ describe('modal reducer', () => {
   })
 
   it('should return the initial state when receveing SET_NETWORK', () => {
+    expect.assertions(1)
     expect(
       reducer(
         {
@@ -37,6 +40,7 @@ describe('modal reducer', () => {
   })
 
   it('should add the modal to the list of modals when receiving SHOW_MODAL', () => {
+    expect.assertions(1)
     const modal = '123'
     expect(
       reducer(
@@ -52,6 +56,7 @@ describe('modal reducer', () => {
   })
 
   it('should not change the list of modals when receiving SHOW_MODAL again', () => {
+    expect.assertions(1)
     const modal = '123'
     expect(
       reducer(
@@ -69,6 +74,7 @@ describe('modal reducer', () => {
   })
 
   it('should remove the modal to the list of modals when receiving HIDE_MODAL', () => {
+    expect.assertions(1)
     const modal = '123'
     expect(
       reducer(
@@ -84,6 +90,7 @@ describe('modal reducer', () => {
   })
 
   it('should not change the list of modals when receiving HIDE_MODAL for a missing modal', () => {
+    expect.assertions(1)
     const modal = '456'
     expect(
       reducer(

--- a/paywall/src/__tests__/reducers/networkReducer.test.js
+++ b/paywall/src/__tests__/reducers/networkReducer.test.js
@@ -5,12 +5,14 @@ describe('network reducer', () => {
   const network = 'dev'
 
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(reducer(undefined, {})).toEqual({
       name: 1984,
     })
   })
 
   it('should set the network accordingly when receiving SET_NETWORK', () => {
+    expect.assertions(1)
     expect(
       reducer(undefined, {
         type: SET_NETWORK,

--- a/paywall/src/__tests__/reducers/providerReducer.test.js
+++ b/paywall/src/__tests__/reducers/providerReducer.test.js
@@ -5,6 +5,7 @@ describe('provider reducer', () => {
   const provider = 'WebSocket'
 
   it('should return the initial state as null if there are no reducers', () => {
+    expect.assertions(1)
     /**
      * It is important that the default state is null and not undefined per this Redux error:
      * Error: Reducer "provider" returned undefined during initialization.If the state passed
@@ -16,6 +17,7 @@ describe('provider reducer', () => {
   })
 
   it('should set the provider accordingly when receiving SET_PROVIDER', () => {
+    expect.assertions(1)
     expect(
       reducer(undefined, {
         type: SET_PROVIDER,

--- a/paywall/src/__tests__/reducers/transactionsReducer.test.js
+++ b/paywall/src/__tests__/reducers/transactionsReducer.test.js
@@ -11,10 +11,12 @@ import { SET_ACCOUNT } from '../../actions/accounts'
 
 describe('transaction reducer', () => {
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(initialState).toEqual({})
   })
 
   it('should return the initial state when receveing SET_PROVIDER', () => {
+    expect.assertions(1)
     const transaction = {
       status: 'pending',
       confirmations: 0,
@@ -34,6 +36,7 @@ describe('transaction reducer', () => {
   })
 
   it('should return the initial state when receveing SET_NETWORK', () => {
+    expect.assertions(1)
     const transaction = {
       status: 'pending',
       confirmations: 0,
@@ -55,6 +58,7 @@ describe('transaction reducer', () => {
   // Upon changing account, we need to clear the existing transaction. The web3 middleware will
   // re-populate them
   it('should clear the transactions when receiving SET_ACCOUNT', () => {
+    expect.assertions(1)
     const account = {}
     const transaction = {
       status: 'pending',
@@ -74,6 +78,7 @@ describe('transaction reducer', () => {
 
   describe('when receiving NEW_TRANSACTION', () => {
     it('should add the new transaction to the store', () => {
+      expect.assertions(1)
       const transaction = {
         hash: '0x123',
         sender: '0xabc',
@@ -96,6 +101,7 @@ describe('transaction reducer', () => {
 
   describe('when receiving ADD_TRANSACTION', () => {
     it('should set the transaction accordingly if it has not been previously added', () => {
+      expect.assertions(1)
       const transaction = {
         status: 'pending',
         confirmations: 0,
@@ -116,6 +122,7 @@ describe('transaction reducer', () => {
     })
 
     it('should update an existing transaction', () => {
+      expect.assertions(1)
       const transaction = {
         status: 'pending',
         confirmations: 0,
@@ -148,6 +155,7 @@ describe('transaction reducer', () => {
 
   describe('when receiving UPDATE_TRANSACTION', () => {
     it('should not change state when trying to update the hash', () => {
+      expect.assertions(1)
       const transaction = {
         status: 'pending',
         confirmations: 0,
@@ -168,6 +176,7 @@ describe('transaction reducer', () => {
     })
 
     it('should not change state when trying to update a transaction which does not exist', () => {
+      expect.assertions(1)
       const transaction = {
         status: 'pending',
         confirmations: 0,
@@ -186,6 +195,7 @@ describe('transaction reducer', () => {
     })
 
     it('should update an existing transaction', () => {
+      expect.assertions(1)
       const transaction = {
         status: 'pending',
         confirmations: 0,
@@ -216,6 +226,7 @@ describe('transaction reducer', () => {
 
   describe('when receiving DELETE_TRANSACTION', () => {
     it('should remove the transaction which has been deleted from the list of all transactions', () => {
+      expect.assertions(1)
       const transaction = {
         hash: '0x123',
         status: 'pending',
@@ -235,6 +246,7 @@ describe('transaction reducer', () => {
     })
 
     it('should keep the transactions when another one has been deleted', () => {
+      expect.assertions(1)
       const transaction = {
         hash: '0x123',
         status: 'pending',

--- a/paywall/src/__tests__/reducers/walletStatusReducer.test.js
+++ b/paywall/src/__tests__/reducers/walletStatusReducer.test.js
@@ -8,18 +8,22 @@ import {
 describe('walletStatusReducer', () => {
   const waiting = { waiting: true }
   it('should return the initial state', () => {
+    expect.assertions(1)
     expect(reducer(undefined, {})).toEqual(initialState)
   })
 
   it('should set waiting to true when receiving WAIT_FOR_WALLET', () => {
+    expect.assertions(1)
     expect(reducer(initialState, { type: WAIT_FOR_WALLET })).toEqual(waiting)
   })
 
   it('should set waiting to false when receiving GOT_WALLET', () => {
+    expect.assertions(1)
     expect(reducer(waiting, { type: GOT_WALLET })).toEqual(initialState)
   })
 
   it('should set waiting to false when receiving DISMISS_CHECK', () => {
+    expect.assertions(1)
     expect(reducer(waiting, { type: DISMISS_CHECK })).toEqual(initialState)
   })
 })

--- a/paywall/src/__tests__/selectors/currency.test.js
+++ b/paywall/src/__tests__/selectors/currency.test.js
@@ -3,46 +3,56 @@ import { formatCurrency, formatEth } from '../../selectors/currency'
 describe('currency conversion and formatting selectors', () => {
   describe('formatEth', () => {
     it('small values', () => {
+      expect.assertions(1)
       expect(formatEth('0.00001')).toBe('< 0.0001')
     })
     it('decimal values', () => {
+      expect.assertions(3)
       expect(formatEth('0.01')).toBe('0.01')
       expect(formatEth('0.99')).toBe('0.99')
       expect(formatEth('0.91111111')).toBe('0.91')
     })
     it('larger values', () => {
+      expect.assertions(2)
       expect(formatEth('2')).toBe('2.00')
       expect(formatEth('22222222')).toBe('22222222.00')
     })
   })
   describe('formatCurrency', () => {
     it('< 0.01', () => {
+      expect.assertions(1)
       expect(formatCurrency('0.004')).toBe('0')
     })
     it('0.01 to 1', () => {
+      expect.assertions(2)
       expect(formatCurrency('0.01')).toBe('0.01')
       expect(formatCurrency('0.991')).toBe('0.99')
     })
     it('1 to 999', () => {
+      expect.assertions(2)
       expect(formatCurrency('1')).toBe('1.00')
       expect(formatCurrency('999.99')).toBe('999.99')
     })
     it('1000 to 99,999', () => {
+      expect.assertions(2)
       expect(formatCurrency('1000')).toBe('1,000')
       expect(formatCurrency('99999')).toBe('99,999')
     })
     it('100k to 1 million', () => {
+      expect.assertions(3)
       expect(formatCurrency('100000')).toBe('100k')
       expect(formatCurrency('100100')).toBe('100.1k')
       expect(formatCurrency('999911')).toBe('999.9k')
     })
     it('1 million to 1 billion', () => {
+      expect.assertions(4)
       expect(formatCurrency('1000000')).toBe('1m')
       expect(formatCurrency('1100000')).toBe('1.1m')
       expect(formatCurrency('10000000')).toBe('10m')
       expect(formatCurrency('999900000')).toBe('999.9m')
     })
     it('1 billion+', () => {
+      expect.assertions(2)
       expect(formatCurrency('1000000000')).toBe('1b')
       expect(formatCurrency('100000000000')).toBe('100b')
     })

--- a/paywall/src/__tests__/services/walletService.test.js
+++ b/paywall/src/__tests__/services/walletService.test.js
@@ -20,7 +20,6 @@ import {
 } from '../../errors'
 
 jest.mock('../../utils/promises')
-jest.unmock('web3')
 
 const nockScope = nock('http://127.0.0.1:8545', { encodedQueryParams: true })
 

--- a/paywall/src/__tests__/services/web3Service.test.js
+++ b/paywall/src/__tests__/services/web3Service.test.js
@@ -12,8 +12,6 @@ import LockContract from '../../artifacts/contracts/PublicLock.json'
 import configure from '../../config'
 import { TRANSACTION_TYPES } from '../../constants'
 
-jest.unmock('web3')
-
 const nodeAccounts = [
   '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
   '0xaca94ef8bd5ffee41947b4585a84bda5a3d3da6e',
@@ -938,14 +936,13 @@ describe('Web3Service', () => {
 
   describe('getKeysForLockOnPage', () => {
     it('should get as many owners as there are per page, starting at the right index', done => {
+      expect.assertions(9)
       const onPage = 0
       const byPage = 5
       const keyHolder = [
         '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
         '0xC66Ef2E0D0eDCce723b3fdd4307db6c5F0Dda1b8',
       ]
-
-      expect.assertions(9)
 
       web3Service._getKeyByLockForOwner = jest.fn(() => {
         return new Promise(resolve => {
@@ -977,6 +974,7 @@ describe('Web3Service', () => {
 
     describe('when the on contract method does not exist', () => {
       it('should use the iterative method of providing keyholder', done => {
+        expect.assertions(3)
         const onPage = 0
         const byPage = 2
 

--- a/paywall/src/__tests__/utils/routes.test.js
+++ b/paywall/src/__tests__/utils/routes.test.js
@@ -1,129 +1,120 @@
-import { lockRoute, getRouteFromWindow } from '../../utils/routes'
+import { lockRoute } from '../../utils/routes'
 
-describe('route utilities', () => {
-  describe('lockRoute', () => {
-    it('should return null value when it does not match', () => {
-      expect(lockRoute('/dashboard')).toEqual({
-        lockAddress: null,
-        prefix: null,
-        redirect: null,
-        account: null,
-      })
-      expect(lockRoute('/lock')).toEqual({
-        lockAddress: null,
-        prefix: null,
-        redirect: null,
-        account: null,
-      })
+describe('lockRoute', () => {
+  it('should return null value when it does not match', () => {
+    expect.assertions(3)
+    expect(lockRoute('/dashboard')).toEqual({
+      lockAddress: null,
+      prefix: null,
+      redirect: null,
+      account: null,
     })
-
-    it('should return the right prefix and lockAddress value when it matches', () => {
-      expect(
-        lockRoute('/lock/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/')
-      ).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: 'lock',
-        redirect: undefined,
-        account: undefined,
-      })
-
-      expect(
-        lockRoute('/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
-      ).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: 'paywall',
-        redirect: undefined,
-        account: undefined,
-      })
-      expect(
-        lockRoute('/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
-      ).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: 'demo',
-        redirect: undefined,
-        account: undefined,
-      })
-      expect(lockRoute('/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: undefined,
-        redirect: undefined,
-        account: undefined,
-      })
+    expect(lockRoute('/lock')).toEqual({
+      lockAddress: null,
+      prefix: null,
+      redirect: null,
+      account: null,
     })
-    it('should return the correct redirect parameter when it matches', () => {
-      expect(
-        lockRoute(
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere'
-        )
-      ).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: 'demo',
-        redirect: 'http://hithere',
-      })
-    })
-    it('should return the correct account parameter when it matches', () => {
-      expect(
-        lockRoute(
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
-        )
-      ).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: 'demo',
-        redirect: 'http://hithere',
-        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      })
-      expect(
-        lockRoute(
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
-        )
-      ).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: 'demo',
-        redirect: undefined,
-        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      })
-    })
-    it('should ignore malformed account parameter', () => {
-      expect(
-        lockRoute(
-          // address is too short
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb'
-        )
-      ).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: 'demo',
-        redirect: 'http://hithere',
-        account: undefined,
-      })
-    })
-    it('should return account parameter if redirect is not present', () => {
-      expect(
-        lockRoute(
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
-        )
-      ).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: 'demo',
-        redirect: undefined,
-        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      })
+    expect(lockRoute('/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')).toEqual({
+      lockAddress: null,
+      prefix: null,
+      redirect: null,
+      account: null,
     })
   })
-  describe('getRouteFromWindow', () => {
-    it('should parse route from window.location', () => {
-      const fakeWindow = {
-        location: {
-          pathname:
-            '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
-          hash: '#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        },
-      }
-      expect(getRouteFromWindow(fakeWindow)).toEqual({
-        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: 'demo',
-        redirect: 'http://hithere',
-        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      })
+
+  it('should return the right prefix and lockAddress value when it matches', () => {
+    expect.assertions(3)
+    expect(
+      lockRoute('/lock/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/')
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'lock',
+      redirect: undefined,
+      account: undefined,
+    })
+
+    expect(
+      lockRoute('/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'paywall',
+      redirect: undefined,
+      account: undefined,
+    })
+    expect(
+      lockRoute('/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: undefined,
+      account: undefined,
+    })
+  })
+
+  it('should return the correct redirect parameter when it matches', () => {
+    expect.assertions(1)
+    expect(
+      lockRoute(
+        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere'
+      )
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: 'http://hithere',
+    })
+  })
+
+  it('should return the correct account parameter when it matches', () => {
+    expect.assertions(2)
+    expect(
+      lockRoute(
+        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+      )
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: 'http://hithere',
+      account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+    })
+    expect(
+      lockRoute(
+        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+      )
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: undefined,
+      account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+    })
+  })
+
+  it('should ignore malformed account parameter', () => {
+    expect.assertions(1)
+    expect(
+      lockRoute(
+        // address is too short
+        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb'
+      )
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: 'http://hithere',
+      account: undefined,
+    })
+  })
+
+  it('should return account parameter if redirect is not present', () => {
+    expect.assertions(1)
+    expect(
+      lockRoute(
+        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+      )
+    ).toEqual({
+      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      prefix: 'demo',
+      redirect: undefined,
+      account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
     })
   })
 })

--- a/paywall/src/__tests__/utils/routes.test.js
+++ b/paywall/src/__tests__/utils/routes.test.js
@@ -1,120 +1,137 @@
-import { lockRoute } from '../../utils/routes'
+import { lockRoute, getRouteFromWindow } from '../../utils/routes'
 
-describe('lockRoute', () => {
-  it('should return null value when it does not match', () => {
-    expect.assertions(3)
-    expect(lockRoute('/dashboard')).toEqual({
-      lockAddress: null,
-      prefix: null,
-      redirect: null,
-      account: null,
+describe('route utilities', () => {
+  describe('lockRoute', () => {
+    it('should return null value when it does not match', () => {
+      expect.assertions(2)
+      expect(lockRoute('/dashboard')).toEqual({
+        lockAddress: null,
+        prefix: null,
+        redirect: null,
+        account: null,
+      })
+      expect(lockRoute('/lock')).toEqual({
+        lockAddress: null,
+        prefix: null,
+        redirect: null,
+        account: null,
+      })
     })
-    expect(lockRoute('/lock')).toEqual({
-      lockAddress: null,
-      prefix: null,
-      redirect: null,
-      account: null,
+
+    it('should return the right prefix and lockAddress value when it matches', () => {
+      expect.assertions(4)
+      expect(
+        lockRoute('/lock/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/')
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'lock',
+        redirect: undefined,
+        account: undefined,
+      })
+
+      expect(
+        lockRoute('/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'paywall',
+        redirect: undefined,
+        account: undefined,
+      })
+      expect(
+        lockRoute('/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: undefined,
+        account: undefined,
+      })
+      expect(lockRoute('/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: undefined,
+        redirect: undefined,
+        account: undefined,
+      })
     })
-    expect(lockRoute('/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')).toEqual({
-      lockAddress: null,
-      prefix: null,
-      redirect: null,
-      account: null,
+    it('should return the correct redirect parameter when it matches', () => {
+      expect.assertions(1)
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+      })
+    })
+    it('should return the correct account parameter when it matches', () => {
+      expect.assertions(2)
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      })
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: undefined,
+        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      })
+    })
+    it('should ignore malformed account parameter', () => {
+      expect.assertions(1)
+      expect(
+        lockRoute(
+          // address is too short
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+        account: undefined,
+      })
+    })
+    it('should return account parameter if redirect is not present', () => {
+      expect.assertions(1)
+
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+        )
+      ).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: undefined,
+        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      })
     })
   })
-
-  it('should return the right prefix and lockAddress value when it matches', () => {
-    expect.assertions(3)
-    expect(
-      lockRoute('/lock/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/')
-    ).toEqual({
-      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      prefix: 'lock',
-      redirect: undefined,
-      account: undefined,
-    })
-
-    expect(
-      lockRoute('/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
-    ).toEqual({
-      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      prefix: 'paywall',
-      redirect: undefined,
-      account: undefined,
-    })
-    expect(
-      lockRoute('/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
-    ).toEqual({
-      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      prefix: 'demo',
-      redirect: undefined,
-      account: undefined,
-    })
-  })
-
-  it('should return the correct redirect parameter when it matches', () => {
-    expect.assertions(1)
-    expect(
-      lockRoute(
-        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere'
-      )
-    ).toEqual({
-      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      prefix: 'demo',
-      redirect: 'http://hithere',
-    })
-  })
-
-  it('should return the correct account parameter when it matches', () => {
-    expect.assertions(2)
-    expect(
-      lockRoute(
-        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
-      )
-    ).toEqual({
-      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      prefix: 'demo',
-      redirect: 'http://hithere',
-      account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-    })
-    expect(
-      lockRoute(
-        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
-      )
-    ).toEqual({
-      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      prefix: 'demo',
-      redirect: undefined,
-      account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-    })
-  })
-
-  it('should ignore malformed account parameter', () => {
-    expect.assertions(1)
-    expect(
-      lockRoute(
-        // address is too short
-        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb'
-      )
-    ).toEqual({
-      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      prefix: 'demo',
-      redirect: 'http://hithere',
-      account: undefined,
-    })
-  })
-
-  it('should return account parameter if redirect is not present', () => {
-    expect.assertions(1)
-    expect(
-      lockRoute(
-        '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
-      )
-    ).toEqual({
-      lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-      prefix: 'demo',
-      redirect: undefined,
-      account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+  describe('getRouteFromWindow', () => {
+    it('should parse route from window.location', () => {
+      expect.assertions(1)
+      const fakeWindow = {
+        location: {
+          pathname:
+            '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
+          hash: '#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        },
+      }
+      expect(getRouteFromWindow(fakeWindow)).toEqual({
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+      })
     })
   })
 })

--- a/paywall/src/actions/storage.js
+++ b/paywall/src/actions/storage.js
@@ -1,5 +1,5 @@
 export const STORAGE_ERROR = 'storage/STORAGE_ERROR'
-export const STORE_LOCK_CREATION = 'storage/STORE_LOCK_CREATION'
+export const STORE_LOCK_NAME = 'storage/STORE_LOCK_NAME'
 
 export function storageError(error) {
   return {
@@ -8,9 +8,9 @@ export function storageError(error) {
   }
 }
 
-export function storeLockCreation(owner, lock, token) {
+export function storeLockName(owner, lock, token) {
   return {
-    type: STORE_LOCK_CREATION,
+    type: STORE_LOCK_NAME,
     owner: owner,
     lock: lock,
     token: token,

--- a/paywall/src/middlewares/walletMiddleware.js
+++ b/paywall/src/middlewares/walletMiddleware.js
@@ -21,7 +21,7 @@ import { TRANSACTION_TYPES, POLLING_INTERVAL } from '../constants' // TODO chang
 
 import WalletService from '../services/walletService'
 import { signatureError } from '../actions/signature'
-import { storeLockCreation } from '../actions/storage'
+import { storeLockName } from '../actions/storage'
 import configure from '../config'
 import { NO_USER_ACCOUNT } from '../errors'
 import generateSignature from '../utils/signature'
@@ -140,7 +140,7 @@ export default function walletMiddleware({ getState, dispatch }) {
                 )
                   .then(token => {
                     dispatch(
-                      storeLockCreation(
+                      storeLockName(
                         getState().account.address,
                         token.data,
                         token.result


### PR DESCRIPTION
# Description

This brings the paywall app tests up to code. 2 bugs found:

1. the assertion in `paywall-builder/build.test.js` in the first test was doing:

```js
expect(blah = 'something')
```
instead of
```js
expect(blah).toBe('something')
```

The other bug was just an unmerged change from unlock-app in storage action

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
