### PR TITLE
fixing the connect function for walletMiddleware

### DIFF
--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -151,7 +151,10 @@ export default function walletMiddleware({ getState, dispatch }) {
 
   return function(next) {
     // Connect to the current provider
-    walletService.connect(getState().provider)
+    // We connect once the middleware has been initialized, using setTimout (warning: fragile?)
+    setTimeout(() => {
+      walletService.connect(getState().provider)
+    })
 
     return function(action) {
       if (action.type === SET_PROVIDER) {

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -56,8 +56,8 @@ export default class WalletService extends EventEmitter {
    * @return
    */
   async connect(providerName) {
-    if (providerName === this.providerName) {
-      // If the provider did not really change, no need to reset it
+    if (providerName && providerName === this.providerName) {
+      // If the provider is set and did not really change, no need to reset it
       return
     }
 


### PR DESCRIPTION
We should only not try to connect when the provider is set previously.


- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->