### PR TITLE
Now using 307 when redirecting on errors.

### DIFF
--- a/unlock-app/src/pages/_error.js
+++ b/unlock-app/src/pages/_error.js
@@ -20,7 +20,7 @@ class Error extends React.Component {
           req.connection.remoteAddress.match(/^127.0.0.1|^localhost/)
         )
       ) {
-        res.writeHead(301, {
+        res.writeHead(307, {
           Location: '/',
         })
         res.end()


### PR DESCRIPTION
Using a 301 status code (permanent redirect) is not quite correct on errors. Switching to 307.


Fixes #1593


- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->