### PR TITLE
If no <meta> lock tags exist, don't block the page

### DIFF
--- a/paywall/src/__tests__/paywall-builder/index.test.js
+++ b/paywall/src/__tests__/paywall-builder/index.test.js
@@ -9,7 +9,7 @@ describe('paywall builder integration', () => {
   let addBlocker
   beforeEach(() => {
     listenForNewLocks = jest
-      .spyOn(mutations, 'listenForNewLocks')
+      .spyOn(mutations, 'default')
       .mockImplementation(() => 'listen')
     buildPaywall = jest
       .spyOn(buildManager, 'default')
@@ -31,7 +31,7 @@ describe('paywall builder integration', () => {
     require('../../paywall-builder')
     window.onload()
 
-    expect(listenForNewLocks.mock.calls[0][1]).toBe(document.head)
+    expect(listenForNewLocks.mock.calls[0][2]).toBe(document.head)
 
     const paywall = listenForNewLocks.mock.calls[0][0]
     expect(paywall).toBeInstanceOf(Function)

--- a/paywall/src/__tests__/paywall-builder/mutationObserver.test.js
+++ b/paywall/src/__tests__/paywall-builder/mutationObserver.test.js
@@ -1,29 +1,4 @@
-import {
-  listenForNewLocks,
-  changeListener,
-} from '../../paywall-builder/mutationObserver'
-
-function tag(tagName, name, content) {
-  return { nodeName: tagName.toUpperCase(), name, content }
-}
-
-function makeMutation(nodes = []) {
-  if (!nodes.length) return {}
-  return [
-    {
-      addedNodes: {
-        length: nodes.length,
-        entries() {
-          return nodes
-            .map(node => {
-              return [0, node]
-            })
-            [Symbol.iterator]()
-        },
-      },
-    },
-  ]
-}
+import listenForNewLocks from '../../paywall-builder/mutationObserver'
 
 function mockHead(content = false) {
   return {
@@ -39,74 +14,27 @@ function mockHead(content = false) {
 }
 
 describe('mutationObserver', () => {
-  describe('changeListener', () => {
-    let callback
-    beforeEach(() => {
-      callback = jest.fn()
-    })
-    it('bails if no nodes added', () => {
-      expect.assertions(1)
-      changeListener(callback, [])
-      expect(callback).not.toBeCalled()
-    })
-    it('bails if node is not a meta tag', () => {
-      expect.assertions(1)
-      const mutations = makeMutation([tag('notmeta', 'hi', 'content')])
-      changeListener(callback, mutations)
-      expect(callback).not.toBeCalled()
-    })
-    it('bails if node is not a meta tag named "lock"', () => {
-      expect.assertions(1)
-      const mutations = makeMutation([
-        tag('notmeta', 'hi', 'content'),
-        tag('meta', 'hi', 'content2'),
-      ])
-      changeListener(callback, mutations)
-      expect(callback).not.toBeCalled()
-    })
-    it('calls callback with content attribute', () => {
-      expect.assertions(1)
-      const mutations = makeMutation([
-        tag('notmeta', 'hi', 'content'),
-        tag('meta', 'hi', 'content2'),
-        tag('meta', 'lock', 'content3'),
-      ])
-      changeListener(callback, mutations)
-      expect(callback).toBeCalledWith('content3')
-    })
-  })
-
   describe('listenForNewLocks', () => {
     let callback
-    let observer
+    let fail
     beforeEach(() => {
       callback = jest.fn()
+      fail = jest.fn()
     })
     afterEach(() => {
       jest.restoreAllMocks()
     })
     it('immediately calls callback if a lock meta tag already exists in the page', () => {
       expect.assertions(1)
-      listenForNewLocks(callback, mockHead('hi'))
+      listenForNewLocks(callback, () => {}, mockHead('hi'))
       expect(callback).toBeCalledWith('hi')
     })
-    it('creates MutationObserver and calls observe', () => {
-      expect.assertions(3)
-      global.MutationObserver = function() {
-        this.observe = jest.fn()
-        observer = this
-      }
-      jest.spyOn(changeListener, 'bind')
+    it('calls fail if a meta tag is not found', () => {
+      expect.assertions(1)
       const head = mockHead()
+      listenForNewLocks(callback, fail, head)
 
-      listenForNewLocks(callback, head)
-
-      expect(changeListener.bind).toHaveBeenCalledWith(null, callback)
-      expect(observer).not.toBeUndefined()
-      expect(observer.observe).toHaveBeenCalledWith(head, {
-        attributes: true,
-        childList: true,
-      })
+      expect(fail).toHaveBeenCalled()
     })
   })
 })

--- a/paywall/src/paywall-builder/index.js
+++ b/paywall/src/paywall-builder/index.js
@@ -7,6 +7,7 @@ window.onload = () => {
   addBlocker(document, blocker)
   listenForNewLocks(
     lock => buildPaywall(window, document, lock, blocker),
+    // our fail callback removes the blocker, since the paywall is useless without a lock to display
     () => removeBlocker(blocker),
     document.head
   )

--- a/paywall/src/paywall-builder/index.js
+++ b/paywall/src/paywall-builder/index.js
@@ -1,5 +1,5 @@
-import { listenForNewLocks } from './mutationObserver'
-import { getBlocker, addBlocker } from './blocker'
+import listenForNewLocks from './mutationObserver'
+import { getBlocker, addBlocker, removeBlocker } from './blocker'
 import buildPaywall from './build'
 
 window.onload = () => {
@@ -7,6 +7,7 @@ window.onload = () => {
   addBlocker(document, blocker)
   listenForNewLocks(
     lock => buildPaywall(window, document, lock, blocker),
+    () => removeBlocker(blocker),
     document.head
   )
 }

--- a/paywall/src/paywall-builder/mutationObserver.js
+++ b/paywall/src/paywall-builder/mutationObserver.js
@@ -9,5 +9,7 @@ export default function listenForNewLocks(callback, fail, head) {
   if (existingLock) {
     return callback(existingLock)
   }
+
+  // if we reach here, there were no locks found on the page, so we call the fail callback
   fail()
 }

--- a/paywall/src/paywall-builder/mutationObserver.js
+++ b/paywall/src/paywall-builder/mutationObserver.js
@@ -4,25 +4,10 @@
  */
 import { findLocks } from './script'
 
-export function changeListener(callback, list) {
-  list.forEach(mutation => {
-    if (!mutation.addedNodes || !mutation.addedNodes.length) return
-    const entries = mutation.addedNodes.entries()
-    while (true) {
-      const info = entries.next()
-      if (info.done) break
-      const entry = info.value[1]
-      if (entry.nodeName !== 'META' || entry.name !== 'lock') continue
-      callback(entry.content)
-    }
-  })
-}
-
-export function listenForNewLocks(callback, head) {
+export default function listenForNewLocks(callback, fail, head) {
   const existingLock = findLocks(head)
   if (existingLock) {
     return callback(existingLock)
   }
-  const observer = new MutationObserver(changeListener.bind(null, callback))
-  observer.observe(head, { childList: true, attributes: true })
+  fail()
 }


### PR DESCRIPTION
# Description

This PR fixes a non-standard situation where someone has put the snippet script in their page without a `<meta>` tag. In this case, the blocker will spin ad infinitum, amen.

As it (also) turns out, because we use `window.onload` to determine when to start setting up the paywall iframe, we also know at this point that we have finished loading all html, and can scan the page for `<meta>` tags. There is no need for the `MutationObserver` code at all!

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2409 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
