### PR TITLE
Add a helper for retrieving paywall URL in integration tests

### DIFF
--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -15,6 +15,7 @@ REPO_ROOT=`dirname "$0"`/..
 DOCKER_COMPOSE_FILE=$REPO_ROOT/docker/docker-compose.ci.yml
 EXTRA_ARGS=$*
 
+
 # Run the tests
 COMMAND="npm run ci"
 

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -15,7 +15,6 @@ REPO_ROOT=`dirname "$0"`/..
 DOCKER_COMPOSE_FILE=$REPO_ROOT/docker/docker-compose.ci.yml
 EXTRA_ARGS=$*
 
-
 # Run the tests
 COMMAND="npm run ci"
 

--- a/tests/helpers/url.js
+++ b/tests/helpers/url.js
@@ -1,6 +1,6 @@
 const host = process.env.UNLOCK_HOST || '127.0.0.1'
 const port = process.env.UNLOCK_PORT || 3000
-const paywall = process.env.PAYWALL_URL || '127.0.0.1:3001'
+const paywall = process.env.PAYWALL_URL || 'http://127.0.0.1:3001'
 
 module.exports = {
   main: (path = '/') => `http://${host}:${port}${path}`,

--- a/tests/helpers/url.js
+++ b/tests/helpers/url.js
@@ -4,5 +4,5 @@ const paywall = process.env.PAYWALL_URL || '127.0.0.1:3001'
 
 module.exports = {
   main: (path = '/') => `http://${host}:${port}${path}`,
-  paywall: (path = '/') => `${paywall}/${path}`,
+  paywall: (path = '/') => `${paywall}${path}`,
 }

--- a/tests/helpers/url.js
+++ b/tests/helpers/url.js
@@ -1,4 +1,8 @@
 const host = process.env.UNLOCK_HOST || '127.0.0.1'
 const port = process.env.UNLOCK_PORT || 3000
+const paywall = process.env.PAYWALL_URL || '127.0.0.1:3001'
 
-module.exports = (path = '/') => `http://${host}:${port}${path}`
+module.exports = {
+  main: (path = '/') => `http://${host}:${port}${path}`,
+  paywall: (path = '/') => `${paywall}/${path}`,
+}

--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -1,4 +1,4 @@
-const url = require('../helpers/url')
+const url = require('../helpers/url').main
 
 describe('The Unlock Dashboard', () => {
   beforeAll(async () => {

--- a/tests/test/home.test.js
+++ b/tests/test/home.test.js
@@ -1,4 +1,4 @@
-const url = require('../helpers/url')
+const url = require('../helpers/url').main
 
 describe('The Unlock Homepage', () => {
   it('should display "unlock" text on page', async () => {

--- a/tests/test/paywall.test.js
+++ b/tests/test/paywall.test.js
@@ -2,8 +2,6 @@ const { main: url } = require('../helpers/url')
 
 jest.setTimeout(30000)
 
-jest.setTimeout(30000)
-
 describe('The Unlock Paywall', () => {
   const testLockAddress = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
 

--- a/tests/test/paywall.test.js
+++ b/tests/test/paywall.test.js
@@ -1,4 +1,4 @@
-const { main: url } = require('../helpers/url')
+const url = require('../helpers/url').main
 
 jest.setTimeout(30000)
 

--- a/tests/test/paywall.test.js
+++ b/tests/test/paywall.test.js
@@ -1,4 +1,6 @@
-const url = require('../helpers/url')
+const { main: url } = require('../helpers/url')
+
+jest.setTimeout(30000)
 
 jest.setTimeout(30000)
 

--- a/tests/test/url-with-defaults.test.js
+++ b/tests/test/url-with-defaults.test.js
@@ -1,0 +1,11 @@
+delete process.env.UNLOCK_HOST
+delete process.env.UNLOCK_PORT
+delete process.env.PAYWALL_URL
+const url = require('../helpers/url')
+
+describe('url test helper, default values', () => {
+  it('main', () => {
+    expect(url.main()).toBe('http://127.0.0.1:3000/')
+    expect(url.main('/path')).toBe('http://127.0.0.1:3000/path')
+  })
+})

--- a/tests/test/url-with-defaults.test.js
+++ b/tests/test/url-with-defaults.test.js
@@ -8,4 +8,8 @@ describe('url test helper, default values', () => {
     expect(url.main()).toBe('http://127.0.0.1:3000/')
     expect(url.main('/path')).toBe('http://127.0.0.1:3000/path')
   })
+  it('paywall', () => {
+    expect(url.paywall()).toBe('http://127.0.0.1:3001/')
+    expect(url.paywall('/path')).toBe('http://127.0.0.1:3001/path')
+  })
 })

--- a/tests/test/url.test.js
+++ b/tests/test/url.test.js
@@ -8,4 +8,8 @@ describe('url test helper, from environment', () => {
     expect(url.main()).toBe('http://host:999/')
     expect(url.main('/path')).toBe('http://host:999/path')
   })
+  it('paywall', () => {
+    expect(url.paywall()).toBe('http://whatever/')
+    expect(url.paywall('/path')).toBe('http://whatever/path')
+  })
 })

--- a/tests/test/url.test.js
+++ b/tests/test/url.test.js
@@ -1,30 +1,11 @@
+process.env.UNLOCK_HOST = 'host'
+process.env.UNLOCK_PORT = 999
+process.env.PAYWALL_URL = 'http://whatever'
+const url = require('../helpers/url')
 
-describe('url test helper', () => {
-  describe('main', () => {
-    it('from env', () => {
-      expect.assertions(2)
-      process.env.UNLOCK_HOST = 'host'
-      process.env.UNLOCK_PORT = 90
-
-      // eslint-disable-next-line
-      const url = require('../helpers/url')
-
-      expect(url.main()).toBe('http://host:90/')
-      expect(url.main('/test')).toBe('http://host:90/test')
-    })
-    it('from defaults', () => {
-      expect.assertions(2)
-      process.env.UNLOCK_HOST = false
-      process.env.UNLOCK_PORT = false
-
-      // eslint-disable-next-line
-      const url = require('../helpers/url')
-
-      expect(url.main()).toBe('http://127.0.0.1:3000/')
-      expect(url.main('/test')).toBe('http://127.0.0.1:3000/test')
-    })
-  })
-  describe('paywall', () => {
-
+describe('url test helper, from environment', () => {
+  it('main', () => {
+    expect(url.main()).toBe('http://host:999/')
+    expect(url.main('/path')).toBe('http://host:999/path')
   })
 })

--- a/tests/test/url.test.js
+++ b/tests/test/url.test.js
@@ -1,0 +1,30 @@
+
+describe('url test helper', () => {
+  describe('main', () => {
+    it('from env', () => {
+      expect.assertions(2)
+      process.env.UNLOCK_HOST = 'host'
+      process.env.UNLOCK_PORT = 90
+
+      // eslint-disable-next-line
+      const url = require('../helpers/url')
+
+      expect(url.main()).toBe('http://host:90/')
+      expect(url.main('/test')).toBe('http://host:90/test')
+    })
+    it('from defaults', () => {
+      expect.assertions(2)
+      process.env.UNLOCK_HOST = false
+      process.env.UNLOCK_PORT = false
+
+      // eslint-disable-next-line
+      const url = require('../helpers/url')
+
+      expect(url.main()).toBe('http://127.0.0.1:3000/')
+      expect(url.main('/test')).toBe('http://127.0.0.1:3000/test')
+    })
+  })
+  describe('paywall', () => {
+
+  })
+})


### PR DESCRIPTION
# Description

This PR modifies the `url` helper for integration tests, to allow it to pull in both the main `unlock-app` url and the `paywall` url.

This will be used to write integration tests for the paywall in the main window

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #1884 #1886 #1887 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
