### PR TITLE
Check totalSupply on createLock

### DIFF
--- a/smart-contracts/contracts/UnlockErrors.sol
+++ b/smart-contracts/contracts/UnlockErrors.sol
@@ -19,6 +19,9 @@ contract UnlockErrors {
   // The specified address is not valid (i.e. must not be 0).
   string public constant INVALID_ADDRESS = 'INVALID_ADDRESS';
 
+  // The address provided does not appear to represent a valid ERC20 token.
+  string public constant INVALID_TOKEN = 'INVALID_TOKEN';
+
   // The specified rate is not valid, the denominator must be greater than 0.
   // To set the rate to 0, set the numerator to 0 and the denominator to 1.
   string public constant INVALID_RATE = 'INVALID_RATE';

--- a/smart-contracts/contracts/mixins/MixinFunds.sol
+++ b/smart-contracts/contracts/mixins/MixinFunds.sol
@@ -19,6 +19,10 @@ contract MixinFunds
     address _tokenAddress
   ) public
   {
+    require(
+      _tokenAddress == address(0) || IERC20(_tokenAddress).totalSupply() > 0,
+      'INVALID_TOKEN'
+    );
     tokenAddress = _tokenAddress;
   }
 
@@ -27,7 +31,7 @@ contract MixinFunds
    *
    * With ETH, this means the function originally called was `payable` and the
    * transaction included at least the amount requested.
-   * 
+   *
    * Security: be wary of re-entrancy when calling this function.
    */
   function _chargeAtLeast(
@@ -50,7 +54,7 @@ contract MixinFunds
 
   /**
    * Transfers funds from the contract to the account provided.
-   * 
+   *
    * Security: be wary of re-entrancy when calling this function.
    */
   function _transfer(


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Adds a check on `createLock` requiring that the `totalSupply` is greater than 0.

This was added as a proxy for 'is the address provided a valid ERC20 token contract address?'.  There does not appear to be a great way to do this check as the ERC165 standard was added later and most ERC20 tokens do not implement it.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2197
Refs #1976

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
