### PR TITLE
Refactor Paywall component to use hooks

### DIFF
--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -38,7 +38,6 @@ const keys = {
 const modals = []
 
 const store = createUnlockStore({ locks, keys, modals, router })
-const noKeyStore = createUnlockStore({ locks, keys: {}, modals, router })
 
 afterEach(() => {
   rtl.cleanup()

--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -12,7 +12,7 @@ const locks = {
 const router = {
   location: {
     pathname: `/paywall/${lock.address}/http%3a%2f%2fexample.com`,
-    search: '',
+    search: '?origin=http%3A%2F%2Fexample.com',
     hash: '',
   },
 }
@@ -20,7 +20,7 @@ const router = {
 const noRedirectRouter = {
   location: {
     pathname: `/paywall/${lock.address}`,
-    search: '',
+    search: '?origin=http%3A%2F%2Fexample.com',
     hash: '',
   },
 }
@@ -43,6 +43,19 @@ afterEach(() => {
   rtl.cleanup()
 })
 describe('Paywall', () => {
+  let fakeWindow
+  beforeEach(() => {
+    fakeWindow = {
+      location: {
+        pathname: `/${lock.address}`,
+        search: '?origin=http%3A%2F%2Fexample.com',
+        hash: '',
+      },
+      parent: { postMessage: jest.fn() },
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }
+  })
   describe('mapStateToProps', () => {
     it('should yield the lock which matches the address of the demo page', () => {
       expect.assertions(1)
@@ -81,14 +94,6 @@ describe('Paywall', () => {
   })
 
   describe('handleIframe', () => {
-    let fakeWindow
-    beforeEach(() => {
-      fakeWindow = {
-        parent: { postMessage: jest.fn(), origin: 'http://example.com' },
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-      }
-    })
     it('should post "locked" when it is locked in iframe', () => {
       expect.assertions(1)
       rtl.act(() => {
@@ -103,7 +108,7 @@ describe('Paywall', () => {
 
       expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith(
         'locked',
-        fakeWindow.parent.origin
+        'http://example.com'
       )
     })
     it('should not post any message when it is in the main window', () => {
@@ -139,20 +144,12 @@ describe('Paywall', () => {
 
       expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith(
         'unlocked',
-        fakeWindow.parent.origin
+        'http://example.com'
       )
     })
   })
 
   describe('the unlocked flag', () => {
-    let fakeWindow
-    beforeEach(() => {
-      fakeWindow = {
-        parent: { postMessage: jest.fn(), origin: 'http://example.com' },
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-      }
-    })
     it('should be present when the paywall is unlocked', () => {
       expect.assertions(1)
       const { queryByText } = rtl.render(

--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -2,11 +2,8 @@ import React from 'react'
 import * as rtl from 'react-testing-library'
 import { Provider } from 'react-redux'
 import createUnlockStore from '../../createUnlockStore'
-import Paywall, { mapStateToProps } from '../../components/Paywall'
-import { lockPage, unlockPage } from '../../services/iframeService'
+import { Paywall, mapStateToProps } from '../../components/Paywall'
 import { ConfigContext } from '../../utils/withConfig'
-
-jest.mock('../../services/iframeService.js')
 
 const lock = { address: '0x4983D5ECDc5cc0E499c2D23BF4Ac32B982bAe53a' }
 const locks = {
@@ -45,7 +42,6 @@ const noKeyStore = createUnlockStore({ locks, keys: {}, modals, router })
 
 afterEach(() => {
   rtl.cleanup()
-  jest.clearAllMocks()
 })
 describe('Paywall', () => {
   describe('mapStateToProps', () => {
@@ -86,38 +82,89 @@ describe('Paywall', () => {
   })
 
   describe('handleIframe', () => {
-    it('should call lockPage when it is locked', () => {
-      expect.assertions(2)
-      rtl.render(
-        <Provider store={noKeyStore}>
-          <Paywall />
-        </Provider>
-      )
-      expect(lockPage).toHaveBeenCalled()
-      expect(unlockPage).not.toHaveBeenCalled()
+    let fakeWindow
+    beforeEach(() => {
+      fakeWindow = {
+        parent: { postMessage: jest.fn(), origin: 'http://example.com' },
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }
     })
+    it('should post "locked" when it is locked in iframe', () => {
+      expect.assertions(1)
+      rtl.act(() => {
+        rtl.render(
+          <ConfigContext.Provider value={{ providers: [], isInIframe: true }}>
+            <Provider store={store}>
+              <Paywall window={fakeWindow} locks={[]} locked redirect={false} />
+            </Provider>
+          </ConfigContext.Provider>
+        )
+      })
 
-    it('should call unlockPage when it is not locked', () => {
-      expect.assertions(2)
-      rtl.render(
-        <ConfigContext.Provider value={{ providers: [] }}>
-          <Provider store={store}>
-            <Paywall />
-          </Provider>
-        </ConfigContext.Provider>
+      expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith(
+        'locked',
+        fakeWindow.parent.origin
       )
-      expect(lockPage).not.toHaveBeenCalled()
-      expect(unlockPage).toHaveBeenCalled()
+    })
+    it('should not post any message when it is in the main window', () => {
+      expect.assertions(1)
+      rtl.act(() => {
+        rtl.render(
+          <ConfigContext.Provider value={{ providers: [], isInIframe: false }}>
+            <Provider store={store}>
+              <Paywall window={fakeWindow} locks={[]} locked redirect={false} />
+            </Provider>
+          </ConfigContext.Provider>
+        )
+      })
+
+      expect(fakeWindow.parent.postMessage).not.toHaveBeenCalled()
+    })
+    it('should post "unlocked" when it is unlocked in iframe', () => {
+      expect.assertions(1)
+      rtl.act(() => {
+        rtl.render(
+          <ConfigContext.Provider value={{ providers: [], isInIframe: true }}>
+            <Provider store={store}>
+              <Paywall
+                window={fakeWindow}
+                locks={[]}
+                locked={false}
+                redirect={false}
+              />
+            </Provider>
+          </ConfigContext.Provider>
+        )
+      })
+
+      expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith(
+        'unlocked',
+        fakeWindow.parent.origin
+      )
     })
   })
 
   describe('the unlocked flag', () => {
+    let fakeWindow
+    beforeEach(() => {
+      fakeWindow = {
+        parent: { postMessage: jest.fn(), origin: 'http://example.com' },
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }
+    })
     it('should be present when the paywall is unlocked', () => {
       expect.assertions(1)
       const { queryByText } = rtl.render(
-        <ConfigContext.Provider value={{ providers: [] }}>
+        <ConfigContext.Provider value={{ providers: [], isInIframe: true }}>
           <Provider store={store}>
-            <Paywall />
+            <Paywall
+              window={fakeWindow}
+              locks={[]}
+              locked={false}
+              redirect={false}
+            />
           </Provider>
         </ConfigContext.Provider>
       )
@@ -128,9 +175,9 @@ describe('Paywall', () => {
     it('should not be present when the paywall is locked', () => {
       expect.assertions(1)
       const { queryByText } = rtl.render(
-        <ConfigContext.Provider value={{ providers: [] }}>
-          <Provider store={noKeyStore}>
-            <Paywall />
+        <ConfigContext.Provider value={{ providers: [], isInIframe: true }}>
+          <Provider store={store}>
+            <Paywall window={fakeWindow} locks={[]} locked redirect={false} />
           </Provider>
         </ConfigContext.Provider>
       )

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -12,7 +12,7 @@ import { lockRoute } from '../utils/routes'
 import useListenForPostMessage from '../hooks/browser/useListenForPostMessage'
 import usePostMessage from '../hooks/browser/usePostMessage'
 
-function Paywall({ locks, locked, redirect }) {
+export function Paywall({ locks, locked, redirect, window }) {
   const data = useListenForPostMessage(window) || { scrollPosition: 0 }
   const scrollPosition = data.scrollPosition || 0
   const { postMessage } = usePostMessage(window)
@@ -48,6 +48,7 @@ Paywall.propTypes = {
   locks: PropTypes.arrayOf(UnlockPropTypes.lock).isRequired,
   locked: PropTypes.bool.isRequired,
   redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  window: PropTypes.shape({ postMessage: PropTypes.func }).isRequired, // for ease of unit testing
 }
 
 Paywall.defaultProps = {
@@ -76,7 +77,7 @@ export const mapStateToProps = ({ locks, keys, modals, router }) => {
 
   const modalShown = !!modals[locksFromUri.map(l => l.address).join('-')]
   const locked = validKeys.length === 0 || modalShown
-  return { locked, locks: locksFromUri, redirect }
+  return { locked, locks: locksFromUri, redirect, window }
 }
 
 export default connect(mapStateToProps)(Paywall)

--- a/paywall/src/hooks/browser/usePostMessage.js
+++ b/paywall/src/hooks/browser/usePostMessage.js
@@ -7,6 +7,7 @@ export default function usePostMessage(window) {
   const [message, postMessage] = useState()
   useEffect(
     () => {
+      console.log('fuck')
       const { origin } = getRouteFromWindow(window)
       if (isServer || !isInIframe || !message || !origin) return
       window.parent.postMessage(message, origin)

--- a/paywall/src/hooks/browser/usePostMessage.js
+++ b/paywall/src/hooks/browser/usePostMessage.js
@@ -7,7 +7,6 @@ export default function usePostMessage(window) {
   const [message, postMessage] = useState()
   useEffect(
     () => {
-      console.log('fuck')
       const { origin } = getRouteFromWindow(window)
       if (isServer || !isInIframe || !message || !origin) return
       window.parent.postMessage(message, origin)


### PR DESCRIPTION
# Description

This PR refactors the Paywall component to take advantage of the cleaner approach of hooks.

The paywall does several local state things:

1. retrieve the scroll position of the parent window by listening for postMessage
2. send the locked status to the parent window by sending postMessage
3. (in the near future) modify the document.body CSS directly on hiding the overlay in order to position the flag correctly

Currently, we don't quite do any of these correctly.

1. the paywall always assumes it is in an iframe. This is not necessarily true
2. the postMessage calls do not send a specific origin, this is a major security hole and opens us up to both XSS and CSRF.

By abstracting these items out into the existing `usePostMessage` and `useListenForPostMessage` hooks, we can easily focus on the behavior inside `Paywall` that is relevant to the paywall, and not the implementation details of `postMessage`.

*I have elected not to merge this into unlock-app, as the split of paywall is imminent*

Screenshots to show same behavior (note: #1731 is why the unlocked flag is way up there)

<img width="1678" alt="screen shot 2019-02-27 at 12 16 12 pm" src="https://user-images.githubusercontent.com/98250/53509333-94a0af80-3a89-11e9-9f5c-c062fac388ae.png">
<img width="1678" alt="screen shot 2019-02-27 at 12 16 02 pm" src="https://user-images.githubusercontent.com/98250/53509334-94a0af80-3a89-11e9-808b-b820970214ba.png">
<img width="1678" alt="screen shot 2019-02-27 at 12 15 11 pm" src="https://user-images.githubusercontent.com/98250/53509335-94a0af80-3a89-11e9-848d-178450df33a1.png">
<img width="1678" alt="screen shot 2019-02-27 at 12 14 58 pm" src="https://user-images.githubusercontent.com/98250/53509336-94a0af80-3a89-11e9-9654-1d9970a8cd04.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1744 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
