### PR TITLE
new integration tests for paywall in main window

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -6210,6 +6210,7 @@ Object {
           </div>
           <a
             class="c6 c7 c8"
+            id="Confirmed_0x123"
           >
             <svg
               class="c9 "
@@ -6283,6 +6284,7 @@ Object {
         </div>
         <a
           class="sc-1hzn3pu-2 ffRwyB is925m-0 kmZaWo"
+          id="Confirmed_0x123"
         >
           <svg
             class="sc-1hzn3pu-0 dozNUb"

--- a/paywall/src/components/lock/ConfirmedKeyLock.js
+++ b/paywall/src/components/lock/ConfirmedKeyLock.js
@@ -28,7 +28,11 @@ const ConfirmedKeyLock = ({ lock, hideModal }) => (
           </React.Fragment>
         )}
       />
-      <ConfirmedKey hideModal={hideModal} size="50px" />
+      <ConfirmedKey
+        hideModal={hideModal}
+        size="50px"
+        id={`Confirmed_${lock.address}`}
+      />
       <NotHoverFooter backgroundColor="var(--green)">
         Payment Confirmed
       </NotHoverFooter>

--- a/tests/test/paywall-in-main-window.test.js
+++ b/tests/test/paywall-in-main-window.test.js
@@ -51,7 +51,7 @@ describe('Paywall in main window', () => {
     await expect(page).toMatch('Example Domain')
   })
 
-  it('redirecting from purchased key when returning to paywall in main window', async () => {
+  it('returning to the main window redirects to content', async () => {
     await Promise.all([
       page.goto(paywall(`/${testLockAddress}/http%3A%2F%2Fexample.com`)),
       page.waitForNavigation(),

--- a/tests/test/paywall-in-main-window.test.js
+++ b/tests/test/paywall-in-main-window.test.js
@@ -1,0 +1,62 @@
+const { main, paywall } = require('../helpers/url')
+
+jest.setTimeout(30000)
+
+describe('Paywall in main window', () => {
+  const testLockAddress = '0x8276A24C03B7ff9307c5bb9c0f31aa60d284375f'
+
+  function lockSelector(name) {
+    return `#${name}_${testLockAddress}`
+  }
+
+  beforeAll(async () => {
+    // create a new lock using the creator dashboard
+    // TODO: design a convenience function that will create a lock for us
+    // to decouple this test from the creator dashboard
+    await page.goto(main('/dashboard'))
+    await page.waitForSelector('#UserAddress')
+    await page.waitFor('#CreateLockButton')
+    await expect(page).toClick('button', { text: 'Create Lock' })
+    await expect(page).toClick('button', { text: 'Submit' })
+    await page.waitFor(1000)
+    // wait for mining. ganache mines every second
+
+    await Promise.all([
+      page.goto(paywall(`/${testLockAddress}/http%3A%2F%2Fexample.com`)),
+      page.waitForNavigation(),
+    ])
+    await page.waitForSelector(lockSelector('Lock'))
+    await page.waitForFunction((ethPriceSelector) => {
+      const eth = document.querySelector(ethPriceSelector)
+      if (!eth) return false
+      return eth.innerText === '0.01 ETH'
+    }, {}, lockSelector('EthPrice'))
+  })
+
+  it('purchasing a key works', async () => {
+    await expect(page).toClick(lockSelector('PurchaseKey'))
+    await page.waitForFunction((footerSelector) => {
+      const footer = document.querySelector(footerSelector)
+      if (!footer) return false
+      return footer.innerText === 'Payment Pending'
+    }, {}, 'footer')
+  })
+
+  it('dismissing the modal redirects to http://example.com', async () => {
+    await page.waitForSelector(lockSelector('Confirmed'))
+    await Promise.all([
+      expect(page).toClick(lockSelector('Confirmed')),
+      page.waitForNavigation(),
+    ])
+    await expect(page).toMatch('Example Domain')
+  })
+
+  it('redirecting from purchased key when returning to paywall in main window', async () => {
+    await Promise.all([
+      page.goto(paywall(`/${testLockAddress}/http%3A%2F%2Fexample.com`)),
+      page.waitForNavigation(),
+    ])
+    await page.waitForNavigation()
+    await expect(page).toMatch('Example Domain')
+  })
+})


### PR DESCRIPTION
# Description

This integration test tests 3 important things:

1. purchasing a key in the main window of the paywall works
2. after dismissing the modal, it redirects to the main content
3. returning to the paywall with a purchased key automatically redirects to the main content.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #1884, Fixes #1887

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
