### PR TITLE
Stop overwriting key data on transfers

### DIFF
--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -66,8 +66,6 @@ contract MixinTransfer is
       toKey.expirationTimestamp = fromKey
         .expirationTimestamp.add(previousExpiration - block.timestamp);
     }
-    // Overwite data in all cases
-    toKey.data = fromKey.data;
 
     // Effectively expiring the key for the previous owner
     fromKey.expirationTimestamp = block.timestamp;

--- a/smart-contracts/test/Lock/erc721/safeTransferFrom.js
+++ b/smart-contracts/test/Lock/erc721/safeTransferFrom.js
@@ -8,6 +8,7 @@ const shouldFail = require('../../helpers/shouldFail')
 const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
+let keyDataAfter
 
 contract('Lock ERC721', accounts => {
   before(async () => {
@@ -34,9 +35,9 @@ contract('Lock ERC721', accounts => {
         from
       })
       let ownerOf = await locks['FIRST'].ownerOf.call(ID)
-      let data = await locks['FIRST'].keyDataFor.call(to)
+      keyDataAfter = await locks['FIRST'].keyDataFor.call(to)
       assert.equal(ownerOf, to)
-      assert.equal(Web3Utils.toUtf8(data), 'Julien')
+      assert.equal(Web3Utils.toUtf8(keyDataAfter), '')
     })
 
     it('should work if some data is passed in ', async () => {
@@ -80,8 +81,9 @@ contract('Lock ERC721', accounts => {
       })
       let ownerOf = await locks['FIRST'].ownerOf.call(ID)
       assert.equal(ownerOf, accounts[6])
-      let data = await locks['FIRST'].keyDataFor.call(accounts[6])
-      assert.equal(Web3Utils.toUtf8(data), 'Julien')
+      keyDataAfter = await locks['FIRST'].keyDataFor.call(receiver)
+      // while we may pass data to the safeTransferFrom function, it is not currently utilized in any way other than being passed to the `onERC721Received` function in MixinTransfer.sol
+      assert.equal(Web3Utils.toUtf8(keyDataAfter), '')
     })
 
     it('should fail if trying to transfer a key to a contract which does not implement onERC721Received', async () => {


### PR DESCRIPTION
# Description

Prior to this, when transferring a key to a new owner, the sender's key data was copied to the recipients key.
# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1753
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
