### PR TITLE
remove icons from footer of paywall landing page

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2048,98 +2048,12 @@ exports[`Storyshots Footer the footer 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c2 {
-  background-color: var(--grey);
-  cursor: pointer;
-  border-radius: 50%;
-  height: 24px;
-  width: 24px;
-  display: inline-block;
-  padding: 0;
-  border: 0;
-  line-height: 24px;
-}
-
-.c2 > svg {
-  fill: white;
-  height: 24px;
-  width: 24px;
-}
-
-.c2:hover {
-  background-color: var(--link);
-}
-
-.c2:hover > svg {
-  fill: white;
-}
-
-.c3 {
-  display: none;
-  position: relative;
-  z-index: var(--alwaysontop);
-  white-space: nowrap;
-  font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
-  font-weight: 400;
-  font-size: 12px;
-  left: 50%;
-  -webkit-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
-  transform: translateX(-50%);
-  color: var(--link);
-}
-
-.c1:hover .c3 {
-  display: inline-block;
-}
-
-.c5 .c1 {
-  background-color: var(--white);
-  -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
-  transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
-  opacity: 1;
-  pointer-events: visible;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c5 .c1:nth-child(1) {
-  pointer-events: none;
-}
-
-.c5 .c1:nth-child(2) {
-  pointer-events: none;
-  display: none;
-}
-
-.c5 .c1 > svg {
-  fill: var(--grey);
-}
-
-.c5 .c1:hover > svg {
-  fill: var(--grey);
-}
-
-.c6 .c1 {
-  margin: 24px;
-}
-
-.c6 .c1 small {
-  display: block;
-  color: var(--grey);
-  text-align: center;
-  top: 5px;
-  width: 100%;
-  text-align: center;
-}
-
-.c0 {
+    .c0 {
   margin-top: 24px;
   margin-bottom: 24px;
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: repeat(3,24px) 1fr;
+  grid-template-columns: 1fr;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2147,7 +2061,7 @@ Object {
   align-items: center;
 }
 
-.c4 {
+.c1 {
   justify-self: end;
   font-size: 12px;
   font-weight: 200;
@@ -2163,95 +2077,8 @@ Object {
       <footer
         class="c0"
       >
-        <a
-          class="c1 c2"
-          href="/about"
-          title="About"
-        >
-          <svg
-            viewBox="0 0 24 24"
-          >
-            <title>
-              About
-            </title>
-            <path
-              clip-rule="evenodd"
-              d="M12 8.4A1.2 1.2 0 1 0 12 6a1.2 1.2 0 0 0 0 2.4zm0 9.6a1 1 0 0 0 1-1v-6a1 1 0 1 0-2 0v6a1 1 0 0 0 1 1z"
-              fill-rule="evenodd"
-            />
-          </svg>
-          <small
-            class="c3"
-          >
-            About
-          </small>
-        </a>
-        <a
-          class="c1 c2"
-          href="/jobs"
-          title="Join us"
-        >
-          <svg
-            name="Jobs"
-            viewBox="0 0 24 24"
-          >
-            <title />
-            <path
-              clip-rule="evenodd"
-              d="M13 5h-2a2 2 0 0 0-2 2H7a2 2 0 0 0-2 2v1h14V9a2 2 0 0 0-2-2h-2a2 2 0 0 0-2-2zm1 2a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1h4zm-9 4h14v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-4z"
-              fill-rule="evenodd"
-            />
-          </svg>
-          <small
-            class="c3"
-          >
-            Join us
-          </small>
-        </a>
-        <a
-          class="c1 c2"
-          href="https://github.com/unlock-protocol/unlock"
-          title="Source Code"
-        >
-          <svg
-            name="Github"
-            viewBox="0 0 24 24"
-          >
-            <title />
-            <path
-              d="M9.021 21.829c.007 1.065.017 2.171.017 2.171h6.136c0-.419.016-1.795.016-3.502 0-1.191-.397-1.97-.84-2.364 2.756-.316 5.65-1.396 5.65-6.3 0-1.394-.479-2.533-1.272-3.426.127-.323.552-1.62-.123-3.378 0 0-1.038-.344-3.4 1.308a11.554 11.554 0 0 0-3.099-.43c-1.053.006-2.11.147-3.098.43C6.644 4.686 5.604 5.03 5.604 5.03c-.673 1.757-.248 3.055-.12 3.378-.793.893-1.275 2.032-1.275 3.426 0 4.892 2.89 5.987 5.638 6.31-.354.319-.674.881-.786 1.706-.706.327-2.498.89-3.602-1.06 0 0-.654-1.226-1.896-1.316 0 0-1.209-.016-.085.776 0 0 .812.393 1.374 1.867 0 0 .726 2.483 4.17 1.712z"
-            />
-          </svg>
-          <small
-            class="c3"
-          >
-            Source Code
-          </small>
-        </a>
-        <a
-          class="c1 c2"
-          href="https://t.me/unlockprotocol"
-          title="Telegram"
-        >
-          <svg
-            name="Telegram"
-            viewBox="0 0 24 24"
-          >
-            <title />
-            <path
-              clip-rule="evenodd"
-              d="M16.801 5.065c.152.13.217.292.195.487L15.144 16.7a.482.482 0 0 1-.227.325.953.953 0 0 1-.228.033.613.613 0 0 1-.195-.033l-3.281-1.332-1.755 2.144a.433.433 0 0 1-.357.163.361.361 0 0 1-.163-.032.409.409 0 0 1-.227-.163c-.065-.087-.087-.173-.065-.26V15.01l6.27-7.702-7.764 6.727-2.86-1.17c-.173-.065-.27-.206-.292-.422 0-.174.076-.315.227-.423l12.087-6.955A.4.4 0 0 1 16.54 5c.087 0 .173.022.26.065z"
-              fill-rule="evenodd"
-            />
-          </svg>
-          <small
-            class="c3"
-          >
-            Telegram
-          </small>
-        </a>
         <span
-          class="c4"
+          class="c1"
         >
           Made with passion in Brooklyn, NY
         </span>
@@ -2264,95 +2091,8 @@ Object {
       rel="stylesheet"
     />
     <footer
-      class="sc-1cn8ycr-0 kFVsfB"
+      class="sc-1cn8ycr-0 cwQrML"
     >
-      <a
-        class="is925m-0 lnZuor"
-        href="/about"
-        title="About"
-      >
-        <svg
-          viewBox="0 0 24 24"
-        >
-          <title>
-            About
-          </title>
-          <path
-            clip-rule="evenodd"
-            d="M12 8.4A1.2 1.2 0 1 0 12 6a1.2 1.2 0 0 0 0 2.4zm0 9.6a1 1 0 0 0 1-1v-6a1 1 0 1 0-2 0v6a1 1 0 0 0 1 1z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <small
-          class="is925m-1 dHyZKY"
-        >
-          About
-        </small>
-      </a>
-      <a
-        class="is925m-0 lnZuor"
-        href="/jobs"
-        title="Join us"
-      >
-        <svg
-          name="Jobs"
-          viewBox="0 0 24 24"
-        >
-          <title />
-          <path
-            clip-rule="evenodd"
-            d="M13 5h-2a2 2 0 0 0-2 2H7a2 2 0 0 0-2 2v1h14V9a2 2 0 0 0-2-2h-2a2 2 0 0 0-2-2zm1 2a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1h4zm-9 4h14v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-4z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <small
-          class="is925m-1 dHyZKY"
-        >
-          Join us
-        </small>
-      </a>
-      <a
-        class="is925m-0 lnZuor"
-        href="https://github.com/unlock-protocol/unlock"
-        title="Source Code"
-      >
-        <svg
-          name="Github"
-          viewBox="0 0 24 24"
-        >
-          <title />
-          <path
-            d="M9.021 21.829c.007 1.065.017 2.171.017 2.171h6.136c0-.419.016-1.795.016-3.502 0-1.191-.397-1.97-.84-2.364 2.756-.316 5.65-1.396 5.65-6.3 0-1.394-.479-2.533-1.272-3.426.127-.323.552-1.62-.123-3.378 0 0-1.038-.344-3.4 1.308a11.554 11.554 0 0 0-3.099-.43c-1.053.006-2.11.147-3.098.43C6.644 4.686 5.604 5.03 5.604 5.03c-.673 1.757-.248 3.055-.12 3.378-.793.893-1.275 2.032-1.275 3.426 0 4.892 2.89 5.987 5.638 6.31-.354.319-.674.881-.786 1.706-.706.327-2.498.89-3.602-1.06 0 0-.654-1.226-1.896-1.316 0 0-1.209-.016-.085.776 0 0 .812.393 1.374 1.867 0 0 .726 2.483 4.17 1.712z"
-          />
-        </svg>
-        <small
-          class="is925m-1 dHyZKY"
-        >
-          Source Code
-        </small>
-      </a>
-      <a
-        class="is925m-0 lnZuor"
-        href="https://t.me/unlockprotocol"
-        title="Telegram"
-      >
-        <svg
-          name="Telegram"
-          viewBox="0 0 24 24"
-        >
-          <title />
-          <path
-            clip-rule="evenodd"
-            d="M16.801 5.065c.152.13.217.292.195.487L15.144 16.7a.482.482 0 0 1-.227.325.953.953 0 0 1-.228.033.613.613 0 0 1-.195-.033l-3.281-1.332-1.755 2.144a.433.433 0 0 1-.357.163.361.361 0 0 1-.163-.032.409.409 0 0 1-.227-.163c-.065-.087-.087-.173-.065-.26V15.01l6.27-7.702-7.764 6.727-2.86-1.17c-.173-.065-.27-.206-.292-.422 0-.174.076-.315.227-.423l12.087-6.955A.4.4 0 0 1 16.54 5c.087 0 .173.022.26.065z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <small
-          class="is925m-1 dHyZKY"
-        >
-          Telegram
-        </small>
-      </a>
       <span
         class="sc-1cn8ycr-1 fAigks"
       >
@@ -3231,7 +2971,7 @@ Object {
   margin-bottom: 24px;
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: repeat(3,24px) 1fr;
+  grid-template-columns: 1fr;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3724,93 +3464,6 @@ Object {
           <footer
             class="c23"
           >
-            <a
-              class="c9 c10"
-              href="/about"
-              title="About"
-            >
-              <svg
-                viewBox="0 0 24 24"
-              >
-                <title>
-                  About
-                </title>
-                <path
-                  clip-rule="evenodd"
-                  d="M12 8.4A1.2 1.2 0 1 0 12 6a1.2 1.2 0 0 0 0 2.4zm0 9.6a1 1 0 0 0 1-1v-6a1 1 0 1 0-2 0v6a1 1 0 0 0 1 1z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                About
-              </small>
-            </a>
-            <a
-              class="c9 c10"
-              href="/jobs"
-              title="Join us"
-            >
-              <svg
-                name="Jobs"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  clip-rule="evenodd"
-                  d="M13 5h-2a2 2 0 0 0-2 2H7a2 2 0 0 0-2 2v1h14V9a2 2 0 0 0-2-2h-2a2 2 0 0 0-2-2zm1 2a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1h4zm-9 4h14v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-4z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                Join us
-              </small>
-            </a>
-            <a
-              class="c9 c10"
-              href="https://github.com/unlock-protocol/unlock"
-              title="Source Code"
-            >
-              <svg
-                name="Github"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  d="M9.021 21.829c.007 1.065.017 2.171.017 2.171h6.136c0-.419.016-1.795.016-3.502 0-1.191-.397-1.97-.84-2.364 2.756-.316 5.65-1.396 5.65-6.3 0-1.394-.479-2.533-1.272-3.426.127-.323.552-1.62-.123-3.378 0 0-1.038-.344-3.4 1.308a11.554 11.554 0 0 0-3.099-.43c-1.053.006-2.11.147-3.098.43C6.644 4.686 5.604 5.03 5.604 5.03c-.673 1.757-.248 3.055-.12 3.378-.793.893-1.275 2.032-1.275 3.426 0 4.892 2.89 5.987 5.638 6.31-.354.319-.674.881-.786 1.706-.706.327-2.498.89-3.602-1.06 0 0-.654-1.226-1.896-1.316 0 0-1.209-.016-.085.776 0 0 .812.393 1.374 1.867 0 0 .726 2.483 4.17 1.712z"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                Source Code
-              </small>
-            </a>
-            <a
-              class="c9 c10"
-              href="https://t.me/unlockprotocol"
-              title="Telegram"
-            >
-              <svg
-                name="Telegram"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  clip-rule="evenodd"
-                  d="M16.801 5.065c.152.13.217.292.195.487L15.144 16.7a.482.482 0 0 1-.227.325.953.953 0 0 1-.228.033.613.613 0 0 1-.195-.033l-3.281-1.332-1.755 2.144a.433.433 0 0 1-.357.163.361.361 0 0 1-.163-.032.409.409 0 0 1-.227-.163c-.065-.087-.087-.173-.065-.26V15.01l6.27-7.702-7.764 6.727-2.86-1.17c-.173-.065-.27-.206-.292-.422 0-.174.076-.315.227-.423l12.087-6.955A.4.4 0 0 1 16.54 5c.087 0 .173.022.26.065z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                Telegram
-              </small>
-            </a>
             <span
               class="c24"
             >
@@ -4115,95 +3768,8 @@ Object {
           </div>
         </section>
         <footer
-          class="sc-1cn8ycr-0 kFVsfB"
+          class="sc-1cn8ycr-0 cwQrML"
         >
-          <a
-            class="is925m-0 lnZuor"
-            href="/about"
-            title="About"
-          >
-            <svg
-              viewBox="0 0 24 24"
-            >
-              <title>
-                About
-              </title>
-              <path
-                clip-rule="evenodd"
-                d="M12 8.4A1.2 1.2 0 1 0 12 6a1.2 1.2 0 0 0 0 2.4zm0 9.6a1 1 0 0 0 1-1v-6a1 1 0 1 0-2 0v6a1 1 0 0 0 1 1z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              About
-            </small>
-          </a>
-          <a
-            class="is925m-0 lnZuor"
-            href="/jobs"
-            title="Join us"
-          >
-            <svg
-              name="Jobs"
-              viewBox="0 0 24 24"
-            >
-              <title />
-              <path
-                clip-rule="evenodd"
-                d="M13 5h-2a2 2 0 0 0-2 2H7a2 2 0 0 0-2 2v1h14V9a2 2 0 0 0-2-2h-2a2 2 0 0 0-2-2zm1 2a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1h4zm-9 4h14v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-4z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              Join us
-            </small>
-          </a>
-          <a
-            class="is925m-0 lnZuor"
-            href="https://github.com/unlock-protocol/unlock"
-            title="Source Code"
-          >
-            <svg
-              name="Github"
-              viewBox="0 0 24 24"
-            >
-              <title />
-              <path
-                d="M9.021 21.829c.007 1.065.017 2.171.017 2.171h6.136c0-.419.016-1.795.016-3.502 0-1.191-.397-1.97-.84-2.364 2.756-.316 5.65-1.396 5.65-6.3 0-1.394-.479-2.533-1.272-3.426.127-.323.552-1.62-.123-3.378 0 0-1.038-.344-3.4 1.308a11.554 11.554 0 0 0-3.099-.43c-1.053.006-2.11.147-3.098.43C6.644 4.686 5.604 5.03 5.604 5.03c-.673 1.757-.248 3.055-.12 3.378-.793.893-1.275 2.032-1.275 3.426 0 4.892 2.89 5.987 5.638 6.31-.354.319-.674.881-.786 1.706-.706.327-2.498.89-3.602-1.06 0 0-.654-1.226-1.896-1.316 0 0-1.209-.016-.085.776 0 0 .812.393 1.374 1.867 0 0 .726 2.483 4.17 1.712z"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              Source Code
-            </small>
-          </a>
-          <a
-            class="is925m-0 lnZuor"
-            href="https://t.me/unlockprotocol"
-            title="Telegram"
-          >
-            <svg
-              name="Telegram"
-              viewBox="0 0 24 24"
-            >
-              <title />
-              <path
-                clip-rule="evenodd"
-                d="M16.801 5.065c.152.13.217.292.195.487L15.144 16.7a.482.482 0 0 1-.227.325.953.953 0 0 1-.228.033.613.613 0 0 1-.195-.033l-3.281-1.332-1.755 2.144a.433.433 0 0 1-.357.163.361.361 0 0 1-.163-.032.409.409 0 0 1-.227-.163c-.065-.087-.087-.173-.065-.26V15.01l6.27-7.702-7.764 6.727-2.86-1.17c-.173-.065-.27-.206-.292-.422 0-.174.076-.315.227-.423l12.087-6.955A.4.4 0 0 1 16.54 5c.087 0 .173.022.26.065z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              Telegram
-            </small>
-          </a>
           <span
             class="sc-1cn8ycr-1 fAigks"
           >
@@ -4467,7 +4033,7 @@ Object {
   margin-bottom: 24px;
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: repeat(3,24px) 1fr;
+  grid-template-columns: 1fr;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4748,93 +4314,6 @@ Object {
           <footer
             class="c15"
           >
-            <a
-              class="c9 c10"
-              href="/about"
-              title="About"
-            >
-              <svg
-                viewBox="0 0 24 24"
-              >
-                <title>
-                  About
-                </title>
-                <path
-                  clip-rule="evenodd"
-                  d="M12 8.4A1.2 1.2 0 1 0 12 6a1.2 1.2 0 0 0 0 2.4zm0 9.6a1 1 0 0 0 1-1v-6a1 1 0 1 0-2 0v6a1 1 0 0 0 1 1z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                About
-              </small>
-            </a>
-            <a
-              class="c9 c10"
-              href="/jobs"
-              title="Join us"
-            >
-              <svg
-                name="Jobs"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  clip-rule="evenodd"
-                  d="M13 5h-2a2 2 0 0 0-2 2H7a2 2 0 0 0-2 2v1h14V9a2 2 0 0 0-2-2h-2a2 2 0 0 0-2-2zm1 2a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1h4zm-9 4h14v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-4z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                Join us
-              </small>
-            </a>
-            <a
-              class="c9 c10"
-              href="https://github.com/unlock-protocol/unlock"
-              title="Source Code"
-            >
-              <svg
-                name="Github"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  d="M9.021 21.829c.007 1.065.017 2.171.017 2.171h6.136c0-.419.016-1.795.016-3.502 0-1.191-.397-1.97-.84-2.364 2.756-.316 5.65-1.396 5.65-6.3 0-1.394-.479-2.533-1.272-3.426.127-.323.552-1.62-.123-3.378 0 0-1.038-.344-3.4 1.308a11.554 11.554 0 0 0-3.099-.43c-1.053.006-2.11.147-3.098.43C6.644 4.686 5.604 5.03 5.604 5.03c-.673 1.757-.248 3.055-.12 3.378-.793.893-1.275 2.032-1.275 3.426 0 4.892 2.89 5.987 5.638 6.31-.354.319-.674.881-.786 1.706-.706.327-2.498.89-3.602-1.06 0 0-.654-1.226-1.896-1.316 0 0-1.209-.016-.085.776 0 0 .812.393 1.374 1.867 0 0 .726 2.483 4.17 1.712z"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                Source Code
-              </small>
-            </a>
-            <a
-              class="c9 c10"
-              href="https://t.me/unlockprotocol"
-              title="Telegram"
-            >
-              <svg
-                name="Telegram"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  clip-rule="evenodd"
-                  d="M16.801 5.065c.152.13.217.292.195.487L15.144 16.7a.482.482 0 0 1-.227.325.953.953 0 0 1-.228.033.613.613 0 0 1-.195-.033l-3.281-1.332-1.755 2.144a.433.433 0 0 1-.357.163.361.361 0 0 1-.163-.032.409.409 0 0 1-.227-.163c-.065-.087-.087-.173-.065-.26V15.01l6.27-7.702-7.764 6.727-2.86-1.17c-.173-.065-.27-.206-.292-.422 0-.174.076-.315.227-.423l12.087-6.955A.4.4 0 0 1 16.54 5c.087 0 .173.022.26.065z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                Telegram
-              </small>
-            </a>
             <span
               class="c16"
             >
@@ -5021,95 +4500,8 @@ Object {
           />
         </header>
         <footer
-          class="sc-1cn8ycr-0 kFVsfB"
+          class="sc-1cn8ycr-0 cwQrML"
         >
-          <a
-            class="is925m-0 lnZuor"
-            href="/about"
-            title="About"
-          >
-            <svg
-              viewBox="0 0 24 24"
-            >
-              <title>
-                About
-              </title>
-              <path
-                clip-rule="evenodd"
-                d="M12 8.4A1.2 1.2 0 1 0 12 6a1.2 1.2 0 0 0 0 2.4zm0 9.6a1 1 0 0 0 1-1v-6a1 1 0 1 0-2 0v6a1 1 0 0 0 1 1z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              About
-            </small>
-          </a>
-          <a
-            class="is925m-0 lnZuor"
-            href="/jobs"
-            title="Join us"
-          >
-            <svg
-              name="Jobs"
-              viewBox="0 0 24 24"
-            >
-              <title />
-              <path
-                clip-rule="evenodd"
-                d="M13 5h-2a2 2 0 0 0-2 2H7a2 2 0 0 0-2 2v1h14V9a2 2 0 0 0-2-2h-2a2 2 0 0 0-2-2zm1 2a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1h4zm-9 4h14v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-4z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              Join us
-            </small>
-          </a>
-          <a
-            class="is925m-0 lnZuor"
-            href="https://github.com/unlock-protocol/unlock"
-            title="Source Code"
-          >
-            <svg
-              name="Github"
-              viewBox="0 0 24 24"
-            >
-              <title />
-              <path
-                d="M9.021 21.829c.007 1.065.017 2.171.017 2.171h6.136c0-.419.016-1.795.016-3.502 0-1.191-.397-1.97-.84-2.364 2.756-.316 5.65-1.396 5.65-6.3 0-1.394-.479-2.533-1.272-3.426.127-.323.552-1.62-.123-3.378 0 0-1.038-.344-3.4 1.308a11.554 11.554 0 0 0-3.099-.43c-1.053.006-2.11.147-3.098.43C6.644 4.686 5.604 5.03 5.604 5.03c-.673 1.757-.248 3.055-.12 3.378-.793.893-1.275 2.032-1.275 3.426 0 4.892 2.89 5.987 5.638 6.31-.354.319-.674.881-.786 1.706-.706.327-2.498.89-3.602-1.06 0 0-.654-1.226-1.896-1.316 0 0-1.209-.016-.085.776 0 0 .812.393 1.374 1.867 0 0 .726 2.483 4.17 1.712z"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              Source Code
-            </small>
-          </a>
-          <a
-            class="is925m-0 lnZuor"
-            href="https://t.me/unlockprotocol"
-            title="Telegram"
-          >
-            <svg
-              name="Telegram"
-              viewBox="0 0 24 24"
-            >
-              <title />
-              <path
-                clip-rule="evenodd"
-                d="M16.801 5.065c.152.13.217.292.195.487L15.144 16.7a.482.482 0 0 1-.227.325.953.953 0 0 1-.228.033.613.613 0 0 1-.195-.033l-3.281-1.332-1.755 2.144a.433.433 0 0 1-.357.163.361.361 0 0 1-.163-.032.409.409 0 0 1-.227-.163c-.065-.087-.087-.173-.065-.26V15.01l6.27-7.702-7.764 6.727-2.86-1.17c-.173-.065-.27-.206-.292-.422 0-.174.076-.315.227-.423l12.087-6.955A.4.4 0 0 1 16.54 5c.087 0 .173.022.26.065z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              Telegram
-            </small>
-          </a>
           <span
             class="sc-1cn8ycr-1 fAigks"
           >
@@ -10672,7 +10064,7 @@ Object {
   margin-bottom: 24px;
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: repeat(3,24px) 1fr;
+  grid-template-columns: 1fr;
   grid-auto-flow: column;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -11164,93 +10556,6 @@ Object {
           <footer
             class="c23"
           >
-            <a
-              class="c9 c10"
-              href="/about"
-              title="About"
-            >
-              <svg
-                viewBox="0 0 24 24"
-              >
-                <title>
-                  About
-                </title>
-                <path
-                  clip-rule="evenodd"
-                  d="M12 8.4A1.2 1.2 0 1 0 12 6a1.2 1.2 0 0 0 0 2.4zm0 9.6a1 1 0 0 0 1-1v-6a1 1 0 1 0-2 0v6a1 1 0 0 0 1 1z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                About
-              </small>
-            </a>
-            <a
-              class="c9 c10"
-              href="/jobs"
-              title="Join us"
-            >
-              <svg
-                name="Jobs"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  clip-rule="evenodd"
-                  d="M13 5h-2a2 2 0 0 0-2 2H7a2 2 0 0 0-2 2v1h14V9a2 2 0 0 0-2-2h-2a2 2 0 0 0-2-2zm1 2a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1h4zm-9 4h14v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-4z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                Join us
-              </small>
-            </a>
-            <a
-              class="c9 c10"
-              href="https://github.com/unlock-protocol/unlock"
-              title="Source Code"
-            >
-              <svg
-                name="Github"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  d="M9.021 21.829c.007 1.065.017 2.171.017 2.171h6.136c0-.419.016-1.795.016-3.502 0-1.191-.397-1.97-.84-2.364 2.756-.316 5.65-1.396 5.65-6.3 0-1.394-.479-2.533-1.272-3.426.127-.323.552-1.62-.123-3.378 0 0-1.038-.344-3.4 1.308a11.554 11.554 0 0 0-3.099-.43c-1.053.006-2.11.147-3.098.43C6.644 4.686 5.604 5.03 5.604 5.03c-.673 1.757-.248 3.055-.12 3.378-.793.893-1.275 2.032-1.275 3.426 0 4.892 2.89 5.987 5.638 6.31-.354.319-.674.881-.786 1.706-.706.327-2.498.89-3.602-1.06 0 0-.654-1.226-1.896-1.316 0 0-1.209-.016-.085.776 0 0 .812.393 1.374 1.867 0 0 .726 2.483 4.17 1.712z"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                Source Code
-              </small>
-            </a>
-            <a
-              class="c9 c10"
-              href="https://t.me/unlockprotocol"
-              title="Telegram"
-            >
-              <svg
-                name="Telegram"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  clip-rule="evenodd"
-                  d="M16.801 5.065c.152.13.217.292.195.487L15.144 16.7a.482.482 0 0 1-.227.325.953.953 0 0 1-.228.033.613.613 0 0 1-.195-.033l-3.281-1.332-1.755 2.144a.433.433 0 0 1-.357.163.361.361 0 0 1-.163-.032.409.409 0 0 1-.227-.163c-.065-.087-.087-.173-.065-.26V15.01l6.27-7.702-7.764 6.727-2.86-1.17c-.173-.065-.27-.206-.292-.422 0-.174.076-.315.227-.423l12.087-6.955A.4.4 0 0 1 16.54 5c.087 0 .173.022.26.065z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="c11"
-              >
-                Telegram
-              </small>
-            </a>
             <span
               class="c24"
             >
@@ -11555,95 +10860,8 @@ Object {
           </div>
         </section>
         <footer
-          class="sc-1cn8ycr-0 kFVsfB"
+          class="sc-1cn8ycr-0 cwQrML"
         >
-          <a
-            class="is925m-0 lnZuor"
-            href="/about"
-            title="About"
-          >
-            <svg
-              viewBox="0 0 24 24"
-            >
-              <title>
-                About
-              </title>
-              <path
-                clip-rule="evenodd"
-                d="M12 8.4A1.2 1.2 0 1 0 12 6a1.2 1.2 0 0 0 0 2.4zm0 9.6a1 1 0 0 0 1-1v-6a1 1 0 1 0-2 0v6a1 1 0 0 0 1 1z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              About
-            </small>
-          </a>
-          <a
-            class="is925m-0 lnZuor"
-            href="/jobs"
-            title="Join us"
-          >
-            <svg
-              name="Jobs"
-              viewBox="0 0 24 24"
-            >
-              <title />
-              <path
-                clip-rule="evenodd"
-                d="M13 5h-2a2 2 0 0 0-2 2H7a2 2 0 0 0-2 2v1h14V9a2 2 0 0 0-2-2h-2a2 2 0 0 0-2-2zm1 2a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1h4zm-9 4h14v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-4z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              Join us
-            </small>
-          </a>
-          <a
-            class="is925m-0 lnZuor"
-            href="https://github.com/unlock-protocol/unlock"
-            title="Source Code"
-          >
-            <svg
-              name="Github"
-              viewBox="0 0 24 24"
-            >
-              <title />
-              <path
-                d="M9.021 21.829c.007 1.065.017 2.171.017 2.171h6.136c0-.419.016-1.795.016-3.502 0-1.191-.397-1.97-.84-2.364 2.756-.316 5.65-1.396 5.65-6.3 0-1.394-.479-2.533-1.272-3.426.127-.323.552-1.62-.123-3.378 0 0-1.038-.344-3.4 1.308a11.554 11.554 0 0 0-3.099-.43c-1.053.006-2.11.147-3.098.43C6.644 4.686 5.604 5.03 5.604 5.03c-.673 1.757-.248 3.055-.12 3.378-.793.893-1.275 2.032-1.275 3.426 0 4.892 2.89 5.987 5.638 6.31-.354.319-.674.881-.786 1.706-.706.327-2.498.89-3.602-1.06 0 0-.654-1.226-1.896-1.316 0 0-1.209-.016-.085.776 0 0 .812.393 1.374 1.867 0 0 .726 2.483 4.17 1.712z"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              Source Code
-            </small>
-          </a>
-          <a
-            class="is925m-0 lnZuor"
-            href="https://t.me/unlockprotocol"
-            title="Telegram"
-          >
-            <svg
-              name="Telegram"
-              viewBox="0 0 24 24"
-            >
-              <title />
-              <path
-                clip-rule="evenodd"
-                d="M16.801 5.065c.152.13.217.292.195.487L15.144 16.7a.482.482 0 0 1-.227.325.953.953 0 0 1-.228.033.613.613 0 0 1-.195-.033l-3.281-1.332-1.755 2.144a.433.433 0 0 1-.357.163.361.361 0 0 1-.163-.032.409.409 0 0 1-.227-.163c-.065-.087-.087-.173-.065-.26V15.01l6.27-7.702-7.764 6.727-2.86-1.17c-.173-.065-.27-.206-.292-.422 0-.174.076-.315.227-.423l12.087-6.955A.4.4 0 0 1 16.54 5c.087 0 .173.022.26.065z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <small
-              class="is925m-1 dHyZKY"
-            >
-              Telegram
-            </small>
-          </a>
           <span
             class="sc-1cn8ycr-1 fAigks"
           >

--- a/paywall/src/components/interface/Footer.js
+++ b/paywall/src/components/interface/Footer.js
@@ -1,13 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import Buttons from './buttons/layout'
 
 const Footer = () => (
   <Container>
-    <Buttons.About />
-    <Buttons.Jobs />
-    <Buttons.Github />
-    <Buttons.Telegram />
     <Colophon>Made with passion in Brooklyn, NY</Colophon>
   </Container>
 )
@@ -19,7 +14,7 @@ const Container = styled.footer`
   margin-bottom: 24px;
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: repeat(3, 24px) 1fr;
+  grid-template-columns: 1fr;
   grid-auto-flow: column;
   align-items: center;
 `


### PR DESCRIPTION
# Description

This removes the icons from the footer of the paywall landing page

<img width="1651" alt="Screen Shot 2019-03-21 at 11 28 09 AM" src="https://user-images.githubusercontent.com/98250/54763695-cf9b8c00-4bcc-11e9-963d-8a35ed5c25f8.png">
<img width="1651" alt="Screen Shot 2019-03-21 at 11 27 52 AM" src="https://user-images.githubusercontent.com/98250/54763696-cf9b8c00-4bcc-11e9-92de-631e0a4b570e.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2248 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
