### PR TITLE
using a hardcoded address for the Unlock smart contract

### DIFF
--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -12,7 +12,6 @@ import WalletService from '../../services/walletService'
 import {
   NOT_ENABLED_IN_PROVIDER,
   MISSING_PROVIDER,
-  NON_DEPLOYED_CONTRACT,
   FAILED_TO_CREATE_LOCK,
   FAILED_TO_PURCHASE_KEY,
   FAILED_TO_UPDATE_KEY_PRICE,
@@ -103,53 +102,6 @@ describe('WalletService', () => {
       })
 
       walletService.connect('AnotherProvider')
-    })
-
-    describe('smart contract has not been deployed on this network', () => {
-      it('should not emit an error event when we have a contract address from config', done => {
-        expect.assertions(3)
-        config.unlockAddress = '0x1234567890123456789012345678901234567890'
-        const walletService2 = new WalletService(config)
-
-        expect(walletService2.ready).toBe(false)
-
-        const netVersion = Math.floor(Math.random() * 100000)
-        netVersionAndYield(netVersion)
-
-        expect(walletService2.ready).toBe(false)
-
-        expect(walletService2.unlockContractAddress).toBe(
-          '0x1234567890123456789012345678901234567890'
-        )
-
-        walletService2.on('error', error => {
-          expect(error).toBe('should not error')
-          done()
-        })
-        walletService2.on('network.changed', () => {
-          done()
-        })
-
-        walletService2.connect('HTTP')
-      })
-
-      it('should emit an error event when there is no config-provided contract address', done => {
-        expect.assertions(3)
-
-        expect(walletService.ready).toBe(false)
-        UnlockContract.networks = {}
-
-        const netVersion = Math.floor(Math.random() * 100000)
-        netVersionAndYield(netVersion)
-
-        expect(walletService.ready).toBe(false)
-        walletService.on('error', error => {
-          expect(error.message).toBe(NON_DEPLOYED_CONTRACT)
-          done()
-        })
-
-        walletService.connect('HTTP')
-      })
     })
 
     it('should silently ignore requests to connect again to the same provider', done => {

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -71,7 +71,8 @@ export default function configure(
   let requiredNetwork = 'Dev'
   let requiredNetworkId = 1984
   let requiredConfirmations = 12
-  let unlockAddress = ''
+  // Unlock address by default (smart contract deployments yield the same address on a "clean" node as long as long as the migration script runs in the same order)
+  let unlockAddress = '0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B'
   let services = {}
   let supportedProviders = []
   let paywallUrl = runtimeConfig.paywallUrl || 'http://localhost:3000/paywall'
@@ -141,7 +142,7 @@ export default function configure(
       'https://staging.unlock-protocol.com/static/paywall.min.js'
 
     // Address for the Unlock smart contract
-    unlockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+    unlockAddress = '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b'
 
     // rinkeby block time is roughly same as main net
     blockTime = 8000
@@ -169,7 +170,7 @@ export default function configure(
       'https://unlock-protocol.com/static/paywall.min.js'
 
     // Address for the Unlock smart contract
-    unlockAddress = '0x3d5409cce1d45233de1d4ebdee74b8e004abdd13'
+    unlockAddress = '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'
 
     // See https://www.reddit.com/r/ethereum/comments/3c8v2i/what_is_the_expected_block_time/
     blockTime = 8000

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -8,7 +8,6 @@ import UnlockContract from '../artifacts/contracts/Unlock.json'
 import configure from '../config'
 import {
   MISSING_PROVIDER,
-  NON_DEPLOYED_CONTRACT,
   NOT_ENABLED_IN_PROVIDER,
   FAILED_TO_CREATE_LOCK,
   FAILED_TO_PURCHASE_KEY,
@@ -27,9 +26,7 @@ export const keyId = (lock, owner) => [lock, owner].join('-')
 export default class WalletService extends EventEmitter {
   constructor({ providers, unlockAddress } = configure()) {
     super()
-    if (unlockAddress) {
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(unlockAddress)
-    }
+    this.unlockContractAddress = unlockAddress
     this.providers = providers
     this.ready = false
     this.providerName = null
@@ -91,18 +88,6 @@ export default class WalletService extends EventEmitter {
     this.web3 = new Web3(provider)
 
     const networkId = await this.web3.eth.net.getId()
-    // unlockContractAddress is set in the constructor if config provides one in unlockAddress
-    // this is set for staging and production
-    if (!this.unlockContractAddress) {
-      if (UnlockContract.networks[networkId]) {
-        // If we do not have an address from config let's use the artifact files
-        this.unlockContractAddress = Web3Utils.toChecksumAddress(
-          UnlockContract.networks[networkId].address
-        )
-      } else {
-        return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
-      }
-    }
 
     if (this.networkId !== networkId) {
       this.networkId = networkId

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -10,14 +10,12 @@ import UnlockContract from '../artifacts/contracts/Unlock.json'
 
 import configure from '../config'
 import { TRANSACTION_TYPES, MAX_UINT, UNLIMITED_KEYS_COUNT } from '../constants'
-import { NON_DEPLOYED_CONTRACT } from '../errors'
 
 const {
   readOnlyProvider,
   providers,
   unlockAddress,
   blockTime,
-  requiredNetworkId,
   requiredConfirmations,
 } = configure()
 
@@ -36,6 +34,8 @@ export default class Web3Service extends EventEmitter {
     } else {
       this.web3 = new Web3(Object.values(providers)[0]) // Defaulting to the first provider.
     }
+
+    this.unlockContractAddress = unlockContractAddress
 
     // TODO: detect discrepancy in providers
 
@@ -108,19 +108,6 @@ export default class Web3Service extends EventEmitter {
           balance: '0', // Must be expressed in Eth!
         })
       },
-    }
-
-    if (unlockContractAddress) {
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(
-        unlockContractAddress
-      )
-    } else if (UnlockContract.networks[requiredNetworkId]) {
-      // If we do not have an address from config let's use the artifact files
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(
-        UnlockContract.networks[requiredNetworkId].address
-      )
-    } else {
-      return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
     }
   }
 


### PR DESCRIPTION
# Description

Extracting the lock address from the artifact is creating a lot of friction when in practice the Unlock smart contract address is consistently the same.

This draft is an effort to see if we can hard code the URL for all environments.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

