### PR TITLE
pass middleware the top-level config

### DIFF
--- a/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
@@ -1,4 +1,5 @@
 import { setConversionRate } from '../../actions/currencyConvert'
+import configure from '../../config'
 
 jest.mock('../../services/currencyLookupService', () => () => ({
   lookupPrice: jest
@@ -9,6 +10,11 @@ jest.mock('../../services/currencyLookupService', () => () => ({
 }))
 
 describe('Currency conversion service retrieval middleware', () => {
+  let config
+  beforeEach(() => {
+    // TODO: write tests that allow testing different services
+    config = configure()
+  })
   it('service called, action dispatched to set currency conversion rate', async () => {
     expect.assertions(2)
     jest.useFakeTimers()
@@ -21,7 +27,7 @@ describe('Currency conversion service retrieval middleware', () => {
       },
     }
 
-    await middleware(store)
+    await middleware(config)(store)
 
     expect(store.dispatch).toHaveBeenCalledWith(
       setConversionRate('USD', '195.99')
@@ -44,7 +50,7 @@ describe('Currency conversion service retrieval middleware', () => {
       dispatch: jest.fn(),
     }
 
-    await middleware(store)
+    await middleware(config)(store)
     store.dispatch = jest.fn() // reset
     store.getState = () => ({ currency: { USD: 195.99 } })
     jest.advanceTimersByTime(10000) // test the setInterval

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -10,6 +10,7 @@ import { addTransaction, NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ACCOUNT } from '../../actions/accounts'
 import { SIGNED_DATA } from '../../actions/signature'
 import UnlockLock from '../../structured_data/unlockLock'
+import configure from '../../config'
 
 /**
  * This is a "fake" middleware caller
@@ -20,6 +21,7 @@ let state
 let account
 let lock
 let network
+let config
 
 const create = () => {
   const store = {
@@ -27,7 +29,7 @@ const create = () => {
     dispatch: jest.fn(() => true),
   }
   const next = jest.fn()
-  const handler = storageMiddleware(store)
+  const handler = storageMiddleware(config)(store)
   const invoke = action => handler(next)(action)
   return { next, invoke, store }
 }
@@ -44,6 +46,7 @@ jest.mock('../../structured_data/unlockLock.js')
 
 describe('Storage middleware', () => {
   beforeEach(() => {
+    config = configure()
     account = {
       address: '0xabc',
     }

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -25,6 +25,7 @@ import {
   SIGNED_DATA,
   SIGNATURE_ERROR,
 } from '../../actions/signature'
+import configure from '../../config'
 
 /**
  * Fake state
@@ -38,6 +39,7 @@ let lock = {
   owner: account,
 }
 let state = {}
+let config
 
 let key = {
   id: '123',
@@ -64,7 +66,7 @@ const create = () => {
   }
   const next = jest.fn()
 
-  const handler = walletMiddleware(store)
+  const handler = walletMiddleware(config)(store)
 
   const invoke = action => handler(next)(action)
 
@@ -96,6 +98,7 @@ jest.useFakeTimers()
 beforeEach(() => {
   // Reset the mock
   mockWalletService = new MockWalletService()
+  config = configure()
 
   // Reset state!
   account = {

--- a/unlock-app/src/middlewares/currencyConversionMiddleware.js
+++ b/unlock-app/src/middlewares/currencyConversionMiddleware.js
@@ -1,29 +1,30 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import { setConversionRate } from '../actions/currencyConvert'
-import configure from '../config'
 import CurrencyLookupService from '../services/currencyLookupService'
 import { CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL } from '../constants'
 
-const { services } = configure(global)
-const currencyPriceLookupURI = services.currencyPriceLookup
+export default ({ services }) => {
+  const currencyPriceLookupURI = services.currencyPriceLookup
+  return store => {
+    const currencyLookupService = new CurrencyLookupService(
+      currencyPriceLookupURI
+    )
 
-export default store => {
-  const currencyLookupService = new CurrencyLookupService(
-    currencyPriceLookupURI
-  )
+    currencyLookupService
+      .lookupPrice('ETH', 'USD')
+      .then(info =>
+        store.dispatch(setConversionRate(info.currency, info.amount))
+      )
 
-  currencyLookupService
-    .lookupPrice('ETH', 'USD')
-    .then(info => store.dispatch(setConversionRate(info.currency, info.amount)))
+    setInterval(() => {
+      currencyLookupService.lookupPrice('ETH', 'USD').then(info => {
+        const current = store.getState().currency[info.currency]
+        if (current === info.amount) return
 
-  setInterval(() => {
-    currencyLookupService.lookupPrice('ETH', 'USD').then(info => {
-      const current = store.getState().currency[info.currency]
-      if (current === info.amount) return
-
-      store.dispatch(setConversionRate(info.currency, info.amount))
-    })
-  }, CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL)
-  return next => action => next(action)
+        store.dispatch(setConversionRate(info.currency, info.amount))
+      })
+    }, CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL)
+    return next => action => next(action)
+  }
 }

--- a/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
+++ b/unlock-app/src/middlewares/interWindowCommunicationMiddleware.js
@@ -21,7 +21,7 @@ function redirectToContentFromPaywall(window, getState) {
 
 // store is unused in this middleware, it is only for listening for actions
 // and converting them into postMessage
-const interWindowCommunicationMiddleware = window => ({
+const createInterWindowCommunicationMiddleware = window => ({
   getState,
   dispatch,
 }) => {
@@ -104,4 +104,4 @@ const interWindowCommunicationMiddleware = window => ({
   }
 }
 
-export default interWindowCommunicationMiddleware
+export default createInterWindowCommunicationMiddleware

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -9,15 +9,12 @@ import {
 import StorageService from '../services/storageService'
 import { STORE_LOCK_NAME, storageError } from '../actions/storage'
 
-import configure from '../config'
 import { NEW_TRANSACTION, addTransaction } from '../actions/transaction'
 import { SET_ACCOUNT } from '../actions/accounts'
 import UnlockLock from '../structured_data/unlockLock'
 import { SIGNED_DATA, signData } from '../actions/signature'
 
-const { services } = configure(global)
-
-export default function storageMiddleware({ getState, dispatch }) {
+const createStorageMiddleware = ({ services }) => ({ getState, dispatch }) => {
   const storageService = new StorageService(services.storage.host)
 
   return next => {
@@ -121,3 +118,5 @@ export default function storageMiddleware({ getState, dispatch }) {
     }
   }
 }
+
+export default createStorageMiddleware

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -26,8 +26,8 @@ import { SIGN_DATA, signedData, signatureError } from '../actions/signature'
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
 
-export default function walletMiddleware({ getState, dispatch }) {
-  const walletService = new WalletService()
+const createWalletMiddleware = config => ({ getState, dispatch }) => {
+  const walletService = new WalletService(config)
 
   /**
    * Helper function which ensures that the walletService is ready
@@ -173,3 +173,5 @@ export default function walletMiddleware({ getState, dispatch }) {
     }
   }
 }
+
+export default createWalletMiddleware

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -24,7 +24,7 @@ const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
 function getOrCreateStore(initialState, path) {
   const middlewares = [
     createInterWindowCommunicationMiddleware(global),
-    web3Middleware(config),
+    web3Middleware,
     createCurrencyConversionMiddleware(config),
     createWalletMiddleware(config),
   ]

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -12,10 +12,10 @@ import WalletCheckOverlay from '../components/interface/FullScreenModals'
 
 // Middlewares
 import web3Middleware from '../middlewares/web3Middleware'
-import currencyConversionMiddleware from '../middlewares/currencyConversionMiddleware'
+import createCurrencyConversionMiddleware from '../middlewares/currencyConversionMiddleware'
 import storageMiddleware from '../middlewares/storageMiddleware'
-import walletMiddleware from '../middlewares/walletMiddleware'
-import interWindowCommunicationMiddleware from '../middlewares/interWindowCommunicationMiddleware'
+import createWalletMiddleware from '../middlewares/walletMiddleware'
+import createInterWindowCommunicationMiddleware from '../middlewares/interWindowCommunicationMiddleware'
 
 const config = configure()
 
@@ -23,10 +23,10 @@ const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
 
 function getOrCreateStore(initialState, path) {
   const middlewares = [
-    interWindowCommunicationMiddleware(global),
-    web3Middleware,
-    currencyConversionMiddleware,
-    walletMiddleware,
+    createInterWindowCommunicationMiddleware(global),
+    web3Middleware(config),
+    createCurrencyConversionMiddleware(config),
+    createWalletMiddleware(config),
   ]
 
   if (config.services.storage) {

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -13,7 +13,7 @@ import WalletCheckOverlay from '../components/interface/FullScreenModals'
 // Middlewares
 import web3Middleware from '../middlewares/web3Middleware'
 import createCurrencyConversionMiddleware from '../middlewares/currencyConversionMiddleware'
-import storageMiddleware from '../middlewares/storageMiddleware'
+import createStorageMiddleware from '../middlewares/storageMiddleware'
 import createWalletMiddleware from '../middlewares/walletMiddleware'
 import createInterWindowCommunicationMiddleware from '../middlewares/interWindowCommunicationMiddleware'
 
@@ -30,7 +30,7 @@ function getOrCreateStore(initialState, path) {
   ]
 
   if (config.services.storage) {
-    middlewares.push(storageMiddleware)
+    middlewares.push(createStorageMiddleware(config))
   }
 
   // Always make a new store if server, otherwise state is shared between requests


### PR DESCRIPTION
# Description

In preparation for fixing #1928, the walletMiddleware needs to get the configuration. This is a pattern shared by three other middlewares.

In order to easily test changing configuration values (for instance, from running on the server to running on the client), there are 2 ways to do this.

1) mock the configuration by making it a parameter
2) mock the configuration by using jest mocks to mock the entire file

This PR is the first approach. These are the tradeoffs involved.

**mocking the configuration by making it a parameter**
Advantages:
1. The dependency is cleaner in the test, we just need to change the local config like:
```js
it('does not work on server', () => {
  config.isServer = false
  const middleware = create()
//...
```
2. no reliance on third-party solutions in order to mock, it will just work.
3. configuration is re-created every time we call `configure()`, both creating unnecessary redundant runtime calls and introducing a point of failure should something in the env it uses to create the config changes.

Disadvantages:
1. a parameter must be passed to create the middleware. This makes the source slightly more complex:
```diff
+const createWalletMiddleware = config => ({ getState, dispatch }) => {
-export default function walletMiddleware({ getState, dispatch }) {
```
2. The dependency must be passed in the top-level `_app.js`, introducing a potential point of failure should that be forgotten.

**mocking the container through a jest mock**
Advantages:
1. The dependency is cleaner in the source, it's a simple import and function call to configure()
2. top-level _app.js does not need to pass the config to work.
3. the source of the dependency is more explicit (the import is in the same file)

Disadvantages:
1. We have to rely upon the testing framework to properly mock the config, and jest mocks are pretty complex to get right.
2. configuration is re-created every time we call `configure()`, both creating unnecessary redundant runtime calls and introducing a point of failure should something in the env it uses to create the config changes.

**How I made this decision**
This is not an easy one to make, the advantages and disadvantages are almost the same. What tips the balance in favor of this PR's solution is the complexity of jest mocking. In my short time at Unlock, I've already seen many hard-to-track-down bugs caused by weird mock behavior, as well as a large learning curve setting up a mock, and continued confusion even after setting up many mocks previously.

The other factor is that the configuration is not just a static import, it requires calling a function and in the global scope of the file. This introduces the equivalent of a global variable, and also an unnecessary performance hit.

I'm open to the other solution, and I am going to make a competing PR with that implementation in a moment. Note that because the current approach is closer to the jest mocking way, there are fewer lines of code that need to be touched.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #1928 
Refs #1967

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
