### PR TITLE
Don't poll for scroll position unless the paywall is locked

### DIFF
--- a/paywall/src/paywall-builder/build.js
+++ b/paywall/src/paywall-builder/build.js
@@ -77,19 +77,19 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
   const origin = new window.URL(paywallUrl).origin
 
   let locked = false
-  let disablePolling
+  let disableScrollPolling = () => {}
   window.addEventListener(
     'message',
     event => {
       if (event.data === POST_MESSAGE_LOCKED && !locked) {
         locked = true
         show(iframe, document)
-        disablePolling = scrollLoop(window, document, iframe, origin)
+        disableScrollPolling = scrollLoop(window, document, iframe, origin)
         blocker.remove()
       }
       if (event.data === POST_MESSAGE_UNLOCKED && locked) {
         locked = false
-        disablePolling()
+        disableScrollPolling()
         hide(iframe, document)
         blocker.remove()
       }

--- a/paywall/src/paywall-builder/build.js
+++ b/paywall/src/paywall-builder/build.js
@@ -17,6 +17,7 @@ const baseBannerHeight = window => {
   // can use it as the basis to scroll from
   return minHeightPct > 30 ? minHeightPct : 30
 }
+let lastIframe
 let scrollPolling = true
 // iOS allows the page to scroll even when the paywall is up. Our
 // solution to this is to make the paywall grow to obscure the page
@@ -27,7 +28,7 @@ export const scrollLoop = (window, document, iframe, origin) => {
   const disablePolling = () => {
     scrollPolling = false
   }
-  if (!scrollPolling) return // the page is unlocked
+  if (!scrollPolling) return disablePolling // the page is unlocked
   const pageTop = window.pageYOffset
   const viewportHeight = window.innerHeight
   const pageHeight = document.documentElement.scrollHeight
@@ -43,6 +44,7 @@ export const scrollLoop = (window, document, iframe, origin) => {
     { type: POST_MESSAGE_SCROLL_POSITION, payload: scrollPosition },
     origin
   )
+  lastIframe = iframe
 
   window.requestAnimationFrame(() =>
     scrollLoop(window, document, iframe, origin)
@@ -83,6 +85,7 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
     event => {
       if (event.data === POST_MESSAGE_LOCKED && !locked) {
         locked = true
+        scrollPolling = true
         show(iframe, document)
         disableScrollPolling = scrollLoop(window, document, iframe, origin)
         blocker.remove()

--- a/paywall/src/paywall-builder/build.js
+++ b/paywall/src/paywall-builder/build.js
@@ -25,7 +25,6 @@ const baseBannerHeight = window => {
 // scroll-handling function here to preserve the context of the actual
 // page, not the iframe.
 export const scrollLoop = (window, document, iframe, origin) => {
-  if (!locked) return // no need to look for this unless the page is locked
   const pageTop = window.pageYOffset
   const viewportHeight = window.innerHeight
   const pageHeight = document.documentElement.scrollHeight
@@ -73,14 +72,13 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
 
   const origin = new window.URL(paywallUrl).origin
 
-  scrollLoop(window, document, iframe, origin)
-
   window.addEventListener(
     'message',
     event => {
       if (event.data === POST_MESSAGE_LOCKED && !locked) {
         locked = true
         show(iframe, document)
+        scrollLoop(window, document, iframe, origin)
         blocker.remove()
       }
       if (event.data === POST_MESSAGE_UNLOCKED && locked) {

--- a/paywall/src/paywall-builder/build.js
+++ b/paywall/src/paywall-builder/build.js
@@ -7,6 +7,8 @@ import {
   POST_MESSAGE_SCROLL_POSITION,
 } from './constants'
 
+let locked = false
+
 // Currently, the constraint on the banner is that it starts out at
 // 30% of height, but at least 375px
 const baseBannerHeight = window => {
@@ -23,6 +25,7 @@ const baseBannerHeight = window => {
 // scroll-handling function here to preserve the context of the actual
 // page, not the iframe.
 export const scrollLoop = (window, document, iframe, origin) => {
+  if (!locked) return // no need to look for this unless the page is locked
   const pageTop = window.pageYOffset
   const viewportHeight = window.innerHeight
   const pageHeight = document.documentElement.scrollHeight
@@ -72,7 +75,6 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
 
   scrollLoop(window, document, iframe, origin)
 
-  let locked = false
   window.addEventListener(
     'message',
     event => {

--- a/paywall/src/paywall-builder/build.js
+++ b/paywall/src/paywall-builder/build.js
@@ -17,7 +17,6 @@ const baseBannerHeight = window => {
   // can use it as the basis to scroll from
   return minHeightPct > 30 ? minHeightPct : 30
 }
-let lastIframe
 let scrollPolling = true
 // iOS allows the page to scroll even when the paywall is up. Our
 // solution to this is to make the paywall grow to obscure the page
@@ -44,7 +43,6 @@ export const scrollLoop = (window, document, iframe, origin) => {
     { type: POST_MESSAGE_SCROLL_POSITION, payload: scrollPosition },
     origin
   )
-  lastIframe = iframe
 
   window.requestAnimationFrame(() =>
     scrollLoop(window, document, iframe, origin)


### PR DESCRIPTION
# Description

The `paywall.min.js` script unnecessarily polls for changes in scroll position and attempts to post the scroll position even when the paywall is unlocked. This can be a major performance problem on slow phones. This PR enables polling if the paywall is marked as locked, and disables it if it is marked as unlocked.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1205 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
