### PR TITLE
rework lock parsing to use URL, add origin url parameter

### DIFF
--- a/paywall/src/__tests__/utils/routes.test.js
+++ b/paywall/src/__tests__/utils/routes.test.js
@@ -1,6 +1,13 @@
 import { lockRoute, getRouteFromWindow } from '../../utils/routes'
 
 describe('route utilities', () => {
+  const baseRoute = {
+    lockAddress: undefined,
+    prefix: undefined,
+    redirect: undefined,
+    account: undefined,
+    origin: undefined,
+  }
   describe('lockRoute', () => {
     it('should return null value when it does not match', () => {
       expect.assertions(2)
@@ -21,70 +28,85 @@ describe('route utilities', () => {
     it('should return the right prefix and lockAddress value when it matches', () => {
       expect.assertions(4)
       expect(
-        lockRoute('/lock/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/')
+        lockRoute(
+          '/lock/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/?origin=origin%2F'
+        )
       ).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'lock',
-        redirect: undefined,
-        account: undefined,
+        origin: 'origin/',
       })
 
       expect(
-        lockRoute('/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
+        lockRoute(
+          '/paywall/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54?origin=origin%2F'
+        )
       ).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'paywall',
-        redirect: undefined,
-        account: undefined,
+        origin: 'origin/',
       })
       expect(
-        lockRoute('/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54?origin=origin%2F'
+        )
       ).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'demo',
-        redirect: undefined,
-        account: undefined,
+        origin: 'origin/',
       })
-      expect(lockRoute('/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')).toEqual({
+      expect(
+        lockRoute(
+          '/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54?origin=origin%2F'
+        )
+      ).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        prefix: undefined,
-        redirect: undefined,
-        account: undefined,
+        origin: 'origin/',
       })
     })
     it('should return the correct redirect parameter when it matches', () => {
       expect.assertions(1)
       expect(
         lockRoute(
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere'
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere?origin=origin%2F'
         )
       ).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'demo',
         redirect: 'http://hithere',
+        origin: 'origin/',
       })
     })
     it('should return the correct account parameter when it matches', () => {
       expect.assertions(2)
       expect(
         lockRoute(
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere?origin=origin%2F#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
         )
       ).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'demo',
         redirect: 'http://hithere',
         account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        origin: 'origin/',
       })
       expect(
         lockRoute(
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/?origin=origin%2F#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
         )
       ).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'demo',
         redirect: undefined,
         account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        origin: 'origin/',
       })
     })
     it('should ignore malformed account parameter', () => {
@@ -92,13 +114,14 @@ describe('route utilities', () => {
       expect(
         lockRoute(
           // address is too short
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb'
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere?origin=origin%2F#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb'
         )
       ).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'demo',
         redirect: 'http://hithere',
-        account: undefined,
+        origin: 'origin/',
       })
     })
     it('should return account parameter if redirect is not present', () => {
@@ -106,13 +129,14 @@ describe('route utilities', () => {
 
       expect(
         lockRoute(
-          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54?origin=origin%2F#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
         )
       ).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'demo',
-        redirect: undefined,
         account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        origin: 'origin/',
       })
     })
   })
@@ -123,14 +147,17 @@ describe('route utilities', () => {
         location: {
           pathname:
             '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere',
+          search: '?origin=origin%2F',
           hash: '#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         },
       }
       expect(getRouteFromWindow(fakeWindow)).toEqual({
+        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'demo',
         redirect: 'http://hithere',
         account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        origin: 'origin/',
       })
     })
   })

--- a/paywall/src/__tests__/utils/routes.test.js
+++ b/paywall/src/__tests__/utils/routes.test.js
@@ -2,27 +2,17 @@ import { lockRoute, getRouteFromWindow } from '../../utils/routes'
 
 describe('route utilities', () => {
   const baseRoute = {
-    lockAddress: undefined,
-    prefix: undefined,
-    redirect: undefined,
-    account: undefined,
-    origin: undefined,
+    lockAddress: null,
+    prefix: null,
+    redirect: null,
+    account: null,
+    origin: null,
   }
   describe('lockRoute', () => {
     it('should return null value when it does not match', () => {
       expect.assertions(2)
-      expect(lockRoute('/dashboard')).toEqual({
-        lockAddress: null,
-        prefix: null,
-        redirect: null,
-        account: null,
-      })
-      expect(lockRoute('/lock')).toEqual({
-        lockAddress: null,
-        prefix: null,
-        redirect: null,
-        account: null,
-      })
+      expect(lockRoute('/dashboard')).toEqual(baseRoute)
+      expect(lockRoute('/lock')).toEqual(baseRoute)
     })
 
     it('should return the right prefix and lockAddress value when it matches', () => {
@@ -104,7 +94,6 @@ describe('route utilities', () => {
         ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'demo',
-        redirect: undefined,
         account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         origin: 'origin/',
       })

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -44,8 +44,8 @@ export const ACCOUNT_REGEXP = new RegExp(accountRegex)
 
 // helpers for the LOCK_PATH_NAME_REGEXP
 const prefix = '[a-z0-9]+'
-const urlEncodedRedirectUrl = '[^#?]+'
-const userAccount = accountRegex
+const urlEncodedUrl = '[^#?]+'
+const urlEncodedRedirectUrl = urlEncodedUrl
 const lockAddress = accountRegex
 
 /**
@@ -61,10 +61,7 @@ const lockAddress = accountRegex
  * You should not use this directly, instead use the utils/routes.js lockRoute function
  */
 export const LOCK_PATH_NAME_REGEXP = new RegExp(
-  `(?:/(${prefix}))?/(${lockAddress})` +
-    // either "/urlEncodedRedirectUrl/#account" or just "#account" and these are all optional
-    // note that "/#account" as in "/paywall/<lockaddress>/#<useraccount>" is also matched
-    `(?:/(${urlEncodedRedirectUrl}))?(?:/?#(${userAccount}))?`
+  `(?:/(${prefix}))?/(${lockAddress})(?:/(${urlEncodedRedirectUrl})/?)?`
 )
 
 export const PAGE_DESCRIPTION =

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -42,26 +42,24 @@ const accountRegex = '0x[a-fA-F0-9]{40}'
  */
 export const ACCOUNT_REGEXP = new RegExp(accountRegex)
 
-// helpers for the LOCK_PATH_NAME_REGEXP
+// private helpers for the LOCK_PATH_NAME_REGEXP
 const prefix = '[a-z0-9]+'
 const urlEncodedUrl = '[^#?]+'
-const urlEncodedRedirectUrl = urlEncodedUrl
 const lockAddress = accountRegex
 
 /**
  * This regexp matches several important parameters passed in the url for the demo and paywall pages.
+ * It does not handle the query parameters or hash, as these are handled separately in lockRoute
  *
  * '/demo/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9/'
  *   will extract 'demo' and the lock address as match 1 and 2
  * '/demo/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9/http%3A%2F%2Fexample.com'
- *   will extract the same variables, and also the url-encoded redirect URL 'http://example.com' as match 4
- * '/paywall/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9/#0xabcddc4CdBda8dc99c82D66d97B264386E41c0E9'
- *   will extract the 'paywall' and lock address as match 1 and 2 and the account address as match 6
+ *   will extract the same variables, and also the url-encoded redirect URL 'http://example.com' as match 3
  *
  * You should not use this directly, instead use the utils/routes.js lockRoute function
  */
 export const LOCK_PATH_NAME_REGEXP = new RegExp(
-  `(?:/(${prefix}))?/(${lockAddress})(?:/(${urlEncodedRedirectUrl})/?)?`
+  `(?:/(${prefix}))?/(${lockAddress})(?:/(${urlEncodedUrl})/?)?`
 )
 
 export const PAGE_DESCRIPTION =

--- a/paywall/src/utils/routes.js
+++ b/paywall/src/utils/routes.js
@@ -8,9 +8,9 @@ export const lockRoute = path => {
   // note: undocumented "feature" of the URL class is that it throws
   // if the URL is invalid. In our case, we are passing in a relative path,
   // and so it throws unless we pass in a base url. Since the base URL
-  // is not used, this passes in a dummy URL
+  // is not used, this passes in an unused URL
   // https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
-  const url = new URL(path, 'http://dummy.com')
+  const url = new URL(path, 'http://paywall.unlock-protocol.com')
   const match = url.pathname.match(LOCK_PATH_NAME_REGEXP)
 
   if (!match) {
@@ -19,21 +19,22 @@ export const lockRoute = path => {
       prefix: null,
       redirect: null,
       account: null,
+      origin: null,
     }
   }
 
   let account = url.hash && url.hash.substring(1)
   const matchAccount = account.match(ACCOUNT_REGEXP)
-  account = matchAccount ? matchAccount[0] : undefined
+  account = matchAccount && matchAccount[0]
 
   return {
-    lockAddress: match[2],
-    prefix: match[1],
-    redirect: match[3] && decodeURIComponent(match[3]),
+    lockAddress: match[2] || null,
+    prefix: match[1] || null,
+    redirect: (match[3] && decodeURIComponent(match[3])) || null,
     account,
     origin: url.searchParams.has('origin')
       ? url.searchParams.get('origin')
-      : undefined,
+      : null,
   }
 }
 

--- a/paywall/src/utils/routes.js
+++ b/paywall/src/utils/routes.js
@@ -1,11 +1,12 @@
-import { LOCK_PATH_NAME_REGEXP } from '../constants'
+import { LOCK_PATH_NAME_REGEXP, ACCOUNT_REGEXP } from '../constants'
 
 /**
  * Returns a hash of lockAddress and prefix based on a path.
  * @param {*} path
  */
 export const lockRoute = path => {
-  const match = path.match(LOCK_PATH_NAME_REGEXP)
+  const url = new URL(path, 'http://dummy.com')
+  const match = url.pathname.match(LOCK_PATH_NAME_REGEXP)
 
   if (!match) {
     return {
@@ -16,11 +17,18 @@ export const lockRoute = path => {
     }
   }
 
+  let account = url.hash && url.hash.substring(1)
+  const matchAccount = account.match(ACCOUNT_REGEXP)
+  account = matchAccount ? matchAccount[0] : undefined
+
   return {
     lockAddress: match[2],
     prefix: match[1],
     redirect: match[3] && decodeURIComponent(match[3]),
-    account: match[4],
+    account,
+    origin: url.searchParams.has('origin')
+      ? url.searchParams.get('origin')
+      : undefined,
   }
 }
 
@@ -28,5 +36,7 @@ export function getRouteFromWindow(window) {
   if (!window) {
     return lockRoute('')
   }
-  return lockRoute(window.location.pathname + window.location.hash)
+  return lockRoute(
+    window.location.pathname + window.location.search + window.location.hash
+  )
 }

--- a/paywall/src/utils/routes.js
+++ b/paywall/src/utils/routes.js
@@ -1,5 +1,14 @@
 import { LOCK_PATH_NAME_REGEXP, ACCOUNT_REGEXP } from '../constants'
 
+if (!global.URL) {
+  // polyfill for server
+  global.URL = function() {
+    return {
+      pathname: '',
+      hash: false,
+    }
+  }
+}
 /**
  * Returns a hash of lockAddress and prefix based on a path.
  * @param {*} path

--- a/paywall/src/utils/routes.js
+++ b/paywall/src/utils/routes.js
@@ -5,6 +5,11 @@ import { LOCK_PATH_NAME_REGEXP, ACCOUNT_REGEXP } from '../constants'
  * @param {*} path
  */
 export const lockRoute = path => {
+  // note: undocumented "feature" of the URL class is that it throws
+  // if the URL is invalid. In our case, we are passing in a relative path,
+  // and so it throws unless we pass in a base url. Since the base URL
+  // is not used, this passes in a dummy URL
+  // https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
   const url = new URL(path, 'http://dummy.com')
   const match = url.pathname.match(LOCK_PATH_NAME_REGEXP)
 


### PR DESCRIPTION
# Description

In preparation for the fix of #1752, this PR introduces a new query parameter to the paywall route parsing, `origin`. This is used to pass the `window.origin` of the 3rd party site loading our paywall through the `paywall.min.js` script, so that we can securely `postMessage` to the parent window and be confident that only it will receive the message.

Follow-up PRs will enable passing origin to the iframe from `paywall.min.js` and then using the parameter in the `usePostMessage` and `useListenForPostMessage` hooks.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #1752

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
