### PR TITLE
error on console.warn or console.error in storyshots tests

### DIFF
--- a/paywall/src/__tests__/storybook/storyshots.test.js
+++ b/paywall/src/__tests__/storybook/storyshots.test.js
@@ -1,4 +1,26 @@
-import initStoryshots from '@storybook/addon-storyshots'
+import initStoryshots, {
+  snapshotWithOptions,
+} from '@storybook/addon-storyshots'
 import { render as renderer } from 'react-testing-library'
 
-initStoryshots({ renderer })
+initStoryshots({
+  renderer,
+  test: info => {
+    /* eslint-disable no-console */
+
+    const error = console.error
+    const warn = console.warn
+
+    try {
+      console.error = jest.fn(console.error)
+      console.warn = jest.fn(console.warn)
+      snapshotWithOptions({ renderer })(info)
+      expect(console.error).not.toHaveBeenCalled()
+      expect(console.warn).not.toHaveBeenCalled()
+    } finally {
+      console.warn = warn
+      console.error = error
+    }
+    /* eslint-enable no-console */
+  },
+})

--- a/unlock-app/src/__tests__/storybook/storyshots.test.js
+++ b/unlock-app/src/__tests__/storybook/storyshots.test.js
@@ -1,4 +1,26 @@
-import initStoryshots from '@storybook/addon-storyshots'
+import initStoryshots, {
+  snapshotWithOptions,
+} from '@storybook/addon-storyshots'
 import { render as renderer } from 'react-testing-library'
 
-initStoryshots({ renderer })
+initStoryshots({
+  renderer,
+  test: info => {
+    /* eslint-disable no-console */
+
+    const error = console.error
+    const warn = console.warn
+
+    try {
+      console.error = jest.fn(console.error)
+      console.warn = jest.fn(console.warn)
+      snapshotWithOptions({ renderer })(info)
+      expect(console.error).not.toHaveBeenCalled()
+      expect(console.warn).not.toHaveBeenCalled()
+    } finally {
+      console.warn = warn
+      console.error = error
+    }
+    /* eslint-enable no-console */
+  },
+})


### PR DESCRIPTION
# Description

This change enables erroring out on prop type failures or component snafus in storybook stories.

<img width="1680" alt="screen shot 2019-03-01 at 11 05 10 am" src="https://user-images.githubusercontent.com/98250/53650218-06a40080-3c12-11e9-89ae-da6a3b7f2fb7.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1807 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
