### PR TITLE
Fix serving, enhance logging in paywall

### DIFF
--- a/paywall/src/_server.js
+++ b/paywall/src/_server.js
@@ -12,7 +12,7 @@ function _server(port, dev) {
 
     app.prepare().then(() => {
       let server = createServer((req, res) => {
-        console.info(`PAYWALL ${req.method} ${req.url} > ${res.statusCode} `)
+        console.info(`${req.method} ${req.url} > ${res.statusCode} `)
         try {
           const parsedUrl = new URL(req.url, `http://${req.headers.host}/`)
           const { pathname, query } = parsedUrl

--- a/paywall/src/_server.js
+++ b/paywall/src/_server.js
@@ -6,20 +6,20 @@ const pathMatch = require('path-match')
 
 function _server(port, dev) {
   return new Promise((resolve, reject) => {
-    const app = next({ dir: `${__dirname}/../`, dev, quiet: true })
+    const app = next({ dir: `${__dirname}/`, dev, quiet: true })
     const handle = app.getRequestHandler()
     const route = pathMatch()
 
     app.prepare().then(() => {
       let server = createServer((req, res) => {
-        console.info(`${req.method} ${req.url} > ${res.statusCode} `)
+        console.info(`PAYWALL ${req.method} ${req.url} > ${res.statusCode} `)
         try {
           const parsedUrl = new URL(req.url, `http://${req.headers.host}/`)
           const { pathname, query } = parsedUrl
 
           // assigning `query` into the params means that we still
           // get the query string passed to our application
-          if (!pathname.match('/paywall')) {
+          if (pathname.match('/0x')) {
             const params = route('/:lockAddress/:redirect?')(pathname)
             app.render(req, res, '/', Object.assign(params, query))
           } else {


### PR DESCRIPTION
# Description

This PR has 3 small but significant changes:

1. the source served was incorrectly looking in `paywall` instead of `paywall/src` which resulted in a `404` for every page requested
2. logging now prepends with `PAYWALL ` in order to differentiate from logging of the unlock-app. This is for `npm run dev` purposes, so I could modify it to check `UNLOCK_ENV` if desired
3. the paywall should only match paths that start with a lock address, and since we no longer serve from `https://<paywall server>/paywall/` but instead from `https://<paywall server>/` the check is adjusted to look for a lock address prefix.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1205 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
