### PR TITLE
don't connect until the middleware chain is complete

### DIFF
--- a/paywall/src/middlewares/walletMiddleware.js
+++ b/paywall/src/middlewares/walletMiddleware.js
@@ -114,7 +114,10 @@ export default function walletMiddleware({ getState, dispatch }) {
 
   return function(next) {
     // Connect to the current provider
-    // We connect once the middleware has been initialized, using setTimout (warning: fragile?)
+    // We connect once the middleware has been initialized, using setTimout
+    // The redux event loop is synchronous, so using setTimeout guarantees
+    // that connect will only be called after all of the other middleware have
+    // been initialized
     setTimeout(() => {
       walletService.connect(getState().provider)
     })

--- a/paywall/src/middlewares/walletMiddleware.js
+++ b/paywall/src/middlewares/walletMiddleware.js
@@ -114,7 +114,10 @@ export default function walletMiddleware({ getState, dispatch }) {
 
   return function(next) {
     // Connect to the current provider
-    walletService.connect(getState().provider)
+    // We connect once the middleware has been initialized, using setTimout (warning: fragile?)
+    setTimeout(() => {
+      walletService.connect(getState().provider)
+    })
 
     return function(action) {
       if (action.type === SET_PROVIDER) {


### PR DESCRIPTION
# Description

This fixes a potential crash if the provider is missing on the paywall, by merging in a change made to walletMiddleware on `unlock-app`. The change guarantees that connection errors will not trigger until the middleware chain is complete. Using `setTimeout` simply guarantees the connection attempt will not happen until the synchronous middleware registration is complete.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2381

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
