### PR TITLE
Deprecating the global error consumer by first using errors passed from the redux store to the consumer

### DIFF
--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
 
-import GlobalErrorConsumer, {
+import {
+  GlobalErrorConsumer,
   displayError,
+  mapStateToProps,
 } from '../../../components/interface/GlobalErrorConsumer'
 import { GlobalErrorContext } from '../../../utils/GlobalErrorProvider'
 import { FATAL_NO_USER_ACCOUNT, FATAL_MISSING_PROVIDER } from '../../../errors'
@@ -72,6 +74,45 @@ describe('GlobalErrorConsumer', () => {
       expect.assertions(1)
       const wrapper = rtl.render(displayError(false, {}, <div>children</div>))
       expect(wrapper.queryByText('children')).not.toBeNull()
+    })
+  })
+
+  describe('mapStateToProps', () => {
+    it('should only map fatal errors', () => {
+      expect.assertions(1)
+      const state = {}
+      const props = mapStateToProps(state)
+      expect(props.error).toBe(undefined)
+    })
+
+    it('should not map non fatal errors', () => {
+      expect.assertions(1)
+      const state = { errors: ['AN_ERROR'] }
+      const props = mapStateToProps(state)
+      expect(props.error).toBe(undefined)
+    })
+
+    it('should map fatal errors', () => {
+      expect.assertions(1)
+      const state = { errors: ['FATAL_ERROR'] }
+      const props = mapStateToProps(state)
+      expect(props.error).toEqual('FATAL_ERROR')
+    })
+  })
+
+  describe('when called with a fatal error', () => {
+    it('should invoke displayError with that error', () => {
+      expect.assertions(2)
+      const fatalError = 'FATAL_ERROR'
+      const listen = jest.fn(() => <div>internal</div>)
+      rtl.render(
+        <GlobalErrorConsumer displayError={listen} error={fatalError}>
+          <p>App</p>
+        </GlobalErrorConsumer>
+      )
+
+      expect(listen).toHaveBeenCalledTimes(1)
+      expect(listen).toHaveBeenCalledWith(fatalError, {}, <p>App</p>)
     })
   })
 })

--- a/unlock-app/src/components/interface/GlobalErrorConsumer.js
+++ b/unlock-app/src/components/interface/GlobalErrorConsumer.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
+import { connect } from 'react-redux'
 import { GlobalErrorContext } from '../../utils/GlobalErrorProvider'
 import Layout from './Layout'
 import { mapErrorToComponent } from '../creator/FatalError'
 
+// DEPRECATED we should not use the Context to detect errors
 const Consumer = GlobalErrorContext.Consumer
 
+// TODO: move that logic back to <GlobalErrorConsumer> once the Context logic is gone
 export const displayError = (error, errorMetadata, children) => {
   if (error) {
     const Error = mapErrorToComponent(error, errorMetadata)
@@ -15,7 +17,14 @@ export const displayError = (error, errorMetadata, children) => {
   return <React.Fragment>{children}</React.Fragment>
 }
 
-export default function GlobalErrorConsumer({ displayError, children }) {
+/**
+ * The GlobalErrorConsumer should be renamed, but its job is simply to "intercept" any fatal error
+ * and prevent the UI from displaying anything else.
+ */
+export function GlobalErrorConsumer({ displayError, children, error }) {
+  if (error) {
+    return displayError(error, {}, children)
+  }
   return (
     <Consumer>
       {({ error, errorMetadata }) => {
@@ -28,8 +37,26 @@ export default function GlobalErrorConsumer({ displayError, children }) {
 GlobalErrorConsumer.propTypes = {
   children: PropTypes.node.isRequired,
   displayError: PropTypes.func,
+  error: PropTypes.string,
 }
 
 GlobalErrorConsumer.defaultProps = {
   displayError,
+  error: null,
 }
+
+/**
+ * Will pass the first fatal error as props.
+ * @param {*} state
+ */
+export const mapStateToProps = state => {
+  if (!state.errors) {
+    return {}
+  }
+  const error = state.errors.find(error => error.startsWith('FATAL_'))
+  return {
+    error: error,
+  }
+}
+
+export default connect(mapStateToProps)(GlobalErrorConsumer)


### PR DESCRIPTION
We are building an approach where rather than *detecting* errors in a context producer, we use redux to
dispatch them.
When they're fatal the global error consumer will just show them and block the app.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread