### PR TITLE
plugging a temporary confirmEmail template

### DIFF
--- a/wedlocks/src/__tests__/templates/confirmEmail.test.js
+++ b/wedlocks/src/__tests__/templates/confirmEmail.test.js
@@ -1,0 +1,17 @@
+import confirmEmail from '../../templates/confirmEmail'
+
+describe('confirmEmail', () => {
+  it('should have the right subject', () => {
+    expect(confirmEmail.subject()).toBe('Please confirm your email address')
+  })
+
+  it('should have the right text', () => {
+    expect(
+      confirmEmail.text({
+        confirmLink: 'https://unlock-protocol.com/confirm...'
+      })
+    ).toBe(
+      'Please confirm your email address by clicking on the following link https://unlock-protocol.com/confirm....'
+    )
+  })
+})

--- a/wedlocks/src/__tests__/templates/index.test.js
+++ b/wedlocks/src/__tests__/templates/index.test.js
@@ -1,0 +1,8 @@
+import templates from '../../templates'
+
+describe('templates', () => {
+  test.each(Object.keys(templates))('%i', template => {
+    expect(templates[template].subject).toBeInstanceOf(Function)
+    expect(templates[template].text).toBeInstanceOf(Function)
+  })
+})

--- a/wedlocks/src/templates/confirmEmail.js
+++ b/wedlocks/src/templates/confirmEmail.js
@@ -1,0 +1,7 @@
+export default {
+  subject: () => 'Please confirm your email address',
+  text: params =>
+    `Please confirm your email address by clicking on the following link ${
+      params.confirmLink
+    }.`
+}

--- a/wedlocks/src/templates/index.js
+++ b/wedlocks/src/templates/index.js
@@ -1,1 +1,5 @@
-export default {}
+import confirmEmail from './confirmEmail'
+
+export default {
+  confirmEmail
+}


### PR DESCRIPTION
In order to fully test we need to add a temporary confirmEmail function.
We will implement the real one when we focus on the UI for the User Accounts.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread