### PR TITLE
prepare for splitting of web3Middleware into app-specific middlewares

### DIFF
--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'events'
 import { LOCATION_CHANGE } from 'connected-next-router'
+import Web3Service from '../../services/web3Service'
 import web3Middleware from '../../middlewares/web3Middleware'
 import { ADD_LOCK, UPDATE_LOCK, CREATE_LOCK } from '../../actions/lock'
 import { UPDATE_KEY } from '../../actions/key'
@@ -44,7 +45,8 @@ const create = () => {
   }
   const next = jest.fn()
 
-  const handler = web3Middleware(store)
+  const service = new Web3Service()
+  const handler = web3Middleware(service)(store)
 
   const invoke = action => handler(next)(action)
 

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -20,7 +20,6 @@ import {
 } from '../actions/transaction'
 import { PGN_ITEMS_PER_PAGE, UNLIMITED_KEYS_COUNT } from '../constants'
 
-import Web3Service from '../services/web3Service'
 import {
   SET_KEYS_ON_PAGE_FOR_LOCK,
   setKeysOnPageForLock,
@@ -29,9 +28,7 @@ import { lockRoute } from '../utils/routes'
 
 // This middleware listen to redux events and invokes the web3Service API.
 // It also listen to events from web3Service and dispatches corresponding actions
-export default function web3Middleware({ getState, dispatch }) {
-  const web3Service = new Web3Service()
-
+const createWeb3Middleware = web3Service => ({ getState, dispatch }) => {
   web3Service.on('account.updated', (account, update) => {
     dispatch(updateAccount(update))
   })
@@ -197,3 +194,5 @@ export default function web3Middleware({ getState, dispatch }) {
     }
   }
 }
+
+export default createWeb3Middleware

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -10,6 +10,8 @@ import { ConfigContext } from '../utils/withConfig'
 
 import WalletCheckOverlay from '../components/interface/FullScreenModals'
 
+// Services
+import Web3Service from '../services/web3Service'
 // Middlewares
 import web3Middleware from '../middlewares/web3Middleware'
 import currencyConversionMiddleware from '../middlewares/currencyConversionMiddleware'
@@ -22,9 +24,10 @@ const config = configure()
 const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
 
 function getOrCreateStore(initialState, path) {
+  const web3Service = new Web3Service()
   const middlewares = [
     interWindowCommunicationMiddleware(global),
-    web3Middleware,
+    web3Middleware(web3Service),
     currencyConversionMiddleware,
     walletMiddleware,
   ]


### PR DESCRIPTION
# Description

In preparation for the splitting of web3Middleware into smaller pieces, this change will allow us to instantiate a single `web3Service` instance to use in both a `dashboardWeb3Middleware` and a `paywallWeb3Middleware` as well as a shared generic `web3Middleware`.

When the paywall app is split off, the `paywallWeb3Middleware` will migrate over there, and the `web3Middleware` will be shared between the apps and synchronized in either a shared location or a shared npm package, depending on what is decided.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1987

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
