### PR TITLE
store screenshots in artifacts on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,8 @@ jobs:
       - run:
           name: Integration Tests
           command: scripts/integration-tests.sh
+      - store_artifacts:
+          path: /tmp/screenshots
 
   deploy-unlock-app-netlify:
     machine: true


### PR DESCRIPTION
# Description

As documented at https://circleci.com/docs/2.0/artifacts/ this enables pulling screenshots out of integration tests and storing them for display or download.  A sample build of the experimental branch can be found here:

https://circleci.com/gh/unlock-protocol/unlock/12687#artifacts/containers/0

Note that when no artifacts exist, nothing happens, it just displays "no artifacts found" as in this example build:

https://circleci.com/gh/unlock-protocol/unlock/12668#tests/containers/0

(scroll down and click `Uploading artifacts` to see the sample output)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2191 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
