### PR TITLE
prepare for split of walletMiddleware by passing a single walletService instance

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -1,4 +1,5 @@
 import EventEmitter from 'events'
+import WalletService from '../../services/walletService'
 import walletMiddleware from '../../middlewares/walletMiddleware'
 import {
   CREATE_LOCK,
@@ -68,7 +69,8 @@ const create = () => {
   }
   const next = jest.fn()
 
-  const handler = walletMiddleware(store)
+  const walletService = new WalletService(mockConfig)
+  const handler = walletMiddleware(walletService)(store)
 
   const invoke = action => handler(next)(action)
 

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -19,7 +19,6 @@ import {
 } from '../actions/walletStatus'
 import { TRANSACTION_TYPES, POLLING_INTERVAL } from '../constants' // TODO change POLLING_INTERVAL into ACCOUNT_POLLING_INTERVAL
 
-import WalletService from '../services/walletService'
 import { FATAL_NO_USER_ACCOUNT } from '../errors'
 import { SIGN_DATA, signedData, signatureError } from '../actions/signature'
 import configure from '../config'
@@ -27,9 +26,8 @@ import configure from '../config'
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
 
-export default function walletMiddleware({ getState, dispatch }) {
+const makeWalletMiddleware = walletService => ({ getState, dispatch }) => {
   const config = configure()
-  const walletService = new WalletService(config)
 
   /**
    * Helper function which ensures that the walletService is ready
@@ -176,3 +174,5 @@ export default function walletMiddleware({ getState, dispatch }) {
     }
   }
 }
+
+export default makeWalletMiddleware

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -10,6 +10,8 @@ import { ConfigContext } from '../utils/withConfig'
 
 import WalletCheckOverlay from '../components/interface/FullScreenModals'
 
+// Services
+import WalletService from '../services/walletService'
 // Middlewares
 import web3Middleware from '../middlewares/web3Middleware'
 import currencyConversionMiddleware from '../middlewares/currencyConversionMiddleware'
@@ -22,11 +24,12 @@ const config = configure()
 const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
 
 function getOrCreateStore(initialState, path) {
+  const walletService = new WalletService(config)
   const middlewares = [
     interWindowCommunicationMiddleware(global),
     web3Middleware,
     currencyConversionMiddleware,
-    walletMiddleware,
+    walletMiddleware(walletService),
   ]
 
   if (config.services.storage) {


### PR DESCRIPTION
# Description

In preparation for the splitting of walletMiddleware into smaller pieces, this change will allow us to instantiate a single `walletService` instance to use in both a `dashboardWalletMiddleware` and a `paywallWalletMiddleware` as well as a shared generic `walletMiddleware`.

When the paywall app is split off, the `paywallWalletMiddleware` will migrate over there, and the `walletMiddleware` will be shared between the apps and synchronized in either a shared location or a shared npm package, depending on what is decided.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1991

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
