### PR TITLE
allow args for debugging

### DIFF
--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -13,8 +13,9 @@ export PAYWALL_SCRIPT_URL=http://unlock:3000/static/paywall.min.js
 # First this script will deploy from an instance of unlock:latest
 REPO_ROOT=`dirname "$0"`/..
 DOCKER_COMPOSE_FILE=$REPO_ROOT/docker/docker-compose.ci.yml
+EXTRA_ARGS=$*
 
 # Run the tests
 COMMAND="npm run ci"
 
-docker-compose -f $DOCKER_COMPOSE_FILE run integration-tests bash -c "$COMMAND"
+docker-compose -f $DOCKER_COMPOSE_FILE run $EXTRA_ARGS integration-tests bash -c "$COMMAND"

--- a/scripts/local-docker-integration-tests.sh
+++ b/scripts/local-docker-integration-tests.sh
@@ -9,6 +9,7 @@
 # First this script will deploy from an instance of unlock:latest
 REPO_ROOT=`dirname "$0"`/..
 DOCKER_COMPOSE_FILE=$REPO_ROOT/docker/docker-compose.ci.yml
+EXTRA_ARGS=$*
 
 # environment variables passed in. Update as needed for testing
 export DB_USERNAME='username'
@@ -30,5 +31,5 @@ docker build -t unlock -f "$REPO_ROOT/docker/unlock.dockerfile" $REPO_ROOT
 docker build -t unlock-integration -f "$REPO_ROOT/docker/unlock-integration.dockerfile" $REPO_ROOT
 
 # Run the tests
-$REPO_ROOT/scripts/integration-tests.sh
+$REPO_ROOT/scripts/integration-tests.sh $EXTRA_ARGS
 


### PR DESCRIPTION
# Description

This PR amends the integration test scripts so that extra arguments can be passed on the command-line. This enables the following life hack:

```bash
scripts/local-docker-integration-tests.sh -v $PWD:/screenshots
```

and now in our tests we can do:

```
await page.screenshot({ path: '/screenshots/test.jpg' })
```

and voila, we can view a screenshot of the running test!

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1890 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
