### PR TITLE
Updates Locksmith Deployment script to truncate deployment messages

### DIFF
--- a/scripts/deploy-elasticbeanstalk.sh
+++ b/scripts/deploy-elasticbeanstalk.sh
@@ -47,7 +47,7 @@ function elasticbeanstalk_create_application_version()
     aws elasticbeanstalk create-application-version \
     --application-name ${APPLICATION} \
     --version-label ${BUILD} \
-    --description "${description}" \
+    --description "${description:0:199}" \
     --source-bundle S3Bucket="${s3_bucket}",S3Key="${artifact}" \
     --auto-create-application \
     --region ${AWS_REGION}


### PR DESCRIPTION
Reactive due to a failed deployment our Elastic Beanstalks 200 character limit for deployment messages.

Some documentation regarding substring extraction can be found here: http://tldp.org/LDP/abs/html/string-manipulation.html

# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
