### PR TITLE
Refactored how lock names are signed

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -20,6 +20,11 @@ import { NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ERROR } from '../../actions/error'
 import { TRANSACTION_TYPES, POLLING_INTERVAL } from '../../constants'
 import { NO_USER_ACCOUNT } from '../../errors'
+import {
+  SIGN_DATA,
+  SIGNED_DATA,
+  SIGNATURE_ERROR,
+} from '../../actions/signature'
 
 /**
  * Fake state
@@ -452,6 +457,63 @@ describe('Wallet middleware', () => {
         '0.03'
       )
       expect(next).toHaveBeenCalledWith(action)
+    })
+  })
+
+  describe('SIGN_DATA', () => {
+    it('should invoke the walletService to sign the data and dispatch an event with the signature', () => {
+      expect.assertions(3)
+
+      const data = 'data to sign'
+      const signature = 'signature'
+
+      const { next, invoke, store } = create()
+      const action = {
+        type: SIGN_DATA,
+        data,
+      }
+      mockWalletService.signData = jest.fn((signer, data, callback) => {
+        return callback(null, signature)
+      })
+      invoke(action)
+      expect(mockWalletService.signData).toHaveBeenCalledWith(
+        store.getState().account.address,
+        data,
+        expect.any(Function)
+      )
+      expect(next).toHaveBeenCalledWith(action)
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: SIGNED_DATA,
+        data,
+        signature,
+      })
+    })
+
+    it('should invoke the walletService to sign the data and handle failures to sign', () => {
+      expect.assertions(3)
+
+      const data = 'data to sign'
+      const error = new Error('error')
+
+      const { next, invoke, store } = create()
+      const action = {
+        type: SIGN_DATA,
+        data,
+      }
+      mockWalletService.signData = jest.fn((signer, data, callback) => {
+        return callback(error)
+      })
+      invoke(action)
+      expect(mockWalletService.signData).toHaveBeenCalledWith(
+        store.getState().account.address,
+        data,
+        expect.any(Function)
+      )
+      expect(next).toHaveBeenCalledWith(action)
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: SIGNATURE_ERROR,
+        error,
+      })
     })
   })
 })


### PR DESCRIPTION
In order to simplify how signatures are done, I refactored the signData method in a [previous PR](https://github.com/unlock-protocol/unlock/pull/1794).
This PR now uses this new signData method by using redux actions passing a message to be signed and a signed message.

After this a cleanup PR will remove all of the previous signature mechanisms


Refs # https://github.com/unlock-protocol/unlock/issues/1776


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread