### PR TITLE
isolating the web3Service to pull it off into its own js module

### DIFF
--- a/paywall/src/__tests__/services/web3Service.test.js
+++ b/paywall/src/__tests__/services/web3Service.test.js
@@ -4,9 +4,7 @@ import Web3Utils from 'web3-utils'
 import Web3EthAbi from 'web3-eth-abi'
 import nock from 'nock'
 import { PublicLock, Unlock } from 'unlock-abi-0'
-import Web3Service from '../../services/web3Service'
-import configure from '../../config'
-import { TRANSACTION_TYPES } from '../../constants'
+import Web3Service, { TransactionType } from '../../services/web3Service'
 
 const nodeAccounts = [
   '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
@@ -19,7 +17,11 @@ const transaction = {
   hash: '0x83f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
 }
 
-const nockScope = nock('http://127.0.0.1:8545', { encodedQueryParams: true })
+const blockTime = 3
+const readOnlyProvider = 'http://127.0.0.1:8545'
+const requiredConfirmations = 12
+
+const nockScope = nock(readOnlyProvider, { encodedQueryParams: true })
 
 let rpcRequestId = 0
 
@@ -89,8 +91,6 @@ nock.emitter.on('no match', function(clientRequestObject, options, body) {
 const unlockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
 
 let web3Service
-
-const { blockTime, readOnlyProvider, requiredConfirmations } = configure()
 
 describe('Web3Service', () => {
   beforeEach(() => {
@@ -828,7 +828,7 @@ describe('Web3Service', () => {
         .createLock('1000', '1000000000', '1')
         .encodeABI()
       expect(web3Service.getTransactionType(Unlock, data)).toBe(
-        TRANSACTION_TYPES.LOCK_CREATION
+        TransactionType.LOCK_CREATION
       )
     })
 
@@ -839,7 +839,7 @@ describe('Web3Service', () => {
         .purchaseFor(nodeAccounts[0], Web3Utils.utf8ToHex(''))
         .encodeABI()
       expect(web3Service.getTransactionType(PublicLock, data)).toBe(
-        TRANSACTION_TYPES.KEY_PURCHASE
+        TransactionType.KEY_PURCHASE
       )
     })
 
@@ -848,7 +848,7 @@ describe('Web3Service', () => {
       const lock = new web3Service.web3.eth.Contract(PublicLock.abi, '')
       const data = lock.methods.withdraw().encodeABI()
       expect(web3Service.getTransactionType(PublicLock, data)).toBe(
-        TRANSACTION_TYPES.WITHDRAWAL
+        TransactionType.WITHDRAWAL
       )
     })
   })

--- a/paywall/src/services/web3Service.js
+++ b/paywall/src/services/web3Service.js
@@ -5,9 +5,20 @@ import ethJsUtil from 'ethereumjs-util'
 
 import { PublicLock, Unlock } from 'unlock-abi-0'
 
-import { TRANSACTION_TYPES, MAX_UINT, UNLIMITED_KEYS_COUNT } from '../constants'
-
 export const keyId = (lock, owner) => [lock, owner].join('-')
+
+export const Constants = {
+  MAX_UINT:
+    '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+  UNLIMITED_KEYS_COUNT: -1,
+}
+
+export const TransactionType = {
+  LOCK_CREATION: 'LOCK_CREATION',
+  KEY_PURCHASE: 'KEY_PURCHASE',
+  WITHDRAWAL: 'WITHDRAWAL',
+  UPDATE_KEY_PRICE: 'UPDATE_KEY_PRICE',
+}
 
 /**
  * This service reads data from the RPC endpoint.
@@ -88,8 +99,8 @@ export default class Web3Service extends EventEmitter {
           lock: newLockAddress,
         })
 
-        if (params._maxNumberOfKeys === MAX_UINT) {
-          params._maxNumberOfKeys = UNLIMITED_KEYS_COUNT
+        if (params._maxNumberOfKeys === Constants.MAX_UINT) {
+          params._maxNumberOfKeys = Constants.UNLIMITED_KEYS_COUNT
         }
 
         this.emit('lock.updated', newLockAddress, {
@@ -142,25 +153,25 @@ export default class Web3Service extends EventEmitter {
     })
 
     if (contract.contractName === 'Unlock' && method.name === 'createLock') {
-      return TRANSACTION_TYPES.LOCK_CREATION
+      return TransactionType.LOCK_CREATION
     }
 
     if (
       contract.contractName === 'PublicLock' &&
       method.name === 'purchaseFor'
     ) {
-      return TRANSACTION_TYPES.KEY_PURCHASE
+      return TransactionType.KEY_PURCHASE
     }
 
     if (contract.contractName === 'PublicLock' && method.name === 'withdraw') {
-      return TRANSACTION_TYPES.WITHDRAWAL
+      return TransactionType.WITHDRAWAL
     }
 
     if (
       contract.contractName === 'PublicLock' &&
       method.name === 'updateKeyPrice'
     ) {
-      return TRANSACTION_TYPES.UPDATE_KEY_PRICE
+      return TransactionType.UPDATE_KEY_PRICE
     }
 
     // Unknown transaction
@@ -495,8 +506,8 @@ export default class Web3Service extends EventEmitter {
       keyPrice: x => Web3Utils.fromWei(x, 'ether'),
       expirationDuration: parseInt,
       maxNumberOfKeys: value => {
-        if (value === MAX_UINT) {
-          return UNLIMITED_KEYS_COUNT
+        if (value === Constants.MAX_UINT) {
+          return Constants.UNLIMITED_KEYS_COUNT
         }
         return parseInt(value)
       },

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -4,9 +4,7 @@ import Web3Utils from 'web3-utils'
 import Web3EthAbi from 'web3-eth-abi'
 import nock from 'nock'
 import { PublicLock, Unlock } from 'unlock-abi-0'
-import Web3Service from '../../services/web3Service'
-import configure from '../../config'
-import { TransactionType } from '../../unlock'
+import Web3Service, { TransactionType } from '../../services/web3Service'
 
 const nodeAccounts = [
   '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
@@ -19,7 +17,11 @@ const transaction = {
   hash: '0x83f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
 }
 
-const nockScope = nock('http://127.0.0.1:8545', { encodedQueryParams: true })
+const blockTime = 3
+const readOnlyProvider = 'http://127.0.0.1:8545'
+const requiredConfirmations = 12
+
+const nockScope = nock(readOnlyProvider, { encodedQueryParams: true })
 
 let rpcRequestId = 0
 
@@ -89,8 +91,6 @@ nock.emitter.on('no match', function(clientRequestObject, options, body) {
 const unlockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
 
 let web3Service
-
-const { blockTime, readOnlyProvider, requiredConfirmations } = configure()
 
 describe('Web3Service', () => {
   beforeEach(() => {

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -5,10 +5,20 @@ import ethJsUtil from 'ethereumjs-util'
 
 import { PublicLock, Unlock } from 'unlock-abi-0'
 
-import { MAX_UINT, UNLIMITED_KEYS_COUNT } from '../constants'
-import { TransactionType } from '../unlock'
-
 export const keyId = (lock, owner) => [lock, owner].join('-')
+
+export const Constants = {
+  MAX_UINT:
+    '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+  UNLIMITED_KEYS_COUNT: -1,
+}
+
+export const TransactionType = {
+  LOCK_CREATION: 'LOCK_CREATION',
+  KEY_PURCHASE: 'KEY_PURCHASE',
+  WITHDRAWAL: 'WITHDRAWAL',
+  UPDATE_KEY_PRICE: 'UPDATE_KEY_PRICE',
+}
 
 /**
  * This service reads data from the RPC endpoint.
@@ -89,8 +99,8 @@ export default class Web3Service extends EventEmitter {
           lock: newLockAddress,
         })
 
-        if (params._maxNumberOfKeys === MAX_UINT) {
-          params._maxNumberOfKeys = UNLIMITED_KEYS_COUNT
+        if (params._maxNumberOfKeys === Constants.MAX_UINT) {
+          params._maxNumberOfKeys = Constants.UNLIMITED_KEYS_COUNT
         }
 
         this.emit('lock.updated', newLockAddress, {
@@ -496,8 +506,8 @@ export default class Web3Service extends EventEmitter {
       keyPrice: x => Web3Utils.fromWei(x, 'ether'),
       expirationDuration: parseInt,
       maxNumberOfKeys: value => {
-        if (value === MAX_UINT) {
-          return UNLIMITED_KEYS_COUNT
+        if (value === Constants.MAX_UINT) {
+          return Constants.UNLIMITED_KEYS_COUNT
         }
         return parseInt(value)
       },


### PR DESCRIPTION
The web3Service will be pulled away from the various apps and in its own JS module so it can be re-used more easily accross apps.


Refs #1873


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread