### PR TITLE
fix running the paywall

### DIFF
--- a/paywall/package.json
+++ b/paywall/package.json
@@ -3,10 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "predev": "npm run before && npm run set-link && npm run set-link",
-    "set-link": "run-script-os",
-    "set-link:darwin:freebsd:linux:sunos": "cd src && ((test -e artifacts && rm -f artifacts) || echo 'no artifacts') && ln -s ../../smart-contracts/build artifacts",
-    "set-link:win32": "cd src && (if exist artifacts (rmdir artifacts /q /s || del artifacts)) && cmd /c mklink /d artifacts ..\\..\\smart-contracts\\build",
+    "predev": "npm run before",
     "dev": "nodemon src/server.js",
     "before": "npm run build-paywall",
     "build": "npm run before && next build src",
@@ -17,7 +14,7 @@
     "lint": "eslint .",
     "reformat": "prettier-eslint \"src/**/*.js\" --write",
     "fail-pending-changes": "../scripts/pending-changes.sh",
-    "build-paywall": "cross-env NODE_ENV=production rollup -c rollup.paywall.config.js -o ./static/paywall.min.js",
+    "build-paywall": "cross-env NODE_ENV=production rollup -c rollup.paywall.config.js -o ./src/static/paywall.min.js",
     "storybook": "start-storybook -p 9002 -c .storybook -s .",
     "ci": "npm run lint && npm test && npm run reformat && npm run fail-pending-changes"
   },

--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -12,6 +12,7 @@ describe('The Unlock Dashboard', () => {
   })
 
   it('should list the address of the current user', async () => {
+    await page.waitForSelector('#UserAddress')
     const userAddress = await page.$eval('#UserAddress', e => e.innerText)
     await expect(userAddress).toMatch('0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2')
   })


### PR DESCRIPTION
# Description

The paywall `npm run dev` script still references the outdated artifacts. In addition, the `npm run build-paywall` command builds the `paywall.min.js` into `static` instead of `src/static`

This PR fixes these issues, and is a must-commit to get a screenshot for the other PRs I'm working on :)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1205 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
