### PR TITLE
Add a numerator to the refund penalty rate

### DIFF
--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -64,6 +64,8 @@ contract MixinRefunds is
     external
     onlyOwner
   {
+    require(_refundPenaltyDenominator != 0, 'INVALID_RATE');
+
     emit RefundPenaltyChanged(
       refundPenaltyNumerator,
       refundPenaltyDenominator,
@@ -112,14 +114,12 @@ contract MixinRefunds is
       // Math: using safeMul in case keyPrice or timeRemaining is very large
       refund = keyPrice.mul(timeRemaining) / expirationDuration;
     }
-    if (refundPenaltyDenominator > 0) {
-      uint penalty = keyPrice.mul(refundPenaltyNumerator) / refundPenaltyDenominator;
-      if (refund > penalty) {
-        // Math: safeSub is not required since the if confirms this won't underflow
-        refund -= penalty;
-      } else {
-        refund = 0;
-      }
+    uint penalty = keyPrice.mul(refundPenaltyNumerator) / refundPenaltyDenominator;
+    if (refund > penalty) {
+      // Math: safeSub is not required since the if confirms this won't underflow
+      refund -= penalty;
+    } else {
+      refund = 0;
     }
   }
 }

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -195,5 +195,9 @@ contract('Lock / cancelAndRefund', accounts => {
         'KEY_NOT_VALID'
       )
     })
+
+    it('attempt to set the denominator to 0', async () => {
+      await shouldFail(lock.updateRefundPenalty(1, 0), 'INVALID_RATE')
+    })
   })
 })

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -114,7 +114,7 @@ contract('Lock / disableLock', accounts => {
     })
 
     it('Lock owner can still updateRefundPenaltyDenominator', async () => {
-      await lock.updateRefundPenaltyDenominator(5)
+      await lock.updateRefundPenalty(5, 100)
     })
 
     it('should fail to setApprovalForAll', async () => {

--- a/smart-contracts/test/helpers/walletServiceMock.js
+++ b/smart-contracts/test/helpers/walletServiceMock.js
@@ -7,7 +7,7 @@
 module.exports = class WalletService {
   static gasAmountConstants() {
     return {
-      createLock: 3000000,
+      createLock: 4000000,
       updateKeyPrice: 1000000,
       purchaseKey: 1000000,
       cancelAndRefund: 1000000,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Adding a numerator to the refund penalty rate definition.  Previously just a denominator was used.

Making this change to be consistent with the transferFee rate.  Recommendation came from #2078 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #2078

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
