### PR TITLE
Don't poll for account changes on the server

### DIFF
--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -22,12 +22,14 @@ import { TRANSACTION_TYPES, POLLING_INTERVAL } from '../constants' // TODO chang
 import WalletService from '../services/walletService'
 import { FATAL_NO_USER_ACCOUNT } from '../errors'
 import { SIGN_DATA, signedData, signatureError } from '../actions/signature'
+import configure from '../config'
 
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
 
 export default function walletMiddleware({ getState, dispatch }) {
-  const walletService = new WalletService()
+  const config = configure()
+  const walletService = new WalletService(config)
 
   /**
    * Helper function which ensures that the walletService is ready
@@ -46,6 +48,7 @@ export default function walletMiddleware({ getState, dispatch }) {
    * The setAccount action will reset other relevant redux state
    */
   walletService.on('account.changed', account => {
+    if (config.isServer) return
     // Let's poll to detect account changes
     setTimeout(walletService.getAccount.bind(walletService), POLLING_INTERVAL)
 


### PR DESCRIPTION
# Description

this disables polling on the server for account changes. It does not have paywall changes for clarity, and will be merged in a subsequent PR

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #1928 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
