### PR TITLE
Rename smart-contract test cases to be more descriptive

### DIFF
--- a/smart-contracts/test/Lock/Lock.js
+++ b/smart-contracts/test/Lock/Lock.js
@@ -6,7 +6,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock', accounts => {
+contract('Lock / Lock', accounts => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {

--- a/smart-contracts/test/Lock/Non_Public_purchaseFor.js
+++ b/smart-contracts/test/Lock/Non_Public_purchaseFor.js
@@ -7,7 +7,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock', (accounts) => {
+contract('Lock / Non_Public_purchaseFor', (accounts) => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -19,16 +19,14 @@ contract('Lock', (accounts) => {
       })
   })
 
-  describe('purchaseFor', () => {
-    // from purchaseFor.js, ln#23:
-    describe.skip('if the contract has a private key release', () => {
-      it('should fail', async () => {
-        const lock = locks['PRIVATE']
-        await shouldFail(lock
-          .purchaseFor(accounts[0], Web3Utils.toHex('Julien')), '')
-        // Making sure we do not have a key set!
-        await shouldFail(lock.keyExpirationTimestampFor.call(accounts[0]), '')
-      })
+  // from purchaseFor.js, ln#23:
+  describe.skip('if the contract has a private key release', () => {
+    it('should fail', async () => {
+      const lock = locks['PRIVATE']
+      await shouldFail(lock
+        .purchaseFor(accounts[0], Web3Utils.toHex('Julien')), '')
+      // Making sure we do not have a key set!
+      await shouldFail(lock.keyExpirationTimestampFor.call(accounts[0]), '')
     })
   })
 

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -7,140 +7,138 @@ const shouldFail = require('../helpers/shouldFail')
 const Unlock = artifacts.require('../Unlock.sol')
 let unlock, locks
 
-contract('Lock', (accounts) => {
+contract('Lock / cancelAndRefund', (accounts) => {
   before(async () => {
     unlock = await Unlock.deployed()
     locks = await deployLocks(unlock, accounts[0])
   })
 
-  describe('cancelAndRefund', () => {
-    let lock
-    const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
-    const keyPrice = new BigNumber(Units.convert(0.01, 'eth', 'wei'))
-    let lockOwner
+  let lock
+  const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
+  const keyPrice = new BigNumber(Units.convert(0.01, 'eth', 'wei'))
+  let lockOwner
+
+  before(async () => {
+    lock = locks['SECOND']
+    const purchases = keyOwners.map((account) => {
+      return lock.purchaseFor(account, Web3Utils.toHex(''), {
+        value: keyPrice.toFixed(),
+        from: account
+      })
+    })
+    await Promise.all(purchases)
+    lockOwner = await lock.owner.call()
+  })
+
+  it('should return the correct penalty', async () => {
+    const penalty = await lock.refundPenaltyDenominator.call()
+    assert.equal(penalty, 10) // default of 10%
+  })
+
+  it('the amount of refund should be less than the original keyPrice', async () => {
+    const estimatedRefund = new BigNumber(await lock.getCancelAndRefundValueFor.call(keyOwners[0]))
+    assert(estimatedRefund.lt(keyPrice))
+  })
+
+  describe('should cancel and refund when enough time remains', () => {
+    let initialLockBalance, initialKeyOwnerBalance, estimatedRefund, txObj, withdrawalAmount
 
     before(async () => {
-      lock = locks['SECOND']
-      const purchases = keyOwners.map((account) => {
-        return lock.purchaseFor(account, Web3Utils.toHex(''), {
-          value: keyPrice.toFixed(),
-          from: account
-        })
+      initialLockBalance = new BigNumber(await web3.eth.getBalance(lock.address))
+      initialKeyOwnerBalance = new BigNumber(await web3.eth.getBalance(keyOwners[0]))
+      estimatedRefund = new BigNumber(await lock.getCancelAndRefundValueFor.call(keyOwners[0]))
+      txObj = await lock.cancelAndRefund({
+        from: keyOwners[0]
       })
-      await Promise.all(purchases)
-      lockOwner = await lock.owner.call()
+      withdrawalAmount = new BigNumber(await web3.eth.getBalance(lock.address)).minus(initialLockBalance)
+    })
+
+    it('should emit a CancelKey event', async () => {
+      assert.equal(txObj.logs[0].event, 'CancelKey')
+    })
+
+    it('the amount of refund should be greater than 0', async () => {
+      const refund = new BigNumber(txObj.logs[0].args.refund)
+      assert(refund.gt(0))
+    })
+
+    it('the amount of refund should be less than or equal to the original key price', async () => {
+      const refund = new BigNumber(txObj.logs[0].args.refund)
+      assert(refund.lt(keyPrice))
+    })
+
+    it('the amount of refund should be less than or equal to the estimated refund', async () => {
+      const refund = new BigNumber(txObj.logs[0].args.refund)
+      assert(refund.lte(estimatedRefund))
+    })
+
+    it('should make the key no longer valid (i.e. expired)', async () => {
+      const isValid = await lock.getHasValidKey.call(keyOwners[0])
+      assert.equal(isValid, false)
+    })
+
+    it('should increase the owner\'s balance with the amount of funds withdrawn from the lock', async () => {
+      const txHash = await web3.eth.getTransaction(txObj.tx)
+      const gasUsed = new BigNumber(txObj.receipt.gasUsed)
+      const gasPrice = new BigNumber(txHash.gasPrice)
+      const txFee = gasPrice.times(gasUsed)
+      const finalOwnerBalance = new BigNumber(await web3.eth.getBalance(keyOwners[0]))
+      assert(finalOwnerBalance.toFixed(), initialKeyOwnerBalance.plus(withdrawalAmount).minus(txFee).toFixed())
+    })
+  })
+
+  describe('allows the Lock owner to specify a different cancelation penalty', () => {
+    let tx
+
+    before(async () => {
+      tx = await lock.updateRefundPenaltyDenominator(5) // 20%
+    })
+
+    it('should trigger an event', async () => {
+      const event = tx.logs.find((log) => {
+        return log.event === 'RefundPenaltyDenominatorChanged'
+      })
+      assert.equal(new BigNumber(event.args.oldPenaltyDenominator).toFixed(), 10)
+      assert.equal(new BigNumber(event.args.refundPenaltyDenominator).toFixed(), 5)
     })
 
     it('should return the correct penalty', async () => {
       const penalty = await lock.refundPenaltyDenominator.call()
-      assert.equal(penalty, 10) // default of 10%
+      assert.equal(penalty, 5) // updated to 20%
     })
 
-    it('the amount of refund should be less than the original keyPrice', async () => {
-      const estimatedRefund = new BigNumber(await lock.getCancelAndRefundValueFor.call(keyOwners[0]))
-      assert(estimatedRefund.lt(keyPrice))
+    it('should still allow refund', async () => {
+      const txObj = await lock.cancelAndRefund({
+        from: keyOwners[2]
+      })
+      const refund = new BigNumber(txObj.logs[0].args.refund)
+      assert(refund.gt(0))
+    })
+  })
+
+  describe('should fail when', () => {
+    it('should fail if the Lock owner withdraws too much funds', async () => {
+      await lock.withdraw({
+        from: lockOwner
+      })
+      await shouldFail(lock.cancelAndRefund({
+        from: keyOwners[3]
+      }), '')
     })
 
-    describe('should cancel and refund when enough time remains', () => {
-      let initialLockBalance, initialKeyOwnerBalance, estimatedRefund, txObj, withdrawalAmount
-
-      before(async () => {
-        initialLockBalance = new BigNumber(await web3.eth.getBalance(lock.address))
-        initialKeyOwnerBalance = new BigNumber(await web3.eth.getBalance(keyOwners[0]))
-        estimatedRefund = new BigNumber(await lock.getCancelAndRefundValueFor.call(keyOwners[0]))
-        txObj = await lock.cancelAndRefund({
-          from: keyOwners[0]
-        })
-        withdrawalAmount = new BigNumber(await web3.eth.getBalance(lock.address)).minus(initialLockBalance)
+    it('the key is expired', async () => {
+      await lock.expireKeyFor(keyOwners[3], {
+        from: lockOwner
       })
-
-      it('should emit a CancelKey event', async () => {
-        assert.equal(txObj.logs[0].event, 'CancelKey')
-      })
-
-      it('the amount of refund should be greater than 0', async () => {
-        const refund = new BigNumber(txObj.logs[0].args.refund)
-        assert(refund.gt(0))
-      })
-
-      it('the amount of refund should be less than or equal to the original key price', async () => {
-        const refund = new BigNumber(txObj.logs[0].args.refund)
-        assert(refund.lt(keyPrice))
-      })
-
-      it('the amount of refund should be less than or equal to the estimated refund', async () => {
-        const refund = new BigNumber(txObj.logs[0].args.refund)
-        assert(refund.lte(estimatedRefund))
-      })
-
-      it('should make the key no longer valid (i.e. expired)', async () => {
-        const isValid = await lock.getHasValidKey.call(keyOwners[0])
-        assert.equal(isValid, false)
-      })
-
-      it('should increase the owner\'s balance with the amount of funds withdrawn from the lock', async () => {
-        const txHash = await web3.eth.getTransaction(txObj.tx)
-        const gasUsed = new BigNumber(txObj.receipt.gasUsed)
-        const gasPrice = new BigNumber(txHash.gasPrice)
-        const txFee = gasPrice.times(gasUsed)
-        const finalOwnerBalance = new BigNumber(await web3.eth.getBalance(keyOwners[0]))
-        assert(finalOwnerBalance.toFixed(), initialKeyOwnerBalance.plus(withdrawalAmount).minus(txFee).toFixed())
-      })
+      await shouldFail(lock.cancelAndRefund({
+        from: keyOwners[3]
+      }), 'KEY_NOT_VALID')
     })
 
-    describe('allows the Lock owner to specify a different cancelation penalty', () => {
-      let tx
-
-      before(async () => {
-        tx = await lock.updateRefundPenaltyDenominator(5) // 20%
-      })
-
-      it('should trigger an event', async () => {
-        const event = tx.logs.find((log) => {
-          return log.event === 'RefundPenaltyDenominatorChanged'
-        })
-        assert.equal(new BigNumber(event.args.oldPenaltyDenominator).toFixed(), 10)
-        assert.equal(new BigNumber(event.args.refundPenaltyDenominator).toFixed(), 5)
-      })
-
-      it('should return the correct penalty', async () => {
-        const penalty = await lock.refundPenaltyDenominator.call()
-        assert.equal(penalty, 5) // updated to 20%
-      })
-
-      it('should still allow refund', async () => {
-        const txObj = await lock.cancelAndRefund({
-          from: keyOwners[2]
-        })
-        const refund = new BigNumber(txObj.logs[0].args.refund)
-        assert(refund.gt(0))
-      })
-    })
-
-    describe('should fail when', () => {
-      it('should fail if the Lock owner withdraws too much funds', async () => {
-        await lock.withdraw({
-          from: lockOwner
-        })
-        await shouldFail(lock.cancelAndRefund({
-          from: keyOwners[3]
-        }), '')
-      })
-
-      it('the key is expired', async () => {
-        await lock.expireKeyFor(keyOwners[3], {
-          from: lockOwner
-        })
-        await shouldFail(lock.cancelAndRefund({
-          from: keyOwners[3]
-        }), 'KEY_NOT_VALID')
-      })
-
-      it('the owner does not have a key', async () => {
-        await shouldFail(lock.cancelAndRefund({
-          from: accounts[7]
-        }), 'KEY_NOT_VALID')
-      })
+    it('the owner does not have a key', async () => {
+      await shouldFail(lock.cancelAndRefund({
+        from: accounts[7]
+      }), 'KEY_NOT_VALID')
     })
   })
 })

--- a/smart-contracts/test/Lock/destroyLock.js
+++ b/smart-contracts/test/Lock/destroyLock.js
@@ -8,7 +8,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock', accounts => {
+contract('Lock / destroyLock', accounts => {
   let lock
 
   before(async () => {
@@ -17,105 +17,103 @@ contract('Lock', accounts => {
     lock = locks['FIRST']
   })
 
-  describe('destroyLock', () => {
-    it('should fail if called by the wrong account', async () => {
-      await shouldFail(lock.destroyLock({ from: accounts[1] }), '')
+  it('should fail if called by the wrong account', async () => {
+    await shouldFail(lock.destroyLock({ from: accounts[1] }), '')
+  })
+
+  describe('when called by the owner', () => {
+    let initialLockBalance, initialOwnerBalance, txObj, event
+
+    before(async () => {
+      await lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
+        value: Units.convert('0.01', 'eth', 'wei')
+      })
+      assert.equal(await lock.getHasValidKey.call(accounts[1]), true) // pre-req
+
+      initialLockBalance = new BigNumber(
+        await web3.eth.getBalance(lock.address)
+      )
+      initialOwnerBalance = new BigNumber(
+        await web3.eth.getBalance(accounts[0])
+      )
+      await lock.disableLock() // We can't destroy a lock without first disabling it
+      txObj = await lock.destroyLock({ from: accounts[0] })
+      event = txObj.logs[0]
     })
 
-    describe('when called by the owner', () => {
-      let initialLockBalance, initialOwnerBalance, txObj, event
+    it('owner should have received funds from the contract', async () => {
+      const finalOwnerBalance = new BigNumber(
+        await web3.eth.getBalance(accounts[0])
+      )
+      assert(finalOwnerBalance.gt(initialOwnerBalance))
+    })
 
-      before(async () => {
+    it('contract should no longer have any funds', async () => {
+      const finalLockBalance = new BigNumber(
+        await web3.eth.getBalance(lock.address)
+      )
+      assert.equal(finalLockBalance.toFixed(), 0)
+    })
+
+    it('should trigger the Destroy event', () => {
+      assert.equal(event.event, 'Destroy')
+      assert.equal(new BigNumber(event.args.balance).toFixed(), initialLockBalance.toFixed())
+      assert.equal(event.args.owner, accounts[0])
+    })
+
+    it('previously valid key is no longer valid', async () => {
+      if (!process.env.TEST_COVERAGE) {
+        try {
+          await lock.getHasValidKey.call(accounts[1])
+        } catch (e) {
+          assert.equal(
+            e,
+            'Error: Returned values aren\'t valid, did it run Out of Gas?'
+          )
+        }
+      } else {
+        try {
+          await lock.getHasValidKey.call(accounts[1])
+        } catch (e) {
+          assert(e.message.endsWith('is not a contract address'))
+          return
+        }
+        throw new Error('Expected error')
+      }
+    })
+
+    // After selfdestruct, a user can't buy a key, but if they try they loose their money.
+    it('does not allow people to purchase new keys', async () => {
+      if (!process.env.TEST_COVERAGE) {
+        let initialLockBalance = new BigNumber(
+          await web3.eth.getBalance(lock.address)
+        ).toFixed()
+        assert.equal(initialLockBalance, 0)
+
+        // This line does not fail, but instead calls the fallback function and sends msg.value to the destroyed contract.
         await lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
           value: Units.convert('0.01', 'eth', 'wei')
         })
-        assert.equal(await lock.getHasValidKey.call(accounts[1]), true) // pre-req
 
-        initialLockBalance = new BigNumber(
+        let finalLockBalance = new BigNumber(
           await web3.eth.getBalance(lock.address)
-        )
-        initialOwnerBalance = new BigNumber(
-          await web3.eth.getBalance(accounts[0])
-        )
-        await lock.disableLock() // We can't destroy a lock without first disabling it
-        txObj = await lock.destroyLock({ from: accounts[0] })
-        event = txObj.logs[0]
-      })
+        ).toFixed()
+        assert.equal(finalLockBalance, 10000000000000000)
 
-      it('owner should have received funds from the contract', async () => {
-        const finalOwnerBalance = new BigNumber(
-          await web3.eth.getBalance(accounts[0])
-        )
-        assert(finalOwnerBalance.gt(initialOwnerBalance))
-      })
-
-      it('contract should no longer have any funds', async () => {
-        const finalLockBalance = new BigNumber(
-          await web3.eth.getBalance(lock.address)
-        )
-        assert.equal(finalLockBalance.toFixed(), 0)
-      })
-
-      it('should trigger the Destroy event', () => {
-        assert.equal(event.event, 'Destroy')
-        assert.equal(new BigNumber(event.args.balance).toFixed(), initialLockBalance.toFixed())
-        assert.equal(event.args.owner, accounts[0])
-      })
-
-      it('previously valid key is no longer valid', async () => {
-        if (!process.env.TEST_COVERAGE) {
-          try {
-            await lock.getHasValidKey.call(accounts[1])
-          } catch (e) {
-            assert.equal(
-              e,
-              'Error: Returned values aren\'t valid, did it run Out of Gas?'
-            )
-          }
-        } else {
-          try {
-            await lock.getHasValidKey.call(accounts[1])
-          } catch (e) {
-            assert(e.message.endsWith('is not a contract address'))
-            return
-          }
-          throw new Error('Expected error')
-        }
-      })
-
-      // After selfdestruct, a user can't buy a key, but if they try they loose their money.
-      it('does not allow people to purchase new keys', async () => {
-        if (!process.env.TEST_COVERAGE) {
-          let initialLockBalance = new BigNumber(
-            await web3.eth.getBalance(lock.address)
-          ).toFixed()
-          assert.equal(initialLockBalance, 0)
-
-          // This line does not fail, but instead calls the fallback function and sends msg.value to the destroyed contract.
+        // The user did not purchase a key, but still sent their eth to the contract.
+        // Calling getHasValidKey will fail
+        // assert.equal(await lock.getHasValidKey.call(accounts[1]), false)
+      } else {
+        try {
           await lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
             value: Units.convert('0.01', 'eth', 'wei')
           })
-
-          let finalLockBalance = new BigNumber(
-            await web3.eth.getBalance(lock.address)
-          ).toFixed()
-          assert.equal(finalLockBalance, 10000000000000000)
-
-          // The user did not purchase a key, but still sent their eth to the contract.
-          // Calling getHasValidKey will fail
-          // assert.equal(await lock.getHasValidKey.call(accounts[1]), false)
-        } else {
-          try {
-            await lock.purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
-              value: Units.convert('0.01', 'eth', 'wei')
-            })
-          } catch (e) {
-            assert(e.message.endsWith('is not a contract address'))
-            return
-          }
-          throw new Error('Expected error')
+        } catch (e) {
+          assert(e.message.endsWith('is not a contract address'))
+          return
         }
-      })
+        throw new Error('Expected error')
+      }
     })
   })
 })

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -7,7 +7,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks, ID
 
-contract('Lock', accounts => {
+contract('Lock / disableLock', accounts => {
   let lock
   let keyOwner = accounts[1]
   let keyOwner2 = accounts[2]
@@ -25,145 +25,143 @@ contract('Lock', accounts => {
     ID = new BigNumber(await lock.getTokenIdFor(keyOwner)).toFixed()
   })
 
-  describe('disableLock', () => {
-    it('should fail if called by the wrong account', async () => {
-      await shouldFail(lock.disableLock({ from: keyOwner }), '')
+  it('should fail if called by the wrong account', async () => {
+    await shouldFail(lock.disableLock({ from: keyOwner }), '')
+  })
+
+  it('should fail if called before the lock is disabled', async () => {
+    await shouldFail(
+      lock.destroyLock(),
+      'DISABLE_FIRST'
+    )
+  })
+
+  describe('when the lock has been disabled', () => {
+    let txObj, event
+    before(async () => {
+      txObj = await lock.disableLock({ from: accounts[0] })
+      event = txObj.logs[0]
     })
 
-    it('should fail if called before the lock is disabled', async () => {
+    it('should trigger the Disable event', () => {
+      assert.equal(event.event, 'Disable')
+    })
+
+    it('should fail if called while lock is disabled', async () => {
       await shouldFail(
-        lock.destroyLock(),
-        'DISABLE_FIRST'
+        lock.disableLock(),
+        'LOCK_DEPRECATED'
       )
     })
 
-    describe('when the lock has been disabled', () => {
-      let txObj, event
-      before(async () => {
-        txObj = await lock.disableLock({ from: accounts[0] })
-        event = txObj.logs[0]
-      })
+    it('should fail if a user tries to purchase a key', async () => {
+      await shouldFail(
+        lock.purchaseFor(keyOwner, Web3Utils.toHex('Julien'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        }),
+        'LOCK_DEPRECATED'
+      )
+    })
 
-      it('should trigger the Disable event', () => {
-        assert.equal(event.event, 'Disable')
-      })
-
-      it('should fail if called while lock is disabled', async () => {
-        await shouldFail(
-          lock.disableLock(),
-          'LOCK_DEPRECATED'
-        )
-      })
-
-      it('should fail if a user tries to purchase a key', async () => {
-        await shouldFail(
-          lock.purchaseFor(keyOwner, Web3Utils.toHex('Julien'), {
+    it('should fail if a user tries to purchase a key with a referral', async () => {
+      await shouldFail(
+        lock.purchaseForFrom(
+          keyOwner,
+          accounts[3],
+          Web3Utils.toHex('Julien'),
+          {
             value: Units.convert('0.01', 'eth', 'wei')
-          }),
-          'LOCK_DEPRECATED'
-        )
-      })
+          }
+        ),
+        'LOCK_DEPRECATED'
+      )
+    })
 
-      it('should fail if a user tries to purchase a key with a referral', async () => {
-        await shouldFail(
-          lock.purchaseForFrom(
-            keyOwner,
-            accounts[3],
-            Web3Utils.toHex('Julien'),
-            {
-              value: Units.convert('0.01', 'eth', 'wei')
-            }
-          ),
-          'LOCK_DEPRECATED'
-        )
-      })
+    it('should fail if a user tries to transfer a key', async () => {
+      await shouldFail(
+        lock.transferFrom(keyOwner, accounts[3], ID, {
+          from: keyOwner,
+          value: Units.convert('0.01', 'eth', 'wei')
+        }),
+        'LOCK_DEPRECATED'
+      )
+    })
 
-      it('should fail if a user tries to transfer a key', async () => {
-        await shouldFail(
-          lock.transferFrom(keyOwner, accounts[3], ID, {
-            from: keyOwner,
-            value: Units.convert('0.01', 'eth', 'wei')
-          }),
-          'LOCK_DEPRECATED'
-        )
-      })
-
-      it('should fail if a key owner tries to a approve an address', async () => {
-        await shouldFail(
-          lock.approve(accounts[3], ID, {
-            from: keyOwner
-          }),
-          'LOCK_DEPRECATED'
-        )
-      })
-
-      it('should still allow access to non-payable contract functions', async () => {
-        let HasValidKey = await lock.getHasValidKey.call(keyOwner)
-        assert.equal(HasValidKey, true)
-      })
-
-      it('Key owners can still cancel for a partial refund', async () => {
-        await lock.cancelAndRefund({
+    it('should fail if a key owner tries to a approve an address', async () => {
+      await shouldFail(
+        lock.approve(accounts[3], ID, {
           from: keyOwner
-        })
-      })
+        }),
+        'LOCK_DEPRECATED'
+      )
+    })
 
-      it('Lock owner can still partialWithdraw', async () => {
-        await lock.partialWithdraw(1)
-      })
+    it('should still allow access to non-payable contract functions', async () => {
+      let HasValidKey = await lock.getHasValidKey.call(keyOwner)
+      assert.equal(HasValidKey, true)
+    })
 
-      it('Lock owner can still withdraw', async () => {
-        await lock.withdraw()
+    it('Key owners can still cancel for a partial refund', async () => {
+      await lock.cancelAndRefund({
+        from: keyOwner
       })
+    })
 
-      it('Lock owner can still expireKeyFor', async () => {
-        await lock.expireKeyFor(keyOwner2)
-      })
+    it('Lock owner can still partialWithdraw', async () => {
+      await lock.partialWithdraw(1)
+    })
 
-      it('Lock owner can still updateLockName', async () => {
-        await lock.updateLockName('Hardly')
-      })
+    it('Lock owner can still withdraw', async () => {
+      await lock.withdraw()
+    })
 
-      it('Lock owner can still updateRefundPenaltyDenominator', async () => {
-        await lock.updateRefundPenaltyDenominator(5)
-      })
+    it('Lock owner can still expireKeyFor', async () => {
+      await lock.expireKeyFor(keyOwner2)
+    })
 
-      it('should fail to setApprovalForAll', async () => {
-        await shouldFail(
-          lock.setApprovalForAll(accounts[3], true, {
-            from: keyOwner
-          }),
-          'LOCK_DEPRECATED'
-        )
-      })
+    it('Lock owner can still updateLockName', async () => {
+      await lock.updateLockName('Hardly')
+    })
 
-      it('should fail to updateKeyPrice', async () => {
-        await shouldFail(
-          lock.updateKeyPrice(1),
-          'LOCK_DEPRECATED'
-        )
-      })
+    it('Lock owner can still updateRefundPenaltyDenominator', async () => {
+      await lock.updateRefundPenaltyDenominator(5)
+    })
 
-      it('should fail to safeTransferFrom w/o data', async () => {
-        await shouldFail(
-          lock.safeTransferFrom(keyOwner, accounts[3], ID, {
-            from: keyOwner,
-            value: Units.convert('0.01', 'eth', 'wei')
-          }),
-          'LOCK_DEPRECATED'
-        )
-      })
+    it('should fail to setApprovalForAll', async () => {
+      await shouldFail(
+        lock.setApprovalForAll(accounts[3], true, {
+          from: keyOwner
+        }),
+        'LOCK_DEPRECATED'
+      )
+    })
 
-      it('should fail to safeTransferFrom w/ data', async () => {
-        ID = await lock.getTokenIdFor.call(keyOwner)
-        await shouldFail(
-          lock.methods['safeTransferFrom(address,address,uint256,bytes)'](keyOwner, accounts[3], ID, Web3Utils.toHex('Julien'), {
-            from: keyOwner,
-            value: Units.convert('0.01', 'eth', 'wei')
-          }),
-          'LOCK_DEPRECATED'
-        )
-      })
+    it('should fail to updateKeyPrice', async () => {
+      await shouldFail(
+        lock.updateKeyPrice(1),
+        'LOCK_DEPRECATED'
+      )
+    })
+
+    it('should fail to safeTransferFrom w/o data', async () => {
+      await shouldFail(
+        lock.safeTransferFrom(keyOwner, accounts[3], ID, {
+          from: keyOwner,
+          value: Units.convert('0.01', 'eth', 'wei')
+        }),
+        'LOCK_DEPRECATED'
+      )
+    })
+
+    it('should fail to safeTransferFrom w/ data', async () => {
+      ID = await lock.getTokenIdFor.call(keyOwner)
+      await shouldFail(
+        lock.methods['safeTransferFrom(address,address,uint256,bytes)'](keyOwner, accounts[3], ID, Web3Utils.toHex('Julien'), {
+          from: keyOwner,
+          value: Units.convert('0.01', 'eth', 'wei')
+        }),
+        'LOCK_DEPRECATED'
+      )
     })
   })
 })

--- a/smart-contracts/test/Lock/erc165.js
+++ b/smart-contracts/test/Lock/erc165.js
@@ -3,7 +3,7 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC165', accounts => {
+contract('Lock / erc165', accounts => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -15,11 +15,9 @@ contract('Lock ERC165', accounts => {
       })
   })
 
-  describe('Supports ERC165 Interface', () => {
-    it('should support the erc165 interface()', async function () {
-      // 0x01ffc9a7 === bytes4(keccak256('supportsInterface(bytes4)'))
-      const result = await locks['FIRST'].supportsInterface.call('0x01ffc9a7')
-      assert.equal(result, true)
-    })
+  it('should support the erc165 interface()', async function () {
+    // 0x01ffc9a7 === bytes4(keccak256('supportsInterface(bytes4)'))
+    const result = await locks['FIRST'].supportsInterface.call('0x01ffc9a7')
+    assert.equal(result, true)
   })
 })

--- a/smart-contracts/test/Lock/erc721/Non_Public_approve.js
+++ b/smart-contracts/test/Lock/erc721/Non_Public_approve.js
@@ -6,7 +6,7 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC721', (accounts) => {
+contract('Lock / erc721 / Non_Public_approve', (accounts) => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {

--- a/smart-contracts/test/Lock/erc721/Non_Public_getApproved.js
+++ b/smart-contracts/test/Lock/erc721/Non_Public_getApproved.js
@@ -3,7 +3,7 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC721', (accounts) => {
+contract('Lock / erc721 / Non_Public_getApproved', (accounts) => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -15,23 +15,21 @@ contract('Lock ERC721', (accounts) => {
       })
   })
 
-  describe('getApproved', () => {
-    let lockOwner
+  let lockOwner
 
-    before(() => {
-      return locks['FIRST'].owner.call().then((_owner) => {
-        lockOwner = _owner
-      })
+  before(() => {
+    return locks['FIRST'].owner.call().then((_owner) => {
+      lockOwner = _owner
     })
-    // from approve.js, ln# 27:
-    it.skip('should return the address of the approved owner for a key', () => {
-      return locks['FIRST'].approve(accounts[3], accounts[3], {
-        from: lockOwner
-      }).then(() => {
-        return locks['FIRST'].getApproved.call(accounts[3])
-      }).then((approved) => {
-        assert.equal(accounts[3], approved)
-      })
+  })
+  // from approve.js, ln# 27:
+  it.skip('should return the address of the approved owner for a key', () => {
+    return locks['FIRST'].approve(accounts[3], accounts[3], {
+      from: lockOwner
+    }).then(() => {
+      return locks['FIRST'].getApproved.call(accounts[3])
+    }).then((approved) => {
+      assert.equal(accounts[3], approved)
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/Non_Public_transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/Non_Public_transferFrom.js
@@ -3,7 +3,7 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock
 
-contract('Lock ERC721', (accounts) => {
+contract('Lock / erc721 / Non_Public_transferFrom', (accounts) => {
   before(async () => {
     unlock = await Unlock.deployed()
     await deployLocks(unlock, accounts[0])

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -6,61 +6,81 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks, ID
 
-contract('Lock ERC721', accounts => {
+contract('Lock / erc721 / approve', accounts => {
   before(async () => {
     unlock = await Unlock.deployed()
     locks = await deployLocks(unlock, accounts[0])
   })
 
-  describe('approve', () => {
-    describe('when the token does not exist', () => {
+  describe('when the token does not exist', () => {
+    it('should fail', async () => {
+      await shouldFail(
+        locks['FIRST'].approve(accounts[2], 42, {
+          from: accounts[1]
+        }),
+        'NO_SUCH_KEY'
+      )
+    })
+  })
+
+  describe('when the key exists', () => {
+    before(() => {
+      return locks['FIRST'].purchaseFor(
+        accounts[1],
+        Web3Utils.toHex('Satoshi'),
+        {
+          value: Units.convert('0.01', 'eth', 'wei'),
+          from: accounts[1]
+        }
+      )
+    })
+
+    describe('when the sender is not the token owner', () => {
       it('should fail', async () => {
+        ID = await locks['FIRST'].getTokenIdFor.call(accounts[1])
         await shouldFail(
-          locks['FIRST'].approve(accounts[2], 42, {
-            from: accounts[1]
+          locks['FIRST'].approve(accounts[2], ID, {
+            from: accounts[2]
           }),
-          'NO_SUCH_KEY'
+          'ONLY_KEY_OWNER_OR_APPROVED'
         )
       })
     })
 
-    describe('when the key exists', () => {
-      before(() => {
-        return locks['FIRST'].purchaseFor(
-          accounts[1],
-          Web3Utils.toHex('Satoshi'),
-          {
-            value: Units.convert('0.01', 'eth', 'wei'),
+    describe('when the sender is self approving', () => {
+      it('should fail', async () => {
+        await shouldFail(
+          locks['FIRST'].approve(accounts[1], ID, {
             from: accounts[1]
-          }
+          }),
+          'APPROVE_SELF'
         )
       })
+    })
 
-      describe('when the sender is not the token owner', () => {
-        it('should fail', async () => {
-          ID = await locks['FIRST'].getTokenIdFor.call(accounts[1])
-          await shouldFail(
-            locks['FIRST'].approve(accounts[2], ID, {
-              from: accounts[2]
-            }),
-            'ONLY_KEY_OWNER_OR_APPROVED'
-          )
+    describe('when the approval succeeds', () => {
+      let event
+      before(async () => {
+        let result = await locks['FIRST'].approve(accounts[2], ID, {
+          from: accounts[1]
+        })
+        event = result.logs[0]
+      })
+
+      it('should assign the approvedForTransfer value', () => {
+        return locks['FIRST'].getApproved.call(ID).then(approved => {
+          assert.equal(approved, accounts[2])
         })
       })
 
-      describe('when the sender is self approving', () => {
-        it('should fail', async () => {
-          await shouldFail(
-            locks['FIRST'].approve(accounts[1], ID, {
-              from: accounts[1]
-            }),
-            'APPROVE_SELF'
-          )
-        })
+      it('should trigger the Approval event', () => {
+        assert.equal(event.event, 'Approval')
+        assert.equal(event.args._owner, accounts[1])
+        assert.equal(event.args._approved, accounts[2])
+        assert(event.args._tokenId.eq(ID))
       })
 
-      describe('when the approval succeeds', () => {
-        let event
+      describe('when reaffirming the approved address', () => {
         before(async () => {
           let result = await locks['FIRST'].approve(accounts[2], ID, {
             from: accounts[1]
@@ -68,46 +88,24 @@ contract('Lock ERC721', accounts => {
           event = result.logs[0]
         })
 
-        it('should assign the approvedForTransfer value', () => {
-          return locks['FIRST'].getApproved.call(ID).then(approved => {
-            assert.equal(approved, accounts[2])
-          })
-        })
-
-        it('should trigger the Approval event', () => {
+        it('Approval emits when the approved address is reaffirmed', async () => {
           assert.equal(event.event, 'Approval')
           assert.equal(event.args._owner, accounts[1])
           assert.equal(event.args._approved, accounts[2])
           assert(event.args._tokenId.eq(ID))
         })
+      })
 
-        describe('when reaffirming the approved address', () => {
-          before(async () => {
-            let result = await locks['FIRST'].approve(accounts[2], ID, {
-              from: accounts[1]
-            })
-            event = result.logs[0]
+      describe('when clearing the approved address', () => {
+        before(async () => {
+          let result = await locks['FIRST'].approve(Web3Utils.padLeft(0, 40), ID, {
+            from: accounts[1]
           })
-
-          it('Approval emits when the approved address is reaffirmed', async () => {
-            assert.equal(event.event, 'Approval')
-            assert.equal(event.args._owner, accounts[1])
-            assert.equal(event.args._approved, accounts[2])
-            assert(event.args._tokenId.eq(ID))
-          })
+          event = result.logs[0]
         })
 
-        describe('when clearing the approved address', () => {
-          before(async () => {
-            let result = await locks['FIRST'].approve(Web3Utils.padLeft(0, 40), ID, {
-              from: accounts[1]
-            })
-            event = result.logs[0]
-          })
-
-          it('The zero address indicates there is no approved address', async () => {
-            await shouldFail(locks['FIRST'].getApproved.call(ID), 'NONE_APPROVED')
-          })
+        it('The zero address indicates there is no approved address', async () => {
+          await shouldFail(locks['FIRST'].getApproved.call(ID), 'NONE_APPROVED')
         })
       })
     })

--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -8,7 +8,7 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC721', (accounts) => {
+contract('Lock / erc721 / balanceOf', (accounts) => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -20,35 +20,33 @@ contract('Lock ERC721', (accounts) => {
       })
   })
 
-  describe('balanceOf', () => {
-    it('should fail if the user address is 0', async () => {
-      await shouldFail(locks['FIRST'].balanceOf.call(Web3Utils.padLeft(0, 40)), 'INVALID_ADDRESS')
-    })
+  it('should fail if the user address is 0', async () => {
+    await shouldFail(locks['FIRST'].balanceOf.call(Web3Utils.padLeft(0, 40)), 'INVALID_ADDRESS')
+  })
 
-    it('should return 0 if the user has no key', async () => {
-      const balance = new BigNumber(await locks['FIRST'].balanceOf.call(accounts[3]))
-      assert.equal(balance.toFixed(), 0)
-    })
+  it('should return 0 if the user has no key', async () => {
+    const balance = new BigNumber(await locks['FIRST'].balanceOf.call(accounts[3]))
+    assert.equal(balance.toFixed(), 0)
+  })
 
-    it('should return 1 if the user has a non expired key', async () => {
-      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
-        value: Units.convert('0.01', 'eth', 'wei'),
-        from: accounts[1]
-      })
-      const balance = new BigNumber(await locks['FIRST'].balanceOf.call(accounts[1]))
-      assert.equal(balance.toFixed(), 1)
+  it('should return 1 if the user has a non expired key', async () => {
+    await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
+      value: Units.convert('0.01', 'eth', 'wei'),
+      from: accounts[1]
     })
+    const balance = new BigNumber(await locks['FIRST'].balanceOf.call(accounts[1]))
+    assert.equal(balance.toFixed(), 1)
+  })
 
-    it('should return 1 if the user has an expired key', async () => {
-      await locks['FIRST'].purchaseFor(accounts[5], Web3Utils.toHex('Satoshi'), {
-        value: Units.convert('0.01', 'eth', 'wei'),
-        from: accounts[5]
-      })
-      await locks['FIRST'].expireKeyFor(accounts[5], {
-        from: accounts[0]
-      })
-      const balance = new BigNumber(await locks['FIRST'].balanceOf.call(accounts[5]))
-      assert.equal(balance.toFixed(), 1)
+  it('should return 1 if the user has an expired key', async () => {
+    await locks['FIRST'].purchaseFor(accounts[5], Web3Utils.toHex('Satoshi'), {
+      value: Units.convert('0.01', 'eth', 'wei'),
+      from: accounts[5]
     })
+    await locks['FIRST'].expireKeyFor(accounts[5], {
+      from: accounts[0]
+    })
+    const balance = new BigNumber(await locks['FIRST'].balanceOf.call(accounts[5]))
+    assert.equal(balance.toFixed(), 1)
   })
 })

--- a/smart-contracts/test/Lock/erc721/compliance.js
+++ b/smart-contracts/test/Lock/erc721/compliance.js
@@ -3,7 +3,7 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC165', accounts => {
+contract('Lock / erc721 / compliance', accounts => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -15,11 +15,9 @@ contract('Lock ERC165', accounts => {
       })
   })
 
-  describe('Supports ERC721 Interface', () => {
-    it('should support the erc721 interface()', async function () {
-      // Note: the ERC-165 identifier for the erc721 interface is "0x80ac58cd"
-      const result = await locks['FIRST'].supportsInterface.call('0x80ac58cd')
-      assert.equal(result, true)
-    })
+  it('should support the erc721 interface()', async function () {
+    // Note: the ERC-165 identifier for the erc721 interface is "0x80ac58cd"
+    const result = await locks['FIRST'].supportsInterface.call('0x80ac58cd')
+    assert.equal(result, true)
   })
 })

--- a/smart-contracts/test/Lock/erc721/getApproved.js
+++ b/smart-contracts/test/Lock/erc721/getApproved.js
@@ -10,7 +10,7 @@ const Unlock = Contracts.getFromLocal('Unlock')
 
 let locks, ID
 
-contract('Lock ERC721', accounts => {
+contract('Lock / erc721 / getApproved', accounts => {
   const proxyAdmin = accounts[1]
   const unlockOwner = accounts[2]
   const keyPurchaser = accounts[3]
@@ -26,26 +26,24 @@ contract('Lock ERC721', accounts => {
     locks = await deployLocks(this.unlock, accounts[0])
   })
 
-  describe('getApproved', () => {
-    before(async function () {
-      await locks['FIRST'].purchaseFor(
-        keyPurchaser,
-        Web3Utils.toHex('Vitalik'),
-        {
-          value: Units.convert('0.01', 'eth', 'wei'),
-          from: keyPurchaser
-        }
-      )
-      ID = await locks['FIRST'].getTokenIdFor.call(keyPurchaser)
-    })
+  before(async function () {
+    await locks['FIRST'].purchaseFor(
+      keyPurchaser,
+      Web3Utils.toHex('Vitalik'),
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: keyPurchaser
+      }
+    )
+    ID = await locks['FIRST'].getTokenIdFor.call(keyPurchaser)
+  })
 
-    describe('getApproved', () => {
-      it('should fail if no one was approved for a key', async () => {
-        await shouldFail(
-          locks['FIRST'].getApproved.call(ID),
-          'NONE_APPROVED'
-        )
-      })
+  describe('getApproved', () => {
+    it('should fail if no one was approved for a key', async () => {
+      await shouldFail(
+        locks['FIRST'].getApproved.call(ID),
+        'NONE_APPROVED'
+      )
     })
   })
 })

--- a/smart-contracts/test/Lock/erc721/getTokenIdFor.js
+++ b/smart-contracts/test/Lock/erc721/getTokenIdFor.js
@@ -8,35 +8,33 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC721', accounts => {
+contract('Lock / erc721 / getTokenIdFor', accounts => {
   before(async () => {
     unlock = await Unlock.deployed()
     locks = await deployLocks(unlock, accounts[0])
   })
 
-  describe('getTokenIdFor', () => {
-    it('should abort when the key has no owner', async () => {
-      await shouldFail(
-        locks['FIRST'].getTokenIdFor.call(accounts[3]),
-        'NO_SUCH_KEY'
-      )
-    })
+  it('should abort when the key has no owner', async () => {
+    await shouldFail(
+      locks['FIRST'].getTokenIdFor.call(accounts[3]),
+      'NO_SUCH_KEY'
+    )
+  })
 
-    it("should return the tokenId for the owner's key", async () => {
-      await locks['FIRST'].purchaseFor(
-        accounts[1],
-        Web3Utils.toHex('Satoshi'),
-        {
-          value: Units.convert('0.01', 'eth', 'wei'),
-          from: accounts[1]
-        }
-      )
-      let ID = new BigNumber(
-        await locks['FIRST'].getTokenIdFor.call(accounts[1])
-      )
-      // Note that as we implement ERC721 support, the tokenId will no longer
-      // be the same as the user's address
-      assert(ID.eq(1))
-    })
+  it("should return the tokenId for the owner's key", async () => {
+    await locks['FIRST'].purchaseFor(
+      accounts[1],
+      Web3Utils.toHex('Satoshi'),
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[1]
+      }
+    )
+    let ID = new BigNumber(
+      await locks['FIRST'].getTokenIdFor.call(accounts[1])
+    )
+    // Note that as we implement ERC721 support, the tokenId will no longer
+    // be the same as the user's address
+    assert(ID.eq(1))
   })
 })

--- a/smart-contracts/test/Lock/erc721/name.js
+++ b/smart-contracts/test/Lock/erc721/name.js
@@ -4,75 +4,73 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, lock
 
-contract('Lock ERC721', accounts => {
+contract('Lock / erc721 / name', accounts => {
   before(async () => {
     unlock = await Unlock.deployed()
     const locks = await deployLocks(unlock)
     lock = locks['FIRST']
   })
 
-  describe('name', () => {
-    describe('when there is no name', () => {
-      it('should return nothing when attempting to read the name', async () => {
-        assert.equal(await lock.name.call(), '')
-      })
+  describe('when there is no name', () => {
+    it('should return nothing when attempting to read the name', async () => {
+      assert.equal(await lock.name.call(), '')
+    })
 
-      it('should fail if someone other than the owner tries to set the name', async () => {
-        await shouldFail(
-          lock.updateLockName('Hardly', {
-            from: accounts[1]
-          })
-        )
-      })
-
-      it('should allow the owner to set a name', async () => {
-        await lock.updateLockName('Hardly', {
-          from: accounts[0]
+    it('should fail if someone other than the owner tries to set the name', async () => {
+      await shouldFail(
+        lock.updateLockName('Hardly', {
+          from: accounts[1]
         })
+      )
+    })
+
+    it('should allow the owner to set a name', async () => {
+      await lock.updateLockName('Hardly', {
+        from: accounts[0]
+      })
+    })
+  })
+
+  describe('when the Lock has a name', () => {
+    before(async () => {
+      await lock.updateLockName('Hardly', {
+        from: accounts[0]
       })
     })
 
-    describe('when the Lock has a name', () => {
+    it('should return return the expected name', async () => {
+      assert.equal(await lock.name.call(), 'Hardly')
+    })
+
+    it('should fail if someone other than the owner tries to change the name', async () => {
+      await shouldFail(
+        lock.updateLockName('Difficult', {
+          from: accounts[1]
+        })
+      )
+    })
+
+    describe('should allow the owner to set a name', () => {
       before(async () => {
-        await lock.updateLockName('Hardly', {
+        await lock.updateLockName('Difficult', {
           from: accounts[0]
         })
       })
 
       it('should return return the expected name', async () => {
-        assert.equal(await lock.name.call(), 'Hardly')
+        assert.equal(await lock.name.call(), 'Difficult')
       })
+    })
 
-      it('should fail if someone other than the owner tries to change the name', async () => {
-        await shouldFail(
-          lock.updateLockName('Difficult', {
-            from: accounts[1]
-          })
-        )
-      })
-
-      describe('should allow the owner to set a name', () => {
-        before(async () => {
-          await lock.updateLockName('Difficult', {
-            from: accounts[0]
-          })
-        })
-
-        it('should return return the expected name', async () => {
-          assert.equal(await lock.name.call(), 'Difficult')
+    describe('should allow the owner to unset the name', () => {
+      before(async () => {
+        await lock.updateLockName('', {
+          from: accounts[0]
         })
       })
 
-      describe('should allow the owner to unset the name', () => {
-        before(async () => {
-          await lock.updateLockName('', {
-            from: accounts[0]
-          })
-        })
-
-        it('should return return the expected name', async () => {
-          assert.equal(await lock.name.call(), '')
-        })
+      it('should return return the expected name', async () => {
+        assert.equal(await lock.name.call(), '')
       })
     })
   })

--- a/smart-contracts/test/Lock/erc721/onERC721Received.js
+++ b/smart-contracts/test/Lock/erc721/onERC721Received.js
@@ -6,7 +6,7 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks, operator, from, tokenId, data
 
-contract('Lock Receiver', accounts => {
+contract('Lock / erc721 / onERC721Received', accounts => {
   operator = accounts[5]
   from = accounts[5]
   tokenId = 11
@@ -23,18 +23,16 @@ contract('Lock Receiver', accounts => {
       })
   })
 
-  describe('Implements IERC721Receiver interface', () => {
-    it('should implement the onERC721Received() function', async function () {
-      // PublicLock.onERC721Received.selector == 0x150b7a02`
-      const ERC721_RECEIVED = 0x150b7a02
-      const result = await locks['FIRST'].onERC721Received.call(
-        operator,
-        from,
-        tokenId,
-        data,
-        {}
-      )
-      assert.equal(result, ERC721_RECEIVED)
-    })
+  it('should implement the onERC721Received() function', async function () {
+    // PublicLock.onERC721Received.selector == 0x150b7a02`
+    const ERC721_RECEIVED = 0x150b7a02
+    const result = await locks['FIRST'].onERC721Received.call(
+      operator,
+      from,
+      tokenId,
+      data,
+      {}
+    )
+    assert.equal(result, ERC721_RECEIVED)
   })
 })

--- a/smart-contracts/test/Lock/erc721/ownerOf.js
+++ b/smart-contracts/test/Lock/erc721/ownerOf.js
@@ -7,29 +7,27 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC721', accounts => {
+contract('Lock / erc721 / ownerOf', accounts => {
   before(async () => {
     unlock = await Unlock.deployed()
     locks = await deployLocks(unlock, accounts[0])
   })
 
-  describe('ownerOf', () => {
-    it('should abort when the key has no owner', async () => {
-      await shouldFail(locks['FIRST'].ownerOf.call(accounts[3]), 'NO_SUCH_KEY')
-    })
+  it('should abort when the key has no owner', async () => {
+    await shouldFail(locks['FIRST'].ownerOf.call(accounts[3]), 'NO_SUCH_KEY')
+  })
 
-    it('should return the owner of the key', async () => {
-      await locks['FIRST'].purchaseFor(
-        accounts[1],
-        Web3Utils.toHex('Satoshi'),
-        {
-          value: Units.convert('0.01', 'eth', 'wei'),
-          from: accounts[1]
-        }
-      )
-      let ID = await locks['FIRST'].getTokenIdFor.call(accounts[1])
-      let address = await locks['FIRST'].ownerOf.call(ID)
-      assert.equal(address, accounts[1])
-    })
+  it('should return the owner of the key', async () => {
+    await locks['FIRST'].purchaseFor(
+      accounts[1],
+      Web3Utils.toHex('Satoshi'),
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[1]
+      }
+    )
+    let ID = await locks['FIRST'].getTokenIdFor.call(accounts[1])
+    let address = await locks['FIRST'].ownerOf.call(ID)
+    assert.equal(address, accounts[1])
   })
 })

--- a/smart-contracts/test/Lock/erc721/safeTransferFrom.js
+++ b/smart-contracts/test/Lock/erc721/safeTransferFrom.js
@@ -7,74 +7,73 @@ const Unlock = artifacts.require('../../Unlock.sol')
 let unlock, locks
 let keyDataAfter
 
-contract('Lock ERC721', accounts => {
+contract('Lock / erc721 / safeTransferFrom', accounts => {
   before(async () => {
     unlock = await Unlock.deployed()
     locks = await deployLocks(unlock, accounts[0])
   })
+
   // function safeTransferFrom() still uses transferFrom() under the hood, but adds an additional check afterwards. transferFrom is already well-tested, so here we add a few checks to test only the new functionality.
-  describe('safeTransferFrom', () => {
-    const from = accounts[1]
-    const to = accounts[2]
-    let ID
+  const from = accounts[1]
+  const to = accounts[2]
+  let ID
 
-    before(async () => {
-      // first, let's purchase a brand new key that we can transfer
-      await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+  before(async () => {
+    // first, let's purchase a brand new key that we can transfer
+    await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+      value: Units.convert('0.01', 'eth', 'wei'),
+      from
+    })
+    ID = await locks['FIRST'].getTokenIdFor.call(from)
+  })
+
+  it('should work if no data is passed in', async () => {
+    await locks['FIRST'].safeTransferFrom(from, to, ID, {
+      from
+    })
+    let ownerOf = await locks['FIRST'].ownerOf.call(ID)
+    keyDataAfter = await locks['FIRST'].keyDataFor.call(to)
+    assert.equal(ownerOf, to)
+    assert.equal(keyDataAfter, null)
+  })
+
+  it('should work if some data is passed in', async () => {
+    await locks['FIRST'].purchaseFor(accounts[7], Web3Utils.toHex('Julien'), {
+      value: Units.convert('0.01', 'eth', 'wei'),
+      from: accounts[7]
+    })
+    ID = await locks['FIRST'].getTokenIdFor.call(accounts[7])
+    await locks['FIRST'].methods['safeTransferFrom(address,address,uint256,bytes)'](
+      accounts[7], accounts[6], Web3Utils.toHex(ID), Web3Utils.toHex('Julien'), { from: accounts[7] }
+    )
+    let ownerOf = await locks['FIRST'].ownerOf.call(ID)
+    assert.equal(ownerOf, accounts[6])
+    keyDataAfter = await locks['FIRST'].keyDataFor.call(accounts[7])
+    // while we may pass data to the safeTransferFrom function, it is not currently utilized in any way other than being passed to the `onERC721Received` function in MixinTransfer.sol
+    assert.equal(await locks['FIRST'].keyDataFor.call(accounts[6]), null)
+    assert.equal(Web3Utils.toUtf8(await locks['FIRST'].keyDataFor.call(accounts[7])), 'Julien')
+  })
+
+  it('should fail if trying to transfer a key to a contract which does not implement onERC721Received', async () => {
+    await locks['FIRST'].purchaseFor(
+      accounts[5],
+      Web3Utils.toHex('Someone Else'),
+      {
         value: Units.convert('0.01', 'eth', 'wei'),
-        from
-      })
-      ID = await locks['FIRST'].getTokenIdFor.call(from)
-    })
-
-    it('should work if no data is passed in', async () => {
-      await locks['FIRST'].safeTransferFrom(from, to, ID, {
-        from
-      })
-      let ownerOf = await locks['FIRST'].ownerOf.call(ID)
-      keyDataAfter = await locks['FIRST'].keyDataFor.call(to)
-      assert.equal(ownerOf, to)
-      assert.equal(keyDataAfter, null)
-    })
-
-    it('should work if some data is passed in', async () => {
-      await locks['FIRST'].purchaseFor(accounts[7], Web3Utils.toHex('Julien'), {
-        value: Units.convert('0.01', 'eth', 'wei'),
-        from: accounts[7]
-      })
-      ID = await locks['FIRST'].getTokenIdFor.call(accounts[7])
-      await locks['FIRST'].methods['safeTransferFrom(address,address,uint256,bytes)'](
-        accounts[7], accounts[6], Web3Utils.toHex(ID), Web3Utils.toHex('Julien'), { from: accounts[7] }
-      )
-      let ownerOf = await locks['FIRST'].ownerOf.call(ID)
-      assert.equal(ownerOf, accounts[6])
-      keyDataAfter = await locks['FIRST'].keyDataFor.call(accounts[7])
-      // while we may pass data to the safeTransferFrom function, it is not currently utilized in any way other than being passed to the `onERC721Received` function in MixinTransfer.sol
-      assert.equal(await locks['FIRST'].keyDataFor.call(accounts[6]), null)
-      assert.equal(Web3Utils.toUtf8(await locks['FIRST'].keyDataFor.call(accounts[7])), 'Julien')
-    })
-
-    it('should fail if trying to transfer a key to a contract which does not implement onERC721Received', async () => {
-      await locks['FIRST'].purchaseFor(
-        accounts[5],
-        Web3Utils.toHex('Someone Else'),
-        {
-          value: Units.convert('0.01', 'eth', 'wei'),
-          from: accounts[5]
-        }
-      )
-      ID = await locks['FIRST'].getTokenIdFor.call(accounts[5])
-      // A contract which does NOT implement onERC721Received:
-      let nonCompliantContract = unlock.address
-      await shouldFail(
-        locks['FIRST'].safeTransferFrom(accounts[5], nonCompliantContract, ID, {
-          from: accounts[5]
-        }),
-        'NO_FALLBACK'
-      )
-      // make sure the key was not transferred
-      let ownerOf = await locks['FIRST'].ownerOf.call(ID)
-      assert.equal(ownerOf, accounts[5])
-    })
+        from: accounts[5]
+      }
+    )
+    ID = await locks['FIRST'].getTokenIdFor.call(accounts[5])
+    // A contract which does NOT implement onERC721Received:
+    let nonCompliantContract = unlock.address
+    await shouldFail(
+      locks['FIRST'].safeTransferFrom(accounts[5], nonCompliantContract, ID, {
+        from: accounts[5]
+      }),
+      'NO_FALLBACK'
+    )
+    // make sure the key was not transferred
+    let ownerOf = await locks['FIRST'].ownerOf.call(ID)
+    assert.equal(ownerOf, accounts[5])
   })
 })

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -8,315 +8,313 @@ const Unlock = artifacts.require('../../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock ERC721', accounts => {
+contract('Lock / erc721 / transferFrom', accounts => {
   before(async () => {
     unlock = await Unlock.deployed()
     locks = await deployLocks(unlock, accounts[0])
   })
 
-  describe('transferFrom', () => {
-    const from = accounts[1]
-    const to = accounts[2]
-    const accountWithNoKey = accounts[3]
-    const accountWithKey = accounts[4]
-    const accountWithKeyApproved = accounts[5]
-    const accountNotApproved = accounts[6]
-    const accountApproved = accounts[7]
-    const accountWithExpiredKey = accounts[8]
-    let keyExpiration
-    let ID
-    let keyDataBefore
-    let keyDataAfter
+  const from = accounts[1]
+  const to = accounts[2]
+  const accountWithNoKey = accounts[3]
+  const accountWithKey = accounts[4]
+  const accountWithKeyApproved = accounts[5]
+  const accountNotApproved = accounts[6]
+  const accountApproved = accounts[7]
+  const accountWithExpiredKey = accounts[8]
+  let keyExpiration
+  let ID
+  let keyDataBefore
+  let keyDataAfter
 
-    before(() => {
-      return Promise.all([
-        locks['FIRST'].purchaseFor(accountWithKey, Web3Utils.toHex('Satoshi'), {
+  before(() => {
+    return Promise.all([
+      locks['FIRST'].purchaseFor(accountWithKey, Web3Utils.toHex('Satoshi'), {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accountWithKey
+      }),
+      locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from
+      }),
+      locks['FIRST'].purchaseFor(
+        accountWithExpiredKey,
+        Web3Utils.toHex('Finley'),
+        {
           value: Units.convert('0.01', 'eth', 'wei'),
-          from: accountWithKey
-        }),
-        locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+          from: accountWithExpiredKey
+        }
+      ),
+      locks['FIRST'].purchaseFor(
+        accountWithKeyApproved,
+        Web3Utils.toHex('Ben'),
+        {
           value: Units.convert('0.01', 'eth', 'wei'),
-          from
-        }),
-        locks['FIRST'].purchaseFor(
-          accountWithExpiredKey,
-          Web3Utils.toHex('Finley'),
+          from: accountWithKeyApproved
+        }
+      )
+    ]).then(async () => {
+      keyExpiration = new BigNumber(
+        await locks['FIRST'].keyExpirationTimestampFor.call(from)
+      )
+    })
+  })
+
+  /// @dev Throws unless `msg.sender` is the current owner, an authorized
+  ///  operator, or the approved address for this NFT. Throws if `_from` is
+  ///  not the current owner. Throws if `_to` is the zero address. Throws if
+  ///  `_tokenId` is not a valid NFT.
+
+  describe('when the lock is public', () => {
+    it('should abort when there is no key to transfer', async () => {
+      await shouldFail(
+        locks['FIRST'].transferFrom(accountWithNoKey, to, 999),
+        'KEY_NOT_VALID'
+      )
+    })
+
+    it('should abort if the recipient is 0x', async () => {
+      await shouldFail(
+        locks['FIRST'].transferFrom(
+          from,
+          Web3Utils.padLeft(0, 40),
+          await locks['FIRST'].getTokenIdFor.call(from),
           {
-            value: Units.convert('0.01', 'eth', 'wei'),
-            from: accountWithExpiredKey
+            from
           }
         ),
-        locks['FIRST'].purchaseFor(
-          accountWithKeyApproved,
-          Web3Utils.toHex('Ben'),
-          {
-            value: Units.convert('0.01', 'eth', 'wei'),
-            from: accountWithKeyApproved
-          }
-        )
-      ]).then(async () => {
-        keyExpiration = new BigNumber(
+        'INVALID_ADDRESS'
+      )
+      // Ensuring that ownership of the key did not change
+      const expirationTimestamp = new BigNumber(
+        await locks['FIRST'].keyExpirationTimestampFor.call(from)
+      )
+      assert.equal(keyExpiration.toFixed(), expirationTimestamp.toFixed())
+    })
+
+    describe('when the recipient already has an expired key', () => {
+      it('should transfer the key validity without extending it', async () => {
+        // First let's make sure from has a key!
+        let fromExpirationTimestamp, ID
+        await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+          value: Units.convert('0.01', 'eth', 'wei'),
+          from
+        })
+        // Get the tokenID
+        ID = await locks['FIRST'].getTokenIdFor.call(from)
+        // Let's check the expiration date for that key
+        fromExpirationTimestamp = new BigNumber(
           await locks['FIRST'].keyExpirationTimestampFor.call(from)
         )
+        // Then let's expire the key for accountWithExpiredKey
+        await locks['FIRST'].expireKeyFor(accountWithExpiredKey)
+        keyDataBefore = await locks['FIRST'].keyDataFor.call(
+          accountWithExpiredKey
+        )
+        await locks['FIRST'].transferFrom(from, accountWithExpiredKey, ID, {
+          from
+        })
+        const expirationTimestamp = new BigNumber(
+          await locks['FIRST'].keyExpirationTimestampFor.call(
+            accountWithExpiredKey
+          )
+        )
+        assert.equal(
+          expirationTimestamp.toFixed(),
+          fromExpirationTimestamp.toFixed()
+        )
+      })
+
+      it("should preserve the recipient's key data", async () => {
+        keyDataAfter = await locks['FIRST'].keyDataFor.call(
+          accountWithExpiredKey
+        )
+        assert.equal(keyDataBefore, keyDataAfter)
       })
     })
 
-    /// @dev Throws unless `msg.sender` is the current owner, an authorized
-    ///  operator, or the approved address for this NFT. Throws if `_from` is
-    ///  not the current owner. Throws if `_to` is the zero address. Throws if
-    ///  `_tokenId` is not a valid NFT.
+    describe('when the recipient already has a non expired key', () => {
+      let transferedKeyTimestamp
+      let previousExpirationTimestamp
 
-    describe('when the lock is public', () => {
-      it('should abort when there is no key to transfer', async () => {
-        await shouldFail(
-          locks['FIRST'].transferFrom(accountWithNoKey, to, 999),
-          'KEY_NOT_VALID'
+      before(async () => {
+        await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+          value: Units.convert('0.01', 'eth', 'wei'),
+          from
+        })
+        ID = await locks['FIRST'].getTokenIdFor.call(from)
+        // First let's get the current expiration
+        transferedKeyTimestamp = new BigNumber(
+          await locks['FIRST'].keyExpirationTimestampFor.call(from)
+        )
+        previousExpirationTimestamp = new BigNumber(
+          await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1])
+        )
+        keyDataBefore = await locks['FIRST'].keyDataFor.call(accountWithKey)
+        await locks['FIRST'].transferFrom(from, accountWithKey, ID, {
+          from
+        })
+      })
+
+      it("should expand the key's validity", async () => {
+        const expirationTimestamp = new BigNumber(
+          await locks['FIRST'].keyExpirationTimestampFor.call(accountWithKey)
+        )
+        const now = Math.floor(new Date().getTime() / 1000)
+        // Check +/- 10 seconds
+        assert(
+          expirationTimestamp.gt(
+            previousExpirationTimestamp
+              .plus(transferedKeyTimestamp)
+              .minus(now + 10)
+          )
+        )
+        assert(
+          expirationTimestamp.lt(
+            previousExpirationTimestamp
+              .plus(transferedKeyTimestamp)
+              .minus(now - 10)
+          )
         )
       })
 
-      it('should abort if the recipient is 0x', async () => {
+      it("should expire the previous owner's key", async () => {
+        const expirationTimestamp = new BigNumber(
+          await locks['FIRST'].keyExpirationTimestampFor.call(from)
+        )
+        const now = Math.floor(new Date().getTime() / 1000)
+        // Check only 10 seconds in the future to ensure deterministic test
+        assert(expirationTimestamp.lt(now + 10))
+      })
+
+      it("should preserve the recipient's key data", async () => {
+        keyDataAfter = await locks['FIRST'].keyDataFor.call(accountWithKey)
+        assert.equal(keyDataBefore, keyDataAfter)
+      })
+    })
+
+    describe('when the key owner is not the sender', async () => {
+      it('should fail if the sender has not been approved for that key', async () => {
+        const previousExpirationTimestamp = new BigNumber(
+          await locks['FIRST'].keyExpirationTimestampFor.call(from)
+        )
         await shouldFail(
-          locks['FIRST'].transferFrom(
-            from,
-            Web3Utils.padLeft(0, 40),
-            await locks['FIRST'].getTokenIdFor.call(from),
-            {
-              from
-            }
-          ),
-          'INVALID_ADDRESS'
+          locks['FIRST'].transferFrom(from, accountNotApproved, ID, {
+            from: accountNotApproved
+          }),
+          'KEY_NOT_VALID'
         )
         // Ensuring that ownership of the key did not change
         const expirationTimestamp = new BigNumber(
           await locks['FIRST'].keyExpirationTimestampFor.call(from)
         )
-        assert.equal(keyExpiration.toFixed(), expirationTimestamp.toFixed())
+        assert.equal(
+          previousExpirationTimestamp.toFixed(),
+          expirationTimestamp.toFixed()
+        )
       })
 
-      describe('when the recipient already has an expired key', () => {
-        it('should transfer the key validity without extending it', async () => {
-          // First let's make sure from has a key!
-          let fromExpirationTimestamp, ID
-          await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+      it('should succeed if the sender has been approved for that key', async () => {
+        ID = await locks['FIRST'].getTokenIdFor.call(accountWithKeyApproved)
+        await locks['FIRST'].approve(accountApproved, ID, {
+          from: accountWithKeyApproved
+        })
+        await locks['FIRST'].transferFrom(
+          accountWithKeyApproved,
+          accountApproved,
+          ID,
+          {
+            from: accountApproved
+          }
+        )
+        let balance = await locks['FIRST'].balanceOf.call(accountApproved)
+        assert.equal(balance, 1)
+      })
+
+      it('approval should be cleared after a transfer', async () => {
+        await shouldFail(
+          locks['FIRST'].getApproved(accountApproved),
+          'NONE_APPROVED'
+        )
+      })
+    })
+
+    describe('when the key owner is the sender', () => {
+      before(async () => {
+        // first, let's purchase a brand new key that we can transfer
+        await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
+          value: Units.convert('0.01', 'eth', 'wei'),
+          from
+        })
+        ID = await locks['FIRST'].getTokenIdFor.call(from)
+        keyExpiration = new BigNumber(
+          await locks['FIRST'].keyExpirationTimestampFor.call(from)
+        )
+        await locks['FIRST'].transferFrom(from, to, ID, {
+          from
+        })
+      })
+
+      it('should mark the previous owner`s key as expired', async () => {
+        const expirationTimestamp = new BigNumber(
+          await locks['FIRST'].keyExpirationTimestampFor.call(from)
+        )
+        assert(expirationTimestamp.gt(0))
+        assert(expirationTimestamp.lt(keyExpiration))
+      })
+
+      it('should have assigned the key`s previous expiration to the new owner', async () => {
+        const expirationTimestamp = new BigNumber(
+          await locks['FIRST'].keyExpirationTimestampFor.call(to)
+        )
+        assert.equal(expirationTimestamp.toFixed(), keyExpiration.toFixed())
+      })
+
+      it('should have cleared the key data field for the new owner', () => {
+        return locks['FIRST'].keyDataFor.call(to).then(keyData => {
+          assert.equal(keyData, null)
+        })
+      })
+    })
+
+    describe('when the lock is sold out', () => {
+      before(async () => {
+        // first we create a lock with only 1 key
+        await locks['SINGLE KEY'].purchaseFor(
+          from,
+          Web3Utils.toHex('Julien'),
+          {
             value: Units.convert('0.01', 'eth', 'wei'),
             from
-          })
-          // Get the tokenID
-          ID = await locks['FIRST'].getTokenIdFor.call(from)
-          // Let's check the expiration date for that key
-          fromExpirationTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(from)
-          )
-          // Then let's expire the key for accountWithExpiredKey
-          await locks['FIRST'].expireKeyFor(accountWithExpiredKey)
-          keyDataBefore = await locks['FIRST'].keyDataFor.call(
-            accountWithExpiredKey
-          )
-          await locks['FIRST'].transferFrom(from, accountWithExpiredKey, ID, {
-            from
-          })
-          const expirationTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(
-              accountWithExpiredKey
-            )
-          )
-          assert.equal(
-            expirationTimestamp.toFixed(),
-            fromExpirationTimestamp.toFixed()
-          )
-        })
-
-        it("should preserve the recipient's key data", async () => {
-          keyDataAfter = await locks['FIRST'].keyDataFor.call(
-            accountWithExpiredKey
-          )
-          assert.equal(keyDataBefore, keyDataAfter)
-        })
-      })
-
-      describe('when the recipient already has a non expired key', () => {
-        let transferedKeyTimestamp
-        let previousExpirationTimestamp
-
-        before(async () => {
-          await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
-            value: Units.convert('0.01', 'eth', 'wei'),
-            from
-          })
-          ID = await locks['FIRST'].getTokenIdFor.call(from)
-          // First let's get the current expiration
-          transferedKeyTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(from)
-          )
-          previousExpirationTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1])
-          )
-          keyDataBefore = await locks['FIRST'].keyDataFor.call(accountWithKey)
-          await locks['FIRST'].transferFrom(from, accountWithKey, ID, {
-            from
-          })
-        })
-
-        it("should expand the key's validity", async () => {
-          const expirationTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(accountWithKey)
-          )
-          const now = Math.floor(new Date().getTime() / 1000)
-          // Check +/- 10 seconds
-          assert(
-            expirationTimestamp.gt(
-              previousExpirationTimestamp
-                .plus(transferedKeyTimestamp)
-                .minus(now + 10)
-            )
-          )
-          assert(
-            expirationTimestamp.lt(
-              previousExpirationTimestamp
-                .plus(transferedKeyTimestamp)
-                .minus(now - 10)
-            )
-          )
-        })
-
-        it("should expire the previous owner's key", async () => {
-          const expirationTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(from)
-          )
-          const now = Math.floor(new Date().getTime() / 1000)
-          // Check only 10 seconds in the future to ensure deterministic test
-          assert(expirationTimestamp.lt(now + 10))
-        })
-
-        it("should preserve the recipient's key data", async () => {
-          keyDataAfter = await locks['FIRST'].keyDataFor.call(accountWithKey)
-          assert.equal(keyDataBefore, keyDataAfter)
-        })
-      })
-
-      describe('when the key owner is not the sender', async () => {
-        it('should fail if the sender has not been approved for that key', async () => {
-          const previousExpirationTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(from)
-          )
-          await shouldFail(
-            locks['FIRST'].transferFrom(from, accountNotApproved, ID, {
-              from: accountNotApproved
-            }),
-            'KEY_NOT_VALID'
-          )
-          // Ensuring that ownership of the key did not change
-          const expirationTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(from)
-          )
-          assert.equal(
-            previousExpirationTimestamp.toFixed(),
-            expirationTimestamp.toFixed()
-          )
-        })
-
-        it('should succeed if the sender has been approved for that key', async () => {
-          ID = await locks['FIRST'].getTokenIdFor.call(accountWithKeyApproved)
-          await locks['FIRST'].approve(accountApproved, ID, {
-            from: accountWithKeyApproved
-          })
-          await locks['FIRST'].transferFrom(
-            accountWithKeyApproved,
-            accountApproved,
-            ID,
-            {
-              from: accountApproved
-            }
-          )
-          let balance = await locks['FIRST'].balanceOf.call(accountApproved)
-          assert.equal(balance, 1)
-        })
-
-        it('approval should be cleared after a transfer', async () => {
-          await shouldFail(
-            locks['FIRST'].getApproved(accountApproved),
-            'NONE_APPROVED'
-          )
-        })
-      })
-
-      describe('when the key owner is the sender', () => {
-        before(async () => {
-          // first, let's purchase a brand new key that we can transfer
-          await locks['FIRST'].purchaseFor(from, Web3Utils.toHex('Julien'), {
-            value: Units.convert('0.01', 'eth', 'wei'),
-            from
-          })
-          ID = await locks['FIRST'].getTokenIdFor.call(from)
-          keyExpiration = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(from)
-          )
-          await locks['FIRST'].transferFrom(from, to, ID, {
-            from
-          })
-        })
-
-        it('should mark the previous owner`s key as expired', async () => {
-          const expirationTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(from)
-          )
-          assert(expirationTimestamp.gt(0))
-          assert(expirationTimestamp.lt(keyExpiration))
-        })
-
-        it('should have assigned the key`s previous expiration to the new owner', async () => {
-          const expirationTimestamp = new BigNumber(
-            await locks['FIRST'].keyExpirationTimestampFor.call(to)
-          )
-          assert.equal(expirationTimestamp.toFixed(), keyExpiration.toFixed())
-        })
-
-        it('should have cleared the key data field for the new owner', () => {
-          return locks['FIRST'].keyDataFor.call(to).then(keyData => {
-            assert.equal(keyData, null)
-          })
-        })
-      })
-
-      describe('when the lock is sold out', () => {
-        before(async () => {
-          // first we create a lock with only 1 key
-          await locks['SINGLE KEY'].purchaseFor(
-            from,
+          }
+        )
+        // confirm that the lock is sold out
+        await shouldFail(
+          locks['SINGLE KEY'].purchaseFor(
+            accounts[8],
             Web3Utils.toHex('Julien'),
             {
               value: Units.convert('0.01', 'eth', 'wei'),
-              from
+              from: accounts[8]
             }
-          )
-          // confirm that the lock is sold out
-          await shouldFail(
-            locks['SINGLE KEY'].purchaseFor(
-              accounts[8],
-              Web3Utils.toHex('Julien'),
-              {
-                value: Units.convert('0.01', 'eth', 'wei'),
-                from: accounts[8]
-              }
-            ),
-            'LOCK_SOLD_OUT'
-          )
-        })
+          ),
+          'LOCK_SOLD_OUT'
+        )
+      })
 
-        it('should still allow the transfer of keys', async () => {
-          ID = await locks['SINGLE KEY'].getTokenIdFor.call(from)
-          let ownerOfBefore = await locks['SINGLE KEY'].ownerOf.call(ID)
-          await locks['SINGLE KEY'].transferFrom(
-            ownerOfBefore,
-            accounts[9],
-            ID,
-            {
-              from: ownerOfBefore
-            }
-          )
-          let ownerOfAfter = await locks['SINGLE KEY'].ownerOf.call(ID)
-          assert.equal(ownerOfAfter, accounts[9])
-        })
+      it('should still allow the transfer of keys', async () => {
+        ID = await locks['SINGLE KEY'].getTokenIdFor.call(from)
+        let ownerOfBefore = await locks['SINGLE KEY'].ownerOf.call(ID)
+        await locks['SINGLE KEY'].transferFrom(
+          ownerOfBefore,
+          accounts[9],
+          ID,
+          {
+            from: ownerOfBefore
+          }
+        )
+        let ownerOfAfter = await locks['SINGLE KEY'].ownerOf.call(ID)
+        assert.equal(ownerOfAfter, accounts[9])
       })
     })
   })

--- a/smart-contracts/test/Lock/expireKeyFor.js
+++ b/smart-contracts/test/Lock/expireKeyFor.js
@@ -7,7 +7,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock', (accounts) => {
+contract('Lock / expireKeyFor', (accounts) => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -19,65 +19,63 @@ contract('Lock', (accounts) => {
       })
   })
 
-  describe('expireKeyFor', () => {
-    it('should fail if not invoked by lock owner', async () => {
-      await shouldFail(locks['FIRST'].expireKeyFor(accounts[1], {
-        from: accounts[8]
-      }), '')
-    })
+  it('should fail if not invoked by lock owner', async () => {
+    await shouldFail(locks['FIRST'].expireKeyFor(accounts[1], {
+      from: accounts[8]
+    }), '')
+  })
 
-    it('should fail if there is no such key', async () => {
-      await shouldFail(locks['FIRST'].expireKeyFor(accounts[1], {
-        from: accounts[0]
-      }), 'KEY_NOT_VALID')
-    })
+  it('should fail if there is no such key', async () => {
+    await shouldFail(locks['FIRST'].expireKeyFor(accounts[1], {
+      from: accounts[0]
+    }), 'KEY_NOT_VALID')
+  })
 
-    it('should fail if the key has already expired', async () => {
-      await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('Julien'), {
+  it('should fail if the key has already expired', async () => {
+    await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('Julien'), {
+      value: locks['FIRST'].params.keyPrice.toFixed(),
+      from: accounts[0]
+    })
+    const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[2]))
+    const now = Math.floor(new Date().getTime() / 1000)
+    assert(expirationTimestamp.gt(now))
+    await locks['FIRST'].expireKeyFor(accounts[2], {
+      from: accounts[0]
+    })
+    await shouldFail(locks['FIRST'].expireKeyFor(accounts[2], {
+      from: accounts[0]
+    }), 'KEY_NOT_VALID')
+  })
+
+  describe('should expire a valid key', () => {
+    let ID
+    let event
+
+    before(async () => {
+      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
         value: locks['FIRST'].params.keyPrice.toFixed(),
         from: accounts[0]
       })
-      const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[2]))
+      ID = await locks['FIRST'].getTokenIdFor(accounts[1])
+      const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
       const now = Math.floor(new Date().getTime() / 1000)
+      // Pre-condition
       assert(expirationTimestamp.gt(now))
-      await locks['FIRST'].expireKeyFor(accounts[2], {
+      const result = await locks['FIRST'].expireKeyFor(accounts[1], {
         from: accounts[0]
       })
-      await shouldFail(locks['FIRST'].expireKeyFor(accounts[2], {
-        from: accounts[0]
-      }), 'KEY_NOT_VALID')
+      event = result.logs[0]
     })
 
-    describe('should expire a valid key', () => {
-      let ID
-      let event
+    it('should expire a valid key', async () => {
+      const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
+      const now = Math.floor(new Date().getTime() / 1000)
+      assert(expirationTimestamp.lte(now))
+    })
 
-      before(async () => {
-        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Julien'), {
-          value: locks['FIRST'].params.keyPrice.toFixed(),
-          from: accounts[0]
-        })
-        ID = await locks['FIRST'].getTokenIdFor(accounts[1])
-        const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
-        const now = Math.floor(new Date().getTime() / 1000)
-        // Pre-condition
-        assert(expirationTimestamp.gt(now))
-        const result = await locks['FIRST'].expireKeyFor(accounts[1], {
-          from: accounts[0]
-        })
-        event = result.logs[0]
-      })
-
-      it('should expire a valid key', async () => {
-        const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
-        const now = Math.floor(new Date().getTime() / 1000)
-        assert(expirationTimestamp.lte(now))
-      })
-
-      it('should emit an ExpireKey event', async () => {
-        assert.equal(event.event, 'ExpireKey')
-        assert.equal(event.args.tokenId.toString(), ID)
-      })
+    it('should emit an ExpireKey event', async () => {
+      assert.equal(event.event, 'ExpireKey')
+      assert.equal(event.args.tokenId.toString(), ID)
     })
   })
 })

--- a/smart-contracts/test/Lock/gas.js
+++ b/smart-contracts/test/Lock/gas.js
@@ -7,23 +7,21 @@ const WalletService = require('../helpers/walletServiceMock.js')
 
 let unlock, lock
 
-contract('Lock', (accounts) => {
+contract('Lock / gas', (accounts) => {
   beforeEach(async () => {
     unlock = await Unlock.deployed()
     const locks = await deployLocks(unlock)
     lock = locks['FIRST']
   })
 
-  describe('gas usage', () => {
-    it(`gas used to purchaseFor is less than wallet service limit`, async () => {
-      let tx = await lock
-        .purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
-          value: Units.convert('0.01', 'eth', 'wei')
-        })
-      const gasUsed = new BigNumber(tx.receipt.gasUsed)
-      if (!process.env.TEST_COVERAGE) {
-        assert(gasUsed.lte(WalletService.gasAmountConstants().purchaseKey))
-      }
-    })
+  it(`gas used to purchaseFor is less than wallet service limit`, async () => {
+    let tx = await lock
+      .purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
+        value: Units.convert('0.01', 'eth', 'wei')
+      })
+    const gasUsed = new BigNumber(tx.receipt.gasUsed)
+    if (!process.env.TEST_COVERAGE) {
+      assert(gasUsed.lte(WalletService.gasAmountConstants().purchaseKey))
+    }
   })
 })

--- a/smart-contracts/test/Lock/getOwnersByPage.js
+++ b/smart-contracts/test/Lock/getOwnersByPage.js
@@ -7,7 +7,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock', (accounts) => {
+contract('Lock / getOwnersByPage', (accounts) => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -19,61 +19,59 @@ contract('Lock', (accounts) => {
       })
   })
 
-  describe('getOwnersByPage', () => {
-    describe('when there are 0 key owners', () => {
-      it('should return an error', async () => {
-        await shouldFail(locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[5] }), 'NO_OUTSTANDING_KEYS')
-      })
+  describe('when there are 0 key owners', () => {
+    it('should return an error', async () => {
+      await shouldFail(locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[5] }), 'NO_OUTSTANDING_KEYS')
     })
+  })
 
-    describe('when there are less owners than the page size', () => {
-      it('should return all of the key owners', async () => {
-        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('alpha'), { value: Units.convert('0.01', 'eth', 'wei') })
-        let result = await locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
-        assert.equal(result.length, 1)
-        assert.include(result, accounts[1])
-      })
+  describe('when there are less owners than the page size', () => {
+    it('should return all of the key owners', async () => {
+      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('alpha'), { value: Units.convert('0.01', 'eth', 'wei') })
+      let result = await locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
+      assert.equal(result.length, 1)
+      assert.include(result, accounts[1])
     })
+  })
 
-    describe('when there are more owners than the page size', () => {
-      it('return page size number of key owners', async () => {
-        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('alpha'), {
-          value: Units.convert('0.01', 'eth', 'wei')
-        })
-
-        await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('beta'), {
-          value: Units.convert('0.01', 'eth', 'wei')
-        })
-
-        await locks['FIRST'].purchaseFor(accounts[3], Web3Utils.toHex('gamma'), {
-          value: Units.convert('0.01', 'eth', 'wei')
-        })
-
-        let result = await locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
-        assert.equal(result.length, 2)
-        assert.include(result, accounts[1])
-        assert.include(result, accounts[2])
+  describe('when there are more owners than the page size', () => {
+    it('return page size number of key owners', async () => {
+      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('alpha'), {
+        value: Units.convert('0.01', 'eth', 'wei')
       })
+
+      await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('beta'), {
+        value: Units.convert('0.01', 'eth', 'wei')
+      })
+
+      await locks['FIRST'].purchaseFor(accounts[3], Web3Utils.toHex('gamma'), {
+        value: Units.convert('0.01', 'eth', 'wei')
+      })
+
+      let result = await locks['FIRST'].getOwnersByPage.call(0, 2, { from: accounts[0] })
+      assert.equal(result.length, 2)
+      assert.include(result, accounts[1])
+      assert.include(result, accounts[2])
     })
+  })
 
-    describe('when requesting a secondary page', () => {
-      it('return page size number of key owners', async () => {
-        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('alpha'), {
-          value: Units.convert('0.01', 'eth', 'wei')
-        })
-
-        await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('beta'), {
-          value: Units.convert('0.01', 'eth', 'wei')
-        })
-
-        await locks['FIRST'].purchaseFor(accounts[3], Web3Utils.toHex('gamma'), {
-          value: Units.convert('0.01', 'eth', 'wei')
-        })
-
-        let result = await locks['FIRST'].getOwnersByPage.call(1, 2, { from: accounts[0] })
-        assert.equal(result.length, 1)
-        assert.equal(accounts[3], result[0])
+  describe('when requesting a secondary page', () => {
+    it('return page size number of key owners', async () => {
+      await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('alpha'), {
+        value: Units.convert('0.01', 'eth', 'wei')
       })
+
+      await locks['FIRST'].purchaseFor(accounts[2], Web3Utils.toHex('beta'), {
+        value: Units.convert('0.01', 'eth', 'wei')
+      })
+
+      await locks['FIRST'].purchaseFor(accounts[3], Web3Utils.toHex('gamma'), {
+        value: Units.convert('0.01', 'eth', 'wei')
+      })
+
+      let result = await locks['FIRST'].getOwnersByPage.call(1, 2, { from: accounts[0] })
+      assert.equal(result.length, 1)
+      assert.equal(accounts[3], result[0])
     })
   })
 })

--- a/smart-contracts/test/Lock/noFallback.js
+++ b/smart-contracts/test/Lock/noFallback.js
@@ -6,34 +6,32 @@ const abi = new Web3Abi.AbiCoder()
 
 let lock
 
-contract('Unlock', accounts => {
+contract('Lock / noFallback', accounts => {
   before(async () => {
     const unlock = await Unlock.deployed()
     const locks = await deployLocks(unlock, accounts[0])
     lock = locks['FIRST']
   })
 
-  describe('noFallback', () => {
-    it('cannot call the fallback function directly', async () => {
-      await shouldFail(lock.sendTransaction(), 'NO_FALLBACK')
-    })
+  it('cannot call the fallback function directly', async () => {
+    await shouldFail(lock.sendTransaction(), 'NO_FALLBACK')
+  })
 
-    it('does not accept ETH directly', async () => {
-      await shouldFail(lock.send(1))
-    })
+  it('does not accept ETH directly', async () => {
+    await shouldFail(lock.send(1))
+  })
 
-    it('can call a function by name', async () => {
-      await web3.eth.call({
-        to: lock.address,
-        data: abi.encodeFunctionSignature('numberOfOwners()')
-      })
+  it('can call a function by name', async () => {
+    await web3.eth.call({
+      to: lock.address,
+      data: abi.encodeFunctionSignature('numberOfOwners()')
     })
+  })
 
-    it('cannot call a function which does not exist', async () => {
-      await shouldFail(web3.eth.call({
-        to: lock.address,
-        data: abi.encodeFunctionSignature('dne()')
-      }), 'NO_FALLBACK')
-    })
+  it('cannot call a function which does not exist', async () => {
+    await shouldFail(web3.eth.call({
+      to: lock.address,
+      data: abi.encodeFunctionSignature('dne()')
+    }), 'NO_FALLBACK')
   })
 })

--- a/smart-contracts/test/Lock/partialWithdraw.js
+++ b/smart-contracts/test/Lock/partialWithdraw.js
@@ -7,77 +7,75 @@ const shouldFail = require('../helpers/shouldFail')
 const Unlock = artifacts.require('../Unlock.sol')
 let unlock, locks
 
-contract('Lock', (accounts) => {
+contract('Lock / partialWithdraw', (accounts) => {
   before(async () => {
     unlock = await Unlock.deployed()
     locks = await deployLocks(unlock, accounts[0])
   })
 
-  describe('partialWithdraw', () => {
-    let owner, price, initialLockBalance, withdrawalAmount
-    price = new BigNumber(Units.convert('0.01', 'eth', 'wei'))
-    withdrawalAmount = new BigNumber(Units.convert('0.005', 'eth', 'wei'))
+  let owner, price, initialLockBalance, withdrawalAmount
+  price = new BigNumber(Units.convert('0.01', 'eth', 'wei'))
+  withdrawalAmount = new BigNumber(Units.convert('0.005', 'eth', 'wei'))
 
-    before(() => {
-      const purchases = [accounts[1], accounts[2]].map((account) => {
-        return locks['OWNED'].purchaseFor(account, Web3Utils.toHex(''), {
-          value: price.toFixed(),
-          from: account
-        })
+  before(() => {
+    const purchases = [accounts[1], accounts[2]].map((account) => {
+      return locks['OWNED'].purchaseFor(account, Web3Utils.toHex(''), {
+        value: price.toFixed(),
+        from: account
       })
-      return Promise.all(purchases)
-        .then(() => {
-          return locks['OWNED'].owner.call()
-        })
-        .then((_owner) => {
-          owner = _owner
-        })
     })
+    return Promise.all(purchases)
+      .then(() => {
+        return locks['OWNED'].owner.call()
+      })
+      .then((_owner) => {
+        owner = _owner
+      })
+  })
 
-    it('should fail if called by address other than owner', async () => {
-      assert.notEqual(owner, accounts[1]) // Making sure
-      await shouldFail(locks['OWNED'].partialWithdraw(withdrawalAmount.toFixed(), {
-        from: accounts[1]
-      }), '')
-    })
+  it('should fail if called by address other than owner', async () => {
+    assert.notEqual(owner, accounts[1]) // Making sure
+    await shouldFail(locks['OWNED'].partialWithdraw(withdrawalAmount.toFixed(), {
+      from: accounts[1]
+    }), '')
+  })
 
-    it('should fail if too much is withdrawn', async () => {
-      initialLockBalance = new BigNumber(await web3.eth.getBalance(locks['OWNED'].address))
-      await shouldFail(locks['OWNED'].partialWithdraw(initialLockBalance.plus(withdrawalAmount).toFixed(), {
+  it('should fail if too much is withdrawn', async () => {
+    initialLockBalance = new BigNumber(await web3.eth.getBalance(locks['OWNED'].address))
+    await shouldFail(locks['OWNED'].partialWithdraw(initialLockBalance.plus(withdrawalAmount).toFixed(), {
+      from: owner
+    }), 'NOT_ENOUGH_FUNDS')
+  })
+
+  it('should fail if requesting partial withdraw of 0', async () => {
+    await shouldFail(locks['OWNED'].partialWithdraw(0, {
+      from: owner
+    }), 'GREATER_THAN_ZERO')
+  })
+
+  describe('when the owner withdraws some funds', () => {
+    let initialOwnerBalance, expectedLockBalance, finalLockBalance, finalOwnerBalance, gasPrice, gasUsed, txObj, txHash, txFee
+
+    before(async () => {
+      expectedLockBalance = initialLockBalance.minus(withdrawalAmount)
+      initialOwnerBalance = new BigNumber(await web3.eth.getBalance(owner))
+      txObj = await locks['OWNED'].partialWithdraw(withdrawalAmount.toFixed(), {
         from: owner
-      }), 'NOT_ENOUGH_FUNDS')
+      })
     })
 
-    it('should fail if requesting partial withdraw of 0', async () => {
-      await shouldFail(locks['OWNED'].partialWithdraw(0, {
-        from: owner
-      }), 'GREATER_THAN_ZERO')
+    it('should increase the owner\'s balance with the amount of funds withdrawn from the lock', async () => {
+      txHash = await web3.eth.getTransaction(txObj.tx)
+      gasUsed = new BigNumber(txObj.receipt.gasUsed)
+      gasPrice = new BigNumber(txHash.gasPrice)
+      txFee = gasPrice.times(gasUsed)
+      finalOwnerBalance = new BigNumber(await web3.eth.getBalance(owner))
+      assert.equal(finalOwnerBalance.toFixed(), initialOwnerBalance.plus(withdrawalAmount).minus(txFee).toFixed())
     })
 
-    describe('when the owner withdraws some funds', () => {
-      let initialOwnerBalance, expectedLockBalance, finalLockBalance, finalOwnerBalance, gasPrice, gasUsed, txObj, txHash, txFee
-
-      before(async () => {
-        expectedLockBalance = initialLockBalance.minus(withdrawalAmount)
-        initialOwnerBalance = new BigNumber(await web3.eth.getBalance(owner))
-        txObj = await locks['OWNED'].partialWithdraw(withdrawalAmount.toFixed(), {
-          from: owner
-        })
-      })
-
-      it('should increase the owner\'s balance with the amount of funds withdrawn from the lock', async () => {
-        txHash = await web3.eth.getTransaction(txObj.tx)
-        gasUsed = new BigNumber(txObj.receipt.gasUsed)
-        gasPrice = new BigNumber(txHash.gasPrice)
-        txFee = gasPrice.times(gasUsed)
-        finalOwnerBalance = new BigNumber(await web3.eth.getBalance(owner))
-        assert.equal(finalOwnerBalance.toFixed(), initialOwnerBalance.plus(withdrawalAmount).minus(txFee).toFixed())
-      })
-
-      it('should decrease the lock\'s balance by the amount of funds withdrawn from the lock', async () => {
-        finalLockBalance = new BigNumber(await web3.eth.getBalance(locks['OWNED'].address))
-        assert.equal(finalLockBalance.toFixed(), expectedLockBalance.toFixed())
-      })
+    it('should decrease the lock\'s balance by the amount of funds withdrawn from the lock', async () => {
+      finalLockBalance = new BigNumber(await web3.eth.getBalance(locks['OWNED'].address))
+      assert.equal(finalLockBalance.toFixed(), expectedLockBalance.toFixed())
     })
   })
 })

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -8,7 +8,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock', (accounts) => {
+contract('Lock / purchaseFor', (accounts) => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -20,127 +20,125 @@ contract('Lock', (accounts) => {
       })
   })
 
-  describe('purchaseFor', () => {
-    describe('when the contract has a public key release', () => {
-      it('should fail if the price is not enough', async () => {
-        await shouldFail(locks['FIRST']
-          .purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
-            value: Units.convert('0.0001', 'eth', 'wei')
-          }), 'NOT_ENOUGH_FUNDS')
-        // Making sure we do not have a key set!
-        await shouldFail(locks['FIRST'].keyExpirationTimestampFor.call(accounts[0]), 'NO_SUCH_KEY')
+  describe('when the contract has a public key release', () => {
+    it('should fail if the price is not enough', async () => {
+      await shouldFail(locks['FIRST']
+        .purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
+          value: Units.convert('0.0001', 'eth', 'wei')
+        }), 'NOT_ENOUGH_FUNDS')
+      // Making sure we do not have a key set!
+      await shouldFail(locks['FIRST'].keyExpirationTimestampFor.call(accounts[0]), 'NO_SUCH_KEY')
+    })
+
+    it('should fail if we reached the max number of keys', async () => {
+      await locks['SINGLE KEY']
+        .purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+      const keyData = await locks['SINGLE KEY'].keyDataFor.call(accounts[0])
+      assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
+      await shouldFail(locks['SINGLE KEY'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[1]
+      }), 'LOCK_SOLD_OUT')
+      await shouldFail(locks['SINGLE KEY'].keyDataFor.call(accounts[1]), 'NO_SUCH_KEY')
+    })
+
+    it('should trigger an event when successful', async () => {
+      const tx = await locks['FIRST']
+        .purchaseFor(accounts[2], Web3Utils.toHex('Vitalik'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+      assert.equal(tx.logs[0].event, 'Transfer')
+      assert.equal(tx.logs[0].args._from, 0)
+      assert.equal(tx.logs[0].args._to, accounts[2])
+    })
+
+    describe('when the user already owns an expired key', () => {
+      it('should expand the validity by the default key duration', async () => {
+        await locks['SECOND'].purchaseFor(accounts[4], Web3Utils.toHex('Satoshi'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+        // let's now expire the key
+        await locks['SECOND'].expireKeyFor(accounts[4])
+        // Purchase a new one
+        await locks['SECOND'].purchaseFor(accounts[4], Web3Utils.toHex('Satoshi'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+        // And check the expiration which shiuld be exactly now + keyDuration
+        const expirationTimestamp = new BigNumber(await locks['SECOND'].keyExpirationTimestampFor.call(accounts[4]))
+        const now = parseInt(new Date().getTime() / 1000)
+        // we check +/- 10 seconds to fix for now being different inside the EVM and here... :(
+        assert(expirationTimestamp.gt(locks['SECOND'].params.expirationDuration.plus(now - 10)))
+        assert(expirationTimestamp.lt(locks['SECOND'].params.expirationDuration.plus(now + 10)))
+      })
+    })
+
+    describe('when the user already owns a non expired key', () => {
+      it('should expand the validity by the default key duration', async () => {
+        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+        const firstKeyData = await locks['FIRST'].keyDataFor.call(accounts[1])
+        assert.equal(Web3Utils.toUtf8(firstKeyData), 'Satoshi')
+        const firstExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
+        assert(firstExpiration.gt(0))
+        await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Szabo'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
+        const keyData = await locks['FIRST'].keyDataFor.call(accounts[1])
+        assert.equal(Web3Utils.toUtf8(keyData), 'Szabo')
+        const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
+        assert.equal(expirationTimestamp.toFixed(), firstExpiration.plus(locks['FIRST'].params.expirationDuration).toFixed())
+      })
+    })
+
+    describe('when the key was successfuly purchased', () => {
+      let outstandingKeys, numberOfOwners, balance, now
+
+      before(async () => {
+        balance = new BigNumber(await web3.eth.getBalance(locks['FIRST'].address))
+        outstandingKeys = new BigNumber(await locks['FIRST'].outstandingKeys.call())
+        now = parseInt(new Date().getTime() / 1000)
+        numberOfOwners = new BigNumber(await locks['FIRST'].numberOfOwners.call())
+        return locks['FIRST'].purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
+          value: Units.convert('0.01', 'eth', 'wei')
+        })
       })
 
-      it('should fail if we reached the max number of keys', async () => {
-        await locks['SINGLE KEY']
-          .purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
-            value: Units.convert('0.01', 'eth', 'wei')
+      it('should have the right data for the key', () => {
+        return locks['FIRST']
+          .keyDataFor.call(accounts[0])
+          .then(keyData => {
+            assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
           })
-        const keyData = await locks['SINGLE KEY'].keyDataFor.call(accounts[0])
-        assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
-        await shouldFail(locks['SINGLE KEY'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
-          value: Units.convert('0.01', 'eth', 'wei'),
-          from: accounts[1]
-        }), 'LOCK_SOLD_OUT')
-        await shouldFail(locks['SINGLE KEY'].keyDataFor.call(accounts[1]), 'NO_SUCH_KEY')
       })
 
-      it('should trigger an event when successful', async () => {
-        const tx = await locks['FIRST']
-          .purchaseFor(accounts[2], Web3Utils.toHex('Vitalik'), {
-            value: Units.convert('0.01', 'eth', 'wei')
-          })
-        assert.equal(tx.logs[0].event, 'Transfer')
-        assert.equal(tx.logs[0].args._from, 0)
-        assert.equal(tx.logs[0].args._to, accounts[2])
+      it('should have the right expiration timestamp for the key', async () => {
+        const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[0]))
+        const expirationDuration = new BigNumber(await locks['FIRST'].expirationDuration.call())
+        assert(expirationTimestamp.gte(expirationDuration.plus(now)))
       })
 
-      describe('when the user already owns an expired key', () => {
-        it('should expand the validity by the default key duration', async () => {
-          await locks['SECOND'].purchaseFor(accounts[4], Web3Utils.toHex('Satoshi'), {
-            value: Units.convert('0.01', 'eth', 'wei')
-          })
-          // let's now expire the key
-          await locks['SECOND'].expireKeyFor(accounts[4])
-          // Purchase a new one
-          await locks['SECOND'].purchaseFor(accounts[4], Web3Utils.toHex('Satoshi'), {
-            value: Units.convert('0.01', 'eth', 'wei')
-          })
-          // And check the expiration which shiuld be exactly now + keyDuration
-          const expirationTimestamp = new BigNumber(await locks['SECOND'].keyExpirationTimestampFor.call(accounts[4]))
-          const now = parseInt(new Date().getTime() / 1000)
-          // we check +/- 10 seconds to fix for now being different inside the EVM and here... :(
-          assert(expirationTimestamp.gt(locks['SECOND'].params.expirationDuration.plus(now - 10)))
-          assert(expirationTimestamp.lt(locks['SECOND'].params.expirationDuration.plus(now + 10)))
-        })
+      it('should have added the funds to the contract', async () => {
+        let newBalance = new BigNumber(await web3.eth.getBalance(locks['FIRST'].address))
+        assert.equal(parseFloat(Units.convert(newBalance, 'wei', 'eth')), parseFloat(Units.convert(balance, 'wei', 'eth')) + 0.01)
       })
 
-      describe('when the user already owns a non expired key', () => {
-        it('should expand the validity by the default key duration', async () => {
-          await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Satoshi'), {
-            value: Units.convert('0.01', 'eth', 'wei')
-          })
-          const firstKeyData = await locks['FIRST'].keyDataFor.call(accounts[1])
-          assert.equal(Web3Utils.toUtf8(firstKeyData), 'Satoshi')
-          const firstExpiration = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
-          assert(firstExpiration.gt(0))
-          await locks['FIRST'].purchaseFor(accounts[1], Web3Utils.toHex('Szabo'), {
-            value: Units.convert('0.01', 'eth', 'wei')
-          })
-          const keyData = await locks['FIRST'].keyDataFor.call(accounts[1])
-          assert.equal(Web3Utils.toUtf8(keyData), 'Szabo')
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[1]))
-          assert.equal(expirationTimestamp.toFixed(), firstExpiration.plus(locks['FIRST'].params.expirationDuration).toFixed())
-        })
+      it('should have increased the number of outstanding keys', async () => {
+        const _outstandingKeys = new BigNumber(await locks['FIRST'].outstandingKeys.call())
+        assert.equal(
+          _outstandingKeys.toFixed(),
+          outstandingKeys.plus(1).toFixed()
+        )
       })
 
-      describe('when the key was successfuly purchased', () => {
-        let outstandingKeys, numberOfOwners, balance, now
-
-        before(async () => {
-          balance = new BigNumber(await web3.eth.getBalance(locks['FIRST'].address))
-          outstandingKeys = new BigNumber(await locks['FIRST'].outstandingKeys.call())
-          now = parseInt(new Date().getTime() / 1000)
-          numberOfOwners = new BigNumber(await locks['FIRST'].numberOfOwners.call())
-          return locks['FIRST'].purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
-            value: Units.convert('0.01', 'eth', 'wei')
-          })
-        })
-
-        it('should have the right data for the key', () => {
-          return locks['FIRST']
-            .keyDataFor.call(accounts[0])
-            .then(keyData => {
-              assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
-            })
-        })
-
-        it('should have the right expiration timestamp for the key', async () => {
-          const expirationTimestamp = new BigNumber(await locks['FIRST'].keyExpirationTimestampFor.call(accounts[0]))
-          const expirationDuration = new BigNumber(await locks['FIRST'].expirationDuration.call())
-          assert(expirationTimestamp.gte(expirationDuration.plus(now)))
-        })
-
-        it('should have added the funds to the contract', async () => {
-          let newBalance = new BigNumber(await web3.eth.getBalance(locks['FIRST'].address))
-          assert.equal(parseFloat(Units.convert(newBalance, 'wei', 'eth')), parseFloat(Units.convert(balance, 'wei', 'eth')) + 0.01)
-        })
-
-        it('should have increased the number of outstanding keys', async () => {
-          const _outstandingKeys = new BigNumber(await locks['FIRST'].outstandingKeys.call())
-          assert.equal(
-            _outstandingKeys.toFixed(),
-            outstandingKeys.plus(1).toFixed()
-          )
-        })
-
-        it('should have increased the number of owners', async () => {
-          const _numberOfOwners = new BigNumber(await locks['FIRST'].numberOfOwners.call())
-          assert.equal(
-            _numberOfOwners.toFixed(),
-            numberOfOwners.plus(1).toFixed()
-          )
-        })
+      it('should have increased the number of owners', async () => {
+        const _numberOfOwners = new BigNumber(await locks['FIRST'].numberOfOwners.call())
+        assert.equal(
+          _numberOfOwners.toFixed(),
+          numberOfOwners.plus(1).toFixed()
+        )
       })
     })
   })

--- a/smart-contracts/test/Lock/purchaseForFrom.js
+++ b/smart-contracts/test/Lock/purchaseForFrom.js
@@ -7,7 +7,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock', (accounts) => {
+contract('Lock / purchaseForFrom', (accounts) => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -19,34 +19,32 @@ contract('Lock', (accounts) => {
       })
   })
 
-  describe('purchaseForFrom', () => {
-    describe('if the referrer does not have a key', () => {
-      it('should fail', async () => {
-        const lock = locks['FIRST']
-        await shouldFail(lock
-          .purchaseForFrom(accounts[0], accounts[1], Web3Utils.toHex('Julien')), 'KEY_NOT_VALID')
-        // Making sure we do not have a key set!
-        await shouldFail(lock.keyExpirationTimestampFor.call(accounts[0]), 'NO_SUCH_KEY')
-      })
+  describe('if the referrer does not have a key', () => {
+    it('should fail', async () => {
+      const lock = locks['FIRST']
+      await shouldFail(lock
+        .purchaseForFrom(accounts[0], accounts[1], Web3Utils.toHex('Julien')), 'KEY_NOT_VALID')
+      // Making sure we do not have a key set!
+      await shouldFail(lock.keyExpirationTimestampFor.call(accounts[0]), 'NO_SUCH_KEY')
     })
+  })
 
-    describe('if the referrer has a key', () => {
-      it('should succeed', () => {
-        const lock = locks['FIRST']
-        return lock.purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
+  describe('if the referrer has a key', () => {
+    it('should succeed', () => {
+      const lock = locks['FIRST']
+      return lock.purchaseFor(accounts[0], Web3Utils.toHex('Julien'), {
+        value: Units.convert('0.01', 'eth', 'wei')
+      }).then(() => {
+        return lock.keyDataFor.call(accounts[0])
+      }).then((keyData) => {
+        assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
+        return lock.purchaseForFrom(accounts[1], accounts[0], Web3Utils.toHex('Vitalik'), {
           value: Units.convert('0.01', 'eth', 'wei')
-        }).then(() => {
-          return lock.keyDataFor.call(accounts[0])
-        }).then((keyData) => {
-          assert.equal(Web3Utils.toUtf8(keyData), 'Julien')
-          return lock.purchaseForFrom(accounts[1], accounts[0], Web3Utils.toHex('Vitalik'), {
-            value: Units.convert('0.01', 'eth', 'wei')
-          })
-        }).then(() => {
-          return lock.keyDataFor.call(accounts[1])
-        }).then((keyData) => {
-          assert.equal(Web3Utils.toUtf8(keyData), 'Vitalik')
         })
+      }).then(() => {
+        return lock.keyDataFor.call(accounts[1])
+      }).then((keyData) => {
+        assert.equal(Web3Utils.toUtf8(keyData), 'Vitalik')
       })
     })
   })

--- a/smart-contracts/test/Lock/withdraw.js
+++ b/smart-contracts/test/Lock/withdraw.js
@@ -8,7 +8,7 @@ const Unlock = artifacts.require('../Unlock.sol')
 
 let unlock, locks
 
-contract('Lock', (accounts) => {
+contract('Lock / withdraw', (accounts) => {
   before(() => {
     return Unlock.deployed()
       .then(_unlock => {
@@ -20,55 +20,53 @@ contract('Lock', (accounts) => {
       })
   })
 
-  describe('withdraw', () => {
-    let owner
-    let price = Units.convert('0.01', 'eth', 'wei')
+  let owner
+  let price = Units.convert('0.01', 'eth', 'wei')
 
-    before(() => {
-      const purchases = [accounts[1], accounts[2]].map((account) => {
-        return locks['OWNED'].purchaseFor(account, Web3Utils.toHex(''), {
-          value: price,
-          from: account
-        })
+  before(() => {
+    const purchases = [accounts[1], accounts[2]].map((account) => {
+      return locks['OWNED'].purchaseFor(account, Web3Utils.toHex(''), {
+        value: price,
+        from: account
       })
-      return Promise.all(purchases)
-        .then(() => {
-          return locks['OWNED'].owner.call()
-        })
-        .then((_owner) => {
-          owner = _owner
-        })
+    })
+    return Promise.all(purchases)
+      .then(() => {
+        return locks['OWNED'].owner.call()
+      })
+      .then((_owner) => {
+        owner = _owner
+      })
+  })
+
+  it('should only allow the owner to withdraw', async () => {
+    assert.notEqual(owner, accounts[1]) // Making sure
+    await shouldFail(locks['OWNED'].withdraw({
+      from: accounts[1]
+    }), '')
+  })
+
+  describe('when the owner withdraws funds', () => {
+    let ownerBalance
+    before(async () => {
+      ownerBalance = new BigNumber(await web3.eth.getBalance(owner))
+      return locks['OWNED'].withdraw({
+        from: owner
+      })
+    })
+    it('should increase the owner\'s balance with the funds from the lock', async () => {
+      const balance = new BigNumber(await web3.eth.getBalance(owner))
+      assert(balance.gt(ownerBalance))
     })
 
-    it('should only allow the owner to withdraw', async () => {
-      assert.notEqual(owner, accounts[1]) // Making sure
+    it('should set the lock\'s balance to 0', async () => {
+      assert.equal(await web3.eth.getBalance(locks['OWNED'].address), 0)
+    })
+
+    it('should fail if there is nothing left to withdraw', async () => {
       await shouldFail(locks['OWNED'].withdraw({
-        from: accounts[1]
-      }), '')
-    })
-
-    describe('when the owner withdraws funds', () => {
-      let ownerBalance
-      before(async () => {
-        ownerBalance = new BigNumber(await web3.eth.getBalance(owner))
-        return locks['OWNED'].withdraw({
-          from: owner
-        })
-      })
-      it('should increase the owner\'s balance with the funds from the lock', async () => {
-        const balance = new BigNumber(await web3.eth.getBalance(owner))
-        assert(balance.gt(ownerBalance))
-      })
-
-      it('should set the lock\'s balance to 0', async () => {
-        assert.equal(await web3.eth.getBalance(locks['OWNED'].address), 0)
-      })
-
-      it('should fail if there is nothing left to withdraw', async () => {
-        await shouldFail(locks['OWNED'].withdraw({
-          from: owner
-        }), 'NOT_ENOUGH_FUNDS')
-      })
+        from: owner
+      }), 'NOT_ENOUGH_FUNDS')
     })
   })
 })

--- a/smart-contracts/test/Unlock/UnlockProxy.js
+++ b/smart-contracts/test/Unlock/UnlockProxy.js
@@ -5,24 +5,22 @@ const { ZWeb3, Contracts } = require('zos-lib')
 ZWeb3.initialize(web3.currentProvider)
 const Unlock = Contracts.getFromLocal('Unlock')
 
-contract('Unlock', function (accounts) {
+contract('Unlock / UnlockProxy', function (accounts) {
   const proxyAdmin = accounts[1]
   const unlockOwner = accounts[2]
 
-  describe('Proxy Unlock contract', function () {
-    beforeEach(async function () {
-      // TestHelper retrieves project structure from the zos.json file and deploys everything to the current test network.
-      this.project = await TestHelper({ from: proxyAdmin })
-      this.proxy = await this.project.createProxy(Unlock, {
-        Unlock,
-        initMethod: 'initialize',
-        initArgs: [unlockOwner]
-      })
-      this.unlock = await Unlock.at(this.proxy.address)
+  beforeEach(async function () {
+    // TestHelper retrieves project structure from the zos.json file and deploys everything to the current test network.
+    this.project = await TestHelper({ from: proxyAdmin })
+    this.proxy = await this.project.createProxy(Unlock, {
+      Unlock,
+      initMethod: 'initialize',
+      initArgs: [unlockOwner]
     })
+    this.unlock = await Unlock.at(this.proxy.address)
+  })
 
-    describe('should function as a proxy', function () {
-      shared.shouldBehaveLikeV1(accounts, unlockOwner)
-    })
+  describe('should function as a proxy', function () {
+    shared.shouldBehaveLikeV1(accounts, unlockOwner)
   })
 })

--- a/smart-contracts/test/Unlock/behaviors/computeAvailableDiscountFor.js
+++ b/smart-contracts/test/Unlock/behaviors/computeAvailableDiscountFor.js
@@ -1,7 +1,7 @@
 const deployLocks = require('../../helpers/deployLocks')
 
 exports.shouldComputeAvailableDiscountFor = function (accounts) {
-  describe('computeAvailableDiscountFor', function () {
+  describe('Unlock / behaviors / computeAvailableDiscountFor', function () {
     beforeEach(async function () {
       await deployLocks(this.unlock, accounts[0])
     })

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -4,7 +4,7 @@ const shouldFail = require('../../helpers/shouldFail')
 const PublicLock = artifacts.require('../../PublicLock.sol')
 
 exports.shouldCreateLock = function (accounts) {
-  describe('createLock', function () {
+  describe('Unlock / behaviors / createLock', function () {
     describe('lock created successfully', function () {
       let transaction
       beforeEach(async function () {

--- a/smart-contracts/test/Unlock/behaviors/createLockWithInfiniteKeys.js
+++ b/smart-contracts/test/Unlock/behaviors/createLockWithInfiniteKeys.js
@@ -7,55 +7,53 @@ const { ZWeb3, Contracts } = require('zos-lib')
 ZWeb3.initialize(web3.currentProvider)
 const Unlock = Contracts.getFromLocal('Unlock')
 
-contract('PublicLock', accounts => {
+contract('Unlock / behaviors / createLockWithInfiniteKeys', accounts => {
   const proxyAdmin = accounts[1]
   const unlockOwner = accounts[2]
 
-  describe('Locks with infinite or 0 keys', function () {
+  before(async function () {
+    this.project = await TestHelper({ from: proxyAdmin })
+    this.proxy = await this.project.createProxy(Unlock, { initMethod: 'initialize', initArgs: [unlockOwner], initFrom: unlockOwner })
+    this.unlock = await Unlock.at(this.proxy.address)
+  })
+
+  describe('Create a Lock with infinite keys', function () {
+    let transaction
     before(async function () {
-      this.project = await TestHelper({ from: proxyAdmin })
-      this.proxy = await this.project.createProxy(Unlock, { initMethod: 'initialize', initArgs: [unlockOwner], initFrom: unlockOwner })
-      this.unlock = await Unlock.at(this.proxy.address)
-    })
-
-    describe('Create a Lock with infinite keys', function () {
-      let transaction
-      before(async function () {
-        transaction = await this.unlock.methods.createLock(
-          60 * 60 * 24 * 30, // expirationDuration: 30 days
-          Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
-          -1 // maxNumberOfKeys
-        ).send({
-          from: accounts[0],
-          gas: 4000000
-        })
-      })
-
-      it('should have created the lock with an infinite number of keys', async function () {
-        let publicLock = await PublicLock.at(transaction.events.NewLock.returnValues.newLockAddress)
-        const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())
-        assert.equal(maxNumberOfKeys.toFixed(), new BigNumber(2).pow(256).minus(1).toFixed())
+      transaction = await this.unlock.methods.createLock(
+        60 * 60 * 24 * 30, // expirationDuration: 30 days
+        Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
+        -1 // maxNumberOfKeys
+      ).send({
+        from: accounts[0],
+        gas: 4000000
       })
     })
 
-    describe('Create a Lock with 0 keys', function () {
-      let transaction
-      before(async function () {
-        transaction = await this.unlock.methods.createLock(
-          60 * 60 * 24 * 30, // expirationDuration: 30 days
-          Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
-          0 // maxNumberOfKeys
-        ).send({
-          from: accounts[0],
-          gas: 4000000
-        })
-      })
+    it('should have created the lock with an infinite number of keys', async function () {
+      let publicLock = await PublicLock.at(transaction.events.NewLock.returnValues.newLockAddress)
+      const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())
+      assert.equal(maxNumberOfKeys.toFixed(), new BigNumber(2).pow(256).minus(1).toFixed())
+    })
+  })
 
-      it('should have created the lock with 0 keys', async function () {
-        let publicLock = await PublicLock.at(transaction.events.NewLock.returnValues.newLockAddress)
-        const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())
-        assert.equal(maxNumberOfKeys.toFixed(), 0)
+  describe('Create a Lock with 0 keys', function () {
+    let transaction
+    before(async function () {
+      transaction = await this.unlock.methods.createLock(
+        60 * 60 * 24 * 30, // expirationDuration: 30 days
+        Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
+        0 // maxNumberOfKeys
+      ).send({
+        from: accounts[0],
+        gas: 4000000
       })
+    })
+
+    it('should have created the lock with 0 keys', async function () {
+      let publicLock = await PublicLock.at(transaction.events.NewLock.returnValues.newLockAddress)
+      const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())
+      assert.equal(maxNumberOfKeys.toFixed(), 0)
     })
   })
 })

--- a/smart-contracts/test/Unlock/behaviors/initialization.js
+++ b/smart-contracts/test/Unlock/behaviors/initialization.js
@@ -2,7 +2,7 @@ const Web3Utils = require('web3-utils')
 const BigNumber = require('bignumber.js')
 
 exports.shouldHaveInitialized = function (unlockOwner) {
-  describe('initialization', function () {
+  describe('Unlock / behaviors / initialization', function () {
     it('should have an owner', async function () {
       const owner = await this.unlock.methods.owner().call()
       assert.equal(owner, Web3Utils.toChecksumAddress(unlockOwner))

--- a/smart-contracts/test/Unlock/behaviors/recordConsumedDiscount.js
+++ b/smart-contracts/test/Unlock/behaviors/recordConsumedDiscount.js
@@ -1,7 +1,7 @@
 const deployLocks = require('../../helpers/deployLocks')
 
 exports.shouldRecordConsumedDiscount = function (accounts) {
-  describe('recordConsumedDiscount', function () {
+  describe('Unlock / behaviors / recordConsumedDiscount', function () {
     beforeEach(async function () {
       await deployLocks(this.unlock, accounts[0])
     })

--- a/smart-contracts/test/Unlock/behaviors/recordKeyPurchase.js
+++ b/smart-contracts/test/Unlock/behaviors/recordKeyPurchase.js
@@ -2,7 +2,7 @@
 const deployLocks = require('../../helpers/deployLocks')
 
 exports.shouldRecordKeyPurchase = function (accounts) {
-  describe('recordKeyPurchase', function () {
+  describe('Unlock / behaviors / recordKeyPurchase', function () {
     beforeEach(async function () {
       await deployLocks(this.unlock, accounts[0])
     })

--- a/smart-contracts/test/Unlock/behaviors/shared.js
+++ b/smart-contracts/test/Unlock/behaviors/shared.js
@@ -5,7 +5,7 @@ const recordConsumedDiscount = require('./recordConsumedDiscount')
 const recordKeyPurchase = require('./recordKeyPurchase')
 
 exports.shouldBehaveLikeV1 = function (accounts, unlockOwner) {
-  describe('should behave like v1', function () {
+  describe('Unlock / behaviors / shared', function () {
     initialization.shouldHaveInitialized(unlockOwner)
     computeAvailableDiscountFor.shouldComputeAvailableDiscountFor(accounts)
     createLock.shouldCreateLock(accounts)

--- a/smart-contracts/test/Unlock/gas.js
+++ b/smart-contracts/test/Unlock/gas.js
@@ -5,29 +5,25 @@ const WalletService = require('../helpers/walletServiceMock.js')
 
 let unlock
 
-contract('Unlock', (accounts) => {
+contract('Unlock / gas', (accounts) => {
+  let createLockGas = new BigNumber(42)
+
   beforeEach(async () => {
     unlock = await Unlock.deployed()
+
+    let tx = await unlock.createLock(
+      60 * 60 * 24 * 30, // expirationDuration: 30 days
+      Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
+      100 // maxNumberOfKeys
+      , {
+        from: accounts[0]
+      })
+    createLockGas = new BigNumber(tx.receipt.gasUsed)
   })
 
-  describe('gas usage', () => {
-    let createLockGas = new BigNumber(42)
-
-    beforeEach(async () => {
-      let tx = await unlock.createLock(
-        60 * 60 * 24 * 30, // expirationDuration: 30 days
-        Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
-        100 // maxNumberOfKeys
-        , {
-          from: accounts[0]
-        })
-      createLockGas = new BigNumber(tx.receipt.gasUsed)
-    })
-
-    it(`gas used to createLock is less than wallet service limit`, async () => {
-      if (!process.env.TEST_COVERAGE) {
-        assert(createLockGas.lte(WalletService.gasAmountConstants().createLock))
-      }
-    })
+  it(`gas used to createLock is less than wallet service limit`, async () => {
+    if (!process.env.TEST_COVERAGE) {
+      assert(createLockGas.lte(WalletService.gasAmountConstants().createLock))
+    }
   })
 })

--- a/smart-contracts/test/Unlock/noFallback.js
+++ b/smart-contracts/test/Unlock/noFallback.js
@@ -5,32 +5,30 @@ const abi = new Web3Abi.AbiCoder()
 
 let unlock
 
-contract('Unlock', accounts => {
+contract('Unlock / noFallback', accounts => {
   before(async () => {
     unlock = await Unlock.deployed()
   })
 
-  describe('noFallback', () => {
-    it('cannot call the fallback function directly', async () => {
-      await shouldFail(unlock.sendTransaction(), 'NO_FALLBACK')
-    })
+  it('cannot call the fallback function directly', async () => {
+    await shouldFail(unlock.sendTransaction(), 'NO_FALLBACK')
+  })
 
-    it('does not accept ETH directly', async () => {
-      await shouldFail(unlock.send(1))
-    })
+  it('does not accept ETH directly', async () => {
+    await shouldFail(unlock.send(1))
+  })
 
-    it('can call a function by name', async () => {
-      await web3.eth.call({
-        to: unlock.address,
-        data: abi.encodeFunctionSignature('totalDiscountGranted()')
-      })
+  it('can call a function by name', async () => {
+    await web3.eth.call({
+      to: unlock.address,
+      data: abi.encodeFunctionSignature('totalDiscountGranted()')
     })
+  })
 
-    it('cannot call a function which does not exist', async () => {
-      await shouldFail(web3.eth.call({
-        to: unlock.address,
-        data: abi.encodeFunctionSignature('dne()')
-      }), 'NO_FALLBACK')
-    })
+  it('cannot call a function which does not exist', async () => {
+    await shouldFail(web3.eth.call({
+      to: unlock.address,
+      data: abi.encodeFunctionSignature('dne()')
+    }), 'NO_FALLBACK')
   })
 })

--- a/smart-contracts/test/Unlock/upgrades.js
+++ b/smart-contracts/test/Unlock/upgrades.js
@@ -24,7 +24,7 @@ contract('Unlock / upgrades', accounts => {
     project = await TestHelper({ from: unlockOwner })
 
     // Deploy
-      UnlockV0.schema.contractName = 'UnlockV0'
+    UnlockV0.schema.contractName = 'UnlockV0'
     proxy = await project.createProxy(UnlockV0, {
       UnlockV0,
       initMethod: 'initialize',
@@ -61,10 +61,10 @@ contract('Unlock / upgrades', accounts => {
     v0LockData = await unlock.methods.locks(lockV0._address).call()
   })
 
-    it('v0 Key is owned', async () => {
-      const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
-      assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
-    })
+  it('v0 Key is owned', async () => {
+    const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
+    assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
+  })
 
   it('the versions V0 and V1 have different bytecode', async () => {
     assert.notEqual(UnlockV1.schema.bytecode, UnlockV0.schema.bytecode)
@@ -79,7 +79,7 @@ contract('Unlock / upgrades', accounts => {
     describe('Lock created with UnlockV0 is still available', () => {
       it('v0 Key is still owned', async () => {
         const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
-          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
+        assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
       })
 
       it('New keys may still be purchased', async () => {
@@ -179,8 +179,8 @@ contract('Unlock / upgrades', accounts => {
       })
 
       it('v0 Key is still owned', async () => {
-          const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
-          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
+        const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
+        assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
       })
     })
   })

--- a/smart-contracts/test/Unlock/upgrades.js
+++ b/smart-contracts/test/Unlock/upgrades.js
@@ -12,180 +12,175 @@ const PublicLockV1 = Contracts.getFromLocal('PublicLock')
 
 let project, proxy, unlock
 
-contract('Unlock', accounts => {
+contract('Unlock / upgrades', accounts => {
   const unlockOwner = accounts[9]
   const lockOwner = accounts[1]
   const keyOwner = accounts[2]
   const keyPrice = Units.convert('0.01', 'eth', 'wei')
+  let lockV0
+  let v0LockData
 
   before(async () => {
     project = await TestHelper({ from: unlockOwner })
-  })
 
-  describe('Upgrade from v0 to v1', () => {
-    let lockV0
-    let v0LockData
-
-    before(async () => {
-      // Deploy
+    // Deploy
       UnlockV0.schema.contractName = 'UnlockV0'
-      proxy = await project.createProxy(UnlockV0, {
-        UnlockV0,
-        initMethod: 'initialize',
-        initArgs: [unlockOwner]
+    proxy = await project.createProxy(UnlockV0, {
+      UnlockV0,
+      initMethod: 'initialize',
+      initArgs: [unlockOwner]
+    })
+
+    unlock = await UnlockV0.at(proxy.address)
+
+    // Create Lock
+    const lockTx = await unlock.methods
+      .createLock(
+        60 * 60 * 24, // expirationDuration 1 day
+        keyPrice,
+        5 // maxNumberOfKeys
+      )
+      .send({ from: lockOwner, gas: 4000000 })
+    // THIS API IS LIKELY TO BREAK BECAUSE IT ASSUMES SO MUCH
+    const evt = lockTx.events.NewLock
+    lockV0 = new web3.eth.Contract(
+      PublicLockV0.abi,
+      evt.returnValues.newLockAddress
+    )
+
+    // Buy Key
+    await lockV0.methods
+      .purchaseFor(keyOwner, Web3Utils.toHex('Julien'))
+      .send({
+        value: keyPrice,
+        from: keyOwner,
+        gas: 4000000
       })
 
-      unlock = await UnlockV0.at(proxy.address)
-
-      // Create Lock
-      const lockTx = await unlock.methods
-        .createLock(
-          60 * 60 * 24, // expirationDuration 1 day
-          keyPrice,
-          5 // maxNumberOfKeys
-        )
-        .send({ from: lockOwner, gas: 4000000 })
-      // THIS API IS LIKELY TO BREAK BECAUSE IT ASSUMES SO MUCH
-      const evt = lockTx.events.NewLock
-      lockV0 = new web3.eth.Contract(
-        PublicLockV0.abi,
-        evt.returnValues.newLockAddress
-      )
-
-      // Buy Key
-      await lockV0.methods
-        .purchaseFor(keyOwner, Web3Utils.toHex('Julien'))
-        .send({
-          value: keyPrice,
-          from: keyOwner,
-          gas: 4000000
-        })
-
-      // Record sample lock data
-      v0LockData = await unlock.methods.locks(lockV0._address).call()
-    })
+    // Record sample lock data
+    v0LockData = await unlock.methods.locks(lockV0._address).call()
+  })
 
     it('v0 Key is owned', async () => {
       const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
       assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
     })
 
-    it('the versions V0 and V1 have different bytecode', async () => {
-      assert.notEqual(UnlockV1.schema.bytecode, UnlockV0.schema.bytecode)
+  it('the versions V0 and V1 have different bytecode', async () => {
+    assert.notEqual(UnlockV1.schema.bytecode, UnlockV0.schema.bytecode)
+  })
+
+  describe('v1', () => {
+    before(async () => {
+      project.upgradeProxy(proxy.address, UnlockV1)
+      unlock = UnlockV1.at(proxy.address)
     })
 
-    describe('v1', () => {
+    describe('Lock created with UnlockV0 is still available', () => {
+      it('v0 Key is still owned', async () => {
+        const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
+          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
+      })
+
+      it('New keys may still be purchased', async () => {
+        const tx = await lockV0.methods
+          .purchaseFor(accounts[6], Web3Utils.toHex('Julien'))
+          .send({
+            value: keyPrice,
+            from: accounts[6],
+            gas: 4000000
+          })
+        assert.equal(tx.events.Transfer.event, 'Transfer')
+      })
+
+      it('Keys may still be transfered', async () => {
+        await lockV0.methods
+          .purchaseFor(accounts[7], Web3Utils.toHex('Julien'))
+          .send({
+            value: keyPrice,
+            from: accounts[7],
+            gas: 4000000
+          })
+        const tx = await lockV0.methods
+          .transferFrom(
+            accounts[7],
+            accounts[8],
+            await lockV0.methods.getTokenIdFor(accounts[7]).call()
+          )
+          .send({
+            from: accounts[7],
+            gas: 4000000
+          })
+        assert.equal(tx.events.Transfer.event, 'Transfer')
+      })
+
+      it('grossNetworkProduct remains', async () => {
+        const grossNetworkProduct = new BigNumber(
+          await unlock.methods.grossNetworkProduct().call()
+        )
+        assert.equal(
+          grossNetworkProduct.toFixed(),
+          new BigNumber(keyPrice).times(3).toFixed()
+        )
+      })
+
+      it('lock data should persist state between upgrades', async function () {
+        const resultsAfter = await unlock.methods
+          .locks(lockV0._address)
+          .call()
+        assert.equal(JSON.stringify(resultsAfter), JSON.stringify(v0LockData))
+      })
+    })
+
+    describe('Using v1 after an upgrade', () => {
+      let lockV1
+
       before(async () => {
-        project.upgradeProxy(proxy.address, UnlockV1)
-        unlock = UnlockV1.at(proxy.address)
+        // Create a new Lock
+        const lockTx = await unlock.methods
+          .createLock(
+            60 * 60 * 24, // expirationDuration 1 day
+            keyPrice,
+            5 // maxNumberOfKeys
+          )
+          .send({
+            from: lockOwner,
+            gas: 4000000
+          })
+        // THIS API IS LIKELY TO BREAK BECAUSE IT ASSUMES SO MUCH
+        const evt = lockTx.events.NewLock
+        lockV1 = await PublicLockV1.at(evt.returnValues.newLockAddress)
+
+        // Buy Key
+        await lockV1.methods
+          .purchaseFor(keyOwner, Web3Utils.toHex('Julien'))
+          .send({
+            value: keyPrice,
+            from: keyOwner,
+            gas: 4000000
+          })
       })
 
-      describe('Lock created with UnlockV0 is still available', () => {
-        it('v0 Key is still owned', async () => {
-          const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
-          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
-        })
-
-        it('New keys may still be purchased', async () => {
-          const tx = await lockV0.methods
-            .purchaseFor(accounts[6], Web3Utils.toHex('Julien'))
-            .send({
-              value: keyPrice,
-              from: accounts[6],
-              gas: 4000000
-            })
-          assert.equal(tx.events.Transfer.event, 'Transfer')
-        })
-
-        it('Keys may still be transfered', async () => {
-          await lockV0.methods
-            .purchaseFor(accounts[7], Web3Utils.toHex('Julien'))
-            .send({
-              value: keyPrice,
-              from: accounts[7],
-              gas: 4000000
-            })
-          const tx = await lockV0.methods
-            .transferFrom(
-              accounts[7],
-              accounts[8],
-              await lockV0.methods.getTokenIdFor(accounts[7]).call()
-            )
-            .send({
-              from: accounts[7],
-              gas: 4000000
-            })
-          assert.equal(tx.events.Transfer.event, 'Transfer')
-        })
-
-        it('grossNetworkProduct remains', async () => {
-          const grossNetworkProduct = new BigNumber(
-            await unlock.methods.grossNetworkProduct().call()
-          )
-          assert.equal(
-            grossNetworkProduct.toFixed(),
-            new BigNumber(keyPrice).times(3).toFixed()
-          )
-        })
-
-        it('lock data should persist state between upgrades', async function () {
-          const resultsAfter = await unlock.methods
-            .locks(lockV0._address)
-            .call()
-          assert.equal(JSON.stringify(resultsAfter), JSON.stringify(v0LockData))
-        })
+      it('grossNetworkProduct sums previous version purchases with new version purchases', async () => {
+        const grossNetworkProduct = new BigNumber(
+          await unlock.methods.grossNetworkProduct().call()
+        )
+        assert.equal(
+          grossNetworkProduct.toFixed(),
+          new BigNumber(keyPrice).times(4).toFixed()
+        )
       })
 
-      describe('Using v1 after an upgrade', () => {
-        let lockV1
+      it('v1 Key is owned', async () => {
+        const id = new BigNumber(
+          await lockV1.methods.getTokenIdFor(keyOwner).call()
+        )
+        assert.equal(id.toFixed(), 1)
+      })
 
-        before(async () => {
-          // Create a new Lock
-          const lockTx = await unlock.methods
-            .createLock(
-              60 * 60 * 24, // expirationDuration 1 day
-              keyPrice,
-              5 // maxNumberOfKeys
-            )
-            .send({
-              from: lockOwner,
-              gas: 4000000
-            })
-          // THIS API IS LIKELY TO BREAK BECAUSE IT ASSUMES SO MUCH
-          const evt = lockTx.events.NewLock
-          lockV1 = await PublicLockV1.at(evt.returnValues.newLockAddress)
-
-          // Buy Key
-          await lockV1.methods
-            .purchaseFor(keyOwner, Web3Utils.toHex('Julien'))
-            .send({
-              value: keyPrice,
-              from: keyOwner,
-              gas: 4000000
-            })
-        })
-
-        it('grossNetworkProduct sums previous version purchases with new version purchases', async () => {
-          const grossNetworkProduct = new BigNumber(
-            await unlock.methods.grossNetworkProduct().call()
-          )
-          assert.equal(
-            grossNetworkProduct.toFixed(),
-            new BigNumber(keyPrice).times(4).toFixed()
-          )
-        })
-
-        it('v1 Key is owned', async () => {
-          const id = new BigNumber(
-            await lockV1.methods.getTokenIdFor(keyOwner).call()
-          )
-          assert.equal(id.toFixed(), 1)
-        })
-
-        it('v0 Key is still owned', async () => {
+      it('v0 Key is still owned', async () => {
           const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
           assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
-        })
       })
     })
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Renaming the top level `contract` or `description` string for each test to match the directory / name of the file itself.  

Previously the convention we were using put just `Lock` or `Unlock` at the top level and then had another `describe` section added detail.  The trouble is sometimes when a test fails it does so before the second level header prints.  By making the top level string more descriptive like this I believe we will have an easier time following up on issues.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
