### PR TITLE
Connect header with router

### DIFF
--- a/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
+++ b/unlock-app/src/__tests__/components/interface/GlobalErrorConsumer.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
 
+import { Provider } from 'react-redux'
 import {
   GlobalErrorConsumer,
   displayError,
@@ -8,8 +9,16 @@ import {
 } from '../../../components/interface/GlobalErrorConsumer'
 import { GlobalErrorContext } from '../../../utils/GlobalErrorProvider'
 import { FATAL_NO_USER_ACCOUNT, FATAL_MISSING_PROVIDER } from '../../../errors'
+import { createUnlockStore } from '../../../createUnlockStore'
 
-const Provider = GlobalErrorContext.Provider
+const store = createUnlockStore({
+  router: {
+    location: {
+      pathname: '',
+      search: '',
+    },
+  },
+})
 
 describe('GlobalErrorConsumer', () => {
   it('passes error and errorMetadata to displayError prop', () => {
@@ -17,14 +26,14 @@ describe('GlobalErrorConsumer', () => {
 
     const listen = jest.fn(() => <div>internal</div>)
     const wrapper = rtl.render(
-      <Provider
+      <GlobalErrorContext.Provider
         value={{
           error: FATAL_NO_USER_ACCOUNT,
           errorMetadata: { thing: 'thingy' },
         }}
       >
         <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
-      </Provider>
+      </GlobalErrorContext.Provider>
     )
 
     expect(wrapper.getByText('internal')).not.toBeNull()
@@ -44,14 +53,14 @@ describe('GlobalErrorConsumer', () => {
 
     const listen = jest.fn(() => <div>internal</div>)
     const wrapper = rtl.render(
-      <Provider
+      <GlobalErrorContext.Provider
         value={{
           error: false,
           errorMetadata: {},
         }}
       >
         <GlobalErrorConsumer displayError={listen}>hi</GlobalErrorConsumer>
-      </Provider>
+      </GlobalErrorContext.Provider>
     )
 
     expect(wrapper.queryByText('internal')).not.toBeNull()
@@ -64,7 +73,9 @@ describe('GlobalErrorConsumer', () => {
     it('displays the error if initialized', () => {
       expect.assertions(2)
       const wrapper = rtl.render(
-        displayError(FATAL_MISSING_PROVIDER, {}, <div>children</div>)
+        <Provider store={store}>
+          {displayError(FATAL_MISSING_PROVIDER, {}, <div>children</div>)}
+        </Provider>
       )
       expect(wrapper.queryByText('Wallet missing')).not.toBeNull()
       expect(wrapper.queryByText('children')).toBeNull()
@@ -72,7 +83,11 @@ describe('GlobalErrorConsumer', () => {
 
     it('displays the children if no error is initialized', () => {
       expect.assertions(1)
-      const wrapper = rtl.render(displayError(false, {}, <div>children</div>))
+      const wrapper = rtl.render(
+        <Provider store={store}>
+          {displayError(false, {}, <div>children</div>)}
+        </Provider>
+      )
       expect(wrapper.queryByText('children')).not.toBeNull()
     })
   })

--- a/unlock-app/src/__tests__/components/interface/Header.test.js
+++ b/unlock-app/src/__tests__/components/interface/Header.test.js
@@ -1,0 +1,21 @@
+import { mapStateToProps } from '../../../components/interface/Header'
+import { createUnlockStore } from '../../../createUnlockStore'
+
+const router = {
+  location: {
+    pathname: '/',
+    search: '',
+    hash: '',
+  },
+}
+
+const store = createUnlockStore({ router })
+
+describe('mapStateToProps', () => {
+  it('should return the pathname from the router as a prop', () => {
+    expect.assertions(1)
+    const state = store.getState()
+    const props = mapStateToProps(state)
+    expect(props).toHaveProperty('pathname', '/')
+  })
+})

--- a/unlock-app/src/__tests__/pages/pages.test.js
+++ b/unlock-app/src/__tests__/pages/pages.test.js
@@ -20,6 +20,8 @@ const currency = {
 const router = {
   location: {
     pathname: '/',
+    search: '',
+    hash: '',
   },
 }
 ETHEREUM_NETWORKS_NAMES[network.name] = ['A Name']

--- a/unlock-app/src/__tests__/pages/pages.test.js
+++ b/unlock-app/src/__tests__/pages/pages.test.js
@@ -11,6 +11,20 @@ import createUnlockStore from '../../createUnlockStore'
 
 jest.mock('../../constants')
 
+const network = {
+  name: 4,
+}
+const currency = {
+  USD: 195.99,
+}
+const router = {
+  location: {
+    pathname: '/',
+  },
+}
+ETHEREUM_NETWORKS_NAMES[network.name] = ['A Name']
+const store = createUnlockStore({ currency, network, router })
+
 describe('Pages', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -22,7 +36,11 @@ describe('Pages', () => {
       const config = {
         env: 'prod',
       }
-      rtl.render(<Home config={config} />)
+      rtl.render(
+        <Provider store={store}>
+          <Home config={config} />
+        </Provider>
+      )
       expect(pageTitle).toBeCalled()
     })
   })
@@ -30,7 +48,11 @@ describe('Pages', () => {
   describe('Jobs', () => {
     it('should render title correctly', () => {
       expect.assertions(1)
-      rtl.render(<Jobs />)
+      rtl.render(
+        <Provider store={store}>
+          <Jobs />
+        </Provider>
+      )
       expect(pageTitle).toBeCalledWith('Work at Unlock')
     })
   })
@@ -38,7 +60,11 @@ describe('Pages', () => {
   describe('About', () => {
     it('should render title correctly', () => {
       expect.assertions(1)
-      rtl.render(<About />)
+      rtl.render(
+        <Provider store={store}>
+          <About />
+        </Provider>
+      )
       expect(pageTitle).toBeCalledWith('About')
     })
   })
@@ -46,14 +72,7 @@ describe('Pages', () => {
   describe('Dashboard', () => {
     it('should render title correctly', () => {
       expect.assertions(1)
-      const network = {
-        name: 4,
-      }
-      const currency = {
-        USD: 195.99,
-      }
-      ETHEREUM_NETWORKS_NAMES[network.name] = ['A Name']
-      const store = createUnlockStore({ currency, network })
+
       const account = {
         address: '0xabc',
         privateKey: 'deadbeef',

--- a/unlock-app/src/components/interface/Header.js
+++ b/unlock-app/src/components/interface/Header.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 import React from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
@@ -15,7 +16,13 @@ const navigationButtons = [
   Buttons.Telegram,
 ]
 
-export default class Header extends React.PureComponent {
+export const mapStateToProps = ({
+  router: {
+    location: { pathname },
+  },
+}) => ({ pathname })
+
+export class Header extends React.PureComponent {
   constructor(props) {
     super(props)
     this.toggleMenu = this.toggleMenu.bind(this)
@@ -88,6 +95,8 @@ Header.defaultProps = {
   title: 'Unlock',
   forContent: false,
 }
+
+export default connect(mapStateToProps)(Header)
 
 const TopHeader = styled.header`
   display: grid;

--- a/unlock-app/src/stories/creator/Dashboard.stories.js
+++ b/unlock-app/src/stories/creator/Dashboard.stories.js
@@ -65,7 +65,11 @@ const locks = {
 }
 
 const router = {
-  route: '/dashboard',
+  location: {
+    pathname: '/dashboard',
+    search: '',
+    hash: '',
+  },
 }
 
 const currency = {

--- a/unlock-app/src/stories/creator/Log.stories.js
+++ b/unlock-app/src/stories/creator/Log.stories.js
@@ -40,7 +40,11 @@ const transactions = {
 }
 
 const router = {
-  route: '/dashboard',
+  location: {
+    pathname: '/dashboard',
+    search: '',
+    hash: '',
+  },
 }
 
 const currency = {

--- a/unlock-app/src/stories/interface/Header.stories.js
+++ b/unlock-app/src/stories/interface/Header.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import Header from '../../components/interface/Header'
+import { Header } from '../../components/interface/Header'
 
 storiesOf('Header', module)
   .add('the header without a title', () => {

--- a/unlock-app/src/stories/interface/Layout.stories.js
+++ b/unlock-app/src/stories/interface/Layout.stories.js
@@ -1,8 +1,21 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { Provider } from 'react-redux'
 import Layout from '../../components/interface/Layout'
+import { createUnlockStore } from '../../createUnlockStore'
+
+const store = createUnlockStore({
+  router: {
+    location: {
+      pathname: '/',
+      search: '',
+      hash: '',
+    },
+  },
+})
 
 storiesOf('Layout', module)
+  .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('the layout for the dashboard', () => {
     return <Layout title="Unlock Dashboard" />
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
As part of splitting up the log page navigation PR, this PR connects the `Header` component to Redux so that it can access the router state. A future PR will use the router state as part of the navigation between the dashboard and log pages.

Because so many of the stories rely on the `Header` somewhere, there are a lot of changes to tests and stories that simply amount to adding a provider with a mock store around the component. In one case I was able to import an unconnected `Header` since that story used the header directly.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #1895

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
