### PR TITLE
Adding an action to change the lock's name

### DIFF
--- a/unlock-app/src/__tests__/actions/lock.test.js
+++ b/unlock-app/src/__tests__/actions/lock.test.js
@@ -11,6 +11,8 @@ import {
   UPDATE_LOCK,
   WITHDRAW_FROM_LOCK,
   UPDATE_LOCK_KEY_PRICE,
+  updateLockName,
+  UPDATE_LOCK_NAME,
 } from '../../actions/lock'
 
 describe('lock actions', () => {
@@ -79,5 +81,18 @@ describe('lock actions', () => {
     }
 
     expect(updateKeyPrice(address, price)).toEqual(expectedAction)
+  })
+
+  it('should create an action to update the lock name', () => {
+    expect.assertions(1)
+    const address = '0x123'
+    const name = 'The Lock'
+    const expectedAction = {
+      type: UPDATE_LOCK_NAME,
+      address,
+      name,
+    }
+
+    expect(updateLockName(address, name)).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/actions/lock.js
+++ b/unlock-app/src/actions/lock.js
@@ -3,6 +3,7 @@ export const CREATE_LOCK = 'lock/CREATE_LOCK'
 export const DELETE_LOCK = 'lock/DELETE_LOCK'
 export const UPDATE_LOCK = 'lock/UPDATE_LOCK'
 export const UPDATE_LOCK_KEY_PRICE = 'lock/UPDATE_LOCK_KEY_PRICE'
+export const UPDATE_LOCK_NAME = 'lock/UPDATE_LOCK_NAME'
 export const WITHDRAW_FROM_LOCK = 'lock/WITHDRAW_FROM_LOCK'
 
 export const createLock = lock => ({
@@ -32,8 +33,15 @@ export const withdrawFromLock = lock => ({
   lock,
 })
 
+// TODO: name should be updateLockKeyPrice
 export const updateKeyPrice = (address, price) => ({
   type: UPDATE_LOCK_KEY_PRICE,
   address,
   price,
+})
+
+export const updateLockName = (address, name) => ({
+  type: UPDATE_LOCK_NAME,
+  address,
+  name,
 })


### PR DESCRIPTION
This action will be triggered by the creatorLokcForm component when a lock's name is changed



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread