### PR TITLE
Actually fix handing the dev environment the contract address

### DIFF
--- a/paywall/next.config.js
+++ b/paywall/next.config.js
@@ -5,13 +5,20 @@ const withSourceMaps = require('@zeit/next-source-maps')
 
 const copyFile = promisify(fs.copyFile)
 
+const publicRuntimeConfig = {
+  unlockEnv: process.env.UNLOCK_ENV || 'dev',
+  httpProvider: process.env.HTTP_PROVIDER || '127.0.0.1',
+  readOnlyProvider: process.env.READ_ONLY_PROVIDER,
+  locksmithHost: process.env.LOCKSMITH_HOST,
+}
+
+if (publicRuntimeConfig.unlockEnv === 'dev') {
+  publicRuntimeConfig.unlockAddress =
+    '0x885EF47c3439ADE0CB9b33a4D3c534C99964Db93'
+}
+
 module.exports = withSourceMaps({
-  publicRuntimeConfig: {
-    unlockEnv: process.env.UNLOCK_ENV || 'dev',
-    httpProvider: process.env.HTTP_PROVIDER || '127.0.0.1',
-    readOnlyProvider: process.env.READ_ONLY_PROVIDER,
-    locksmithHost: process.env.LOCKSMITH_HOST,
-  },
+  publicRuntimeConfig: {},
   webpack: config => {
     // Fixes npm packages that depend on `fs` module
     config.node = {

--- a/paywall/next.config.js
+++ b/paywall/next.config.js
@@ -13,12 +13,15 @@ const publicRuntimeConfig = {
 }
 
 if (publicRuntimeConfig.unlockEnv === 'dev') {
+  // Dev setup script can't set environment variables in a way that we can
+  // access them everywhere we need them, so this gets hardcoded. Update if abi
+  // package changes.
   publicRuntimeConfig.unlockAddress =
     '0x885EF47c3439ADE0CB9b33a4D3c534C99964Db93'
 }
 
 module.exports = withSourceMaps({
-  publicRuntimeConfig: {},
+  publicRuntimeConfig,
   webpack: config => {
     // Fixes npm packages that depend on `fs` module
     config.node = {

--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -18,6 +18,14 @@ const requiredConfigVariables = {
     process.env.UNLOCK_ADDRESS || '0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B', // default for CI
 }
 
+if (requiredConfigVariables.unlockEnv === 'dev') {
+  // Dev setup script can't set environment variables in a way that we can
+  // access them everywhere we need them, so this gets hardcoded. Update if abi
+  // package changes.
+  requiredConfigVariables.unlockAddress =
+    '0x885EF47c3439ADE0CB9b33a4D3c534C99964Db93'
+}
+
 Object.keys(requiredConfigVariables).forEach(configVariableName => {
   if (!requiredConfigVariables[configVariableName]) {
     if (requiredConfigVariables.unlockEnv === 'test') return

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -68,7 +68,7 @@
     "build-paywall": "cross-env NODE_ENV=production rollup -c rollup.paywall.config.js -o ./src/static/paywall.min.js",
     "deploy": "next export src -o out",
     "deploy-netlify": "./scripts/deploy-netlify.sh",
-    "deploy-unlock-contract": "export UNLOCK_ADDRESS=`node scripts/deploy-unlock.js`",
+    "deploy-unlock-contract": "node scripts/deploy-unlock.js",
     "start": "cross-env NODE_ENV=production node src/server.js",
     "start-ganache": "run-script-os",
     "start-ganache:darwin:freebsd:linux:sunos": "cd .. && (npm run start-ganache -- -b 3 &) ",

--- a/unlock-app/scripts/deploy-unlock.js
+++ b/unlock-app/scripts/deploy-unlock.js
@@ -1,6 +1,10 @@
 /* eslint-disable no-console */
 
 const Web3 = require('web3')
+
+// If you upgrade this dependency, the contract address will change. As a
+// result, the fallback addresses in the `unlock-app` and the `paywall` configs
+// will need to be updated to reflect the new address.
 const Unlock = require('unlock-abi-0').Unlock
 
 /*


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR is the dirty hack that #1929 wishes it was. Given that we only run the `deploy-unlock-contract` script on dev, and we can't set environment variables from within NPM scripts in such a way that they will be accessible to all the components that need them (paywall...), we have moved to hardcoding the dev address for the contract in both `unlock-app` and the split `paywall`. Helpful warnings have been included to let people know that 

This is still only a stopgap solution until we come up with something better--personally I think that for this sort of thing we're going to need more complex scripts (possibly from outside NPM) to orchestrate getting the app running.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
