### PR TITLE
fixing unlimited key count

### DIFF
--- a/paywall/src/__tests__/services/web3Service.test.js
+++ b/paywall/src/__tests__/services/web3Service.test.js
@@ -690,7 +690,6 @@ describe('Web3Service', () => {
           keyPrice: Web3Utils.fromWei('10000000000000000', 'ether'),
           expirationDuration: 2592000,
           maxNumberOfKeys: 10,
-          unlimitedKeys: false,
           owner: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
           outstandingKeys: 17,
           asOf: 1337,
@@ -735,7 +734,6 @@ describe('Web3Service', () => {
         expect(address).toBe(lockAddress)
         expect(update).toMatchObject({
           maxNumberOfKeys: -1,
-          unlimitedKeys: true,
         })
         done()
       })

--- a/paywall/src/services/web3Service.js
+++ b/paywall/src/services/web3Service.js
@@ -98,6 +98,11 @@ export default class Web3Service extends EventEmitter {
         this.emit('transaction.updated', transactionHash, {
           lock: newLockAddress,
         })
+
+        if (params._maxNumberOfKeys === MAX_UINT) {
+          params._maxNumberOfKeys = UNLIMITED_KEYS_COUNT
+        }
+
         this.emit('lock.updated', newLockAddress, {
           transaction: transactionHash,
           address: newLockAddress,
@@ -541,7 +546,6 @@ export default class Web3Service extends EventEmitter {
 
     // Once all lock attributes have been fetched
     return Promise.all(constantPromises).then(() => {
-      update.unlimitedKeys = update.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
       this.emit('lock.updated', address, update)
       return update
     })

--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -11,7 +11,7 @@ import {
 } from '../../actions/transaction'
 import { SET_ERROR } from '../../actions/error'
 import { SET_KEYS_ON_PAGE_FOR_LOCK } from '../../actions/keysPages'
-import { PGN_ITEMS_PER_PAGE } from '../../constants'
+import { PGN_ITEMS_PER_PAGE, UNLIMITED_KEYS_COUNT } from '../../constants'
 
 /**
  * Fake state
@@ -180,6 +180,31 @@ describe('Lock middleware', () => {
           type: ADD_LOCK,
           address: lock.address,
           lock: update,
+        })
+      )
+    })
+
+    it('it should ADD_LOCK with the right unlimitedKey field', () => {
+      expect.assertions(1)
+      const { store } = create()
+      const lock = {
+        address: '0x123',
+      }
+
+      const update = {
+        maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+      }
+      mockWeb3Service.getKeyByLockForOwner = jest.fn()
+
+      mockWeb3Service.emit('lock.updated', lock.address, update)
+      expect(store.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: ADD_LOCK,
+          address: lock.address,
+          lock: expect.objectContaining({
+            maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+            unlimitedKeys: true,
+          }),
         })
       )
     })

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -690,7 +690,6 @@ describe('Web3Service', () => {
           keyPrice: Web3Utils.fromWei('10000000000000000', 'ether'),
           expirationDuration: 2592000,
           maxNumberOfKeys: 10,
-          unlimitedKeys: false,
           owner: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
           outstandingKeys: 17,
           asOf: 1337,
@@ -735,7 +734,6 @@ describe('Web3Service', () => {
         expect(address).toBe(lockAddress)
         expect(update).toMatchObject({
           maxNumberOfKeys: -1,
-          unlimitedKeys: true,
         })
         done()
       })

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -18,7 +18,7 @@ import {
   ADD_TRANSACTION,
   NEW_TRANSACTION,
 } from '../actions/transaction'
-import { PGN_ITEMS_PER_PAGE } from '../constants'
+import { PGN_ITEMS_PER_PAGE, UNLIMITED_KEYS_COUNT } from '../constants'
 
 import Web3Service from '../services/web3Service'
 import {
@@ -52,6 +52,12 @@ export default function web3Middleware({ getState, dispatch }) {
    */
   web3Service.on('lock.updated', (address, update) => {
     const lock = getState().locks[address]
+
+    // Our app defines a unlimitedKeys boolean
+    if (update.maxNumberOfKeys) {
+      update.unlimitedKeys = update.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
+    }
+
     if (lock) {
       // Only dispatch the updates which are more recent than the current value
       if (!lock.asOf || lock.asOf < update.asOf) {

--- a/unlock-app/src/propTypes.js
+++ b/unlock-app/src/propTypes.js
@@ -18,6 +18,7 @@ export const lock = PropTypes.shape({
   owner: PropTypes.string,
   outstandingKeys: PropTypes.number,
   balance: PropTypes.string, // Must be expressed in Eth!
+  unlimitedKeys: PropTypes.bool,
 })
 
 export const transaction = PropTypes.shape({

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -98,6 +98,11 @@ export default class Web3Service extends EventEmitter {
         this.emit('transaction.updated', transactionHash, {
           lock: newLockAddress,
         })
+
+        if (params._maxNumberOfKeys === MAX_UINT) {
+          params._maxNumberOfKeys = UNLIMITED_KEYS_COUNT
+        }
+
         this.emit('lock.updated', newLockAddress, {
           transaction: transactionHash,
           address: newLockAddress,
@@ -541,7 +546,6 @@ export default class Web3Service extends EventEmitter {
 
     // Once all lock attributes have been fetched
     return Promise.all(constantPromises).then(() => {
-      update.unlimitedKeys = update.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
       this.emit('lock.updated', address, update)
       return update
     })


### PR DESCRIPTION
We wre not setting the unlimitedKeys flag in the right part (only on locks being read from chain) which
meant that we are not detecting it on lock creations.


Fixes #1880



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread