### PR TITLE
Make TransactionType values more human-friendly

### DIFF
--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -28,10 +28,10 @@ export const pageTitle = title => {
  * Transaction types
  */
 export const TRANSACTION_TYPES = {
-  LOCK_CREATION: 'LOCK_CREATION',
-  KEY_PURCHASE: 'KEY_PURCHASE',
-  WITHDRAWAL: 'WITHDRAWAL',
-  UPDATE_KEY_PRICE: 'UPDATE_KEY_PRICE',
+  LOCK_CREATION: 'Lock Creation',
+  KEY_PURCHASE: 'Key Purchase',
+  WITHDRAWAL: 'Withdrawal',
+  UPDATE_KEY_PRICE: 'Update Key Price',
 }
 
 // used in defining the helpers for LOCK_PATH_NAME_REGEXP and ACCOUNT_REGEXP

--- a/unlock-app/src/__tests__/components/content/LogContent.test.js
+++ b/unlock-app/src/__tests__/components/content/LogContent.test.js
@@ -1,7 +1,4 @@
-import {
-  mapStateToProps,
-  humanize,
-} from '../../../components/content/LogContent'
+import { mapStateToProps } from '../../../components/content/LogContent'
 import { TransactionType } from '../../../unlock'
 import configure from '../../../config'
 

--- a/unlock-app/src/__tests__/components/content/LogContent.test.js
+++ b/unlock-app/src/__tests__/components/content/LogContent.test.js
@@ -33,17 +33,6 @@ const transactions = {
 }
 
 describe('Transaction Log', () => {
-  describe('humanize - make transaction types more readable', () => {
-    it('should correctly handle transaction types of various lengths', () => {
-      expect.assertions(3)
-      expect(humanize(TransactionType.LOCK_CREATION)).toEqual('Lock Creation')
-      expect(humanize(TransactionType.WITHDRAWAL)).toEqual('Withdrawal')
-      expect(humanize(TransactionType.UPDATE_KEY_PRICE)).toEqual(
-        'Update Key Price'
-      )
-    })
-  })
-
   describe('mapStateToProps', () => {
     const state = {
       account: {},
@@ -59,11 +48,10 @@ describe('Transaction Log', () => {
       expect(transactionFeed[1].blockNumber).toEqual(2)
       expect(transactionFeed[2].blockNumber).toEqual(1)
     })
-    it('should include href to explorer and readable name in the feed', () => {
-      expect.assertions(2)
+    it('should include href to explorer in the feed', () => {
+      expect.assertions(1)
       const tx = transactionFeed[0]
       expect(tx).toHaveProperty('href')
-      expect(tx).toHaveProperty('readableName')
     })
   })
 })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -60531,7 +60531,7 @@ Object {
             </a>
             <div
               class="c33"
-              type="LOCK_CREATION"
+              type="Lock Creation"
             >
               Lock Creation
             </div>
@@ -60548,7 +60548,7 @@ Object {
             </a>
             <div
               class="c34"
-              type="UPDATE_KEY_PRICE"
+              type="Update Key Price"
             >
               Update Key Price
             </div>
@@ -60565,7 +60565,7 @@ Object {
             </a>
             <div
               class="c33"
-              type="LOCK_CREATION"
+              type="Lock Creation"
             >
               Lock Creation
             </div>
@@ -60977,7 +60977,7 @@ Object {
           </a>
           <div
             class="sc-14l6ji-2 sc-14l6ji-3 zafjW"
-            type="LOCK_CREATION"
+            type="Lock Creation"
           >
             Lock Creation
           </div>
@@ -60994,7 +60994,7 @@ Object {
           </a>
           <div
             class="sc-14l6ji-2 sc-14l6ji-3 fOybBE"
-            type="UPDATE_KEY_PRICE"
+            type="Update Key Price"
           >
             Update Key Price
           </div>
@@ -61011,7 +61011,7 @@ Object {
           </a>
           <div
             class="sc-14l6ji-2 sc-14l6ji-3 zafjW"
-            type="LOCK_CREATION"
+            type="Lock Creation"
           >
             Lock Creation
           </div>

--- a/unlock-app/src/components/content/LogContent.js
+++ b/unlock-app/src/components/content/LogContent.js
@@ -11,12 +11,6 @@ import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import { pageTitle } from '../../constants'
 import withConfig from '../../utils/withConfig'
 
-export const humanize = type => {
-  if (!type) return ''
-  let parts = type.split('_')
-  return parts.map(part => part[0] + part.slice(1).toLowerCase()).join(' ')
-}
-
 export const LogContent = ({ account, network, transactionFeed }) => {
   return (
     <GlobalErrorConsumer>
@@ -37,7 +31,7 @@ export const LogContent = ({ account, network, transactionFeed }) => {
                   <Address href={tx.href} target="_blank">
                     {tx.lock}
                   </Address>
-                  <Type type={tx.type}>{tx.readableName}</Type>
+                  <Type type={tx.type}>{tx.type}</Type>
                 </React.Fragment>
               ))}
             </Content>
@@ -83,7 +77,7 @@ const LogElement = styled.div`
 
 // TODO: determine which transaction types get which color
 const typeColors = {
-  LOCK_CREATION: 'green',
+  'Lock Creation': 'green',
 }
 
 const Type = styled(LogElement)`
@@ -108,7 +102,6 @@ export const mapStateToProps = (
   transactionFeed.forEach((tx, i) => {
     transactionFeed[i].href =
       chainExplorerUrlBuilders.etherScan(tx.lock) || undefined
-    transactionFeed[i].readableName = humanize(tx.type)
   })
 
   return {

--- a/unlock-app/src/unlock.ts
+++ b/unlock-app/src/unlock.ts
@@ -2,10 +2,10 @@
 // throughout unlock-app.
 
 export enum TransactionType {
-  LOCK_CREATION = 'LOCK_CREATION',
-  KEY_PURCHASE  = 'KEY_PURCHASE',
-  WITHDRAWAL    = 'WITHDRAWAL',
-  UPDATE_KEY_PRICE = 'UPDATE_KEY_PRICE',
+  LOCK_CREATION = 'Lock Creation',
+  KEY_PURCHASE  = 'Key Purchase',
+  WITHDRAWAL    = 'Withdrawal',
+  UPDATE_KEY_PRICE = 'Update Key Price',
 }
 
 export interface Transaction {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR changes the values of the `TransactionType` enum to be nicer looking strings. For example,
```
'LOCK_CREATION' => 'Lock Creation'
```
Because of this change, the `humanize` function in `LogContent` is superfluous, so it has been removed along with its tests. Additionally, an update was made so that the correct color for the transaction type can still be selected given this change. This PR smooths the road for #2224.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2247 
Refs #2238 **This one may need to be updated, since it duplicates the TransactionType (hopefully temporarily)**

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
