### PR TITLE
Set correct lock address on lock creation transactions

### DIFF
--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -875,6 +875,27 @@ describe('Web3Service', () => {
       expect(web3Service.getLock).toHaveBeenCalledWith(params.newLockAddress)
     })
 
+    it('should handle NewLock and emit transaction.updated with the new lock address', () => {
+      const transactionHash = '0x123'
+      const contractAddress = '0x456'
+      const blockNumber = 1337
+      const params = {
+        newLockAddress: ' 0x789',
+      }
+      web3Service.getLock = jest.fn()
+
+      web3Service.once('transaction.updated', (hash, update) => {
+        expect(update.lock).toBe(params.newLockAddress)
+      })
+      web3Service.emitContractEvent(
+        transactionHash,
+        contractAddress,
+        blockNumber,
+        'NewLock',
+        params
+      )
+    })
+
     it('should handle Transfer and emit key.save', done => {
       expect.assertions(3)
       const transactionHash = '0x123'

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -876,6 +876,7 @@ describe('Web3Service', () => {
     })
 
     it('should handle NewLock and emit transaction.updated with the new lock address', () => {
+      expect.assertions(1)
       const transactionHash = '0x123'
       const contractAddress = '0x456'
       const blockNumber = 1337

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -41,7 +41,7 @@ export default class Web3Service extends EventEmitter {
     this.eventsHandlers = {
       NewLock: (transactionHash, contractAddress, blockNumber, args) => {
         this.emit('transaction.updated', transactionHash, {
-          lock: contractAddress,
+          lock: args.newLockAddress,
         })
         this.emit('lock.updated', args.newLockAddress, {
           asOf: blockNumber,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
<img width="545" alt="image" src="https://user-images.githubusercontent.com/9300702/54032804-a4527f00-4180-11e9-8a0f-644a2f3320a9.png">

Before this PR, the `lock` property on lock creation transactions was set to the address of the smart contract, and not the address of the lock that was created. This PR addresses that by setting the lock address to the correct value once we have the transaction receipt.

**This PR is a draft** until I handle what happens with pending lock creations.

It seems that we get the lock address right as we submit, before any new block is mined:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/9300702/54034271-73744900-4184-11e9-8eff-c4977d418f6d.png">

That seems sufficient to me, any thoughts?

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1917 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
