### PR TITLE
Lock names can be updated

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
@@ -2,11 +2,19 @@ import React from 'react'
 import * as rtl from 'react-testing-library'
 import { Provider } from 'react-redux'
 
-import { CreatorLock } from '../../../components/creator/CreatorLock'
+import {
+  CreatorLock,
+  mapDispatchToProps,
+} from '../../../components/creator/CreatorLock'
 import configure from '../../../config'
 import createUnlockStore from '../../../createUnlockStore'
 import { UNLIMITED_KEYS_COUNT } from '../../../constants'
 import { ConfigContext } from '../../../utils/withConfig'
+import {
+  UPDATE_LOCK_KEY_PRICE,
+  UPDATE_LOCK,
+  UPDATE_LOCK_NAME,
+} from '../../../actions/lock'
 
 jest.mock('next/link', () => {
   return ({ children }) => children
@@ -62,6 +70,8 @@ describe('CreatorLock', () => {
             lock={lock}
             transaction={transaction}
             updateKeyPrice={() => {}}
+            updateLockName={() => {}}
+            updateLock={() => {}}
           />
         </Provider>
       </ConfigProvider>
@@ -100,6 +110,8 @@ describe('CreatorLock', () => {
             lock={lock}
             transaction={transaction}
             updateKeyPrice={() => {}}
+            updateLockName={() => {}}
+            updateLock={() => {}}
           />
         </Provider>
       </ConfigProvider>
@@ -131,6 +143,8 @@ describe('CreatorLock', () => {
             lock={keylock}
             transaction={transaction}
             updateKeyPrice={() => {}}
+            updateLockName={() => {}}
+            updateLock={() => {}}
           />
         </Provider>
       </ConfigProvider>
@@ -159,11 +173,60 @@ describe('CreatorLock', () => {
             lock={unlimitedlock}
             transaction={transaction}
             updateKeyPrice={() => {}}
+            updateLockName={() => {}}
+            updateLock={() => {}}
           />
         </Provider>
       </ConfigProvider>
     )
 
     expect(wrapper.queryByText('1/∞')).not.toBeNull()
+  })
+
+  describe('mapDispatchToProps', () => {
+    it('should dispatch updateKeyPrice if the lock key price has been changed', () => {
+      expect.assertions(1)
+      const newLock = Object.assign({}, unlimitedlock)
+      newLock.keyPrice = '6.66'
+      const dispatch = jest.fn()
+      const { updateLock } = mapDispatchToProps(dispatch, { lock })
+      updateLock(newLock)
+
+      expect(dispatch).toHaveBeenCalledWith({
+        address: lock.address,
+        price: '6.66',
+        type: UPDATE_LOCK_KEY_PRICE,
+      })
+    })
+
+    it('should dispatch updateLockName if the lock name has been changed', () => {
+      expect.assertions(1)
+      const newLock = Object.assign({}, unlimitedlock)
+      newLock.name = 'A New name'
+      const dispatch = jest.fn()
+      const { updateLock } = mapDispatchToProps(dispatch, { lock })
+      updateLock(newLock)
+
+      expect(dispatch).toHaveBeenCalledWith({
+        address: lock.address,
+        name: newLock.name,
+        type: UPDATE_LOCK_NAME,
+      })
+    })
+
+    it('should dispatch updateLock', () => {
+      expect.assertions(1)
+      const newLock = Object.assign({}, unlimitedlock)
+      newLock.name = 'A New name'
+      const dispatch = jest.fn()
+      const { updateLock } = mapDispatchToProps(dispatch, { lock })
+      updateLock(newLock)
+
+      expect(dispatch).toHaveBeenCalledWith({
+        address: lock.address,
+        update: newLock,
+        type: UPDATE_LOCK,
+      })
+    })
   })
 })

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,5 +1,10 @@
 import storageMiddleware from '../../middlewares/storageMiddleware'
-import { UPDATE_LOCK, updateLock, CREATE_LOCK } from '../../actions/lock'
+import {
+  UPDATE_LOCK,
+  updateLock,
+  CREATE_LOCK,
+  UPDATE_LOCK_NAME,
+} from '../../actions/lock'
 import { STORE_LOCK_NAME } from '../../actions/storage'
 import { addTransaction, NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ACCOUNT } from '../../actions/accounts'
@@ -227,6 +232,39 @@ describe('Storage middleware', () => {
       })
       const { next, invoke, store } = create()
       const action = { type: CREATE_LOCK, lock }
+
+      invoke(action)
+      expect(UnlockLock.build).toHaveBeenCalledWith(lock)
+      expect(next).toHaveBeenCalledTimes(1)
+      expect(store.dispatch).toHaveBeenCalledWith({
+        data,
+        type: 'signature/SIGN_DATA',
+      })
+    })
+  })
+
+  describe('UPDATE_LOCK_NAME', () => {
+    it('should dispatch an action to sign message to update the name of a lock', () => {
+      expect.assertions(3)
+      const lock = {
+        address: '0x123',
+        name: 'my lock',
+        owner: '0xabc',
+      }
+      const data = {
+        message: {
+          lock: {},
+        },
+      }
+      const newName = 'a new name'
+      const { next, invoke, store } = create()
+      state.locks[lock.address] = lock
+
+      const action = {
+        type: UPDATE_LOCK_NAME,
+        address: lock.address,
+        name: newName,
+      }
 
       invoke(action)
       expect(UnlockLock.build).toHaveBeenCalledWith(lock)

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -22673,7 +22673,6 @@ Object {
         >
           <input
             data-valid="true"
-            disabled=""
             name="name"
             type="text"
             value="Existing Lock"
@@ -22826,7 +22825,6 @@ Object {
       >
         <input
           data-valid="true"
-          disabled=""
           name="name"
           type="text"
           value="Existing Lock"

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -23,7 +23,7 @@ import {
   DoubleHeightCell,
   BalanceContainer,
 } from './LockStyles'
-import { updateKeyPrice } from '../../actions/lock'
+import { updateKeyPrice, updateLockName, updateLock } from '../../actions/lock'
 
 import { INFINITY } from '../../constants'
 
@@ -56,11 +56,6 @@ export class CreatorLock extends React.Component {
     this.toggleKeys = this.toggleKeys.bind(this)
   }
 
-  updateLock(lock) {
-    const { updateKeyPrice } = this.props
-    updateKeyPrice(lock.address, lock.keyPrice)
-  }
-
   toggleEmbedCode() {
     this.setState(previousState => ({
       showEmbedCode: !previousState.showEmbedCode,
@@ -76,7 +71,7 @@ export class CreatorLock extends React.Component {
   render() {
     // TODO add all-time balance to lock
 
-    const { lock } = this.props
+    const { lock, updateLock } = this.props
     const { showEmbedCode, showKeys, editing } = this.state
 
     if (editing) {
@@ -84,7 +79,7 @@ export class CreatorLock extends React.Component {
         <CreatorLockForm
           lock={lock}
           hideAction={() => this.setState({ editing: false })}
-          createLock={lock => this.updateLock(lock)}
+          createLock={newLock => updateLock(newLock)}
         />
       )
     }
@@ -142,11 +137,28 @@ export class CreatorLock extends React.Component {
 }
 
 CreatorLock.propTypes = {
-  updateKeyPrice: PropTypes.func.isRequired,
+  updateLock: PropTypes.func.isRequired,
   lock: UnlockPropTypes.lock.isRequired,
 }
 
-const mapDispatchToProps = { updateKeyPrice }
+export const mapDispatchToProps = (dispatch, { lock }) => {
+  return {
+    updateLock: newLock => {
+      // If the price has changed
+      if (lock.keyPrice !== newLock.keyPrice) {
+        dispatch(updateKeyPrice(lock.address, newLock.keyPrice))
+      }
+
+      // If the name has changed
+      if (lock.name !== newLock.name) {
+        dispatch(updateLockName(lock.address, newLock.name))
+      }
+
+      // Reflect all changes
+      dispatch(updateLock(lock.address, newLock))
+    },
+  }
+}
 
 export default connect(
   undefined,

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -167,14 +167,13 @@ export class CreatorLockForm extends React.Component {
   }
 
   saveLock() {
-    const { account, createLock, lock } = this.props
+    const { account, createLock } = this.props
     const newLock = formValuesToLock(this.state)
-    if (!lock.address || lock.keyPrice !== newLock.keyPrice) {
-      createLock({
-        ...newLock,
-        owner: account.address,
-      })
-    }
+    // TODO: createLock is not a great name, because it is actually also being used to update an existing lock
+    createLock({
+      ...newLock,
+      owner: account.address,
+    })
   }
 
   /**
@@ -256,7 +255,6 @@ export class CreatorLockForm extends React.Component {
             defaultValue={name}
             data-valid={valid.name}
             required={isNew}
-            disabled={!isNew}
           />
         </FormLockName>
         <FormLockDuration>

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -1,6 +1,11 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
-import { UPDATE_LOCK, updateLock, CREATE_LOCK } from '../actions/lock'
+import {
+  UPDATE_LOCK,
+  updateLock,
+  CREATE_LOCK,
+  UPDATE_LOCK_NAME,
+} from '../actions/lock'
 import StorageService from '../services/storageService'
 import { STORE_LOCK_NAME, storageError } from '../actions/storage'
 
@@ -70,6 +75,18 @@ export default function storageMiddleware({ getState, dispatch }) {
           name: action.lock.name,
           owner: action.lock.owner,
           address: action.lock.address,
+        })
+        // Ask someone to sign it!
+        dispatch(signData(data))
+      }
+
+      if (action.type === UPDATE_LOCK_NAME) {
+        const lock = getState().locks[action.address]
+        // Build the data to sign
+        let data = UnlockLock.build({
+          name: action.name,
+          owner: lock.owner,
+          address: lock.address,
         })
         // Ask someone to sign it!
         dispatch(signData(data))


### PR DESCRIPTION
This is the final PR to allow the lock owner to update their lock's name.
This fixes #1771


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread