### PR TITLE
Routing emails based on their templates

### DIFF
--- a/wedlocks/src/__tests__/route.test.js
+++ b/wedlocks/src/__tests__/route.test.js
@@ -1,0 +1,121 @@
+import nodemailer from 'nodemailer'
+import { route } from '../route'
+import templates from '../templates'
+import config from '../config'
+
+jest.mock('nodemailer')
+jest.mock('../templates')
+
+describe('route', () => {
+  describe('when there is no matching template', () => {
+    it('should yield an error', done => {
+      expect.assertions(2)
+      route({ template: 'notATemplate' }, (error, info) => {
+        expect(info).toBe(undefined)
+        expect(error.message).toBe('Missing template')
+        done()
+      })
+    })
+  })
+
+  describe('when there is a matching template', () => {
+    it('should send the email using the transporter', done => {
+      expect.assertions(4)
+      templates['template'] = {
+        subject: jest.fn(() => 'subject'),
+        text: jest.fn(() => 'text')
+      }
+      const args = {
+        template: 'template',
+        params: { hello: 'world' },
+        recipient: 'julien@unlock-protocol.com'
+      }
+      const transporter = {
+        sendMail: jest.fn((options, callback) => {
+          expect(options).toEqual({
+            from: config.sender,
+            html: null,
+            subject: 'subject',
+            text: 'text',
+            to: args.recipient
+          })
+          return callback()
+        })
+      }
+      nodemailer.createTransport = jest.fn(params => {
+        expect(params).toEqual(config)
+        return transporter
+      })
+
+      route(args, () => {
+        expect(templates['template'].subject).toHaveBeenCalledWith(args.params)
+        expect(templates['template'].text).toHaveBeenCalledWith(args.params)
+        done()
+      })
+    })
+
+    describe('when the email was sent succesfuly', () => {
+      it('should yield its enveloppe', done => {
+        expect.assertions(3)
+        templates['template'] = {
+          subject: jest.fn(() => 'subject'),
+          text: jest.fn(() => 'text')
+        }
+        const args = {
+          template: 'template',
+          params: { hello: 'world' },
+          recipient: 'julien@unlock-protocol.com'
+        }
+        const transporter = {
+          sendMail: jest.fn((options, callback) => {
+            return callback(null, {
+              messageId: 'abc123'
+            })
+          })
+        }
+        nodemailer.createTransport = jest.fn(params => {
+          expect(params).toEqual(config)
+          return transporter
+        })
+
+        route(args, (error, result) => {
+          expect(error).toBe(null)
+          expect(result).toEqual({
+            messageId: 'abc123'
+          })
+          done()
+        })
+      })
+    })
+
+    describe('when the email was not sent succesfuly', () => {
+      it('should yield the error message', done => {
+        expect.assertions(3)
+        templates['template'] = {
+          subject: jest.fn(() => 'subject'),
+          text: jest.fn(() => 'text')
+        }
+        const args = {
+          template: 'template',
+          params: { hello: 'world' },
+          recipient: 'julien@unlock-protocol.com'
+        }
+        const transporter = {
+          sendMail: jest.fn((options, callback) => {
+            return callback(new Error('something went wrong'))
+          })
+        }
+        nodemailer.createTransport = jest.fn(params => {
+          expect(params).toEqual(config)
+          return transporter
+        })
+
+        route(args, (error, result) => {
+          expect(result).toBe(undefined)
+          expect(error.message).toBe('something went wrong')
+          done()
+        })
+      })
+    })
+  })
+})

--- a/wedlocks/src/config.js
+++ b/wedlocks/src/config.js
@@ -1,0 +1,11 @@
+export default {
+  host: process.env.SMTP_HOST,
+  port: process.env.SMTP_PORT || 587,
+  secure: false,
+  auth: {
+    user: process.env.SMTP_USERNAME,
+    pass: process.env.SMTP_PASSWORD
+  },
+  sender:
+    process.env.SMTP_FROM_ADDRESS || 'Unlock <no-reply@unlock-protocol.com>' // TODO: can we do better eventually?
+}

--- a/wedlocks/src/route.js
+++ b/wedlocks/src/route.js
@@ -1,12 +1,32 @@
-// This function dispatches the perfom the actual email sending
-// TODO: implement me
-// params: {
+import nodemailer from 'nodemailer'
+import templates from './templates'
+import config from './config'
+
+// This function loads the template and performs the actual email sending
+// args: {
 //  template: templateName string
 //  recipient: email aderess string
 //  params: params for the template (as a hash)
 // }
-export const route = (params, callback) => {
-  return callback(null, { message: 'hello world!' })
+export const route = (args, callback) => {
+  const template = templates[args.template]
+
+  if (!template) {
+    return callback(new Error('Missing template'))
+  }
+  nodemailer.createTransport(config).sendMail(
+    {
+      from: config.sender,
+      to: args.recipient,
+      subject: template.subject(args.params),
+      text: template.text(args.params),
+      // optional extra arguments for SendRawEmail
+      html: null // TODO: support later
+    },
+    (err, info) => {
+      return callback(err, info)
+    }
+  )
 }
 
 export default {

--- a/wedlocks/src/templates/index.js
+++ b/wedlocks/src/templates/index.js
@@ -1,0 +1,1 @@
+export default {}


### PR DESCRIPTION
Emails can now be sent! Well, since there is no template, none will actually be sent, but everything
is in place for them to be sent!


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread