### PR TITLE
Registering the erc721 interface

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -52,6 +52,7 @@ contract PublicLock is
     public
     MixinLockCore(_owner, _expirationDuration, _keyPrice, _maxNumberOfKeys, _version)
   {
+    _registerInterface(0x80ac58cd);
   }
 
   /**

--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -52,6 +52,8 @@ contract PublicLock is
     public
     MixinLockCore(_owner, _expirationDuration, _keyPrice, _maxNumberOfKeys, _version)
   {
+    // registering the interface for erc721 with ERC165.sol using
+    // the ID specified in the standard: https://eips.ethereum.org/EIPS/eip-721
     _registerInterface(0x80ac58cd);
   }
 

--- a/smart-contracts/test/Lock/erc721/compliance.js
+++ b/smart-contracts/test/Lock/erc721/compliance.js
@@ -19,8 +19,7 @@ contract('Lock ERC165', accounts => {
     it('should support the erc721 interface()', async function () {
       // Note: the ERC-165 identifier for the erc721 interface is "0x80ac58cd"
       const result = await locks['FIRST'].supportsInterface.call('0x80ac58cd')
-      // when ERC721 interfaceID is registered, this will break and we change to `assert.equal(result, true)`
-      assert.equal(result, false)
+      assert.equal(result, true)
     })
   })
 })


### PR DESCRIPTION
# Description

This PR fixes #148 and fixes #838 
- Adds one line to the constructor for `PublicLock`, and is the final step in making our lock contracts fully erc721-compliant.
- Modifies 1 test in `compliance.js` as per the comment found there:
```
describe('Supports ERC721 Interface', () => {
    it('should support the erc721 interface()', async function () {
      // Note: the ERC-165 identifier for the erc721 interface is "0x80ac58cd"
      const result = await locks['FIRST'].supportsInterface.call('0x80ac58cd')
      // when ERC721 interfaceID is registered, this will break and we change to `assert.equal(result, true)`
      assert.equal(result, false)
```

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
