### PR TITLE
use /tmp/screenshots for /screenshots mounts for all integration tests

### DIFF
--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -18,4 +18,7 @@ EXTRA_ARGS=$*
 # Run the tests
 COMMAND="npm run ci"
 
-docker-compose -f $DOCKER_COMPOSE_FILE run $EXTRA_ARGS integration-tests bash -c "$COMMAND"
+mkdir -p /tmp/screenshots
+chmod 0777 /tmp/screenshots
+
+docker-compose -f $DOCKER_COMPOSE_FILE run -v /tmp/screenshots:/screenshots $EXTRA_ARGS integration-tests bash -c "$COMMAND"

--- a/scripts/local-docker-integration-tests.sh
+++ b/scripts/local-docker-integration-tests.sh
@@ -31,5 +31,5 @@ docker build -t unlock -f "$REPO_ROOT/docker/unlock.dockerfile" $REPO_ROOT
 docker build -t unlock-integration -f "$REPO_ROOT/docker/unlock-integration.dockerfile" $REPO_ROOT
 
 # Run the tests
-$REPO_ROOT/scripts/integration-tests.sh -v $PWD:/screenshots $EXTRA_ARGS
+$REPO_ROOT/scripts/integration-tests.sh $EXTRA_ARGS
 


### PR DESCRIPTION
# Description

This PR standardizes screenshot volume mounting for all integration test runs to use `/tmp/screenshots` both locally and for CI. This is a no-op until the other PRs are merged to enable screenshotting, but is a step on the path.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2191 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
