### PR TITLE
useLocksmith hook for retrieving simple API on the paywall

### DIFF
--- a/paywall/src/__tests__/hooks/useLocksmith.test.js
+++ b/paywall/src/__tests__/hooks/useLocksmith.test.js
@@ -1,0 +1,94 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import * as rtl from 'react-testing-library'
+
+import useLocksmith from '../../hooks/useLocksmith'
+import { WindowContext } from '../../hooks/browser/useWindow'
+import { ConfigContext } from '../../utils/withConfig'
+import configure from '../../config'
+
+const WindowProvider = WindowContext.Provider
+const ConfigProvider = ConfigContext.Provider
+const config = configure()
+
+describe('useLocksmith hook', () => {
+  let fakeWindow
+  let fakeResponse
+  let finishFetch
+  const fetchResponse = {
+    json: () => fakeResponse,
+  }
+
+  function MockLocksmither({ api = '/hi' }) {
+    const result = useLocksmith(api)
+
+    return <div>{JSON.stringify(result)}</div>
+  }
+
+  MockLocksmither.propTypes = {
+    api: PropTypes.string,
+  }
+
+  MockLocksmither.defaultProps = {
+    api: '/hi',
+  }
+
+  beforeEach(() => {
+    fakeResponse = {
+      thing: '1',
+    }
+    fakeWindow = {
+      fetch: jest.fn(() => {
+        return {
+          then: cb => {
+            finishFetch = cb
+            return {
+              catch: () => {},
+            }
+          },
+        }
+      }),
+    }
+  })
+
+  it('passes the correct URL to fetch', () => {
+    expect.assertions(1)
+
+    rtl.act(() => {
+      rtl.render(
+        <WindowProvider value={fakeWindow}>
+          <ConfigProvider value={config}>
+            <MockLocksmither />
+          </ConfigProvider>
+        </WindowProvider>
+      )
+    })
+
+    rtl.act(() => {
+      finishFetch(fetchResponse)
+    })
+
+    expect(fakeWindow.fetch).toHaveBeenCalledWith(config.locksmithUri + '/hi')
+  })
+
+  it('returns the response', () => {
+    expect.assertions(1)
+
+    let wrapper
+    rtl.act(() => {
+      wrapper = rtl.render(
+        <WindowProvider value={fakeWindow}>
+          <ConfigProvider value={config}>
+            <MockLocksmither />
+          </ConfigProvider>
+        </WindowProvider>
+      )
+    })
+
+    rtl.act(() => {
+      finishFetch(fetchResponse)
+    })
+
+    expect(wrapper.getByText(JSON.stringify(fakeResponse))).not.toBeNull()
+  })
+})

--- a/paywall/src/__tests__/hooks/useLocksmith.test.js
+++ b/paywall/src/__tests__/hooks/useLocksmith.test.js
@@ -68,7 +68,7 @@ describe('useLocksmith hook', () => {
       finishFetch(fetchResponse)
     })
 
-    expect(fakeWindow.fetch).toHaveBeenCalledWith(config.locksmithUri + '/hi')
+    expect(fakeWindow.fetch).toHaveBeenCalledWith(config.locksmithHost + '/hi')
   })
 
   it('returns the response', () => {

--- a/paywall/src/hooks/useLocksmith.js
+++ b/paywall/src/hooks/useLocksmith.js
@@ -8,12 +8,12 @@ import useConfig from './utils/useConfig'
 // It only re-fetches if the api path changes.
 export default function useLocksmith(api, defaultValue) {
   const window = useWindow()
-  const { locksmithUri } = useConfig()
+  const { locksmithHost } = useConfig()
   const [result, setResult] = useState(defaultValue)
 
   const fetch = window.fetch
   // remove double / if there are any
-  const url = locksmithUri + ('/' + api).replace(/\/+/g, '/')
+  const url = locksmithHost + ('/' + api).replace(/\/+/g, '/')
 
   useEffect(() => {
     fetch(url)

--- a/paywall/src/hooks/useLocksmith.js
+++ b/paywall/src/hooks/useLocksmith.js
@@ -2,6 +2,10 @@ import { useEffect, useState } from 'react'
 import useWindow from './browser/useWindow'
 import useConfig from './utils/useConfig'
 
+// This hook uses fetch to retrieve a read-only API endpoint from locksmith.
+// It takes a default value to return prior to the API success, and then
+// replaces it upon receiving a result with the result.
+// It only re-fetches if the api path changes.
 export default function useLocksmith(api, defaultValue) {
   const window = useWindow()
   const { locksmithUri } = useConfig()

--- a/paywall/src/hooks/useLocksmith.js
+++ b/paywall/src/hooks/useLocksmith.js
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+import useWindow from './browser/useWindow'
+import useConfig from './utils/useConfig'
+
+export default function useLocksmith(api, defaultValue) {
+  const window = useWindow()
+  const { locksmithUri } = useConfig()
+  const [result, setResult] = useState(defaultValue)
+
+  const fetch = window.fetch
+  // remove double / if there are any
+  const url = locksmithUri + ('/' + api).replace(/\/+/g, '/')
+
+  useEffect(() => {
+    fetch(url)
+      .then(response => setResult(response.json()))
+      .catch(error => console.error(error)) // eslint-disable-line no-console
+  }, [api])
+  return result
+}


### PR DESCRIPTION
# Description

In order to make a call to the `/transaction/:hash/odds` endpoint on locksmith, this hook makes it simple to do, without the heaviness of a middleware, actions, reducers, and so on.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2403 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
