### PR TITLE
Remove unneeded networks from truffle config

### DIFF
--- a/smart-contracts/truffle-config.js
+++ b/smart-contracts/truffle-config.js
@@ -31,22 +31,10 @@ const mainnetProvider = function () {
 
 module.exports = {
   networks: {
-    local: {
+    development: {
       // used for local dev
       host: '127.0.0.1',
       port: 8545,
-      network_id: '*' // Match any network id
-    },
-    development: {
-      // used for solidity-coverage
-      host: testHost,
-      port: 8545,
-      network_id: '*' // Match any network id
-    },
-    ganache: {
-      // used for local dev but with the ganache gui
-      host: '127.0.0.1',
-      port: 8546, // We use ganache-gui and this is its default port
       network_id: '*' // Match any network id
     },
     rinkeby: {

--- a/smart-contracts/truffle-config.js
+++ b/smart-contracts/truffle-config.js
@@ -33,7 +33,7 @@ module.exports = {
   networks: {
     development: {
       // used for local dev
-      host: '127.0.0.1',
+      host: testHost,
       port: 8545,
       network_id: '*' // Match any network id
     },


### PR DESCRIPTION
# Description

This is a small config-only PR to remove the"local" and "ganache" networks from `truffle-config.js` as we don't need or use them.

# Issues

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
