### PR TITLE
Cap refund on cancel Key

### DIFF
--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -102,8 +102,12 @@ contract MixinRefunds is
     Key storage key = _getKeyFor(_owner);
     // Math: safeSub is not required since `hasValidKey` confirms timeRemaining is positive
     uint timeRemaining = key.expirationTimestamp - block.timestamp;
-    // Math: using safeMul in case keyPrice or timeRemaining is very large
-    refund = keyPrice.mul(timeRemaining) / expirationDuration;
+    if(timeRemaining >= expirationDuration) {
+      refund = keyPrice;
+    } else {
+      // Math: using safeMul in case keyPrice or timeRemaining is very large
+      refund = keyPrice.mul(timeRemaining) / expirationDuration;
+    }
     if (refundPenaltyDenominator > 0) {
       uint penalty = keyPrice / refundPenaltyDenominator;
       if (refund > penalty) {

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -35,9 +35,17 @@ contract('Lock / cancelAndRefund', accounts => {
     assert.equal(penalty, 10) // default of 10%
   })
 
-  it('the amount of refund should be less than the original keyPrice', async () => {
+  it('the amount of refund should be less than the original keyPrice when purchased normally', async () => {
     const estimatedRefund = new BigNumber(
       await lock.getCancelAndRefundValueFor.call(keyOwners[0])
+    )
+    assert(estimatedRefund.lt(keyPrice))
+  })
+
+  it('the amount of refund should be less than the original keyPrice when expiration is very far in the future', async () => {
+    await lock.grantKey(accounts[5], 999999999999, { from: accounts[0] })
+    const estimatedRefund = new BigNumber(
+      await lock.getCancelAndRefundValueFor.call(accounts[5])
     )
     assert(estimatedRefund.lt(keyPrice))
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

If a key owner has a long time remaining relative to the expirationDuration, `cancelAndRefund` would have previously refunded more than `keyPrice`.  This may be desirable but I suspect it is not, and it's a risk if a Lock owner uses `grantKey(address, -1)` without realizing the implications - this avoids that concern.

A bit more detail in the issue.  We can reject this if I'm wrong here.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2000 
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
