### PR TITLE
Integration test proving the paywall loads a lock

### DIFF
--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -72,7 +72,6 @@ describe('The Unlock Dashboard', () => {
         page.goto(url(`/demo/${testLockAddress}`)),
         page.waitForNavigation(),
       ])
-      await page.waitFor(1000)
     })
     afterAll(async () => {
       await Promise.all([
@@ -81,6 +80,7 @@ describe('The Unlock Dashboard', () => {
       ])
     })
     it('should display a lock on the demo page with a paywall', async () => {
+      await page.waitForFunction(() => window.frames.length, { polling: 'mutation' })
       const paywallBody = await page.mainFrame().childFrames()[0].$('body')
       await page.mainFrame().childFrames()[0].waitForSelector(`#Lock_${testLockAddress}`)
       await expect(paywallBody).toMatch('0.33 Eth')

--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -67,15 +67,23 @@ describe('The Unlock Dashboard', () => {
   })
 
   describe('Paywall demo', () => {
-    it('should display a lock on the demo page with a paywall', async () => {
-      await expect(page).toClick('button', { text: 'Create Lock' })
-      await expect(page).toClick('button', { text: 'Submit' })
-
+    beforeAll(async () => {
       await Promise.all([
         page.goto(url(`/demo/${testLockAddress}`)),
         page.waitForNavigation(),
       ])
-      await expect(page).toMatchElement(`#Lock_${testLockAddress}`)
+      await page.waitFor(1000)
+    })
+    afterAll(async () => {
+      await Promise.all([
+        page.goto(url('/dashboard')),
+        page.waitForNavigation(),
+      ])
+    })
+    it('should display a lock on the demo page with a paywall', async () => {
+      const paywallBody = await page.mainFrame().childFrames()[0].$('body')
+      await page.mainFrame().childFrames()[0].waitForSelector(`#Lock_${testLockAddress}`)
+      await expect(paywallBody).toMatch('0.33 Eth')
     }, 10000)
   })
 })

--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -65,4 +65,17 @@ describe('The Unlock Dashboard', () => {
       })
     })
   })
+
+  describe('Paywall demo', () => {
+    it('should display a lock on the demo page with a paywall', async () => {
+      await expect(page).toClick('button', { text: 'Create Lock' })
+      await expect(page).toClick('button', { text: 'Submit' })
+
+      await Promise.all([
+        page.goto(url(`/demo/${testLockAddress}`)),
+        page.waitForNavigation(),
+      ])
+      await expect(page).toMatchElement(`#Lock_${testLockAddress}`)
+    }, 10000)
+  })
 })

--- a/unlock-app/src/components/lock/NoKeyLock.js
+++ b/unlock-app/src/components/lock/NoKeyLock.js
@@ -25,8 +25,8 @@ export const NoKeyLock = ({
       amount={lock.keyPrice}
       render={(ethPrice, fiatPrice) => (
         <div>
-          <Body disabled={disabled}>
-            <EthPrice>{ethPrice} Eth</EthPrice>
+          <Body disabled={disabled} id={`Lock_${lock.address}`}>
+            <EthPrice id={`EthPrice_${lock.address}`}>{ethPrice} Eth</EthPrice>
             <div>
               <FiatPrice>${fiatPrice}</FiatPrice>
               <Separator> | </Separator>


### PR DESCRIPTION
# Description

This PR adds an integration test that verifies that the paywall displays a lock price when the demo page is loaded.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1882 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
