### PR TITLE
Rename outstandingKeys to totalSupply

### DIFF
--- a/smart-contracts/README.md
+++ b/smart-contracts/README.md
@@ -63,8 +63,8 @@ It has the following fields:
 These are the function which change some parameters for the Lock or check its status
 
 - setKeyPrice (TODO) : updates the price of new keys
-- outstandingKeys : get the number of outstanding keys
-- numberOfOwners : get the total number of unique owners (both expired and valid).  This may be larger than outstandingKeys.
+- totalSupply : get the number of outstanding keys
+- numberOfOwners : get the total number of unique owners (both expired and valid).  This may be larger than totalSupply.
 - balanceOf (ERC721) : get the number of keys for a given owner (0 or 1)
 - ownerOf (ERC721) : get the owner of a key (if applicable)
 - keyDataFor : get the value of the data field for a key

--- a/smart-contracts/contracts/interfaces/ILockCore.sol
+++ b/smart-contracts/contracts/interfaces/ILockCore.sol
@@ -112,7 +112,7 @@ interface ILockCore {
 
   /**
    * Public function which returns the total number of unique owners (both expired
-   * and valid).  This may be larger than outstandingKeys.
+   * and valid).  This may be larger than totalSupply.
    */
   function numberOfOwners()
     external
@@ -121,8 +121,14 @@ interface ILockCore {
 
   /**
    * Public function which returns the total number of keys (both expired and valid)
+   *
+   * This function signature is from the ERC-721 enumerable extension.
+   * https://eips.ethereum.org/EIPS/eip-721
+   * @notice Count NFTs tracked by this contract
+   * @return A count of valid NFTs tracked by this contract, where each one of
+   * them has an assigned and queryable owner not equal to the zero address
    */
-  function outstandingKeys()
+  function totalSupply()
     external
     view
     returns (uint);

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -201,7 +201,7 @@ contract MixinKeys is
 
   /**
    * Public function which returns the total number of unique owners (both expired
-   * and valid).  This may be larger than outstandingKeys.
+   * and valid).  This may be larger than totalSupply.
    */
   function numberOfOwners()
     public

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -119,7 +119,7 @@ contract MixinLockCore is
    * Public function which returns the total number of unique keys sold (both
    * expired and valid)
    */
-  function outstandingKeys()
+  function totalSupply()
     public
     view
     returns (uint)

--- a/smart-contracts/test/Lock/Lock.js
+++ b/smart-contracts/test/Lock/Lock.js
@@ -19,7 +19,7 @@ contract('Lock / Lock', accounts => {
       lock.expirationDuration.call(),
       lock.keyPrice.call(),
       lock.maxNumberOfKeys.call(),
-      lock.outstandingKeys.call(),
+      lock.totalSupply.call(),
       lock.numberOfOwners.call(),
       lock.publicLockVersion.call(),
       lock.isAlive.call()
@@ -29,7 +29,7 @@ contract('Lock / Lock', accounts => {
         expirationDuration,
         keyPrice,
         maxNumberOfKeys,
-        outstandingKeys,
+        totalSupply,
         numberOfOwners,
         publicLockVersion,
         isAlive
@@ -37,14 +37,14 @@ contract('Lock / Lock', accounts => {
         expirationDuration = new BigNumber(expirationDuration)
         keyPrice = new BigNumber(keyPrice)
         maxNumberOfKeys = new BigNumber(maxNumberOfKeys)
-        outstandingKeys = new BigNumber(outstandingKeys)
+        totalSupply = new BigNumber(totalSupply)
         numberOfOwners = new BigNumber(numberOfOwners)
         publicLockVersion = new BigNumber(publicLockVersion)
         assert.strictEqual(owner, accounts[0])
         assert.equal(expirationDuration.toFixed(), 60 * 60 * 24 * 30)
         assert.strictEqual(Units.convert(keyPrice, 'wei', 'eth'), '0.01')
         assert.equal(maxNumberOfKeys.toFixed(), 10)
-        assert.equal(outstandingKeys.toFixed(), 0)
+        assert.equal(totalSupply.toFixed(), 0)
         assert.equal(numberOfOwners.toFixed(), 0)
         assert.equal(publicLockVersion.toFixed(), 1) // needs updating each lock-version change
         assert.equal(isAlive, true)

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -37,8 +37,8 @@ contract('Lock / owners', accounts => {
   })
 
   it('should have the right number of keys', async () => {
-    const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
-    assert.equal(outstandingKeys.toFixed(), 4)
+    const totalSupply = new BigNumber(await lock.totalSupply.call())
+    assert.equal(totalSupply.toFixed(), 4)
   })
 
   it('should have the right number of owners', async () => {
@@ -73,13 +73,13 @@ contract('Lock / owners', accounts => {
     })
 
     it('should have the right number of keys', async () => {
-      const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
-      assert.equal(outstandingKeys.toFixed(), 4)
+      const totalSupply = new BigNumber(await lock.totalSupply.call())
+      assert.equal(totalSupply.toFixed(), 4)
     })
 
     it('should have the right number of keys', async () => {
-      const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
-      assert.equal(outstandingKeys.toFixed(), 4)
+      const totalSupply = new BigNumber(await lock.totalSupply.call())
+      assert.equal(totalSupply.toFixed(), 4)
     })
 
     it('should have the right number of owners', async () => {
@@ -109,13 +109,13 @@ contract('Lock / owners', accounts => {
     })
 
     it('should have the right number of keys', async () => {
-      const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
-      assert.equal(outstandingKeys.toFixed(), 4)
+      const totalSupply = new BigNumber(await lock.totalSupply.call())
+      assert.equal(totalSupply.toFixed(), 4)
     })
 
     it('should have the right number of keys', async () => {
-      const outstandingKeys = new BigNumber(await lock.outstandingKeys.call())
-      assert.equal(outstandingKeys.toFixed(), 4)
+      const totalSupply = new BigNumber(await lock.totalSupply.call())
+      assert.equal(totalSupply.toFixed(), 4)
     })
 
     it('should have the right number of owners', async () => {

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -106,14 +106,14 @@ contract('Lock / purchaseFor', accounts => {
     })
 
     describe('when the key was successfuly purchased', () => {
-      let outstandingKeys, numberOfOwners, balance, now
+      let totalSupply, numberOfOwners, balance, now
 
       before(async () => {
         balance = new BigNumber(
           await web3.eth.getBalance(locks['FIRST'].address)
         )
-        outstandingKeys = new BigNumber(
-          await locks['FIRST'].outstandingKeys.call()
+        totalSupply = new BigNumber(
+          await locks['FIRST'].totalSupply.call()
         )
         now = parseInt(new Date().getTime() / 1000)
         numberOfOwners = new BigNumber(
@@ -145,12 +145,12 @@ contract('Lock / purchaseFor', accounts => {
       })
 
       it('should have increased the number of outstanding keys', async () => {
-        const _outstandingKeys = new BigNumber(
-          await locks['FIRST'].outstandingKeys.call()
+        const _totalSupply = new BigNumber(
+          await locks['FIRST'].totalSupply.call()
         )
         assert.equal(
-          _outstandingKeys.toFixed(),
-          outstandingKeys.plus(1).toFixed()
+          _totalSupply.toFixed(),
+          totalSupply.plus(1).toFixed()
         )
       })
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

I started this task with the intention of implementing the ERC721 enumerable standard, however as I started on this I realized that 2 of 3 functions in that standard do not seem to offer any value for our use case.  However 1 of the functions is `totalSupply` which functionally matches what we had previously called `outstandingKeys` given the current implementation.  

I suggest we match the standard where we can, therefore renaming this function.  However we will not be registering as supporting the enumerable extension with ERC165 since we do not have implementations of the other functions.

The excluded methods:
```
    function tokenByIndex(uint256 _index) external view returns (uint256);
```
For our use case this would return the `_index` provided.

```
    function tokenOfOwnerByIndex(address _owner, uint256 _index) external view returns (uint256);
```
For our use case this requires `_index == 0`, and then returns what we currently call `getTokenIdFor`

We could reconsider and include these functions if we would prefer to implement the enumerable extension.  `tokenByIndex` is basically a no-op, but I could see an argument in favor of switching `getTokenIdFor` to `tokenOfOwnerByIndex` even though `_index` is not relevant for us..

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2082
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
