### PR TITLE
Pass proper type for keyPrice

### DIFF
--- a/unlock-app/src/stories/creator/CreatorLockForm-errors.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm-errors.stories.js
@@ -60,7 +60,7 @@ storiesOf('CreatorLockForm/invalid', module)
   })
   .add('invalid key price', () => {
     const lock = {
-      keyPrice: -1,
+      keyPrice: '-1',
       valid: false,
     }
     return (


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR fixes a failing PropType in the `CreatorLockForm-errors` story. `keyPrice` was passed in as a number, but the expected type is a string.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes # 1802

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
