### PR TITLE
Refusing to build the application when some env variables are missing

### DIFF
--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -1,3 +1,5 @@
+/* eslint no-console: 0 */
+
 const fs = require('fs')
 const { join } = require('path')
 const { promisify } = require('util')
@@ -5,15 +7,31 @@ const withSourceMaps = require('@zeit/next-source-maps')
 
 const copyFile = promisify(fs.copyFile)
 
+const requiredConfigVariables = {
+  unlockEnv: process.env.UNLOCK_ENV || 'dev',
+  httpProvider: process.env.HTTP_PROVIDER || '127.0.0.1',
+  paywallUrl: process.env.PAYWALL_URL,
+  paywallScriptUrl: process.env.PAYWALL_SCRIPT_URL,
+  readOnlyProvider: process.env.READ_ONLY_PROVIDER,
+  locksmithHost: process.env.LOCKSMITH_URI,
+}
+
+Object.keys(requiredConfigVariables).forEach(configVariableName => {
+  if (!requiredConfigVariables[configVariableName]) {
+    if (['test', 'dev'].indexOf(requiredConfigVariables.unlockEnv) > -1) {
+      console.error(
+        `The configuration variable ${configVariableName} is falsy.`
+      )
+    } else {
+      process.exit(
+        `The application cannot be started because the variable ${configVariableName} is falsy`
+      )
+    }
+  }
+})
+
 module.exports = withSourceMaps({
-  publicRuntimeConfig: {
-    unlockEnv: process.env.UNLOCK_ENV || 'dev',
-    httpProvider: process.env.HTTP_PROVIDER || '127.0.0.1',
-    paywallUrl: process.env.PAYWALL_URL,
-    paywallScriptUrl: process.env.PAYWALL_SCRIPT_URL,
-    readOnlyProvider: process.env.READ_ONLY_PROVIDER,
-    locksmithHost: process.env.LOCKSMITH_URI,
-  },
+  publicRuntimeConfig: requiredConfigVariables,
   webpack(config) {
     return config
   },


### PR DESCRIPTION
This is a way to ensure that the app is only starting if all the required configuration are available.


Fixes #1859


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread