### PR TITLE
retrieve keys immediately for users when their account is set

### DIFF
--- a/paywall/src/__tests__/middlewares/web3Middleware.test.js
+++ b/paywall/src/__tests__/middlewares/web3Middleware.test.js
@@ -355,7 +355,7 @@ describe('Lock middleware', () => {
       mockWeb3Service.getPastLockTransactions = jest.fn()
 
       const lock = '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9'
-      state.router.location.pathname = `/paywall/${lock}/`
+      state.router.location.pathname = `/${lock}/`
 
       const { invoke } = create()
 

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -175,8 +175,8 @@ export default function web3Middleware({ getState, dispatch }) {
           },
         } = getState()
 
-        const { lockAddress, prefix } = lockRoute(pathname)
-        if (lockAddress && prefix === 'paywall') {
+        const { lockAddress } = lockRoute(pathname)
+        if (lockAddress) {
           web3Service.getKeyByLockForOwner(lockAddress, action.account.address)
         }
       }


### PR DESCRIPTION
# Description

When web3Middleware was last synced from `unlock_app` to `paywall`, unfortunately a subtle bug was introduced. In `unlock_app`, the only place we need to retrieve keys is if we are on path `/paywall`, but in the paywall, it is on any path. This results in keys being fetched slower than they should be.

This corrects that regression, and fixes the test as well

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2243 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
