### PR TITLE
pass transaction type to emission of transaction.pending

### DIFF
--- a/paywall/src/__tests__/services/walletService.test.js
+++ b/paywall/src/__tests__/services/walletService.test.js
@@ -15,6 +15,7 @@ import {
   FAILED_TO_UPDATE_KEY_PRICE,
   FAILED_TO_WITHDRAW_FROM_LOCK,
 } from '../../errors'
+import { TRANSACTION_TYPES } from '../../constants'
 
 jest.mock('../../utils/promises')
 
@@ -449,7 +450,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().createLock,
             contract: Unlock,
           },
-          expect.any(Function)
+          expect.any(Function),
+          TRANSACTION_TYPES.LOCK_CREATION
         )
       })
 
@@ -538,7 +540,8 @@ describe('WalletService', () => {
             contract: PublicLock,
             value: '100000000000000000000000000', // Web3Utils.toWei(keyPrice, 'ether')
           },
-          expect.any(Function)
+          expect.any(Function),
+          TRANSACTION_TYPES.KEY_PURCHASE
         )
       })
 
@@ -602,7 +605,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().updateKeyPrice,
             contract: PublicLock,
           },
-          expect.any(Function)
+          expect.any(Function),
+          TRANSACTION_TYPES.UPDATE_KEY_PRICE
         )
       })
 
@@ -728,7 +732,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().partialWithdrawFromLock,
             contract: PublicLock,
           },
-          expect.any(Function)
+          expect.any(Function),
+          TRANSACTION_TYPES.WITHDRAWAL
         )
       })
 
@@ -805,7 +810,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().withdrawFromLock,
             contract: PublicLock,
           },
-          expect.any(Function)
+          expect.any(Function),
+          TRANSACTION_TYPES.WITHDRAWAL
         )
       })
 

--- a/paywall/src/__tests__/services/walletService.test.js
+++ b/paywall/src/__tests__/services/walletService.test.js
@@ -323,6 +323,7 @@ describe('WalletService', () => {
 
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           () => {}
         )
 
@@ -337,12 +338,13 @@ describe('WalletService', () => {
 
       it('should trigger the transaction.pending event', done => {
         expect.assertions(1)
-        walletService.on('transaction.pending', () => {
-          expect(true).toBe(true)
+        walletService.on('transaction.pending', type => {
+          expect(type).toBe('type')
           done()
         })
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           () => {}
         )
       })
@@ -364,6 +366,7 @@ describe('WalletService', () => {
 
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           () => {}
         )
 
@@ -375,6 +378,7 @@ describe('WalletService', () => {
         const transactionHash = '0x123'
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           (error, hash) => {
             expect(hash).toEqual(transactionHash)
             done()
@@ -390,6 +394,7 @@ describe('WalletService', () => {
 
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           error => {
             expect(error).toBe(error)
             done()
@@ -450,8 +455,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().createLock,
             contract: Unlock,
           },
-          expect.any(Function),
-          TRANSACTION_TYPES.LOCK_CREATION
+          TRANSACTION_TYPES.LOCK_CREATION,
+          expect.any(Function)
         )
       })
 
@@ -459,7 +464,7 @@ describe('WalletService', () => {
         expect.assertions(2)
         const hash = '0x1213'
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(null, hash)
         })
 
@@ -478,7 +483,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -540,8 +545,8 @@ describe('WalletService', () => {
             contract: PublicLock,
             value: '100000000000000000000000000', // Web3Utils.toWei(keyPrice, 'ether')
           },
-          expect.any(Function),
-          TRANSACTION_TYPES.KEY_PURCHASE
+          TRANSACTION_TYPES.KEY_PURCHASE,
+          expect.any(Function)
         )
       })
 
@@ -549,7 +554,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -605,8 +610,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().updateKeyPrice,
             contract: PublicLock,
           },
-          expect.any(Function),
-          TRANSACTION_TYPES.UPDATE_KEY_PRICE
+          TRANSACTION_TYPES.UPDATE_KEY_PRICE,
+          expect.any(Function)
         )
       })
 
@@ -614,7 +619,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -732,8 +737,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().partialWithdrawFromLock,
             contract: PublicLock,
           },
-          expect.any(Function),
-          TRANSACTION_TYPES.WITHDRAWAL
+          TRANSACTION_TYPES.WITHDRAWAL,
+          expect.any(Function)
         )
       })
 
@@ -741,7 +746,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -757,7 +762,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = undefined
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -810,8 +815,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().withdrawFromLock,
             contract: PublicLock,
           },
-          expect.any(Function),
-          TRANSACTION_TYPES.WITHDRAWAL
+          TRANSACTION_TYPES.WITHDRAWAL,
+          expect.any(Function)
         )
       })
 
@@ -819,7 +824,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 

--- a/paywall/src/services/walletService.js
+++ b/paywall/src/services/walletService.js
@@ -12,6 +12,7 @@ import {
   FAILED_TO_UPDATE_KEY_PRICE,
   FAILED_TO_WITHDRAW_FROM_LOCK,
 } from '../errors'
+import { TRANSACTION_TYPES } from '../constants'
 
 export const keyId = (lock, owner) => [lock, owner].join('-')
 
@@ -139,7 +140,7 @@ export default class WalletService extends EventEmitter {
    * receipt... etc)
    * @private
    */
-  _sendTransaction({ to, from, data, value, gas }, callback) {
+  _sendTransaction({ to, from, data, value, gas }, callback, transactionType) {
     const web3TransactionPromise = this.web3.eth.sendTransaction({
       to,
       from,
@@ -148,7 +149,7 @@ export default class WalletService extends EventEmitter {
       gas,
     })
 
-    this.emit('transaction.pending')
+    this.emit('transaction.pending', transactionType)
 
     return web3TransactionPromise
       .once('transactionHash', hash => {
@@ -184,7 +185,8 @@ export default class WalletService extends EventEmitter {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_UPDATE_KEY_PRICE))
         }
-      }
+      },
+      TRANSACTION_TYPES.UPDATE_KEY_PRICE
     )
   }
 
@@ -223,7 +225,8 @@ export default class WalletService extends EventEmitter {
         // This is an exception because, until we are able to determine the lock address
         // before the transaction is mined, we need to link the lock and transaction.
         return this.emit('lock.updated', lock.address, { transaction: hash })
-      }
+      },
+      TRANSACTION_TYPES.LOCK_CREATION
     )
   }
 
@@ -258,7 +261,8 @@ export default class WalletService extends EventEmitter {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_PURCHASE_KEY))
         }
-      }
+      },
+      TRANSACTION_TYPES.KEY_PURCHASE
     )
   }
 
@@ -289,7 +293,8 @@ export default class WalletService extends EventEmitter {
           return callback(error)
         }
         return callback()
-      }
+      },
+      TRANSACTION_TYPES.WITHDRAWAL
     )
   }
 
@@ -315,7 +320,8 @@ export default class WalletService extends EventEmitter {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_WITHDRAW_FROM_LOCK))
         }
-      }
+      },
+      TRANSACTION_TYPES.WITHDRAWAL
     )
   }
 

--- a/paywall/src/services/walletService.js
+++ b/paywall/src/services/walletService.js
@@ -140,7 +140,7 @@ export default class WalletService extends EventEmitter {
    * receipt... etc)
    * @private
    */
-  _sendTransaction({ to, from, data, value, gas }, callback, transactionType) {
+  _sendTransaction({ to, from, data, value, gas }, transactionType, callback) {
     const web3TransactionPromise = this.web3.eth.sendTransaction({
       to,
       from,
@@ -181,12 +181,12 @@ export default class WalletService extends EventEmitter {
         gas: WalletService.gasAmountConstants().updateKeyPrice,
         contract: PublicLock,
       },
+      TRANSACTION_TYPES.UPDATE_KEY_PRICE,
       error => {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_UPDATE_KEY_PRICE))
         }
-      },
-      TRANSACTION_TYPES.UPDATE_KEY_PRICE
+      }
     )
   }
 
