### PR TITLE
Adding the fatal error when the user has not approved Unlock in their provider

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -36375,6 +36375,153 @@ Object {
 }
 `;
 
+exports[`Storyshots FatalError Provider not approved 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c0 {
+  display: grid;
+  row-gap: 16px;
+  -webkit-column-gap: 32px;
+  column-gap: 32px;
+  border: solid 1px var(--lightgrey);
+  grid-template-columns: 72px;
+  grid-auto-flow: column;
+  border-radius: 4px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 32px;
+  padding-bottom: 40px;
+}
+
+.c1 {
+  width: 72px;
+}
+
+.c2 {
+  display: grid;
+  grid-gap: 16px;
+}
+
+.c2 > h1 {
+  font-weight: bold;
+  color: var(--red);
+  margin: 0px;
+  padding: 0px;
+}
+
+.c2 > p {
+  margin: 0px;
+  padding: 0px;
+  font-size: 16px;
+  color: var(--dimgrey);
+}
+
+@media (max-width:500px) {
+  .c0 {
+    grid-template-columns: 1fr;
+    grid-auto-flow: row;
+    padding: 16px;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <section
+        class="c0"
+      >
+        <img
+          class="c1"
+          src="/static/images/illustrations/error.svg"
+        />
+        <div
+          class="c2"
+        >
+          <h1>
+            Not enabled in provider
+          </h1>
+          <p>
+            You did not approve Unlock in your web3 wallet.
+          </p>
+        </div>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <section
+      class="sc-1g6piw8-0 jXGMmL"
+    >
+      <img
+        class="sc-1g6piw8-1 fcKGMu"
+        src="/static/images/illustrations/error.svg"
+      />
+      <div
+        class="sc-1g6piw8-2 gCvXha"
+      >
+        <h1>
+          Not enabled in provider
+        </h1>
+        <p>
+          You did not approve Unlock in your web3 wallet.
+        </p>
+      </div>
+    </section>
+  </div>,
+  "debug": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots FatalError Unlock not deployed 1`] = `
 Object {
   "asFragment": [Function],

--- a/unlock-app/src/components/creator/FatalError.js
+++ b/unlock-app/src/components/creator/FatalError.js
@@ -125,11 +125,18 @@ export const ContractNotDeployed = () => (
   </DefaultError>
 )
 
+export const NotEnabledInProvider = () => (
+  <DefaultError title="Not enabled in provider">
+    <p>You did not approve Unlock in your web3 wallet.</p>
+  </DefaultError>
+)
+
 export const mapping = {
   FATAL_MISSING_PROVIDER: MissingProvider,
   FATAL_NO_USER_ACCOUNT: MissingAccount,
   FATAL_WRONG_NETWORK: WrongNetwork,
   FATAL_NON_DEPLOYED_CONTRACT: ContractNotDeployed,
+  FATAL_NOT_ENABLED_IN_PROVIDER: NotEnabledInProvider,
   '*': DefaultError,
 }
 
@@ -154,4 +161,5 @@ export default {
   MissingProvider,
   MissingAccount,
   ContractNotDeployed,
+  NotEnabledInProvider,
 }

--- a/unlock-app/src/stories/creator/FatalError.stories.js
+++ b/unlock-app/src/stories/creator/FatalError.stories.js
@@ -20,6 +20,9 @@ storiesOf('FatalError', module)
   .add('Unlock not deployed', () => {
     return <FatalError.ContractNotDeployed />
   })
+  .add('Provider not approved', () => {
+    return <FatalError.NotEnabledInProvider />
+  })
   .add('Non-critical error', () => {
     return (
       <FatalError.DefaultError title="Non-critical error" critical={false} />


### PR DESCRIPTION
We missed that error previously...



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread