### PR TITLE
show children in iframe on missing provider

### DIFF
--- a/paywall/src/__tests__/components/lock/Overlay.test.js
+++ b/paywall/src/__tests__/components/lock/Overlay.test.js
@@ -36,6 +36,7 @@ describe('Overlay', () => {
       })
     })
   })
+
   describe('mapStateToProps', () => {
     it('should set openInNewWindow based on the value of account', () => {
       expect.assertions(3)
@@ -68,6 +69,7 @@ describe('Overlay', () => {
       })
     })
   })
+
   describe('displayError', () => {
     it('should display children if there is no error', () => {
       expect.assertions(1)
@@ -77,6 +79,7 @@ describe('Overlay', () => {
 
       expect(wrapper.getByText('children')).not.toBeNull()
     })
+
     it('should display error', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
@@ -85,6 +88,7 @@ describe('Overlay', () => {
 
       expect(wrapper.getByText('Fatal Error')).not.toBeNull()
     })
+
     it('should display children if provider is missing and in the iframe', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
@@ -97,6 +101,7 @@ describe('Overlay', () => {
 
       expect(wrapper.queryByText('Wallet missing')).toBeNull()
     })
+
     it('should display error if provider is missing and in the main window', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
@@ -109,6 +114,7 @@ describe('Overlay', () => {
 
       expect(wrapper.getByText('Wallet missing')).not.toBeNull()
     })
+
     it('should display children if account is missing and in the iframe', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
@@ -121,6 +127,7 @@ describe('Overlay', () => {
 
       expect(wrapper.queryByText('error')).toBeNull()
     })
+
     it('should display error if account is missing and in the main window', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
@@ -143,6 +150,7 @@ describe('Overlay', () => {
     }
     let store
     beforeEach(() => (store = createUnlockStore()))
+
     it('displays lock when there is no error', () => {
       expect.assertions(3)
       const wrapper = rtl.render(
@@ -170,6 +178,7 @@ describe('Overlay', () => {
         )
       ).not.toBeNull()
     })
+
     it('displays error, headline, and flag when there is an error', () => {
       expect.assertions(3)
       const wrapper = rtl.render(
@@ -197,6 +206,7 @@ describe('Overlay', () => {
         )
       ).not.toBeNull()
     })
+
     it('displays lock when the error is missing account', () => {
       expect.assertions(3)
       const wrapper = rtl.render(

--- a/paywall/src/__tests__/components/lock/Overlay.test.js
+++ b/paywall/src/__tests__/components/lock/Overlay.test.js
@@ -77,7 +77,27 @@ describe('Overlay', () => {
 
       expect(wrapper.getByText('children')).not.toBeNull()
     })
-    it('should display error if present', () => {
+    it('should display error', () => {
+      expect.assertions(1)
+      const wrapper = rtl.render(
+        displayError(true /* isMainWindow */)('foobar', {}, <div>children</div>)
+      )
+
+      expect(wrapper.getByText('Fatal Error')).not.toBeNull()
+    })
+    it('should display children if provider is missing and in the iframe', () => {
+      expect.assertions(1)
+      const wrapper = rtl.render(
+        displayError(false /* iframe */)(
+          FATAL_MISSING_PROVIDER,
+          {},
+          <div>children</div>
+        )
+      )
+
+      expect(wrapper.queryByText('Wallet missing')).toBeNull()
+    })
+    it('should display error if provider is missing and in the main window', () => {
       expect.assertions(1)
       const wrapper = rtl.render(
         displayError(true /* isMainWindow */)(
@@ -157,9 +177,7 @@ describe('Overlay', () => {
           <ConfigProvider
             value={{ requiredConfirmations: 12, isInIframe: true }}
           >
-            <ErrorProvider
-              value={{ error: FATAL_MISSING_PROVIDER, errorMetadata: {} }}
-            >
+            <ErrorProvider value={{ error: 'foobar', errorMetadata: {} }}>
               <Overlay
                 scrollPosition={0}
                 hideModal={() => {}}

--- a/paywall/src/components/lock/Overlay.js
+++ b/paywall/src/components/lock/Overlay.js
@@ -8,7 +8,7 @@ import { hideModal, showModal } from '../../actions/modal'
 import { LockedFlag } from './UnlockFlag'
 import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import { mapErrorToComponent } from '../creator/FatalError'
-import { FATAL_NO_USER_ACCOUNT } from '../../errors'
+import { FATAL_NO_USER_ACCOUNT, FATAL_MISSING_PROVIDER } from '../../errors'
 import withConfig from '../../utils/withConfig'
 
 export const displayError = isMainWindow =>
@@ -28,7 +28,11 @@ export const displayError = isMainWindow =>
         return Error
       }
     } else {
-      if (error && error !== FATAL_NO_USER_ACCOUNT) {
+      if (
+        error &&
+        error !== FATAL_NO_USER_ACCOUNT &&
+        error !== FATAL_MISSING_PROVIDER
+      ) {
         return Error
       }
     }


### PR DESCRIPTION
# Description

This PR shows the lock if the current browser does not have a provider when it runs in the iframe.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2230 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
