### PR TITLE
Add lock creation form visibility to state

### DIFF
--- a/unlock-app/src/__tests__/actions/lockFormVisibility.test.ts
+++ b/unlock-app/src/__tests__/actions/lockFormVisibility.test.ts
@@ -1,0 +1,24 @@
+import {
+  showForm,
+  hideForm,
+  SHOW_FORM,
+  HIDE_FORM,
+} from '../../actions/lockFormVisibility'
+
+describe('Lock form visibility actions', () => {
+  it('should create an action to show the form', () => {
+    expect.assertions(1)
+    const expectedAction = {
+      type: SHOW_FORM,
+    }
+    expect(showForm()).toEqual(expectedAction)
+  })
+
+  it('should create an action to hide the form', () => {
+    expect.assertions(1)
+    const expectedAction = {
+      type: HIDE_FORM,
+    }
+    expect(hideForm()).toEqual(expectedAction)
+  })
+})

--- a/unlock-app/src/__tests__/reducers/lockFormVisibilityReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/lockFormVisibilityReducer.test.ts
@@ -2,6 +2,7 @@ import reducer, { initialState } from '../../reducers/lockFormVisibilityReducer'
 import { SHOW_FORM, HIDE_FORM } from '../../actions/lockFormVisibility'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
+import { SET_ACCOUNT } from '../../actions/accounts'
 
 describe('lock form visibility reducer', () => {
   it('should return the initial state', () => {
@@ -18,6 +19,12 @@ describe('lock form visibility reducer', () => {
   it('should return the initial state when receiving SET_NETWORK', () => {
     expect.assertions(1)
     expect(reducer({ visible: true }, { type: SET_NETWORK }))
+      .toEqual(initialState)
+  })
+
+  it('should return the initial state when receiving SET_ACCOUNT', () => {
+    expect.assertions(1)
+    expect(reducer({ visible: true }, { type: SET_ACCOUNT }))
       .toEqual(initialState)
   })
 

--- a/unlock-app/src/__tests__/reducers/lockFormVisibilityReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/lockFormVisibilityReducer.test.ts
@@ -1,0 +1,38 @@
+import reducer, { initialState } from '../../reducers/lockFormVisibilityReducer'
+import { SHOW_FORM, HIDE_FORM } from '../../actions/lockFormVisibility'
+import { SET_PROVIDER } from '../../actions/provider'
+import { SET_NETWORK } from '../../actions/network'
+
+describe('lock form visibility reducer', () => {
+  it('should return the initial state', () => {
+    expect.assertions(1)
+    expect(reducer(undefined, { type: 'aaa' })).toEqual(initialState)
+  })
+
+  it('should return the initial state when receiving SET_PROVIDER', () => {
+    expect.assertions(1)
+    expect(reducer({ showLockCreationForm: true }, { type: SET_PROVIDER }))
+      .toEqual(initialState)
+  })
+
+  it('should return the initial state when receiving SET_NETWORK', () => {
+    expect.assertions(1)
+    expect(reducer({ showLockCreationForm: true }, { type: SET_NETWORK }))
+      .toEqual(initialState)
+  })
+
+  it('should show the form', () => {
+    expect.assertions(1)
+    expect(reducer(initialState, { type: SHOW_FORM })).toEqual({
+      showLockCreationForm: true,
+    })
+  })
+
+  it('should hide the form', () => {
+    expect.assertions(1)
+    expect(reducer({ showLockCreationForm: true },
+                   { type: HIDE_FORM })).toEqual({
+      showLockCreationForm: false,
+    })
+  })
+})

--- a/unlock-app/src/__tests__/reducers/lockFormVisibilityReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/lockFormVisibilityReducer.test.ts
@@ -11,28 +11,28 @@ describe('lock form visibility reducer', () => {
 
   it('should return the initial state when receiving SET_PROVIDER', () => {
     expect.assertions(1)
-    expect(reducer({ showLockCreationForm: true }, { type: SET_PROVIDER }))
+    expect(reducer({ visible: true }, { type: SET_PROVIDER }))
       .toEqual(initialState)
   })
 
   it('should return the initial state when receiving SET_NETWORK', () => {
     expect.assertions(1)
-    expect(reducer({ showLockCreationForm: true }, { type: SET_NETWORK }))
+    expect(reducer({ visible: true }, { type: SET_NETWORK }))
       .toEqual(initialState)
   })
 
   it('should show the form', () => {
     expect.assertions(1)
     expect(reducer(initialState, { type: SHOW_FORM })).toEqual({
-      showLockCreationForm: true,
+      visible: true,
     })
   })
 
   it('should hide the form', () => {
     expect.assertions(1)
-    expect(reducer({ showLockCreationForm: true },
+    expect(reducer({ visible: true },
                    { type: HIDE_FORM })).toEqual({
-      showLockCreationForm: false,
+      visible: false,
     })
   })
 })

--- a/unlock-app/src/actions/lockFormVisibility.ts
+++ b/unlock-app/src/actions/lockFormVisibility.ts
@@ -1,0 +1,10 @@
+export const SHOW_FORM = 'formVisibility/ON'
+export const HIDE_FORM = 'formVisibility/OFF'
+
+export const showForm = () => ({
+  type: SHOW_FORM,
+})
+
+export const hideForm = () => ({
+  type: HIDE_FORM,
+})

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -41,6 +41,9 @@ import modalReducer, {
 import walletStatusReducer, {
   initialState as defaultWalletStatus,
 } from './reducers/walletStatusReducer'
+import lockFormVisibilityReducer, {
+  initialState as defaultLockFormVisibility,
+} from './reducers/lockFormVisibilityReducer'
 
 const config = configure()
 
@@ -62,6 +65,7 @@ export const createUnlockStore = (
     currency: currencyReducer,
     errors: errorsReducer,
     walletStatus: walletStatusReducer,
+    lockFormStatus: lockFormVisibilityReducer,
   }
 
   // Cleanup the defaultState to remove all null values so that we do not overwrite existing
@@ -86,6 +90,7 @@ export const createUnlockStore = (
       currency: defaultCurrency,
       errors: defaultError,
       walletStatus: defaultWalletStatus,
+      lockFormStatus: defaultLockFormVisibility,
     },
     {
       provider: Object.keys(config.providers)[0],

--- a/unlock-app/src/reducers/lockFormVisibilityReducer.ts
+++ b/unlock-app/src/reducers/lockFormVisibilityReducer.ts
@@ -5,7 +5,7 @@ import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 
 export const initialState = {
-  showLockCreationForm: false,
+  visible: false,
 }
 
 const lockFormVisibilityReducer = (state = initialState,
@@ -16,7 +16,7 @@ const lockFormVisibilityReducer = (state = initialState,
 
   if (action.type === SHOW_FORM) {
     return {
-      showLockCreationForm: true,
+      visible: true,
     }
   }
 

--- a/unlock-app/src/reducers/lockFormVisibilityReducer.ts
+++ b/unlock-app/src/reducers/lockFormVisibilityReducer.ts
@@ -1,0 +1,30 @@
+import { SHOW_FORM,
+         HIDE_FORM,
+} from '../actions/lockFormVisibility'
+import { SET_PROVIDER } from '../actions/provider'
+import { SET_NETWORK } from '../actions/network'
+
+export const initialState = {
+  showLockCreationForm: false,
+}
+
+const lockFormVisibilityReducer = (state = initialState,
+                                   action: { type: string }) => {
+  if ([SET_PROVIDER, SET_NETWORK].indexOf(action.type) > -1) {
+    return initialState
+  }
+
+  if (action.type === SHOW_FORM) {
+    return {
+      showLockCreationForm: true,
+    }
+  }
+
+  if (action.type === HIDE_FORM) {
+    return initialState
+  }
+
+  return state
+}
+
+export default lockFormVisibilityReducer

--- a/unlock-app/src/reducers/lockFormVisibilityReducer.ts
+++ b/unlock-app/src/reducers/lockFormVisibilityReducer.ts
@@ -3,6 +3,7 @@ import { SHOW_FORM,
 } from '../actions/lockFormVisibility'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
+import { SET_ACCOUNT } from '../actions/accounts'
 
 export const initialState = {
   visible: false,
@@ -10,7 +11,7 @@ export const initialState = {
 
 const lockFormVisibilityReducer = (state = initialState,
                                    action: { type: string }) => {
-  if ([SET_PROVIDER, SET_NETWORK].indexOf(action.type) > -1) {
+  if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
     return initialState
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
In order to make #1945 work, we need a way to communicate whether the lock creation form should open across components. This PR adds the actions and reducer necessary for the "Create Lock" button to do its thing  across pages.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
