### PR TITLE
Re-enable the unlock flag on paywall

### DIFF
--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -162,21 +162,26 @@ describe('Paywall', () => {
         'http://example.com'
       )
     })
-    it('should update body css', () => {
-      expect.assertions(1)
+    describe('updating body css', () => {
+      it.each([
+        ['mobile', 412, { display: 'none', height: 0 }],
+        ['desktop', 1000, { display: 'flex', height: '160px' }],
+      ])('%s', (type, size, expected) => {
+        expect.assertions(1)
 
-      config.isInIframe = true
-      rtl.act(() => {
-        renderMockPaywall({ locked: false })
-      })
+        fakeWindow.innerWidth = size
+        config.isInIframe = true
+        rtl.act(() => {
+          renderMockPaywall({ locked: false })
+        })
 
-      expect(fakeWindow.document.body.style).toEqual({
-        display: 'flex',
-        flexDirection: 'column',
-        height: '160px',
-        justifyContent: 'center',
-        margin: '0',
-        overflow: 'hidden',
+        expect(fakeWindow.document.body.style).toEqual({
+          ...expected,
+          flexDirection: 'column',
+          justifyContent: 'center',
+          margin: '0',
+          overflow: 'hidden',
+        })
       })
     })
   })

--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5620,7 +5620,10 @@ Object {
 
 @media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
-    display: none;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
   }
 }
 
@@ -5664,7 +5667,7 @@ Object {
       style="position: absolute; right: 0px; bottom: 105px; width: 134px; height: 160px; margin-right: -104px; transition: margin-right 0.4s ease-in;"
     >
       <footer
-        class="sc-1549ebs-8 sc-15m75z9-0 jLFIBx"
+        class="sc-1549ebs-8 sc-15m75z9-0 ctTzbX"
         id="UnlockFlag"
       >
         <div
@@ -5818,7 +5821,10 @@ Object {
 
 @media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
-    display: none;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
   }
 }
 
@@ -5855,7 +5861,7 @@ Object {
       rel="stylesheet"
     />
     <footer
-      class="sc-1549ebs-8 sc-15m75z9-0 jLFIBx"
+      class="sc-1549ebs-8 sc-15m75z9-0 ctTzbX"
       id="UnlockFlag"
     >
       <div

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -35,8 +35,8 @@ export function Paywall({ locks, locked, redirect }) {
         const height = '160px'
         const body = window.document.body
         body.style.margin = '0'
-        body.style.height = height
-        body.style.display = 'flex'
+        body.style.height = window.innerWidth >= 768 ? height : 0
+        body.style.display = window.innerWidth >= 768 ? 'flex' : 'none'
         body.style.flexDirection = 'column'
         body.style.justifyContent = 'center'
         body.style.overflow = 'hidden'

--- a/paywall/src/components/lock/UnlockFlag.js
+++ b/paywall/src/components/lock/UnlockFlag.js
@@ -34,6 +34,6 @@ const Flag = styled(Colophon)`
   }
 
   ${Media.phone`
-    display: none;
-  `}
+    display: flex;
+`}
 `


### PR DESCRIPTION
# Description

Changing the media query to use `min-width` instead of `min-device-width` broke the paywall flag, because the paywall iframe width was shrunk to an infinitesimal size. This PR moves the hiding of the flag on mobile to the `Paywall` component and out of the flag, so we can actually measure the window width properly.

<img width="400" alt="Screen Shot 2019-03-13 at 2 53 00 PM" src="https://user-images.githubusercontent.com/98250/54306506-d65c4a80-459f-11e9-908a-2dd2637ef505.png">
<img width="1680" alt="Screen Shot 2019-03-13 at 2 52 44 PM" src="https://user-images.githubusercontent.com/98250/54306507-d65c4a80-459f-11e9-98eb-27d8bb164bb2.png">
<img width="1680" alt="Screen Shot 2019-03-13 at 2 52 35 PM" src="https://user-images.githubusercontent.com/98250/54306508-d6f4e100-459f-11e9-8605-fff244373b1b.png">
<img width="1680" alt="Screen Shot 2019-03-13 at 2 52 05 PM" src="https://user-images.githubusercontent.com/98250/54306509-d6f4e100-459f-11e9-8b6d-1f817211f594.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1205 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
