### PR TITLE
using a single method to set and update lock names

### DIFF
--- a/locksmith/jest.config.js
+++ b/locksmith/jest.config.js
@@ -4,9 +4,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 77.42,
-      functions: 86.21,
-      lines: 92.63,
-      statements: 92.63,
+      functions: 82.76,
+      lines: 91.63,
+      statements: 91.63,
     },
   },
 }

--- a/locksmith/src/locksmithLogger.js
+++ b/locksmith/src/locksmithLogger.js
@@ -22,4 +22,7 @@ module.exports = {
   logFailureRequestingBlockTimestamp: error => {
     logger.error(error)
   },
+  logFailureToStoreLock: error => {
+    logger.error(error)
+  },
 }

--- a/locksmith/src/routes/lock.js
+++ b/locksmith/src/routes/lock.js
@@ -3,8 +3,7 @@ var express = require('express')
 var router = express.Router()
 var lockController = require('../controllers/lockController')
 
-router.put('/lock/:lockAddress', lockController.lockUpdate)
-router.post('/lock', lockController.lockCreate)
+router.post('/lock', lockController.lockSave)
 router.get('/lock/:lockAddress', lockController.lockGet)
 router.get('/:owner/locks', lockController.lockOwnerGet)
 


### PR DESCRIPTION
Per our discussion, I refactored Locksmith so that we use a single API endpoint to create or update
a lock's name.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread