### PR TITLE
sync changes from unlock-app to paywall

### DIFF
--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -28,10 +28,10 @@ export const pageTitle = title => {
  * Transaction types
  */
 export const TRANSACTION_TYPES = {
-  LOCK_CREATION: 'LOCK_CREATION',
-  KEY_PURCHASE: 'KEY_PURCHASE',
-  WITHDRAWAL: 'WITHDRAWAL',
-  UPDATE_KEY_PRICE: 'UPDATE_KEY_PRICE',
+  LOCK_CREATION: 'Lock Creation',
+  KEY_PURCHASE: 'Key Purchase',
+  WITHDRAWAL: 'Withdrawal',
+  UPDATE_KEY_PRICE: 'Update Key Price',
 }
 
 // used in defining the helpers for LOCK_PATH_NAME_REGEXP and ACCOUNT_REGEXP

--- a/paywall/src/services/web3Service.js
+++ b/paywall/src/services/web3Service.js
@@ -14,10 +14,10 @@ export const Constants = {
 }
 
 export const TransactionType = {
-  LOCK_CREATION: 'LOCK_CREATION',
-  KEY_PURCHASE: 'KEY_PURCHASE',
-  WITHDRAWAL: 'WITHDRAWAL',
-  UPDATE_KEY_PRICE: 'UPDATE_KEY_PRICE',
+  LOCK_CREATION: 'Lock Creation',
+  KEY_PURCHASE: 'Key Purchase',
+  WITHDRAWAL: 'Withdrawal',
+  UPDATE_KEY_PRICE: 'Update Key Price',
 }
 
 /**


### PR DESCRIPTION
# Description

This restores @cnasc 's nice human-readable transaction types to the paywall, and fixes the bug it introduced by also making this change in `constants.js`'s `TRANSACTION_TYPES` map. It also syncs a small change in `walletService` that didn't get synced to `paywall`.

<img width="1679" alt="Screen Shot 2019-03-22 at 9 34 22 PM" src="https://user-images.githubusercontent.com/98250/54860030-98230180-4cea-11e9-8a20-2ffed77eccc6.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2307
Refs #2250 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
