### PR TITLE
fix usePostMessage swallowing all but most recent call

### DIFF
--- a/paywall/src/__tests__/hooks/browser/usePostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/usePostMessage.test.js
@@ -118,13 +118,7 @@ describe('usePostMessage hook', () => {
 
     rtl.act(() => {
       postMessage('hi')
-    })
-
-    rtl.act(() => {
       postMessage('hi')
-    })
-
-    rtl.act(() => {
       postMessage('bye')
     })
     expect(fakeWindow.parent.postMessage).toHaveBeenCalledTimes(2)

--- a/paywall/src/hooks/browser/usePostMessage.js
+++ b/paywall/src/hooks/browser/usePostMessage.js
@@ -6,6 +6,7 @@ import useWindow from './useWindow'
 export default function usePostMessage() {
   const window = useWindow()
   const { isInIframe, isServer } = useConfig()
+  // track the last message sent. useRef is the equivalent to using this.lastMessage in a class-based component
   const lastMessage = useRef()
   const postMessage = useCallback(
     message => {
@@ -20,8 +21,7 @@ export default function usePostMessage() {
         return
       lastMessage.current = message
       window.parent.postMessage(message, origin)
-    }, // not just when the postMessage call has changed the state to something else // This is important because the hook will be called on every render, // this next line tells React to only post the message if it has changed.
-    // and we only want to post the message on the very first time it is requested
+    },
     [isServer, isInIframe]
   )
   return { postMessage }

--- a/paywall/src/hooks/browser/usePostMessage.js
+++ b/paywall/src/hooks/browser/usePostMessage.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useRef } from 'react'
 import useConfig from '../utils/useConfig'
 import { getRouteFromWindow } from '../../utils/routes'
 import useWindow from './useWindow'
@@ -6,15 +6,23 @@ import useWindow from './useWindow'
 export default function usePostMessage() {
   const window = useWindow()
   const { isInIframe, isServer } = useConfig()
-  const [message, postMessage] = useState()
-  useEffect(
-    () => {
+  const lastMessage = useRef()
+  const postMessage = useCallback(
+    message => {
       const { origin } = getRouteFromWindow(window)
-      if (isServer || !isInIframe || !message || !origin) return
+      if (
+        isServer ||
+        !isInIframe ||
+        !message ||
+        !origin ||
+        lastMessage.current === message
+      )
+        return
+      lastMessage.current = message
       window.parent.postMessage(message, origin)
     }, // not just when the postMessage call has changed the state to something else // This is important because the hook will be called on every render, // this next line tells React to only post the message if it has changed.
     // and we only want to post the message on the very first time it is requested
-    [message]
+    [isServer, isInIframe]
   )
   return { postMessage }
 }


### PR DESCRIPTION
# Description

This PR fixes the swallowing of postMessage calls in `usePostMessage`. The key mistake in the tests that allowed this behavior through was calling `rtl.act()` 3 times instead of just once in the `does call postMessage when the message changes` test. By doing it 3 times, it did not catch how it would work if called in the same synchronous loop.

The implementation had to change in order to support this. It was incorrect to use `useState`, because this hook does not affect rendering at all, it only passes information to the parent window. Thus, it is more appropriate to use a memoized callback with `useCallback` for the actual posting of messages. To track whether a message has been sent before, we use `useRef` to track the previously sent message across render boundaries. This is the equivalent of using `this.lastMessage` in a class-based component.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2389 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
