### PR TITLE
Renamed variable name to avoid confusion

### DIFF
--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -63,17 +63,16 @@ export default class StorageService {
    * Store the details of the provide Lock. In the case of failure a rejected promise is
    * returned to the caller.
    *
-   * @param {*} lock
+   * @param {*} lockDetails
    * @param {*} token
    */
-  async storeLockDetails(lock, token) {
+  async storeLockDetails(lockDetails, token) {
     const opts = {}
     if (token) {
       opts.headers = this.genAuthorizationHeader(token)
     }
-
     try {
-      return await axios.post(`${this.host}/lock`, lock, opts)
+      return await axios.post(`${this.host}/lock`, lockDetails, opts)
     } catch (error) {
       return Promise.reject(error)
     }


### PR DESCRIPTION
Again, part of the large signature refactor... I got confused by the name!



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread