### PR TITLE
Paywall: redirect to content if requested

### DIFF
--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -215,6 +215,18 @@ describe('Paywall', () => {
     })
   })
 
+  describe('on unlocking', () => {
+    it('should redirect if requested', () => {
+      expect.assertions(1)
+
+      rtl.act(() => {
+        renderMockPaywall({ locked: false, redirect: 'http://example.com' })
+      })
+
+      expect(fakeWindow.location.href).toBe('http://example.com')
+    })
+  })
+
   describe('the unlocked flag', () => {
     it('should be present when the paywall is unlocked', () => {
       expect.assertions(1)

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -31,6 +31,9 @@ export function Paywall({ locks, locked, redirect }) {
       postMessage(POST_MESSAGE_LOCKED)
     } else {
       postMessage(POST_MESSAGE_UNLOCKED)
+      if (redirect) {
+        window.location.href = redirect
+      }
       const height = '160px'
       const body = window.document.body
       body.style.margin = '0'


### PR DESCRIPTION
# Description

This PR restores the missing behavior of redirecting back to content after purchase. More importantly, it adds a regression test that ensures this will never be removed again!

<img width="1651" alt="Screen Shot 2019-03-21 at 11 12 21 AM" src="https://user-images.githubusercontent.com/98250/54762418-7a5e7b00-4bca-11e9-8b58-4a38f4f3e8b8.png">
<img width="1651" alt="Screen Shot 2019-03-21 at 11 12 05 AM" src="https://user-images.githubusercontent.com/98250/54762419-7a5e7b00-4bca-11e9-8568-66095b3d656e.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2251

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
