### PR TITLE
Reset ZOS when migrations is `--reset`

### DIFF
--- a/smart-contracts/helpers/ZosNetworkFile.js
+++ b/smart-contracts/helpers/ZosNetworkFile.js
@@ -1,0 +1,22 @@
+const Zos = require('zos')
+const { ZosPackageFile } = Zos.files
+const packageFile = new ZosPackageFile()
+
+module.exports = function getNetworkFile (web3) {
+  return web3.eth.net
+    .getId()
+    .then(_Id => {
+      let network
+      switch (_Id) {
+        case '1':
+          network = 'mainnet'
+          break
+        case '4':
+          network = 'rinkeby'
+          break
+        default:
+          network = `dev-${_Id}`
+      }
+      return packageFile.networkFile(`${network}`)
+    })
+}

--- a/smart-contracts/helpers/ZosNetworkFile.js
+++ b/smart-contracts/helpers/ZosNetworkFile.js
@@ -17,6 +17,6 @@ module.exports = function getNetworkFile (web3) {
         default:
           network = `dev-${_Id}`
       }
-      return packageFile.networkFile(`${network}`)
+      return packageFile.networkFile(network)
     })
 }

--- a/smart-contracts/migrations/1_initial_migration.js
+++ b/smart-contracts/migrations/1_initial_migration.js
@@ -1,5 +1,13 @@
 const Migrations = artifacts.require('./Migrations.sol')
+const getNetworkFile = require('../helpers/ZosNetworkFile.js')
+const fs = require('fs')
 
 module.exports = function initialMigration (deployer) {
-  deployer.deploy(Migrations)
+  // If the network is `--reset`, then also delete the ZOS configuration so that ZOS resets.
+  // This prevents an error where ZOS attempts to use a proxy which does not exist any longer.
+  return getNetworkFile(web3).then((networkFile) => {
+    fs.unlink(networkFile.fileName, () => {})
+
+    return deployer.deploy(Migrations)
+  })
 }

--- a/smart-contracts/test/helpers/proxy.js
+++ b/smart-contracts/test/helpers/proxy.js
@@ -1,38 +1,19 @@
-const Zos = require('zos')
-const { ZosPackageFile } = Zos.files
-const packageFile = new ZosPackageFile()
+const getNetworkFile = require('../../helpers/ZosNetworkFile.js')
 
-let networkFile
 let proxies
 let mostRecentProxy
 let ProxyAddress
 let proxiedUnlock
-let network
 
 module.exports = function getUnlockProxy (_Unlock) {
-  return web3.eth.net
-    .getId()
-    .then(_Id => {
-      switch (_Id) {
-        case '1':
-          network = 'mainnet'
-          break
-        case '4':
-          network = 'rinkeby'
-          break
-        default:
-          network = `dev-${_Id}`
-      }
-    })
-    .then(() => {
-      networkFile = packageFile.networkFile(`${network}`)
-      proxies = networkFile.getProxies({ contract: `Unlock` })
-      mostRecentProxy = proxies.length - 1
-      ProxyAddress = proxies[mostRecentProxy].address
-      return _Unlock.at(ProxyAddress)
-    })
-    .then(_proxiedUnlock => {
-      proxiedUnlock = _proxiedUnlock
-      return proxiedUnlock
-    })
+  return getNetworkFile(web3).then(networkFile => {
+    proxies = networkFile.getProxies({ contract: `Unlock` })
+    mostRecentProxy = proxies.length - 1
+    ProxyAddress = proxies[mostRecentProxy].address
+    return _Unlock.at(ProxyAddress)
+      .then(_proxiedUnlock => {
+        proxiedUnlock = _proxiedUnlock
+        return proxiedUnlock
+      })
+  })
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

When ganache is restarted, we have to manually `--reset` migrations.  When we do so, then ZOS will fail on migrations step 3 with an error `Cannot set a proxy implementation to a non-contract address`.

This deletes the .json file for the current network when migrations are re-run.
It also moves some shared logic into a new helper file.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
