### PR TITLE
enable configuration for paywall demo

### DIFF
--- a/paywall/next.config.js
+++ b/paywall/next.config.js
@@ -10,6 +10,8 @@ module.exports = withSourceMaps({
     unlockEnv: process.env.UNLOCK_ENV || 'dev',
     httpProvider: process.env.HTTP_PROVIDER || '127.0.0.1',
     readOnlyProvider: process.env.READ_ONLY_PROVIDER,
+    paywallUrl: process.env.PAYWALL_URL,
+    paywallScriptUrl: process.env.PAYWALL_SCRIPT_PATH,
     locksmithHost: process.env.LOCKSMITH_URI || 'http://127.0.0.1:8080',
     unlockAddress:
       process.env.UNLOCK_ADDRESS ||

--- a/paywall/next.config.js
+++ b/paywall/next.config.js
@@ -11,7 +11,7 @@ module.exports = withSourceMaps({
     httpProvider: process.env.HTTP_PROVIDER || '127.0.0.1',
     readOnlyProvider: process.env.READ_ONLY_PROVIDER,
     paywallUrl: process.env.PAYWALL_URL,
-    paywallScriptUrl: process.env.PAYWALL_SCRIPT_PATH,
+    paywallScriptPath: process.env.PAYWALL_SCRIPT_PATH,
     locksmithHost: process.env.LOCKSMITH_URI || 'http://127.0.0.1:8080',
     unlockAddress:
       process.env.UNLOCK_ADDRESS ||

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -68,6 +68,8 @@ export default function configure(
 
   const env = runtimeConfig.unlockEnv
 
+  // note: the choice of 127.0.0.1 instead of localhost is deliberate, as it will
+  // allow us to test cross-origin requests from localhost/demo
   let paywallUrl = runtimeConfig.paywallUrl || 'http://127.0.0.1:3001'
   let paywallScriptPath =
     runtimeConfig.paywallScriptPath || '/static/paywall.min.js'

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -139,7 +139,8 @@ export default function configure(
     unlockAddress = '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b'
 
     // Paywall URL for staging
-    paywallUrl = 'https://staging-paywall.unlock-protocol.com'
+    paywallUrl =
+      runtimeConfig.paywallUrl || 'https://staging-paywall.unlock-protocol.com'
 
     // rinkeby block time is roughly same as main net
     blockTime = 8000
@@ -162,7 +163,8 @@ export default function configure(
     unlockAddress = '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'
 
     // Paywall URL for production
-    paywallUrl = 'https://paywall.unlock-protocol.com'
+    paywallUrl =
+      runtimeConfig.paywallUrl || 'https://paywall.unlock-protocol.com'
 
     // See https://www.reddit.com/r/ethereum/comments/3c8v2i/what_is_the_expected_block_time/
     blockTime = 8000

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -68,6 +68,9 @@ export default function configure(
 
   const env = runtimeConfig.unlockEnv
 
+  let paywallUrl = runtimeConfig.paywallUrl || 'http://127.0.0.1:3001'
+  let paywallScriptPath =
+    runtimeConfig.paywallScriptPath || '/static/paywall.min.js'
   let providers = {}
   let isRequiredNetwork = () => false
   let requiredNetwork = 'Dev'
@@ -135,6 +138,9 @@ export default function configure(
     // Address for the Unlock smart contract
     unlockAddress = '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b'
 
+    // Paywall URL for staging
+    paywallUrl = 'https://staging-paywall.unlock-protocol.com'
+
     // rinkeby block time is roughly same as main net
     blockTime = 8000
   }
@@ -154,6 +160,9 @@ export default function configure(
 
     // Address for the Unlock smart contract
     unlockAddress = '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'
+
+    // Paywall URL for production
+    paywallUrl = 'https://paywall.unlock-protocol.com'
 
     // See https://www.reddit.com/r/ethereum/comments/3c8v2i/what_is_the_expected_block_time/
     blockTime = 8000
@@ -182,5 +191,7 @@ export default function configure(
     unlockAddress,
     services,
     supportedProviders,
+    paywallScriptPath,
+    paywallUrl,
   }
 }


### PR DESCRIPTION
# Description

In preparation for the move of the demo page to the paywall app, this adds 2 variables to the paywall. The first is the path to the paywall, which is defined by `PAYWALL_URL` in the environment. The second (and this is a departure from unlock-app) is `PAYWALL_SCRIPT_PATH` which is `'/static/paywall.min.js'` by default. The demo page uses the paywall URL plus the path to locate the paywall script. Doing things this way means we don't need a separate value for dev, staging and master, and removes an unnecessary point of failure.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2324 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
