### PR TITLE
passing env variables to the running docker container for tests

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -7,4 +7,9 @@ REPO_ROOT=`dirname "$0"`/..
 DOCKER_COMPOSE_FILE=$REPO_ROOT/docker/docker-compose.ci.yml
 COMMAND="npm run ci"
 
-docker-compose -f $DOCKER_COMPOSE_FILE run -e CI=true $SERVICE $COMMAND
+# We pass only the relevent env vars, which are prefixed with the service name, uppercased
+# UNLOCK_APP_X will be passed to the container for tests in unlock_app as X.
+ENV_VARS_PREFIX="${SERVICE^^}_"
+ENV_VARS=`env | grep $ENV_VARS_PREFIX | awk '{print "-e ",$1}' ORS=' ' | sed -e "s/$ENV_VARS_PREFIX//g"`
+
+docker-compose -f $DOCKER_COMPOSE_FILE run -e CI=true $ENV_VARS $SERVICE $COMMAND


### PR DESCRIPTION
This is required if we want to pass environment variables such as CHROMATIC_APP_CODE for CI.


Refs #1856


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread