### PR TITLE
implement purchaseFor inputsHandler in web3Service

### DIFF
--- a/paywall/src/__tests__/services/web3Service.test.js
+++ b/paywall/src/__tests__/services/web3Service.test.js
@@ -450,6 +450,7 @@ describe('Web3Service', () => {
       )
       await Promise.all([lockUpdater, transactionUpdater])
     })
+
     it('purchaseFor', async () => {
       expect.assertions(4)
       let resolveKeySaver

--- a/paywall/src/__tests__/services/web3Service.test.js
+++ b/paywall/src/__tests__/services/web3Service.test.js
@@ -4,7 +4,7 @@ import Web3Utils from 'web3-utils'
 import Web3EthAbi from 'web3-eth-abi'
 import nock from 'nock'
 import { PublicLock, Unlock } from 'unlock-abi-0'
-import Web3Service, { TransactionType } from '../../services/web3Service'
+import Web3Service, { TransactionType, keyId } from '../../services/web3Service'
 
 const nodeAccounts = [
   '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
@@ -397,6 +397,101 @@ describe('Web3Service', () => {
         `${method.signature}${input}`,
         web3Service.unlockAddress
       )
+    })
+  })
+
+  describe('inputsHandlers', () => {
+    it('createLock', async () => {
+      expect.assertions(4)
+      let resolveLockUpdater
+      let resolveTransactionUpdater
+      const fakeLockAddress = '0x123'
+      const fakeParams = {
+        _keyPrice: '100000000000000000',
+        _expirationDuration: '123',
+        _maxNumberOfKeys: '-1',
+      }
+      const fakeHash = '0x12345'
+
+      const lockUpdater = new Promise(resolve => {
+        resolveLockUpdater = resolve
+      })
+      const transactionUpdater = new Promise(resolve => {
+        resolveTransactionUpdater = resolve
+      })
+      web3Service.generateLockAddress = () => Promise.resolve(fakeLockAddress)
+
+      web3Service.once('lock.updated', (lockAddress, params) => {
+        expect(lockAddress).toBe(fakeLockAddress)
+        expect(params).toEqual({
+          transaction: fakeHash,
+          address: fakeLockAddress,
+          expirationDuration: 123,
+          keyPrice: '0.1',
+          maxNumberOfKeys: -1,
+          outstandingKeys: 0,
+          balance: '0',
+        })
+        resolveLockUpdater()
+      })
+
+      web3Service.once('transaction.updated', (transactionHash, params) => {
+        expect(transactionHash).toBe(fakeHash)
+        expect(params).toEqual({
+          lock: fakeLockAddress,
+        })
+        resolveTransactionUpdater()
+      })
+
+      web3Service.inputsHandlers.createLock(
+        fakeHash,
+        web3Service.unlockAddress,
+        fakeParams
+      )
+      await Promise.all([lockUpdater, transactionUpdater])
+    })
+    it('purchaseFor', async () => {
+      expect.assertions(4)
+      let resolveKeySaver
+      let resolveTransactionUpdater
+      const owner = '0x9876'
+      const fakeParams = {
+        _recipient: owner,
+      }
+      const fakeContractAddress = '0xabc'
+      const fakeHash = '0x12345'
+
+      const keySaver = new Promise(resolve => {
+        resolveKeySaver = resolve
+      })
+      const transactionUpdater = new Promise(resolve => {
+        resolveTransactionUpdater = resolve
+      })
+
+      web3Service.once('transaction.updated', (transactionHash, params) => {
+        expect(transactionHash).toBe(fakeHash)
+        expect(params).toEqual({
+          key: keyId(fakeContractAddress, owner),
+          lock: fakeContractAddress,
+        })
+        resolveTransactionUpdater()
+      })
+
+      web3Service.once('key.saved', (id, params) => {
+        expect(id).toBe(keyId(fakeContractAddress, owner))
+        expect(params).toEqual({
+          owner,
+          lock: fakeContractAddress,
+        })
+        resolveKeySaver()
+      })
+
+      web3Service.inputsHandlers.purchaseFor(
+        fakeHash,
+        fakeContractAddress,
+        fakeParams
+      )
+      await Promise.all([keySaver, transactionUpdater])
     })
   })
 

--- a/paywall/src/services/web3Service.js
+++ b/paywall/src/services/web3Service.js
@@ -113,6 +113,17 @@ export default class Web3Service extends EventEmitter {
           balance: '0', // Must be expressed in Eth!
         })
       },
+      purchaseFor: async (transactionHash, contractAddress, params) => {
+        const owner = params._recipient
+        this.emit('transaction.updated', transactionHash, {
+          key: keyId(contractAddress, owner),
+          lock: contractAddress,
+        })
+        return this.emit('key.saved', keyId(contractAddress, owner), {
+          lock: contractAddress,
+          owner,
+        })
+      },
     }
   }
 


### PR DESCRIPTION
# Description

This PR adds the missing glue needed to make the blue "purchase pending" lock work on the paywall

<img width="1073" alt="Screen Shot 2019-03-27 at 10 01 07 AM" src="https://user-images.githubusercontent.com/98250/55092379-e2a8d300-5088-11e9-8642-69a04d4144eb.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2365 #2284 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
