### PR TITLE
use responsive width not dependent on device for media queries

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2983,7 +2983,7 @@ Object {
   grid-column: 1;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c13 {
     display: none;
   }
@@ -3250,7 +3250,7 @@ Object {
             </li>
           </ul>
           <footer
-            class="sc-1549ebs-8 SGDXW"
+            class="sc-1549ebs-8 ckuUyi"
           >
             <div
               class="sth0f3-0 kwQJpX"
@@ -3471,7 +3471,7 @@ Object {
   grid-column: 1;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c7 {
     display: none;
   }
@@ -3690,7 +3690,7 @@ Object {
             </section>
           </ul>
           <footer
-            class="sc-1549ebs-8 SGDXW"
+            class="sc-1549ebs-8 ckuUyi"
           >
             <div
               class="sth0f3-0 kwQJpX"
@@ -3979,7 +3979,7 @@ Object {
   grid-column: 1;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c13 {
     display: none;
   }
@@ -4246,7 +4246,7 @@ Object {
             </li>
           </ul>
           <footer
-            class="sc-1549ebs-8 SGDXW"
+            class="sc-1549ebs-8 ckuUyi"
           >
             <div
               class="sth0f3-0 kwQJpX"
@@ -4467,7 +4467,7 @@ Object {
   grid-column: 1;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c7 {
     display: none;
   }
@@ -4686,7 +4686,7 @@ Object {
             </section>
           </ul>
           <footer
-            class="sc-1549ebs-8 SGDXW"
+            class="sc-1549ebs-8 ckuUyi"
           >
             <div
               class="sth0f3-0 kwQJpX"
@@ -4975,7 +4975,7 @@ Object {
   grid-column: 1;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c13 {
     display: none;
   }
@@ -5334,7 +5334,7 @@ Object {
             </li>
           </ul>
           <footer
-            class="sc-1549ebs-8 SGDXW"
+            class="sc-1549ebs-8 ckuUyi"
           >
             <div
               class="sth0f3-0 kwQJpX"
@@ -5550,13 +5550,13 @@ Object {
   transition: opacity 0.4s ease-in;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: none;
   }
@@ -5601,7 +5601,7 @@ Object {
       style="position: absolute; right: 0px; bottom: 105px; width: 134px; height: 160px; margin-right: -104px; transition: margin-right 0.4s ease-in;"
     >
       <footer
-        class="sc-1549ebs-8 sc-15m75z9-0 dLWldV"
+        class="sc-1549ebs-8 sc-15m75z9-0 jLFIBx"
       >
         <div
           class="sth0f3-0 kwQJpX"
@@ -5746,13 +5746,13 @@ Object {
   transition: opacity 0.4s ease-in;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: none;
   }
@@ -5790,7 +5790,7 @@ Object {
       rel="stylesheet"
     />
     <footer
-      class="sc-1549ebs-8 sc-15m75z9-0 dLWldV"
+      class="sc-1549ebs-8 sc-15m75z9-0 jLFIBx"
     >
       <div
         class="sth0f3-0 kwQJpX"

--- a/paywall/src/theme/media.js
+++ b/paywall/src/theme/media.js
@@ -27,10 +27,8 @@ sizes.nodesktop = {
 
 const Media = Object.keys(sizes).reduce((acc, label) => {
   acc[label] = (...args) => css`
-    @media only screen and (min-device-width: ${sizes[label].min}px) ${sizes[
-        label
-      ].max
-        ? `and (max-device-width: ${sizes[label].max}px)`
+    @media only screen and (min-width: ${sizes[label].min}px) ${sizes[label].max
+        ? `and (max-width: ${sizes[label].max}px)`
         : ''} {
       ${css(...args)};
     }

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -6698,7 +6698,7 @@ Object {
   color: var(--darkgrey);
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -6706,37 +6706,37 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c9 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c9 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c11 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -6747,13 +6747,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c24 {
     display: none;
   }
@@ -7421,16 +7421,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       />
       <div
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <a
             href="/"
@@ -7448,7 +7448,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -7539,7 +7539,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -7575,7 +7575,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -8066,7 +8066,7 @@ Object {
         </footer>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -8494,7 +8494,7 @@ Object {
   font-size: 20px;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -8502,37 +8502,37 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c9 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c9 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c11 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -8543,13 +8543,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c28 {
     display: none;
   }
@@ -8936,16 +8936,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       />
       <div
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <a
             href="/"
@@ -8963,7 +8963,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -9054,7 +9054,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -9090,7 +9090,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <h1
@@ -9300,7 +9300,7 @@ Object {
         </footer>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -9654,7 +9654,7 @@ Object {
   font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -9662,37 +9662,37 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c9 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c9 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c11 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -9703,13 +9703,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c26 {
     display: none;
   }
@@ -10537,16 +10537,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       />
       <div
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <a
             href="/"
@@ -10564,7 +10564,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -10655,7 +10655,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -10691,7 +10691,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -11342,7 +11342,7 @@ Object {
         </footer>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -11662,7 +11662,7 @@ Object {
   font-weight: 300;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -11670,37 +11670,37 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c9 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c9 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c11 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -11711,13 +11711,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c21 {
     display: none;
   }
@@ -12486,16 +12486,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       />
       <div
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <a
             href="/"
@@ -12513,7 +12513,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -12604,7 +12604,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -12640,7 +12640,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -13232,7 +13232,7 @@ Object {
         </footer>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -13552,7 +13552,7 @@ Object {
   font-weight: 300;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -13560,37 +13560,37 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c9 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c9 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c11 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -13601,13 +13601,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c21 {
     display: none;
   }
@@ -14483,16 +14483,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       />
       <div
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <a
             href="/"
@@ -14510,7 +14510,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -14601,7 +14601,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -14637,7 +14637,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -15336,7 +15336,7 @@ Object {
         </footer>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -15490,7 +15490,7 @@ Object {
   color: var(--darkgrey);
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
@@ -15498,7 +15498,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     height: 0px;
   }
@@ -15660,10 +15660,10 @@ Object {
         </span>
       </header>
       <div
-        class="sc-9u6rci-3 fIGRgk"
+        class="sc-9u6rci-3 fSzJBJ"
       >
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         >
           <div
             class="paper"
@@ -15730,19 +15730,19 @@ Object {
           Balance
         </div>
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
           class="sc-9u6rci-6 gvRTKt"
@@ -15923,7 +15923,7 @@ Object {
   color: var(--darkgrey);
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
@@ -15931,7 +15931,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     height: 0px;
   }
@@ -16093,10 +16093,10 @@ Object {
         </span>
       </header>
       <div
-        class="sc-9u6rci-3 fIGRgk"
+        class="sc-9u6rci-3 fSzJBJ"
       >
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         >
           <div
             class="paper"
@@ -16163,19 +16163,19 @@ Object {
           Balance
         </div>
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
-          class="sc-9u6rci-4 ejQGsP"
+          class="sc-9u6rci-4 eXwiFo"
         />
         <div
           class="sc-9u6rci-6 gvRTKt"
@@ -16400,19 +16400,19 @@ Object {
   text-overflow: ellipsis;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c10 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -16420,7 +16420,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -16428,7 +16428,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     grid-column: span 2;
   }
@@ -16658,7 +16658,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 cwroZy"
+      class="mlglvd-0 iujibU"
     >
       <div
         class="mlglvd-2 hfdYVl"
@@ -16737,7 +16737,7 @@ Object {
         </svg>
       </div>
       <div
-        class="mlglvd-4 dJSWdY"
+        class="mlglvd-4 dRpwNO"
       >
         New Lock
         <div
@@ -16794,7 +16794,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-1w50r7k-0 jokqwX"
+          class="sc-1w50r7k-0 fSpCqa"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -16830,7 +16830,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-1w50r7k-1 dNQuza"
+          class="sc-1w50r7k-1 cwqVOH"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -17114,25 +17114,25 @@ Object {
   text-overflow: ellipsis;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c10 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -17140,7 +17140,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -17148,7 +17148,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     grid-column: span 2;
   }
@@ -17438,7 +17438,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 cwroZy"
+      class="mlglvd-0 iujibU"
     >
       <div
         class="mlglvd-2 hfdYVl"
@@ -17517,7 +17517,7 @@ Object {
         </svg>
       </div>
       <div
-        class="mlglvd-4 dJSWdY"
+        class="mlglvd-4 dRpwNO"
       >
         New Lock
         <div
@@ -17574,7 +17574,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-1w50r7k-0 jokqwX"
+          class="sc-1w50r7k-0 fSpCqa"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -17610,7 +17610,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-1w50r7k-1 dNQuza"
+          class="sc-1w50r7k-1 cwqVOH"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -17635,7 +17635,7 @@ Object {
         class="sc-1dp5gbn-2 fpHeqB"
       >
         <div
-          class="sc-1dp5gbn-0 kHcBbB"
+          class="sc-1dp5gbn-0 kDgfkC"
         >
           <div
             class="sc-1dp5gbn-1 hxNcaM"
@@ -17954,25 +17954,25 @@ Object {
   text-overflow: ellipsis;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c10 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -17980,7 +17980,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -17988,7 +17988,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     grid-column: span 2;
   }
@@ -18278,7 +18278,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 cwroZy"
+      class="mlglvd-0 iujibU"
     >
       <div
         class="mlglvd-2 hfdYVl"
@@ -18357,7 +18357,7 @@ Object {
         </svg>
       </div>
       <div
-        class="mlglvd-4 dJSWdY"
+        class="mlglvd-4 dRpwNO"
       >
         New Lock
         <div
@@ -18414,7 +18414,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-1w50r7k-0 jokqwX"
+          class="sc-1w50r7k-0 fSpCqa"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -18450,7 +18450,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-1w50r7k-1 dNQuza"
+          class="sc-1w50r7k-1 cwqVOH"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -18475,7 +18475,7 @@ Object {
         class="sc-1dp5gbn-2 fpHeqB"
       >
         <div
-          class="sc-1dp5gbn-0 kHcBbB"
+          class="sc-1dp5gbn-0 kDgfkC"
         >
           <div
             class="sc-1dp5gbn-1 hxNcaM"
@@ -18743,19 +18743,19 @@ Object {
   text-overflow: ellipsis;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c10 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -18763,7 +18763,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -18771,7 +18771,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     grid-column: span 2;
   }
@@ -18997,7 +18997,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 cwroZy"
+      class="mlglvd-0 iujibU"
     >
       <div
         class="mlglvd-2 hfdYVl"
@@ -19076,7 +19076,7 @@ Object {
         </svg>
       </div>
       <div
-        class="mlglvd-4 dJSWdY"
+        class="mlglvd-4 dRpwNO"
       >
         New Lock
         <div
@@ -19133,7 +19133,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-1w50r7k-0 jokqwX"
+          class="sc-1w50r7k-0 fSpCqa"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -19169,7 +19169,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-1w50r7k-1 dNQuza"
+          class="sc-1w50r7k-1 cwqVOH"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -19449,25 +19449,25 @@ Object {
   text-overflow: ellipsis;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c10 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -19475,7 +19475,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -19483,7 +19483,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     grid-column: span 2;
   }
@@ -19773,7 +19773,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 cwroZy"
+      class="mlglvd-0 iujibU"
     >
       <div
         class="mlglvd-2 hfdYVl"
@@ -19852,7 +19852,7 @@ Object {
         </svg>
       </div>
       <div
-        class="mlglvd-4 dJSWdY"
+        class="mlglvd-4 dRpwNO"
       >
         New Lock
         <div
@@ -19909,7 +19909,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-1w50r7k-0 jokqwX"
+          class="sc-1w50r7k-0 fSpCqa"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -19945,7 +19945,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-1w50r7k-1 dNQuza"
+          class="sc-1w50r7k-1 cwqVOH"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -19970,7 +19970,7 @@ Object {
         class="sc-1dp5gbn-2 fpHeqB"
       >
         <div
-          class="sc-1dp5gbn-0 kHcBbB"
+          class="sc-1dp5gbn-0 kDgfkC"
         >
           <div
             class="sc-1dp5gbn-1 hxNcaM"
@@ -20289,25 +20289,25 @@ Object {
   text-overflow: ellipsis;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c10 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -20315,7 +20315,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -20323,7 +20323,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     grid-column: span 2;
   }
@@ -20613,7 +20613,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 cwroZy"
+      class="mlglvd-0 iujibU"
     >
       <div
         class="mlglvd-2 hfdYVl"
@@ -20692,7 +20692,7 @@ Object {
         </svg>
       </div>
       <div
-        class="mlglvd-4 dJSWdY"
+        class="mlglvd-4 dRpwNO"
       >
         New Lock
         <div
@@ -20749,7 +20749,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-1w50r7k-0 jokqwX"
+          class="sc-1w50r7k-0 fSpCqa"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -20785,7 +20785,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-1w50r7k-1 dNQuza"
+          class="sc-1w50r7k-1 cwqVOH"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -20810,7 +20810,7 @@ Object {
         class="sc-1dp5gbn-2 fpHeqB"
       >
         <div
-          class="sc-1dp5gbn-0 kHcBbB"
+          class="sc-1dp5gbn-0 kDgfkC"
         >
           <div
             class="sc-1dp5gbn-1 hxNcaM"
@@ -21129,25 +21129,25 @@ Object {
   text-overflow: ellipsis;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c10 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -21155,7 +21155,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -21163,7 +21163,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     grid-column: span 2;
   }
@@ -21453,7 +21453,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 cwroZy"
+      class="mlglvd-0 iujibU"
     >
       <div
         class="mlglvd-2 hfdYVl"
@@ -21532,7 +21532,7 @@ Object {
         </svg>
       </div>
       <div
-        class="mlglvd-4 dJSWdY"
+        class="mlglvd-4 dRpwNO"
       >
         New Lock
         <div
@@ -21589,7 +21589,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-1w50r7k-0 jokqwX"
+          class="sc-1w50r7k-0 fSpCqa"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -21625,7 +21625,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-1w50r7k-1 dNQuza"
+          class="sc-1w50r7k-1 cwqVOH"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -21650,7 +21650,7 @@ Object {
         class="sc-1dp5gbn-2 fpHeqB"
       >
         <div
-          class="sc-1dp5gbn-0 kHcBbB"
+          class="sc-1dp5gbn-0 kDgfkC"
         >
           <div
             class="sc-1dp5gbn-1 hxNcaM"
@@ -21964,7 +21964,7 @@ Object {
   transition: color 100ms ease;
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -21972,7 +21972,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -21980,7 +21980,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     grid-column: span 2;
   }
@@ -22150,7 +22150,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 sc-1u8ov25-1 dxrMNO"
+      class="mlglvd-0 sc-1u8ov25-1 PMwHK"
     >
       <svg
         viewBox="0 0 216 216"
@@ -22225,7 +22225,7 @@ Object {
         </g>
       </svg>
       <div
-        class="mlglvd-4 sc-1u8ov25-3 cRRiTm"
+        class="mlglvd-4 sc-1u8ov25-3 dEeEwP"
       >
         <input
           data-valid="true"
@@ -22534,7 +22534,7 @@ Object {
   transition: color 100ms ease;
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -22542,7 +22542,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -22550,7 +22550,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     grid-column: span 2;
   }
@@ -22714,7 +22714,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 sc-1u8ov25-1 dxrMNO"
+      class="mlglvd-0 sc-1u8ov25-1 PMwHK"
     >
       <svg
         viewBox="0 0 216 216"
@@ -22789,7 +22789,7 @@ Object {
         </g>
       </svg>
       <div
-        class="mlglvd-4 sc-1u8ov25-3 cRRiTm"
+        class="mlglvd-4 sc-1u8ov25-3 dEeEwP"
       >
         <input
           data-valid="true"
@@ -23099,7 +23099,7 @@ Object {
   transition: color 100ms ease;
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -23107,7 +23107,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -23115,7 +23115,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     grid-column: span 2;
   }
@@ -23285,7 +23285,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 sc-1u8ov25-1 dxrMNO"
+      class="mlglvd-0 sc-1u8ov25-1 PMwHK"
     >
       <svg
         viewBox="0 0 216 216"
@@ -23360,7 +23360,7 @@ Object {
         </g>
       </svg>
       <div
-        class="mlglvd-4 sc-1u8ov25-3 cRRiTm"
+        class="mlglvd-4 sc-1u8ov25-3 dEeEwP"
       >
         <input
           data-valid="true"
@@ -23676,7 +23676,7 @@ Object {
   transition: color 100ms ease;
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -23684,7 +23684,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -23692,7 +23692,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     grid-column: span 2;
   }
@@ -23862,7 +23862,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 sc-1u8ov25-1 dxrMNO"
+      class="mlglvd-0 sc-1u8ov25-1 PMwHK"
     >
       <svg
         viewBox="0 0 216 216"
@@ -23937,7 +23937,7 @@ Object {
         </g>
       </svg>
       <div
-        class="mlglvd-4 sc-1u8ov25-3 cRRiTm"
+        class="mlglvd-4 sc-1u8ov25-3 dEeEwP"
       >
         <input
           data-valid="true"
@@ -24253,7 +24253,7 @@ Object {
   transition: color 100ms ease;
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -24261,7 +24261,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -24269,7 +24269,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     grid-column: span 2;
   }
@@ -24439,7 +24439,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 sc-1u8ov25-1 dxrMNO"
+      class="mlglvd-0 sc-1u8ov25-1 PMwHK"
     >
       <svg
         viewBox="0 0 216 216"
@@ -24514,7 +24514,7 @@ Object {
         </g>
       </svg>
       <div
-        class="mlglvd-4 sc-1u8ov25-3 cRRiTm"
+        class="mlglvd-4 sc-1u8ov25-3 dEeEwP"
       >
         <input
           data-valid="true"
@@ -24830,7 +24830,7 @@ Object {
   transition: color 100ms ease;
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c0 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -24838,7 +24838,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -24846,7 +24846,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     grid-column: span 2;
   }
@@ -25016,7 +25016,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="mlglvd-0 sc-1u8ov25-1 dxrMNO"
+      class="mlglvd-0 sc-1u8ov25-1 PMwHK"
     >
       <svg
         viewBox="0 0 216 216"
@@ -25091,7 +25091,7 @@ Object {
         </g>
       </svg>
       <div
-        class="mlglvd-4 sc-1u8ov25-3 cRRiTm"
+        class="mlglvd-4 sc-1u8ov25-3 dEeEwP"
       >
         <input
           data-valid="false"
@@ -25661,19 +25661,19 @@ Object {
   background-color: var(--activegreen);
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c31 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c32 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c17 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
@@ -25681,13 +25681,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c18 {
     height: 0px;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -25695,7 +25695,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: grid;
     grid-gap: 0;
@@ -25703,43 +25703,43 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c14 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c14 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c6 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -25750,13 +25750,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c37 {
     display: none;
   }
@@ -25770,7 +25770,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c27 {
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -25782,19 +25782,19 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c28 {
     grid-row: span 2;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c30 {
     grid-row: span 2;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c33 {
     display: none;
   }
@@ -26199,10 +26199,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       >
         <a
           href="/"
@@ -26225,13 +26225,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <h1
-            class="sc-1glv5oz-1 eozQRg"
+            class="sc-1glv5oz-1 fBXkFl"
           >
             <div
-              class="sc-1glv5oz-5 bgXdkG"
+              class="sc-1glv5oz-5 jGNGoL"
             >
               <a
                 href="/"
@@ -26253,7 +26253,7 @@ Object {
             Creator Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -26344,7 +26344,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -26380,7 +26380,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -26399,10 +26399,10 @@ Object {
             </span>
           </header>
           <div
-            class="sc-9u6rci-3 fIGRgk"
+            class="sc-9u6rci-3 fSzJBJ"
           >
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             >
               <div
                 class="paper"
@@ -26469,19 +26469,19 @@ Object {
               Balance
             </div>
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
               class="sc-9u6rci-6 gvRTKt"
@@ -26515,10 +26515,10 @@ Object {
           class="sc-1olgoav-0 gKWPIY"
         >
           <div
-            class="sc-1olgoav-1 kpajuy"
+            class="sc-1olgoav-1 gBcaxh"
           >
             <div
-              class="sc-1olgoav-2 kSYiJB"
+              class="sc-1olgoav-2 irfbOa"
             >
               Locks
             </div>
@@ -26533,7 +26533,7 @@ Object {
               Key Duration
             </div>
             <div
-              class="sc-1olgoav-3 sc-1olgoav-4 bEVbBR"
+              class="sc-1olgoav-3 sc-1olgoav-4 cahOOH"
             >
               Key Quantity
             </div>
@@ -26546,18 +26546,18 @@ Object {
               class="sc-1olgoav-3 hxpbwC"
             >
               <div
-                class="sc-1w50r7k-0 jokqwX"
+                class="sc-1w50r7k-0 fSpCqa"
               >
                 Balance
               </div>
               <div
-                class="sc-1w50r7k-1 dNQuza"
+                class="sc-1w50r7k-1 cwqVOH"
               >
                 Balance
               </div>
             </div>
             <button
-              class="sc-1olgoav-5 sc-1olgoav-6 gxvXkd"
+              class="sc-1olgoav-5 sc-1olgoav-6 dOthuf"
             >
               Create Lock
             </button>
@@ -26581,7 +26581,7 @@ Object {
         </section>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -26895,7 +26895,7 @@ Object {
   color: var(--dimgrey);
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -26903,7 +26903,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: grid;
     grid-gap: 0;
@@ -26911,43 +26911,43 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c14 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c14 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c6 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -26958,13 +26958,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c18 {
     display: none;
   }
@@ -27199,10 +27199,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       >
         <a
           href="/"
@@ -27225,13 +27225,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <h1
-            class="sc-1glv5oz-1 eozQRg"
+            class="sc-1glv5oz-1 fBXkFl"
           >
             <div
-              class="sc-1glv5oz-5 bgXdkG"
+              class="sc-1glv5oz-5 jGNGoL"
             >
               <a
                 href="/"
@@ -27253,7 +27253,7 @@ Object {
             
           </h1>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -27344,7 +27344,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -27380,7 +27380,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -27403,7 +27403,7 @@ Object {
         </section>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -27717,7 +27717,7 @@ Object {
   color: var(--dimgrey);
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -27725,7 +27725,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: grid;
     grid-gap: 0;
@@ -27733,43 +27733,43 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c14 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c14 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c6 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -27780,13 +27780,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c18 {
     display: none;
   }
@@ -28021,10 +28021,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       >
         <a
           href="/"
@@ -28047,13 +28047,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <h1
-            class="sc-1glv5oz-1 eozQRg"
+            class="sc-1glv5oz-1 fBXkFl"
           >
             <div
-              class="sc-1glv5oz-5 bgXdkG"
+              class="sc-1glv5oz-5 jGNGoL"
             >
               <a
                 href="/"
@@ -28075,7 +28075,7 @@ Object {
             
           </h1>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -28166,7 +28166,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -28202,7 +28202,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -28225,7 +28225,7 @@ Object {
         </section>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -28865,19 +28865,19 @@ Object {
   background-color: var(--activegreen);
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c31 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c32 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c17 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
@@ -28885,19 +28885,19 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c18 {
     height: 0px;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c43 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c34 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -28905,7 +28905,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c34 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -28913,13 +28913,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c36 {
     grid-column: span 2;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -28927,7 +28927,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: grid;
     grid-gap: 0;
@@ -28935,43 +28935,43 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c14 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c14 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c6 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -28982,19 +28982,19 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c48 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c27 {
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -29006,19 +29006,19 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c28 {
     grid-row: span 2;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c30 {
     grid-row: span 2;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c33 {
     display: none;
   }
@@ -30100,10 +30100,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       >
         <a
           href="/"
@@ -30126,13 +30126,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <h1
-            class="sc-1glv5oz-1 eozQRg"
+            class="sc-1glv5oz-1 fBXkFl"
           >
             <div
-              class="sc-1glv5oz-5 bgXdkG"
+              class="sc-1glv5oz-5 jGNGoL"
             >
               <a
                 href="/"
@@ -30154,7 +30154,7 @@ Object {
             Creator Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -30245,7 +30245,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -30281,7 +30281,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -30300,10 +30300,10 @@ Object {
             </span>
           </header>
           <div
-            class="sc-9u6rci-3 fIGRgk"
+            class="sc-9u6rci-3 fSzJBJ"
           >
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             >
               <div
                 class="paper"
@@ -30370,19 +30370,19 @@ Object {
               Balance
             </div>
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
               class="sc-9u6rci-6 gvRTKt"
@@ -30416,10 +30416,10 @@ Object {
           class="sc-1olgoav-0 gKWPIY"
         >
           <div
-            class="sc-1olgoav-1 kpajuy"
+            class="sc-1olgoav-1 gBcaxh"
           >
             <div
-              class="sc-1olgoav-2 kSYiJB"
+              class="sc-1olgoav-2 irfbOa"
             >
               Locks
             </div>
@@ -30434,7 +30434,7 @@ Object {
               Key Duration
             </div>
             <div
-              class="sc-1olgoav-3 sc-1olgoav-4 bEVbBR"
+              class="sc-1olgoav-3 sc-1olgoav-4 cahOOH"
             >
               Key Quantity
             </div>
@@ -30447,24 +30447,24 @@ Object {
               class="sc-1olgoav-3 hxpbwC"
             >
               <div
-                class="sc-1w50r7k-0 jokqwX"
+                class="sc-1w50r7k-0 fSpCqa"
               >
                 Balance
               </div>
               <div
-                class="sc-1w50r7k-1 dNQuza"
+                class="sc-1w50r7k-1 cwqVOH"
               >
                 Balance
               </div>
             </div>
             <button
-              class="sc-1olgoav-5 sc-1olgoav-6 gxvXkd"
+              class="sc-1olgoav-5 sc-1olgoav-6 dOthuf"
             >
               Create Lock
             </button>
           </div>
           <div
-            class="mlglvd-0 cwroZy"
+            class="mlglvd-0 iujibU"
           >
             <div
               class="mlglvd-2 hfdYVl"
@@ -30543,7 +30543,7 @@ Object {
               </svg>
             </div>
             <div
-              class="mlglvd-4 dJSWdY"
+              class="mlglvd-4 dRpwNO"
             >
               Infinite Lock
               <div
@@ -30600,7 +30600,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-1w50r7k-0 jokqwX"
+                class="sc-1w50r7k-0 fSpCqa"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -30636,7 +30636,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-1w50r7k-1 dNQuza"
+                class="sc-1w50r7k-1 cwqVOH"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -30675,7 +30675,7 @@ Object {
             </div>
           </div>
           <div
-            class="mlglvd-0 cwroZy"
+            class="mlglvd-0 iujibU"
           >
             <div
               class="mlglvd-2 hfdYVl"
@@ -30754,7 +30754,7 @@ Object {
               </svg>
             </div>
             <div
-              class="mlglvd-4 dJSWdY"
+              class="mlglvd-4 dRpwNO"
             >
               New Lock
               <div
@@ -30811,7 +30811,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-1w50r7k-0 jokqwX"
+                class="sc-1w50r7k-0 fSpCqa"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -30847,7 +30847,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-1w50r7k-1 dNQuza"
+                class="sc-1w50r7k-1 cwqVOH"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -30886,7 +30886,7 @@ Object {
             </div>
           </div>
           <div
-            class="mlglvd-0 cwroZy"
+            class="mlglvd-0 iujibU"
           >
             <div
               class="mlglvd-2 hfdYVl"
@@ -30965,7 +30965,7 @@ Object {
               </svg>
             </div>
             <div
-              class="mlglvd-4 dJSWdY"
+              class="mlglvd-4 dRpwNO"
             >
               My Blog
               <div
@@ -31022,7 +31022,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-1w50r7k-0 jokqwX"
+                class="sc-1w50r7k-0 fSpCqa"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -31058,7 +31058,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-1w50r7k-1 dNQuza"
+                class="sc-1w50r7k-1 cwqVOH"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -31083,7 +31083,7 @@ Object {
               class="sc-1dp5gbn-2 fpHeqB"
             >
               <div
-                class="sc-1dp5gbn-0 kHcBbB"
+                class="sc-1dp5gbn-0 kDgfkC"
               >
                 <div
                   class="sc-1dp5gbn-1 hxNcaM"
@@ -31159,7 +31159,7 @@ Object {
         </section>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -31862,19 +31862,19 @@ Object {
   z-index: var(--alwaysontop);
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c34 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c35 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c20 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
@@ -31882,19 +31882,19 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c21 {
     height: 0px;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c46 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c37 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
@@ -31902,7 +31902,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c37 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
@@ -31910,13 +31910,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c39 {
     grid-column: span 2;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c7 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -31924,7 +31924,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: grid;
     grid-gap: 0;
@@ -31932,43 +31932,43 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c15 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c15 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c17 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c17 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c9 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -31979,19 +31979,19 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c51 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c30 {
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -32003,19 +32003,19 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c31 {
     grid-row: span 2;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c33 {
     grid-row: span 2;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c36 {
     display: none;
   }
@@ -33129,10 +33129,10 @@ Object {
       </div>
     </div>
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       >
         <a
           href="/"
@@ -33155,13 +33155,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <h1
-            class="sc-1glv5oz-1 eozQRg"
+            class="sc-1glv5oz-1 fBXkFl"
           >
             <div
-              class="sc-1glv5oz-5 bgXdkG"
+              class="sc-1glv5oz-5 jGNGoL"
             >
               <a
                 href="/"
@@ -33183,7 +33183,7 @@ Object {
             Creator Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -33274,7 +33274,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -33310,7 +33310,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -33329,10 +33329,10 @@ Object {
             </span>
           </header>
           <div
-            class="sc-9u6rci-3 fIGRgk"
+            class="sc-9u6rci-3 fSzJBJ"
           >
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             >
               <div
                 class="paper"
@@ -33399,19 +33399,19 @@ Object {
               Balance
             </div>
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
               class="sc-9u6rci-6 gvRTKt"
@@ -33445,10 +33445,10 @@ Object {
           class="sc-1olgoav-0 gKWPIY"
         >
           <div
-            class="sc-1olgoav-1 kpajuy"
+            class="sc-1olgoav-1 gBcaxh"
           >
             <div
-              class="sc-1olgoav-2 kSYiJB"
+              class="sc-1olgoav-2 irfbOa"
             >
               Locks
             </div>
@@ -33463,7 +33463,7 @@ Object {
               Key Duration
             </div>
             <div
-              class="sc-1olgoav-3 sc-1olgoav-4 bEVbBR"
+              class="sc-1olgoav-3 sc-1olgoav-4 cahOOH"
             >
               Key Quantity
             </div>
@@ -33476,24 +33476,24 @@ Object {
               class="sc-1olgoav-3 hxpbwC"
             >
               <div
-                class="sc-1w50r7k-0 jokqwX"
+                class="sc-1w50r7k-0 fSpCqa"
               >
                 Balance
               </div>
               <div
-                class="sc-1w50r7k-1 dNQuza"
+                class="sc-1w50r7k-1 cwqVOH"
               >
                 Balance
               </div>
             </div>
             <button
-              class="sc-1olgoav-5 sc-1olgoav-6 gxvXkd"
+              class="sc-1olgoav-5 sc-1olgoav-6 dOthuf"
             >
               Create Lock
             </button>
           </div>
           <div
-            class="mlglvd-0 cwroZy"
+            class="mlglvd-0 iujibU"
           >
             <div
               class="mlglvd-2 hfdYVl"
@@ -33572,7 +33572,7 @@ Object {
               </svg>
             </div>
             <div
-              class="mlglvd-4 dJSWdY"
+              class="mlglvd-4 dRpwNO"
             >
               Infinite Lock
               <div
@@ -33629,7 +33629,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-1w50r7k-0 jokqwX"
+                class="sc-1w50r7k-0 fSpCqa"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -33665,7 +33665,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-1w50r7k-1 dNQuza"
+                class="sc-1w50r7k-1 cwqVOH"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -33704,7 +33704,7 @@ Object {
             </div>
           </div>
           <div
-            class="mlglvd-0 cwroZy"
+            class="mlglvd-0 iujibU"
           >
             <div
               class="mlglvd-2 hfdYVl"
@@ -33783,7 +33783,7 @@ Object {
               </svg>
             </div>
             <div
-              class="mlglvd-4 dJSWdY"
+              class="mlglvd-4 dRpwNO"
             >
               New Lock
               <div
@@ -33840,7 +33840,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-1w50r7k-0 jokqwX"
+                class="sc-1w50r7k-0 fSpCqa"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -33876,7 +33876,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-1w50r7k-1 dNQuza"
+                class="sc-1w50r7k-1 cwqVOH"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -33915,7 +33915,7 @@ Object {
             </div>
           </div>
           <div
-            class="mlglvd-0 cwroZy"
+            class="mlglvd-0 iujibU"
           >
             <div
               class="mlglvd-2 hfdYVl"
@@ -33994,7 +33994,7 @@ Object {
               </svg>
             </div>
             <div
-              class="mlglvd-4 dJSWdY"
+              class="mlglvd-4 dRpwNO"
             >
               My Blog
               <div
@@ -34051,7 +34051,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-1w50r7k-0 jokqwX"
+                class="sc-1w50r7k-0 fSpCqa"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -34087,7 +34087,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-1w50r7k-1 dNQuza"
+                class="sc-1w50r7k-1 cwqVOH"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -34112,7 +34112,7 @@ Object {
               class="sc-1dp5gbn-2 fpHeqB"
             >
               <div
-                class="sc-1dp5gbn-0 kHcBbB"
+                class="sc-1dp5gbn-0 kDgfkC"
               >
                 <div
                   class="sc-1dp5gbn-1 hxNcaM"
@@ -34188,7 +34188,7 @@ Object {
         </section>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -36312,7 +36312,7 @@ Object {
   text-align: center;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -36320,31 +36320,31 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c2 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c6 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c6 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c8 {
     display: none;
   }
@@ -36512,7 +36512,7 @@ Object {
       rel="stylesheet"
     />
     <header
-      class="sc-1glv5oz-0 cOQbpj"
+      class="sc-1glv5oz-0 hSJSZX"
     >
       <a
         href="/"
@@ -36530,7 +36530,7 @@ Object {
         </svg>
       </a>
       <div
-        class="sc-1glv5oz-2 bijesQ"
+        class="sc-1glv5oz-2 bnaOgb"
       >
         <a
           class="sc-850ddk-0 deshEQ"
@@ -36621,7 +36621,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-3 eGBYUU"
+        class="sc-1glv5oz-3 eaQBIV"
       >
         <a
           class="sc-850ddk-0 bRsbmn"
@@ -36657,7 +36657,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-4 gFLKTL"
+        class="sc-1glv5oz-4 AAfz"
       />
     </header>
   </div>,
@@ -36899,7 +36899,7 @@ Object {
   padding-top: 2px;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -36907,7 +36907,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: grid;
     grid-gap: 0;
@@ -36915,37 +36915,37 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c8 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c10 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c10 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c2 {
     display: none;
   }
@@ -37123,13 +37123,13 @@ Object {
       rel="stylesheet"
     />
     <header
-      class="sc-1glv5oz-0 cOQbpj"
+      class="sc-1glv5oz-0 hSJSZX"
     >
       <h1
-        class="sc-1glv5oz-1 eozQRg"
+        class="sc-1glv5oz-1 fBXkFl"
       >
         <div
-          class="sc-1glv5oz-5 bgXdkG"
+          class="sc-1glv5oz-5 jGNGoL"
         >
           <a
             href="/"
@@ -37151,7 +37151,7 @@ Object {
         Roses are red
       </h1>
       <div
-        class="sc-1glv5oz-2 bijesQ"
+        class="sc-1glv5oz-2 bnaOgb"
       >
         <a
           class="sc-850ddk-0 deshEQ"
@@ -37242,7 +37242,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-3 eGBYUU"
+        class="sc-1glv5oz-3 eaQBIV"
       >
         <a
           class="sc-850ddk-0 bRsbmn"
@@ -37278,7 +37278,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-4 gFLKTL"
+        class="sc-1glv5oz-4 AAfz"
       />
     </header>
   </div>,
@@ -37520,7 +37520,7 @@ Object {
   padding-top: 2px;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -37528,7 +37528,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: grid;
     grid-gap: 0;
@@ -37536,37 +37536,37 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c8 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c10 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c10 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c2 {
     display: none;
   }
@@ -37744,13 +37744,13 @@ Object {
       rel="stylesheet"
     />
     <header
-      class="sc-1glv5oz-0 cOQbpj"
+      class="sc-1glv5oz-0 hSJSZX"
     >
       <h1
-        class="sc-1glv5oz-1 eozQRg"
+        class="sc-1glv5oz-1 fBXkFl"
       >
         <div
-          class="sc-1glv5oz-5 bgXdkG"
+          class="sc-1glv5oz-5 jGNGoL"
         >
           <a
             href="/"
@@ -37772,7 +37772,7 @@ Object {
         Unlock
       </h1>
       <div
-        class="sc-1glv5oz-2 bijesQ"
+        class="sc-1glv5oz-2 bnaOgb"
       >
         <a
           class="sc-850ddk-0 deshEQ"
@@ -37863,7 +37863,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-3 eGBYUU"
+        class="sc-1glv5oz-3 eaQBIV"
       >
         <a
           class="sc-850ddk-0 bRsbmn"
@@ -37899,7 +37899,7 @@ Object {
         </a>
       </div>
       <div
-        class="sc-1glv5oz-4 gFLKTL"
+        class="sc-1glv5oz-4 AAfz"
       />
     </header>
   </div>,
@@ -42128,7 +42128,7 @@ Object {
   width: 100%;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -42136,37 +42136,37 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c9 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c9 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c11 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c11 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -42177,13 +42177,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c14 {
     display: none;
   }
@@ -42461,16 +42461,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       />
       <div
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <a
             href="/"
@@ -42488,7 +42488,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -42579,7 +42579,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -42615,7 +42615,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <footer
@@ -42716,7 +42716,7 @@ Object {
         </footer>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -42990,7 +42990,7 @@ Object {
   width: 100%;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -42998,7 +42998,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: grid;
     grid-gap: 0;
@@ -43006,43 +43006,43 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c14 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c14 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c6 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -43053,13 +43053,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c15 {
     display: none;
   }
@@ -43268,10 +43268,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       >
         <a
           href="/"
@@ -43294,13 +43294,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <h1
-            class="sc-1glv5oz-1 eozQRg"
+            class="sc-1glv5oz-1 fBXkFl"
           >
             <div
-              class="sc-1glv5oz-5 bgXdkG"
+              class="sc-1glv5oz-5 jGNGoL"
             >
               <a
                 href="/"
@@ -43322,7 +43322,7 @@ Object {
             Unlock Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -43413,7 +43413,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -43449,12 +43449,12 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -46560,7 +46560,7 @@ Object {
   text-align: center;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: none;
   }
@@ -46658,7 +46658,7 @@ Object {
       class="sc-1dp5gbn-2 fpHeqB"
     >
       <div
-        class="sc-1dp5gbn-0 kHcBbB"
+        class="sc-1dp5gbn-0 kDgfkC"
       >
         <div
           class="sc-1dp5gbn-1 hxNcaM"
@@ -47292,7 +47292,7 @@ Object {
   grid-column: 1;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c13 {
     display: none;
   }
@@ -47559,7 +47559,7 @@ Object {
             </li>
           </ul>
           <footer
-            class="sc-1ws9jnj-8 qRrum"
+            class="sc-1ws9jnj-8 bMvCsG"
           >
             <div
               class="cenpj1-0 dhCRxc"
@@ -47788,7 +47788,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c7 {
     display: none;
   }
@@ -47999,7 +47999,7 @@ Object {
             </section>
           </ul>
           <footer
-            class="sc-1ws9jnj-8 qRrum"
+            class="sc-1ws9jnj-8 bMvCsG"
           >
             <div
               class="cenpj1-0 dhCRxc"
@@ -48288,7 +48288,7 @@ Object {
   grid-column: 1;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c13 {
     display: none;
   }
@@ -48555,7 +48555,7 @@ Object {
             </li>
           </ul>
           <footer
-            class="sc-1ws9jnj-8 qRrum"
+            class="sc-1ws9jnj-8 bMvCsG"
           >
             <div
               class="cenpj1-0 dhCRxc"
@@ -48784,7 +48784,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c7 {
     display: none;
   }
@@ -48995,7 +48995,7 @@ Object {
             </section>
           </ul>
           <footer
-            class="sc-1ws9jnj-8 qRrum"
+            class="sc-1ws9jnj-8 bMvCsG"
           >
             <div
               class="cenpj1-0 dhCRxc"
@@ -49284,7 +49284,7 @@ Object {
   grid-column: 1;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c13 {
     display: none;
   }
@@ -49643,7 +49643,7 @@ Object {
             </li>
           </ul>
           <footer
-            class="sc-1ws9jnj-8 qRrum"
+            class="sc-1ws9jnj-8 bMvCsG"
           >
             <div
               class="cenpj1-0 dhCRxc"
@@ -51818,13 +51818,13 @@ Object {
   transition: opacity 0.4s ease-in;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: none;
   }
@@ -51862,7 +51862,7 @@ Object {
       rel="stylesheet"
     />
     <footer
-      class="sc-1ws9jnj-8 sc-18dedc6-0 jeFBMt"
+      class="sc-1ws9jnj-8 sc-18dedc6-0 eJOOXB"
     >
       <div
         class="cenpj1-0 dhCRxc"
@@ -53606,7 +53606,7 @@ Object {
   background-color: #74ce63;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     grid-template-columns: 0px 1fr 0px;
   }
@@ -53688,7 +53688,7 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hzj1u1-0 WXRVm"
+      class="hzj1u1-0 dWtuQx"
     >
       <div
         class="hzj1u1-1 gVDIgs"
@@ -54158,7 +54158,7 @@ Object {
   font-family: 'IBM Plex Mono',Courier,monospace;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c17 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
@@ -54166,13 +54166,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c18 {
     height: 0px;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     grid-template-columns: [first] 1fr [second] 48px;
     grid-template-rows: [first] auto;
@@ -54180,7 +54180,7 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c5 {
     display: grid;
     grid-gap: 0;
@@ -54188,43 +54188,43 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c8 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c12 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c12 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c14 {
     display: grid;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c14 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:736px) {
+@media only screen and (min-width:736px) {
   .c6 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -54235,13 +54235,13 @@ Object {
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c32 {
     display: none;
   }
@@ -54648,10 +54648,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="hm3mhg-0 gurzDr"
+      class="hm3mhg-0 evMwRH"
     >
       <div
-        class="hm3mhg-1 gaqtYG"
+        class="hm3mhg-1 hHesyi"
       >
         <a
           href="/"
@@ -54674,13 +54674,13 @@ Object {
         class="hm3mhg-3 yKIjT"
       >
         <header
-          class="sc-1glv5oz-0 cOQbpj"
+          class="sc-1glv5oz-0 hSJSZX"
         >
           <h1
-            class="sc-1glv5oz-1 eozQRg"
+            class="sc-1glv5oz-1 fBXkFl"
           >
             <div
-              class="sc-1glv5oz-5 bgXdkG"
+              class="sc-1glv5oz-5 jGNGoL"
             >
               <a
                 href="/"
@@ -54702,7 +54702,7 @@ Object {
             Creator Log
           </h1>
           <div
-            class="sc-1glv5oz-2 bijesQ"
+            class="sc-1glv5oz-2 bnaOgb"
           >
             <a
               class="sc-850ddk-0 deshEQ"
@@ -54793,7 +54793,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-3 eGBYUU"
+            class="sc-1glv5oz-3 eaQBIV"
           >
             <a
               class="sc-850ddk-0 bRsbmn"
@@ -54829,7 +54829,7 @@ Object {
             </a>
           </div>
           <div
-            class="sc-1glv5oz-4 gFLKTL"
+            class="sc-1glv5oz-4 AAfz"
           />
         </header>
         <section
@@ -54848,10 +54848,10 @@ Object {
             </span>
           </header>
           <div
-            class="sc-9u6rci-3 fIGRgk"
+            class="sc-9u6rci-3 fSzJBJ"
           >
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             >
               <div
                 class="paper"
@@ -54918,19 +54918,19 @@ Object {
               Balance
             </div>
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
-              class="sc-9u6rci-4 ejQGsP"
+              class="sc-9u6rci-4 eXwiFo"
             />
             <div
               class="sc-9u6rci-6 gvRTKt"
@@ -55032,7 +55032,7 @@ Object {
         </div>
       </div>
       <div
-        class="hm3mhg-2 iUzlxA"
+        class="hm3mhg-2 kyyqtC"
       />
     </div>
   </div>,
@@ -55161,13 +55161,13 @@ Object {
   transition: opacity 0.4s ease-in;
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: none;
   }
 }
 
-@media only screen and (min-device-width:0px) and (max-device-width:736px) {
+@media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: none;
   }
@@ -55205,7 +55205,7 @@ Object {
       rel="stylesheet"
     />
     <footer
-      class="sc-1ws9jnj-8 sc-18dedc6-0 jeFBMt"
+      class="sc-1ws9jnj-8 sc-18dedc6-0 eJOOXB"
     >
       <div
         class="cenpj1-0 dhCRxc"

--- a/unlock-app/src/theme/media.js
+++ b/unlock-app/src/theme/media.js
@@ -27,10 +27,8 @@ sizes.nodesktop = {
 
 const Media = Object.keys(sizes).reduce((acc, label) => {
   acc[label] = (...args) => css`
-    @media only screen and (min-device-width: ${sizes[label].min}px) ${sizes[
-        label
-      ].max
-        ? `and (max-device-width: ${sizes[label].max}px)`
+    @media only screen and (min-width: ${sizes[label].min}px) ${sizes[label].max
+        ? `and (max-width: ${sizes[label].max}px)`
         : ''} {
       ${css(...args)};
     }


### PR DESCRIPTION
# Description

This PR is a prerequisite for implementing #973 

This change makes it possible to see how our CSS responds to different viewports in the desktop browser simply by resizing the window. Using `*-device-width` prevents this.

<img width="400" alt="screen shot 2019-03-06 at 10 05 54 pm" src="https://user-images.githubusercontent.com/98250/53929550-0feefc00-405c-11e9-991d-c04e7e95b269.png">
<img width="1665" alt="screen shot 2019-03-06 at 10 05 44 pm" src="https://user-images.githubusercontent.com/98250/53929551-0feefc00-405c-11e9-81bb-a16c3eb56956.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #973

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
