### PR TITLE
remove warning on paywall

### DIFF
--- a/paywall/paywall-builder/mutationObserver.js
+++ b/paywall/paywall-builder/mutationObserver.js
@@ -3,8 +3,11 @@ import { findLocks } from './script'
 export function changeListener(callback, list) {
   list.forEach(mutation => {
     if (!mutation.addedNodes || !mutation.addedNodes.length) return
-    for (let info of mutation.addedNodes.entries()) {
-      const entry = info[1]
+    const entries = mutation.addedNodes.entries()
+    while (true) {
+      const info = entries.next()
+      if (info.done) break
+      const entry = info.value[1]
       if (entry.nodeName !== 'META' || entry.name !== 'lock') continue
       callback(entry.content)
     }

--- a/paywall/src/__tests__/paywall-builder/mutationObserver.test.js
+++ b/paywall/src/__tests__/paywall-builder/mutationObserver.test.js
@@ -14,9 +14,11 @@ function makeMutation(nodes = []) {
       addedNodes: {
         length: nodes.length,
         entries() {
-          return nodes.map(node => {
-            return [0, node]
-          })
+          return nodes
+            .map(node => {
+              return [0, node]
+            })
+            [Symbol.iterator]()
         },
       },
     },


### PR DESCRIPTION
# Description

This both fixes a warning in rollup's build of the paywall, and the underlying issue, which was that using `for...of` forced babel to include a polyfill. This code is refactored to use the iterator directly that is returned from the node list in the mutation observer

<img width="1674" alt="screen shot 2019-03-05 at 8 46 04 pm" src="https://user-images.githubusercontent.com/98250/53849954-b6b59880-3f87-11e9-997b-d1b941508d57.png">
<img width="1674" alt="screen shot 2019-03-05 at 8 45 44 pm" src="https://user-images.githubusercontent.com/98250/53849955-b6b59880-3f87-11e9-9066-a42e1868654b.png">
<img width="1674" alt="screen shot 2019-03-05 at 8 45 34 pm" src="https://user-images.githubusercontent.com/98250/53849956-b6b59880-3f87-11e9-8cb3-b697182a49cd.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1662

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
