### PR TITLE
KEY_PURCHASE transactions now have the lock address

### DIFF
--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -901,6 +901,31 @@ describe('Web3Service', () => {
       )
     })
 
+    it('should handle Transfer and also emit transaction.updated', done => {
+      expect.assertions(2)
+      const transactionHash = '0x123'
+      const contractAddress = '0x456'
+      const blockNumber = 1337
+
+      const params = {
+        _to: '0x789',
+      }
+
+      web3Service.once('transaction.updated', (transactionHash, update) => {
+        expect(update.lock).toBe(contractAddress)
+        expect(update.key).toBe('0x456-0x789')
+        done()
+      })
+
+      web3Service.emitContractEvent(
+        transactionHash,
+        contractAddress,
+        blockNumber,
+        'Transfer',
+        params
+      )
+    })
+
     it('should handle PriceChanged and emit key.save', done => {
       expect.assertions(3)
       const transactionHash = '0x123'

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -111,7 +111,7 @@ export default class Web3Service extends EventEmitter {
           balance: '0', // Must be expressed in Eth!
         })
       },
-      purchaseFor: async (transactionHash, contractAddress, params) => {
+      purchaseFor: async (transactionHash, contractAddress) => {
         this.emit('transaction.updated', transactionHash, {
           lock: contractAddress,
         })

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -54,6 +54,7 @@ export default class Web3Service extends EventEmitter {
         const owner = args._to
         this.emit('transaction.updated', transactionHash, {
           key: keyId(contractAddress, owner),
+          lock: contractAddress,
         })
         return this.emit('key.saved', keyId(contractAddress, owner), {
           lock: contractAddress,

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -110,6 +110,11 @@ export default class Web3Service extends EventEmitter {
           balance: '0', // Must be expressed in Eth!
         })
       },
+      purchaseFor: async (transactionHash, contractAddress, params) => {
+        this.emit('transaction.updated', transactionHash, {
+          lock: contractAddress,
+        })
+      },
     }
   }
 

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -111,11 +111,6 @@ export default class Web3Service extends EventEmitter {
           balance: '0', // Must be expressed in Eth!
         })
       },
-      purchaseFor: async (transactionHash, contractAddress) => {
-        this.emit('transaction.updated', transactionHash, {
-          lock: contractAddress,
-        })
-      },
     }
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR is a second, hopefully cleaner, pass at what #1707 tried to do. When we pull in transactions, any key purchase should have a field that identifies which lock it is associated with.

There is some additional work needed on the log page, however:
#1707 also tried to fix the issue of accidentally mutating the redux state. This PR does not, so that fix will have to come in a later PR.

This is now ready for review, and is much smaller and simpler than the draft PR. Still could use some advice on testing; it actually looks like the handlers aren't directly tested currently.

<img width="514" alt="image" src="https://user-images.githubusercontent.com/9300702/53766618-51877780-3ea1-11e9-9dc4-342ae9a5c64c.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1834 #1704 
Refs #1707

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
