### PR TITLE
add unlock-js to paywall

### DIFF
--- a/paywall/package-lock.json
+++ b/paywall/package-lock.json
@@ -1832,6 +1832,18 @@
         "@types/unist": "*"
       }
     },
+    "@unlock-protocol/unlock-js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@unlock-protocol/unlock-js/-/unlock-js-0.0.2.tgz",
+      "integrity": "sha512-QpZorffWb1sqQ9pYbBo4MTCD0eCQQj9dwnzR9ZhqPeSfN7h6P6DczoVnHMT/EeqDTbaRZdk2yPM4D0EtW4g8WA==",
+      "requires": {
+        "ethereumjs-util": "^6.0.0",
+        "unlock-abi-0": "^1.0.1",
+        "web3": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",

--- a/paywall/package.json
+++ b/paywall/package.json
@@ -28,6 +28,7 @@
     "@types/node": "^10.12.24",
     "@types/react": "^16.8.2",
     "@types/react-dom": "^16.8.0",
+    "@unlock-protocol/unlock-js": "0.0.2",
     "@zeit/next-source-maps": "0.0.3",
     "axios": "^0.18.0",
     "babel-plugin-require-context-hook": "^1.0.0",


### PR DESCRIPTION
# Description

Adds `@unlock-protocol/unlock-js` to the paywall. The next step is to use web3Service from it

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2374

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
