### PR TITLE
add loading spinner to the blocker

### DIFF
--- a/paywall/src/__tests__/paywall-builder/blocker.test.js
+++ b/paywall/src/__tests__/paywall-builder/blocker.test.js
@@ -1,9 +1,15 @@
 import * as blockerManager from '../../paywall-builder/blocker'
 
+jest.mock('../../paywall-builder/script', () => {
+  return {
+    findPaywallUrl: () => 'https://foo',
+  }
+})
+
 describe('paywall builder', () => {
   describe('blocker', () => {
     it('getBlocker', () => {
-      expect.assertions(2)
+      expect.assertions(3)
       const document = {
         createElement() {
           return { style: {}, appendChild: jest.fn() }
@@ -19,6 +25,7 @@ describe('paywall builder', () => {
             alignItems: 'center',
             background: 'white',
             display: 'flex',
+            flexDirection: 'column',
             fontSize: '30px',
             height: '100vh',
             justifyContent: 'center',
@@ -31,9 +38,22 @@ describe('paywall builder', () => {
         })
       )
 
-      expect(blocker.appendChild).toHaveBeenCalledWith(
+      expect(blocker.appendChild).toHaveBeenNthCalledWith(
+        1,
         expect.objectContaining({
           innerText: 'Loading access rights...',
+        })
+      )
+
+      expect(blocker.appendChild).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          src: 'https://foo/static/images/loading.svg',
+          style: {
+            height: '80px',
+            width: '80px',
+            border: 'none',
+          },
         })
       )
     })

--- a/paywall/src/paywall-builder/blocker.js
+++ b/paywall/src/paywall-builder/blocker.js
@@ -1,3 +1,5 @@
+import { findPaywallUrl } from './script'
+
 export function getBlocker(document) {
   const blocker = document.createElement('div')
 
@@ -10,6 +12,7 @@ export function getBlocker(document) {
   blocker.style.left = 0
   blocker.style.background = 'white'
   blocker.style.display = 'flex'
+  blocker.style.flexDirection = 'column'
   blocker.style.justifyContent = 'center'
   blocker.style.alignItems = 'center'
   blocker.style.fontSize = '30px'
@@ -19,6 +22,15 @@ export function getBlocker(document) {
 
   text.innerText = 'Loading access rights...'
   blocker.appendChild(text)
+
+  const spinner = document.createElement('img')
+
+  spinner.style.height = '80px'
+  spinner.style.width = '80px'
+  spinner.style.border = 'none'
+  spinner.src = findPaywallUrl(document) + '/static/images/loading.svg'
+
+  blocker.appendChild(spinner)
 
   return blocker
 }

--- a/paywall/src/static/images/loading.svg
+++ b/paywall/src/static/images/loading.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="#e4e4e4">
+  <circle cx="16" cy="3" r="0">
+    <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
+  </circle>
+  <circle transform="rotate(45 16 16)" cx="16" cy="3" r="0">
+    <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0.125s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
+  </circle>
+  <circle transform="rotate(90 16 16)" cx="16" cy="3" r="0">
+    <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0.25s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
+  </circle>
+  <circle transform="rotate(135 16 16)" cx="16" cy="3" r="0">
+    <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0.375s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
+  </circle>
+  <circle transform="rotate(180 16 16)" cx="16" cy="3" r="0">
+    <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0.5s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
+  </circle>
+  <circle transform="rotate(225 16 16)" cx="16" cy="3" r="0">
+    <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0.625s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
+  </circle>
+  <circle transform="rotate(270 16 16)" cx="16" cy="3" r="0">
+    <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0.75s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
+  </circle>
+  <circle transform="rotate(315 16 16)" cx="16" cy="3" r="0">
+    <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0.875s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
+  </circle>
+  <circle transform="rotate(180 16 16)" cx="16" cy="3" r="0">
+    <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0.5s" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
+  </circle>
+</svg>


### PR DESCRIPTION
# Description

This adds a loading spinner to the blocker we display prior to the paywall popping up
![54458881-6e426b80-473b-11e9-8699-68eaf49ec903](https://user-images.githubusercontent.com/98250/54468959-61883c80-4768-11e9-8838-db27684be672.gif)
![54458832-523eca00-473b-11e9-800a-94923ac1e837](https://user-images.githubusercontent.com/98250/54468960-61883c80-4768-11e9-9c49-81c13d08814e.gif)
# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1458

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