@@ -217,6 +217,7 @@ export default class WalletService extends EventEmitter {
         gas: WalletService.gasAmountConstants().createLock,
         contract: Unlock,
       },
+      TRANSACTION_TYPES.LOCK_CREATION,
       (error, hash) => {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_CREATE_LOCK))
@@ -225,8 +226,7 @@ export default class WalletService extends EventEmitter {
         // This is an exception because, until we are able to determine the lock address
         // before the transaction is mined, we need to link the lock and transaction.
         return this.emit('lock.updated', lock.address, { transaction: hash })
-      },
-      TRANSACTION_TYPES.LOCK_CREATION
+      }
     )
   }
 
@@ -257,12 +257,12 @@ export default class WalletService extends EventEmitter {
         value: Web3Utils.toWei(keyPrice, 'ether'),
         contract: PublicLock,
       },
+      TRANSACTION_TYPES.KEY_PURCHASE,
       error => {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_PURCHASE_KEY))
         }
-      },
-      TRANSACTION_TYPES.KEY_PURCHASE
+      }
     )
   }
 
@@ -287,14 +287,14 @@ export default class WalletService extends EventEmitter {
         gas: WalletService.gasAmountConstants().partialWithdrawFromLock,
         contract: PublicLock,
       },
+      TRANSACTION_TYPES.WITHDRAWAL,
       error => {
         if (error) {
           this.emit('error', new Error(FAILED_TO_WITHDRAW_FROM_LOCK))
           return callback(error)
         }
         return callback()
-      },
-      TRANSACTION_TYPES.WITHDRAWAL
+      }
     )
   }
 
@@ -316,12 +316,12 @@ export default class WalletService extends EventEmitter {
         gas: WalletService.gasAmountConstants().withdrawFromLock,
         contract: PublicLock,
       },
+      TRANSACTION_TYPES.WITHDRAWAL,
       error => {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_WITHDRAW_FROM_LOCK))
         }
-      },
-      TRANSACTION_TYPES.WITHDRAWAL
+      }
     )
   }
 

--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -15,6 +15,7 @@ import {
   FAILED_TO_UPDATE_KEY_PRICE,
   FAILED_TO_WITHDRAW_FROM_LOCK,
 } from '../../errors'
+import { TransactionType } from '../../services/web3Service'
 
 jest.mock('../../utils/promises')
 
@@ -449,7 +450,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().createLock,
             contract: Unlock,
           },
-          expect.any(Function)
+          expect.any(Function),
+          TransactionType.LOCK_CREATION
         )
       })
 
@@ -538,7 +540,8 @@ describe('WalletService', () => {
             contract: PublicLock,
             value: '100000000000000000000000000', // Web3Utils.toWei(keyPrice, 'ether')
           },
-          expect.any(Function)
+          expect.any(Function),
+          TransactionType.KEY_PURCHASE
         )
       })
 
@@ -602,7 +605,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().updateKeyPrice,
             contract: PublicLock,
           },
-          expect.any(Function)
+          expect.any(Function),
+          TransactionType.UPDATE_KEY_PRICE
         )
       })
 
@@ -728,7 +732,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().partialWithdrawFromLock,
             contract: PublicLock,
           },
-          expect.any(Function)
+          expect.any(Function),
+          TransactionType.WITHDRAWAL
         )
       })
 
@@ -805,7 +810,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().withdrawFromLock,
             contract: PublicLock,
           },
-          expect.any(Function)
+          expect.any(Function),
+          TransactionType.WITHDRAWAL
         )
       })
 

--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -323,6 +323,7 @@ describe('WalletService', () => {
 
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           () => {}
         )
 
@@ -337,12 +338,13 @@ describe('WalletService', () => {
 
       it('should trigger the transaction.pending event', done => {
         expect.assertions(1)
-        walletService.on('transaction.pending', () => {
-          expect(true).toBe(true)
+        walletService.on('transaction.pending', type => {
+          expect(type).toBe('type')
           done()
         })
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           () => {}
         )
       })
@@ -364,6 +366,7 @@ describe('WalletService', () => {
 
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           () => {}
         )
 
@@ -375,6 +378,7 @@ describe('WalletService', () => {
         const transactionHash = '0x123'
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           (error, hash) => {
             expect(hash).toEqual(transactionHash)
             done()
@@ -390,6 +394,7 @@ describe('WalletService', () => {
 
         walletService._sendTransaction(
           { to, from, data, value, gas, privateKey, contract },
+          'type',
           error => {
             expect(error).toBe(error)
             done()
@@ -450,8 +455,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().createLock,
             contract: Unlock,
           },
-          expect.any(Function),
-          TransactionType.LOCK_CREATION
+          TransactionType.LOCK_CREATION,
+          expect.any(Function)
         )
       })
 
@@ -459,7 +464,7 @@ describe('WalletService', () => {
         expect.assertions(2)
         const hash = '0x1213'
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(null, hash)
         })
 
@@ -478,7 +483,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -540,8 +545,8 @@ describe('WalletService', () => {
             contract: PublicLock,
             value: '100000000000000000000000000', // Web3Utils.toWei(keyPrice, 'ether')
           },
-          expect.any(Function),
-          TransactionType.KEY_PURCHASE
+          TransactionType.KEY_PURCHASE,
+          expect.any(Function)
         )
       })
 
@@ -549,7 +554,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -605,8 +610,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().updateKeyPrice,
             contract: PublicLock,
           },
-          expect.any(Function),
-          TransactionType.UPDATE_KEY_PRICE
+          TransactionType.UPDATE_KEY_PRICE,
+          expect.any(Function)
         )
       })
 
@@ -614,7 +619,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -732,8 +737,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().partialWithdrawFromLock,
             contract: PublicLock,
           },
-          expect.any(Function),
-          TransactionType.WITHDRAWAL
+          TransactionType.WITHDRAWAL,
+          expect.any(Function)
         )
       })
 
@@ -741,7 +746,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -757,7 +762,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = undefined
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 
@@ -810,8 +815,8 @@ describe('WalletService', () => {
             gas: WalletService.gasAmountConstants().withdrawFromLock,
             contract: PublicLock,
           },
-          expect.any(Function),
-          TransactionType.WITHDRAWAL
+          TransactionType.WITHDRAWAL,
+          expect.any(Function)
         )
       })
 
@@ -819,7 +824,7 @@ describe('WalletService', () => {
         expect.assertions(1)
         const error = {}
 
-        walletService._sendTransaction = jest.fn((args, cb) => {
+        walletService._sendTransaction = jest.fn((args, type, cb) => {
           return cb(error)
         })
 

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -140,7 +140,7 @@ export default class WalletService extends EventEmitter {
    * receipt... etc)
    * @private
    */
-  _sendTransaction({ to, from, data, value, gas }, callback, transactionType) {
+  _sendTransaction({ to, from, data, value, gas }, transactionType, callback) {
     const web3TransactionPromise = this.web3.eth.sendTransaction({
       to,
       from,
@@ -181,12 +181,12 @@ export default class WalletService extends EventEmitter {
         gas: WalletService.gasAmountConstants().updateKeyPrice,
         contract: PublicLock,
       },
+      TransactionType.UPDATE_KEY_PRICE,
       error => {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_UPDATE_KEY_PRICE))
         }
-      },
-      TransactionType.UPDATE_KEY_PRICE
+      }
     )
   }
 
@@ -217,6 +217,7 @@ export default class WalletService extends EventEmitter {
         gas: WalletService.gasAmountConstants().createLock,
         contract: Unlock,
       },
+      TransactionType.LOCK_CREATION,
       (error, hash) => {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_CREATE_LOCK))
@@ -225,8 +226,7 @@ export default class WalletService extends EventEmitter {
         // This is an exception because, until we are able to determine the lock address
         // before the transaction is mined, we need to link the lock and transaction.
         return this.emit('lock.updated', lock.address, { transaction: hash })
-      },
-      TransactionType.LOCK_CREATION
+      }
     )
   }
 
@@ -257,12 +257,12 @@ export default class WalletService extends EventEmitter {
         value: Web3Utils.toWei(keyPrice, 'ether'),
         contract: PublicLock,
       },
+      TransactionType.KEY_PURCHASE,
       error => {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_PURCHASE_KEY))
         }
-      },
-      TransactionType.KEY_PURCHASE
+      }
     )
   }
 
@@ -287,14 +287,14 @@ export default class WalletService extends EventEmitter {
         gas: WalletService.gasAmountConstants().partialWithdrawFromLock,
         contract: PublicLock,
       },
+      TransactionType.WITHDRAWAL,
       error => {
         if (error) {
           this.emit('error', new Error(FAILED_TO_WITHDRAW_FROM_LOCK))
           return callback(error)
         }
         return callback()
-      },
-      TransactionType.WITHDRAWAL
+      }
     )
   }
 
@@ -316,12 +316,12 @@ export default class WalletService extends EventEmitter {
         gas: WalletService.gasAmountConstants().withdrawFromLock,
         contract: PublicLock,
       },
+      TransactionType.WITHDRAWAL,
       error => {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_WITHDRAW_FROM_LOCK))
         }
-      },
-      TransactionType.WITHDRAWAL
+      }
     )
   }
 

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -12,6 +12,7 @@ import {
   FAILED_TO_UPDATE_KEY_PRICE,
   FAILED_TO_WITHDRAW_FROM_LOCK,
 } from '../errors'
+import { TransactionType } from './web3Service'
 
 export const keyId = (lock, owner) => [lock, owner].join('-')
 
@@ -139,7 +140,7 @@ export default class WalletService extends EventEmitter {
    * receipt... etc)
    * @private
    */
-  _sendTransaction({ to, from, data, value, gas }, callback) {
+  _sendTransaction({ to, from, data, value, gas }, callback, transactionType) {
     const web3TransactionPromise = this.web3.eth.sendTransaction({
       to,
       from,
@@ -148,7 +149,7 @@ export default class WalletService extends EventEmitter {
       gas,
     })
 
-    this.emit('transaction.pending')
+    this.emit('transaction.pending', transactionType)
 
     return web3TransactionPromise
       .once('transactionHash', hash => {
@@ -184,7 +185,8 @@ export default class WalletService extends EventEmitter {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_UPDATE_KEY_PRICE))
         }
-      }
+      },
+      TransactionType.UPDATE_KEY_PRICE
     )
   }
 
@@ -223,7 +225,8 @@ export default class WalletService extends EventEmitter {
         // This is an exception because, until we are able to determine the lock address
         // before the transaction is mined, we need to link the lock and transaction.
         return this.emit('lock.updated', lock.address, { transaction: hash })
-      }
+      },
+      TransactionType.LOCK_CREATION
     )
   }
 
@@ -258,7 +261,8 @@ export default class WalletService extends EventEmitter {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_PURCHASE_KEY))
         }
-      }
+      },
+      TransactionType.KEY_PURCHASE
     )
   }
 
@@ -289,7 +293,8 @@ export default class WalletService extends EventEmitter {
           return callback(error)
         }
         return callback()
-      }
+      },
+      TransactionType.WITHDRAWAL
     )
   }
 
@@ -315,7 +320,8 @@ export default class WalletService extends EventEmitter {
         if (error) {
           return this.emit('error', new Error(FAILED_TO_WITHDRAW_FROM_LOCK))
         }
-      }
+      },
+      TransactionType.WITHDRAWAL
     )
   }
 


### PR DESCRIPTION
# Description

In preparation for #2284 this PR passes the transaction type to `_sendTransaction`, and then emits it with the `'transaction.pending'` event so that the UI can use this to display a pending state as soon as the user initiates the transaction by clicking/tapping on the button that sends it.

(Note that #2307 addresses the inconsistency across the apps and will follow this one)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2300 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
