### PR TITLE
Refactor paywall to use hooks

### DIFF
--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -17,13 +17,13 @@ import {
 } from '../../paywall-builder/constants'
 import { isPositiveInteger } from '../utils/validators'
 
-export function Paywall({ locks, locked, redirect, window }) {
-  const scrollPosition = useListenForPostMessage(window, {
+export function Paywall({ locks, locked, redirect }) {
+  const scrollPosition = useListenForPostMessage({
     type: 'scrollPosition',
     defaultValue: 0,
     validator: isPositiveInteger,
   })
-  const { postMessage } = usePostMessage(window)
+  const { postMessage } = usePostMessage()
   useEffect(
     () => {
       if (locked) {
@@ -56,7 +56,6 @@ Paywall.propTypes = {
   locks: PropTypes.arrayOf(UnlockPropTypes.lock).isRequired,
   locked: PropTypes.bool.isRequired,
   redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  window: PropTypes.shape({ postMessage: PropTypes.func }).isRequired, // for ease of unit testing
 }
 
 Paywall.defaultProps = {
@@ -85,7 +84,7 @@ export const mapStateToProps = ({ locks, keys, modals, router }) => {
 
   const modalShown = !!modals[locksFromUri.map(l => l.address).join('-')]
   const locked = validKeys.length === 0 || modalShown
-  return { locked, locks: locksFromUri, redirect, window }
+  return { locked, locks: locksFromUri, redirect }
 }
 
 export default connect(mapStateToProps)(Paywall)

--- a/paywall/src/components/lock/Overlay.js
+++ b/paywall/src/components/lock/Overlay.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux'
 import Lock from './Lock'
 import UnlockPropTypes from '../../propTypes'
 import { hideModal, showModal } from '../../actions/modal'
-import { unlockPage } from '../../services/iframeService'
 import { LockedFlag } from './UnlockFlag'
 import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import { mapErrorToComponent } from '../creator/FatalError'
@@ -82,8 +81,7 @@ export const mapStateToProps = ({ account }) => ({
 
 export const mapDispatchToProps = (dispatch, { locks }) => ({
   hideModal: () => {
-    unlockPage()
-    return dispatch(hideModal(locks.map(l => l.address).join('-')))
+    dispatch(hideModal(locks.map(l => l.address).join('-')))
   },
   showModal: () => {
     dispatch(showModal(locks.map(l => l.address).join('-')))

--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -47,7 +47,6 @@ export default function useListenForPostMessage({
   const { isInIframe, isServer } = useConfig()
   const parent = window && window.parent
   const [data, setData] = useState(defaultValue)
-
   const saveData = event => {
     // origin is passed in by the paywall, see paywall-builder/build.js
     const { origin } = getRouteFromWindow(window)

--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -47,6 +47,7 @@ export default function useListenForPostMessage({
   const { isInIframe, isServer } = useConfig()
   const parent = window && window.parent
   const [data, setData] = useState(defaultValue)
+
   const saveData = event => {
     // origin is passed in by the paywall, see paywall-builder/build.js
     const { origin } = getRouteFromWindow(window)

--- a/paywall/src/services/iframeService.js
+++ b/paywall/src/services/iframeService.js
@@ -1,7 +1,0 @@
-export const lockPage = () => {
-  window.parent.postMessage('locked', '*')
-}
-
-export const unlockPage = () => {
-  window.parent.postMessage('unlocked', '*')
-}


### PR DESCRIPTION
# Description

This replaces the `iframeService` with hooks inside `Paywall`. Screenshots show it working. The key lines to look at are:

```js
  const scrollPosition = useListenForPostMessage({
    type: 'scrollPosition',
    defaultValue: 0,
    validator: isPositiveInteger,
  })
  const { postMessage } = usePostMessage()
  useEffect(
    () => {
      if (locked) {
        postMessage(POST_MESSAGE_LOCKED)
      } else {
        postMessage(POST_MESSAGE_UNLOCKED)
      }
    },
    [locked]
  )
```

These lines declaratively get the current scrollPosition, validating it to confirm it is a positive integer, and returning `0` if a scrollPosition postMessage has not yet been received. Then, it posts the locked status to the paywall, again declaratively. All of the implementation details are in the custom hooks.

<img width="1675" alt="screen shot 2019-03-04 at 1 14 37 pm" src="https://user-images.githubusercontent.com/98250/53753533-7ec32e00-3e7f-11e9-8471-d744515d8176.png">
<img width="1675" alt="screen shot 2019-03-04 at 1 14 32 pm" src="https://user-images.githubusercontent.com/98250/53753534-7ec32e00-3e7f-11e9-9d47-414732cd0e6d.png">
<img width="1675" alt="screen shot 2019-03-04 at 1 14 09 pm" src="https://user-images.githubusercontent.com/98250/53753535-7ec32e00-3e7f-11e9-84fd-e18e71e32e33.png">
<img width="1675" alt="screen shot 2019-03-04 at 1 14 01 pm" src="https://user-images.githubusercontent.com/98250/53753536-7ec32e00-3e7f-11e9-8aab-93b80b543293.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1744 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
