### PR TITLE
re-enabled the integration tests for the paywall

### DIFF
--- a/tests/test/paywall.test.js
+++ b/tests/test/paywall.test.js
@@ -1,8 +1,13 @@
 const url = require('../helpers/url').main
 
+// TODO: understand why this is needed... and probably get rid of it!
 jest.setTimeout(30000)
 
-describe.skip('The Unlock Paywall', () => {
+describe('The Unlock Paywall', () => {
+  // TODO Have more confidence that this address is the real lock address
+  // One way to achieve this is to actually start by explicitly deploying a lock, and using
+  // its address, rather than 'hope' that someone else deployed a lock at that address.
+  // This would also make tests faster because we can run them in parallel.
   const testLockAddress = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
 
   function lockSelector(name) {


### PR DESCRIPTION
Now that we know the tests were actually failing for a reason, we can re-enable these tests.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread