### PR TITLE
Using camelCase on LockSmith

### DIFF
--- a/locksmith/src/controllers/lockController.js
+++ b/locksmith/src/controllers/lockController.js
@@ -5,7 +5,7 @@ const Lock = require('../lock')
 
 const Op = Sequelize.Op
 
-const lock_update = async (req, res) => {
+const lockUpdate = async (req, res) => {
   let lock = req.body.message.lock
 
   if (lock && lock.address == req.params.lockAddress) {
@@ -36,7 +36,7 @@ const lock_update = async (req, res) => {
   }
 }
 
-const lock_create = async (req, res) => {
+const lockCreate = async (req, res) => {
   let lock = req.body.message.lock
 
   if (lock.address && lock.name) {
@@ -60,7 +60,7 @@ const lock_create = async (req, res) => {
   }
 }
 
-const lock_get = async (req, res) => {
+const lockGet = async (req, res) => {
   let lockAddress = ethJsUtil.toChecksumAddress(req.params.lockAddress)
   logger.logLockDetailsRequest(lockAddress)
 
@@ -77,7 +77,7 @@ const lock_get = async (req, res) => {
   }
 }
 
-const lock_owner_get = async (req, res) => {
+const lockOwnerGet = async (req, res) => {
   const owner = ethJsUtil.toChecksumAddress(req.params.owner)
 
   let locks = await Lock.findAll({
@@ -90,4 +90,4 @@ const lock_owner_get = async (req, res) => {
   res.json({ locks: locks })
 }
 
-module.exports = { lock_get, lock_owner_get, lock_create, lock_update }
+module.exports = { lockGet, lockOwnerGet, lockCreate, lockUpdate }

--- a/locksmith/src/routes/lock.js
+++ b/locksmith/src/routes/lock.js
@@ -1,11 +1,11 @@
 var express = require('express')
 
 var router = express.Router()
-var lock_controller = require('../controllers/lockController')
+var lockController = require('../controllers/lockController')
 
-router.put('/lock/:lockAddress', lock_controller.lock_update)
-router.post('/lock', lock_controller.lock_create)
-router.get('/lock/:lockAddress', lock_controller.lock_get)
-router.get('/:owner/locks', lock_controller.lock_owner_get)
+router.put('/lock/:lockAddress', lockController.lockUpdate)
+router.post('/lock', lockController.lockCreate)
+router.get('/lock/:lockAddress', lockController.lockGet)
+router.get('/:owner/locks', lockController.lockOwnerGet)
 
 module.exports = router


### PR DESCRIPTION
Quick nit to make it consisent accross all of our JS apps.



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread