### PR TITLE
waiting for locksmith and paywall to be up before running  the test suite

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,7 @@ what is being rendered on screen.
 - start a local ganache node (at the root): `npm run start-ganache -- -b 1` (the -b 1 means that the node will mine blocks every second, even if no transaction has been added)
 - deploy the smart contracts (in `/unlock-app`): `npm run deploy-unlock-contract`
 - run the dashboard application (in `/unlock-app`): `npm run start` (you may need to build the application first: `npm run build`)
+- run the locksmith application (in `/locksmith`): `npm run start`
 - run the paywall application (in `/paywall`): `npm run start` (you may need to build the application first: `npm run build`)
 - execute the tests (in `/tests`): `npm run test`
 

--- a/tests/helpers/serverIsUp.js
+++ b/tests/helpers/serverIsUp.js
@@ -1,0 +1,33 @@
+const net = require('net')
+
+/**
+ * This is a helper function to ensure that we start the test suite only when the server is up
+ * We will retry for
+ */
+const serverIsUp = (host, port, delay, maxAttempts) => new Promise((resolve, reject) => {
+  let attempts = 1
+  const tryConnecting = () => {
+    const socket = net.connect(
+      port,
+      host,
+      () => {
+        resolve()
+        return socket.end() // clean-up
+      }
+    )
+
+    socket.on('error', (error) => {
+      if (error.code === 'ECONNREFUSED') {
+        if (attempts < maxAttempts) {
+          attempts += 1
+          return setTimeout(tryConnecting, delay)
+        }
+        return reject(error)
+      }
+      return reject(error)
+    })
+  }
+  tryConnecting()
+})
+
+module.exports = serverIsUp


### PR DESCRIPTION
This should solve our integration test timing issues.



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread