### PR TITLE
Changing the shape of Errors

### DIFF
--- a/unlock-app/src/__tests__/actions/error.test.js
+++ b/unlock-app/src/__tests__/actions/error.test.js
@@ -11,9 +11,11 @@ describe('error actions', () => {
   it('should create an action to set the error', () => {
     expect.assertions(1)
     const error = MY_ERROR
+    const data = {}
     const expectedAction = {
       type: SET_ERROR,
       error,
+      data,
     }
 
     expect(setError(error)).toEqual(expectedAction)
@@ -25,6 +27,7 @@ describe('error actions', () => {
     const expectedAction = {
       type: SET_ERROR,
       error,
+      data: {},
     }
 
     expect(setError(error)).toEqual(expectedAction)

--- a/unlock-app/src/__tests__/components/interface/Errors.test.js
+++ b/unlock-app/src/__tests__/components/interface/Errors.test.js
@@ -26,7 +26,7 @@ describe('Errors Component', () => {
       expect.assertions(2)
       const close = jest.fn()
       const wrapper = rtl.render(
-        <Errors close={close} errors={['There was an error.']} />
+        <Errors close={close} errors={[{ name: 'There was an error.' }]} />
       )
       rtl.fireEvent.click(wrapper.getByTitle(/close/i))
       expect(close).toHaveBeenCalledTimes(1)
@@ -38,7 +38,9 @@ describe('Errors Component', () => {
     it('should display the content of the children', () => {
       expect.assertions(1)
       const message = 'Broken'
-      const wrapper = rtl.render(<Errors close={close} errors={[message]} />)
+      const wrapper = rtl.render(
+        <Errors close={close} errors={[{ name: message }]} />
+      )
       expect(
         wrapper.queryByText(
           'There was an error (Broken). Please retry and report if it happens again.'
@@ -50,7 +52,11 @@ describe('Errors Component', () => {
   describe('connecting to redux', () => {
     it('mapStateToProps', () => {
       expect.assertions(1)
-      const expectedState = ['error 1', 'error 2', 'error 3']
+      const expectedState = [
+        { name: 'error 1' },
+        { name: 'error 2' },
+        { name: 'error 3' },
+      ]
       expect(mapStateToProps({ errors: expectedState })).toEqual({
         errors: expectedState,
       })

--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -87,23 +87,23 @@ describe('GlobalErrorConsumer', () => {
 
     it('should not map non fatal errors', () => {
       expect.assertions(1)
-      const state = { errors: ['AN_ERROR'] }
+      const state = { errors: [{ name: 'AN_ERROR' }] }
       const props = mapStateToProps(state)
       expect(props.error).toBe(undefined)
     })
 
     it('should map fatal errors', () => {
       expect.assertions(1)
-      const state = { errors: ['FATAL_ERROR'] }
+      const state = { errors: [{ name: 'FATAL_ERROR' }] }
       const props = mapStateToProps(state)
-      expect(props.error).toEqual('FATAL_ERROR')
+      expect(props.error).toEqual({ name: 'FATAL_ERROR' })
     })
   })
 
   describe('when called with a fatal error', () => {
     it('should invoke displayError with that error', () => {
       expect.assertions(2)
-      const fatalError = 'FATAL_ERROR'
+      const fatalError = { name: 'FATAL_ERROR', data: {} }
       const listen = jest.fn(() => <div>internal</div>)
       rtl.render(
         <GlobalErrorConsumer displayError={listen} error={fatalError}>
@@ -112,7 +112,11 @@ describe('GlobalErrorConsumer', () => {
       )
 
       expect(listen).toHaveBeenCalledTimes(1)
-      expect(listen).toHaveBeenCalledWith(fatalError, {}, <p>App</p>)
+      expect(listen).toHaveBeenCalledWith(
+        fatalError.name,
+        fatalError.data,
+        <p>App</p>
+      )
     })
   })
 })

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -330,6 +330,7 @@ describe('Wallet middleware', () => {
       expect(store.dispatch).toHaveBeenCalledWith({
         type: SET_ERROR,
         error: FATAL_NO_USER_ACCOUNT,
+        data: {},
       })
 
       expect(mockWalletService.purchaseKey).not.toHaveBeenCalled()
@@ -365,6 +366,7 @@ describe('Wallet middleware', () => {
       expect(store.dispatch).toHaveBeenCalledWith({
         type: SET_ERROR,
         error: FATAL_NO_USER_ACCOUNT,
+        data: {},
       })
 
       expect(mockWalletService.withdrawFromLock).not.toHaveBeenCalled()
@@ -398,6 +400,7 @@ describe('Wallet middleware', () => {
         expect(store.dispatch).toHaveBeenCalledWith({
           type: SET_ERROR,
           error: FATAL_NO_USER_ACCOUNT,
+          data: {},
         })
 
         expect(mockWalletService.createLock).not.toHaveBeenCalled()
@@ -454,6 +457,7 @@ describe('Wallet middleware', () => {
       expect(store.dispatch).toHaveBeenCalledWith({
         type: SET_ERROR,
         error: FATAL_NO_USER_ACCOUNT,
+        data: {},
       })
 
       expect(mockWalletService.updateKeyPrice).not.toHaveBeenCalled()

--- a/unlock-app/src/__tests__/reducers/errorsReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/errorsReducer.test.js
@@ -34,17 +34,56 @@ describe('errors reducer', () => {
 
   it('should set the error accordingly when receiving SET_ERROR', () => {
     expect.assertions(1)
-    expect(reducer(undefined, action)).toEqual([error])
+    expect(reducer(undefined, action)).toEqual([
+      {
+        name: error,
+        data: {},
+      },
+    ])
   })
 
-  it('should set add an error when receiving SET_ERROR again', () => {
+  it('should add another error when receiving SET_ERROR again', () => {
     expect.assertions(1)
-    expect(reducer([error], action2)).toEqual([error, error2])
+    expect(
+      reducer(
+        [
+          {
+            name: error,
+            data: {},
+          },
+        ],
+        action2
+      )
+    ).toEqual([
+      {
+        name: error,
+        data: {},
+      },
+      {
+        name: error2,
+        data: {},
+      },
+    ])
   })
 
   it('should not set the same error twice', () => {
     expect.assertions(1)
-    expect(reducer([error], action)).toEqual([error])
+    expect(
+      reducer(
+        [
+          {
+            name: error,
+            data: {},
+          },
+        ],
+        action
+      )
+    ).toEqual([
+      {
+        name: error,
+        data: {},
+      },
+    ])
   })
 
   it('should not change state if RESET_ERROR with non-existing error is called', () => {
@@ -60,8 +99,9 @@ describe('errors reducer', () => {
 
   it('should reset a specific error if RESET_ERROR is called with a specific error', () => {
     expect.assertions(3)
-    expect(reducer([1, 2], resetError(1))).toEqual([2])
-    expect(reducer([1, 2], resetError(2))).toEqual([1])
-    expect(reducer([1, 2], resetError(3))).toEqual([1, 2])
+    const state = [{ name: 1, data: {} }, { name: 2, data: {} }]
+    expect(reducer(state, resetError(1))).toEqual([{ name: 2, data: {} }])
+    expect(reducer(state, resetError(2))).toEqual([{ name: 1, data: {} }])
+    expect(reducer(state, resetError(3))).toEqual(state)
   })
 })

--- a/unlock-app/src/actions/error.js
+++ b/unlock-app/src/actions/error.js
@@ -1,9 +1,10 @@
 export const SET_ERROR = 'error/SET_ERROR'
 export const RESET_ERROR = 'error/RESET_ERROR'
 
-export const setError = error => ({
+export const setError = (error, data = {}) => ({
   type: SET_ERROR,
   error,
+  data,
 })
 
 export const resetError = error => ({

--- a/unlock-app/src/components/interface/Errors.js
+++ b/unlock-app/src/components/interface/Errors.js
@@ -5,12 +5,13 @@ import styled from 'styled-components'
 import { resetError } from '../../actions/error'
 import Buttons from './buttons/layout'
 import ErrorMessage from '../helpers/ErrorMessage'
+import UnlockPropTypes from '../../propTypes'
 
 export const Errors = ({ errors, close }) => {
   const content = errors.map(error => (
-    <Wrapper key={error}>
-      <Error>{ErrorMessage(error)}</Error>
-      <Buttons.Close as="button" onClick={() => close(error)} size="16px">
+    <Wrapper key={error.name}>
+      <Error>{ErrorMessage(error.name)}</Error>
+      <Buttons.Close as="button" onClick={() => close(error.name)} size="16px">
         X
       </Buttons.Close>
     </Wrapper>
@@ -31,7 +32,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 Errors.propTypes = {
-  errors: PropTypes.arrayOf(PropTypes.string),
+  errors: PropTypes.arrayOf(UnlockPropTypes.error),
   close: PropTypes.func.isRequired,
 }
 

--- a/unlock-app/src/components/interface/GlobalErrorConsumer.js
+++ b/unlock-app/src/components/interface/GlobalErrorConsumer.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import { GlobalErrorContext } from '../../utils/GlobalErrorProvider'
 import Layout from './Layout'
 import { mapErrorToComponent } from '../creator/FatalError'
+import UnlockPropTypes from '../../propTypes'
 
 // DEPRECATED we should not use the Context to detect errors
 const Consumer = GlobalErrorContext.Consumer
@@ -22,8 +23,9 @@ export const displayError = (error, errorMetadata, children) => {
  * and prevent the UI from displaying anything else.
  */
 export function GlobalErrorConsumer({ displayError, children, error }) {
+  // the error object in this case is coming from the redux store and has a structure of {name, data}
   if (error) {
-    return displayError(error, {}, children)
+    return displayError(error.name, error.data, children)
   }
   return (
     <Consumer>
@@ -37,7 +39,7 @@ export function GlobalErrorConsumer({ displayError, children, error }) {
 GlobalErrorConsumer.propTypes = {
   children: PropTypes.node.isRequired,
   displayError: PropTypes.func,
-  error: PropTypes.string,
+  error: UnlockPropTypes.error,
 }
 
 GlobalErrorConsumer.defaultProps = {
@@ -53,7 +55,7 @@ export const mapStateToProps = state => {
   if (!state.errors) {
     return {}
   }
-  const error = state.errors.find(error => error.startsWith('FATAL_'))
+  const error = state.errors.find(error => error.name.startsWith('FATAL_'))
   return {
     error: error,
   }

--- a/unlock-app/src/propTypes.js
+++ b/unlock-app/src/propTypes.js
@@ -31,6 +31,11 @@ export const transaction = PropTypes.shape({
   type: PropTypes.oneOf(Object.values(TRANSACTION_TYPES)),
 })
 
+export const error = PropTypes.shape({
+  name: PropTypes.string,
+  data: PropTypes.shape({}),
+})
+
 export const conversion = PropTypes.objectOf(PropTypes.number)
 
 export const children = PropTypes.shape({})
@@ -82,6 +87,7 @@ export default {
   conversion,
   delay,
   element,
+  error,
   layout,
   lock,
   locks,

--- a/unlock-app/src/reducers/errorsReducer.js
+++ b/unlock-app/src/reducers/errorsReducer.js
@@ -25,16 +25,10 @@ const errorsReducer = (state = initialState, action) => {
     if (!action.error) return initialState
 
     // If the error to be reset is not in the list, nothing changes
-    if (!state.map(error => error.name).includes(action.error)) return state
+    if (!state.find(error => action.error === error.name)) return state
 
     // Otherwise, only push to new state the all the other errors
-    const newState = []
-    state.forEach(error => {
-      if (error.name !== action.error) {
-        newState.push(error)
-      }
-    })
-    return newState
+    return state.filter(error => error.name !== action.error)
   }
 
   return state

--- a/unlock-app/src/reducers/errorsReducer.js
+++ b/unlock-app/src/reducers/errorsReducer.js
@@ -10,16 +10,30 @@ const errorsReducer = (state = initialState, action) => {
   }
 
   if (action.type === SET_ERROR) {
-    if (state.includes(action.error)) return state
-    return [...state, action.error]
+    if (state.map(error => error.name).includes(action.error)) return state
+    return [
+      ...state,
+      {
+        name: action.error,
+        data: action.data,
+      },
+    ]
   }
 
   if (action.type === RESET_ERROR) {
+    // The no error is passed, reset all errors
     if (!action.error) return initialState
-    if (!state.includes(action.error)) return state
-    const newState = [...state]
-    const newIndex = newState.indexOf(action.error)
-    newState.splice(newIndex, 1)
+
+    // If the error to be reset is not in the list, nothing changes
+    if (!state.map(error => error.name).includes(action.error)) return state
+
+    // Otherwise, only push to new state the all the other errors
+    const newState = []
+    state.forEach(error => {
+      if (error.name !== action.error) {
+        newState.push(error)
+      }
+    })
     return newState
   }
 

--- a/unlock-app/src/stories/interface/Errors.stories.js
+++ b/unlock-app/src/stories/interface/Errors.stories.js
@@ -3,14 +3,14 @@ import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Errors } from '../../components/interface/Errors'
 
-const errors = ['error 1', 'error 2', 'error 3']
+const errors = [{ name: 'error 1' }, { name: 'error 2' }, { name: 'error 3' }]
 
 storiesOf('Errors', module)
   .add('Simple Error', () => {
     return (
       <Errors
         close={action('close')}
-        errors={['We could not process that transaction.']}
+        errors={[{ name: 'We could not process that transaction.' }]}
       />
     )
   })


### PR DESCRIPTION
Our errors are just a string which means that it is hard to pass data relevant to the error which
could be helpful for the user. The GlobalErrorProvider/Consumer uses a metadata object, but since
we're moving away from that approach to a redux based error handling we need a similar capaibility.

This PR has more changes that I'd like to see but I could not find a better way to split it.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread