### PR TITLE
Displaying docker compose logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,10 @@ jobs:
           command: scripts/integration-tests.sh
       - store_artifacts:
           path: /tmp/screenshots
+      - run:
+          name: Log failing tests
+          command: ./scripts/docker-compose-log.sh
+          when: on_fail
 
   deploy-unlock-app-netlify:
     machine: true

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,7 @@
   "description": "Integration tests for Unlock",
   "main": "index.js",
   "scripts": {
-    "test": "jest --detectOpenHandles --runInBand",
+    "test": "jest --detectOpenHandles --runInBand --bail",
     "lint": "eslint .",
     "ci": "npm run lint && npm test"
   },

--- a/tests/test/paywall.test.js
+++ b/tests/test/paywall.test.js
@@ -40,7 +40,9 @@ describe.skip('The Unlock Paywall', () => {
     await page.waitForFunction(() => window.frames.length)
     const paywallIframe = page.mainFrame().childFrames()[0]
     await paywallIframe.waitForSelector('#Paywall_Headline')
-    const headlineLocation = await paywallIframe.evaluate(() => document.querySelector('#Paywall_Headline').getBoundingClientRect().top)
+    const headlineLocation = await paywallIframe.evaluate(
+      () => document.querySelector('#Paywall_Headline').getBoundingClientRect().top
+    )
     // paywall has grown to hide the content.
     // actual value of the headline is 45.390625
     // when scrolling has not happened, it is 270.39062


### PR DESCRIPTION
When the integration tests fail, it can be useful to look at the logs and be able to identify what
happened. (smart contracts being deployed... etc)


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread