### PR TITLE
fix scrolling on paywall

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -9379,6 +9379,7 @@ Object {
         >
           <div
             class="c1"
+            data-testid="paywall-banner"
             style="height: 0%;"
           >
             <h1
@@ -9524,6 +9525,7 @@ Object {
       >
         <div
           class="sc-7wmxqm-1 kmwBAR"
+          data-testid="paywall-banner"
           style="height: 0%;"
         >
           <h1
@@ -9881,6 +9883,7 @@ Object {
         >
           <div
             class="c1"
+            data-testid="paywall-banner"
             style="height: 0%;"
           >
             <h1
@@ -9995,6 +9998,7 @@ Object {
       >
         <div
           class="sc-7wmxqm-1 kmwBAR"
+          data-testid="paywall-banner"
           style="height: 0%;"
         >
           <h1
@@ -10381,6 +10385,7 @@ Object {
         >
           <div
             class="c1"
+            data-testid="paywall-banner"
             style="height: 0%;"
           >
             <h1
@@ -10526,6 +10531,7 @@ Object {
       >
         <div
           class="sc-7wmxqm-1 kmwBAR"
+          data-testid="paywall-banner"
           style="height: 0%;"
         >
           <h1
@@ -10883,6 +10889,7 @@ Object {
         >
           <div
             class="c1"
+            data-testid="paywall-banner"
             style="height: 0%;"
           >
             <h1
@@ -10997,6 +11004,7 @@ Object {
       >
         <div
           class="sc-7wmxqm-1 kmwBAR"
+          data-testid="paywall-banner"
           style="height: 0%;"
         >
           <h1
@@ -11383,6 +11391,7 @@ Object {
         >
           <div
             class="c1"
+            data-testid="paywall-banner"
             style="height: 0%;"
           >
             <h1
@@ -11577,6 +11586,7 @@ Object {
       >
         <div
           class="sc-7wmxqm-1 kmwBAR"
+          data-testid="paywall-banner"
           style="height: 0%;"
         >
           <h1

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -15,7 +15,7 @@ import {
   POST_MESSAGE_LOCKED,
   POST_MESSAGE_UNLOCKED,
 } from '../paywall-builder/constants'
-import { isPositiveInteger } from '../utils/validators'
+import { isPositiveNumber } from '../utils/validators'
 import useWindow from '../hooks/browser/useWindow'
 
 export function Paywall({ locks, locked, redirect }) {
@@ -23,7 +23,7 @@ export function Paywall({ locks, locked, redirect }) {
   const scrollPosition = useListenForPostMessage({
     type: 'scrollPosition',
     defaultValue: 0,
-    validator: isPositiveInteger,
+    validator: isPositiveNumber,
   })
   const { postMessage } = usePostMessage()
   useEffect(() => {

--- a/paywall/src/components/lock/Overlay.js
+++ b/paywall/src/components/lock/Overlay.js
@@ -44,7 +44,7 @@ export const Overlay = ({
   config: { isInIframe },
 }) => (
   <FullPage>
-    <Banner scrollPosition={scrollPosition}>
+    <Banner scrollPosition={scrollPosition} data-testid="paywall-banner">
       <Headline>
         You have reached your limit of free articles. Please purchase access
       </Headline>


### PR DESCRIPTION
# Description

This fixes the immediate issue of scrolling not blocking content on the paywall. The problem was the incorrect validator `isPositiveInteger` was being used, instead of `isPositiveNumber`. The PR adds a regression test so this won't happen again.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2194 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
