### PR TITLE
update configuration to use the split-off paywall by default

### DIFF
--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -77,10 +77,10 @@ export default function configure(
   let unlockAddress = runtimeConfig.unlockAddress
   let services = {}
   let supportedProviders = []
-  let paywallUrl = runtimeConfig.paywallUrl || 'http://localhost:3000/paywall'
+  let paywallUrl = runtimeConfig.paywallUrl || 'http://localhost:3001'
   let paywallScriptUrl =
     runtimeConfig.paywallScriptUrl ||
-    'http://localhost:3000/static/paywall.min.js'
+    'http://localhost:3001/static/paywall.min.js'
   let blockTime = 8000 // in mseconds.
   let chainExplorerUrlBuilders = {
     etherScan: () => false,
@@ -143,10 +143,10 @@ export default function configure(
     supportedProviders = ['Metamask', 'Opera']
     services['storage'] = { host: runtimeConfig.locksmithHost }
     paywallUrl =
-      runtimeConfig.paywallUrl || 'https://staging.unlock-protocol.com/paywall'
+      runtimeConfig.paywallUrl || 'https://staging-paywall.unlock-protocol.com'
     paywallScriptUrl =
       runtimeConfig.paywallScriptUrl ||
-      'https://staging.unlock-protocol.com/static/paywall.min.js'
+      'https://staging-paywall.unlock-protocol.com/static/paywall.min.js'
 
     // Address for the Unlock smart contract
     unlockAddress = '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b'
@@ -171,10 +171,10 @@ export default function configure(
     supportedProviders = ['Metamask', 'Opera']
     services['storage'] = { host: runtimeConfig.locksmithHost }
     paywallUrl =
-      runtimeConfig.paywallUrl || 'https://unlock-protocol.com/paywall'
+      runtimeConfig.paywallUrl || 'https://paywall.unlock-protocol.com/'
     paywallScriptUrl =
       runtimeConfig.paywallScriptUrl ||
-      'https://unlock-protocol.com/static/paywall.min.js'
+      'https://paywall.unlock-protocol.com/static/paywall.min.js'
 
     // Address for the Unlock smart contract
     unlockAddress = '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'


### PR DESCRIPTION
# Description

This is the final PR in the splitting of the paywall from unlock-app. This enables the split-off paywall as the default paywall for `unlock-app`.

The only visible change is to the snippet, which will use the paywall address. Note that these are the addresses used for the split-off paywall:

dev: http://localhost:3001/
staging: https://paywall-staging.unlock-protocol.com (as seen in the deploy https://circleci.com/gh/unlock-protocol/unlock/7857?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification)
master: https://paywall.unlock-protocol.com

The script is loaded from:

dev: http://localhost:3001/static/paywall.min.js
staging: https://paywall-staging.unlock-protocol.com/static/paywall.min.js
master: https://paywall.unlock-protocol.com/static/paywall.min.js

To run the demo in local dev, you'll have to `npm run dev` inside `paywall/` in a new window going forward.

<img width="1653" alt="Screen Shot 2019-03-13 at 3 02 54 PM" src="https://user-images.githubusercontent.com/98250/54307093-30a9db00-45a1-11e9-841b-4baa29268be4.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1205 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
