### PR TITLE
Coerce expirationDuration and maxNumberOfKeys to numbers

### DIFF
--- a/paywall/src/services/web3Service.js
+++ b/paywall/src/services/web3Service.js
@@ -95,9 +95,9 @@ export default class Web3Service extends EventEmitter {
         this.emit('lock.updated', newLockAddress, {
           transaction: transactionHash,
           address: newLockAddress,
-          expirationDuration: params._expirationDuration,
+          expirationDuration: +params._expirationDuration,
           keyPrice: Web3Utils.fromWei(params._keyPrice, 'ether'), // Must be expressed in Eth!
-          maxNumberOfKeys: params._maxNumberOfKeys,
+          maxNumberOfKeys: +params._maxNumberOfKeys,
           outstandingKeys: 0,
           balance: '0', // Must be expressed in Eth!
         })

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -1081,8 +1081,9 @@ describe('Web3Service', () => {
         const params = {
           _expirationDuration: '7',
           _maxNumberOfKeys: '5',
-          _keyPrice: '0.05',
+          _keyPrice: '5',
         }
+        web3Service.generateLockAddress = jest.fn()
         web3Service.on('lock.updated', (newLockAddress, update) => {
           expect(update.expirationDuration).toBe(7)
           expect(update.maxNumberOfKeys).toBe(5)

--- a/unlock-app/src/__tests__/services/web3Service.test.js
+++ b/unlock-app/src/__tests__/services/web3Service.test.js
@@ -1073,4 +1073,24 @@ describe('Web3Service', () => {
       expect(web3Service.getTransaction).toHaveBeenCalledWith(transactionHash)
     })
   })
+
+  describe('inputsHandlers', () => {
+    describe('createLock', () => {
+      it('should emit lock.updated with correctly typed values', async done => {
+        expect.assertions(2)
+        const params = {
+          _expirationDuration: '7',
+          _maxNumberOfKeys: '5',
+          _keyPrice: '0.05',
+        }
+        web3Service.on('lock.updated', (newLockAddress, update) => {
+          expect(update.expirationDuration).toBe(7)
+          expect(update.maxNumberOfKeys).toBe(5)
+          done()
+        })
+
+        await web3Service.inputsHandlers.createLock('0x123', '0x456', params)
+      })
+    })
+  })
 })

--- a/unlock-app/src/services/web3Service.js
+++ b/unlock-app/src/services/web3Service.js
@@ -96,9 +96,9 @@ export default class Web3Service extends EventEmitter {
         this.emit('lock.updated', newLockAddress, {
           transaction: transactionHash,
           address: newLockAddress,
-          expirationDuration: params._expirationDuration,
+          expirationDuration: +params._expirationDuration,
           keyPrice: Web3Utils.fromWei(params._keyPrice, 'ether'), // Must be expressed in Eth!
-          maxNumberOfKeys: params._maxNumberOfKeys,
+          maxNumberOfKeys: +params._maxNumberOfKeys,
           outstandingKeys: 0,
           balance: '0', // Must be expressed in Eth!
         })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR ensures that `expirationDuration` and `maxNumberOfKeys` will enter the app as numbers rather than strings, fixing some PropTypes noise in the console.

(I think in the near-term we're going to want to TypeScriptify the services, since they are the outer boundary of the app. Data comes in through them, so they have to be the first trusted point)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2102 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
