### PR TITLE
fixing git command to checkout old version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ workflows:
   deploy: # The deploy workflow will not re-run tests, just build an image with the "older" version and deploy it
     triggers:
       - schedule:
-          cron: "0,5,10,15,20,25,30,35,40,45,50,55 * * * *" # use cron syntax to set the schedule
+          cron: "0,10,20,30,40,50 * * * *" # use cron syntax to set the schedule
           filters:
             branches:
               only:

--- a/scripts/get-git-history.sh
+++ b/scripts/get-git-history.sh
@@ -3,4 +3,4 @@
 # This script gets the git history as by default CircleCI will only get the most recent commit.
 git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
 git fetch >> /dev/null
-git checkout @{4.days.ago}
+git checkout `git rev-list -1 --before={4.days.ago} master`


### PR DESCRIPTION
The previous command was not right because of some obscure reflog thing that I do not understand.
I tested this one on an actual master build and it works as expected.


- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread