### PR TITLE
setting CHROMATIC_APP_CODE inside the build config so it can be used by external PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,8 @@ jobs:
       - run:
           name: Creator Dashboard stories
           command: scripts/storybook.sh unlock-app "$CIRCLE_BRANCH"
+          environment:
+            CHROMATIC_APP_CODE: swpc6wf70qp
 
   smart-contracts-tests:
     machine: true


### PR DESCRIPTION
The code is safe in the sense that it can only be used to run builds.


Refs #1796


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread