### PR TITLE
Updating script due to pushd not being available to sh

### DIFF
--- a/locksmith/scripts/dist.sh
+++ b/locksmith/scripts/dist.sh
@@ -8,6 +8,6 @@ if [ -z "$1" ]
 fi
 
 # Archive artifacts
-pushd 'build'
+cd 'build'
 zip ${archive} -r . ../package.json ../package-lock.json
-popd
+cd '..'


### PR DESCRIPTION
# Description

After some review, we believe the fault in our script is due to `pushd` not being available when running out dist script with sh.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
