### PR TITLE
Adds a decoy user to Locksmith

### DIFF
--- a/locksmith/__tests__/controllers/userController.test.ts
+++ b/locksmith/__tests__/controllers/userController.test.ts
@@ -101,7 +101,7 @@ describe('User Controller', () => {
     })
 
     describe('when the provided email does not exist within the existing persistence layer', () => {
-      it('returns an error code', async () => {
+      it('returns details from the decoy user', async () => {
         let emailAddress = 'non-existing@example.com'
         let response = await request(app).get(
           `/users/${emailAddress}/privatekey`
@@ -127,7 +127,7 @@ describe('User Controller', () => {
     })
 
     describe('when the user does not exist', () => {
-      it('returns an error code', async () => {
+      it('returns details from the decoy user', async () => {
         let response = await request(app).get(
           `/users/non-existing@example.com/recoveryphrase`
         )

--- a/locksmith/__tests__/controllers/userController.test.ts
+++ b/locksmith/__tests__/controllers/userController.test.ts
@@ -100,13 +100,18 @@ describe('User Controller', () => {
       })
     })
 
-    describe('when the provided email does not within the existing persistence layer', () => {
+    describe('when the provided email does not exist within the existing persistence layer', () => {
       it('returns an error code', async () => {
         let emailAddress = 'non-existing@example.com'
         let response = await request(app).get(
           `/users/${emailAddress}/privatekey`
         )
-        expect(response.statusCode).toBe(400)
+
+        let passwordEncryptedPrivateKey = JSON.parse(response.body.passwordEncryptedPrivateKey) 
+
+        expect(passwordEncryptedPrivateKey).toHaveProperty('address')
+        expect(passwordEncryptedPrivateKey).toHaveProperty('id')
+        expect(passwordEncryptedPrivateKey).toHaveProperty('version')
       })
     })
   })
@@ -126,7 +131,10 @@ describe('User Controller', () => {
         let response = await request(app).get(
           `/users/non-existing@example.com/recoveryphrase`
         )
-        expect(response.statusCode).toBe(400)
+
+        expect(response.body).not.toEqual({ recoveryPhrase: 'a recovery phrase' })
+        expect(response.body.recoveryPhrase).toBeDefined()
+        expect(response.statusCode).toBe(200)
       })
     })
   })

--- a/locksmith/__tests__/utils/decoyUser.test.ts
+++ b/locksmith/__tests__/utils/decoyUser.test.ts
@@ -1,0 +1,23 @@
+import { DecoyUser } from '../../src/utils/decoyUser'
+
+describe('DecoyUser', () => {
+  let decoyUser = new DecoyUser()
+  describe('recoveryPhrase', () => {
+    it('returns a randomly generate string', () => {
+      let recoveryPhrase = decoyUser.recoveryPhrase()
+      expect(recoveryPhrase.length).not.toBe(0)
+    })
+  })
+
+  describe('encryptedPrivateKey', () => {
+    it('returns an encrypted keystore v3 JSON', async () => {
+      let encryptedPrivateKey = JSON.parse(
+        await decoyUser.encryptedPrivateKey()
+      )
+
+      expect(encryptedPrivateKey).toHaveProperty('address')
+      expect(encryptedPrivateKey).toHaveProperty('id')
+      expect(encryptedPrivateKey).toHaveProperty('version')
+    })
+  })
+})

--- a/locksmith/package-lock.json
+++ b/locksmith/package-lock.json
@@ -6910,6 +6910,11 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
+    "random-words": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/random-words/-/random-words-1.1.0.tgz",
+      "integrity": "sha512-GyV8PlSmQE08S/RSCjG9Uh0uQaUC7iRpA18PWk9OSnvNCzKQ+B2NxqqN/cYBej4t7dfBWxh10KFBYSiNcg1jlg=="
+    },
     "randombytes": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",

--- a/locksmith/package.json
+++ b/locksmith/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "prestart": "npm run build",
-    "start" : "node ./build/server.js",
+    "start": "node ./build/server.js",
     "predev": "NODE_ENV=development npm run db:migrate",
     "dev": "tsc-watch --onSuccess 'node build/server.js' --onFailure 'echo Beep! Compilation Failed'",
     "pretest": "NODE_ENV=test sequelize db:migrate",
@@ -18,7 +18,7 @@
     "ci": "npm run lint && npm test && npm run reformat && npm run fail-pending-changes",
     "build": "tsc",
     "tsc": "tsc",
-    "dist" : "sh ./scripts/dist.sh"
+    "dist": "sh ./scripts/dist.sh"
   },
   "lint-staged": {
     "linters": {
@@ -32,7 +32,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/express": "^4.16.1",
     "@types/jest": "^24.0.11",
+    "@types/node": "^11.11.3",
     "body-parser": "^1.18.3",
     "cors": "^2.8.5",
     "cross-env": "^5.2.0",
@@ -48,12 +50,11 @@
     "nock": "~10.0.6",
     "node-mocks-http": "^1.7.3",
     "pg": "^7.7.1",
+    "random-words": "^1.1.0",
     "sequelize": "^4.41.2",
     "sequelize-cli": "^5.4.0",
     "supertest": "^3.3.0",
     "ts-jest": "^24.0.0",
-    "@types/express": "^4.16.1",
-    "@types/node": "^11.11.3",
     "typescript": "^3.3.3333",
     "web3": "^1.0.0-beta.37",
     "winston": "^3.1.0"

--- a/locksmith/src/controllers/userController.ts
+++ b/locksmith/src/controllers/userController.ts
@@ -1,5 +1,6 @@
 import UserOperations = require('../operations/userOperations')
 import { Request, Response } from 'express-serve-static-core'
+import { DecoyUser } from '../utils/decoyUser'
 
 namespace UserController {
   export async function createUser(req: Request, res: Response): Promise<any> {
@@ -34,7 +35,11 @@ namespace UserController {
     if (result) {
       return res.json({ passwordEncryptedPrivateKey: result })
     } else {
-      return res.sendStatus(400)
+      let result = await new DecoyUser().encryptedPrivateKey()
+
+      return res.json({
+        passwordEncryptedPrivateKey: result,
+      })
     }
   }
 
@@ -43,13 +48,15 @@ namespace UserController {
     res: Response
   ): Promise<any> {
     let emailAddress = req.params.emailAddress
-    let result = await UserOperations.getUserRecoveryPhraseByEmailAddress(emailAddress)
-
+    let result = await UserOperations.getUserRecoveryPhraseByEmailAddress(
+      emailAddress
+    )
 
     if (result) {
       return res.json({ recoveryPhrase: result })
     } else {
-      return res.sendStatus(400)
+      let recoveryPhrase = new DecoyUser().recoveryPhrase()
+      return res.json({ recoveryPhrase: recoveryPhrase })
     }
   }
 }

--- a/locksmith/src/utils/decoyUser.ts
+++ b/locksmith/src/utils/decoyUser.ts
@@ -1,0 +1,15 @@
+import { encrypt } from 'ethers/utils/secret-storage'
+import randomWords from 'random-words'
+
+export class DecoyUser {
+  recoveryPhrase(): String {
+      return randomWords(5).join(' ')
+  }
+
+  async encryptedPrivateKey() {
+    return encrypt(
+      '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
+      randomWords(5).join(' ')
+    )
+  }
+}

--- a/locksmith/tsconfig.json
+++ b/locksmith/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+      "baseUrl": ".",
+      "paths": { "*": ["types/*"] },
     /* Basic Options */
     "target": "es2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */

--- a/locksmith/types/random-words.d.ts
+++ b/locksmith/types/random-words.d.ts
@@ -1,0 +1,5 @@
+export = index;
+declare function index(options: any): any;
+declare namespace index {
+    const wordList: string[];
+}


### PR DESCRIPTION
# Description

Introduces a decoy user to the existing user paths of Locksmith for their respective fail scenarios. This should not be considered a robust security feature, but provides a small bit of obfuscation around if a user exists.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
