### PR TITLE
redirect to valid URLs from invalid URLs on the paywall

### DIFF
--- a/paywall/src/_server.js
+++ b/paywall/src/_server.js
@@ -19,7 +19,8 @@ function _server(port, dev) {
 
           // assigning `query` into the params means that we still
           // get the query string passed to our application
-          if (pathname.match('/0x')) {
+          const fixedPathname = pathname.replace(/\/+/g, '/')
+          if (fixedPathname.match('/0x')) {
             const params = route('/:lockAddress/:redirect?')(pathname)
             app.render(req, res, '/', Object.assign(params, query))
           } else {

--- a/paywall/src/_server.js
+++ b/paywall/src/_server.js
@@ -12,6 +12,15 @@ function _server(port, dev) {
 
     app.prepare().then(() => {
       let server = createServer((req, res) => {
+        const fixedPathname = req.url.replace(/\/+/g, '/')
+        if (req.url !== fixedPathname) {
+          console.info(`${req.url} --> ${fixedPathname}`)
+          res.writeHead(301, {
+            Location: fixedPathname,
+          })
+          resolve(res.end())
+          return
+        }
         console.info(`${req.method} ${req.url} > ${res.statusCode} `)
         try {
           const parsedUrl = new URL(req.url, `http://${req.headers.host}/`)
@@ -19,8 +28,7 @@ function _server(port, dev) {
 
           // assigning `query` into the params means that we still
           // get the query string passed to our application
-          const fixedPathname = pathname.replace(/\/+/g, '/')
-          if (fixedPathname.match('/0x')) {
+          if (pathname.match('/0x')) {
             const params = route('/:lockAddress/:redirect?')(pathname)
             app.render(req, res, '/', Object.assign(params, query))
           } else {
@@ -28,7 +36,7 @@ function _server(port, dev) {
             return
           }
         } catch (error) {
-          reject(error)
+          throw reject(error)
         }
       }).listen(port, err => {
         if (err) throw reject(err)


### PR DESCRIPTION
# Description

This PR fixes invalid URLs by redirecting to a valid URL. Next's router does not process invalid URLs correctly, causing internal errors we don't have control over. This solution converts double `//` (or more than double) to single `/` and compares it to the current URL. If they're different, it redirects permanently to the valid URL. The screencast shows it working in action.

In addition, I discovered that the server hangs on errors in URL parsing, so this causes the reject to throw. I'm not sure this is the best approach, but it does work here in that it kills the server.

![out](https://user-images.githubusercontent.com/98250/54476432-b614d180-47d3-11e9-831f-f8445afe4751.gif)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2103

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
