### PR TITLE
the service name cannot use dash and needs an underscore

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -9,7 +9,8 @@ COMMAND="npm run ci"
 
 # We pass only the relevent env vars, which are prefixed with the service name, uppercased
 # UNLOCK_APP_X will be passed to the container for tests in unlock_app as X.
-ENV_VARS_PREFIX="${SERVICE^^}_"
+UPCASE_SERVICE="${SERVICE^^}"
+ENV_VARS_PREFIX="${UPCASE_SERVICE//-/_}_"
 ENV_VARS=`env | grep $ENV_VARS_PREFIX | awk '{print "-e ",$1}' ORS=' ' | sed -e "s/$ENV_VARS_PREFIX//g"`
 
 docker-compose -f $DOCKER_COMPOSE_FILE run -e CI=true $ENV_VARS $SERVICE $COMMAND


### PR DESCRIPTION
This is a addendum for #1864 because our CI tool does not let us use - in env variables names.


Refs #1864


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread