### PR TITLE
integration tests for the paywall

### DIFF
--- a/tests/test/paywall.test.js
+++ b/tests/test/paywall.test.js
@@ -1,0 +1,52 @@
+const url = require('../helpers/url')
+
+describe('The Unlock Paywall', () => {
+  const testLockAddress = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
+
+  function lockSelector(name) {
+    return `#${name}_${testLockAddress}`
+  }
+
+  beforeAll(async () => {
+    await page.goto(url('/dashboard'))
+    await expect(page).toMatch('Creator Dashboard')
+    await page.waitFor('#CreateLockButton')
+    await page.waitForSelector(`#LockEmbeddCode_${testLockAddress}`)
+    await expect(page).toMatch('30 days')
+    await Promise.all([
+      page.goto(url(`/demo/${testLockAddress}`)),
+      page.waitForNavigation(),
+    ])
+    await page.waitForFunction(() => window.frames.length)
+  })
+
+  it('should load the creator dashboard', async () => {
+    const paywallIframe = page.mainFrame().childFrames()[0]
+    await paywallIframe.waitForSelector(lockSelector('Lock'))
+    await paywallIframe.waitForFunction((ethPriceSelector) => {
+      const eth = document.querySelector(ethPriceSelector)
+      if (!eth) return false
+      return eth.innerText === '0.33 ETH'
+    }, {}, lockSelector('EthPrice'))
+  }, 20000)
+  it('clicking the lock purchases a key', async () => {
+    const paywallIframe = page.mainFrame().childFrames()[0]
+    const paywallBody = await paywallIframe.$('body')
+    await expect(paywallBody).toClick(lockSelector('PurchaseKey'))
+    await paywallIframe.waitForFunction((footerSelector) => {
+      const footer = document.querySelector(footerSelector)
+      if (!footer) return false
+      return footer.innerText === 'Payment Pending'
+    }, {}, 'footer')
+  }, 15000)
+  it('after key purchase, unlocked flag appears', async () => {
+    await page.reload()
+    await page.waitForFunction(() => window.frames.length)
+    const paywallIframe = page.mainFrame().childFrames()[0]
+    await paywallIframe.waitForFunction(() => {
+      const unlockFlag = document.querySelector('#UnlockFlag')
+      if (!unlockFlag) return false
+      return true
+    })
+  }, 15000)
+})

--- a/tests/test/paywall.test.js
+++ b/tests/test/paywall.test.js
@@ -1,5 +1,7 @@
 const url = require('../helpers/url')
 
+jest.setTimeout(30000)
+
 describe('The Unlock Paywall', () => {
   const testLockAddress = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
 
@@ -17,10 +19,14 @@ describe('The Unlock Paywall', () => {
       page.goto(url(`/demo/${testLockAddress}`)),
       page.waitForNavigation(),
     ])
-    await page.waitForFunction(() => window.frames.length)
+  }, 10000)
+
+  it('should remove the blocker', async () => {
+    await page.waitForFunction(() => !document.querySelector('#_unlock_blocker'))
   })
 
-  it('should load the creator dashboard', async () => {
+  it('should display the lock after the blocker is gone', async () => {
+    await page.waitForFunction(() => window.frames.length)
     const paywallIframe = page.mainFrame().childFrames()[0]
     await paywallIframe.waitForSelector(lockSelector('Lock'))
     await paywallIframe.waitForFunction((ethPriceSelector) => {

--- a/tests/test/paywall.test.js
+++ b/tests/test/paywall.test.js
@@ -10,11 +10,6 @@ describe('The Unlock Paywall', () => {
   }
 
   beforeAll(async () => {
-    await page.goto(url('/dashboard'))
-    await expect(page).toMatch('Creator Dashboard')
-    await page.waitFor('#CreateLockButton')
-    await page.waitForSelector(`#LockEmbeddCode_${testLockAddress}`)
-    await expect(page).toMatch('30 days')
     await Promise.all([
       page.goto(url(`/demo/${testLockAddress}`)),
       page.waitForNavigation(),
@@ -34,7 +29,8 @@ describe('The Unlock Paywall', () => {
       if (!eth) return false
       return eth.innerText === '0.33 ETH'
     }, {}, lockSelector('EthPrice'))
-  }, 20000)
+  })
+
   it('clicking the lock purchases a key', async () => {
     const paywallIframe = page.mainFrame().childFrames()[0]
     const paywallBody = await paywallIframe.$('body')
@@ -44,7 +40,8 @@ describe('The Unlock Paywall', () => {
       if (!footer) return false
       return footer.innerText === 'Payment Pending'
     }, {}, 'footer')
-  }, 15000)
+  })
+
   it('after key purchase, unlocked flag appears', async () => {
     await page.reload()
     await page.waitForFunction(() => window.frames.length)
@@ -54,5 +51,5 @@ describe('The Unlock Paywall', () => {
       if (!unlockFlag) return false
       return true
     })
-  }, 15000)
+  })
 })


### PR DESCRIPTION
# Description

This PR implements 3 integration tests for the paywall. The first checks if a lock displays on the demo page, the second purchases a key, and the third checks to see if the unlock flag displays when a key exists on page reload.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1882 
Fixes #1883 
Fixes #1885

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
