### PR TITLE
fix setting of baseline in master builds on chromatic

### DIFF
--- a/scripts/storybook.sh
+++ b/scripts/storybook.sh
@@ -10,9 +10,9 @@ COMMAND="npm run chromatic"
 
 # on master, we will auto-accept any changes, because they have been approved in the pull request stage
 if [ "$BRANCH" == "master" ]; then
-  AUTO_ACCEPT_CHANGES = "--auto-accept-changes"
+  AUTO_ACCEPT_CHANGES="--auto-accept-changes"
 else
-  AUTO_ACCEPT_CHANGES = ""
+  AUTO_ACCEPT_CHANGES=""
 fi
 
 # We pass only the relevent env vars, which are prefixed with the service name, uppercased


### PR DESCRIPTION
# Description

Bash script variable setting is whitespace-sensitive, this fixes chromatic

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1922 

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
