### PR TITLE
use the typescript parser for prettier

### DIFF
--- a/paywall/package.json
+++ b/paywall/package.json
@@ -12,7 +12,7 @@
     "start": "cross-env NODE_ENV=production node src/server.js",
     "test": "cross-env UNLOCK_ENV=test jest --env=jsdom",
     "lint": "eslint .",
-    "reformat": "prettier-eslint \"src/**/*.js\" --write",
+    "reformat": "prettier-eslint \"src/**/*.js\" --write --parser typescript",
     "fail-pending-changes": "../scripts/pending-changes.sh",
     "svg-2-components": "./node_modules/@svgr/cli/bin/svgr --title-prop --no-dimensions --template src/components/interface/svg/template.js --no-dimensions -d src/components/interface/svg/ src/static/images/svg/",
     "build-paywall": "cross-env NODE_ENV=production rollup -c rollup.paywall.config.js -o ./src/static/paywall.min.js",

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -26,24 +26,21 @@ export function Paywall({ locks, locked, redirect }) {
     validator: isPositiveInteger,
   })
   const { postMessage } = usePostMessage()
-  useEffect(
-    () => {
-      if (locked) {
-        postMessage(POST_MESSAGE_LOCKED)
-      } else {
-        postMessage(POST_MESSAGE_UNLOCKED)
-        const height = '160px'
-        const body = window.document.body
-        body.style.margin = '0'
-        body.style.height = window.innerWidth >= 768 ? height : 0
-        body.style.display = window.innerWidth >= 768 ? 'flex' : 'none'
-        body.style.flexDirection = 'column'
-        body.style.justifyContent = 'center'
-        body.style.overflow = 'hidden'
-      }
-    },
-    [locked]
-  )
+  useEffect(() => {
+    if (locked) {
+      postMessage(POST_MESSAGE_LOCKED)
+    } else {
+      postMessage(POST_MESSAGE_UNLOCKED)
+      const height = '160px'
+      const body = window.document.body
+      body.style.margin = '0'
+      body.style.height = window.innerWidth >= 768 ? height : 0
+      body.style.display = window.innerWidth >= 768 ? 'flex' : 'none'
+      body.style.flexDirection = 'column'
+      body.style.justifyContent = 'center'
+      body.style.overflow = 'hidden'
+    }
+  }, [locked])
 
   return (
     <GlobalErrorProvider>

--- a/paywall/src/hooks/browser/useLocalStorage.js
+++ b/paywall/src/hooks/browser/useLocalStorage.js
@@ -17,8 +17,7 @@ export default function useLocalStorage(key) {
     () => {
       if (!available) return // do nothing if localStorage can't be used
       window.localStorage.setItem(key, value)
-    },
-    // this effect only runs when the value changes
+    }, // this effect only runs when the value changes
     // and not on every update to the component containing the hook
     [value]
   )

--- a/paywall/src/hooks/browser/usePostMessage.js
+++ b/paywall/src/hooks/browser/usePostMessage.js
@@ -12,8 +12,7 @@ export default function usePostMessage() {
       const { origin } = getRouteFromWindow(window)
       if (isServer || !isInIframe || !message || !origin) return
       window.parent.postMessage(message, origin)
-    },
-    // this next line tells React to only post the message if it has changed.
+    }, // this next line tells React to only post the message if it has changed.
     // This is important because the hook will be called on every render,
     // not just when the postMessage call has changed the state to something else
     // and we only want to post the message on the very first time it is requested

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -87,7 +87,7 @@
     "start-ganache:win32": "cd .. && (START /b npm run start-ganache -- -b 3 ) ",
     "test": "cross-env UNLOCK_ENV=test jest --env=jsdom",
     "lint": "eslint .",
-    "reformat": "prettier-eslint \"src/**/*.js\" --write",
+    "reformat": "prettier-eslint \"src/**/*.js\" --write --parser typescript",
     "fail-pending-changes": "../scripts/pending-changes.sh",
     "storybook": "start-storybook -p 9001 -c .storybook -s src",
     "chromatic": "chromatic test --exit-zero-on-changes",


### PR DESCRIPTION
# Description

The move to typescript in `unlock-app` has had some unintended consequences in the `paywall` app. On CI, prettier is defaulting to using the `typescript` parser, instead of the `babel` parser. However, it appears that in some cases, it will detect and use `babel` in the `paywall` directory. This probably has to do with both being present after `link-parent-bin` is called. This results in a deadlock on files in paywall.

This PR makes the parser explicitly the typescript parser. Because typescript is javascript, this has no negative side effects on the paywall, it just makes reformatting consistent.

The 3 files that have been giving errors are all reformatted by this PR.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1477 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
