### PR TITLE
Paywall: fix npm start to work

### DIFF
--- a/paywall/package.json
+++ b/paywall/package.json
@@ -9,7 +9,7 @@
     "build": "npm run before && next build src",
     "deploy": "next export src -o out",
     "deploy-netlify": "./scripts/deploy-netlify.sh",
-    "start": "npm run before && next start",
+    "start": "cross-env NODE_ENV=production node src/server.js",
     "test": "cross-env UNLOCK_ENV=test jest --env=jsdom",
     "lint": "eslint .",
     "reformat": "prettier-eslint \"src/**/*.js\" --write",


### PR DESCRIPTION
# Description

While working on moving the integration tests for the paywall to use the new split-off paywall, I discovered that the `npm start` command differed substantially from the one inside `unlock-app` when it should be identical. This was causing some weird errors when running in the integration tests, and I assume also in production that we just had not seen yet.

In addition, it was doing a build step that belonged in `npm run build`. This PR corrects both problems.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1205 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
