### PR TITLE
adding variable substitution when running webpack and failing if env variables are missing

### DIFF
--- a/docker/unlock.dockerfile
+++ b/docker/unlock.dockerfile
@@ -102,7 +102,6 @@ RUN npm run build
 # Build wedlocks
 WORKDIR /home/unlock/wedlocks
 COPY --chown=node wedlocks/ /home/unlock/wedlocks/.
-RUN npm run build
 
 WORKDIR /home/unlock/
 

--- a/wedlocks/webpack.config.js
+++ b/wedlocks/webpack.config.js
@@ -1,7 +1,18 @@
+/* eslint no-console: 0 */
+
 const path = require('path')
+const webpack = require('webpack')
 
 const SRC_DIR = path.resolve(__dirname, 'src')
 const OUT_DIR = path.resolve(__dirname, 'build')
+
+const requiredVariables = ['SMTP_HOST', 'SMTP_USERNAME', 'SMTP_PASSWORD']
+requiredVariables.forEach(envVar => {
+  if (!process.env[envVar]) {
+    console.error(`Environment variable ${envVar} is required.`)
+    process.exit(1)
+  }
+})
 
 const config = {
   mode: 'production',
@@ -30,7 +41,18 @@ const config = {
         }
       }
     ]
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.SMTP_HOST': JSON.stringify(process.env.SMTP_HOST),
+      'process.env.SMTP_PORT': JSON.stringify(process.env.SMTP_PORT),
+      'process.env.SMTP_USERNAME': JSON.stringify(process.env.SMTP_USERNAME),
+      'process.env.SMTP_PASSWORD': JSON.stringify(process.env.SMTP_PASSWORD),
+      'process.env.SMTP_FROM_ADDRESS': JSON.stringify(
+        process.env.SMTP_FROM_ADDRESS
+      )
+    })
+  ]
 }
 
 module.exports = config


### PR DESCRIPTION
We cannot set env variables on AWS lambda, so we have to place them at build time.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread