### PR TITLE
connecting the origin to postMessage handling in the paywall

### DIFF
--- a/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
@@ -18,8 +18,11 @@ describe('useListenForPostMessage hook', () => {
     fakeWindow = {
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
-      parent: {
-        origin: 'origin',
+      parent: {},
+      location: {
+        pathname: '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        search: '?origin=origin',
+        hash: '',
       },
     }
     config = { isServer: false, isInIframe: true }
@@ -115,7 +118,7 @@ describe('useListenForPostMessage hook', () => {
     rtl.act(() =>
       eventCallback({
         source: fakeWindow.parent,
-        origin: fakeWindow.parent.origin,
+        origin: 'origin',
         data: 'data',
       })
     )
@@ -140,14 +143,14 @@ describe('useListenForPostMessage hook', () => {
       rtl.act(() =>
         eventCallback({
           source: fakeWindow.parent,
-          origin: fakeWindow.parent.origin,
+          origin: 'origin',
           data: 'data',
         })
       )
       rtl.act(() =>
         eventCallback({
           source: 'nope',
-          origin: fakeWindow.parent.origin,
+          origin: 'origin',
           data: 'next',
         })
       )
@@ -170,7 +173,7 @@ describe('useListenForPostMessage hook', () => {
       rtl.act(() =>
         eventCallback({
           source: fakeWindow.parent,
-          origin: fakeWindow.parent.origin,
+          origin: 'origin',
           data: 'data',
         })
       )

--- a/paywall/src/__tests__/hooks/browser/usePostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/usePostMessage.test.js
@@ -18,7 +18,11 @@ describe('usePostMessage hook', () => {
     fakeWindow = {
       parent: {
         postMessage: jest.fn(),
-        origin: 'origin',
+      },
+      location: {
+        pathname: '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        search: '?origin=origin',
+        hash: '',
       },
     }
     config = { isServer: false, isInIframe: true }
@@ -79,6 +83,24 @@ describe('usePostMessage hook', () => {
   })
   it('ignores calls with an empty message', () => {
     expect.assertions(1)
+
+    const {
+      result: {
+        current: { postMessage },
+      },
+    } = rtl.testHook(() => usePostMessage(fakeWindow), {
+      wrapper,
+    })
+
+    rtl.act(() => {
+      postMessage()
+    })
+    expect(fakeWindow.parent.postMessage).not.toHaveBeenCalled()
+  })
+  it('ignores calls with an empty origin', () => {
+    expect.assertions(1)
+
+    fakeWindow.location.search = '' // remove origin
 
     const {
       result: {

--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
 import useConfig from '../utils/useConfig'
+import { getRouteFromWindow } from '../../utils/routes'
 
 export default function useListenForPostmessage(window) {
   const { isInIframe, isServer } = useConfig()
   const parent = window && window.parent
   const [data, setData] = useState()
   const saveData = event => {
+    const { origin } = getRouteFromWindow(window)
     // ignore messages that do not come from our parent window
-    if (event.source !== parent || event.origin !== parent.origin) return
+    if (event.source !== parent || event.origin !== origin) return
     setData(event.data)
   }
 

--- a/paywall/src/hooks/browser/usePostMessage.js
+++ b/paywall/src/hooks/browser/usePostMessage.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import useConfig from '../utils/useConfig'
 import { getRouteFromWindow } from '../../utils/routes'
 
-export default function usePostmessage(window) {
+export default function usePostMessage(window) {
   const { isInIframe, isServer } = useConfig()
   const [message, postMessage] = useState()
   useEffect(

--- a/paywall/src/hooks/browser/usePostMessage.js
+++ b/paywall/src/hooks/browser/usePostMessage.js
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
 import useConfig from '../utils/useConfig'
+import { getRouteFromWindow } from '../../utils/routes'
 
 export default function usePostmessage(window) {
   const { isInIframe, isServer } = useConfig()
   const [message, postMessage] = useState()
   useEffect(
     () => {
-      if (isServer || !isInIframe || !message) return
-      window.parent.postMessage(message, window.parent.origin)
+      const { origin } = getRouteFromWindow(window)
+      if (isServer || !isInIframe || !message || !origin) return
+      window.parent.postMessage(message, origin)
     },
     // this next line tells React to only post the message if it has changed.
     // This is important because the hook will be called on every render,


### PR DESCRIPTION
# Description

This PR enables use of the origin passed to the paywall in URL by the `usePostMessage` and `useListenToPostmessage` hooks in order to securely use `window.postmessage`, as god and MDN intended.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1752 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
