### PR TITLE
add screenshotOnFail and use .png for screenshots

### DIFF
--- a/tests/helpers/debugging.js
+++ b/tests/helpers/debugging.js
@@ -74,7 +74,7 @@ module.exports = {
     const runTest = async () => {
       try {
         // await will do nothing for non-async code, and make async tests work
-        module.exports.debugPage(page, true, true)
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await
         await code()
         // if the code does not throw, we did not fail
       } catch (e) {

--- a/tests/helpers/debugging.js
+++ b/tests/helpers/debugging.js
@@ -1,30 +1,51 @@
 /* eslint no-console: 0 */
 
 /**
- * debugPage
- ***********
+ * debugPage [local dev only]
  *
- * debugPage is used to turn on the display of console.log calls within the browser context.
- * This includes calls within page.evaluate and page.waitForFunction.
- *
- * Usage:
+ * Use debugPage() to display the output of console.log from within the page context.
+ * It should be called at the point you would like logging to begin with:
  *
  * debugPage(page, true)
  *
- * screenshot
- ************
+ * ****************************
+ * screenshot [local or CI dev]
  *
- * screenshot is used to take a screenshot. It will work both locally when run with the
- * scripts/local-docker-integration-tests.sh script or on CI. Screenshots locally are
- * placed in the current directory. In CI, they are found in the artifacts on CircleCI.
+ * screenshot() will immediately take a screenshot and save it. It accepts
+ * an optional filename prefix, which defaults to 'test'. With each call to
+ * screenshot, the file generated has a unique name based on a counter. The
+ * counter increments every time screenshot is called regardless of the filename
+ * prefix. These calls:
  *
- * Usage:
+ * screenshot(page)
+ * screenshot(page, 'different')
+ * screenshot(page)
  *
- * await screenshot(page) // creates test-1.jpg
- * await screenshot(page) // creates test-2.jpg
- * await screenshot(page, 'another') // creates another-3.jpg
+ * will generate files '/screenshots/test-1.png', '/screenshots/different-2.png', and
+ * '/screenshots/test-3.png'
  *
- * The numeric prefix is always unique and represents the order of the screenshot.
+ * screenshot can be used either in development or production. Be aware that on Mac
+ * OS X screenshots take a minimum of 1/6 second, and can distort timing results, so
+ * should only be used for development of integration tests.
+ *
+ * screenshots are saved into /tmp/screenshots
+ *
+ * ****************************
+ * screenshotOnFail [local and CI]
+ *
+ * screenshotOnFail() is designed to be a replacement for jest's "it"
+ * that is used to take a screenshot on any test failure. It is a factory
+ * that returns the replacement for "it." Usage:
+ *
+ * const it = screenshotOnFail(page)
+ *
+ * Note that there is no requirement that it replace "it", and one could just as easily use:
+ *
+ * const itWithScreenshot = screenshotOnFail(page)
+ *
+ * screenshots are saved into /tmp/screenshots for local dev, and will appear on CircleCI
+ * in the Artifacts section of integration tests for viewing when the tests conplete.
+ * Screenshot names are based on the test description.
  */
 let counter = 1
 module.exports = {

--- a/tests/helpers/debugging.js
+++ b/tests/helpers/debugging.js
@@ -44,9 +44,34 @@ module.exports = {
   },
   async screenshot(page, file = 'test') {
     await page.screenshot({
-      path: `/screenshots/${file}-${counter}.jpg`,
+      path: `/screenshots/${file}-${counter}.png`,
       fullPage: true,
     })
     counter += 1
+  },
+  screenshotOnFail: page => (testDescription, code) => {
+    const runTest = async () => {
+      try {
+        // await will do nothing for non-async code, and make async tests work
+        module.exports.debugPage(page, true, true)
+        await code()
+        // if the code does not throw, we did not fail
+      } catch (e) {
+        // locally, we use the volume mounted at /screenshots
+        // on CI, we use the /home/unlock/screenshots directory used to retrieve artifacts
+        const screenshotPath = `/screenshots/${testDescription.replace(
+          /[ ,/"'^$\\]+/g,
+          '-'
+        )}.png`
+        console.error(`writing screenshot to ${screenshotPath}`)
+        try {
+          await page.screenshot({ path: screenshotPath, fullPage: true })
+        } catch (screenshotError) {
+          console.error(screenshotError)
+        }
+        throw e
+      }
+    }
+    it(testDescription, runTest)
   },
 }


### PR DESCRIPTION
# Description

This helper creates a new `screenshotOnFail` helper which is designed to automatically take screenshots when integration tests fail, and save them to `/screenshots`. This is designed to work inside a docker context. `/screenshots` will be mapped to `/tmp/screenshots` for both local and CI work.

## Usage

At the top of the file
```js
const { screenshotOnFail } = require('../helpers/debugging')

const it = screenshotOnFail(page)
```

This replaces the jest `it` seamlessly. Passing tests run normally, failing ones take a screenshot with the test title replaced.

Note that documentation for all helpers is part of #2209 and separate from this PR.

This PR also standardizes screenshots to use png, which is better than jpg for our use cases (fewer visual artifacts)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2191 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
