### PR TITLE
Loading the transaction rather than loading all past transactions.

### DIFF
--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -331,17 +331,15 @@ describe('Lock middleware', () => {
     it('should handle SET_ACCOUNT by refreshing balance and retrieving historical unlock transactions', async () => {
       expect.assertions(4)
       const mockTx = {
-        returnValues: {
-          newLockAddress: '0x0',
-        },
+        transactionHash: '0x123',
       }
-      const lockCreationTransaction = Promise.resolve([mockTx])
       mockWeb3Service.refreshAccountBalance = jest.fn()
+      const lockCreationTransaction = Promise.resolve([mockTx])
       mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn(
         () => lockCreationTransaction
       )
       mockWeb3Service.getKeyByLockForOwner = jest.fn()
-      mockWeb3Service.getPastLockTransactions = jest.fn()
+      mockWeb3Service.getTransaction = jest.fn()
 
       const { invoke } = create()
 
@@ -356,9 +354,12 @@ describe('Lock middleware', () => {
       expect(
         mockWeb3Service.getPastLockCreationsTransactionsForUser
       ).toHaveBeenCalledWith(newAccount.address)
-      await lockCreationTransaction
       // We need to await this for the next assertion to work
-      expect(mockWeb3Service.getPastLockTransactions).toHaveBeenCalled()
+      await lockCreationTransaction
+
+      expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
+        mockTx.transactionHash
+      )
       expect(mockWeb3Service.getKeyByLockForOwner).not.toHaveBeenCalled()
     })
   })
@@ -367,9 +368,7 @@ describe('Lock middleware', () => {
     it('should handle SET_ACCOUNT by getting all keys for the owner of that account', async () => {
       expect.assertions(4)
       const mockTx = {
-        returnValues: {
-          newLockAddress: '0x0',
-        },
+        transactionHash: '0x123',
       }
       const lockCreationTransaction = Promise.resolve([mockTx])
       mockWeb3Service.refreshAccountBalance = jest.fn()
@@ -377,7 +376,7 @@ describe('Lock middleware', () => {
         () => lockCreationTransaction
       )
       mockWeb3Service.getKeyByLockForOwner = jest.fn()
-      mockWeb3Service.getPastLockTransactions = jest.fn()
+      mockWeb3Service.getTransaction = jest.fn()
 
       const lock = '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9'
       state.router.location.pathname = `/paywall/${lock}/`
@@ -395,7 +394,9 @@ describe('Lock middleware', () => {
       ).toHaveBeenCalled()
       // We need to await this for the next assertion to work
       await lockCreationTransaction
-      expect(mockWeb3Service.getPastLockTransactions).toHaveBeenCalled()
+      expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
+        mockTx.transactionHash
+      )
       expect(mockWeb3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
         lock,
         '0x345'

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -163,15 +163,8 @@ export default function web3Middleware({ getState, dispatch }) {
         web3Service
           .getPastLockCreationsTransactionsForUser(action.account.address)
           .then(lockCreations => {
-            // For each lock this user created, go get the history of
-            // interactions with that lock. TODO: Only get the lock interactions
-            // (such as key price update, withdrawals) done by the user. Very
-            // popular locks in the future may have thousands of key purchases,
-            // and we almost certainly don't want to pull them all down here.
             lockCreations.forEach(lockCreation => {
-              web3Service.getPastLockTransactions(
-                lockCreation.returnValues.newLockAddress
-              )
+              web3Service.getTransaction(lockCreation.transactionHash)
             })
           })
         const {


### PR DESCRIPTION
This a small improvment: it loads the lock creation transaction rather than loading all past lock
transactions. This allows for a slightly faster rendering of the UI, as well as saves 1 transaction per lock...


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread