### PR TITLE
Pass the user account back to the paywall in the iframe on redirect

### DIFF
--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -216,11 +216,27 @@ describe('Paywall', () => {
   })
 
   describe('on unlocking', () => {
-    it('should redirect if requested', () => {
+    it('should redirect with account if requested', () => {
       expect.assertions(1)
 
       rtl.act(() => {
-        renderMockPaywall({ locked: false, redirect: 'http://example.com' })
+        renderMockPaywall({
+          locked: false,
+          redirect: 'http://example.com',
+          account: 'account',
+        })
+      })
+
+      expect(fakeWindow.location.href).toBe('http://example.com#account')
+    })
+    it('should redirect without account if requested', () => {
+      expect.assertions(1)
+
+      rtl.act(() => {
+        renderMockPaywall({
+          locked: false,
+          redirect: 'http://example.com',
+        })
       })
 
       expect(fakeWindow.location.href).toBe('http://example.com')

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -18,7 +18,7 @@ import {
 import { isPositiveNumber } from '../utils/validators'
 import useWindow from '../hooks/browser/useWindow'
 
-export function Paywall({ locks, locked, redirect }) {
+export function Paywall({ locks, locked, redirect, account }) {
   const window = useWindow()
   const scrollPosition = useListenForPostMessage({
     type: 'scrollPosition',
@@ -32,7 +32,8 @@ export function Paywall({ locks, locked, redirect }) {
     } else {
       postMessage(POST_MESSAGE_UNLOCKED)
       if (redirect) {
-        window.location.href = redirect
+        const withAccount = account ? '#' + account : ''
+        window.location.href = redirect + withAccount
       }
       const height = '160px'
       const body = window.document.body
@@ -66,13 +67,15 @@ Paywall.propTypes = {
   locks: PropTypes.arrayOf(UnlockPropTypes.lock).isRequired,
   locked: PropTypes.bool.isRequired,
   redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  account: PropTypes.string,
 }
 
 Paywall.defaultProps = {
   redirect: false,
+  account: null,
 }
 
-export const mapStateToProps = ({ locks, keys, modals, router }) => {
+export const mapStateToProps = ({ locks, keys, modals, router, account }) => {
   const { lockAddress, redirect } = lockRoute(router.location.pathname)
 
   const lockFromUri = Object.values(locks).find(
@@ -94,7 +97,12 @@ export const mapStateToProps = ({ locks, keys, modals, router }) => {
 
   const modalShown = !!modals[locksFromUri.map(l => l.address).join('-')]
   const locked = validKeys.length === 0 || modalShown
-  return { locked, locks: locksFromUri, redirect }
+  return {
+    locked,
+    locks: locksFromUri,
+    redirect,
+    account: account && account.address,
+  }
 }
 
 export default connect(mapStateToProps)(Paywall)


### PR DESCRIPTION
# Description

This is a follow-up PR to #2252 that ensures we pass the account back to the content so that the iframe can retrieve the purchased key on the lock.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2251 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
