### PR TITLE
ensure paywall URL pathnames have valid path separators

### DIFF
--- a/paywall/src/_server.js
+++ b/paywall/src/_server.js
@@ -19,7 +19,8 @@ function _server(port, dev) {
 
           // assigning `query` into the params means that we still
           // get the query string passed to our application
-          if (pathname.match('/0x')) {
+          const fixedPathname = pathname.replace(/\/+/g, '/')
+          if (fixedPathname.match('/0x')) {
             const params = route('/:lockAddress/:redirect?')(pathname)
             app.render(req, res, '/', Object.assign(params, query))
           } else {


### PR DESCRIPTION
# Description

This fixes the issue that brought down the paywall earlier today, which was a pathname like `https://staging.unlock-protocol.com//0x18326419236491649813649817634`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2103 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
