### PR TITLE
Passing environment variables to the deploy scripts

### DIFF
--- a/paywall/scripts/deploy-netlify.sh
+++ b/paywall/scripts/deploy-netlify.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
 # This script deploys a static build to netlify.
-# It requires NETLIFY_AUTH_TOKEN to be set, as well as
-# is production in the netlify sense, so it could be on staging.unlock-protocol.com).
+# It requires AUTH_TOKEN and SITE_ID to be set (see details on how to set them using deploy.sh)
 
 APP_PATH=$1
 DEPLOY_ENV=$2
 COMMIT=$3
 PUBLISH=$4
-BUILD_PATH="src/out/";
+BUILD_PATH="out/";
 
 if [ "$DEPLOY_ENV" = "staging" ]; then
   if [ "$PUBLISH" = "true" ]; then
@@ -27,10 +26,13 @@ if [ "$DEPLOY_ENV" = "prod" ]; then
   MESSAGE="Deploying version $COMMIT to production";
 fi
 
-if [ -n "$NETLIFY_SITE_ID" ] && [ -n "$NETLIFY_AUTH_TOKEN" ]; then
+if [ -n "$SITE_ID" ] && [ -n "$AUTH_TOKEN" ]; then
+  # Package
   UNLOCK_ENV="$DEPLOY_ENV" npm run deploy;
+  # And ship!
   echo $MESSAGE
-  netlify deploy -s $NETLIFY_SITE_ID --dir=$BUILD_PATH $PROD --message='$MESSAGE'
+  netlify deploy -s $SITE_ID --dir=$BUILD_PATH $PROD --message='$MESSAGE'
 else
-  echo "Skipping deployment to Netlify ($NETLIFY_SITE_ID)"
+  echo "Failed to deploy to Netlify because we're missing SITE_ID and/or AUTH_TOKEN"
+  exit 1
 fi

--- a/unlock-app/scripts/deploy-netlify.sh
+++ b/unlock-app/scripts/deploy-netlify.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 # This script deploys a static build to netlify.
-# It requires NETLIFY_AUTH_TOKEN to be set, as well as
-# is production in the netlify sense, so it could be on staging.unlock-protocol.com).
+# It requires AUTH_TOKEN and SITE_ID to be set (see details on how to set them using deploy.sh)
 
 APP_PATH=$1
 DEPLOY_ENV=$2
@@ -27,11 +26,13 @@ if [ "$DEPLOY_ENV" = "prod" ]; then
   MESSAGE="Deploying version $COMMIT to production";
 fi
 
-if [ -n "$NETLIFY_SITE_ID" ] && [ -n "$NETLIFY_AUTH_TOKEN" ]; then
+if [ -n "$SITE_ID" ] && [ -n "$AUTH_TOKEN" ]; then
+  # Package
   UNLOCK_ENV="$DEPLOY_ENV" npm run deploy;
-
+  # And ship!
   echo $MESSAGE
-  netlify deploy -s $NETLIFY_SITE_ID --dir=$BUILD_PATH $PROD --message='$MESSAGE'
+  netlify deploy -s $SITE_ID --dir=$BUILD_PATH $PROD --message='$MESSAGE'
 else
-  echo "Skipping deployment to Netlify ($NETLIFY_SITE_ID)"
+  echo "Failed to deploy to Netlify because we're missing SITE_ID and/or AUTH_TOKEN"
+  exit 1
 fi


### PR DESCRIPTION
The deploy script now passes environment variables to the service specific script.
This is a pre-requisite in order to deploy the paywall.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread