### PR TITLE
Fix smart-contract upgrades test

### DIFF
--- a/smart-contracts/test/Unlock/upgrades.js
+++ b/smart-contracts/test/Unlock/upgrades.js
@@ -28,6 +28,7 @@ contract('Unlock', accounts => {
 
     before(async () => {
       // Deploy
+      UnlockV0.schema.contractName = 'UnlockV0'
       proxy = await project.createProxy(UnlockV0, {
         UnlockV0,
         initMethod: 'initialize',
@@ -64,6 +65,11 @@ contract('Unlock', accounts => {
       v0LockData = await unlock.methods.locks(lockV0._address).call()
     })
 
+    it('v0 Key is owned', async () => {
+      const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
+      assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
+    })
+
     it('the versions V0 and V1 have different bytecode', async () => {
       assert.notEqual(UnlockV1.schema.bytecode, UnlockV0.schema.bytecode)
     })
@@ -77,7 +83,7 @@ contract('Unlock', accounts => {
       describe('Lock created with UnlockV0 is still available', () => {
         it('v0 Key is still owned', async () => {
           const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
-          assert.equal(id, 1)
+          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
         })
 
         it('New keys may still be purchased', async () => {
@@ -177,10 +183,8 @@ contract('Unlock', accounts => {
         })
 
         it('v0 Key is still owned', async () => {
-          const id = new BigNumber(
-            await lockV0.methods.getTokenIdFor(keyOwner).call()
-          )
-          assert.equal(id.toFixed(), 1)
+          const id = await lockV0.methods.getTokenIdFor(keyOwner).call()
+          assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
         })
       })
     })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Due to an unexpected caching issue by ZOS, the upgrades test as originally written actually deployed the V1 contract and then upgraded to V1 and confirmed data.  Adding the .schema line fixes this.  I should have caught this sooner since the tokenId was address in v0 and a sequence id in v1.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
