### PR TITLE
Add ExpireKey event

### DIFF
--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -19,6 +19,9 @@ contract MixinKeys is
     bytes data; // Note: This can be expensive?
   }
 
+  // Called when the Lock owner expires a user's Key
+  event ExpireKey(uint tokenId);
+
   // Keys
   // Each owner can have at most exactly one key
   // TODO: could we use public here? (this could be confusing though because it getter will
@@ -86,7 +89,9 @@ contract MixinKeys is
     onlyOwner
     hasValidKey(_owner)
   {
-    keyByOwner[_owner].expirationTimestamp = block.timestamp; // Effectively expiring the key
+    Key storage key = keyByOwner[_owner];
+    key.expirationTimestamp = block.timestamp; // Effectively expiring the key
+    emit ExpireKey(key.tokenId);
   }
 
   /**

--- a/smart-contracts/test/Lock/expireKeyFor.js
+++ b/smart-contracts/test/Lock/expireKeyFor.js
@@ -48,20 +48,36 @@ contract('Lock', (accounts) => {
       }), 'KEY_NOT_VALID')
     })
 
-    it('should expire a valid key', async () => {
-      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
-        value: locks['FIRST'].params.keyPrice.toFixed(),
-        from: accounts[0]
+    describe('should expire a valid key', () => {
+      let ID
+      let event
+
+      before(async () => {
+        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
+          value: locks['FIRST'].params.keyPrice.toFixed(),
+          from: accounts[0]
+        })
+        ID = await locks['FIRST'].getTokenIdFor(accounts[1])
+        const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
+        const now = Math.floor(new Date().getTime() / 1000)
+        // Pre-condition
+        assert(expirationTimestamp.gt(now))
+        const result = await locks['FIRST'].expireKeyFor(accounts[1], {
+          from: accounts[0]
+        })
+        event = result.logs[0]
       })
-      let expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
-      let now = Math.floor(new Date().getTime() / 1000)
-      assert(expirationTimestamp.gt(now))
-      await locks['FIRST'].expireKeyFor(accounts[1], {
-        from: accounts[0]
+
+      it('should expire a valid key', async () => {
+        const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
+        const now = Math.floor(new Date().getTime() / 1000)
+        assert(expirationTimestamp.lte(now))
       })
-      expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
-      now = Math.floor(new Date().getTime() / 1000)
-      assert(expirationTimestamp.lte(now))
+
+      it('should emit an ExpireKey event', async () => {
+        assert.equal(event.event, 'ExpireKey')
+        assert.equal(event.args.tokenId.toString(), ID)
+      })
     })
   })
 })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Adding an event for when the Lock owner expires a user's Key.  I believe for transparency/easy discovery actions an admin takes like this should be emited as a log.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #1762

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - x ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
