### PR TITLE
Fixes blog post image responsiveness bug

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -1455,7 +1455,7 @@ Object {
 }
 
 .c18 img {
-  max-width: 730px;
+  max-width: 100%;
 }
 
 .c17 {
@@ -2090,7 +2090,7 @@ are intentionally not generated from this file date, in case we want to override
             </div>
           </div>
           <div
-            class="b1qsww-4 bKHcAy"
+            class="b1qsww-4 dhqFyH"
           >
             <div>
               <p>
@@ -2932,7 +2932,7 @@ Object {
 }
 
 .c5 img {
-  max-width: 730px;
+  max-width: 100%;
 }
 
 .c4 {
@@ -3190,7 +3190,7 @@ genuinely collaborative ecosystem, where many companies and services can operate
         </div>
       </div>
       <div
-        class="b1qsww-4 bKHcAy"
+        class="b1qsww-4 dhqFyH"
       >
         <div>
           <p>
@@ -3472,7 +3472,7 @@ Object {
 }
 
 .c4 img {
-  max-width: 730px;
+  max-width: 100%;
 }
 
 .c3 {
@@ -3722,7 +3722,7 @@ genuinely collaborative ecosystem, where many companies and services can operate
         </div>
       </div>
       <div
-        class="b1qsww-4 bKHcAy"
+        class="b1qsww-4 dhqFyH"
       >
         <div>
           <p>
@@ -4004,7 +4004,7 @@ Object {
 }
 
 .c4 img {
-  max-width: 730px;
+  max-width: 100%;
 }
 
 .c3 {
@@ -4254,7 +4254,7 @@ genuinely collaborative ecosystem, where many companies and services can operate
         </div>
       </div>
       <div
-        class="b1qsww-4 bKHcAy"
+        class="b1qsww-4 dhqFyH"
       >
         <div>
           <p>
@@ -4544,7 +4544,7 @@ Object {
 }
 
 .c5 img {
-  max-width: 730px;
+  max-width: 100%;
 }
 
 .c4 {
@@ -4802,7 +4802,7 @@ genuinely collaborative ecosystem, where many companies and services can operate
         </div>
       </div>
       <div
-        class="b1qsww-4 bKHcAy"
+        class="b1qsww-4 dhqFyH"
       >
         <div>
           <p>

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -3119,7 +3119,7 @@ and the first service to use the open Unlock protocol for payments.
             <p>
               <img
                 alt="Unlock"
-                src="https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png?sanitize=true"
+                src="/static/images/unlock-word-mark.png"
               />
             </p>
             
@@ -3337,7 +3337,7 @@ and the first service to use the open Unlock protocol for payments.
           <p>
             <img
               alt="Unlock"
-              src="https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png?sanitize=true"
+              src="/static/images/unlock-word-mark.png"
             />
           </p>
           
@@ -3655,7 +3655,7 @@ and the first service to use the open Unlock protocol for payments.
             <p>
               <img
                 alt="Unlock"
-                src="https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png?sanitize=true"
+                src="/static/images/unlock-word-mark.png"
               />
             </p>
             
@@ -3869,7 +3869,7 @@ and the first service to use the open Unlock protocol for payments.
           <p>
             <img
               alt="Unlock"
-              src="https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png?sanitize=true"
+              src="/static/images/unlock-word-mark.png"
             />
           </p>
           
@@ -4187,7 +4187,7 @@ and the first service to use the open Unlock protocol for payments.
             <p>
               <img
                 alt="Unlock"
-                src="https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png?sanitize=true"
+                src="/static/images/unlock-word-mark.png"
               />
             </p>
             
@@ -4401,7 +4401,7 @@ and the first service to use the open Unlock protocol for payments.
           <p>
             <img
               alt="Unlock"
-              src="https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png?sanitize=true"
+              src="/static/images/unlock-word-mark.png"
             />
           </p>
           
@@ -4731,7 +4731,7 @@ and the first service to use the open Unlock protocol for payments.
             <p>
               <img
                 alt="Unlock"
-                src="https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png?sanitize=true"
+                src="/static/images/unlock-word-mark.png"
               />
             </p>
             
@@ -4949,7 +4949,7 @@ and the first service to use the open Unlock protocol for payments.
           <p>
             <img
               alt="Unlock"
-              src="https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png?sanitize=true"
+              src="/static/images/unlock-word-mark.png"
             />
           </p>
           

--- a/unlock-app/src/components/content/BlogPost.js
+++ b/unlock-app/src/components/content/BlogPost.js
@@ -93,7 +93,7 @@ const Body = styled.div`
   }
 
   img {
-    max-width: 730px;
+    max-width: 90%;
   }
 `
 

--- a/unlock-app/src/components/content/BlogPost.js
+++ b/unlock-app/src/components/content/BlogPost.js
@@ -93,7 +93,7 @@ const Body = styled.div`
   }
 
   img {
-    max-width: 90%;
+    max-width: 100%;
   }
 `
 

--- a/unlock-app/src/stories/content/BlogPost.stories.js
+++ b/unlock-app/src/stories/content/BlogPost.stories.js
@@ -44,7 +44,7 @@ And a numbered list:
  
 And an image:
 
-![Unlock](https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png?sanitize=true)
+![Unlock](/static/images/unlock-word-mark.png)
 
 ## Why do we need to remove middlemen?
 


### PR DESCRIPTION
# Description

Images were previously set with a max width that made sense on desktop but nowhere else. This fix ensures they will never be wider than 100% of the page.

# Issues

Refs #586 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<img width="438" alt="Screen Shot 2019-03-20 at 10 36 47 AM" src="https://user-images.githubusercontent.com/624104/54706420-179eae00-4afc-11e9-821a-e594c99ea41e.png">

<img width="1330" alt="Screen Shot 2019-03-20 at 10 36 42 AM" src="https://user-images.githubusercontent.com/624104/54706427-1b323500-4afc-11e9-8811-c6d08368f8b7.png">
