### PR TITLE
don't reset lock state when account is changed

### DIFF
--- a/paywall/src/__tests__/reducers/locksReducer.test.js
+++ b/paywall/src/__tests__/reducers/locksReducer.test.js
@@ -113,20 +113,18 @@ describe('locks reducer', () => {
 
   // Upon changing account, we need to clear the existing locks. The web3 middleware will
   // re-populate them
-  it('should clear the locks when receiving SET_ACCOUNT', () => {
+  it('should not clear the locks when receiving SET_ACCOUNT', () => {
     expect.assertions(1)
     const account = {}
+    const locks = {
+      [lock.address]: lock,
+    }
     expect(
-      reducer(
-        {
-          [lock.address]: lock,
-        },
-        {
-          type: SET_ACCOUNT,
-          account,
-        }
-      )
-    ).toBe(initialState)
+      reducer(locks, {
+        type: SET_ACCOUNT,
+        account,
+      })
+    ).toBe(locks)
   })
 
   describe('DELETE_LOCK', () => {

--- a/paywall/src/reducers/locksReducer.js
+++ b/paywall/src/reducers/locksReducer.js
@@ -8,12 +8,11 @@ import {
 import { DELETE_TRANSACTION } from '../actions/transaction'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
-import { SET_ACCOUNT } from '../actions/accounts'
 
 export const initialState = {}
 
 const locksReducer = (state = initialState, action) => {
-  if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
+  if ([SET_PROVIDER, SET_NETWORK].indexOf(action.type) > -1) {
     return initialState
   }
 


### PR DESCRIPTION
# Description

This PR fixes a race condition on the paywall. If the user account is set after the lock is retrieved from the chain, this causes the lock to disappear. Unlike in the dashboard app, locks are not coupled to the user account, and should not respond to changes.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2292

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
