### PR TITLE
fix key purchase on coinbase wallet

### DIFF
--- a/paywall/src/__tests__/components/lock/Lock.test.js
+++ b/paywall/src/__tests__/components/lock/Lock.test.js
@@ -1,10 +1,17 @@
-import {
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { Provider } from 'react-redux'
+
+import Lock, {
   mapStateToProps,
   mapDispatchToProps,
 } from '../../../components/lock/Lock'
 import { purchaseKey } from '../../../actions/key'
 import { TRANSACTION_TYPES } from '../../../constants'
-import { openNewWindowModal } from '../../../actions/modal'
+import createUnlockStore from '../../../createUnlockStore'
+import { ConfigContext } from '../../../utils/withConfig'
+import { WindowContext } from '../../../hooks/browser/useWindow'
+import { POST_MESSAGE_REDIRECT } from '../../../paywall-builder/constants'
 
 describe('Lock', () => {
   describe('mapDispatchToProps', () => {
@@ -21,22 +28,6 @@ describe('Lock', () => {
       newProps.purchaseKey(key)
       expect(props.showModal).toHaveBeenCalledWith()
       expect(dispatch).toHaveBeenCalledWith(purchaseKey(key))
-    })
-
-    it('should dispatch openNewWindowModal if the openNewWindow prop is truthy', () => {
-      expect.assertions(2)
-      const dispatch = jest.fn()
-      const props = {
-        showModal: jest.fn(),
-        openInNewWindow: true,
-      }
-      const key = {}
-
-      const newProps = mapDispatchToProps(dispatch, props)
-
-      newProps.purchaseKey(key)
-      expect(props.showModal).not.toHaveBeenCalled()
-      expect(dispatch).toHaveBeenCalledWith(openNewWindowModal())
     })
   })
 
@@ -101,6 +92,106 @@ describe('Lock', () => {
       expect(newProps.lockKey.data).toEqual('hello')
       expect(newProps.lockKey.expiration).toEqual(1000)
       expect(newProps.transaction).toEqual(state.transactions['0x777'])
+    })
+  })
+  describe('Purchase key behavior in an iframe', () => {
+    let fakeWindow
+    let state
+    let config
+    let store
+    let hideModal
+    let showModal
+
+    const lock = {
+      address: '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e',
+      name: 'Monthly',
+      keyPrice: '0.23',
+      fiatPrice: 240.38,
+      expirationDuration: 2592000,
+    }
+
+    function renderMockLock(openInNewWindow) {
+      store = createUnlockStore(state)
+      store.dispatch = jest.fn()
+      return rtl.render(
+        <Provider store={store}>
+          <ConfigContext.Provider value={config}>
+            <WindowContext.Provider value={fakeWindow}>
+              <Lock
+                lock={lock}
+                transaction={null}
+                lockKey={null}
+                purchaseKey={purchaseKey}
+                config={config}
+                hideModal={hideModal}
+                showModal={showModal}
+                openInNewWindow={openInNewWindow}
+              />
+            </WindowContext.Provider>
+          </ConfigContext.Provider>
+        </Provider>
+      )
+    }
+    beforeEach(() => {
+      hideModal = jest.fn()
+      showModal = jest.fn()
+      fakeWindow = {
+        parent: {
+          postMessage: jest.fn(),
+        },
+        location: {
+          pathname: `/${lock.address}`,
+          search: '?origin=origin',
+          hash: '',
+        },
+      }
+      config = {
+        isInIframe: true,
+        isServer: false,
+        requiredConfirmations: 12,
+      }
+      state = {
+        network: {},
+        account: {
+          address: '0x123',
+        },
+      }
+    })
+    describe('no user account', () => {
+      it('should try to open a new window via postMessage', () => {
+        expect.assertions(3)
+        state.account = null
+        const component = renderMockLock(true)
+
+        rtl.act(() => {
+          rtl.fireEvent.click(component.getByText('Monthly'))
+        })
+
+        expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith(
+          POST_MESSAGE_REDIRECT,
+          'origin'
+        )
+        expect(showModal).not.toHaveBeenCalled()
+        expect(store.dispatch).not.toHaveBeenCalled()
+      })
+    })
+    describe('has user account', () => {
+      it('should dispatch an action to purchase', () => {
+        expect.assertions(3)
+        const component = renderMockLock(false)
+
+        rtl.fireEvent.click(component.getByText('Monthly'))
+
+        const expectedAction = purchaseKey({
+          lock: lock.address,
+          owner: state.account.address,
+        })
+        expect(fakeWindow.parent.postMessage).not.toHaveBeenCalled()
+        expect(showModal).toHaveBeenCalled()
+        expect(store.dispatch).toHaveBeenCalledWith(
+          expect.objectContaining(expectedAction)
+        )
+      })
     })
   })
 })

--- a/paywall/src/__tests__/components/lock/Lock.test.js
+++ b/paywall/src/__tests__/components/lock/Lock.test.js
@@ -136,6 +136,7 @@ describe('Lock', () => {
         </Provider>
       )
     }
+
     it('should call useKeyPurchase purchase', () => {
       expect.assertions(1)
       purchase = jest.fn()

--- a/paywall/src/__tests__/components/lock/Lock.test.js
+++ b/paywall/src/__tests__/components/lock/Lock.test.js
@@ -94,6 +94,7 @@ describe('Lock', () => {
       expect(newProps.transaction).toEqual(state.transactions['0x777'])
     })
   })
+
   describe('usePurchaseKey is called for purchases', () => {
     let purchase
     const config = {

--- a/paywall/src/__tests__/hooks/usePurchaseKey.test.js
+++ b/paywall/src/__tests__/hooks/usePurchaseKey.test.js
@@ -25,6 +25,7 @@ describe('usePurchaseKey hook', () => {
       </button>
     )
   }
+
   describe('purchase', () => {
     it('calls purchaseKey if openInNewWindow is false', () => {
       expect.assertions(2)
@@ -39,6 +40,7 @@ describe('usePurchaseKey hook', () => {
       expect(purchaseKey).toHaveBeenCalledWith('hi')
       expect(postMessage).not.toHaveBeenCalled()
     })
+
     it('calls postMessage if openInNewWindow is true', () => {
       expect.assertions(2)
 

--- a/paywall/src/__tests__/hooks/usePurchaseKey.test.js
+++ b/paywall/src/__tests__/hooks/usePurchaseKey.test.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+
+import usePostMessage from '../../hooks/browser/usePostMessage'
+import usePurchaseKey from '../../hooks/usePurchaseKey'
+import { POST_MESSAGE_REDIRECT } from '../../paywall-builder/constants'
+
+jest.mock('../../hooks/browser/usePostMessage')
+describe('usePurchaseKey hook', () => {
+  let postMessage
+  let openInNewWindow
+  let purchaseKey
+  beforeEach(() => {
+    postMessage = jest.fn()
+    purchaseKey = jest.fn()
+    usePostMessage.mockImplementation(() => ({
+      postMessage,
+    }))
+  })
+  function MockPurchaseKey() {
+    const purchase = usePurchaseKey(purchaseKey, openInNewWindow)
+    return (
+      <button type="button" onClick={() => purchase('hi')}>
+        Click
+      </button>
+    )
+  }
+  describe('purchase', () => {
+    it('calls purchaseKey if openInNewWindow is false', () => {
+      expect.assertions(2)
+
+      openInNewWindow = false
+      const component = rtl.render(<MockPurchaseKey />)
+
+      rtl.act(() => {
+        rtl.fireEvent.click(component.getByText('Click'))
+      })
+
+      expect(purchaseKey).toHaveBeenCalledWith('hi')
+      expect(postMessage).not.toHaveBeenCalled()
+    })
+    it('calls postMessage if openInNewWindow is true', () => {
+      expect.assertions(2)
+
+      openInNewWindow = true
+      const component = rtl.render(<MockPurchaseKey />)
+
+      rtl.act(() => {
+        rtl.fireEvent.click(component.getByText('Click'))
+      })
+
+      expect(purchaseKey).not.toHaveBeenCalled()
+      expect(postMessage).toHaveBeenCalledWith(POST_MESSAGE_REDIRECT)
+    })
+  })
+})

--- a/paywall/src/components/lock/Lock.js
+++ b/paywall/src/components/lock/Lock.js
@@ -11,8 +11,7 @@ import ConfirmingKeyLock from './ConfirmingKeyLock'
 import ConfirmedKeyLock from './ConfirmedKeyLock'
 import NoKeyLock from './NoKeyLock'
 import { UNLIMITED_KEYS_COUNT, TRANSACTION_TYPES } from '../../constants'
-import usePostMessage from '../../hooks/browser/usePostMessage'
-import { POST_MESSAGE_REDIRECT } from '../../paywall-builder/constants'
+import usePurchaseKey from '../../hooks/usePurchaseKey'
 
 export const Lock = ({
   account,
@@ -25,13 +24,7 @@ export const Lock = ({
   hideModal,
   openInNewWindow,
 }) => {
-  const { postMessage } = usePostMessage()
-  const purchase = key => {
-    if (openInNewWindow) {
-      return postMessage(POST_MESSAGE_REDIRECT)
-    }
-    purchaseKey(key)
-  }
+  const purchase = usePurchaseKey(purchaseKey, openInNewWindow)
   if (
     transaction &&
     ['submitted', 'pending'].indexOf(transaction.status) > -1

--- a/paywall/src/components/lock/Lock.js
+++ b/paywall/src/components/lock/Lock.js
@@ -5,13 +5,14 @@ import UnlockPropTypes from '../../propTypes'
 import withConfig from '../../utils/withConfig'
 
 import { purchaseKey } from '../../actions/key'
-import { openNewWindowModal } from '../../actions/modal'
 
 import PendingKeyLock from './PendingKeyLock'
 import ConfirmingKeyLock from './ConfirmingKeyLock'
 import ConfirmedKeyLock from './ConfirmedKeyLock'
 import NoKeyLock from './NoKeyLock'
 import { UNLIMITED_KEYS_COUNT, TRANSACTION_TYPES } from '../../constants'
+import usePostMessage from '../../hooks/browser/usePostMessage'
+import { POST_MESSAGE_REDIRECT } from '../../paywall-builder/constants'
 
 export const Lock = ({
   account,
@@ -22,7 +23,15 @@ export const Lock = ({
   config,
   disabled,
   hideModal,
+  openInNewWindow,
 }) => {
+  const { postMessage } = usePostMessage()
+  const purchase = key => {
+    if (openInNewWindow) {
+      return postMessage(POST_MESSAGE_REDIRECT)
+    }
+    purchaseKey(key)
+  }
   if (
     transaction &&
     ['submitted', 'pending'].indexOf(transaction.status) > -1
@@ -52,7 +61,7 @@ export const Lock = ({
       <NoKeyLock
         lock={lock}
         disabled={disabled}
-        purchaseKey={purchaseKey}
+        purchaseKey={purchase}
         soldOut={soldOut}
         tooExpensive={tooExpensive}
         lockKey={lockKey}
@@ -68,6 +77,7 @@ Lock.propTypes = {
   purchaseKey: PropTypes.func.isRequired,
   config: UnlockPropTypes.configuration.isRequired,
   hideModal: PropTypes.func.isRequired,
+  showModal: PropTypes.func.isRequired,
   openInNewWindow: PropTypes.bool.isRequired,
 }
 
@@ -76,14 +86,8 @@ Lock.defaultProps = {
   transaction: null,
 }
 
-export const mapDispatchToProps = (
-  dispatch,
-  { showModal, openInNewWindow }
-) => ({
+export const mapDispatchToProps = (dispatch, { showModal }) => ({
   purchaseKey: key => {
-    if (openInNewWindow) {
-      return dispatch(openNewWindowModal())
-    }
     showModal()
     dispatch(purchaseKey(key))
   },

--- a/paywall/src/hooks/usePurchaseKey.js
+++ b/paywall/src/hooks/usePurchaseKey.js
@@ -1,0 +1,17 @@
+import { useCallback } from 'react'
+import usePostMessage from './browser/usePostMessage'
+import { POST_MESSAGE_REDIRECT } from '../paywall-builder/constants'
+
+export default function usePurchaseKey(purchaseKey, openInNewWindow) {
+  const { postMessage } = usePostMessage()
+  const purchase = useCallback(
+    key => {
+      if (openInNewWindow) {
+        return postMessage(POST_MESSAGE_REDIRECT)
+      }
+      purchaseKey(key)
+    },
+    [purchaseKey, postMessage, openInNewWindow]
+  )
+  return purchase
+}

--- a/paywall/src/hooks/usePurchaseKey.js
+++ b/paywall/src/hooks/usePurchaseKey.js
@@ -4,7 +4,7 @@ import { POST_MESSAGE_REDIRECT } from '../paywall-builder/constants'
 
 export default function usePurchaseKey(purchaseKey, openInNewWindow) {
   const { postMessage } = usePostMessage()
-  const purchase = useCallback(
+  return useCallback(
     key => {
       if (openInNewWindow) {
         return postMessage(POST_MESSAGE_REDIRECT)
@@ -13,5 +13,4 @@ export default function usePurchaseKey(purchaseKey, openInNewWindow) {
     },
     [purchaseKey, postMessage, openInNewWindow]
   )
-  return purchase
 }

--- a/paywall/src/stories/lock/Lock.stories.js
+++ b/paywall/src/stories/lock/Lock.stories.js
@@ -5,11 +5,22 @@ import { Lock } from '../../components/lock/Lock'
 import createUnlockStore from '../../createUnlockStore'
 import { ConfigContext } from '../../utils/withConfig'
 import { UNLIMITED_KEYS_COUNT } from '../../constants'
+import { WindowContext } from '../../hooks/browser/useWindow'
 
 // lock, account, keys, purchaseKey
 const purchaseKey = () => {}
 const config = {
   requiredConfirmations: 3,
+  isInIframe: false,
+  isServer: false,
+}
+const fakeWindow = {
+  location: {
+    href: '/',
+    pathname: '',
+    search: '',
+    hash: '',
+  },
 }
 
 const lock = {
@@ -32,6 +43,7 @@ const store = createUnlockStore({
 })
 
 const ConfigProvider = ConfigContext.Provider
+const WindowProvider = WindowContext.Provider
 
 const storyConfig = {
   requiredConfirmations: 12,
@@ -39,9 +51,12 @@ const storyConfig = {
 
 storiesOf('Lock', module)
   .addDecorator(getStory => (
-    <ConfigProvider value={storyConfig}>{getStory()}</ConfigProvider>
+    <ConfigProvider value={storyConfig}>
+      <WindowProvider value={fakeWindow}>
+        <Provider store={store}>{getStory()}</Provider>
+      </WindowProvider>
+    </ConfigProvider>
   ))
-  .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
   .add('with no key (check hover state too)', () => {
     return (
       <Lock
@@ -51,6 +66,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        showModal={() => {}}
         openInNewWindow={false}
       />
     )
@@ -65,6 +81,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        showModal={() => {}}
         openInNewWindow={false}
       />
     )
@@ -78,6 +95,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        showModal={() => {}}
         openInNewWindow={false}
       />
     )
@@ -95,6 +113,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        showModal={() => {}}
         openInNewWindow={false}
       />
     )
@@ -114,6 +133,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        showModal={() => {}}
         openInNewWindow={false}
       />
     )
@@ -134,6 +154,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        showModal={() => {}}
         openInNewWindow={false}
       />
     )
@@ -154,6 +175,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        showModal={() => {}}
         openInNewWindow={false}
       />
     )
@@ -175,6 +197,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        showModal={() => {}}
         openInNewWindow={false}
       />
     )
@@ -192,6 +215,7 @@ storiesOf('Lock', module)
         purchaseKey={purchaseKey}
         config={config}
         hideModal={() => {}}
+        showModal={() => {}}
         openInNewWindow={false}
       />
     )

--- a/paywall/src/stories/lock/Overlay.stories.js
+++ b/paywall/src/stories/lock/Overlay.stories.js
@@ -12,6 +12,16 @@ const ErrorProvider = GlobalErrorContext.Provider
 const ConfigProvider = ConfigContext.Provider
 const WindowProvider = WindowContext.Provider
 
+const fakeWindow = {
+  location: {
+    href: '/',
+    pathname: '',
+    search: '',
+    hash: '',
+  },
+  document: { body: { style: {} } },
+}
+
 const config = {
   isInIframe: true,
   requiredConfirmations: 12,
@@ -70,7 +80,7 @@ const render = (
     </ul>
 
     <ConfigProvider value={thisConfig}>
-      <WindowProvider value={{ document: { body: { style: {} } } }}>
+      <WindowProvider value={fakeWindow}>
         <ErrorProvider value={errors}>
           <Overlay
             scrollPosition={0}


### PR DESCRIPTION
# Description

This PR fixes a final piece of the puzzle missed in the refactor of the paywall to use hooks. Redirecting to a new window uses postMessage, but the `Lock` component did not use this. Because the old system did not pass the origin in messages, which was insecure, the `interWindowCommunicationMiddleware` call to `window.parent.postMessage` was being discarded by the paywall.

This PR fixes that issue by using the new (far more secure) `usePostMessage` hook, which pulls the parent window's origin from the URL and uses that to call `postMessage` properly.

This PR also introduces new testing for the Lock using `react-testing-library` which will make it far less fragile when making future changes, and much more likely to catch regressions.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2129 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
