### PR TITLE
remove text on paywall blocker

### DIFF
--- a/paywall/src/__tests__/paywall-builder/blocker.test.js
+++ b/paywall/src/__tests__/paywall-builder/blocker.test.js
@@ -9,7 +9,7 @@ jest.mock('../../paywall-builder/script', () => {
 describe('paywall builder', () => {
   describe('blocker', () => {
     it('getBlocker', () => {
-      expect.assertions(3)
+      expect.assertions(2)
       const document = {
         createElement() {
           return { style: {}, appendChild: jest.fn() }
@@ -40,13 +40,6 @@ describe('paywall builder', () => {
 
       expect(blocker.appendChild).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({
-          innerText: 'Loading access rights...',
-        })
-      )
-
-      expect(blocker.appendChild).toHaveBeenNthCalledWith(
-        2,
         expect.objectContaining({
           src: 'https://foo/static/images/loading.svg',
           style: {

--- a/paywall/src/paywall-builder/blocker.js
+++ b/paywall/src/paywall-builder/blocker.js
@@ -18,11 +18,6 @@ export function getBlocker(document) {
   blocker.style.fontSize = '30px'
   blocker.style.zIndex = 222222222222222
 
-  const text = document.createElement('div')
-
-  text.innerText = 'Loading access rights...'
-  blocker.appendChild(text)
-
   const spinner = document.createElement('img')
 
   spinner.style.height = '80px'


### PR DESCRIPTION
# Description

This changes the paywall blocker to only show the spinner while the paywall is loading, and no text.

<img width="1678" alt="Screen Shot 2019-03-21 at 12 19 18 AM" src="https://user-images.githubusercontent.com/98250/54733271-31c5a400-4b6f-11e9-8312-d8f24fb0ba01.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2213 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
