### PR TITLE
husky pre-push hook: only match the directory if it is the start of the path

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -22,7 +22,7 @@ const lintStaged = path => {
 // It will try to amend the latest commit if possible to fix.
 const eslint = path => {
   return {
-    command: `git diff --name-only --diff-filter=d $(git merge-base origin/master HEAD) | grep ${path}.*js$ | sed 's/${path}\\///' | xargs eslint --fix`,
+    command: `git diff --name-only --diff-filter=d $(git merge-base origin/master HEAD) | grep "^${path}.*js$" | sed 's/${path}\\///' | xargs eslint --fix`,
     path: path
   }
 }


### PR DESCRIPTION
# Description

The husky pre-push hook has this line in it:

```js
    command: `git diff --name-only --diff-filter=d $(git merge-base origin/master HEAD) | grep ${path}.*js$ | sed 's/${path}\\///' | xargs eslint --fix`,
```

The command is run once for each directory, in order to lint files in that directory using the lint rules for that directory only.

The first part (`git diff`) generates a list of files modified in the branch like so:

```
unlock-app/blahblah/blah.js
paywall/blahabla/blah.js
smart-contracts/blablajbla/blah.sol
```

it then filters them using grep:

```
grep ${path}.*js$
```

Unfortunately, this regex is too general, and will match the path anywhere in the file name, so when linting inside paywall, it will match:

```
unlock-app/rollup.paywall.config.js
paywall/<any file in paywall>
```

This causes an error because the file name will not be found in the current app directory.

The fix is simple: using the `^` prefix, it forces grep to only match the start of the path.

```
grep "^${path}.*js$"
```

Tested locally, looking for @nfurfaro to verify this fixes the issue on his end. Basically, in any of your branches, prior to pushing, copy this change into your .huskyrc.js (you need not commit it to test) and run push. Reply here to let us know if that allowed you to push without --no-verify.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1962

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
