### PR TITLE
refactor <></> to <React.Fragment></React.Fragment>

### DIFF
--- a/paywall/src/__tests__/test-helpers/helpers.js
+++ b/paywall/src/__tests__/test-helpers/helpers.js
@@ -19,7 +19,7 @@ export class Catcher extends React.Component {
     const { children } = this.props
     const { error } = this.state
     if (error) return <div>{error}</div>
-    return <>{children}</>
+    return <React.Fragment>{children}</React.Fragment>
   }
 }
 

--- a/paywall/src/components/interface/GlobalErrorConsumer.js
+++ b/paywall/src/components/interface/GlobalErrorConsumer.js
@@ -9,9 +9,9 @@ const Consumer = GlobalErrorContext.Consumer
 export const displayError = (error, errorMetadata, children) => {
   if (error) {
     const Error = mapErrorToComponent(error, errorMetadata)
-    return <>{Error}</> // note: this is different from the main repo
+    return <React.Fragment>{Error}</React.Fragment> // note: this is different from the main repo
   }
-  return <>{children}</>
+  return <React.Fragment>{children}</React.Fragment>
 }
 
 export default function GlobalErrorConsumer({ displayError, children }) {

--- a/paywall/src/components/lock/ConfirmedKeyLock.js
+++ b/paywall/src/components/lock/ConfirmedKeyLock.js
@@ -20,12 +20,12 @@ const ConfirmedKeyLock = ({ lock, hideModal }) => (
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
-          <>
+          <React.Fragment>
             <LockDetails>
               <LockDetail bold>{ethPrice} ETH</LockDetail>
               <LockDetail>${fiatPrice}</LockDetail>
             </LockDetails>
-          </>
+          </React.Fragment>
         )}
       />
       <ConfirmedKey hideModal={hideModal} size="50px" />

--- a/paywall/src/components/lock/ConfirmingKeyLock.js
+++ b/paywall/src/components/lock/ConfirmingKeyLock.js
@@ -20,12 +20,12 @@ export const ConfirmingKeyLock = ({ lock, transaction, config }) => (
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
-          <>
+          <React.Fragment>
             <LockDetails>
               <LockDetail bold>{ethPrice} ETH</LockDetail>
               <LockDetail>${fiatPrice}</LockDetail>
             </LockDetails>
-          </>
+          </React.Fragment>
         )}
       />
       <TransactionStatus>

--- a/paywall/src/components/lock/Overlay.js
+++ b/paywall/src/components/lock/Overlay.js
@@ -32,7 +32,7 @@ export const displayError = isMainWindow =>
         return Error
       }
     }
-    return <>{children}</>
+    return <React.Fragment>{children}</React.Fragment>
   }
 
 export const Overlay = ({

--- a/paywall/src/components/lock/PendingKeyLock.js
+++ b/paywall/src/components/lock/PendingKeyLock.js
@@ -19,12 +19,12 @@ export const PendingKeyLock = ({ lock }) => (
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
-          <>
+          <React.Fragment>
             <LockDetails>
               <LockDetail bold>{ethPrice} ETH</LockDetail>
               <LockDetail>${fiatPrice}</LockDetail>
             </LockDetails>
-          </>
+          </React.Fragment>
         )}
       />
       <TransactionStatus>Waiting for mining confirmation.</TransactionStatus>

--- a/paywall/src/components/lock/ShowWhenUnlocked.js
+++ b/paywall/src/components/lock/ShowWhenUnlocked.js
@@ -8,7 +8,7 @@ export default function ShowWhenUnlocked({ locked, children }) {
     return null
   }
 
-  return <>{children}</>
+  return <React.Fragment>{children}</React.Fragment>
 }
 
 ShowWhenUnlocked.propTypes = {

--- a/unlock-app/src/components/creator/lock/CreatorLockStatus.js
+++ b/unlock-app/src/components/creator/lock/CreatorLockStatus.js
@@ -10,9 +10,9 @@ export function CreatorLockStatus({ config, status, confirmations }) {
       <Status>{status}</Status>
       <Confirmations>
         {confirmations > 0 && (
-          <>
+          <React.Fragment>
             {confirmations} / {config.requiredConfirmations}
-          </>
+          </React.Fragment>
         )}
       </Confirmations>
     </LockStatus>

--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -65,16 +65,16 @@ export function LockIconBar({
       <SubStatus>
         {withdrawalTransaction &&
           withdrawalTransaction.status === 'submitted' && (
-            <>Submitted to Network...</>
+            <React.Fragment>Submitted to Network...</React.Fragment>
           )}
         {withdrawalTransaction &&
           withdrawalTransaction.status === 'mined' &&
           withdrawalTransaction.confirmations <
             config.requiredConfirmations && (
-            <>
+            <React.Fragment>
               Confirming Withdrawal {withdrawalTransaction.confirmations}/
               {config.requiredConfirmations}
-            </>
+            </React.Fragment>
           )}
       </SubStatus>
     </StatusBlock>

--- a/unlock-app/src/components/interface/Errors.js
+++ b/unlock-app/src/components/interface/Errors.js
@@ -19,7 +19,7 @@ export const Errors = ({ errors, close }) => {
     return null
   }
 
-  return <>{content}</>
+  return <React.Fragment>{content}</React.Fragment>
 }
 
 export const mapStateToProps = ({ errors }) => ({ errors })

--- a/unlock-app/src/components/interface/GlobalErrorConsumer.js
+++ b/unlock-app/src/components/interface/GlobalErrorConsumer.js
@@ -12,7 +12,7 @@ export const displayError = (error, errorMetadata, children) => {
     const Error = mapErrorToComponent(error, errorMetadata)
     return <Layout title="">{Error}</Layout>
   }
-  return <>{children}</>
+  return <React.Fragment>{children}</React.Fragment>
 }
 
 export default function GlobalErrorConsumer({ displayError, children }) {

--- a/unlock-app/src/components/interface/buttons/homepage/HomepageButton.js
+++ b/unlock-app/src/components/interface/buttons/homepage/HomepageButton.js
@@ -25,7 +25,7 @@ export class HomepageButton extends React.Component {
     const { acceptedTerms } = this.state
 
     return (
-      <>
+      <React.Fragment>
         {acceptedTerms !== true && (
           <Action>
             <DashboardButton onClick={this.acceptTerms}>
@@ -56,7 +56,7 @@ export class HomepageButton extends React.Component {
             </Link>
           </TermsBox>
         )}
-      </>
+      </React.Fragment>
     )
   }
 }

--- a/unlock-app/src/components/lock/ConfirmedKeyLock.js
+++ b/unlock-app/src/components/lock/ConfirmedKeyLock.js
@@ -20,12 +20,12 @@ const ConfirmedKeyLock = ({ lock, hideModal }) => (
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
-          <>
+          <React.Fragment>
             <LockDetails>
               <LockDetail bold>{ethPrice} ETH</LockDetail>
               <LockDetail>${fiatPrice}</LockDetail>
             </LockDetails>
-          </>
+          </React.Fragment>
         )}
       />
       <ConfirmedKey hideModal={hideModal} size="50px" />

--- a/unlock-app/src/components/lock/ConfirmingKeyLock.js
+++ b/unlock-app/src/components/lock/ConfirmingKeyLock.js
@@ -20,12 +20,12 @@ export const ConfirmingKeyLock = ({ lock, transaction, config }) => (
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
-          <>
+          <React.Fragment>
             <LockDetails>
               <LockDetail bold>{ethPrice} ETH</LockDetail>
               <LockDetail>${fiatPrice}</LockDetail>
             </LockDetails>
-          </>
+          </React.Fragment>
         )}
       />
       <TransactionStatus>

--- a/unlock-app/src/components/lock/Overlay.js
+++ b/unlock-app/src/components/lock/Overlay.js
@@ -33,7 +33,7 @@ export const displayError = isMainWindow =>
         return Error
       }
     }
-    return <>{children}</>
+    return <React.Fragment>{children}</React.Fragment>
   }
 
 export const Overlay = ({

--- a/unlock-app/src/components/lock/PendingKeyLock.js
+++ b/unlock-app/src/components/lock/PendingKeyLock.js
@@ -19,12 +19,12 @@ export const PendingKeyLock = ({ lock }) => (
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
-          <>
+          <React.Fragment>
             <LockDetails>
               <LockDetail bold>{ethPrice} ETH</LockDetail>
               <LockDetail>${fiatPrice}</LockDetail>
             </LockDetails>
-          </>
+          </React.Fragment>
         )}
       />
       <TransactionStatus>Waiting for mining confirmation.</TransactionStatus>

--- a/unlock-app/src/components/lock/ShowWhenUnlocked.js
+++ b/unlock-app/src/components/lock/ShowWhenUnlocked.js
@@ -6,7 +6,7 @@ export default function ShowWhenUnlocked({ locked, children }) {
     return null
   }
 
-  return <>{children}</>
+  return <React.Fragment>{children}</React.Fragment>
 }
 
 ShowWhenUnlocked.propTypes = {

--- a/unlock-app/src/components/page/OpenGraphTags.js
+++ b/unlock-app/src/components/page/OpenGraphTags.js
@@ -14,13 +14,13 @@ export const OpenGraphTags = ({ title, description, image, canonicalPath }) => {
   if (!canonicalPath) canonicalPath = '/'
 
   return (
-    <>
+    <React.Fragment>
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:type" content="website" />
       <meta property="og:url" content={CANONICAL_BASE_URL + canonicalPath} />
       <meta property="og:image" content={image} />
-    </>
+    </React.Fragment>
   )
 }
 

--- a/unlock-app/src/components/page/TwitterTags.js
+++ b/unlock-app/src/components/page/TwitterTags.js
@@ -12,13 +12,13 @@ export const TwitterTags = ({ title, description, image }) => {
   if (!image) image = PAGE_DEFAULT_IMAGE
 
   return (
-    <>
+    <React.Fragment>
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@UnlockProtocol" />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:image" content={image} />
-    </>
+    </React.Fragment>
   )
 }
 

--- a/unlock-app/src/pages/about.js
+++ b/unlock-app/src/pages/about.js
@@ -73,7 +73,7 @@ const monthNames = [
 ]
 
 const Post = ({ date, summary, link }) => (
-  <>
+  <React.Fragment>
     <p>
       {monthNames[date.getMonth()]}
       &nbsp;
@@ -86,7 +86,7 @@ const Post = ({ date, summary, link }) => (
         More...
       </a>
     </p>
-  </>
+  </React.Fragment>
 )
 
 Post.propTypes = {


### PR DESCRIPTION
# Description

For consistency, and because `<></>` does not allow `key` attribute to be set and we have at least one place in the code (log page) that needs `key`, refactor all of them to `<React.Fragment></React.Fragment>`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1784

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
