### PR TITLE
using a hardcoded address for the Unlock smart contract

### DIFF
--- a/paywall/src/__tests__/services/walletService.test.js
+++ b/paywall/src/__tests__/services/walletService.test.js
@@ -12,7 +12,6 @@ import WalletService from '../../services/walletService'
 import {
   NOT_ENABLED_IN_PROVIDER,
   MISSING_PROVIDER,
-  NON_DEPLOYED_CONTRACT,
   FAILED_TO_CREATE_LOCK,
   FAILED_TO_PURCHASE_KEY,
   FAILED_TO_UPDATE_KEY_PRICE,
@@ -103,53 +102,6 @@ describe('WalletService', () => {
       })
 
       walletService.connect('AnotherProvider')
-    })
-
-    describe('smart contract has not been deployed on this network', () => {
-      it('should not emit an error event when we have a contract address from config', done => {
-        expect.assertions(3)
-        config.unlockAddress = '0x1234567890123456789012345678901234567890'
-        const walletService2 = new WalletService(config)
-
-        expect(walletService2.ready).toBe(false)
-
-        const netVersion = Math.floor(Math.random() * 100000)
-        netVersionAndYield(netVersion)
-
-        expect(walletService2.ready).toBe(false)
-
-        expect(walletService2.unlockContractAddress).toBe(
-          '0x1234567890123456789012345678901234567890'
-        )
-
-        walletService2.on('error', error => {
-          expect(error).toBe('should not error')
-          done()
-        })
-        walletService2.on('network.changed', () => {
-          done()
-        })
-
-        walletService2.connect('HTTP')
-      })
-
-      it('should emit an error event when there is no config-provided contract address', done => {
-        expect.assertions(3)
-
-        expect(walletService.ready).toBe(false)
-        UnlockContract.networks = {}
-
-        const netVersion = Math.floor(Math.random() * 100000)
-        netVersionAndYield(netVersion)
-
-        expect(walletService.ready).toBe(false)
-        walletService.on('error', error => {
-          expect(error.message).toBe(NON_DEPLOYED_CONTRACT)
-          done()
-        })
-
-        walletService.connect('HTTP')
-      })
     })
 
     it('should silently ignore requests to connect again to the same provider', done => {
@@ -425,17 +377,6 @@ describe('WalletService', () => {
 
         walletService._sendTransaction = jest.fn()
 
-        const unlockMockContract = {
-          methods: {
-            createLock: jest.fn(() => {
-              return unlockMockContract.methods
-            }),
-            encodeABI: jest.fn(() => {
-              return data
-            }),
-          },
-        }
-
         const ContractClass = class {
           constructor(abi, address) {
             expect(abi).toBe(UnlockContract.abi)
@@ -461,7 +402,7 @@ describe('WalletService', () => {
             to: walletService.unlockContractAddress,
             from: owner,
             data,
-            gas: 3000000,
+            gas: WalletService.gasAmountConstants().createLock,
             contract: UnlockContract,
           },
           expect.any(Function)
@@ -525,17 +466,6 @@ describe('WalletService', () => {
 
         walletService._sendTransaction = jest.fn()
 
-        const unlockMockContract = {
-          methods: {
-            purchaseFor: jest.fn(() => {
-              return unlockMockContract.methods
-            }),
-            encodeABI: jest.fn(() => {
-              return data
-            }),
-          },
-        }
-
         const ContractClass = class {
           constructor(abi, address) {
             expect(abi).toBe(LockContract.abi)
@@ -560,7 +490,7 @@ describe('WalletService', () => {
             to: lock,
             from: account,
             data,
-            gas: 1000000,
+            gas: WalletService.gasAmountConstants().purchaseKey,
             contract: LockContract,
             value: '100000000000000000000000000', // Web3Utils.toWei(keyPrice, 'ether')
           },
@@ -602,17 +532,6 @@ describe('WalletService', () => {
 
         walletService._sendTransaction = jest.fn()
 
-        const unlockMockContract = {
-          methods: {
-            updateKeyPrice: jest.fn(() => {
-              return unlockMockContract.methods
-            }),
-            encodeABI: jest.fn(() => {
-              return data
-            }),
-          },
-        }
-
         const ContractClass = class {
           constructor(abi, address) {
             expect(abi).toBe(LockContract.abi)
@@ -636,7 +555,7 @@ describe('WalletService', () => {
             to: lock,
             from: account,
             data,
-            gas: 1000000,
+            gas: WalletService.gasAmountConstants().updateKeyPrice,
             contract: LockContract,
           },
           expect.any(Function)
@@ -662,73 +581,141 @@ describe('WalletService', () => {
 
     describe('signData', () => {
       const account = '0x123'
-      const data = 'please sign me'
+      let data = 'please sign me'
 
-      it('should call first eth.personal.sign', done => {
-        expect.assertions(4)
-        walletService.web3.eth.personal.sign = jest.fn(
-          (dataToSign, signer, callback) => {
-            expect(dataToSign).toEqual(data)
-            expect(signer).toEqual(account)
-            return callback(null /* error */, 'signature')
-          }
-        )
+      describe('if the provider is metamask', () => {
+        it('should use eth_signTypedData_v3 and stringify the data', done => {
+          expect.assertions(2)
+          data = []
+          walletService.web3.currentProvider.isMetaMask = true
+          walletService.web3.currentProvider.send = jest.fn((args, cb) => {
+            expect(args.method).toBe('eth_signTypedData_v3')
+            expect(args.params[1]).toBe(JSON.stringify(data))
+            return cb(null, { result: '' })
+          })
+          walletService.signData(account, data, () => {
+            done()
+          })
+        })
+      })
+
+      it('should send the the method to the provider with the right params and yield the signature when it is not metamask (legacy/opaque signing)', done => {
+        expect.assertions(5)
+        const result = 'RESULT'
+        walletService.web3.currentProvider.send = jest.fn((args, cb) => {
+          expect(args.method).toBe('eth_signTypedData')
+          expect(args.params[0]).toBe(account)
+          expect(args.params[1]).toBe(data)
+          expect(args.from).toBe(account)
+          return cb(null, {
+            result,
+          })
+        })
         walletService.signData(account, data, (error, signature) => {
-          expect(walletService.web3.eth.personal.sign).toHaveBeenCalled()
-          expect(signature).toEqual('signature')
+          expect(signature).toBe(Buffer.from(result).toString('base64'))
           done()
         })
       })
 
-      it('should call web3.eth.sign if eth.personal.sign fails', done => {
-        expect.assertions(7)
-
-        walletService.web3.eth.personal.sign = jest.fn(
-          (dataToSign, signer, callback) => {
-            expect(dataToSign).toEqual(data)
-            expect(signer).toEqual(account)
-            const error = {}
-            return callback(error, null /* signature */)
-          }
-        )
-
-        walletService.web3.eth.sign = jest.fn(
-          (dataToSign, signer, callback) => {
-            expect(dataToSign).toEqual(data)
-            expect(signer).toEqual(account)
-            return callback(null /* error */, 'signature')
-          }
-        )
-
-        walletService.signData(account, data, (error, signature) => {
-          expect(walletService.web3.eth.personal.sign).toHaveBeenCalled()
-          expect(walletService.web3.eth.sign).toHaveBeenCalled()
-          expect(signature).toEqual('signature')
+      it('should yield an error if there was a network error', done => {
+        expect.assertions(1)
+        const networkError = new Error('network')
+        walletService.web3.currentProvider.send = jest.fn((args, cb) => {
+          return cb(networkError, null)
+        })
+        walletService.signData(account, data, error => {
+          expect(error).toBe(networkError)
           done()
         })
       })
 
-      it('should call web3.eth.sign if eth.personal.sign throws', done => {
-        expect.assertions(7)
+      it('should yield an error if there was a signature error', done => {
+        expect.assertions(1)
+        const signatureError = new Error('signature')
+        walletService.web3.currentProvider.send = jest.fn((args, cb) => {
+          return cb(null, { error: signatureError })
+        })
+        walletService.signData(account, data, error => {
+          expect(error).toBe(signatureError)
+          done()
+        })
+      })
+    })
 
-        walletService.web3.eth.personal.sign = jest.fn((dataToSign, signer) => {
-          expect(dataToSign).toEqual(data)
-          expect(signer).toEqual(account)
-          throw new Error()
+    describe('partialWithdrawFromLock', () => {
+      let lock
+      let account
+
+      beforeEach(() => {
+        lock = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+        account = '0xdeadbeef'
+      })
+
+      it('should invoke sendTransaction with the right params', done => {
+        expect.assertions(3)
+        const data = '' // mock abi data for partialWithdraw
+
+        walletService._sendTransaction = jest.fn(() => {
+          done()
         })
 
-        walletService.web3.eth.sign = jest.fn(
-          (dataToSign, signer, callback) => {
-            expect(dataToSign).toEqual(data)
-            expect(signer).toEqual(account)
-            return callback(null /* error */, 'signature')
+        const MockContractClass = class {
+          constructor(abi, address) {
+            expect(abi).toBe(LockContract.abi)
+            expect(address).toBe(lock)
+            this.methods = {
+              partialWithdraw: () => this,
+            }
+            this.encodeABI = jest.fn(() => data)
           }
-        )
+        }
 
-        walletService.signData(account, data, (error, signature) => {
-          expect(walletService.web3.eth.personal.sign).toHaveBeenCalled()
-          expect(walletService.web3.eth.sign).toHaveBeenCalled()
-          expect(signature).toEqual('signature')
+        walletService.web3.eth.Contract = MockContractClass
+
+        walletService.partialWithdrawFromLock(lock, account, '3', () => {
+          done()
+        })
+
+        expect(walletService._sendTransaction).toHaveBeenCalledWith(
+          {
+            to: lock,
+            from: account,
+            data,
+            gas: WalletService.gasAmountConstants().partialWithdrawFromLock,
+            contract: LockContract,
+          },
+          expect.any(Function)
+        )
+      })
+
+      it('should emit an error if the transaction cannot be sent', done => {
+        expect.assertions(1)
+        const error = {}
+
+        walletService._sendTransaction = jest.fn((args, cb) => {
+          return cb(error)
+        })
+
+        walletService.on('error', error => {
+          expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
+          done()
+        })
+
+        walletService.partialWithdrawFromLock(lock, account, '3', () => {})
+      })
+
+      it('should not emit an error when `error` is falsy', done => {
+        expect.assertions(1)
+        const error = undefined
+
+        walletService._sendTransaction = jest.fn((args, cb) => {
+          return cb(error)
+        })
+
+        walletService.emit = jest.fn()
+
+        walletService.partialWithdrawFromLock(lock, account, '3', () => {
+          expect(walletService.emit).not.toHaveBeenCalled()
           done()
         })
       })
@@ -748,17 +735,6 @@ describe('WalletService', () => {
         const data = '' // mock abi data for purchaseKey
 
         walletService._sendTransaction = jest.fn()
-
-        const unlockMockContract = {
-          methods: {
-            withdrawFromLock: jest.fn(() => {
-              return unlockMockContract.methods
-            }),
-            encodeABI: jest.fn(() => {
-              return data
-            }),
-          },
-        }
 
         const ContractClass = class {
           constructor(abi, address) {
@@ -782,7 +758,7 @@ describe('WalletService', () => {
             to: lock,
             from: account,
             data,
-            gas: 1000000,
+            gas: WalletService.gasAmountConstants().withdrawFromLock,
             contract: LockContract,
           },
           expect.any(Function)

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -73,7 +73,10 @@ export default function configure(
   let requiredNetwork = 'Dev'
   let requiredNetworkId = 1984
   let requiredConfirmations = 12
-  let unlockAddress = ''
+  // Unlock address by default
+  // Smart contract deployments yield the same address on a "clean" node as long as long as the
+  // migration script runs in the same order.
+  let unlockAddress = '0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B'
   let services = {}
   let supportedProviders = []
   let blockTime = 8000 // in mseconds.
@@ -128,7 +131,7 @@ export default function configure(
     services['storage'] = { host: runtimeConfig.locksmithHost }
 
     // Address for the Unlock smart contract
-    unlockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+    unlockAddress = '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b'
 
     // rinkeby block time is roughly same as main net
     blockTime = 8000
@@ -148,7 +151,7 @@ export default function configure(
     supportedProviders = ['Metamask', 'Opera']
 
     // Address for the Unlock smart contract
-    unlockAddress = '0x3d5409cce1d45233de1d4ebdee74b8e004abdd13'
+    unlockAddress = '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'
 
     // See https://www.reddit.com/r/ethereum/comments/3c8v2i/what_is_the_expected_block_time/
     blockTime = 8000

--- a/paywall/src/services/web3Service.js
+++ b/paywall/src/services/web3Service.js
@@ -10,14 +10,12 @@ import UnlockContract from '../artifacts/contracts/Unlock.json'
 
 import configure from '../config'
 import { TRANSACTION_TYPES, MAX_UINT, UNLIMITED_KEYS_COUNT } from '../constants'
-import { NON_DEPLOYED_CONTRACT } from '../errors'
 
 const {
   readOnlyProvider,
   providers,
   unlockAddress,
   blockTime,
-  requiredNetworkId,
   requiredConfirmations,
 } = configure()
 
@@ -36,6 +34,8 @@ export default class Web3Service extends EventEmitter {
     } else {
       this.web3 = new Web3(Object.values(providers)[0]) // Defaulting to the first provider.
     }
+
+    this.unlockContractAddress = unlockContractAddress
 
     // TODO: detect discrepancy in providers
 
@@ -108,19 +108,6 @@ export default class Web3Service extends EventEmitter {
           balance: '0', // Must be expressed in Eth!
         })
       },
-    }
-
-    if (unlockContractAddress) {
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(
-        unlockContractAddress
-      )
-    } else if (UnlockContract.networks[requiredNetworkId]) {
-      // If we do not have an address from config let's use the artifact files
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(
-        UnlockContract.networks[requiredNetworkId].address
-      )
-    } else {
-      return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
     }
   }
 

--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -12,7 +12,6 @@ import WalletService from '../../services/walletService'
 import {
   NOT_ENABLED_IN_PROVIDER,
   MISSING_PROVIDER,
-  NON_DEPLOYED_CONTRACT,
   FAILED_TO_CREATE_LOCK,
   FAILED_TO_PURCHASE_KEY,
   FAILED_TO_UPDATE_KEY_PRICE,
@@ -103,53 +102,6 @@ describe('WalletService', () => {
       })
 
       walletService.connect('AnotherProvider')
-    })
-
-    describe('smart contract has not been deployed on this network', () => {
-      it('should not emit an error event when we have a contract address from config', done => {
-        expect.assertions(3)
-        config.unlockAddress = '0x1234567890123456789012345678901234567890'
-        const walletService2 = new WalletService(config)
-
-        expect(walletService2.ready).toBe(false)
-
-        const netVersion = Math.floor(Math.random() * 100000)
-        netVersionAndYield(netVersion)
-
-        expect(walletService2.ready).toBe(false)
-
-        expect(walletService2.unlockContractAddress).toBe(
-          '0x1234567890123456789012345678901234567890'
-        )
-
-        walletService2.on('error', error => {
-          expect(error).toBe('should not error')
-          done()
-        })
-        walletService2.on('network.changed', () => {
-          done()
-        })
-
-        walletService2.connect('HTTP')
-      })
-
-      it('should emit an error event when there is no config-provided contract address', done => {
-        expect.assertions(3)
-
-        expect(walletService.ready).toBe(false)
-        UnlockContract.networks = {}
-
-        const netVersion = Math.floor(Math.random() * 100000)
-        netVersionAndYield(netVersion)
-
-        expect(walletService.ready).toBe(false)
-        walletService.on('error', error => {
-          expect(error.message).toBe(NON_DEPLOYED_CONTRACT)
-          done()
-        })
-
-        walletService.connect('HTTP')
-      })
     })
 
     it('should silently ignore requests to connect again to the same provider', done => {

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -71,7 +71,10 @@ export default function configure(
   let requiredNetwork = 'Dev'
   let requiredNetworkId = 1984
   let requiredConfirmations = 12
-  let unlockAddress = ''
+  // Unlock address by default
+  // Smart contract deployments yield the same address on a "clean" node as long as long as the
+  // migration script runs in the same order.
+  let unlockAddress = '0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B'
   let services = {}
   let supportedProviders = []
   let paywallUrl = runtimeConfig.paywallUrl || 'http://localhost:3000/paywall'
@@ -144,7 +147,7 @@ export default function configure(
       'https://staging.unlock-protocol.com/static/paywall.min.js'
 
     // Address for the Unlock smart contract
-    unlockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+    unlockAddress = '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b'
 
     // rinkeby block time is roughly same as main net
     blockTime = 8000
@@ -172,7 +175,7 @@ export default function configure(
       'https://unlock-protocol.com/static/paywall.min.js'
 
     // Address for the Unlock smart contract
-    unlockAddress = '0x3d5409cce1d45233de1d4ebdee74b8e004abdd13'
+    unlockAddress = '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'
 
     // See https://www.reddit.com/r/ethereum/comments/3c8v2i/what_is_the_expected_block_time/
     blockTime = 8000

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -8,7 +8,6 @@ import UnlockContract from '../artifacts/contracts/Unlock.json'
 import configure from '../config'
 import {
   MISSING_PROVIDER,
-  NON_DEPLOYED_CONTRACT,
   NOT_ENABLED_IN_PROVIDER,
   FAILED_TO_CREATE_LOCK,
   FAILED_TO_PURCHASE_KEY,
@@ -27,9 +26,7 @@ export const keyId = (lock, owner) => [lock, owner].join('-')
 export default class WalletService extends EventEmitter {
   constructor({ providers, unlockAddress } = configure()) {
     super()
-    if (unlockAddress) {
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(unlockAddress)
-    }
+    this.unlockContractAddress = unlockAddress
     this.providers = providers
     this.ready = false
     this.providerName = null
@@ -91,18 +88,6 @@ export default class WalletService extends EventEmitter {
     this.web3 = new Web3(provider)
 
     const networkId = await this.web3.eth.net.getId()
-    // unlockContractAddress is set in the constructor if config provides one in unlockAddress
-    // this is set for staging and production
-    if (!this.unlockContractAddress) {
-      if (UnlockContract.networks[networkId]) {
-        // If we do not have an address from config let's use the artifact files
-        this.unlockContractAddress = Web3Utils.toChecksumAddress(
-          UnlockContract.networks[networkId].address
-        )
-      } else {
-        return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
-      }
-    }
 
     if (this.networkId !== networkId) {
       this.networkId = networkId

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -10,14 +10,12 @@ import UnlockContract from '../artifacts/contracts/Unlock.json'
 
 import configure from '../config'
 import { TRANSACTION_TYPES, MAX_UINT, UNLIMITED_KEYS_COUNT } from '../constants'
-import { NON_DEPLOYED_CONTRACT } from '../errors'
 
 const {
   readOnlyProvider,
   providers,
   unlockAddress,
   blockTime,
-  requiredNetworkId,
   requiredConfirmations,
 } = configure()
 
@@ -36,6 +34,8 @@ export default class Web3Service extends EventEmitter {
     } else {
       this.web3 = new Web3(Object.values(providers)[0]) // Defaulting to the first provider.
     }
+
+    this.unlockContractAddress = unlockContractAddress
 
     // TODO: detect discrepancy in providers
 
@@ -108,19 +108,6 @@ export default class Web3Service extends EventEmitter {
           balance: '0', // Must be expressed in Eth!
         })
       },
-    }
-
-    if (unlockContractAddress) {
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(
-        unlockContractAddress
-      )
-    } else if (UnlockContract.networks[requiredNetworkId]) {
-      // If we do not have an address from config let's use the artifact files
-      this.unlockContractAddress = Web3Utils.toChecksumAddress(
-        UnlockContract.networks[requiredNetworkId].address
-      )
-    } else {
-      return this.emit('error', new Error(NON_DEPLOYED_CONTRACT))
     }
   }
 


### PR DESCRIPTION
Extracting the Unlock smart contract address from the ABI is error prone and forces us to "couple"
the smart contract development cycle with the web application development cycle (include deployments).
This is also work in the context of https://github.com/unlock-protocol/unlock/issues/1842


Refs #1840


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread