### PR TITLE
Move the CreateLock button inline with Account info

### DIFF
--- a/unlock-app/src/__tests__/components/content/DashboardContent.test.js
+++ b/unlock-app/src/__tests__/components/content/DashboardContent.test.js
@@ -1,4 +1,12 @@
-import { mapStateToProps } from '../../../components/content/DashboardContent'
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { Provider } from 'react-redux'
+import DashboardContent, {
+  mapStateToProps,
+} from '../../../components/content/DashboardContent'
+import createUnlockStore from '../../../createUnlockStore'
+import { ConfigContext } from '../../../utils/withConfig'
+import configure from '../../../config'
 
 const transactions = {
   '0x1234': {
@@ -94,49 +102,108 @@ const lockFormStatus = {
   visible: false,
 }
 
+const config = configure()
+const ConfigProvider = ConfigContext.Provider
+
 describe('DashboardContent', () => {
-  it('should sort locks in descending order by blockNumber', () => {
-    expect.assertions(4)
-    const state = {
-      account,
-      network,
-      locks,
-      transactions,
-      lockFormStatus,
-    }
+  describe('mapStateToProps', () => {
+    it('should sort locks in descending order by blockNumber', () => {
+      expect.assertions(4)
+      const state = {
+        account,
+        network,
+        locks,
+        transactions,
+        lockFormStatus,
+      }
 
-    const props = mapStateToProps(state)
-    const lockFeed = props.lockFeed
+      const props = mapStateToProps(state)
+      const lockFeed = props.lockFeed
 
-    expect(lockFeed).toHaveLength(3)
-    // Lock "The Gamma Blog" has the highest blockNumber, so it should always appear first
-    expect(lockFeed[0].name).toEqual('The Gamma Blog')
-    // "The Beta Blog" has the second highest blockNumber, so it should appear second
-    expect(lockFeed[1].name).toEqual('The Beta Blog')
-    // "The Alpha Blog" with the lowest  blockNumber appears last
-    expect(lockFeed[2].name).toEqual('The Alpha Blog')
+      expect(lockFeed).toHaveLength(3)
+      // Lock "The Gamma Blog" has the highest blockNumber, so it should always appear first
+      expect(lockFeed[0].name).toEqual('The Gamma Blog')
+      // "The Beta Blog" has the second highest blockNumber, so it should appear second
+      expect(lockFeed[1].name).toEqual('The Beta Blog')
+      // "The Alpha Blog" with the lowest  blockNumber appears last
+      expect(lockFeed[2].name).toEqual('The Alpha Blog')
+    })
+
+    it('should also sort correctly when a lock has no transaction yet', () => {
+      expect.assertions(4)
+      const state = {
+        account,
+        network,
+        locks: locksMinusATransaction,
+        transactions,
+        lockFormStatus,
+      }
+
+      const props = mapStateToProps(state)
+      const lockFeed = props.lockFeed
+
+      expect(lockFeed).toHaveLength(3)
+      // This time "The Beta Blog" has no associated transaction, which means it is a brand
+      // new lock, and should always appear at the head of the list.
+      expect(lockFeed[0].name).toEqual('The Beta Blog')
+      // "The Gamma Blog" then has the highest blockNumber, so it should come next.
+      expect(lockFeed[1].name).toEqual('The Gamma Blog')
+      // And "The Alpha Blog" with the lowest blockNumber comes last again.
+      expect(lockFeed[2].name).toEqual('The Alpha Blog')
+    })
   })
 
-  it('should also sort correctly when a lock has no transaction yet', () => {
-    expect.assertions(4)
-    const state = {
-      account,
-      network,
-      locks: locksMinusATransaction,
-      transactions,
-      lockFormStatus,
-    }
+  describe('create lock button', () => {
+    let store
+    let wrapper
+    beforeEach(() => {
+      store = createUnlockStore({
+        account,
+        network,
+        lockFormStatus: {
+          visible: false,
+        },
+      })
 
-    const props = mapStateToProps(state)
-    const lockFeed = props.lockFeed
+      wrapper = rtl.render(
+        <Provider store={store}>
+          <ConfigProvider value={config}>
+            <DashboardContent />
+          </ConfigProvider>
+        </Provider>
+      )
+    })
 
-    expect(lockFeed).toHaveLength(3)
-    // This time "The Beta Blog" has no associated transaction, which means it is a brand
-    // new lock, and should always appear at the head of the list.
-    expect(lockFeed[0].name).toEqual('The Beta Blog')
-    // "The Gamma Blog" then has the highest blockNumber, so it should come next.
-    expect(lockFeed[1].name).toEqual('The Gamma Blog')
-    // And "The Alpha Blog" with the lowest blockNumber comes last again.
-    expect(lockFeed[2].name).toEqual('The Alpha Blog')
+    it('should open the creator lock form when the create lock button is clicked', () => {
+      expect.assertions(4)
+
+      expect(wrapper.queryByValue('New Lock')).toBeNull()
+      expect(wrapper.queryByText('Submit')).toBeNull()
+
+      const createButton = wrapper.getByText('Create Lock')
+      rtl.fireEvent.click(createButton)
+
+      expect(wrapper.queryByValue('New Lock')).not.toBeNull()
+      expect(wrapper.queryByText('Submit')).not.toBeNull()
+    })
+
+    it('should disappear when cancel button is clicked', () => {
+      // This is really testing the behavior of the creator lock form...  But in
+      // order to test it end-to-end, it has to happen at this level so we have
+      // access to the button.
+      expect.assertions(4)
+
+      let createButton = wrapper.getByText('Create Lock')
+      rtl.fireEvent.click(createButton)
+
+      expect(wrapper.queryByValue('New Lock')).not.toBeNull()
+      expect(wrapper.queryByText('Submit')).not.toBeNull()
+
+      let cancelButton = wrapper.getByText('Cancel')
+      rtl.fireEvent.click(cancelButton)
+
+      expect(wrapper.queryByValue('New Lock')).toBeNull()
+      expect(wrapper.queryByText('Submit')).toBeNull()
+    })
   })
 })

--- a/unlock-app/src/__tests__/components/content/DashboardContent.test.js
+++ b/unlock-app/src/__tests__/components/content/DashboardContent.test.js
@@ -81,14 +81,28 @@ const locksMinusATransaction = {
   },
 }
 
+const account = {
+  address: '0x12345678',
+  balance: '5',
+}
+
+const network = {
+  name: 1984,
+}
+
+const lockFormStatus = {
+  visible: false,
+}
+
 describe('DashboardContent', () => {
   it('should sort locks in descending order by blockNumber', () => {
     expect.assertions(4)
     const state = {
-      account: {},
-      network: {},
+      account,
+      network,
       locks,
       transactions,
+      lockFormStatus,
     }
 
     const props = mapStateToProps(state)
@@ -106,10 +120,11 @@ describe('DashboardContent', () => {
   it('should also sort correctly when a lock has no transaction yet', () => {
     expect.assertions(4)
     const state = {
-      account: {},
-      network: {},
+      account,
+      network,
       locks: locksMinusATransaction,
       transactions,
+      lockFormStatus,
     }
 
     const props = mapStateToProps(state)

--- a/unlock-app/src/__tests__/components/content/LogContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/LogContent.test.tsx
@@ -1,5 +1,12 @@
-import { mapStateToProps } from '../../../components/content/LogContent'
+import React from 'react'
+import { Provider } from 'react-redux'
+import * as rtl from 'react-testing-library'
+import {
+  LogContent,
+  mapStateToProps,
+} from '../../../components/content/LogContent'
 import * as UnlockTypes from '../../../unlock'
+import createUnlockStore from '../../../createUnlockStore'
 
 const transactions = {
   '0x12345678': {
@@ -31,27 +38,34 @@ const transactions = {
   },
 }
 
+const account: UnlockTypes.Account = {
+  address: '0x12345678',
+  balance: '5',
+}
+
+const network: UnlockTypes.Network = {
+  name: 1984,
+}
+
+const state = {
+  account,
+  network,
+  transactions,
+}
+
+const config = {
+  chainExplorerUrlBuilders: {
+    etherScan: (address: string) =>
+      `https://blockchain.party/address/${address}/`,
+  },
+}
+
 describe('Transaction Log', () => {
   describe('mapStateToProps', () => {
-    const state = {
-      account: {
-        address: '0x123456',
-        balance: '5',
-      },
-      network: {
-        name: 1984,
-      },
-      transactions,
-    }
-    const config = {
-      chainExplorerUrlBuilders: {
-        etherScan: (address: string) =>
-          `https://blockchain.party/address/${address}/`,
-      },
-    }
     const { transactionFeed, explorerLinks } = mapStateToProps(state, {
       config,
     })
+
     it('Should provide a feed of transactions sorted by blockNumber, descending', () => {
       expect.assertions(4)
       expect(transactionFeed).toHaveLength(3)
@@ -59,12 +73,42 @@ describe('Transaction Log', () => {
       expect(transactionFeed[1].blockNumber).toEqual(2)
       expect(transactionFeed[2].blockNumber).toEqual(1)
     })
+
     it('should include a separate feed of URLs to chain explorer for each transaction', () => {
       expect.assertions(2)
       expect(Object.keys(explorerLinks)).toHaveLength(3)
       expect(explorerLinks['0x9abcdef0']).toBe(
         'https://blockchain.party/address/0x9abcdef0a/'
       )
+    })
+  })
+
+  jest.mock('next/router', () => {})
+  describe('create lock button', () => {
+    // TODO: We need to test that clicking this button actually does something.
+    it('should have a create lock button', () => {
+      expect.assertions(1)
+      const showForm = jest.fn()
+      const {
+        account,
+        network,
+        transactionFeed,
+        explorerLinks,
+      } = mapStateToProps(state, { config })
+
+      const wrapper = rtl.render(
+        <Provider store={createUnlockStore(state)}>
+          <LogContent
+            account={account}
+            network={network}
+            transactionFeed={transactionFeed}
+            explorerLinks={explorerLinks}
+            showForm={showForm}
+          />
+        </Provider>
+      )
+
+      expect(wrapper.getByText('Create Lock')).not.toBeNull()
     })
   })
 })

--- a/unlock-app/src/__tests__/components/content/LogContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/LogContent.test.tsx
@@ -8,6 +8,8 @@ import {
 import * as UnlockTypes from '../../../unlock'
 import createUnlockStore from '../../../createUnlockStore'
 
+jest.mock('next/router', () => {})
+
 const transactions = {
   '0x12345678': {
     hash: '0x12345678',
@@ -83,7 +85,6 @@ describe('Transaction Log', () => {
     })
   })
 
-  jest.mock('next/router', () => {})
   describe('create lock button', () => {
     // TODO: We need to test that clicking this button actually does something.
     it('should have a create lock button', () => {

--- a/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLocks.test.js
@@ -13,53 +13,6 @@ jest.mock('next/link', () => {
 })
 
 describe('CreatorLocks', () => {
-  it('should display form when create lock button is clicked', () => {
-    expect.assertions(4)
-    const store = createUnlockStore({
-      account: {},
-    })
-
-    const wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks createLock={() => {}} />
-      </Provider>
-    )
-
-    expect(wrapper.queryByValue('New Lock')).toBeNull()
-    expect(wrapper.queryByText('Submit')).toBeNull()
-
-    const createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
-
-    expect(wrapper.queryByValue('New Lock')).not.toBeNull()
-    expect(wrapper.queryByText('Submit')).not.toBeNull()
-  })
-
-  it('should disappear when cancel button is clicked', () => {
-    expect.assertions(4)
-    const store = createUnlockStore({
-      account: {},
-    })
-
-    let wrapper = rtl.render(
-      <Provider store={store}>
-        <CreatorLocks createLock={() => {}} />
-      </Provider>
-    )
-
-    let createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
-
-    expect(wrapper.queryByValue('New Lock')).not.toBeNull()
-    expect(wrapper.queryByText('Submit')).not.toBeNull()
-
-    let cancelButton = wrapper.getByText('Cancel')
-    rtl.fireEvent.click(cancelButton)
-
-    expect(wrapper.queryByValue('New Lock')).toBeNull()
-    expect(wrapper.queryByText('Submit')).toBeNull()
-  })
-
   it('should call createLock when submit button is pressed', () => {
     expect.assertions(1)
     const createLock = jest.fn()
@@ -70,12 +23,13 @@ describe('CreatorLocks', () => {
 
     const wrapper = rtl.render(
       <Provider store={store}>
-        <CreatorLocks createLock={createLock} />
+        <CreatorLocks
+          createLock={createLock}
+          formIsVisible
+          hideForm={() => {}}
+        />
       </Provider>
     )
-
-    const createButton = wrapper.getByText('Create Lock')
-    rtl.fireEvent.click(createButton)
 
     const submitButton = wrapper.getByText('Submit')
     rtl.fireEvent.click(submitButton)
@@ -94,6 +48,8 @@ describe('CreatorLocks', () => {
           lockFeed={lockFeed}
           loading={loading}
           createLock={() => {}}
+          formIsVisible={false}
+          hideForm={() => {}}
         />
       </Provider>
     )
@@ -111,6 +67,8 @@ describe('CreatorLocks', () => {
           lockFeed={lockFeed}
           loading={loading}
           createLock={() => {}}
+          formIsVisible={false}
+          hideForm={() => {}}
         />
       </Provider>
     )
@@ -120,8 +78,22 @@ describe('CreatorLocks', () => {
   describe('mapStateToProps', () => {
     it('should yield a loading boolean based on state', () => {
       expect.assertions(2)
-      expect(mapStateToProps({ loading: 3 }).loading).toBe(true)
-      expect(mapStateToProps({ loading: 0 }).loading).toBe(false)
+      expect(
+        mapStateToProps({
+          loading: 3,
+          lockFormStatus: {
+            visible: false,
+          },
+        }).loading
+      ).toBe(true)
+      expect(
+        mapStateToProps({
+          loading: 0,
+          lockFormStatus: {
+            visible: false,
+          },
+        }).loading
+      ).toBe(false)
     })
   })
 })

--- a/unlock-app/src/__tests__/pages/pages.test.js
+++ b/unlock-app/src/__tests__/pages/pages.test.js
@@ -6,7 +6,7 @@ import Home from '../../pages/home'
 import Jobs from '../../pages/jobs'
 import About from '../../pages/about'
 import Log from '../../pages/log'
-import Dashboard from '../../pages/dashboard'
+import DashboardContent from '../../components/content/DashboardContent'
 import Privacy from '../../pages/privacy'
 import Terms from '../../pages/terms'
 
@@ -68,11 +68,13 @@ describe('Pages', () => {
       rtl.render(
         <ConfigProvider value={config}>
           <Provider store={store}>
-            <Dashboard
+            <DashboardContent
               account={account}
               network={network}
               transactions={{}}
               locks={{}}
+              hideForm={() => {}}
+              showForm={() => {}}
             />
           </Provider>
         </ConfigProvider>

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -28300,44 +28300,194 @@ exports[`Storyshots CreatorLocks no lock, showForm 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c7 {
-  display: grid;
-  row-gap: 16px;
-  -webkit-column-gap: 32px;
-  column-gap: 32px;
-  border: solid 1px var(--lightgrey);
-  grid-template-columns: 72px;
-  grid-auto-flow: column;
+    .c13 {
+  width: 1.3em;
+  text-align: right;
+  padding-right: 0.5em;
+}
+
+.c13:before {
+  content: '三';
+}
+
+.c11 {
+  color: var(--link);
+  font-size: 11px;
+  width: 100%;
+  padding: 5px;
+}
+
+.c7 {
+  font-family: 'IBM Plex Mono','Courier New',Serif;
+  font-weight: 200;
+  min-height: 48px;
+  padding-left: 8px;
+  color: var(--slate);
+  font-size: 14px;
+  box-shadow: 0 0 40px 0 rgba(0,0,0,0.08);
+  -webkit-transition: box-shadow 100ms ease;
+  transition: box-shadow 100ms ease;
   border-radius: 4px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  padding: 32px;
-  padding-bottom: 40px;
+  display: grid;
+  grid-row-gap: 0;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  cursor: pointer;
+  -webkit-animation: 400ms ease slideIn;
+  animation: 400ms ease slideIn;
+}
+
+.c7 > * {
+  padding-top: 16px;
+}
+
+.c7:hover {
+  box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
+  -webkit-transition: box-shadow 100ms ease;
+  transition: box-shadow 100ms ease;
+}
+
+.c7 input[type='number'] {
+  -moz-appearance: textfield;
+}
+
+.c7 input::-webkit-outer-spin-button,
+.c7 input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.c7 input {
+  background: var(--lightgrey);
+  border: 1px solid var(--lightgrey);
+  border-radius: 4px;
+  height: 26px;
+  padding: 0 8px;
+  font-family: 'IBM Plex Mono',sans serif;
+  font-size: 14px;
+  font-weight: 200;
+}
+
+.c7 input:focus {
+  outline: none;
+  border: 1px solid var(--grey);
+  -webkit-transition: border 100ms ease;
+  transition: border 100ms ease;
+}
+
+.c7 input[data-valid='false'] {
+  border: 1px solid var(--red);
+}
+
+.c7 input:disabled {
+  color: var(--silver);
+}
+
+.c7 100% {
+  -webkit-transform: translateY(0);
+  -ms-transform: translateY(0);
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.c14 {
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: grid;
+  text-transform: capitalize;
+  background-color: var(--lightgrey);
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-weight: 200;
+  color: var(--grey);
+  border-radius: 0 4px 4px 0;
+  padding-bottom: 15px;
 }
 
 .c8 {
-  width: 72px;
+  color: var(--link);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.c9 {
-  display: grid;
-  grid-gap: 16px;
+.c8 input[type='text'],
+.c8 input[type='number'] {
+  min-width: 70px;
+  width: 80%;
 }
 
-.c9 > h1 {
-  font-weight: bold;
-  color: var(--grey);
-  margin: 0px;
-  padding: 0px;
+.c9 input[type='text'],
+.c9 input[type='number'] {
+  min-width: 30px;
+  width: 50%;
+  text-align: right;
 }
 
-.c9 > p {
-  margin: 0px;
-  padding: 0px;
-  font-size: 16px;
-  color: var(--dimgrey);
+.c10 input[type='text'],
+.c10 input[type='number'] {
+  min-width: 30px;
+  width: 80%;
+  text-align: right;
+}
+
+.c12 {
+  white-space: nowrap;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c12 input[type='text'],
+.c12 input[type='number'] {
+  min-width: 30px;
+  width: 77%;
+  padding-right: 0;
+}
+
+.c15 {
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  -webkit-align-self: end;
+  -ms-flex-item-align: end;
+  align-self: end;
+  background: none;
+  color: inherit;
+  border: none;
+  outline: inherit;
+  padding: 0;
+}
+
+.c15:hover {
+  color: #333;
+  -webkit-transition: color 100ms ease;
+  transition: color 100ms ease;
+}
+
+.c16 {
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  background: none;
+  color: inherit;
+  border: none;
+  outline: inherit;
+  padding: 0;
+}
+
+.c16:hover {
+  color: #333;
+  -webkit-transition: color 100ms ease;
+  transition: color 100ms ease;
 }
 
 .c0 {
@@ -28415,11 +28565,25 @@ Object {
   }
 }
 
-@media (max-width:500px) {
+@media only screen and (min-width:736px) {
   .c7 {
-    grid-template-columns: 1fr;
-    grid-auto-flow: row;
-    padding: 16px;
+    grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
+    grid-template-rows: 84px;
+    grid-column-gap: 16px;
+  }
+}
+
+@media only screen and (min-width:0px) and (max-width:736px) {
+  .c7 {
+    grid-column-gap: 4px;
+    grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
+    grid-auto-flow: column;
+  }
+}
+
+@media only screen and (min-width:0px) and (max-width:736px) {
+  .c8 {
+    grid-column: span 2;
   }
 }
 
@@ -28499,22 +28663,158 @@ Object {
             </div>
           </div>
         </div>
-        <section
+        <div
           class="c7"
         >
-          <img
+          <svg
+            viewBox="0 0 216 216"
+            width="100%"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <defs>
+              <circle
+                cx="108"
+                cy="108"
+                id="a"
+                r="108"
+              />
+              <circle
+                cx="108"
+                cy="108"
+                id="c"
+                r="60.75"
+              />
+            </defs>
+            <g>
+              <mask
+                fill="#fff"
+                id="b"
+              >
+                <use
+                  xlink:href="#a"
+                />
+              </mask>
+              <g
+                transform="rotate(0, 108, 108)"
+              >
+                <circle
+                  cx="195.75"
+                  cy="114.75"
+                  fill="#8c8c8c"
+                  mask="url(#b)"
+                  r="114.75"
+                />
+                <circle
+                  cx="33.75"
+                  cy="162"
+                  fill="#e8e8e8"
+                  mask="url(#b)"
+                  r="114.75"
+                />
+                <circle
+                  cx="121.5"
+                  cy="0"
+                  fill="#c3c3c3"
+                  mask="url(#b)"
+                  r="114.75"
+                />
+              </g>
+              <mask
+                fill="#fff"
+                id="d"
+              >
+                <use
+                  xlink:href="#c"
+                />
+              </mask>
+              <use
+                fill="#FFF"
+                xlink:href="#c"
+              />
+              <path
+                d="M121.179 116.422c-.001.895-.05 1.797-.168 2.683-1.047 7.845-9.512 12.951-17.006 10.275-5.482-1.958-8.917-6.786-8.921-12.582-.003-3.972-.003-7.944-.003-11.916h26.103c-.001 3.847-.002 7.694-.005 11.54m16.198-34.477V81h-16.335v16.198H94.936l.001-15.26v-.918h-16.28c-.014.196-.035.34-.035.483.001 5.232-.012 10.463-.019 15.695H74.25v7.694h4.353c.004 4.167.015 8.334.05 12.5.07 8.231 3.508 15.052 9.88 20.2 9.188 7.422 19.562 9 30.636 4.94 10.486-3.846 18.35-13.87 18.231-26.081-.037-3.853-.05-7.706-.054-11.559h4.404v-7.694h-4.4c.01-5.085.027-10.17.027-15.253"
+                fill="#8c8c8c"
+                mask="url(#d)"
+              />
+            </g>
+          </svg>
+          <div
             class="c8"
-            src="/static/images/illustrations/lock.svg"
-          />
+          >
+            <input
+              data-valid="true"
+              name="name"
+              required=""
+              type="text"
+              value="New Lock"
+            />
+          </div>
           <div
             class="c9"
           >
-            <h1>
-              Create a lock to get started
-            </h1>
-            You have not created any locks yet. Create your first lock in seconds by clicking on the ‘Create Lock’ button.
+            <input
+              data-valid="true"
+              inputmode="numeric"
+              name="expirationDuration"
+              required=""
+              step="1"
+              type="number"
+              value="30"
+            />
+             
+            days
           </div>
-        </section>
+          <div
+            class="c10"
+          >
+            <input
+              data-valid="true"
+              name="maxNumberOfKeys"
+              required=""
+              type="text"
+              value="10"
+            />
+            <div
+              class="c11"
+            >
+              Unlimited
+            </div>
+          </div>
+          <span
+            class="c12"
+          >
+            <span
+              class="c13"
+            />
+            <input
+              data-valid="true"
+              id="KeyPriceEditField_undefined"
+              inputmode="numeric"
+              name="keyPrice"
+              required=""
+              step="0.00001"
+              type="number"
+              value="0.01"
+            />
+          </span>
+          <div>
+            -
+          </div>
+          <div
+            class="c14"
+          >
+            <button
+              class="c15"
+            >
+              Submit
+            </button>
+            <button
+              class="c16"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
       </section>
     </div>
   </body>,
@@ -28570,22 +28870,158 @@ Object {
           </div>
         </div>
       </div>
-      <section
-        class="sc-1g6piw8-0 jXGMmL"
+      <div
+        class="mlglvd-0 sc-1u8ov25-1 hyBsBZ"
       >
-        <img
-          class="sc-1g6piw8-1 fcKGMu"
-          src="/static/images/illustrations/lock.svg"
-        />
-        <div
-          class="sc-1g6piw8-2 evbCld"
+        <svg
+          viewBox="0 0 216 216"
+          width="100%"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
         >
-          <h1>
-            Create a lock to get started
-          </h1>
-          You have not created any locks yet. Create your first lock in seconds by clicking on the ‘Create Lock’ button.
+          <defs>
+            <circle
+              cx="108"
+              cy="108"
+              id="a"
+              r="108"
+            />
+            <circle
+              cx="108"
+              cy="108"
+              id="c"
+              r="60.75"
+            />
+          </defs>
+          <g>
+            <mask
+              fill="#fff"
+              id="b"
+            >
+              <use
+                xlink:href="#a"
+              />
+            </mask>
+            <g
+              transform="rotate(0, 108, 108)"
+            >
+              <circle
+                cx="195.75"
+                cy="114.75"
+                fill="#8c8c8c"
+                mask="url(#b)"
+                r="114.75"
+              />
+              <circle
+                cx="33.75"
+                cy="162"
+                fill="#e8e8e8"
+                mask="url(#b)"
+                r="114.75"
+              />
+              <circle
+                cx="121.5"
+                cy="0"
+                fill="#c3c3c3"
+                mask="url(#b)"
+                r="114.75"
+              />
+            </g>
+            <mask
+              fill="#fff"
+              id="d"
+            >
+              <use
+                xlink:href="#c"
+              />
+            </mask>
+            <use
+              fill="#FFF"
+              xlink:href="#c"
+            />
+            <path
+              d="M121.179 116.422c-.001.895-.05 1.797-.168 2.683-1.047 7.845-9.512 12.951-17.006 10.275-5.482-1.958-8.917-6.786-8.921-12.582-.003-3.972-.003-7.944-.003-11.916h26.103c-.001 3.847-.002 7.694-.005 11.54m16.198-34.477V81h-16.335v16.198H94.936l.001-15.26v-.918h-16.28c-.014.196-.035.34-.035.483.001 5.232-.012 10.463-.019 15.695H74.25v7.694h4.353c.004 4.167.015 8.334.05 12.5.07 8.231 3.508 15.052 9.88 20.2 9.188 7.422 19.562 9 30.636 4.94 10.486-3.846 18.35-13.87 18.231-26.081-.037-3.853-.05-7.706-.054-11.559h4.404v-7.694h-4.4c.01-5.085.027-10.17.027-15.253"
+              fill="#8c8c8c"
+              mask="url(#d)"
+            />
+          </g>
+        </svg>
+        <div
+          class="mlglvd-4 sc-1u8ov25-3 kHCPXz"
+        >
+          <input
+            data-valid="true"
+            name="name"
+            required=""
+            type="text"
+            value="New Lock"
+          />
         </div>
-      </section>
+        <div
+          class="mlglvd-6 sc-1u8ov25-4 bBCopM"
+        >
+          <input
+            data-valid="true"
+            inputmode="numeric"
+            name="expirationDuration"
+            required=""
+            step="1"
+            type="number"
+            value="30"
+          />
+           
+          days
+        </div>
+        <div
+          class="mlglvd-7 sc-1u8ov25-5 foqKED"
+        >
+          <input
+            data-valid="true"
+            name="maxNumberOfKeys"
+            required=""
+            type="text"
+            value="10"
+          />
+          <div
+            class="mlglvd-1 sc-1u8ov25-0 eiQcmf"
+          >
+            Unlimited
+          </div>
+        </div>
+        <span
+          class="buwkmd-5 sc-1u8ov25-6 louuyM"
+        >
+          <span
+            class="buwkmd-2 buwkmd-3 cwENmW"
+          />
+          <input
+            data-valid="true"
+            id="KeyPriceEditField_undefined"
+            inputmode="numeric"
+            name="keyPrice"
+            required=""
+            step="0.00001"
+            type="number"
+            value="0.01"
+          />
+        </span>
+        <div>
+          -
+        </div>
+        <div
+          class="aicx7v-0 sc-1u8ov25-2 dpNRpO"
+        >
+          <button
+            class="sc-1u8ov25-7 jSpMeN"
+          >
+            Submit
+          </button>
+          <button
+            class="sc-1u8ov25-7 gScjsJ"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
     </section>
   </div>,
   "debug": [Function],

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -8441,7 +8441,7 @@ Object {
           class="sc-9upljg-3 kjuFdI"
         >
           <button
-            class="sc-cSHVUG sc-9upljg-0 cTMzWy"
+            class="sc-gZMcBi sc-9upljg-0 cTMzWy"
           >
             Go to Your Dashboard
           </button>
@@ -30252,7 +30252,7 @@ Object {
   display: inline-block;
 }
 
-.c24 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -30262,7 +30262,7 @@ Object {
   flex-direction: column;
 }
 
-.c25 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -30273,22 +30273,22 @@ Object {
   padding-bottom: 0.5em;
 }
 
-.c26 {
+.c27 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c26:before {
+.c27:before {
   content: '三';
 }
 
-.c27 {
+.c28 {
   white-space: nowrap;
   text-transform: uppercase;
 }
 
-.c35 {
+.c37 {
   display: grid;
   row-gap: 16px;
   -webkit-column-gap: 32px;
@@ -30305,35 +30305,35 @@ Object {
   padding-bottom: 40px;
 }
 
-.c36 {
+.c38 {
   width: 72px;
 }
 
-.c37 {
+.c39 {
   display: grid;
   grid-gap: 16px;
 }
 
-.c37 > h1 {
+.c39 > h1 {
   font-weight: bold;
   color: var(--grey);
   margin: 0px;
   padding: 0px;
 }
 
-.c37 > p {
+.c39 > p {
   margin: 0px;
   padding: 0px;
   font-size: 16px;
   color: var(--dimgrey);
 }
 
-.c28 {
+.c30 {
   display: grid;
   grid-gap: 32px;
 }
 
-.c29 {
+.c31 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   padding-left: 8px;
@@ -30347,7 +30347,7 @@ Object {
   align-items: center;
 }
 
-.c30 {
+.c32 {
   font-family: 'IBM Plex Sans';
   font-size: 13px;
   font-weight: bold;
@@ -30361,7 +30361,7 @@ Object {
   color: var(--grey);
 }
 
-.c31 {
+.c33 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -30376,7 +30376,7 @@ Object {
   color: var(--darkgrey);
 }
 
-.c32 {
+.c34 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -30555,7 +30555,7 @@ Object {
   width: 100%;
 }
 
-.c21 {
+.c22 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   font-weight: 500;
@@ -30564,7 +30564,7 @@ Object {
   text-transform: none;
 }
 
-.c18 {
+.c19 {
   font-family: 'IBM Plex Mono',monospace;
   display: grid;
   row-gap: 8px;
@@ -30573,7 +30573,7 @@ Object {
   grid-template-columns: 40px 200px repeat(2,100px) repeat(3,24px) 1fr;
 }
 
-.c19 {
+.c20 {
   display: grid;
   height: 40px;
   grid-row: span 2;
@@ -30586,7 +30586,7 @@ Object {
   align-content: start;
 }
 
-.c20 {
+.c21 {
   font-weight: 100;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
@@ -30596,7 +30596,7 @@ Object {
   font-size: 8px;
 }
 
-.c22 {
+.c23 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   width: 128px;
@@ -30605,26 +30605,57 @@ Object {
   word-break: break-all;
 }
 
-.c23 {
+.c24 {
   font-size: 16px;
   font-weight: 500;
   color: var(--darkgrey);
 }
 
+.c29 {
+  background-color: var(--green);
+  border: none;
+  font-size: 16px;
+  color: var(--darkgrey);
+  font-family: 'IBM Plex Sans',sans-serif;
+  border-radius: 4px;
+  cursor: pointer;
+  outline: none;
+  -webkit-transition: background-color 200ms ease;
+  transition: background-color 200ms ease;
+  padding: 10px;
+  -webkit-align-self: end;
+  -ms-flex-item-align: end;
+  align-self: end;
+  height: 48px;
+}
+
+.c29 :hover {
+  background-color: var(--activegreen);
+}
+
+.c18 {
+  display: grid;
+  grid-template-columns: 1fr 144px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c33 {
+  .c35 {
     display: none;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c34 {
+  .c36 {
     display: none;
   }
 }
 
 @media (max-width:500px) {
-  .c35 {
+  .c37 {
     grid-template-columns: 1fr;
     grid-auto-flow: row;
     padding: 16px;
@@ -30632,7 +30663,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c29 {
+  .c31 {
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
     -webkit-align-items: start;
@@ -30644,13 +30675,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c30 {
+  .c32 {
     grid-row: span 2;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c32 {
+  .c34 {
     grid-row: span 2;
   }
 }
@@ -30731,13 +30762,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c38 {
+  .c40 {
     display: none;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c18 {
+  .c19 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
     grid-template-columns: 45px 145px repeat(2,80px);
@@ -30745,8 +30776,14 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c19 {
+  .c20 {
     height: 0px;
+  }
+}
+
+@media only screen and (min-width:0px) and (max-width:736px) {
+  .c29 {
+    display: none;
   }
 }
 
@@ -30988,186 +31025,196 @@ Object {
               class="c17"
             />
           </header>
-          <section
-            class=""
+          <div
+            class="c18"
           >
-            <div
-              class="c18"
+            <section
+              class=""
             >
               <div
                 class="c19"
               >
                 <div
-                  class="paper"
-                  style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
+                  class="c20"
                 >
-                  <svg
-                    height="40"
-                    width="40"
-                    x="0"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0"
+                  <div
+                    class="paper"
+                    style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
                   >
-                    <rect
-                      fill="#F5B400"
+                    <svg
                       height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
                       width="40"
                       x="0"
+                      xmlns="http://www.w3.org/2000/svg"
                       y="0"
-                    />
-                    <rect
-                      fill="#F92F01"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#FB186F"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#18A9F2"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
-              <div
-                class="c20"
-              >
-                Address
-                <span
-                  class="c21"
-                  id="NetworkName"
-                >
-                  Winston
-                </span>
-              </div>
-              <div
-                class="c20"
-              >
-                Balance
-              </div>
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c22"
-                id="UserAddress"
-              >
-                0x3ca206264762caf81a8f0a843bbb850987b41e16
-              </div>
-              <div
-                class="c23"
-                id="AccountBalance"
-              >
-                <div
-                  class="c24"
-                >
-                  <span
-                    class="c25"
-                  >
-                    <span
-                      class="c26"
-                    />
-                    <span
-                      class="c27"
                     >
-                       - 
-                    </span>
-                  </span>
-                  
+                      <rect
+                        fill="#F5B400"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#F92F01"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#FB186F"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#18A9F2"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                    </svg>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </section>
-          <section
-            class="c28"
-          >
-            <div
-              class="c29"
-              id="LockHeaderRow"
-            >
-              <div
-                class="c30"
-              >
-                Locks
-              </div>
-              <div
-                class="c31"
-              >
-                Name / Address
-              </div>
-              <div
-                class="c31"
-              >
-                Key Duration
-              </div>
-              <div
-                class="c32"
-              >
-                Key Quantity
-              </div>
-              <div
-                class="c31"
-              >
-                Price
-              </div>
-              <div
-                class="c31"
-              >
                 <div
-                  class="c33"
+                  class="c21"
+                >
+                  Address
+                  <span
+                    class="c22"
+                    id="NetworkName"
+                  >
+                    Winston
+                  </span>
+                </div>
+                <div
+                  class="c21"
                 >
                   Balance
                 </div>
                 <div
-                  class="c34"
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c23"
+                  id="UserAddress"
+                >
+                  0x3ca206264762caf81a8f0a843bbb850987b41e16
+                </div>
+                <div
+                  class="c24"
+                  id="AccountBalance"
+                >
+                  <div
+                    class="c25"
+                  >
+                    <span
+                      class="c26"
+                    >
+                      <span
+                        class="c27"
+                      />
+                      <span
+                        class="c28"
+                      >
+                        5.00
+                      </span>
+                    </span>
+                    
+                  </div>
+                </div>
+              </div>
+            </section>
+            <button
+              class="c29"
+              id="CreateLockButton"
+            >
+              Create Lock
+            </button>
+          </div>
+          <section
+            class="c30"
+          >
+            <div
+              class="c31"
+              id="LockHeaderRow"
+            >
+              <div
+                class="c32"
+              >
+                Locks
+              </div>
+              <div
+                class="c33"
+              >
+                Name / Address
+              </div>
+              <div
+                class="c33"
+              >
+                Key Duration
+              </div>
+              <div
+                class="c34"
+              >
+                Key Quantity
+              </div>
+              <div
+                class="c33"
+              >
+                Price
+              </div>
+              <div
+                class="c33"
+              >
+                <div
+                  class="c35"
+                >
+                  Balance
+                </div>
+                <div
+                  class="c36"
                 >
                   Balance
                 </div>
               </div>
             </div>
             <section
-              class="c35"
+              class="c37"
             >
               <img
-                class="c36"
+                class="c38"
                 src="/static/images/illustrations/lock.svg"
               />
               <div
-                class="c37"
+                class="c39"
               >
                 <h1>
                   Create a lock to get started
@@ -31178,7 +31225,7 @@ Object {
           </section>
         </div>
         <div
-          class="c38"
+          class="c40"
         />
       </div>
     </div>
@@ -31421,130 +31468,140 @@ Object {
             class="sc-1glv5oz-5 bjHPyP"
           />
         </header>
-        <section
-          class="sc-ifAKCX cFlEyZ"
+        <div
+          class="sc-VigVT jqbjAH"
         >
-          <div
-            class="sc-bZQynM ePIBLw"
+          <section
+            class="sc-ifAKCX cFlEyZ"
           >
             <div
-              class="sc-gzVnrw gZXrCQ"
+              class="sc-bZQynM ePIBLw"
             >
               <div
-                class="paper"
-                style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
+                class="sc-gzVnrw gZXrCQ"
               >
-                <svg
-                  height="40"
-                  width="40"
-                  x="0"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
+                <div
+                  class="paper"
+                  style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
                 >
-                  <rect
-                    fill="#F5B400"
+                  <svg
                     height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
                     width="40"
                     x="0"
+                    xmlns="http://www.w3.org/2000/svg"
                     y="0"
-                  />
-                  <rect
-                    fill="#F92F01"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#FB186F"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#18A9F2"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Address
-              <span
-                class="sc-EHOje ePRmVK"
-                id="NetworkName"
-              >
-                Winston
-              </span>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Balance
-            </div>
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-dnqmqq iSoGqQ"
-              id="UserAddress"
-            >
-              0x3ca206264762caf81a8f0a843bbb850987b41e16
-            </div>
-            <div
-              class="sc-iwsKbI caSLHP"
-              id="AccountBalance"
-            >
-              <div
-                class="buwkmd-0 bYclZI"
-              >
-                <span
-                  class="buwkmd-1 jZYwNd"
-                >
-                  <span
-                    class="buwkmd-2 buwkmd-3 cwENmW"
-                  />
-                  <span
-                    class="buwkmd-5 dKpFcq"
                   >
-                     - 
-                  </span>
+                    <rect
+                      fill="#F5B400"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#F92F01"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#FB186F"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#18A9F2"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="sc-htoDjs erHdrS"
+              >
+                Address
+                <span
+                  class="sc-EHOje ePRmVK"
+                  id="NetworkName"
+                >
+                  Winston
                 </span>
-                
+              </div>
+              <div
+                class="sc-htoDjs erHdrS"
+              >
+                Balance
+              </div>
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-dnqmqq iSoGqQ"
+                id="UserAddress"
+              >
+                0x3ca206264762caf81a8f0a843bbb850987b41e16
+              </div>
+              <div
+                class="sc-iwsKbI caSLHP"
+                id="AccountBalance"
+              >
+                <div
+                  class="buwkmd-0 bYclZI"
+                >
+                  <span
+                    class="buwkmd-1 jZYwNd"
+                  >
+                    <span
+                      class="buwkmd-2 buwkmd-3 cwENmW"
+                    />
+                    <span
+                      class="buwkmd-5 dKpFcq"
+                    >
+                      5.00
+                    </span>
+                  </span>
+                  
+                </div>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
+          <button
+            class="sc-gZMcBi sc-gqjmRU dHaPpi"
+            id="CreateLockButton"
+          >
+            Create Lock
+          </button>
+        </div>
         <section
           class="sc-1olgoav-1 lotZQF"
         >
@@ -31804,145 +31861,6 @@ Object {
   display: inline-block;
 }
 
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding-bottom: 0.5em;
-}
-
-.c26 {
-  width: 1.3em;
-  text-align: right;
-  padding-right: 0.5em;
-}
-
-.c26:before {
-  content: '三';
-}
-
-.c27 {
-  white-space: nowrap;
-  text-transform: uppercase;
-}
-
-.c35 {
-  display: grid;
-  row-gap: 16px;
-  -webkit-column-gap: 32px;
-  column-gap: 32px;
-  border: solid 1px var(--lightgrey);
-  grid-template-columns: 72px;
-  grid-auto-flow: column;
-  border-radius: 4px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  padding: 32px;
-  padding-bottom: 40px;
-}
-
-.c36 {
-  width: 72px;
-}
-
-.c37 {
-  display: grid;
-  grid-gap: 16px;
-}
-
-.c37 > h1 {
-  font-weight: bold;
-  color: var(--grey);
-  margin: 0px;
-  padding: 0px;
-}
-
-.c37 > p {
-  margin: 0px;
-  padding: 0px;
-  font-size: 16px;
-  color: var(--dimgrey);
-}
-
-.c28 {
-  display: grid;
-  grid-gap: 32px;
-}
-
-.c29 {
-  font-family: 'IBM Plex Mono','Courier New',Serif;
-  font-weight: 200;
-  padding-left: 8px;
-  font-size: 14px;
-  display: grid;
-  grid-gap: 16px;
-  grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c30 {
-  font-family: 'IBM Plex Sans';
-  font-size: 13px;
-  font-weight: bold;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  -webkit-letter-spacing: normal;
-  -moz-letter-spacing: normal;
-  -ms-letter-spacing: normal;
-  letter-spacing: normal;
-  color: var(--grey);
-}
-
-.c31 {
-  font-family: 'IBM Plex Mono';
-  font-size: 8px;
-  font-weight: thin;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  color: var(--darkgrey);
-}
-
-.c32 {
-  font-family: 'IBM Plex Mono';
-  font-size: 8px;
-  font-weight: thin;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  color: var(--darkgrey);
-}
-
 .c2 {
   background-color: var(--brand);
   height: 56px;
@@ -32107,106 +32025,6 @@ Object {
   width: 100%;
 }
 
-.c21 {
-  font-family: 'IBM Plex Mono',monospace;
-  font-size: 10px;
-  font-weight: 500;
-  color: var(--red);
-  margin-left: 1em;
-  text-transform: none;
-}
-
-.c18 {
-  font-family: 'IBM Plex Mono',monospace;
-  display: grid;
-  row-gap: 8px;
-  -webkit-column-gap: 16px;
-  column-gap: 16px;
-  grid-template-columns: 40px 200px repeat(2,100px) repeat(3,24px) 1fr;
-}
-
-.c19 {
-  display: grid;
-  height: 40px;
-  grid-row: span 2;
-  -webkit-align-self: start;
-  -ms-flex-item-align: start;
-  align-self: start;
-  font-size: 24px;
-  -webkit-align-content: start;
-  -ms-flex-line-pack: start;
-  align-content: start;
-}
-
-.c20 {
-  font-weight: 100;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 8px;
-}
-
-.c22 {
-  font-family: 'IBM Plex Mono',monospace;
-  font-size: 10px;
-  width: 128px;
-  font-weight: 300;
-  word-wrap: break-word;
-  word-break: break-all;
-}
-
-.c23 {
-  font-size: 16px;
-  font-weight: 500;
-  color: var(--darkgrey);
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c33 {
-    display: none;
-  }
-}
-
-@media only screen and (min-width:736px) {
-  .c34 {
-    display: none;
-  }
-}
-
-@media (max-width:500px) {
-  .c35 {
-    grid-template-columns: 1fr;
-    grid-auto-flow: row;
-    padding: 16px;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c29 {
-    grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
-    grid-auto-flow: column;
-    -webkit-align-items: start;
-    -webkit-box-align: start;
-    -ms-flex-align: start;
-    align-items: start;
-    grid-gap: 4px;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c30 {
-    grid-row: span 2;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c32 {
-    grid-row: span 2;
-  }
-}
-
 @media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     grid-template-columns: [first] 1fr [second] 48px;
@@ -32283,22 +32101,8 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c38 {
-    display: none;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
   .c18 {
-    -webkit-column-gap: 2px;
-    column-gap: 2px;
-    grid-template-columns: 45px 145px repeat(2,80px);
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c19 {
-    height: 0px;
+    display: none;
   }
 }
 
@@ -32540,197 +32344,9 @@ Object {
               class="c17"
             />
           </header>
-          <section
-            class=""
-          >
-            <div
-              class="c18"
-            >
-              <div
-                class="c19"
-              >
-                <div
-                  class="paper"
-                  style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
-                >
-                  <svg
-                    height="40"
-                    width="40"
-                    x="0"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0"
-                  >
-                    <rect
-                      fill="#F5B400"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#F92F01"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#FB186F"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#18A9F2"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
-              <div
-                class="c20"
-              >
-                Address
-                <span
-                  class="c21"
-                  id="NetworkName"
-                >
-                  Winston
-                </span>
-              </div>
-              <div
-                class="c20"
-              >
-                Balance
-              </div>
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c22"
-                id="UserAddress"
-              >
-                0x3ca206264762caf81a8f0a843bbb850987b41e16
-              </div>
-              <div
-                class="c23"
-                id="AccountBalance"
-              >
-                <div
-                  class="c24"
-                >
-                  <span
-                    class="c25"
-                  >
-                    <span
-                      class="c26"
-                    />
-                    <span
-                      class="c27"
-                    >
-                       - 
-                    </span>
-                  </span>
-                  
-                </div>
-              </div>
-            </div>
-          </section>
-          <section
-            class="c28"
-          >
-            <div
-              class="c29"
-              id="LockHeaderRow"
-            >
-              <div
-                class="c30"
-              >
-                Locks
-              </div>
-              <div
-                class="c31"
-              >
-                Name / Address
-              </div>
-              <div
-                class="c31"
-              >
-                Key Duration
-              </div>
-              <div
-                class="c32"
-              >
-                Key Quantity
-              </div>
-              <div
-                class="c31"
-              >
-                Price
-              </div>
-              <div
-                class="c31"
-              >
-                <div
-                  class="c33"
-                >
-                  Balance
-                </div>
-                <div
-                  class="c34"
-                >
-                  Balance
-                </div>
-              </div>
-            </div>
-            <section
-              class="c35"
-            >
-              <img
-                class="c36"
-                src="/static/images/illustrations/lock.svg"
-              />
-              <div
-                class="c37"
-              >
-                <h1>
-                  Create a lock to get started
-                </h1>
-                You have not created any locks yet. Create your first lock in seconds by clicking on the ‘Create Lock’ button.
-              </div>
-            </section>
-          </section>
         </div>
         <div
-          class="c38"
+          class="c18"
         />
       </div>
     </div>
@@ -32973,194 +32589,6 @@ Object {
             class="sc-1glv5oz-5 bjHPyP"
           />
         </header>
-        <section
-          class="sc-ifAKCX cFlEyZ"
-        >
-          <div
-            class="sc-bZQynM ePIBLw"
-          >
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            >
-              <div
-                class="paper"
-                style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
-              >
-                <svg
-                  height="40"
-                  width="40"
-                  x="0"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
-                >
-                  <rect
-                    fill="#F5B400"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F92F01"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#FB186F"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#18A9F2"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Address
-              <span
-                class="sc-EHOje ePRmVK"
-                id="NetworkName"
-              >
-                Winston
-              </span>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Balance
-            </div>
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-dnqmqq iSoGqQ"
-              id="UserAddress"
-            >
-              0x3ca206264762caf81a8f0a843bbb850987b41e16
-            </div>
-            <div
-              class="sc-iwsKbI caSLHP"
-              id="AccountBalance"
-            >
-              <div
-                class="buwkmd-0 bYclZI"
-              >
-                <span
-                  class="buwkmd-1 jZYwNd"
-                >
-                  <span
-                    class="buwkmd-2 buwkmd-3 cwENmW"
-                  />
-                  <span
-                    class="buwkmd-5 dKpFcq"
-                  >
-                     - 
-                  </span>
-                </span>
-                
-              </div>
-            </div>
-          </div>
-        </section>
-        <section
-          class="sc-1olgoav-1 lotZQF"
-        >
-          <div
-            class="sc-1olgoav-2 cWUOhu"
-            id="LockHeaderRow"
-          >
-            <div
-              class="sc-1olgoav-3 gFgVul"
-            >
-              Locks
-            </div>
-            <div
-              class="sc-1olgoav-4 hEEWiT"
-            >
-              Name / Address
-            </div>
-            <div
-              class="sc-1olgoav-4 hEEWiT"
-            >
-              Key Duration
-            </div>
-            <div
-              class="sc-1olgoav-4 sc-1olgoav-5 liuyaW"
-            >
-              Key Quantity
-            </div>
-            <div
-              class="sc-1olgoav-4 hEEWiT"
-            >
-              Price
-            </div>
-            <div
-              class="sc-1olgoav-4 hEEWiT"
-            >
-              <div
-                class="sc-bdVaJa beefPf"
-              >
-                Balance
-              </div>
-              <div
-                class="sc-bwzfXH fezIEM"
-              >
-                Balance
-              </div>
-            </div>
-          </div>
-          <section
-            class="sc-1g6piw8-0 jXGMmL"
-          >
-            <img
-              class="sc-1g6piw8-1 fcKGMu"
-              src="/static/images/illustrations/lock.svg"
-            />
-            <div
-              class="sc-1g6piw8-2 evbCld"
-            >
-              <h1>
-                Create a lock to get started
-              </h1>
-              You have not created any locks yet. Create your first lock in seconds by clicking on the ‘Create Lock’ button.
-            </div>
-          </section>
-        </section>
       </div>
       <div
         class="hm3mhg-2 dBxAQT"
@@ -33217,7 +32645,7 @@ exports[`Storyshots DashboardContent the dashboard 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c46 {
+    .c48 {
   background-color: white;
   cursor: pointer;
   border-radius: 50%;
@@ -33229,21 +32657,21 @@ Object {
   line-height: 15px;
 }
 
-.c46 > svg {
+.c48 > svg {
   fill: var(--lightgrey);
   height: 24px;
   width: 24px;
 }
 
-.c46:hover {
+.c48:hover {
   background-color: white;
 }
 
-.c46:hover > svg {
+.c48:hover > svg {
   fill: var(--lightgrey);
 }
 
-.c46:focus {
+.c48:focus {
   outline: none;
 }
 
@@ -33386,7 +32814,7 @@ Object {
   display: inline-block;
 }
 
-.c41 {
+.c43 {
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
@@ -33403,7 +32831,7 @@ Object {
   border-radius: 0 4px 4px 0;
 }
 
-.c42 {
+.c44 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -33415,7 +32843,7 @@ Object {
   align-self: end;
 }
 
-.c43 {
+.c45 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -33428,19 +32856,19 @@ Object {
   margin-bottom: 15px;
 }
 
-.c44 {
+.c46 {
   display: grid;
   justify-items: end;
   padding-right: 24px;
 }
 
-.c45 {
+.c47 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(3,24px);
 }
 
-.c47 {
+.c49 {
   margin-top: 13px;
   font-size: 10px;
   font-family: 'IBM Plex Sans',sans-serif;
@@ -33450,7 +32878,7 @@ Object {
   padding-right: 24px;
 }
 
-.c24 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -33460,7 +32888,7 @@ Object {
   flex-direction: column;
 }
 
-.c25 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -33471,38 +32899,38 @@ Object {
   padding-bottom: 0.5em;
 }
 
-.c26 {
+.c27 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c26:before {
+.c27:before {
   content: '三';
 }
 
-.c40 {
+.c42 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c40:before {
+.c42:before {
   content: '$';
 }
 
-.c27 {
+.c28 {
   white-space: nowrap;
   text-transform: uppercase;
 }
 
-.c39 {
+.c41 {
   font-size: 10px;
   color: var(--darkgrey);
   margin-top: 5px;
 }
 
-.c35 {
+.c37 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   min-height: 48px;
@@ -33522,28 +32950,28 @@ Object {
   cursor: pointer;
 }
 
-.c35 > * {
+.c37 > * {
   padding-top: 16px;
 }
 
-.c35:hover {
+.c37:hover {
   box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
   -webkit-transition: box-shadow 100ms ease;
   transition: box-shadow 100ms ease;
 }
 
-.c36 {
+.c38 {
   grid-row: span 2;
 }
 
-.c37 {
+.c39 {
   color: var(--link);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c38 {
+.c40 {
   color: var(--grey);
   font-weight: 200;
   white-space: nowrap;
@@ -33552,12 +32980,12 @@ Object {
   text-overflow: ellipsis;
 }
 
-.c28 {
+.c30 {
   display: grid;
   grid-gap: 32px;
 }
 
-.c29 {
+.c31 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   padding-left: 8px;
@@ -33571,7 +32999,7 @@ Object {
   align-items: center;
 }
 
-.c30 {
+.c32 {
   font-family: 'IBM Plex Sans';
   font-size: 13px;
   font-weight: bold;
@@ -33585,7 +33013,7 @@ Object {
   color: var(--grey);
 }
 
-.c31 {
+.c33 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -33600,7 +33028,7 @@ Object {
   color: var(--darkgrey);
 }
 
-.c32 {
+.c34 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -33779,7 +33207,7 @@ Object {
   width: 100%;
 }
 
-.c21 {
+.c22 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   font-weight: 500;
@@ -33788,7 +33216,7 @@ Object {
   text-transform: none;
 }
 
-.c18 {
+.c19 {
   font-family: 'IBM Plex Mono',monospace;
   display: grid;
   row-gap: 8px;
@@ -33797,7 +33225,7 @@ Object {
   grid-template-columns: 40px 200px repeat(2,100px) repeat(3,24px) 1fr;
 }
 
-.c19 {
+.c20 {
   display: grid;
   height: 40px;
   grid-row: span 2;
@@ -33810,7 +33238,7 @@ Object {
   align-content: start;
 }
 
-.c20 {
+.c21 {
   font-weight: 100;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
@@ -33820,7 +33248,7 @@ Object {
   font-size: 8px;
 }
 
-.c22 {
+.c23 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   width: 128px;
@@ -33829,32 +33257,63 @@ Object {
   word-break: break-all;
 }
 
-.c23 {
+.c24 {
   font-size: 16px;
   font-weight: 500;
   color: var(--darkgrey);
 }
 
+.c29 {
+  background-color: var(--green);
+  border: none;
+  font-size: 16px;
+  color: var(--darkgrey);
+  font-family: 'IBM Plex Sans',sans-serif;
+  border-radius: 4px;
+  cursor: pointer;
+  outline: none;
+  -webkit-transition: background-color 200ms ease;
+  transition: background-color 200ms ease;
+  padding: 10px;
+  -webkit-align-self: end;
+  -ms-flex-item-align: end;
+  align-self: end;
+  height: 48px;
+}
+
+.c29 :hover {
+  background-color: var(--activegreen);
+}
+
+.c18 {
+  display: grid;
+  grid-template-columns: 1fr 144px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c33 {
-    display: none;
-  }
-}
-
-@media only screen and (min-width:736px) {
-  .c34 {
-    display: none;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c44 {
-    display: none;
-  }
-}
-
-@media only screen and (min-width:736px) {
   .c35 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c36 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:0px) and (max-width:736px) {
+  .c46 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c37 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
     grid-column-gap: 16px;
@@ -33862,7 +33321,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c35 {
+  .c37 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -33870,13 +33329,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c37 {
+  .c39 {
     grid-column: span 2;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c29 {
+  .c31 {
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
     -webkit-align-items: start;
@@ -33888,13 +33347,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c30 {
+  .c32 {
     grid-row: span 2;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c32 {
+  .c34 {
     grid-row: span 2;
   }
 }
@@ -33975,13 +33434,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c48 {
+  .c50 {
     display: none;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c18 {
+  .c19 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
     grid-template-columns: 45px 145px repeat(2,80px);
@@ -33989,8 +33448,14 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c19 {
+  .c20 {
     height: 0px;
+  }
+}
+
+@media only screen and (min-width:0px) and (max-width:736px) {
+  .c29 {
+    display: none;
   }
 }
 
@@ -34232,183 +33697,193 @@ Object {
               class="c17"
             />
           </header>
-          <section
-            class=""
+          <div
+            class="c18"
           >
-            <div
-              class="c18"
+            <section
+              class=""
             >
               <div
                 class="c19"
               >
                 <div
-                  class="paper"
-                  style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
+                  class="c20"
                 >
-                  <svg
-                    height="40"
-                    width="40"
-                    x="0"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0"
+                  <div
+                    class="paper"
+                    style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
                   >
-                    <rect
-                      fill="#F5B400"
+                    <svg
                       height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
                       width="40"
                       x="0"
+                      xmlns="http://www.w3.org/2000/svg"
                       y="0"
-                    />
-                    <rect
-                      fill="#F92F01"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#FB186F"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#18A9F2"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
+                    >
+                      <rect
+                        fill="#F5B400"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#F92F01"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#FB186F"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#18A9F2"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                    </svg>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="c20"
-              >
-                Address
-                <span
+                <div
                   class="c21"
-                  id="NetworkName"
                 >
-                  Winston
-                </span>
-              </div>
-              <div
-                class="c20"
-              >
-                Balance
-              </div>
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c22"
-                id="UserAddress"
-              >
-                0x3ca206264762caf81a8f0a843bbb850987b41e16
-              </div>
-              <div
-                class="c23"
-                id="AccountBalance"
-              >
+                  Address
+                  <span
+                    class="c22"
+                    id="NetworkName"
+                  >
+                    Winston
+                  </span>
+                </div>
+                <div
+                  class="c21"
+                >
+                  Balance
+                </div>
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c23"
+                  id="UserAddress"
+                >
+                  0x3ca206264762caf81a8f0a843bbb850987b41e16
+                </div>
                 <div
                   class="c24"
+                  id="AccountBalance"
                 >
-                  <span
+                  <div
                     class="c25"
                   >
                     <span
                       class="c26"
-                    />
-                    <span
-                      class="c27"
                     >
-                       - 
+                      <span
+                        class="c27"
+                      />
+                      <span
+                        class="c28"
+                      >
+                        5.00
+                      </span>
                     </span>
-                  </span>
-                  
+                    
+                  </div>
                 </div>
               </div>
-            </div>
-          </section>
+            </section>
+            <button
+              class="c29"
+              id="CreateLockButton"
+            >
+              Create Lock
+            </button>
+          </div>
           <section
-            class="c28"
+            class="c30"
           >
             <div
-              class="c29"
+              class="c31"
               id="LockHeaderRow"
             >
               <div
-                class="c30"
+                class="c32"
               >
                 Locks
               </div>
               <div
-                class="c31"
+                class="c33"
               >
                 Name / Address
               </div>
               <div
-                class="c31"
+                class="c33"
               >
                 Key Duration
               </div>
               <div
-                class="c32"
+                class="c34"
               >
                 Key Quantity
               </div>
               <div
-                class="c31"
+                class="c33"
               >
                 Price
               </div>
               <div
-                class="c31"
+                class="c33"
               >
                 <div
-                  class="c33"
+                  class="c35"
                 >
                   Balance
                 </div>
                 <div
-                  class="c34"
+                  class="c36"
                 >
                   Balance
                 </div>
               </div>
             </div>
             <div
-              class="c35"
+              class="c37"
               id="LockRow_0x9abcdef0"
             >
               <div
-                class="c36"
+                class="c38"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -34484,11 +33959,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c37"
+                class="c39"
               >
                 Infinite Lock
                 <div
-                  class="c38"
+                  class="c40"
                 >
                   0x9abcdef0
                 </div>
@@ -34507,31 +33982,31 @@ Object {
                 10/0
               </div>
               <div
-                class="c24"
+                class="c25"
               >
                 <span
-                  class="c25"
+                  class="c26"
                 >
                   <span
-                    class="c26"
+                    class="c27"
                   />
                   <span
-                    class="c27"
+                    class="c28"
                   >
                     0.027
                   </span>
                 </span>
                 <div
-                  class="c39"
+                  class="c41"
                 >
                   <span
-                    class="c25"
+                    class="c26"
                   >
                     <span
-                      class="c40"
+                      class="c42"
                     />
                     <span
-                      class="c27"
+                      class="c28"
                     >
                       5.29
                     </span>
@@ -34542,34 +34017,34 @@ Object {
                 class=""
               >
                 <div
-                  class="c33"
+                  class="c35"
                 >
                   <div
-                    class="c24"
+                    class="c25"
                   >
                     <span
-                      class="c25"
+                      class="c26"
                     >
                       <span
-                        class="c26"
+                        class="c27"
                       />
                       <span
-                        class="c27"
+                        class="c28"
                       >
                          - 
                       </span>
                     </span>
                     <div
-                      class="c39"
+                      class="c41"
                     >
                       <span
-                        class="c25"
+                        class="c26"
                       >
                         <span
-                          class="c40"
+                          class="c42"
                         />
                         <span
-                          class="c27"
+                          class="c28"
                         >
                            - 
                         </span>
@@ -34578,19 +34053,19 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c34"
+                  class="c36"
                 >
                   <div
-                    class="c24"
+                    class="c25"
                   >
                     <span
-                      class="c25"
+                      class="c26"
                     >
                       <span
-                        class="c26"
+                        class="c27"
                       />
                       <span
-                        class="c27"
+                        class="c28"
                       >
                          - 
                       </span>
@@ -34600,15 +34075,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c41"
+                class="c43"
               >
                 <div
-                  class="c42"
+                  class="c44"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c43"
+                  class="c45"
                 >
                   2
                    / 
@@ -34617,11 +34092,11 @@ Object {
               </div>
             </div>
             <div
-              class="c35"
+              class="c37"
               id="LockRow_0x56781234a"
             >
               <div
-                class="c36"
+                class="c38"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -34697,11 +34172,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c37"
+                class="c39"
               >
                 New Lock
                 <div
-                  class="c38"
+                  class="c40"
                 >
                   0x56781234a
                 </div>
@@ -34720,31 +34195,31 @@ Object {
                 32/800
               </div>
               <div
-                class="c24"
+                class="c25"
               >
                 <span
-                  class="c25"
+                  class="c26"
                 >
                   <span
-                    class="c26"
+                    class="c27"
                   />
                   <span
-                    class="c27"
+                    class="c28"
                   >
                     0.01
                   </span>
                 </span>
                 <div
-                  class="c39"
+                  class="c41"
                 >
                   <span
-                    class="c25"
+                    class="c26"
                   >
                     <span
-                      class="c40"
+                      class="c42"
                     />
                     <span
-                      class="c27"
+                      class="c28"
                     >
                       1.96
                     </span>
@@ -34755,34 +34230,34 @@ Object {
                 class=""
               >
                 <div
-                  class="c33"
+                  class="c35"
                 >
                   <div
-                    class="c24"
+                    class="c25"
                   >
                     <span
-                      class="c25"
+                      class="c26"
                     >
                       <span
-                        class="c26"
+                        class="c27"
                       />
                       <span
-                        class="c27"
+                        class="c28"
                       >
                          - 
                       </span>
                     </span>
                     <div
-                      class="c39"
+                      class="c41"
                     >
                       <span
-                        class="c25"
+                        class="c26"
                       >
                         <span
-                          class="c40"
+                          class="c42"
                         />
                         <span
-                          class="c27"
+                          class="c28"
                         >
                            - 
                         </span>
@@ -34791,19 +34266,19 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c34"
+                  class="c36"
                 >
                   <div
-                    class="c24"
+                    class="c25"
                   >
                     <span
-                      class="c25"
+                      class="c26"
                     >
                       <span
-                        class="c26"
+                        class="c27"
                       />
                       <span
-                        class="c27"
+                        class="c28"
                       >
                          - 
                       </span>
@@ -34813,15 +34288,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c41"
+                class="c43"
               >
                 <div
-                  class="c42"
+                  class="c44"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c43"
+                  class="c45"
                 >
                   4
                    / 
@@ -34830,11 +34305,11 @@ Object {
               </div>
             </div>
             <div
-              class="c35"
+              class="c37"
               id="LockRow_0x12345678a"
             >
               <div
-                class="c36"
+                class="c38"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -34910,11 +34385,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c37"
+                class="c39"
               >
                 My Blog
                 <div
-                  class="c38"
+                  class="c40"
                 >
                   0x12345678a
                 </div>
@@ -34933,31 +34408,31 @@ Object {
                 3/240
               </div>
               <div
-                class="c24"
+                class="c25"
               >
                 <span
-                  class="c25"
+                  class="c26"
                 >
                   <span
-                    class="c26"
+                    class="c27"
                   />
                   <span
-                    class="c27"
+                    class="c28"
                   >
                     0.027
                   </span>
                 </span>
                 <div
-                  class="c39"
+                  class="c41"
                 >
                   <span
-                    class="c25"
+                    class="c26"
                   >
                     <span
-                      class="c40"
+                      class="c42"
                     />
                     <span
-                      class="c27"
+                      class="c28"
                     >
                       5.29
                     </span>
@@ -34968,34 +34443,34 @@ Object {
                 class=""
               >
                 <div
-                  class="c33"
+                  class="c35"
                 >
                   <div
-                    class="c24"
+                    class="c25"
                   >
                     <span
-                      class="c25"
+                      class="c26"
                     >
                       <span
-                        class="c26"
+                        class="c27"
                       />
                       <span
-                        class="c27"
+                        class="c28"
                       >
                          - 
                       </span>
                     </span>
                     <div
-                      class="c39"
+                      class="c41"
                     >
                       <span
-                        class="c25"
+                        class="c26"
                       >
                         <span
-                          class="c40"
+                          class="c42"
                         />
                         <span
-                          class="c27"
+                          class="c28"
                         >
                            - 
                         </span>
@@ -35004,19 +34479,19 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c34"
+                  class="c36"
                 >
                   <div
-                    class="c24"
+                    class="c25"
                   >
                     <span
-                      class="c25"
+                      class="c26"
                     >
                       <span
-                        class="c26"
+                        class="c27"
                       />
                       <span
-                        class="c27"
+                        class="c28"
                       >
                          - 
                       </span>
@@ -35029,13 +34504,13 @@ Object {
                 class=""
               >
                 <div
-                  class="c44"
+                  class="c46"
                 >
                   <div
-                    class="c45"
+                    class="c47"
                   >
                     <button
-                      class="c9 c46"
+                      class="c9 c48"
                     >
                       <svg
                         name="Withdraw"
@@ -35100,14 +34575,14 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c47"
+                  class="c49"
                 />
               </div>
             </div>
           </section>
         </div>
         <div
-          class="c48"
+          class="c50"
         />
       </div>
     </div>
@@ -35350,130 +34825,140 @@ Object {
             class="sc-1glv5oz-5 bjHPyP"
           />
         </header>
-        <section
-          class="sc-ifAKCX cFlEyZ"
+        <div
+          class="sc-VigVT jqbjAH"
         >
-          <div
-            class="sc-bZQynM ePIBLw"
+          <section
+            class="sc-ifAKCX cFlEyZ"
           >
             <div
-              class="sc-gzVnrw gZXrCQ"
+              class="sc-bZQynM ePIBLw"
             >
               <div
-                class="paper"
-                style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
+                class="sc-gzVnrw gZXrCQ"
               >
-                <svg
-                  height="40"
-                  width="40"
-                  x="0"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
+                <div
+                  class="paper"
+                  style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
                 >
-                  <rect
-                    fill="#F5B400"
+                  <svg
                     height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
                     width="40"
                     x="0"
+                    xmlns="http://www.w3.org/2000/svg"
                     y="0"
-                  />
-                  <rect
-                    fill="#F92F01"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#FB186F"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#18A9F2"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Address
-              <span
-                class="sc-EHOje ePRmVK"
-                id="NetworkName"
-              >
-                Winston
-              </span>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Balance
-            </div>
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-dnqmqq iSoGqQ"
-              id="UserAddress"
-            >
-              0x3ca206264762caf81a8f0a843bbb850987b41e16
-            </div>
-            <div
-              class="sc-iwsKbI caSLHP"
-              id="AccountBalance"
-            >
-              <div
-                class="buwkmd-0 bYclZI"
-              >
-                <span
-                  class="buwkmd-1 jZYwNd"
-                >
-                  <span
-                    class="buwkmd-2 buwkmd-3 cwENmW"
-                  />
-                  <span
-                    class="buwkmd-5 dKpFcq"
                   >
-                     - 
-                  </span>
+                    <rect
+                      fill="#F5B400"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#F92F01"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#FB186F"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#18A9F2"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="sc-htoDjs erHdrS"
+              >
+                Address
+                <span
+                  class="sc-EHOje ePRmVK"
+                  id="NetworkName"
+                >
+                  Winston
                 </span>
-                
+              </div>
+              <div
+                class="sc-htoDjs erHdrS"
+              >
+                Balance
+              </div>
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-dnqmqq iSoGqQ"
+                id="UserAddress"
+              >
+                0x3ca206264762caf81a8f0a843bbb850987b41e16
+              </div>
+              <div
+                class="sc-iwsKbI caSLHP"
+                id="AccountBalance"
+              >
+                <div
+                  class="buwkmd-0 bYclZI"
+                >
+                  <span
+                    class="buwkmd-1 jZYwNd"
+                  >
+                    <span
+                      class="buwkmd-2 buwkmd-3 cwENmW"
+                    />
+                    <span
+                      class="buwkmd-5 dKpFcq"
+                    >
+                      5.00
+                    </span>
+                  </span>
+                  
+                </div>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
+          <button
+            class="sc-gZMcBi sc-gqjmRU dHaPpi"
+            id="CreateLockButton"
+          >
+            Create Lock
+          </button>
+        </div>
         <section
           class="sc-1olgoav-1 lotZQF"
         >
@@ -36279,7 +35764,7 @@ exports[`Storyshots DashboardContent the dashboard, waiting for wallet 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c49 {
+    .c51 {
   background-color: white;
   cursor: pointer;
   border-radius: 50%;
@@ -36291,21 +35776,21 @@ Object {
   line-height: 15px;
 }
 
-.c49 > svg {
+.c51 > svg {
   fill: var(--lightgrey);
   height: 24px;
   width: 24px;
 }
 
-.c49:hover {
+.c51:hover {
   background-color: white;
 }
 
-.c49:hover > svg {
+.c51:hover > svg {
   fill: var(--lightgrey);
 }
 
-.c49:focus {
+.c51:focus {
   outline: none;
 }
 
@@ -36448,7 +35933,7 @@ Object {
   display: inline-block;
 }
 
-.c44 {
+.c46 {
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
@@ -36465,7 +35950,7 @@ Object {
   border-radius: 0 4px 4px 0;
 }
 
-.c45 {
+.c47 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -36477,7 +35962,7 @@ Object {
   align-self: end;
 }
 
-.c46 {
+.c48 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -36490,19 +35975,19 @@ Object {
   margin-bottom: 15px;
 }
 
-.c47 {
+.c49 {
   display: grid;
   justify-items: end;
   padding-right: 24px;
 }
 
-.c48 {
+.c50 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(3,24px);
 }
 
-.c50 {
+.c52 {
   margin-top: 13px;
   font-size: 10px;
   font-family: 'IBM Plex Sans',sans-serif;
@@ -36512,7 +35997,7 @@ Object {
   padding-right: 24px;
 }
 
-.c27 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -36522,7 +36007,7 @@ Object {
   flex-direction: column;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -36533,38 +36018,38 @@ Object {
   padding-bottom: 0.5em;
 }
 
-.c29 {
+.c30 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c29:before {
+.c30:before {
   content: '三';
 }
 
-.c43 {
+.c45 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c43:before {
+.c45:before {
   content: '$';
 }
 
-.c30 {
+.c31 {
   white-space: nowrap;
   text-transform: uppercase;
 }
 
-.c42 {
+.c44 {
   font-size: 10px;
   color: var(--darkgrey);
   margin-top: 5px;
 }
 
-.c38 {
+.c40 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   min-height: 48px;
@@ -36584,28 +36069,28 @@ Object {
   cursor: pointer;
 }
 
-.c38 > * {
+.c40 > * {
   padding-top: 16px;
 }
 
-.c38:hover {
+.c40:hover {
   box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
   -webkit-transition: box-shadow 100ms ease;
   transition: box-shadow 100ms ease;
 }
 
-.c39 {
+.c41 {
   grid-row: span 2;
 }
 
-.c40 {
+.c42 {
   color: var(--link);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c41 {
+.c43 {
   color: var(--grey);
   font-weight: 200;
   white-space: nowrap;
@@ -36614,12 +36099,12 @@ Object {
   text-overflow: ellipsis;
 }
 
-.c31 {
+.c33 {
   display: grid;
   grid-gap: 32px;
 }
 
-.c32 {
+.c34 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   padding-left: 8px;
@@ -36633,7 +36118,7 @@ Object {
   align-items: center;
 }
 
-.c33 {
+.c35 {
   font-family: 'IBM Plex Sans';
   font-size: 13px;
   font-weight: bold;
@@ -36647,7 +36132,7 @@ Object {
   color: var(--grey);
 }
 
-.c34 {
+.c36 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -36662,7 +36147,7 @@ Object {
   color: var(--darkgrey);
 }
 
-.c35 {
+.c37 {
   font-family: 'IBM Plex Mono';
   font-size: 8px;
   font-weight: thin;
@@ -36841,7 +36326,7 @@ Object {
   width: 100%;
 }
 
-.c24 {
+.c25 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   font-weight: 500;
@@ -36850,7 +36335,7 @@ Object {
   text-transform: none;
 }
 
-.c21 {
+.c22 {
   font-family: 'IBM Plex Mono',monospace;
   display: grid;
   row-gap: 8px;
@@ -36859,7 +36344,7 @@ Object {
   grid-template-columns: 40px 200px repeat(2,100px) repeat(3,24px) 1fr;
 }
 
-.c22 {
+.c23 {
   display: grid;
   height: 40px;
   grid-row: span 2;
@@ -36872,7 +36357,7 @@ Object {
   align-content: start;
 }
 
-.c23 {
+.c24 {
   font-weight: 100;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
@@ -36882,7 +36367,7 @@ Object {
   font-size: 8px;
 }
 
-.c25 {
+.c26 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   width: 128px;
@@ -36891,10 +36376,41 @@ Object {
   word-break: break-all;
 }
 
-.c26 {
+.c27 {
   font-size: 16px;
   font-weight: 500;
   color: var(--darkgrey);
+}
+
+.c32 {
+  background-color: var(--green);
+  border: none;
+  font-size: 16px;
+  color: var(--darkgrey);
+  font-family: 'IBM Plex Sans',sans-serif;
+  border-radius: 4px;
+  cursor: pointer;
+  outline: none;
+  -webkit-transition: background-color 200ms ease;
+  transition: background-color 200ms ease;
+  padding: 10px;
+  -webkit-align-self: end;
+  -ms-flex-item-align: end;
+  align-self: end;
+  height: 48px;
+}
+
+.c32 :hover {
+  background-color: var(--activegreen);
+}
+
+.c21 {
+  display: grid;
+  grid-template-columns: 1fr 144px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c2 {
@@ -36961,25 +36477,25 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c36 {
+  .c38 {
     display: none;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c37 {
+  .c39 {
     display: none;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c47 {
+  .c49 {
     display: none;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c38 {
+  .c40 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
     grid-column-gap: 16px;
@@ -36987,7 +36503,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c38 {
+  .c40 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -36995,13 +36511,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c40 {
+  .c42 {
     grid-column: span 2;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c32 {
+  .c34 {
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
     -webkit-align-items: start;
@@ -37013,13 +36529,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c33 {
+  .c35 {
     grid-row: span 2;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c35 {
+  .c37 {
     grid-row: span 2;
   }
 }
@@ -37100,13 +36616,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c51 {
+  .c53 {
     display: none;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c21 {
+  .c22 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
     grid-template-columns: 45px 145px repeat(2,80px);
@@ -37114,8 +36630,14 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c22 {
+  .c23 {
     height: 0px;
+  }
+}
+
+@media only screen and (min-width:0px) and (max-width:736px) {
+  .c32 {
+    display: none;
   }
 }
 
@@ -37373,183 +36895,193 @@ Object {
               class="c20"
             />
           </header>
-          <section
-            class=""
+          <div
+            class="c21"
           >
-            <div
-              class="c21"
+            <section
+              class=""
             >
               <div
                 class="c22"
               >
                 <div
-                  class="paper"
-                  style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
+                  class="c23"
                 >
-                  <svg
-                    height="40"
-                    width="40"
-                    x="0"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0"
+                  <div
+                    class="paper"
+                    style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
                   >
-                    <rect
-                      fill="#F5B400"
+                    <svg
                       height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
                       width="40"
                       x="0"
+                      xmlns="http://www.w3.org/2000/svg"
                       y="0"
-                    />
-                    <rect
-                      fill="#F92F01"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#FB186F"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#18A9F2"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
+                    >
+                      <rect
+                        fill="#F5B400"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#F92F01"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#FB186F"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#18A9F2"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                    </svg>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="c23"
-              >
-                Address
-                <span
+                <div
                   class="c24"
-                  id="NetworkName"
                 >
-                  Winston
-                </span>
-              </div>
-              <div
-                class="c23"
-              >
-                Balance
-              </div>
-              <div
-                class="c22"
-              />
-              <div
-                class="c22"
-              />
-              <div
-                class="c22"
-              />
-              <div
-                class="c22"
-              />
-              <div
-                class="c22"
-              />
-              <div
-                class="c25"
-                id="UserAddress"
-              >
-                0x3ca206264762caf81a8f0a843bbb850987b41e16
-              </div>
-              <div
-                class="c26"
-                id="AccountBalance"
-              >
+                  Address
+                  <span
+                    class="c25"
+                    id="NetworkName"
+                  >
+                    Winston
+                  </span>
+                </div>
+                <div
+                  class="c24"
+                >
+                  Balance
+                </div>
+                <div
+                  class="c23"
+                />
+                <div
+                  class="c23"
+                />
+                <div
+                  class="c23"
+                />
+                <div
+                  class="c23"
+                />
+                <div
+                  class="c23"
+                />
+                <div
+                  class="c26"
+                  id="UserAddress"
+                >
+                  0x3ca206264762caf81a8f0a843bbb850987b41e16
+                </div>
                 <div
                   class="c27"
+                  id="AccountBalance"
                 >
-                  <span
+                  <div
                     class="c28"
                   >
                     <span
                       class="c29"
-                    />
-                    <span
-                      class="c30"
                     >
-                       - 
+                      <span
+                        class="c30"
+                      />
+                      <span
+                        class="c31"
+                      >
+                        5.00
+                      </span>
                     </span>
-                  </span>
-                  
+                    
+                  </div>
                 </div>
               </div>
-            </div>
-          </section>
+            </section>
+            <button
+              class="c32"
+              id="CreateLockButton"
+            >
+              Create Lock
+            </button>
+          </div>
           <section
-            class="c31"
+            class="c33"
           >
             <div
-              class="c32"
+              class="c34"
               id="LockHeaderRow"
             >
               <div
-                class="c33"
+                class="c35"
               >
                 Locks
               </div>
               <div
-                class="c34"
+                class="c36"
               >
                 Name / Address
               </div>
               <div
-                class="c34"
+                class="c36"
               >
                 Key Duration
               </div>
               <div
-                class="c35"
+                class="c37"
               >
                 Key Quantity
               </div>
               <div
-                class="c34"
+                class="c36"
               >
                 Price
               </div>
               <div
-                class="c34"
+                class="c36"
               >
                 <div
-                  class="c36"
+                  class="c38"
                 >
                   Balance
                 </div>
                 <div
-                  class="c37"
+                  class="c39"
                 >
                   Balance
                 </div>
               </div>
             </div>
             <div
-              class="c38"
+              class="c40"
               id="LockRow_0x9abcdef0"
             >
               <div
-                class="c39"
+                class="c41"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -37625,11 +37157,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c40"
+                class="c42"
               >
                 Infinite Lock
                 <div
-                  class="c41"
+                  class="c43"
                 >
                   0x9abcdef0
                 </div>
@@ -37648,31 +37180,31 @@ Object {
                 10/0
               </div>
               <div
-                class="c27"
+                class="c28"
               >
                 <span
-                  class="c28"
+                  class="c29"
                 >
                   <span
-                    class="c29"
+                    class="c30"
                   />
                   <span
-                    class="c30"
+                    class="c31"
                   >
                     0.027
                   </span>
                 </span>
                 <div
-                  class="c42"
+                  class="c44"
                 >
                   <span
-                    class="c28"
+                    class="c29"
                   >
                     <span
-                      class="c43"
+                      class="c45"
                     />
                     <span
-                      class="c30"
+                      class="c31"
                     >
                       5.29
                     </span>
@@ -37683,34 +37215,34 @@ Object {
                 class=""
               >
                 <div
-                  class="c36"
+                  class="c38"
                 >
                   <div
-                    class="c27"
+                    class="c28"
                   >
                     <span
-                      class="c28"
+                      class="c29"
                     >
                       <span
-                        class="c29"
+                        class="c30"
                       />
                       <span
-                        class="c30"
+                        class="c31"
                       >
                          - 
                       </span>
                     </span>
                     <div
-                      class="c42"
+                      class="c44"
                     >
                       <span
-                        class="c28"
+                        class="c29"
                       >
                         <span
-                          class="c43"
+                          class="c45"
                         />
                         <span
-                          class="c30"
+                          class="c31"
                         >
                            - 
                         </span>
@@ -37719,19 +37251,19 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c37"
+                  class="c39"
                 >
                   <div
-                    class="c27"
+                    class="c28"
                   >
                     <span
-                      class="c28"
+                      class="c29"
                     >
                       <span
-                        class="c29"
+                        class="c30"
                       />
                       <span
-                        class="c30"
+                        class="c31"
                       >
                          - 
                       </span>
@@ -37741,15 +37273,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c44"
+                class="c46"
               >
                 <div
-                  class="c45"
+                  class="c47"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c46"
+                  class="c48"
                 >
                   2
                    / 
@@ -37758,11 +37290,11 @@ Object {
               </div>
             </div>
             <div
-              class="c38"
+              class="c40"
               id="LockRow_0x56781234a"
             >
               <div
-                class="c39"
+                class="c41"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -37838,11 +37370,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c40"
+                class="c42"
               >
                 New Lock
                 <div
-                  class="c41"
+                  class="c43"
                 >
                   0x56781234a
                 </div>
@@ -37861,31 +37393,31 @@ Object {
                 32/800
               </div>
               <div
-                class="c27"
+                class="c28"
               >
                 <span
-                  class="c28"
+                  class="c29"
                 >
                   <span
-                    class="c29"
+                    class="c30"
                   />
                   <span
-                    class="c30"
+                    class="c31"
                   >
                     0.01
                   </span>
                 </span>
                 <div
-                  class="c42"
+                  class="c44"
                 >
                   <span
-                    class="c28"
+                    class="c29"
                   >
                     <span
-                      class="c43"
+                      class="c45"
                     />
                     <span
-                      class="c30"
+                      class="c31"
                     >
                       1.96
                     </span>
@@ -37896,34 +37428,34 @@ Object {
                 class=""
               >
                 <div
-                  class="c36"
+                  class="c38"
                 >
                   <div
-                    class="c27"
+                    class="c28"
                   >
                     <span
-                      class="c28"
+                      class="c29"
                     >
                       <span
-                        class="c29"
+                        class="c30"
                       />
                       <span
-                        class="c30"
+                        class="c31"
                       >
                          - 
                       </span>
                     </span>
                     <div
-                      class="c42"
+                      class="c44"
                     >
                       <span
-                        class="c28"
+                        class="c29"
                       >
                         <span
-                          class="c43"
+                          class="c45"
                         />
                         <span
-                          class="c30"
+                          class="c31"
                         >
                            - 
                         </span>
@@ -37932,19 +37464,19 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c37"
+                  class="c39"
                 >
                   <div
-                    class="c27"
+                    class="c28"
                   >
                     <span
-                      class="c28"
+                      class="c29"
                     >
                       <span
-                        class="c29"
+                        class="c30"
                       />
                       <span
-                        class="c30"
+                        class="c31"
                       >
                          - 
                       </span>
@@ -37954,15 +37486,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c44"
+                class="c46"
               >
                 <div
-                  class="c45"
+                  class="c47"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c46"
+                  class="c48"
                 >
                   4
                    / 
@@ -37971,11 +37503,11 @@ Object {
               </div>
             </div>
             <div
-              class="c38"
+              class="c40"
               id="LockRow_0x12345678a"
             >
               <div
-                class="c39"
+                class="c41"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -38051,11 +37583,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c40"
+                class="c42"
               >
                 My Blog
                 <div
-                  class="c41"
+                  class="c43"
                 >
                   0x12345678a
                 </div>
@@ -38074,31 +37606,31 @@ Object {
                 3/240
               </div>
               <div
-                class="c27"
+                class="c28"
               >
                 <span
-                  class="c28"
+                  class="c29"
                 >
                   <span
-                    class="c29"
+                    class="c30"
                   />
                   <span
-                    class="c30"
+                    class="c31"
                   >
                     0.027
                   </span>
                 </span>
                 <div
-                  class="c42"
+                  class="c44"
                 >
                   <span
-                    class="c28"
+                    class="c29"
                   >
                     <span
-                      class="c43"
+                      class="c45"
                     />
                     <span
-                      class="c30"
+                      class="c31"
                     >
                       5.29
                     </span>
@@ -38109,34 +37641,34 @@ Object {
                 class=""
               >
                 <div
-                  class="c36"
+                  class="c38"
                 >
                   <div
-                    class="c27"
+                    class="c28"
                   >
                     <span
-                      class="c28"
+                      class="c29"
                     >
                       <span
-                        class="c29"
+                        class="c30"
                       />
                       <span
-                        class="c30"
+                        class="c31"
                       >
                          - 
                       </span>
                     </span>
                     <div
-                      class="c42"
+                      class="c44"
                     >
                       <span
-                        class="c28"
+                        class="c29"
                       >
                         <span
-                          class="c43"
+                          class="c45"
                         />
                         <span
-                          class="c30"
+                          class="c31"
                         >
                            - 
                         </span>
@@ -38145,19 +37677,19 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c37"
+                  class="c39"
                 >
                   <div
-                    class="c27"
+                    class="c28"
                   >
                     <span
-                      class="c28"
+                      class="c29"
                     >
                       <span
-                        class="c29"
+                        class="c30"
                       />
                       <span
-                        class="c30"
+                        class="c31"
                       >
                          - 
                       </span>
@@ -38170,13 +37702,13 @@ Object {
                 class=""
               >
                 <div
-                  class="c47"
+                  class="c49"
                 >
                   <div
-                    class="c48"
+                    class="c50"
                   >
                     <button
-                      class="c12 c49"
+                      class="c12 c51"
                     >
                       <svg
                         name="Withdraw"
@@ -38241,14 +37773,14 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c50"
+                  class="c52"
                 />
               </div>
             </div>
           </section>
         </div>
         <div
-          class="c51"
+          class="c53"
         />
       </div>
     </div>
@@ -38507,130 +38039,140 @@ Object {
             class="sc-1glv5oz-5 bjHPyP"
           />
         </header>
-        <section
-          class="sc-ifAKCX cFlEyZ"
+        <div
+          class="sc-VigVT jqbjAH"
         >
-          <div
-            class="sc-bZQynM ePIBLw"
+          <section
+            class="sc-ifAKCX cFlEyZ"
           >
             <div
-              class="sc-gzVnrw gZXrCQ"
+              class="sc-bZQynM ePIBLw"
             >
               <div
-                class="paper"
-                style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
+                class="sc-gzVnrw gZXrCQ"
               >
-                <svg
-                  height="40"
-                  width="40"
-                  x="0"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
+                <div
+                  class="paper"
+                  style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
                 >
-                  <rect
-                    fill="#F5B400"
+                  <svg
                     height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
                     width="40"
                     x="0"
+                    xmlns="http://www.w3.org/2000/svg"
                     y="0"
-                  />
-                  <rect
-                    fill="#F92F01"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#FB186F"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#18A9F2"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Address
-              <span
-                class="sc-EHOje ePRmVK"
-                id="NetworkName"
-              >
-                Winston
-              </span>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Balance
-            </div>
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-dnqmqq iSoGqQ"
-              id="UserAddress"
-            >
-              0x3ca206264762caf81a8f0a843bbb850987b41e16
-            </div>
-            <div
-              class="sc-iwsKbI caSLHP"
-              id="AccountBalance"
-            >
-              <div
-                class="buwkmd-0 bYclZI"
-              >
-                <span
-                  class="buwkmd-1 jZYwNd"
-                >
-                  <span
-                    class="buwkmd-2 buwkmd-3 cwENmW"
-                  />
-                  <span
-                    class="buwkmd-5 dKpFcq"
                   >
-                     - 
-                  </span>
+                    <rect
+                      fill="#F5B400"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#F92F01"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#FB186F"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#18A9F2"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="sc-htoDjs erHdrS"
+              >
+                Address
+                <span
+                  class="sc-EHOje ePRmVK"
+                  id="NetworkName"
+                >
+                  Winston
                 </span>
-                
+              </div>
+              <div
+                class="sc-htoDjs erHdrS"
+              >
+                Balance
+              </div>
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-dnqmqq iSoGqQ"
+                id="UserAddress"
+              >
+                0x3ca206264762caf81a8f0a843bbb850987b41e16
+              </div>
+              <div
+                class="sc-iwsKbI caSLHP"
+                id="AccountBalance"
+              >
+                <div
+                  class="buwkmd-0 bYclZI"
+                >
+                  <span
+                    class="buwkmd-1 jZYwNd"
+                  >
+                    <span
+                      class="buwkmd-2 buwkmd-3 cwENmW"
+                    />
+                    <span
+                      class="buwkmd-5 dKpFcq"
+                    >
+                      5.00
+                    </span>
+                  </span>
+                  
+                </div>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
+          <button
+            class="sc-gZMcBi sc-gqjmRU dHaPpi"
+            id="CreateLockButton"
+          >
+            Create Lock
+          </button>
+        </div>
         <section
           class="sc-1olgoav-1 lotZQF"
         >
@@ -43651,7 +43193,7 @@ Object {
         href="/dashboard"
       >
         <button
-          class="sc-cSHVUG sc-9upljg-1 cKpQTs"
+          class="sc-gZMcBi sc-9upljg-1 cKpQTs"
         >
           I Agree
         </button>
@@ -43778,7 +43320,7 @@ Object {
       class="sc-9upljg-3 kjuFdI"
     >
       <button
-        class="sc-cSHVUG sc-9upljg-0 cTMzWy"
+        class="sc-gZMcBi sc-9upljg-0 cTMzWy"
       >
         Go to Your Dashboard
       </button>
@@ -57244,73 +56786,73 @@ Object {
           </div>
         </section>
         <div
-          class="sc-gZMcBi gOZeal"
+          class="sc-jTzLTM emFApi"
         >
           <div
-            class="sc-gqjmRU ckuBkR"
+            class="sc-fjdhpX kwARlo"
           >
             Block Number
           </div>
           <div
-            class="sc-gqjmRU ckuBkR"
+            class="sc-fjdhpX kwARlo"
           >
             Lock Name/Address
           </div>
           <div
-            class="sc-gqjmRU ckuBkR"
+            class="sc-fjdhpX kwARlo"
           >
             Type
           </div>
           <div
-            class="sc-VigVT sc-jTzLTM efoQow"
+            class="sc-jzJRlG sc-cSHVUG dPoieQ"
           >
             3
           </div>
           <a
-            class="sc-fjdhpX ccjzuq"
+            class="sc-kAzzGY bOSCIr"
             href=""
             target="_blank"
           >
             0xc43efE2C7116CB94d563b5A9D68F260CCc44256F
           </a>
           <div
-            class="sc-VigVT sc-jzJRlG edSjIb"
+            class="sc-jzJRlG sc-chPdSV eEuoGw"
             type="Lock Creation"
           >
             Lock Creation
           </div>
           <div
-            class="sc-VigVT sc-jTzLTM efoQow"
+            class="sc-jzJRlG sc-cSHVUG dPoieQ"
           >
             2
           </div>
           <a
-            class="sc-fjdhpX ccjzuq"
+            class="sc-kAzzGY bOSCIr"
             href=""
             target="_blank"
           >
             0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
           </a>
           <div
-            class="sc-VigVT sc-jzJRlG cxsqrt"
+            class="sc-jzJRlG sc-chPdSV fcJkQn"
             type="Update Key Price"
           >
             Update Key Price
           </div>
           <div
-            class="sc-VigVT sc-jTzLTM efoQow"
+            class="sc-jzJRlG sc-cSHVUG dPoieQ"
           >
             1
           </div>
           <a
-            class="sc-fjdhpX ccjzuq"
+            class="sc-kAzzGY bOSCIr"
             href=""
             target="_blank"
           >
             0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
           </a>
           <div
-            class="sc-VigVT sc-jzJRlG edSjIb"
+            class="sc-jzJRlG sc-chPdSV eEuoGw"
             type="Lock Creation"
           >
             Lock Creation

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -247,13 +247,13 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gzVnrw ibZhkv"
+      class="sc-ifAKCX cFlEyZ"
     >
       <div
-        class="sc-dnqmqq igZzXE"
+        class="sc-bZQynM ePIBLw"
       >
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         >
           <div
             class="paper"
@@ -310,44 +310,44 @@ Object {
           </div>
         </div>
         <div
-          class="sc-gZMcBi kEdgDY"
+          class="sc-htoDjs erHdrS"
         >
           Address
           <span
-            class="sc-htoDjs cOlBaJ"
+            class="sc-EHOje ePRmVK"
             id="NetworkName"
           >
             Rinkeby
           </span>
         </div>
         <div
-          class="sc-gZMcBi kEdgDY"
+          class="sc-htoDjs erHdrS"
         >
           Balance
         </div>
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-gqjmRU cdfsbH"
+          class="sc-dnqmqq iSoGqQ"
           id="UserAddress"
         >
           0x3ca206264762caf81a8f0a843bbb850987b41e16
         </div>
         <div
-          class="sc-VigVT gzdgQt"
+          class="sc-iwsKbI caSLHP"
           id="AccountBalance"
         >
           <div
@@ -664,13 +664,13 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gzVnrw ibZhkv"
+      class="sc-ifAKCX cFlEyZ"
     >
       <div
-        class="sc-dnqmqq igZzXE"
+        class="sc-bZQynM ePIBLw"
       >
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         >
           <div
             class="paper"
@@ -727,44 +727,44 @@ Object {
           </div>
         </div>
         <div
-          class="sc-gZMcBi kEdgDY"
+          class="sc-htoDjs erHdrS"
         >
           Address
           <span
-            class="sc-htoDjs cOlBaJ"
+            class="sc-EHOje ePRmVK"
             id="NetworkName"
           >
             Rinkeby
           </span>
         </div>
         <div
-          class="sc-gZMcBi kEdgDY"
+          class="sc-htoDjs erHdrS"
         >
           Balance
         </div>
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-iwsKbI bWJBJz"
+          class="sc-gzVnrw gZXrCQ"
         />
         <div
-          class="sc-gqjmRU cdfsbH"
+          class="sc-dnqmqq iSoGqQ"
           id="UserAddress"
         >
           0x3ca206264762caf81a8f0a843bbb850987b41e16
         </div>
         <div
-          class="sc-VigVT gzdgQt"
+          class="sc-iwsKbI caSLHP"
           id="AccountBalance"
         >
           <div
@@ -8441,7 +8441,7 @@ Object {
           class="sc-9upljg-3 kjuFdI"
         >
           <button
-            class="sc-ifAKCX sc-9upljg-0 cTMzWy"
+            class="sc-cSHVUG sc-9upljg-0 cTMzWy"
           >
             Go to Your Dashboard
           </button>
@@ -23890,7 +23890,7 @@ exports[`Storyshots CreatorLocks loading with locks 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c21 {
+    .c20 {
   background-color: white;
   cursor: pointer;
   border-radius: 50%;
@@ -23902,25 +23902,25 @@ Object {
   line-height: 15px;
 }
 
-.c21 > svg {
+.c20 > svg {
   fill: var(--lightgrey);
   height: 24px;
   width: 24px;
 }
 
-.c21:hover {
+.c20:hover {
   background-color: white;
 }
 
-.c21:hover > svg {
+.c20:hover > svg {
   fill: var(--lightgrey);
 }
 
-.c21:focus {
+.c20:focus {
   outline: none;
 }
 
-.c22 {
+.c21 {
   background-color: var(--lightgrey);
   cursor: pointer;
   border-radius: 50%;
@@ -23932,25 +23932,25 @@ Object {
   line-height: 15px;
 }
 
-.c22 > svg {
+.c21 > svg {
   fill: var(--grey);
   height: 24px;
   width: 24px;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: var(--link);
 }
 
-.c22:hover > svg {
+.c21:hover > svg {
   fill: white;
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
 }
 
-.c23 {
+.c22 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -23965,23 +23965,23 @@ Object {
   color: var(--link);
 }
 
-.c20:hover .c23 {
+.c19:hover .c22 {
   display: inline-block;
 }
 
-.c18 {
+.c17 {
   display: grid;
   justify-items: end;
   padding-right: 24px;
 }
 
-.c19 {
+.c18 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(3,24px);
 }
 
-.c24 {
+.c23 {
   margin-top: 13px;
   font-size: 10px;
   font-family: 'IBM Plex Sans',sans-serif;
@@ -23991,7 +23991,7 @@ Object {
   padding-right: 24px;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -24001,7 +24001,7 @@ Object {
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -24012,38 +24012,38 @@ Object {
   padding-bottom: 0.5em;
 }
 
-.c14 {
+.c13 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c14:before {
+.c13:before {
   content: '三';
 }
 
-.c17 {
+.c16 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c17:before {
+.c16:before {
   content: '$';
 }
 
-.c15 {
+.c14 {
   white-space: nowrap;
   text-transform: uppercase;
 }
 
-.c16 {
+.c15 {
   font-size: 10px;
   color: var(--darkgrey);
   margin-top: 5px;
 }
 
-.c8 {
+.c7 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   min-height: 48px;
@@ -24063,28 +24063,28 @@ Object {
   cursor: pointer;
 }
 
-.c8 > * {
+.c7 > * {
   padding-top: 16px;
 }
 
-.c8:hover {
+.c7:hover {
   box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
   -webkit-transition: box-shadow 100ms ease;
   transition: box-shadow 100ms ease;
 }
 
-.c9 {
+.c8 {
   grid-row: span 2;
 }
 
-.c10 {
+.c9 {
   color: var(--link);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c11 {
+.c10 {
   color: var(--grey);
   font-weight: 200;
   white-space: nowrap;
@@ -24093,34 +24093,12 @@ Object {
   text-overflow: ellipsis;
 }
 
-.c7 {
-  background-color: var(--green);
-  border: none;
-  font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c7 :hover {
-  background-color: var(--activegreen);
-}
-
-.c25 {
+.c24 {
   display: grid;
   justify-items: center;
 }
 
-.c25 svg {
+.c24 svg {
   fill: var(--lightgrey);
   width: 60px;
 }
@@ -24201,13 +24179,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c18 {
+  .c17 {
     display: none;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c8 {
+  .c7 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
     grid-column-gap: 16px;
@@ -24215,7 +24193,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c8 {
+  .c7 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -24223,14 +24201,8 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c10 {
+  .c9 {
     grid-column: span 2;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c7 {
-    display: none;
   }
 }
 
@@ -24309,19 +24281,13 @@ Object {
               Balance
             </div>
           </div>
-          <button
-            class="c7"
-            id="CreateLockButton"
-          >
-            Create Lock
-          </button>
         </div>
         <div
-          class="c8"
+          class="c7"
           id="LockRow_0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e"
         >
           <div
-            class="c9"
+            class="c8"
           >
             <svg
               viewBox="0 0 216 216"
@@ -24397,11 +24363,11 @@ Object {
             </svg>
           </div>
           <div
-            class="c10"
+            class="c9"
           >
             First Lock
             <div
-              class="c11"
+              class="c10"
             >
               0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e
             </div>
@@ -24420,31 +24386,31 @@ Object {
             3/240
           </div>
           <div
-            class="c12"
+            class="c11"
           >
             <span
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               />
               <span
-                class="c15"
+                class="c14"
               >
                 0.01
               </span>
             </span>
             <div
-              class="c16"
+              class="c15"
             >
               <span
-                class="c13"
+                class="c12"
               >
                 <span
-                  class="c17"
+                  class="c16"
                 />
                 <span
-                  class="c15"
+                  class="c14"
                 >
                   ---
                 </span>
@@ -24458,31 +24424,31 @@ Object {
               class="c5"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
                 </span>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <span
-                    class="c13"
+                    class="c12"
                   >
                     <span
-                      class="c17"
+                      class="c16"
                     />
                     <span
-                      class="c15"
+                      class="c14"
                     >
                        - 
                     </span>
@@ -24494,16 +24460,16 @@ Object {
               class="c6"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
@@ -24516,13 +24482,13 @@ Object {
             class=""
           >
             <div
-              class="c18"
+              class="c17"
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <button
-                  class="c20 c21"
+                  class="c19 c20"
                 >
                   <svg
                     name="Withdraw"
@@ -24538,7 +24504,7 @@ Object {
                   
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="EditLockButton_0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e"
                   title="Edit"
                 >
@@ -24557,13 +24523,13 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Edit
                   </small>
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="LockEmbeddCode_0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e"
                   title="Embed"
                 >
@@ -24579,7 +24545,7 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Embed
                   </small>
@@ -24587,16 +24553,16 @@ Object {
               </div>
             </div>
             <div
-              class="c24"
+              class="c23"
             />
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
           id="LockRow_0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83"
         >
           <div
-            class="c9"
+            class="c8"
           >
             <svg
               viewBox="0 0 216 216"
@@ -24672,11 +24638,11 @@ Object {
             </svg>
           </div>
           <div
-            class="c10"
+            class="c9"
           >
             Another Lock
             <div
-              class="c11"
+              class="c10"
             >
               0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83
             </div>
@@ -24695,31 +24661,31 @@ Object {
             1234/∞
           </div>
           <div
-            class="c12"
+            class="c11"
           >
             <span
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               />
               <span
-                class="c15"
+                class="c14"
               >
                 1.00
               </span>
             </span>
             <div
-              class="c16"
+              class="c15"
             >
               <span
-                class="c13"
+                class="c12"
               >
                 <span
-                  class="c17"
+                  class="c16"
                 />
                 <span
-                  class="c15"
+                  class="c14"
                 >
                   ---
                 </span>
@@ -24733,31 +24699,31 @@ Object {
               class="c5"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
                 </span>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <span
-                    class="c13"
+                    class="c12"
                   >
                     <span
-                      class="c17"
+                      class="c16"
                     />
                     <span
-                      class="c15"
+                      class="c14"
                     >
                        - 
                     </span>
@@ -24769,16 +24735,16 @@ Object {
               class="c6"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
@@ -24791,13 +24757,13 @@ Object {
             class=""
           >
             <div
-              class="c18"
+              class="c17"
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <button
-                  class="c20 c21"
+                  class="c19 c20"
                 >
                   <svg
                     name="Withdraw"
@@ -24813,7 +24779,7 @@ Object {
                   
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="EditLockButton_0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83"
                   title="Edit"
                 >
@@ -24832,13 +24798,13 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Edit
                   </small>
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="LockEmbeddCode_0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83"
                   title="Embed"
                 >
@@ -24854,7 +24820,7 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Embed
                   </small>
@@ -24862,12 +24828,12 @@ Object {
               </div>
             </div>
             <div
-              class="c24"
+              class="c23"
             />
           </div>
         </div>
         <section
-          class="c25"
+          class="c24"
         >
           <svg
             viewBox="0 0 32 32"
@@ -25074,12 +25040,6 @@ Object {
             Balance
           </div>
         </div>
-        <button
-          class="sc-ifAKCX sc-EHOje eNCBwO"
-          id="CreateLockButton"
-        >
-          Create Lock
-        </button>
       </div>
       <div
         class="mlglvd-0 jpUcBv"
@@ -25838,33 +25798,11 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     .c7 {
-  background-color: var(--green);
-  border: none;
-  font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c7 :hover {
-  background-color: var(--activegreen);
-}
-
-.c8 {
   display: grid;
   justify-items: center;
 }
 
-.c8 svg {
+.c7 svg {
   fill: var(--lightgrey);
   width: 60px;
 }
@@ -25945,12 +25883,6 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c7 {
-    display: none;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
   .c1 {
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -26025,15 +25957,9 @@ Object {
               Balance
             </div>
           </div>
-          <button
-            class="c7"
-            id="CreateLockButton"
-          >
-            Create Lock
-          </button>
         </div>
         <section
-          class="c8"
+          class="c7"
         >
           <svg
             viewBox="0 0 32 32"
@@ -26240,12 +26166,6 @@ Object {
             Balance
           </div>
         </div>
-        <button
-          class="sc-ifAKCX sc-EHOje eNCBwO"
-          id="CreateLockButton"
-        >
-          Create Lock
-        </button>
       </div>
       <section
         class="sc-1olgoav-0 brRaoP"
@@ -26453,7 +26373,7 @@ exports[`Storyshots CreatorLocks multiple locks 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c21 {
+    .c20 {
   background-color: white;
   cursor: pointer;
   border-radius: 50%;
@@ -26465,25 +26385,25 @@ Object {
   line-height: 15px;
 }
 
-.c21 > svg {
+.c20 > svg {
   fill: var(--lightgrey);
   height: 24px;
   width: 24px;
 }
 
-.c21:hover {
+.c20:hover {
   background-color: white;
 }
 
-.c21:hover > svg {
+.c20:hover > svg {
   fill: var(--lightgrey);
 }
 
-.c21:focus {
+.c20:focus {
   outline: none;
 }
 
-.c22 {
+.c21 {
   background-color: var(--lightgrey);
   cursor: pointer;
   border-radius: 50%;
@@ -26495,25 +26415,25 @@ Object {
   line-height: 15px;
 }
 
-.c22 > svg {
+.c21 > svg {
   fill: var(--grey);
   height: 24px;
   width: 24px;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: var(--link);
 }
 
-.c22:hover > svg {
+.c21:hover > svg {
   fill: white;
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
 }
 
-.c23 {
+.c22 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -26528,23 +26448,23 @@ Object {
   color: var(--link);
 }
 
-.c20:hover .c23 {
+.c19:hover .c22 {
   display: inline-block;
 }
 
-.c18 {
+.c17 {
   display: grid;
   justify-items: end;
   padding-right: 24px;
 }
 
-.c19 {
+.c18 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(3,24px);
 }
 
-.c24 {
+.c23 {
   margin-top: 13px;
   font-size: 10px;
   font-family: 'IBM Plex Sans',sans-serif;
@@ -26554,7 +26474,7 @@ Object {
   padding-right: 24px;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -26564,7 +26484,7 @@ Object {
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -26575,38 +26495,38 @@ Object {
   padding-bottom: 0.5em;
 }
 
-.c14 {
+.c13 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c14:before {
+.c13:before {
   content: '三';
 }
 
-.c17 {
+.c16 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c17:before {
+.c16:before {
   content: '$';
 }
 
-.c15 {
+.c14 {
   white-space: nowrap;
   text-transform: uppercase;
 }
 
-.c16 {
+.c15 {
   font-size: 10px;
   color: var(--darkgrey);
   margin-top: 5px;
 }
 
-.c8 {
+.c7 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   min-height: 48px;
@@ -26626,56 +26546,34 @@ Object {
   cursor: pointer;
 }
 
-.c8 > * {
+.c7 > * {
   padding-top: 16px;
 }
 
-.c8:hover {
+.c7:hover {
   box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
   -webkit-transition: box-shadow 100ms ease;
   transition: box-shadow 100ms ease;
 }
 
-.c9 {
+.c8 {
   grid-row: span 2;
 }
 
-.c10 {
+.c9 {
   color: var(--link);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c11 {
+.c10 {
   color: var(--grey);
   font-weight: 200;
   white-space: nowrap;
   font-size: 10px;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.c7 {
-  background-color: var(--green);
-  border: none;
-  font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c7 :hover {
-  background-color: var(--activegreen);
 }
 
 .c0 {
@@ -26754,13 +26652,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c18 {
+  .c17 {
     display: none;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c8 {
+  .c7 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
     grid-column-gap: 16px;
@@ -26768,7 +26666,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c8 {
+  .c7 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -26776,14 +26674,8 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c10 {
+  .c9 {
     grid-column: span 2;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c7 {
-    display: none;
   }
 }
 
@@ -26862,19 +26754,13 @@ Object {
               Balance
             </div>
           </div>
-          <button
-            class="c7"
-            id="CreateLockButton"
-          >
-            Create Lock
-          </button>
         </div>
         <div
-          class="c8"
+          class="c7"
           id="LockRow_0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e"
         >
           <div
-            class="c9"
+            class="c8"
           >
             <svg
               viewBox="0 0 216 216"
@@ -26950,11 +26836,11 @@ Object {
             </svg>
           </div>
           <div
-            class="c10"
+            class="c9"
           >
             First Lock
             <div
-              class="c11"
+              class="c10"
             >
               0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e
             </div>
@@ -26973,31 +26859,31 @@ Object {
             3/240
           </div>
           <div
-            class="c12"
+            class="c11"
           >
             <span
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               />
               <span
-                class="c15"
+                class="c14"
               >
                 0.01
               </span>
             </span>
             <div
-              class="c16"
+              class="c15"
             >
               <span
-                class="c13"
+                class="c12"
               >
                 <span
-                  class="c17"
+                  class="c16"
                 />
                 <span
-                  class="c15"
+                  class="c14"
                 >
                   ---
                 </span>
@@ -27011,31 +26897,31 @@ Object {
               class="c5"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
                 </span>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <span
-                    class="c13"
+                    class="c12"
                   >
                     <span
-                      class="c17"
+                      class="c16"
                     />
                     <span
-                      class="c15"
+                      class="c14"
                     >
                        - 
                     </span>
@@ -27047,16 +26933,16 @@ Object {
               class="c6"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
@@ -27069,13 +26955,13 @@ Object {
             class=""
           >
             <div
-              class="c18"
+              class="c17"
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <button
-                  class="c20 c21"
+                  class="c19 c20"
                 >
                   <svg
                     name="Withdraw"
@@ -27091,7 +26977,7 @@ Object {
                   
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="EditLockButton_0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e"
                   title="Edit"
                 >
@@ -27110,13 +26996,13 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Edit
                   </small>
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="LockEmbeddCode_0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e"
                   title="Embed"
                 >
@@ -27132,7 +27018,7 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Embed
                   </small>
@@ -27140,16 +27026,16 @@ Object {
               </div>
             </div>
             <div
-              class="c24"
+              class="c23"
             />
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
           id="LockRow_0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83"
         >
           <div
-            class="c9"
+            class="c8"
           >
             <svg
               viewBox="0 0 216 216"
@@ -27225,11 +27111,11 @@ Object {
             </svg>
           </div>
           <div
-            class="c10"
+            class="c9"
           >
             Another Lock
             <div
-              class="c11"
+              class="c10"
             >
               0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83
             </div>
@@ -27248,31 +27134,31 @@ Object {
             1234/∞
           </div>
           <div
-            class="c12"
+            class="c11"
           >
             <span
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               />
               <span
-                class="c15"
+                class="c14"
               >
                 1.00
               </span>
             </span>
             <div
-              class="c16"
+              class="c15"
             >
               <span
-                class="c13"
+                class="c12"
               >
                 <span
-                  class="c17"
+                  class="c16"
                 />
                 <span
-                  class="c15"
+                  class="c14"
                 >
                   ---
                 </span>
@@ -27286,31 +27172,31 @@ Object {
               class="c5"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
                 </span>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <span
-                    class="c13"
+                    class="c12"
                   >
                     <span
-                      class="c17"
+                      class="c16"
                     />
                     <span
-                      class="c15"
+                      class="c14"
                     >
                        - 
                     </span>
@@ -27322,16 +27208,16 @@ Object {
               class="c6"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
@@ -27344,13 +27230,13 @@ Object {
             class=""
           >
             <div
-              class="c18"
+              class="c17"
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <button
-                  class="c20 c21"
+                  class="c19 c20"
                 >
                   <svg
                     name="Withdraw"
@@ -27366,7 +27252,7 @@ Object {
                   
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="EditLockButton_0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83"
                   title="Edit"
                 >
@@ -27385,13 +27271,13 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Edit
                   </small>
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="LockEmbeddCode_0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83"
                   title="Embed"
                 >
@@ -27407,7 +27293,7 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Embed
                   </small>
@@ -27415,7 +27301,7 @@ Object {
               </div>
             </div>
             <div
-              class="c24"
+              class="c23"
             />
           </div>
         </div>
@@ -27473,12 +27359,6 @@ Object {
             Balance
           </div>
         </div>
-        <button
-          class="sc-ifAKCX sc-EHOje eNCBwO"
-          id="CreateLockButton"
-        >
-          Create Lock
-        </button>
       </div>
       <div
         class="mlglvd-0 jpUcBv"
@@ -28082,7 +27962,7 @@ exports[`Storyshots CreatorLocks no lock 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c8 {
+    .c7 {
   display: grid;
   row-gap: 16px;
   -webkit-column-gap: 32px;
@@ -28099,49 +27979,27 @@ Object {
   padding-bottom: 40px;
 }
 
-.c9 {
+.c8 {
   width: 72px;
 }
 
-.c10 {
+.c9 {
   display: grid;
   grid-gap: 16px;
 }
 
-.c10 > h1 {
+.c9 > h1 {
   font-weight: bold;
   color: var(--grey);
   margin: 0px;
   padding: 0px;
 }
 
-.c10 > p {
+.c9 > p {
   margin: 0px;
   padding: 0px;
   font-size: 16px;
   color: var(--dimgrey);
-}
-
-.c7 {
-  background-color: var(--green);
-  border: none;
-  font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c7 :hover {
-  background-color: var(--activegreen);
 }
 
 .c0 {
@@ -28220,16 +28078,10 @@ Object {
 }
 
 @media (max-width:500px) {
-  .c8 {
+  .c7 {
     grid-template-columns: 1fr;
     grid-auto-flow: row;
     padding: 16px;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c7 {
-    display: none;
   }
 }
 
@@ -28308,22 +28160,16 @@ Object {
               Balance
             </div>
           </div>
-          <button
-            class="c7"
-            id="CreateLockButton"
-          >
-            Create Lock
-          </button>
         </div>
         <section
-          class="c8"
+          class="c7"
         >
           <img
-            class="c9"
+            class="c8"
             src="/static/images/illustrations/lock.svg"
           />
           <div
-            class="c10"
+            class="c9"
           >
             <h1>
               Create a lock to get started
@@ -28385,12 +28231,6 @@ Object {
             Balance
           </div>
         </div>
-        <button
-          class="sc-ifAKCX sc-EHOje eNCBwO"
-          id="CreateLockButton"
-        >
-          Create Lock
-        </button>
       </div>
       <section
         class="sc-1g6piw8-0 jXGMmL"
@@ -28460,216 +28300,44 @@ exports[`Storyshots CreatorLocks no lock, showForm 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c14 {
-  width: 1.3em;
-  text-align: right;
-  padding-right: 0.5em;
-}
-
-.c14:before {
-  content: '三';
-}
-
-.c12 {
-  color: var(--link);
-  font-size: 11px;
-  width: 100%;
-  padding: 5px;
+    .c7 {
+  display: grid;
+  row-gap: 16px;
+  -webkit-column-gap: 32px;
+  column-gap: 32px;
+  border: solid 1px var(--lightgrey);
+  grid-template-columns: 72px;
+  grid-auto-flow: column;
+  border-radius: 4px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 32px;
+  padding-bottom: 40px;
 }
 
 .c8 {
-  font-family: 'IBM Plex Mono','Courier New',Serif;
-  font-weight: 200;
-  min-height: 48px;
-  padding-left: 8px;
-  color: var(--slate);
-  font-size: 14px;
-  box-shadow: 0 0 40px 0 rgba(0,0,0,0.08);
-  -webkit-transition: box-shadow 100ms ease;
-  transition: box-shadow 100ms ease;
-  border-radius: 4px;
-  display: grid;
-  grid-row-gap: 0;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  cursor: pointer;
-  -webkit-animation: 400ms ease slideIn;
-  animation: 400ms ease slideIn;
-}
-
-.c8 > * {
-  padding-top: 16px;
-}
-
-.c8:hover {
-  box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
-  -webkit-transition: box-shadow 100ms ease;
-  transition: box-shadow 100ms ease;
-}
-
-.c8 input[type='number'] {
-  -moz-appearance: textfield;
-}
-
-.c8 input::-webkit-outer-spin-button,
-.c8 input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-.c8 input {
-  background: var(--lightgrey);
-  border: 1px solid var(--lightgrey);
-  border-radius: 4px;
-  height: 26px;
-  padding: 0 8px;
-  font-family: 'IBM Plex Mono',sans serif;
-  font-size: 14px;
-  font-weight: 200;
-}
-
-.c8 input:focus {
-  outline: none;
-  border: 1px solid var(--grey);
-  -webkit-transition: border 100ms ease;
-  transition: border 100ms ease;
-}
-
-.c8 input[data-valid='false'] {
-  border: 1px solid var(--red);
-}
-
-.c8 input:disabled {
-  color: var(--silver);
-}
-
-.c8 100% {
-  -webkit-transform: translateY(0);
-  -ms-transform: translateY(0);
-  transform: translateY(0);
-  opacity: 1;
-}
-
-.c15 {
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  display: grid;
-  text-transform: capitalize;
-  background-color: var(--lightgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  font-weight: 200;
-  color: var(--grey);
-  border-radius: 0 4px 4px 0;
-  padding-bottom: 15px;
+  width: 72px;
 }
 
 .c9 {
-  color: var(--link);
-  font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: grid;
+  grid-gap: 16px;
 }
 
-.c9 input[type='text'],
-.c9 input[type='number'] {
-  min-width: 70px;
-  width: 80%;
+.c9 > h1 {
+  font-weight: bold;
+  color: var(--grey);
+  margin: 0px;
+  padding: 0px;
 }
 
-.c10 input[type='text'],
-.c10 input[type='number'] {
-  min-width: 30px;
-  width: 50%;
-  text-align: right;
-}
-
-.c11 input[type='text'],
-.c11 input[type='number'] {
-  min-width: 30px;
-  width: 80%;
-  text-align: right;
-}
-
-.c13 {
-  white-space: nowrap;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-
-.c13 input[type='text'],
-.c13 input[type='number'] {
-  min-width: 30px;
-  width: 77%;
-  padding-right: 0;
-}
-
-.c16 {
-  cursor: pointer;
-  font: inherit;
-  font-size: 13px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  background: none;
-  color: inherit;
-  border: none;
-  outline: inherit;
-  padding: 0;
-}
-
-.c16:hover {
-  color: #333;
-  -webkit-transition: color 100ms ease;
-  transition: color 100ms ease;
-}
-
-.c17 {
-  cursor: pointer;
-  font: inherit;
-  font-size: 10px;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  background: none;
-  color: inherit;
-  border: none;
-  outline: inherit;
-  padding: 0;
-}
-
-.c17:hover {
-  color: #333;
-  -webkit-transition: color 100ms ease;
-  transition: color 100ms ease;
-}
-
-.c7 {
-  background-color: var(--green);
-  border: none;
+.c9 > p {
+  margin: 0px;
+  padding: 0px;
   font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c7 :hover {
-  background-color: var(--activegreen);
+  color: var(--dimgrey);
 }
 
 .c0 {
@@ -28747,31 +28415,11 @@ Object {
   }
 }
 
-@media only screen and (min-width:736px) {
-  .c8 {
-    grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
-    grid-template-rows: 84px;
-    grid-column-gap: 16px;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c8 {
-    grid-column-gap: 4px;
-    grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
-    grid-auto-flow: column;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c9 {
-    grid-column: span 2;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
+@media (max-width:500px) {
   .c7 {
-    display: none;
+    grid-template-columns: 1fr;
+    grid-auto-flow: row;
+    padding: 16px;
   }
 }
 
@@ -28850,165 +28498,23 @@ Object {
               Balance
             </div>
           </div>
-          <button
-            class="c7"
-            id="CreateLockButton"
-          >
-            Create Lock
-          </button>
         </div>
-        <div
-          class="c8"
+        <section
+          class="c7"
         >
-          <svg
-            viewBox="0 0 216 216"
-            width="100%"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <defs>
-              <circle
-                cx="108"
-                cy="108"
-                id="a"
-                r="108"
-              />
-              <circle
-                cx="108"
-                cy="108"
-                id="c"
-                r="60.75"
-              />
-            </defs>
-            <g>
-              <mask
-                fill="#fff"
-                id="b"
-              >
-                <use
-                  xlink:href="#a"
-                />
-              </mask>
-              <g
-                transform="rotate(0, 108, 108)"
-              >
-                <circle
-                  cx="195.75"
-                  cy="114.75"
-                  fill="#8c8c8c"
-                  mask="url(#b)"
-                  r="114.75"
-                />
-                <circle
-                  cx="33.75"
-                  cy="162"
-                  fill="#e8e8e8"
-                  mask="url(#b)"
-                  r="114.75"
-                />
-                <circle
-                  cx="121.5"
-                  cy="0"
-                  fill="#c3c3c3"
-                  mask="url(#b)"
-                  r="114.75"
-                />
-              </g>
-              <mask
-                fill="#fff"
-                id="d"
-              >
-                <use
-                  xlink:href="#c"
-                />
-              </mask>
-              <use
-                fill="#FFF"
-                xlink:href="#c"
-              />
-              <path
-                d="M121.179 116.422c-.001.895-.05 1.797-.168 2.683-1.047 7.845-9.512 12.951-17.006 10.275-5.482-1.958-8.917-6.786-8.921-12.582-.003-3.972-.003-7.944-.003-11.916h26.103c-.001 3.847-.002 7.694-.005 11.54m16.198-34.477V81h-16.335v16.198H94.936l.001-15.26v-.918h-16.28c-.014.196-.035.34-.035.483.001 5.232-.012 10.463-.019 15.695H74.25v7.694h4.353c.004 4.167.015 8.334.05 12.5.07 8.231 3.508 15.052 9.88 20.2 9.188 7.422 19.562 9 30.636 4.94 10.486-3.846 18.35-13.87 18.231-26.081-.037-3.853-.05-7.706-.054-11.559h4.404v-7.694h-4.4c.01-5.085.027-10.17.027-15.253"
-                fill="#8c8c8c"
-                mask="url(#d)"
-              />
-            </g>
-          </svg>
+          <img
+            class="c8"
+            src="/static/images/illustrations/lock.svg"
+          />
           <div
             class="c9"
           >
-            <input
-              data-valid="true"
-              name="name"
-              required=""
-              type="text"
-              value="New Lock"
-            />
+            <h1>
+              Create a lock to get started
+            </h1>
+            You have not created any locks yet. Create your first lock in seconds by clicking on the ‘Create Lock’ button.
           </div>
-          <div
-            class="c10"
-          >
-            <input
-              data-valid="true"
-              inputmode="numeric"
-              name="expirationDuration"
-              required=""
-              step="1"
-              type="number"
-              value="30"
-            />
-             
-            days
-          </div>
-          <div
-            class="c11"
-          >
-            <input
-              data-valid="true"
-              name="maxNumberOfKeys"
-              required=""
-              type="text"
-              value="10"
-            />
-            <div
-              class="c12"
-            >
-              Unlimited
-            </div>
-          </div>
-          <span
-            class="c13"
-          >
-            <span
-              class="c14"
-            />
-            <input
-              data-valid="true"
-              id="KeyPriceEditField_undefined"
-              inputmode="numeric"
-              name="keyPrice"
-              required=""
-              step="0.00001"
-              type="number"
-              value="0.01"
-            />
-          </span>
-          <div>
-            -
-          </div>
-          <div
-            class="c15"
-          >
-            <button
-              class="c16"
-            >
-              Submit
-            </button>
-            <button
-              class="c17"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        </section>
       </section>
     </div>
   </body>,
@@ -29063,165 +28569,23 @@ Object {
             Balance
           </div>
         </div>
-        <button
-          class="sc-ifAKCX sc-EHOje eNCBwO"
-          id="CreateLockButton"
-        >
-          Create Lock
-        </button>
       </div>
-      <div
-        class="mlglvd-0 sc-1u8ov25-1 hyBsBZ"
+      <section
+        class="sc-1g6piw8-0 jXGMmL"
       >
-        <svg
-          viewBox="0 0 216 216"
-          width="100%"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-        >
-          <defs>
-            <circle
-              cx="108"
-              cy="108"
-              id="a"
-              r="108"
-            />
-            <circle
-              cx="108"
-              cy="108"
-              id="c"
-              r="60.75"
-            />
-          </defs>
-          <g>
-            <mask
-              fill="#fff"
-              id="b"
-            >
-              <use
-                xlink:href="#a"
-              />
-            </mask>
-            <g
-              transform="rotate(0, 108, 108)"
-            >
-              <circle
-                cx="195.75"
-                cy="114.75"
-                fill="#8c8c8c"
-                mask="url(#b)"
-                r="114.75"
-              />
-              <circle
-                cx="33.75"
-                cy="162"
-                fill="#e8e8e8"
-                mask="url(#b)"
-                r="114.75"
-              />
-              <circle
-                cx="121.5"
-                cy="0"
-                fill="#c3c3c3"
-                mask="url(#b)"
-                r="114.75"
-              />
-            </g>
-            <mask
-              fill="#fff"
-              id="d"
-            >
-              <use
-                xlink:href="#c"
-              />
-            </mask>
-            <use
-              fill="#FFF"
-              xlink:href="#c"
-            />
-            <path
-              d="M121.179 116.422c-.001.895-.05 1.797-.168 2.683-1.047 7.845-9.512 12.951-17.006 10.275-5.482-1.958-8.917-6.786-8.921-12.582-.003-3.972-.003-7.944-.003-11.916h26.103c-.001 3.847-.002 7.694-.005 11.54m16.198-34.477V81h-16.335v16.198H94.936l.001-15.26v-.918h-16.28c-.014.196-.035.34-.035.483.001 5.232-.012 10.463-.019 15.695H74.25v7.694h4.353c.004 4.167.015 8.334.05 12.5.07 8.231 3.508 15.052 9.88 20.2 9.188 7.422 19.562 9 30.636 4.94 10.486-3.846 18.35-13.87 18.231-26.081-.037-3.853-.05-7.706-.054-11.559h4.404v-7.694h-4.4c.01-5.085.027-10.17.027-15.253"
-              fill="#8c8c8c"
-              mask="url(#d)"
-            />
-          </g>
-        </svg>
+        <img
+          class="sc-1g6piw8-1 fcKGMu"
+          src="/static/images/illustrations/lock.svg"
+        />
         <div
-          class="mlglvd-4 sc-1u8ov25-3 kHCPXz"
+          class="sc-1g6piw8-2 evbCld"
         >
-          <input
-            data-valid="true"
-            name="name"
-            required=""
-            type="text"
-            value="New Lock"
-          />
+          <h1>
+            Create a lock to get started
+          </h1>
+          You have not created any locks yet. Create your first lock in seconds by clicking on the ‘Create Lock’ button.
         </div>
-        <div
-          class="mlglvd-6 sc-1u8ov25-4 bBCopM"
-        >
-          <input
-            data-valid="true"
-            inputmode="numeric"
-            name="expirationDuration"
-            required=""
-            step="1"
-            type="number"
-            value="30"
-          />
-           
-          days
-        </div>
-        <div
-          class="mlglvd-7 sc-1u8ov25-5 foqKED"
-        >
-          <input
-            data-valid="true"
-            name="maxNumberOfKeys"
-            required=""
-            type="text"
-            value="10"
-          />
-          <div
-            class="mlglvd-1 sc-1u8ov25-0 eiQcmf"
-          >
-            Unlimited
-          </div>
-        </div>
-        <span
-          class="buwkmd-5 sc-1u8ov25-6 louuyM"
-        >
-          <span
-            class="buwkmd-2 buwkmd-3 cwENmW"
-          />
-          <input
-            data-valid="true"
-            id="KeyPriceEditField_undefined"
-            inputmode="numeric"
-            name="keyPrice"
-            required=""
-            step="0.00001"
-            type="number"
-            value="0.01"
-          />
-        </span>
-        <div>
-          -
-        </div>
-        <div
-          class="aicx7v-0 sc-1u8ov25-2 dpNRpO"
-        >
-          <button
-            class="sc-1u8ov25-7 jSpMeN"
-          >
-            Submit
-          </button>
-          <button
-            class="sc-1u8ov25-7 gScjsJ"
-          >
-            Cancel
-          </button>
-        </div>
-      </div>
+      </section>
     </section>
   </div>,
   "debug": [Function],
@@ -29274,7 +28638,7 @@ exports[`Storyshots CreatorLocks single lock 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c21 {
+    .c20 {
   background-color: white;
   cursor: pointer;
   border-radius: 50%;
@@ -29286,25 +28650,25 @@ Object {
   line-height: 15px;
 }
 
-.c21 > svg {
+.c20 > svg {
   fill: var(--lightgrey);
   height: 24px;
   width: 24px;
 }
 
-.c21:hover {
+.c20:hover {
   background-color: white;
 }
 
-.c21:hover > svg {
+.c20:hover > svg {
   fill: var(--lightgrey);
 }
 
-.c21:focus {
+.c20:focus {
   outline: none;
 }
 
-.c22 {
+.c21 {
   background-color: var(--lightgrey);
   cursor: pointer;
   border-radius: 50%;
@@ -29316,25 +28680,25 @@ Object {
   line-height: 15px;
 }
 
-.c22 > svg {
+.c21 > svg {
   fill: var(--grey);
   height: 24px;
   width: 24px;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: var(--link);
 }
 
-.c22:hover > svg {
+.c21:hover > svg {
   fill: white;
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
 }
 
-.c23 {
+.c22 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -29349,23 +28713,23 @@ Object {
   color: var(--link);
 }
 
-.c20:hover .c23 {
+.c19:hover .c22 {
   display: inline-block;
 }
 
-.c18 {
+.c17 {
   display: grid;
   justify-items: end;
   padding-right: 24px;
 }
 
-.c19 {
+.c18 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(3,24px);
 }
 
-.c24 {
+.c23 {
   margin-top: 13px;
   font-size: 10px;
   font-family: 'IBM Plex Sans',sans-serif;
@@ -29375,7 +28739,7 @@ Object {
   padding-right: 24px;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -29385,7 +28749,7 @@ Object {
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -29396,38 +28760,38 @@ Object {
   padding-bottom: 0.5em;
 }
 
-.c14 {
+.c13 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c14:before {
+.c13:before {
   content: '三';
 }
 
-.c17 {
+.c16 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c17:before {
+.c16:before {
   content: '$';
 }
 
-.c15 {
+.c14 {
   white-space: nowrap;
   text-transform: uppercase;
 }
 
-.c16 {
+.c15 {
   font-size: 10px;
   color: var(--darkgrey);
   margin-top: 5px;
 }
 
-.c8 {
+.c7 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   min-height: 48px;
@@ -29447,56 +28811,34 @@ Object {
   cursor: pointer;
 }
 
-.c8 > * {
+.c7 > * {
   padding-top: 16px;
 }
 
-.c8:hover {
+.c7:hover {
   box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
   -webkit-transition: box-shadow 100ms ease;
   transition: box-shadow 100ms ease;
 }
 
-.c9 {
+.c8 {
   grid-row: span 2;
 }
 
-.c10 {
+.c9 {
   color: var(--link);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c11 {
+.c10 {
   color: var(--grey);
   font-weight: 200;
   white-space: nowrap;
   font-size: 10px;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.c7 {
-  background-color: var(--green);
-  border: none;
-  font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c7 :hover {
-  background-color: var(--activegreen);
 }
 
 .c0 {
@@ -29575,13 +28917,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c18 {
+  .c17 {
     display: none;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c8 {
+  .c7 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
     grid-column-gap: 16px;
@@ -29589,7 +28931,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c8 {
+  .c7 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -29597,14 +28939,8 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c10 {
+  .c9 {
     grid-column: span 2;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c7 {
-    display: none;
   }
 }
 
@@ -29683,19 +29019,13 @@ Object {
               Balance
             </div>
           </div>
-          <button
-            class="c7"
-            id="CreateLockButton"
-          >
-            Create Lock
-          </button>
         </div>
         <div
-          class="c8"
+          class="c7"
           id="LockRow_0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e"
         >
           <div
-            class="c9"
+            class="c8"
           >
             <svg
               viewBox="0 0 216 216"
@@ -29771,11 +29101,11 @@ Object {
             </svg>
           </div>
           <div
-            class="c10"
+            class="c9"
           >
             First Lock
             <div
-              class="c11"
+              class="c10"
             >
               0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e
             </div>
@@ -29794,31 +29124,31 @@ Object {
             3/240
           </div>
           <div
-            class="c12"
+            class="c11"
           >
             <span
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               />
               <span
-                class="c15"
+                class="c14"
               >
                 0.01
               </span>
             </span>
             <div
-              class="c16"
+              class="c15"
             >
               <span
-                class="c13"
+                class="c12"
               >
                 <span
-                  class="c17"
+                  class="c16"
                 />
                 <span
-                  class="c15"
+                  class="c14"
                 >
                   ---
                 </span>
@@ -29832,31 +29162,31 @@ Object {
               class="c5"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
                 </span>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <span
-                    class="c13"
+                    class="c12"
                   >
                     <span
-                      class="c17"
+                      class="c16"
                     />
                     <span
-                      class="c15"
+                      class="c14"
                     >
                        - 
                     </span>
@@ -29868,16 +29198,16 @@ Object {
               class="c6"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c13"
+                  class="c12"
                 >
                   <span
-                    class="c14"
+                    class="c13"
                   />
                   <span
-                    class="c15"
+                    class="c14"
                   >
                      - 
                   </span>
@@ -29890,13 +29220,13 @@ Object {
             class=""
           >
             <div
-              class="c18"
+              class="c17"
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <button
-                  class="c20 c21"
+                  class="c19 c20"
                 >
                   <svg
                     name="Withdraw"
@@ -29912,7 +29242,7 @@ Object {
                   
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="EditLockButton_0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e"
                   title="Edit"
                 >
@@ -29931,13 +29261,13 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Edit
                   </small>
                 </button>
                 <button
-                  class="c20 c22"
+                  class="c19 c21"
                   id="LockEmbeddCode_0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e"
                   title="Embed"
                 >
@@ -29953,7 +29283,7 @@ Object {
                     />
                   </svg>
                   <small
-                    class="c23"
+                    class="c22"
                   >
                     Embed
                   </small>
@@ -29961,7 +29291,7 @@ Object {
               </div>
             </div>
             <div
-              class="c24"
+              class="c23"
             />
           </div>
         </div>
@@ -30019,12 +29349,6 @@ Object {
             Balance
           </div>
         </div>
-        <button
-          class="sc-ifAKCX sc-EHOje eNCBwO"
-          id="CreateLockButton"
-        >
-          Create Lock
-        </button>
       </div>
       <div
         class="mlglvd-0 jpUcBv"
@@ -30528,7 +29852,7 @@ Object {
   text-transform: uppercase;
 }
 
-.c36 {
+.c35 {
   display: grid;
   row-gap: 16px;
   -webkit-column-gap: 32px;
@@ -30545,49 +29869,27 @@ Object {
   padding-bottom: 40px;
 }
 
-.c37 {
+.c36 {
   width: 72px;
 }
 
-.c38 {
+.c37 {
   display: grid;
   grid-gap: 16px;
 }
 
-.c38 > h1 {
+.c37 > h1 {
   font-weight: bold;
   color: var(--grey);
   margin: 0px;
   padding: 0px;
 }
 
-.c38 > p {
+.c37 > p {
   margin: 0px;
   padding: 0px;
   font-size: 16px;
   color: var(--dimgrey);
-}
-
-.c35 {
-  background-color: var(--green);
-  border: none;
-  font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c35 :hover {
-  background-color: var(--activegreen);
 }
 
 .c28 {
@@ -30886,16 +30188,10 @@ Object {
 }
 
 @media (max-width:500px) {
-  .c36 {
+  .c35 {
     grid-template-columns: 1fr;
     grid-auto-flow: row;
     padding: 16px;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c35 {
-    display: none;
   }
 }
 
@@ -30999,7 +30295,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c39 {
+  .c38 {
     display: none;
   }
 }
@@ -31426,22 +30722,16 @@ Object {
                   Balance
                 </div>
               </div>
-              <button
-                class="c35"
-                id="CreateLockButton"
-              >
-                Create Lock
-              </button>
             </div>
             <section
-              class="c36"
+              class="c35"
             >
               <img
-                class="c37"
+                class="c36"
                 src="/static/images/illustrations/lock.svg"
               />
               <div
-                class="c38"
+                class="c37"
               >
                 <h1>
                   Create a lock to get started
@@ -31452,7 +30742,7 @@ Object {
           </section>
         </div>
         <div
-          class="c39"
+          class="c38"
         />
       </div>
     </div>
@@ -31696,13 +30986,13 @@ Object {
           />
         </header>
         <section
-          class="sc-gzVnrw ibZhkv"
+          class="sc-ifAKCX cFlEyZ"
         >
           <div
-            class="sc-dnqmqq igZzXE"
+            class="sc-bZQynM ePIBLw"
           >
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             >
               <div
                 class="paper"
@@ -31759,44 +31049,44 @@ Object {
               </div>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Address
               <span
-                class="sc-htoDjs cOlBaJ"
+                class="sc-EHOje ePRmVK"
                 id="NetworkName"
               >
                 Winston
               </span>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Balance
             </div>
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-gqjmRU cdfsbH"
+              class="sc-dnqmqq iSoGqQ"
               id="UserAddress"
             >
               0x3ca206264762caf81a8f0a843bbb850987b41e16
             </div>
             <div
-              class="sc-VigVT gzdgQt"
+              class="sc-iwsKbI caSLHP"
               id="AccountBalance"
             >
               <div
@@ -31865,12 +31155,6 @@ Object {
                 Balance
               </div>
             </div>
-            <button
-              class="sc-ifAKCX sc-EHOje eNCBwO"
-              id="CreateLockButton"
-            >
-              Create Lock
-            </button>
           </div>
           <section
             class="sc-1g6piw8-0 jXGMmL"
@@ -32120,7 +31404,7 @@ Object {
   text-transform: uppercase;
 }
 
-.c36 {
+.c35 {
   display: grid;
   row-gap: 16px;
   -webkit-column-gap: 32px;
@@ -32137,49 +31421,27 @@ Object {
   padding-bottom: 40px;
 }
 
-.c37 {
+.c36 {
   width: 72px;
 }
 
-.c38 {
+.c37 {
   display: grid;
   grid-gap: 16px;
 }
 
-.c38 > h1 {
+.c37 > h1 {
   font-weight: bold;
   color: var(--grey);
   margin: 0px;
   padding: 0px;
 }
 
-.c38 > p {
+.c37 > p {
   margin: 0px;
   padding: 0px;
   font-size: 16px;
   color: var(--dimgrey);
-}
-
-.c35 {
-  background-color: var(--green);
-  border: none;
-  font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c35 :hover {
-  background-color: var(--activegreen);
 }
 
 .c28 {
@@ -32478,16 +31740,10 @@ Object {
 }
 
 @media (max-width:500px) {
-  .c36 {
+  .c35 {
     grid-template-columns: 1fr;
     grid-auto-flow: row;
     padding: 16px;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c35 {
-    display: none;
   }
 }
 
@@ -32591,7 +31847,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c39 {
+  .c38 {
     display: none;
   }
 }
@@ -33018,22 +32274,16 @@ Object {
                   Balance
                 </div>
               </div>
-              <button
-                class="c35"
-                id="CreateLockButton"
-              >
-                Create Lock
-              </button>
             </div>
             <section
-              class="c36"
+              class="c35"
             >
               <img
-                class="c37"
+                class="c36"
                 src="/static/images/illustrations/lock.svg"
               />
               <div
-                class="c38"
+                class="c37"
               >
                 <h1>
                   Create a lock to get started
@@ -33044,7 +32294,7 @@ Object {
           </section>
         </div>
         <div
-          class="c39"
+          class="c38"
         />
       </div>
     </div>
@@ -33288,13 +32538,13 @@ Object {
           />
         </header>
         <section
-          class="sc-gzVnrw ibZhkv"
+          class="sc-ifAKCX cFlEyZ"
         >
           <div
-            class="sc-dnqmqq igZzXE"
+            class="sc-bZQynM ePIBLw"
           >
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             >
               <div
                 class="paper"
@@ -33351,44 +32601,44 @@ Object {
               </div>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Address
               <span
-                class="sc-htoDjs cOlBaJ"
+                class="sc-EHOje ePRmVK"
                 id="NetworkName"
               >
                 Winston
               </span>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Balance
             </div>
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-gqjmRU cdfsbH"
+              class="sc-dnqmqq iSoGqQ"
               id="UserAddress"
             >
               0x3ca206264762caf81a8f0a843bbb850987b41e16
             </div>
             <div
-              class="sc-VigVT gzdgQt"
+              class="sc-iwsKbI caSLHP"
               id="AccountBalance"
             >
               <div
@@ -33457,12 +32707,6 @@ Object {
                 Balance
               </div>
             </div>
-            <button
-              class="sc-ifAKCX sc-EHOje eNCBwO"
-              id="CreateLockButton"
-            >
-              Create Lock
-            </button>
           </div>
           <section
             class="sc-1g6piw8-0 jXGMmL"
@@ -33537,7 +32781,7 @@ exports[`Storyshots DashboardContent the dashboard 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c47 {
+    .c46 {
   background-color: white;
   cursor: pointer;
   border-radius: 50%;
@@ -33549,21 +32793,21 @@ Object {
   line-height: 15px;
 }
 
-.c47 > svg {
+.c46 > svg {
   fill: var(--lightgrey);
   height: 24px;
   width: 24px;
 }
 
-.c47:hover {
+.c46:hover {
   background-color: white;
 }
 
-.c47:hover > svg {
+.c46:hover > svg {
   fill: var(--lightgrey);
 }
 
-.c47:focus {
+.c46:focus {
   outline: none;
 }
 
@@ -33706,7 +32950,7 @@ Object {
   display: inline-block;
 }
 
-.c42 {
+.c41 {
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
@@ -33723,7 +32967,7 @@ Object {
   border-radius: 0 4px 4px 0;
 }
 
-.c43 {
+.c42 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -33735,7 +32979,7 @@ Object {
   align-self: end;
 }
 
-.c44 {
+.c43 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -33748,19 +32992,19 @@ Object {
   margin-bottom: 15px;
 }
 
-.c45 {
+.c44 {
   display: grid;
   justify-items: end;
   padding-right: 24px;
 }
 
-.c46 {
+.c45 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(3,24px);
 }
 
-.c48 {
+.c47 {
   margin-top: 13px;
   font-size: 10px;
   font-family: 'IBM Plex Sans',sans-serif;
@@ -33801,13 +33045,13 @@ Object {
   content: '三';
 }
 
-.c41 {
+.c40 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c41:before {
+.c40:before {
   content: '$';
 }
 
@@ -33816,13 +33060,13 @@ Object {
   text-transform: uppercase;
 }
 
-.c40 {
+.c39 {
   font-size: 10px;
   color: var(--darkgrey);
   margin-top: 5px;
 }
 
-.c36 {
+.c35 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   min-height: 48px;
@@ -33842,56 +33086,34 @@ Object {
   cursor: pointer;
 }
 
-.c36 > * {
+.c35 > * {
   padding-top: 16px;
 }
 
-.c36:hover {
+.c35:hover {
   box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
   -webkit-transition: box-shadow 100ms ease;
   transition: box-shadow 100ms ease;
 }
 
-.c37 {
+.c36 {
   grid-row: span 2;
 }
 
-.c38 {
+.c37 {
   color: var(--link);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c39 {
+.c38 {
   color: var(--grey);
   font-weight: 200;
   white-space: nowrap;
   font-size: 10px;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.c35 {
-  background-color: var(--green);
-  border: none;
-  font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c35 :hover {
-  background-color: var(--activegreen);
 }
 
 .c28 {
@@ -34190,13 +33412,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c45 {
+  .c44 {
     display: none;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c36 {
+  .c35 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
     grid-column-gap: 16px;
@@ -34204,7 +33426,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c36 {
+  .c35 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -34212,14 +33434,8 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c38 {
+  .c37 {
     grid-column: span 2;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c35 {
-    display: none;
   }
 }
 
@@ -34323,7 +33539,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c49 {
+  .c48 {
     display: none;
   }
 }
@@ -34750,19 +33966,13 @@ Object {
                   Balance
                 </div>
               </div>
-              <button
-                class="c35"
-                id="CreateLockButton"
-              >
-                Create Lock
-              </button>
             </div>
             <div
-              class="c36"
+              class="c35"
               id="LockRow_0x9abcdef0"
             >
               <div
-                class="c37"
+                class="c36"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -34838,11 +34048,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c38"
+                class="c37"
               >
                 Infinite Lock
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   0x9abcdef0
                 </div>
@@ -34876,13 +34086,13 @@ Object {
                   </span>
                 </span>
                 <div
-                  class="c40"
+                  class="c39"
                 >
                   <span
                     class="c25"
                   >
                     <span
-                      class="c41"
+                      class="c40"
                     />
                     <span
                       class="c27"
@@ -34914,13 +34124,13 @@ Object {
                       </span>
                     </span>
                     <div
-                      class="c40"
+                      class="c39"
                     >
                       <span
                         class="c25"
                       >
                         <span
-                          class="c41"
+                          class="c40"
                         />
                         <span
                           class="c27"
@@ -34954,15 +34164,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c42"
+                class="c41"
               >
                 <div
-                  class="c43"
+                  class="c42"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c44"
+                  class="c43"
                 >
                   2
                    / 
@@ -34971,11 +34181,11 @@ Object {
               </div>
             </div>
             <div
-              class="c36"
+              class="c35"
               id="LockRow_0x56781234a"
             >
               <div
-                class="c37"
+                class="c36"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -35051,11 +34261,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c38"
+                class="c37"
               >
                 New Lock
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   0x56781234a
                 </div>
@@ -35089,13 +34299,13 @@ Object {
                   </span>
                 </span>
                 <div
-                  class="c40"
+                  class="c39"
                 >
                   <span
                     class="c25"
                   >
                     <span
-                      class="c41"
+                      class="c40"
                     />
                     <span
                       class="c27"
@@ -35127,13 +34337,13 @@ Object {
                       </span>
                     </span>
                     <div
-                      class="c40"
+                      class="c39"
                     >
                       <span
                         class="c25"
                       >
                         <span
-                          class="c41"
+                          class="c40"
                         />
                         <span
                           class="c27"
@@ -35167,15 +34377,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c42"
+                class="c41"
               >
                 <div
-                  class="c43"
+                  class="c42"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c44"
+                  class="c43"
                 >
                   4
                    / 
@@ -35184,11 +34394,11 @@ Object {
               </div>
             </div>
             <div
-              class="c36"
+              class="c35"
               id="LockRow_0x12345678a"
             >
               <div
-                class="c37"
+                class="c36"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -35264,11 +34474,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c38"
+                class="c37"
               >
                 My Blog
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   0x12345678a
                 </div>
@@ -35302,13 +34512,13 @@ Object {
                   </span>
                 </span>
                 <div
-                  class="c40"
+                  class="c39"
                 >
                   <span
                     class="c25"
                   >
                     <span
-                      class="c41"
+                      class="c40"
                     />
                     <span
                       class="c27"
@@ -35340,13 +34550,13 @@ Object {
                       </span>
                     </span>
                     <div
-                      class="c40"
+                      class="c39"
                     >
                       <span
                         class="c25"
                       >
                         <span
-                          class="c41"
+                          class="c40"
                         />
                         <span
                           class="c27"
@@ -35383,13 +34593,13 @@ Object {
                 class=""
               >
                 <div
-                  class="c45"
+                  class="c44"
                 >
                   <div
-                    class="c46"
+                    class="c45"
                   >
                     <button
-                      class="c9 c47"
+                      class="c9 c46"
                     >
                       <svg
                         name="Withdraw"
@@ -35454,14 +34664,14 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c48"
+                  class="c47"
                 />
               </div>
             </div>
           </section>
         </div>
         <div
-          class="c49"
+          class="c48"
         />
       </div>
     </div>
@@ -35705,13 +34915,13 @@ Object {
           />
         </header>
         <section
-          class="sc-gzVnrw ibZhkv"
+          class="sc-ifAKCX cFlEyZ"
         >
           <div
-            class="sc-dnqmqq igZzXE"
+            class="sc-bZQynM ePIBLw"
           >
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             >
               <div
                 class="paper"
@@ -35768,44 +34978,44 @@ Object {
               </div>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Address
               <span
-                class="sc-htoDjs cOlBaJ"
+                class="sc-EHOje ePRmVK"
                 id="NetworkName"
               >
                 Winston
               </span>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Balance
             </div>
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-gqjmRU cdfsbH"
+              class="sc-dnqmqq iSoGqQ"
               id="UserAddress"
             >
               0x3ca206264762caf81a8f0a843bbb850987b41e16
             </div>
             <div
-              class="sc-VigVT gzdgQt"
+              class="sc-iwsKbI caSLHP"
               id="AccountBalance"
             >
               <div
@@ -35874,12 +35084,6 @@ Object {
                 Balance
               </div>
             </div>
-            <button
-              class="sc-ifAKCX sc-EHOje eNCBwO"
-              id="CreateLockButton"
-            >
-              Create Lock
-            </button>
           </div>
           <div
             class="mlglvd-0 jpUcBv"
@@ -36639,7 +35843,7 @@ exports[`Storyshots DashboardContent the dashboard, waiting for wallet 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c50 {
+    .c49 {
   background-color: white;
   cursor: pointer;
   border-radius: 50%;
@@ -36651,21 +35855,21 @@ Object {
   line-height: 15px;
 }
 
-.c50 > svg {
+.c49 > svg {
   fill: var(--lightgrey);
   height: 24px;
   width: 24px;
 }
 
-.c50:hover {
+.c49:hover {
   background-color: white;
 }
 
-.c50:hover > svg {
+.c49:hover > svg {
   fill: var(--lightgrey);
 }
 
-.c50:focus {
+.c49:focus {
   outline: none;
 }
 
@@ -36808,7 +36012,7 @@ Object {
   display: inline-block;
 }
 
-.c45 {
+.c44 {
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
@@ -36825,7 +36029,7 @@ Object {
   border-radius: 0 4px 4px 0;
 }
 
-.c46 {
+.c45 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -36837,7 +36041,7 @@ Object {
   align-self: end;
 }
 
-.c47 {
+.c46 {
   display: grid;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -36850,19 +36054,19 @@ Object {
   margin-bottom: 15px;
 }
 
-.c48 {
+.c47 {
   display: grid;
   justify-items: end;
   padding-right: 24px;
 }
 
-.c49 {
+.c48 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(3,24px);
 }
 
-.c51 {
+.c50 {
   margin-top: 13px;
   font-size: 10px;
   font-family: 'IBM Plex Sans',sans-serif;
@@ -36903,13 +36107,13 @@ Object {
   content: '三';
 }
 
-.c44 {
+.c43 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c44:before {
+.c43:before {
   content: '$';
 }
 
@@ -36918,13 +36122,13 @@ Object {
   text-transform: uppercase;
 }
 
-.c43 {
+.c42 {
   font-size: 10px;
   color: var(--darkgrey);
   margin-top: 5px;
 }
 
-.c39 {
+.c38 {
   font-family: 'IBM Plex Mono','Courier New',Serif;
   font-weight: 200;
   min-height: 48px;
@@ -36944,56 +36148,34 @@ Object {
   cursor: pointer;
 }
 
-.c39 > * {
+.c38 > * {
   padding-top: 16px;
 }
 
-.c39:hover {
+.c38:hover {
   box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
   -webkit-transition: box-shadow 100ms ease;
   transition: box-shadow 100ms ease;
 }
 
-.c40 {
+.c39 {
   grid-row: span 2;
 }
 
-.c41 {
+.c40 {
   color: var(--link);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.c42 {
+.c41 {
   color: var(--grey);
   font-weight: 200;
   white-space: nowrap;
   font-size: 10px;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.c38 {
-  background-color: var(--green);
-  border: none;
-  font-size: 16px;
-  color: var(--darkgrey);
-  font-family: 'IBM Plex Sans',sans-serif;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: background-color 200ms ease;
-  transition: background-color 200ms ease;
-  padding: 10px;
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  height: 48px;
-}
-
-.c38 :hover {
-  background-color: var(--activegreen);
 }
 
 .c31 {
@@ -37355,13 +36537,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c48 {
+  .c47 {
     display: none;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c39 {
+  .c38 {
     grid-template-columns: 32px minmax(100px,1fr) repeat(4,minmax(56px,100px)) minmax(174px,1fr);
     grid-template-rows: 84px;
     grid-column-gap: 16px;
@@ -37369,7 +36551,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c39 {
+  .c38 {
     grid-column-gap: 4px;
     grid-template-columns: 43px minmax(80px,140px) repeat(2,minmax(56px,80px));
     grid-auto-flow: column;
@@ -37377,14 +36559,8 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c41 {
+  .c40 {
     grid-column: span 2;
-  }
-}
-
-@media only screen and (min-width:0px) and (max-width:736px) {
-  .c38 {
-    display: none;
   }
 }
 
@@ -37488,7 +36664,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c52 {
+  .c51 {
     display: none;
   }
 }
@@ -37931,19 +37107,13 @@ Object {
                   Balance
                 </div>
               </div>
-              <button
-                class="c38"
-                id="CreateLockButton"
-              >
-                Create Lock
-              </button>
             </div>
             <div
-              class="c39"
+              class="c38"
               id="LockRow_0x9abcdef0"
             >
               <div
-                class="c40"
+                class="c39"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -38019,11 +37189,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c41"
+                class="c40"
               >
                 Infinite Lock
                 <div
-                  class="c42"
+                  class="c41"
                 >
                   0x9abcdef0
                 </div>
@@ -38057,13 +37227,13 @@ Object {
                   </span>
                 </span>
                 <div
-                  class="c43"
+                  class="c42"
                 >
                   <span
                     class="c28"
                   >
                     <span
-                      class="c44"
+                      class="c43"
                     />
                     <span
                       class="c30"
@@ -38095,13 +37265,13 @@ Object {
                       </span>
                     </span>
                     <div
-                      class="c43"
+                      class="c42"
                     >
                       <span
                         class="c28"
                       >
                         <span
-                          class="c44"
+                          class="c43"
                         />
                         <span
                           class="c30"
@@ -38135,15 +37305,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c45"
+                class="c44"
               >
                 <div
-                  class="c46"
+                  class="c45"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c47"
+                  class="c46"
                 >
                   2
                    / 
@@ -38152,11 +37322,11 @@ Object {
               </div>
             </div>
             <div
-              class="c39"
+              class="c38"
               id="LockRow_0x56781234a"
             >
               <div
-                class="c40"
+                class="c39"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -38232,11 +37402,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c41"
+                class="c40"
               >
                 New Lock
                 <div
-                  class="c42"
+                  class="c41"
                 >
                   0x56781234a
                 </div>
@@ -38270,13 +37440,13 @@ Object {
                   </span>
                 </span>
                 <div
-                  class="c43"
+                  class="c42"
                 >
                   <span
                     class="c28"
                   >
                     <span
-                      class="c44"
+                      class="c43"
                     />
                     <span
                       class="c30"
@@ -38308,13 +37478,13 @@ Object {
                       </span>
                     </span>
                     <div
-                      class="c43"
+                      class="c42"
                     >
                       <span
                         class="c28"
                       >
                         <span
-                          class="c44"
+                          class="c43"
                         />
                         <span
                           class="c30"
@@ -38348,15 +37518,15 @@ Object {
                 </div>
               </div>
               <div
-                class="c45"
+                class="c44"
               >
                 <div
-                  class="c46"
+                  class="c45"
                 >
                   Confirming
                 </div>
                 <div
-                  class="c47"
+                  class="c46"
                 >
                   4
                    / 
@@ -38365,11 +37535,11 @@ Object {
               </div>
             </div>
             <div
-              class="c39"
+              class="c38"
               id="LockRow_0x12345678a"
             >
               <div
-                class="c40"
+                class="c39"
               >
                 <svg
                   viewBox="0 0 216 216"
@@ -38445,11 +37615,11 @@ Object {
                 </svg>
               </div>
               <div
-                class="c41"
+                class="c40"
               >
                 My Blog
                 <div
-                  class="c42"
+                  class="c41"
                 >
                   0x12345678a
                 </div>
@@ -38483,13 +37653,13 @@ Object {
                   </span>
                 </span>
                 <div
-                  class="c43"
+                  class="c42"
                 >
                   <span
                     class="c28"
                   >
                     <span
-                      class="c44"
+                      class="c43"
                     />
                     <span
                       class="c30"
@@ -38521,13 +37691,13 @@ Object {
                       </span>
                     </span>
                     <div
-                      class="c43"
+                      class="c42"
                     >
                       <span
                         class="c28"
                       >
                         <span
-                          class="c44"
+                          class="c43"
                         />
                         <span
                           class="c30"
@@ -38564,13 +37734,13 @@ Object {
                 class=""
               >
                 <div
-                  class="c48"
+                  class="c47"
                 >
                   <div
-                    class="c49"
+                    class="c48"
                   >
                     <button
-                      class="c12 c50"
+                      class="c12 c49"
                     >
                       <svg
                         name="Withdraw"
@@ -38635,14 +37805,14 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="c51"
+                  class="c50"
                 />
               </div>
             </div>
           </section>
         </div>
         <div
-          class="c52"
+          class="c51"
         />
       </div>
     </div>
@@ -38902,13 +38072,13 @@ Object {
           />
         </header>
         <section
-          class="sc-gzVnrw ibZhkv"
+          class="sc-ifAKCX cFlEyZ"
         >
           <div
-            class="sc-dnqmqq igZzXE"
+            class="sc-bZQynM ePIBLw"
           >
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             >
               <div
                 class="paper"
@@ -38965,44 +38135,44 @@ Object {
               </div>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Address
               <span
-                class="sc-htoDjs cOlBaJ"
+                class="sc-EHOje ePRmVK"
                 id="NetworkName"
               >
                 Winston
               </span>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Balance
             </div>
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-gqjmRU cdfsbH"
+              class="sc-dnqmqq iSoGqQ"
               id="UserAddress"
             >
               0x3ca206264762caf81a8f0a843bbb850987b41e16
             </div>
             <div
-              class="sc-VigVT gzdgQt"
+              class="sc-iwsKbI caSLHP"
               id="AccountBalance"
             >
               <div
@@ -39071,12 +38241,6 @@ Object {
                 Balance
               </div>
             </div>
-            <button
-              class="sc-ifAKCX sc-EHOje eNCBwO"
-              id="CreateLockButton"
-            >
-              Create Lock
-            </button>
           </div>
           <div
             class="mlglvd-0 jpUcBv"
@@ -44051,7 +43215,7 @@ Object {
         href="/dashboard"
       >
         <button
-          class="sc-ifAKCX sc-9upljg-1 cKpQTs"
+          class="sc-cSHVUG sc-9upljg-1 cKpQTs"
         >
           I Agree
         </button>
@@ -44178,7 +43342,7 @@ Object {
       class="sc-9upljg-3 kjuFdI"
     >
       <button
-        class="sc-ifAKCX sc-9upljg-0 cTMzWy"
+        class="sc-cSHVUG sc-9upljg-0 cTMzWy"
       >
         Go to Your Dashboard
       </button>
@@ -45808,13 +44972,13 @@ Object {
           />
         </header>
         <section
-          class="sc-gzVnrw ibZhkv"
+          class="sc-ifAKCX cFlEyZ"
         >
           <div
-            class="sc-dnqmqq igZzXE"
+            class="sc-bZQynM ePIBLw"
           >
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             >
               <div
                 class="paper"
@@ -45871,44 +45035,44 @@ Object {
               </div>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Address
               <span
-                class="sc-htoDjs cOlBaJ"
+                class="sc-EHOje ePRmVK"
                 id="NetworkName"
               >
                 Winston
               </span>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Balance
             </div>
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-gqjmRU cdfsbH"
+              class="sc-dnqmqq iSoGqQ"
               id="UserAddress"
             >
               0x3ca206264762caf81a8f0a843bbb850987b41e16
             </div>
             <div
-              class="sc-VigVT gzdgQt"
+              class="sc-iwsKbI caSLHP"
               id="AccountBalance"
             >
               <div
@@ -57520,13 +56684,13 @@ Object {
           />
         </header>
         <section
-          class="sc-gzVnrw ibZhkv"
+          class="sc-ifAKCX cFlEyZ"
         >
           <div
-            class="sc-dnqmqq igZzXE"
+            class="sc-bZQynM ePIBLw"
           >
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             >
               <div
                 class="paper"
@@ -57583,44 +56747,44 @@ Object {
               </div>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Address
               <span
-                class="sc-htoDjs cOlBaJ"
+                class="sc-EHOje ePRmVK"
                 id="NetworkName"
               >
                 Winston
               </span>
             </div>
             <div
-              class="sc-gZMcBi kEdgDY"
+              class="sc-htoDjs erHdrS"
             >
               Balance
             </div>
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-iwsKbI bWJBJz"
+              class="sc-gzVnrw gZXrCQ"
             />
             <div
-              class="sc-gqjmRU cdfsbH"
+              class="sc-dnqmqq iSoGqQ"
               id="UserAddress"
             >
               0x3ca206264762caf81a8f0a843bbb850987b41e16
             </div>
             <div
-              class="sc-VigVT gzdgQt"
+              class="sc-iwsKbI caSLHP"
               id="AccountBalance"
             >
               <div
@@ -57644,73 +56808,73 @@ Object {
           </div>
         </section>
         <div
-          class="sc-jTzLTM emFApi"
+          class="sc-gZMcBi gOZeal"
         >
           <div
-            class="sc-fjdhpX kwARlo"
+            class="sc-gqjmRU ckuBkR"
           >
             Block Number
           </div>
           <div
-            class="sc-fjdhpX kwARlo"
+            class="sc-gqjmRU ckuBkR"
           >
             Lock Name/Address
           </div>
           <div
-            class="sc-fjdhpX kwARlo"
+            class="sc-gqjmRU ckuBkR"
           >
             Type
           </div>
           <div
-            class="sc-jzJRlG sc-cSHVUG dPoieQ"
+            class="sc-VigVT sc-jTzLTM efoQow"
           >
             3
           </div>
           <a
-            class="sc-kAzzGY bOSCIr"
+            class="sc-fjdhpX ccjzuq"
             href=""
             target="_blank"
           >
             0xc43efE2C7116CB94d563b5A9D68F260CCc44256F
           </a>
           <div
-            class="sc-jzJRlG sc-chPdSV eEuoGw"
+            class="sc-VigVT sc-jzJRlG edSjIb"
             type="Lock Creation"
           >
             Lock Creation
           </div>
           <div
-            class="sc-jzJRlG sc-cSHVUG dPoieQ"
+            class="sc-VigVT sc-jTzLTM efoQow"
           >
             2
           </div>
           <a
-            class="sc-kAzzGY bOSCIr"
+            class="sc-fjdhpX ccjzuq"
             href=""
             target="_blank"
           >
             0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
           </a>
           <div
-            class="sc-jzJRlG sc-chPdSV fcJkQn"
+            class="sc-VigVT sc-jzJRlG cxsqrt"
             type="Update Key Price"
           >
             Update Key Price
           </div>
           <div
-            class="sc-jzJRlG sc-cSHVUG dPoieQ"
+            class="sc-VigVT sc-jTzLTM efoQow"
           >
             1
           </div>
           <a
-            class="sc-kAzzGY bOSCIr"
+            class="sc-fjdhpX ccjzuq"
             href=""
             target="_blank"
           >
             0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
           </a>
           <div
-            class="sc-jzJRlG sc-chPdSV eEuoGw"
+            class="sc-VigVT sc-jzJRlG edSjIb"
             type="Lock Creation"
           >
             Lock Creation

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -55581,7 +55581,7 @@ Object {
   display: inline-block;
 }
 
-.c24 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -55591,7 +55591,7 @@ Object {
   flex-direction: column;
 }
 
-.c25 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -55602,17 +55602,17 @@ Object {
   padding-bottom: 0.5em;
 }
 
-.c26 {
+.c27 {
   width: 1.3em;
   text-align: right;
   padding-right: 0.5em;
 }
 
-.c26:before {
+.c27:before {
   content: '三';
 }
 
-.c27 {
+.c28 {
   white-space: nowrap;
   text-transform: uppercase;
 }
@@ -55781,7 +55781,7 @@ Object {
   width: 100%;
 }
 
-.c21 {
+.c22 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   font-weight: 500;
@@ -55790,7 +55790,7 @@ Object {
   text-transform: none;
 }
 
-.c18 {
+.c19 {
   font-family: 'IBM Plex Mono',monospace;
   display: grid;
   row-gap: 8px;
@@ -55799,7 +55799,7 @@ Object {
   grid-template-columns: 40px 200px repeat(2,100px) repeat(3,24px) 1fr;
 }
 
-.c19 {
+.c20 {
   display: grid;
   height: 40px;
   grid-row: span 2;
@@ -55812,7 +55812,7 @@ Object {
   align-content: start;
 }
 
-.c20 {
+.c21 {
   font-weight: 100;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
@@ -55822,7 +55822,7 @@ Object {
   font-size: 8px;
 }
 
-.c22 {
+.c23 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   width: 128px;
@@ -55831,20 +55831,51 @@ Object {
   word-break: break-all;
 }
 
-.c23 {
+.c24 {
   font-size: 16px;
   font-weight: 500;
   color: var(--darkgrey);
 }
 
-.c28 {
+.c29 {
+  background-color: var(--green);
+  border: none;
+  font-size: 16px;
+  color: var(--darkgrey);
+  font-family: 'IBM Plex Sans',sans-serif;
+  border-radius: 4px;
+  cursor: pointer;
+  outline: none;
+  -webkit-transition: background-color 200ms ease;
+  transition: background-color 200ms ease;
+  padding: 10px;
+  -webkit-align-self: end;
+  -ms-flex-item-align: end;
+  align-self: end;
+  height: 48px;
+}
+
+.c29 :hover {
+  background-color: var(--activegreen);
+}
+
+.c18 {
+  display: grid;
+  grid-template-columns: 1fr 144px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c30 {
   display: grid;
   grid-template-columns: 125px 2fr 1fr;
   grid-auto-rows: 32px;
   grid-column-gap: 20px;
 }
 
-.c29 {
+.c31 {
   font-size: 10px;
   font-weight: normal;
   text-transform: uppercase;
@@ -55852,7 +55883,7 @@ Object {
   white-space: nowrap;
 }
 
-.c30 {
+.c32 {
   font-size: 14px;
   line-height: 14px;
   color: var(--darkgrey);
@@ -55860,13 +55891,13 @@ Object {
   font-family: 'IBM Plex Mono',Courier,monospace;
 }
 
-.c31 {
+.c33 {
   font-size: 14px;
   font-weight: 300;
   font-family: 'IBM Plex Mono',Courier,monospace;
 }
 
-.c32 {
+.c34 {
   font-size: 14px;
   line-height: 14px;
   color: var(--darkgrey);
@@ -55876,7 +55907,7 @@ Object {
   white-space: nowrap;
 }
 
-.c33 {
+.c35 {
   font-size: 14px;
   line-height: 14px;
   color: var(--darkgrey);
@@ -55962,13 +55993,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c34 {
+  .c36 {
     display: none;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c18 {
+  .c19 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
     grid-template-columns: 45px 145px repeat(2,80px);
@@ -55976,8 +56007,14 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c19 {
+  .c20 {
     height: 0px;
+  }
+}
+
+@media only screen and (min-width:0px) and (max-width:736px) {
+  .c29 {
+    display: none;
   }
 }
 
@@ -56219,198 +56256,208 @@ Object {
               class="c17"
             />
           </header>
-          <section
-            class=""
+          <div
+            class="c18"
           >
-            <div
-              class="c18"
+            <section
+              class=""
             >
               <div
                 class="c19"
               >
                 <div
-                  class="paper"
-                  style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
+                  class="c20"
                 >
-                  <svg
-                    height="40"
-                    width="40"
-                    x="0"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0"
+                  <div
+                    class="paper"
+                    style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
                   >
-                    <rect
-                      fill="#F5B400"
+                    <svg
                       height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
                       width="40"
                       x="0"
+                      xmlns="http://www.w3.org/2000/svg"
                       y="0"
-                    />
-                    <rect
-                      fill="#F92F01"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#FB186F"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#18A9F2"
-                      height="40"
-                      rx="0"
-                      ry="0"
-                      transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                      width="40"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
+                    >
+                      <rect
+                        fill="#F5B400"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#F92F01"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#FB186F"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                      <rect
+                        fill="#18A9F2"
+                        height="40"
+                        rx="0"
+                        ry="0"
+                        transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
+                        width="40"
+                        x="0"
+                        y="0"
+                      />
+                    </svg>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="c20"
-              >
-                Address
-                <span
+                <div
                   class="c21"
-                  id="NetworkName"
                 >
-                  Winston
-                </span>
-              </div>
-              <div
-                class="c20"
-              >
-                Balance
-              </div>
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c19"
-              />
-              <div
-                class="c22"
-                id="UserAddress"
-              >
-                0x3ca206264762caf81a8f0a843bbb850987b41e16
-              </div>
-              <div
-                class="c23"
-                id="AccountBalance"
-              >
+                  Address
+                  <span
+                    class="c22"
+                    id="NetworkName"
+                  >
+                    Winston
+                  </span>
+                </div>
+                <div
+                  class="c21"
+                >
+                  Balance
+                </div>
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c20"
+                />
+                <div
+                  class="c23"
+                  id="UserAddress"
+                >
+                  0x3ca206264762caf81a8f0a843bbb850987b41e16
+                </div>
                 <div
                   class="c24"
+                  id="AccountBalance"
                 >
-                  <span
+                  <div
                     class="c25"
                   >
                     <span
                       class="c26"
-                    />
-                    <span
-                      class="c27"
                     >
-                       - 
+                      <span
+                        class="c27"
+                      />
+                      <span
+                        class="c28"
+                      >
+                         - 
+                      </span>
                     </span>
-                  </span>
-                  
+                    
+                  </div>
                 </div>
               </div>
-            </div>
-          </section>
+            </section>
+            <button
+              class="c29"
+              id="CreateLockButton"
+            >
+              Create Lock
+            </button>
+          </div>
           <div
-            class="c28"
+            class="c30"
           >
             <div
-              class="c29"
+              class="c31"
             >
               Block Number
             </div>
             <div
-              class="c29"
+              class="c31"
             >
               Lock Name/Address
             </div>
             <div
-              class="c29"
+              class="c31"
             >
               Type
             </div>
             <div
-              class="c30"
+              class="c32"
             >
               3
             </div>
             <a
-              class="c31"
+              class="c33"
               href=""
               target="_blank"
             >
               0xc43efE2C7116CB94d563b5A9D68F260CCc44256F
             </a>
             <div
-              class="c32"
+              class="c34"
               type="Lock Creation"
             >
               Lock Creation
             </div>
             <div
-              class="c30"
+              class="c32"
             >
               2
             </div>
             <a
-              class="c31"
+              class="c33"
               href=""
               target="_blank"
             >
               0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
             </a>
             <div
-              class="c33"
+              class="c35"
               type="Update Key Price"
             >
               Update Key Price
             </div>
             <div
-              class="c30"
+              class="c32"
             >
               1
             </div>
             <a
-              class="c31"
+              class="c33"
               href=""
               target="_blank"
             >
               0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
             </a>
             <div
-              class="c32"
+              class="c34"
               type="Lock Creation"
             >
               Lock Creation
@@ -56418,7 +56465,7 @@ Object {
           </div>
         </div>
         <div
-          class="c34"
+          class="c36"
         />
       </div>
     </div>
@@ -56661,130 +56708,140 @@ Object {
             class="sc-1glv5oz-5 bjHPyP"
           />
         </header>
-        <section
-          class="sc-ifAKCX cFlEyZ"
+        <div
+          class="sc-VigVT jqbjAH"
         >
-          <div
-            class="sc-bZQynM ePIBLw"
+          <section
+            class="sc-ifAKCX cFlEyZ"
           >
             <div
-              class="sc-gzVnrw gZXrCQ"
+              class="sc-bZQynM ePIBLw"
             >
               <div
-                class="paper"
-                style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
+                class="sc-gzVnrw gZXrCQ"
               >
-                <svg
-                  height="40"
-                  width="40"
-                  x="0"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
+                <div
+                  class="paper"
+                  style="border-radius: 50px; display: inline-block; margin: 0px; overflow: hidden; padding: 0px; background-color: rgb(1, 142, 137); height: 40px; width: 40px;"
                 >
-                  <rect
-                    fill="#F5B400"
+                  <svg
                     height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
                     width="40"
                     x="0"
+                    xmlns="http://www.w3.org/2000/svg"
                     y="0"
-                  />
-                  <rect
-                    fill="#F92F01"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#FB186F"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#18A9F2"
-                    height="40"
-                    rx="0"
-                    ry="0"
-                    transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Address
-              <span
-                class="sc-EHOje ePRmVK"
-                id="NetworkName"
-              >
-                Winston
-              </span>
-            </div>
-            <div
-              class="sc-htoDjs erHdrS"
-            >
-              Balance
-            </div>
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-gzVnrw gZXrCQ"
-            />
-            <div
-              class="sc-dnqmqq iSoGqQ"
-              id="UserAddress"
-            >
-              0x3ca206264762caf81a8f0a843bbb850987b41e16
-            </div>
-            <div
-              class="sc-iwsKbI caSLHP"
-              id="AccountBalance"
-            >
-              <div
-                class="buwkmd-0 bYclZI"
-              >
-                <span
-                  class="buwkmd-1 jZYwNd"
-                >
-                  <span
-                    class="buwkmd-2 buwkmd-3 cwENmW"
-                  />
-                  <span
-                    class="buwkmd-5 dKpFcq"
                   >
-                     - 
-                  </span>
+                    <rect
+                      fill="#F5B400"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-8.516726993034728 -5.001359274183636) rotate(291.1 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#F92F01"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(19.487272054702824 3.994787375441723) rotate(45.6 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#FB186F"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-28.427236485524897 1.2584814742811758) rotate(199.7 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#18A9F2"
+                      height="40"
+                      rx="0"
+                      ry="0"
+                      transform="translate(-40.94617387266237 -25.242528297898357) rotate(278.7 20 20)"
+                      width="40"
+                      x="0"
+                      y="0"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="sc-htoDjs erHdrS"
+              >
+                Address
+                <span
+                  class="sc-EHOje ePRmVK"
+                  id="NetworkName"
+                >
+                  Winston
                 </span>
-                
+              </div>
+              <div
+                class="sc-htoDjs erHdrS"
+              >
+                Balance
+              </div>
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-gzVnrw gZXrCQ"
+              />
+              <div
+                class="sc-dnqmqq iSoGqQ"
+                id="UserAddress"
+              >
+                0x3ca206264762caf81a8f0a843bbb850987b41e16
+              </div>
+              <div
+                class="sc-iwsKbI caSLHP"
+                id="AccountBalance"
+              >
+                <div
+                  class="buwkmd-0 bYclZI"
+                >
+                  <span
+                    class="buwkmd-1 jZYwNd"
+                  >
+                    <span
+                      class="buwkmd-2 buwkmd-3 cwENmW"
+                    />
+                    <span
+                      class="buwkmd-5 dKpFcq"
+                    >
+                       - 
+                    </span>
+                  </span>
+                  
+                </div>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
+          <button
+            class="sc-gZMcBi sc-gqjmRU dHaPpi"
+            id="CreateLockButton"
+          >
+            Create Lock
+          </button>
+        </div>
         <div
           class="sc-jTzLTM emFApi"
         >

--- a/unlock-app/src/components/content/LogContent.tsx
+++ b/unlock-app/src/components/content/LogContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import Head from 'next/head'
+import Link from 'next/link'
 import Layout from '../interface/Layout'
 import Account from '../interface/Account'
 import BrowserOnly from '../helpers/BrowserOnly'
@@ -12,11 +13,18 @@ import withConfig from '../../utils/withConfig'
 import * as UnlockTypes from '../../unlock'
 /* eslint-enable no-unused-vars */
 
+import {
+  CreateLockButton,
+  AccountWrapper,
+} from '../interface/buttons/ActionButton'
+import { showForm } from '../../actions/lockFormVisibility'
+
 interface Props {
   account: UnlockTypes.Account
   network: UnlockTypes.Network
   transactionFeed: UnlockTypes.Transaction[]
   explorerLinks: { [key: string]: string }
+  showForm?: () => any
 }
 
 export const LogContent = ({
@@ -24,6 +32,7 @@ export const LogContent = ({
   network,
   transactionFeed,
   explorerLinks,
+  showForm,
 }: Props) => {
   return (
     <GlobalErrorConsumer>
@@ -33,7 +42,14 @@ export const LogContent = ({
         </Head>
         {account && (
           <BrowserOnly>
-            <Account network={network} account={account} />
+            <AccountWrapper>
+              <Account network={network} account={account} />
+              <Link href="/dashboard">
+                <CreateLockButton onClick={showForm} id="CreateLockButton">
+                  Create Lock
+                </CreateLockButton>
+              </Link>
+            </AccountWrapper>
             <CreatorLog
               transactionFeed={transactionFeed}
               explorerLinks={explorerLinks}
@@ -77,4 +93,13 @@ export const mapStateToProps = (
   }
 }
 
-export default withConfig(connect(mapStateToProps)(LogContent))
+const mapDispatchToProps = (dispatch: any) => ({
+  showForm: () => dispatch(showForm()),
+})
+
+export default withConfig(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(LogContent)
+)

--- a/unlock-app/src/components/creator/CreatorLocks.js
+++ b/unlock-app/src/components/creator/CreatorLocks.js
@@ -10,98 +10,78 @@ import CreatorLockForm from './CreatorLockForm'
 import Errors from '../interface/Errors'
 import Media, { NoPhone, Phone } from '../../theme/media'
 import { createLock } from '../../actions/lock'
+import { hideForm } from '../../actions/lockFormVisibility'
 import { DefaultError } from './FatalError'
 import Svg from '../interface/svg'
-import { CreateLockButton } from '../interface/buttons/ActionButton'
 
-export class CreatorLocks extends React.Component {
-  constructor(props, context) {
-    super(props, context)
-    const { showForm } = this.props
-    this.state = {
-      showDashboardForm: !!showForm,
-    }
-    this.toggleForm = this.toggleForm.bind(this)
-  }
-
-  toggleForm() {
-    this.setState(previousState => ({
-      showDashboardForm: !previousState.showDashboardForm,
-    }))
-  }
-
-  render() {
-    const { createLock, lockFeed, loading } = this.props
-    const { showDashboardForm } = this.state
-
-    return (
-      <Locks>
-        <LockHeaderRow id="LockHeaderRow">
-          <LockHeader>Locks</LockHeader>
-          <LockMinorHeader>Name / Address</LockMinorHeader>
-          <LockMinorHeader>Key Duration</LockMinorHeader>
-          <Quantity>Key Quantity</Quantity>
-          <LockMinorHeader>Price</LockMinorHeader>
-          <LockMinorHeader>
-            <NoPhone>Balance</NoPhone>
-            <Phone>Balance</Phone>
-          </LockMinorHeader>
-          <CreateLockButton onClick={this.toggleForm} id="CreateLockButton">
-            Create Lock
-          </CreateLockButton>
-        </LockHeaderRow>
-        <Errors />
-        {showDashboardForm && (
-          <CreatorLockForm
-            hideAction={this.toggleForm}
-            createLock={createLock}
-            pending
-          />
-        )}
-        {lockFeed.length > 0 &&
-          lockFeed.map(lock => {
-            return <CreatorLock key={JSON.stringify(lock)} lock={lock} />
-          })}
-        {lockFeed.length === 0 && !loading && !showDashboardForm && (
-          <DefaultError
-            title="Create a lock to get started"
-            illustration="/static/images/illustrations/lock.svg"
-            critical={false}
-          >
-            You have not created any locks yet. Create your first lock in
-            seconds by clicking on the &#8216;Create Lock&#8217; button.
-          </DefaultError>
-        )}
-        {loading && (
-          <LoadingWrapper>
-            <Svg.Loading title="loading" />
-          </LoadingWrapper>
-        )}
-      </Locks>
-    )
-  }
+export const CreatorLocks = props => {
+  const { createLock, lockFeed, loading, formIsVisible, hideForm } = props
+  return (
+    <Locks>
+      <LockHeaderRow id="LockHeaderRow">
+        <LockHeader>Locks</LockHeader>
+        <LockMinorHeader>Name / Address</LockMinorHeader>
+        <LockMinorHeader>Key Duration</LockMinorHeader>
+        <Quantity>Key Quantity</Quantity>
+        <LockMinorHeader>Price</LockMinorHeader>
+        <LockMinorHeader>
+          <NoPhone>Balance</NoPhone>
+          <Phone>Balance</Phone>
+        </LockMinorHeader>
+      </LockHeaderRow>
+      <Errors />
+      {formIsVisible && (
+        <CreatorLockForm
+          hideAction={hideForm}
+          createLock={createLock}
+          pending
+        />
+      )}
+      {lockFeed.length > 0 &&
+        lockFeed.map(lock => {
+          return <CreatorLock key={JSON.stringify(lock)} lock={lock} />
+        })}
+      {lockFeed.length === 0 && !loading && !formIsVisible && (
+        <DefaultError
+          title="Create a lock to get started"
+          illustration="/static/images/illustrations/lock.svg"
+          critical={false}
+        >
+          You have not created any locks yet. Create your first lock in seconds
+          by clicking on the &#8216;Create Lock&#8217; button.
+        </DefaultError>
+      )}
+      {loading && (
+        <LoadingWrapper>
+          <Svg.Loading title="loading" />
+        </LoadingWrapper>
+      )}
+    </Locks>
+  )
 }
 
 CreatorLocks.propTypes = {
   createLock: PropTypes.func.isRequired,
-  showForm: UnlockPropTypes.showDashboardForm,
+  formIsVisible: PropTypes.bool.isRequired,
   lockFeed: PropTypes.arrayOf(UnlockPropTypes.lock),
   loading: PropTypes.bool,
+  hideForm: PropTypes.func.isRequired,
 }
 
 CreatorLocks.defaultProps = {
   loading: false,
-  showForm: false,
   lockFeed: [],
 }
 
 const mapDispatchToProps = dispatch => ({
   createLock: lock => dispatch(createLock(lock)),
+  hideForm: () => dispatch(hideForm()),
 })
 
-export const mapStateToProps = ({ loading }) => {
+export const mapStateToProps = ({ loading, lockFormStatus: { visible } }) => {
   return {
     loading: !!loading,
+    formIsVisible: visible,
   }
 }
 

--- a/unlock-app/src/stories/creator/CreatorLocks.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLocks.stories.js
@@ -46,17 +46,43 @@ storiesOf('CreatorLocks', module)
     <ConfigProvider value={config}>{getStory()}</ConfigProvider>
   ))
   .add('no lock', () => {
-    return <CreatorLocks createLock={createLock} lockFeed={[]} />
+    return (
+      <CreatorLocks
+        createLock={createLock}
+        lockFeed={[]}
+        hideForm={() => {}}
+        formIsVisible={false}
+      />
+    )
   })
   .add('no lock, showForm', () => {
-    return <CreatorLocks createLock={createLock} lockFeed={[]} showForm />
+    return (
+      <CreatorLocks
+        createLock={createLock}
+        lockFeed={[]}
+        hideForm={() => {}}
+        formIsVisible
+      />
+    )
   })
   .add('single lock', () => {
-    return <CreatorLocks createLock={createLock} lockFeed={[lock]} />
+    return (
+      <CreatorLocks
+        createLock={createLock}
+        lockFeed={[lock]}
+        hideForm={() => {}}
+        formIsVisible={false}
+      />
+    )
   })
   .add('multiple locks', () => {
     return (
-      <CreatorLocks createLock={createLock} lockFeed={[lock, anotherLock]} />
+      <CreatorLocks
+        createLock={createLock}
+        lockFeed={[lock, anotherLock]}
+        hideForm={() => {}}
+        formIsVisible={false}
+      />
     )
   })
   .add('loading with locks', () => {
@@ -64,10 +90,20 @@ storiesOf('CreatorLocks', module)
       <CreatorLocks
         createLock={createLock}
         lockFeed={[lock, anotherLock]}
+        formIsVisible={false}
+        hideForm={() => {}}
         loading
       />
     )
   })
   .add('loading with no lock', () => {
-    return <CreatorLocks createLock={createLock} lockFeed={[]} loading />
+    return (
+      <CreatorLocks
+        createLock={createLock}
+        lockFeed={[]}
+        loading
+        hideForm={() => {}}
+        formIsVisible={false}
+      />
+    )
   })

--- a/unlock-app/src/stories/creator/Dashboard.stories.js
+++ b/unlock-app/src/stories/creator/Dashboard.stories.js
@@ -11,6 +11,7 @@ import WalletCheckOverlay from '../../components/interface/FullScreenModals'
 
 const account = {
   address: '0x3ca206264762caf81a8f0a843bbb850987b41e16',
+  balance: '5',
 }
 const network = {
   name: 1984,
@@ -79,7 +80,11 @@ const currency = {
   USD: 195.99,
 }
 
-const store = createUnlockStore({
+const lockFormStatus = {
+  visible: false,
+}
+
+const state = {
   account,
   network,
   router,
@@ -89,7 +94,10 @@ const store = createUnlockStore({
   walletStatus: {
     waiting: false,
   },
-})
+  lockFormStatus,
+}
+
+const store = createUnlockStore(state)
 
 const waitingStore = createUnlockStore({
   account,
@@ -101,12 +109,14 @@ const waitingStore = createUnlockStore({
   walletStatus: {
     waiting: true,
   },
+  lockFormStatus,
 })
 
 const noUserStore = createUnlockStore({
   account: undefined,
   network,
   router,
+  lockFormStatus,
 })
 
 const ConfigProvider = ConfigContext.Provider
@@ -124,29 +134,31 @@ storiesOf('DashboardContent', module)
   .add('the dashboard', () => {
     // The overlay should not render here, because walletStatus:waiting is set
     // to false in the state
-    const lockFeed = mapStateToProps({ locks, transactions, account, network })
-      .lockFeed
+    const props = mapStateToProps(state)
     return (
       <Provider store={store}>
         <WalletCheckOverlay />
         <DashboardContent
           network={network}
           account={account}
-          lockFeed={lockFeed}
+          hideForm={() => {}}
+          showForm={() => {}}
+          {...props}
         />
       </Provider>
     )
   })
   .add('the dashboard, waiting for wallet', () => {
-    const lockFeed = mapStateToProps({ locks, transactions, account, network })
-      .lockFeed
+    const props = mapStateToProps(state)
     return (
       <Provider store={waitingStore}>
         <WalletCheckOverlay />
         <DashboardContent
           network={network}
           account={account}
-          lockFeed={lockFeed}
+          hideForm={() => {}}
+          showForm={() => {}}
+          {...props}
         />
       </Provider>
     )
@@ -154,14 +166,27 @@ storiesOf('DashboardContent', module)
   .add('dashboard, no user account', () => {
     return (
       <Provider store={noUserStore}>
-        <DashboardContent network={network} account={account} />
+        <DashboardContent
+          hideForm={() => {}}
+          showForm={() => {}}
+          network={network}
+          account={null}
+          formIsVisible={false}
+        />
       </Provider>
     )
   })
   .add('dashboard, no locks', () => {
     return (
       <Provider store={store}>
-        <DashboardContent network={network} account={account} lockFeed={[]} />
+        <DashboardContent
+          hideForm={() => {}}
+          showForm={() => {}}
+          network={network}
+          account={account}
+          lockFeed={[]}
+          formIsVisible={false}
+        />
       </Provider>
     )
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR fixes #1945. It moves the "Create Lock" button into the header so that it is accessible both from the log and the dashboard.

<img width="1299" alt="image" src="https://user-images.githubusercontent.com/9300702/55184139-d0519680-5167-11e9-9c09-edc9d3303298.png">

<img width="1299" alt="image" src="https://user-images.githubusercontent.com/9300702/55184171-e3646680-5167-11e9-9fe5-283643663f96.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
