### PR TITLE
validate the source of postMessage messages in paywall.min.js

### DIFF
--- a/paywall/src/__tests__/paywall-builder/build.test.js
+++ b/paywall/src/__tests__/paywall-builder/build.test.js
@@ -18,12 +18,17 @@ const fakeLockAddress = 'lockaddress'
 describe('buildPaywall', () => {
   let document
   let eventListener
+  let mockIframeImpl
   function scrollThatPage(window) {
     window.pageYOffset += 20
   }
 
-  function lockThatPage() {
-    eventListener({ data: POST_MESSAGE_LOCKED })
+  function lockThatPage(iframe = mockIframeImpl) {
+    eventListener({
+      data: POST_MESSAGE_LOCKED,
+      origin: 'origin',
+      source: iframe.contentWindow,
+    })
   }
 
   beforeEach(() => {
@@ -61,7 +66,6 @@ describe('buildPaywall', () => {
   describe('sets up the iframe on load', () => {
     let mockScript
     let mockIframe
-    let mockIframeImpl
     let mockAdd
     let window
     let postMessage
@@ -75,6 +79,7 @@ describe('buildPaywall', () => {
       mockIframeImpl = {
         contentWindow: {
           postMessage,
+          origin: 'origin',
         },
         style: {},
         remove: jest.fn(),
@@ -216,6 +221,7 @@ describe('buildPaywall', () => {
         iframe = {
           contentWindow: {
             postMessage,
+            origin: 'origin',
           },
           style: {},
           remove: jest.fn(),
@@ -231,7 +237,11 @@ describe('buildPaywall', () => {
           throw new Error('thrown')
         })
         expect(() => {
-          callbacks.message({ data: POST_MESSAGE_LOCKED })
+          callbacks.message({
+            data: POST_MESSAGE_LOCKED,
+            origin: 'origin',
+            source: iframe.contentWindow,
+          })
         }).toThrow()
         expect(iframe.remove).toHaveBeenCalled()
         expect(blocker.remove).toHaveBeenCalled()
@@ -239,7 +249,11 @@ describe('buildPaywall', () => {
 
       it('triggers show on locked event', () => {
         expect.assertions(2)
-        callbacks.message({ data: POST_MESSAGE_LOCKED })
+        callbacks.message({
+          data: POST_MESSAGE_LOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
 
         expect(mockShow).toHaveBeenCalledWith(iframe, document)
         expect(mockHide).not.toHaveBeenCalled()
@@ -247,7 +261,11 @@ describe('buildPaywall', () => {
 
       it('closes the blocker on locked event', () => {
         expect.assertions(1)
-        callbacks.message({ data: POST_MESSAGE_LOCKED })
+        callbacks.message({
+          data: POST_MESSAGE_LOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
 
         expect(blocker.remove).toHaveBeenCalled()
       })
@@ -258,8 +276,16 @@ describe('buildPaywall', () => {
           throw new Error('thrown')
         })
         expect(() => {
-          callbacks.message({ data: POST_MESSAGE_LOCKED })
-          callbacks.message({ data: POST_MESSAGE_UNLOCKED })
+          callbacks.message({
+            data: POST_MESSAGE_LOCKED,
+            origin: 'origin',
+            source: iframe.contentWindow,
+          })
+          callbacks.message({
+            data: POST_MESSAGE_UNLOCKED,
+            origin: 'origin',
+            source: iframe.contentWindow,
+          })
         }).toThrow()
         expect(iframe.remove).toHaveBeenCalled()
         expect(blocker.remove).toHaveBeenCalled()
@@ -267,16 +293,32 @@ describe('buildPaywall', () => {
 
       it('closes the blocker on unlocked event', () => {
         expect.assertions(1)
-        callbacks.message({ data: POST_MESSAGE_LOCKED })
-        callbacks.message({ data: POST_MESSAGE_UNLOCKED })
+        callbacks.message({
+          data: POST_MESSAGE_LOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
+        callbacks.message({
+          data: POST_MESSAGE_UNLOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
 
         expect(blocker.remove).toHaveBeenCalledTimes(2)
       })
 
       it('does not trigger show on locked event if already unlocked', () => {
         expect.assertions(2)
-        callbacks.message({ data: POST_MESSAGE_LOCKED })
-        callbacks.message({ data: POST_MESSAGE_LOCKED })
+        callbacks.message({
+          data: POST_MESSAGE_LOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
+        callbacks.message({
+          data: POST_MESSAGE_LOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
 
         expect(mockShow).toHaveBeenCalledTimes(1)
         expect(mockHide).not.toHaveBeenCalled()
@@ -284,9 +326,21 @@ describe('buildPaywall', () => {
 
       it('triggers hide on unlock event', () => {
         expect.assertions(3)
-        callbacks.message({ data: POST_MESSAGE_LOCKED })
-        callbacks.message({ data: POST_MESSAGE_UNLOCKED })
-        callbacks.message({ data: POST_MESSAGE_UNLOCKED })
+        callbacks.message({
+          data: POST_MESSAGE_LOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
+        callbacks.message({
+          data: POST_MESSAGE_UNLOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
+        callbacks.message({
+          data: POST_MESSAGE_UNLOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
 
         expect(mockHide).toHaveBeenCalledWith(iframe, document)
         expect(mockHide).toHaveBeenCalledTimes(1)
@@ -299,7 +353,11 @@ describe('buildPaywall', () => {
           throw new Error('thrown')
         }
         expect(() => {
-          callbacks.message({ data: POST_MESSAGE_REDIRECT })
+          callbacks.message({
+            data: POST_MESSAGE_REDIRECT,
+            origin: 'origin',
+            source: iframe.contentWindow,
+          })
         }).toThrow()
         expect(iframe.remove).toHaveBeenCalled()
         expect(blocker.remove).toHaveBeenCalled()
@@ -307,7 +365,11 @@ describe('buildPaywall', () => {
 
       it('calls redirect on redirect event', () => {
         expect.assertions(1)
-        callbacks.message({ data: POST_MESSAGE_REDIRECT })
+        callbacks.message({
+          data: POST_MESSAGE_REDIRECT,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
 
         expect(window.location.href).toBe('/url/lockaddress/href')
       })
@@ -355,7 +417,7 @@ describe('buildPaywall', () => {
         expect.assertions(1)
 
         buildPaywall(window, document, fakeLockAddress, blocker)
-        lockThatPage()
+        lockThatPage(iframe)
         iframe.contentWindow.postMessage.mockClear()
 
         document.documentElement.scrollHeight = window.innerHeight
@@ -368,7 +430,7 @@ describe('buildPaywall', () => {
         expect.assertions(1)
 
         buildPaywall(window, document, fakeLockAddress, blocker)
-        lockThatPage()
+        lockThatPage(iframe)
         iframe.contentWindow.postMessage.mockClear()
 
         scrollLoop(window, document, iframe, 'origin')
@@ -386,7 +448,7 @@ describe('buildPaywall', () => {
         expect.assertions(2)
 
         buildPaywall(window, document, fakeLockAddress, blocker)
-        lockThatPage()
+        lockThatPage(iframe)
         iframe.contentWindow.postMessage.mockClear()
 
         scrollLoop(window, document, iframe, 'origin')
@@ -416,7 +478,7 @@ describe('buildPaywall', () => {
         expect.assertions(1)
 
         buildPaywall(window, document, fakeLockAddress, blocker)
-        lockThatPage()
+        lockThatPage(iframe)
 
         scrollLoop(window, document, iframe, 'origin')
 
@@ -427,7 +489,7 @@ describe('buildPaywall', () => {
         expect.assertions(2)
 
         buildPaywall(window, document, fakeLockAddress, blocker)
-        lockThatPage()
+        lockThatPage(iframe)
         iframe.contentWindow.postMessage.mockClear()
 
         scrollLoop(window, document, iframe, 'origin')

--- a/paywall/src/paywall-builder/build.js
+++ b/paywall/src/paywall-builder/build.js
@@ -85,6 +85,14 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
       'message',
       event => {
         try {
+          if (
+            event.origin !== origin ||
+            event.source !== iframe.contentWindow
+          ) {
+            // nice try, hackers
+            return
+          }
+
           if (event.data === POST_MESSAGE_LOCKED && !locked) {
             locked = true
             scrollPolling = true


### PR DESCRIPTION
# Description

Prior to this PR, the `postMessage` event listener in `paywall.min.js` was not actually verifying that messages it received were from the iframe. This corrects that security hole.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2392

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
