### PR TITLE
Improve the generation of paywall.min.js

### DIFF
--- a/paywall/.gitignore
+++ b/paywall/.gitignore
@@ -13,7 +13,7 @@
 /dist
 .next/
 out/
-paywall.min.js
+paywall*.min.js*
 
 # misc
 .DS_Store

--- a/paywall/package.json
+++ b/paywall/package.json
@@ -13,7 +13,7 @@
     "test": "cross-env UNLOCK_ENV=test jest --env=jsdom",
     "lint": "eslint .",
     "svg-2-components": "./node_modules/@svgr/cli/bin/svgr --title-prop --no-dimensions --template src/components/interface/svg/template.js --no-dimensions -d src/components/interface/svg/ src/static/images/svg/",
-    "build-paywall": "cross-env NODE_ENV=production rollup -c rollup.paywall.config.js -o ./src/static/paywall.min.js",
+    "build-paywall": "cross-env NODE_ENV=production rollup -c rollup.paywall.config.js",
     "storybook": "start-storybook -p 9002 -c .storybook -s .",
     "ci": "npm run lint && npm test"
   },

--- a/paywall/rollup.paywall.config.js
+++ b/paywall/rollup.paywall.config.js
@@ -6,7 +6,9 @@ const config = {
   input: 'src/paywall-builder/index.js',
   output: {
     format: 'umd',
-    name: 'paywall.min.js',
+    file: __dirname + '/src/static/paywall.min.js',
+    name: 'paywall',
+    sourcemap: true,
   },
   plugins: [
     babel({


### PR DESCRIPTION
# Description

This improves generation of paywall.min.js. There are a couple of things that were suboptimal:

1. no sourcemap was generated
2. the output file was hard-coded in package.json, which precludes using the config to generate multiple paywall scripts (future-proofing)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2395 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
