### PR TITLE
fix docker environment for paywall and integration tests

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -26,7 +26,6 @@ services:
     working_dir: /home/unlock
     expose:
       - 3000
-      - 3001
     environment:
       CI: "${CI}"
       HTTP_PROVIDER: "${HTTP_PROVIDER}"
@@ -48,11 +47,20 @@ services:
     image: unlock
     user: node
     working_dir: /home/unlock/paywall
+    expose:
+      - 3001
+    environment:
+      CI: "${CI}"
+      HTTP_PROVIDER: "${HTTP_PROVIDER}"
+    command: ["npm", "run", "start"]
   integration-tests:
     image: unlock-integration
     user: node
     environment:
       UNLOCK_HOST: "unlock"
+      PAYWALL_URL: "${PAYWALL_URL}"
+      PAYWALL_SCRIPT_URL: "${PAYWALL_SCRIPT_URL}"
+      LOCKSMITH_URI: "${LOCKSMITH_URI}"
       CI: "${CI}"
     depends_on:
       - ganache-integration


### PR DESCRIPTION
# Description

While working on making the paywall integration tests work for the split-off paywall, I discovered a few errors in the `docker-compose.ci.yml` file.

1. environment variables we thought would exist in the integration tests environment did not.
2. same for the paywall
3. the paywall was not actually being run and was not exposing its port in the right location, it needed to copy the way locksmith was set up (hats off to Akeem)

With these changes and the fix to #2142 the paywall service actually runs now in the integration test environment, which is a prerequisite to switching the tests to use the split-off paywall

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1205 #1882 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
