### PR TITLE
retrieve the most current optimism value for key purchase success from locksmith

### DIFF
--- a/paywall/src/__tests__/hooks/useOptimism.test.js
+++ b/paywall/src/__tests__/hooks/useOptimism.test.js
@@ -2,55 +2,165 @@ import React from 'react'
 import * as rtl from 'react-testing-library'
 
 import useOptimism from '../../hooks/useOptimism'
-import useLocksmith from '../../hooks/useLocksmith'
+import { WindowContext } from '../../hooks/browser/useWindow'
+import { ConfigContext } from '../../utils/withConfig'
+import configure from '../../config'
 
-jest.mock('../../hooks/useLocksmith')
+const WindowProvider = WindowContext.Provider
+const ConfigProvider = ConfigContext.Provider
+const config = configure()
+
 jest.useFakeTimers()
 
 describe('useOptimism hook', () => {
-  function MockOptimism() {
-    const result = useOptimism('0x123')
+  let transaction
+  let fakeWindow
+  let finishFetch
+  let fakeResponse
+  const fetchResponse = {
+    json: () => fakeResponse,
+  }
+  function MakeOptimism() {
+    const result = useOptimism(transaction)
 
     return <div>{JSON.stringify(result)}</div>
   }
 
+  function MockOptimism() {
+    return (
+      <WindowProvider value={fakeWindow}>
+        <ConfigProvider value={config}>
+          <MakeOptimism />
+        </ConfigProvider>
+      </WindowProvider>
+    )
+  }
+
   beforeEach(() => {
-    useLocksmith.mockImplementation(() => ({
+    fakeResponse = {
       willSucceed: 1,
-    }))
-  })
-
-  it('calls useLocksmith properly', () => {
-    expect.assertions(1)
-
-    rtl.render(<MockOptimism />)
-
-    expect(useLocksmith).toHaveBeenCalledWith('/transaction/0x123/odds', {
-      willSucceed: 0,
-    })
+    }
+    fakeWindow = {
+      fetch: jest.fn(() => {
+        return {
+          then: cb => {
+            finishFetch = cb
+            return {
+              catch: () => {},
+            }
+          },
+        }
+      }),
+    }
+    transaction = {
+      hash: '0x123',
+      status: 'pending',
+    }
   })
 
   it('returns the result of useLocksmith', () => {
     expect.assertions(1)
 
-    const wrapper = rtl.render(<MockOptimism />)
+    let wrapper
+    rtl.act(() => {
+      wrapper = rtl.render(<MockOptimism />)
+      finishFetch(fetchResponse)
+    })
 
     expect(
       wrapper.getByText(JSON.stringify({ current: 1, past: 0 }))
     ).not.toBeNull()
   })
 
-  it('freaks out after 15 seconds', () => {
-    expect.assertions(1)
+  it('polls again after 15 seconds', () => {
+    expect.assertions(4)
 
     let wrapper
     rtl.act(() => {
       wrapper = rtl.render(<MockOptimism />)
-      jest.runAllTimers()
+      finishFetch(fetchResponse)
+      // ensure we are calling for the new fetcher
+      finishFetch = () => {}
     })
+
+    expect(
+      wrapper.getByText(JSON.stringify({ current: 1, past: 0 }))
+    ).not.toBeNull()
+    expect(fakeWindow.fetch).toHaveBeenCalledTimes(1)
+
+    fakeResponse = {
+      willSucceed: 0,
+    }
+
+    rtl.act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    rtl.act(() => {
+      // initially this was combined with the pending timer run above, but
+      // finishFetch is not set until after leaving the rtl.act,
+      // so it must be in its own block to pass
+      finishFetch(fetchResponse)
+    })
+    expect(fakeWindow.fetch).toHaveBeenCalledTimes(2)
 
     expect(
       wrapper.getByText(JSON.stringify({ current: 0, past: 1 }))
     ).not.toBeNull()
+  })
+
+  it('does not fetch if transaction status is not pending', () => {
+    expect.assertions(1)
+
+    transaction.status = 'mined'
+
+    rtl.act(() => {
+      rtl.render(<MockOptimism />)
+    })
+
+    expect(fakeWindow.fetch).not.toHaveBeenCalled()
+  })
+
+  it('stops polling if transaction.status is no longer pending', () => {
+    expect.assertions(4)
+
+    let wrapper
+    rtl.act(() => {
+      wrapper = rtl.render(<MockOptimism />)
+      finishFetch(fetchResponse)
+      // ensure we are calling for the new fetcher
+      finishFetch = () => {}
+    })
+
+    expect(
+      wrapper.getByText(JSON.stringify({ current: 1, past: 0 }))
+    ).not.toBeNull()
+    expect(fakeWindow.fetch).toHaveBeenCalledTimes(1)
+
+    fakeResponse = {
+      willSucceed: 0,
+    }
+
+    transaction.status = 'mined'
+    rtl.act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(fakeWindow.fetch).toHaveBeenCalledTimes(1)
+    expect(
+      wrapper.getByText(JSON.stringify({ current: 1, past: 0 }))
+    ).not.toBeNull()
+  })
+
+  it('does nothing if transaction is not set', () => {
+    expect.assertions(1)
+
+    transaction = null
+
+    rtl.act(() => {
+      rtl.render(<MockOptimism />)
+    })
+
+    expect(fakeWindow.fetch).not.toHaveBeenCalled()
   })
 })

--- a/paywall/src/__tests__/hooks/useOptimism.test.js
+++ b/paywall/src/__tests__/hooks/useOptimism.test.js
@@ -5,9 +5,10 @@ import useOptimism from '../../hooks/useOptimism'
 import useLocksmith from '../../hooks/useLocksmith'
 
 jest.mock('../../hooks/useLocksmith')
+jest.useFakeTimers()
 
 describe('useOptimism hook', () => {
-  function MockOptimismn() {
+  function MockOptimism() {
     const result = useOptimism('0x123')
 
     return <div>{JSON.stringify(result)}</div>
@@ -15,25 +16,41 @@ describe('useOptimism hook', () => {
 
   beforeEach(() => {
     useLocksmith.mockImplementation(() => ({
-      willSucceed: 0,
+      willSucceed: 1,
     }))
   })
 
   it('calls useLocksmith properly', () => {
     expect.assertions(1)
 
-    rtl.render(<MockOptimismn />)
+    rtl.render(<MockOptimism />)
 
     expect(useLocksmith).toHaveBeenCalledWith('/transaction/0x123/odds', {
-      willSucceed: 1,
+      willSucceed: 0,
     })
   })
 
   it('returns the result of useLocksmith', () => {
     expect.assertions(1)
 
-    const wrapper = rtl.render(<MockOptimismn />)
+    const wrapper = rtl.render(<MockOptimism />)
 
-    expect(wrapper.getByText('0')).not.toBeNull()
+    expect(
+      wrapper.getByText(JSON.stringify({ current: 1, past: 0 }))
+    ).not.toBeNull()
+  })
+
+  it('freaks out after 15 seconds', () => {
+    expect.assertions(1)
+
+    let wrapper
+    rtl.act(() => {
+      wrapper = rtl.render(<MockOptimism />)
+      jest.runAllTimers()
+    })
+
+    expect(
+      wrapper.getByText(JSON.stringify({ current: 0, past: 1 }))
+    ).not.toBeNull()
   })
 })

--- a/paywall/src/__tests__/hooks/useOptimism.test.js
+++ b/paywall/src/__tests__/hooks/useOptimism.test.js
@@ -20,6 +20,7 @@ describe('useOptimism hook', () => {
   const fetchResponse = {
     json: () => fakeResponse,
   }
+
   function MakeOptimism() {
     const result = useOptimism(transaction)
 

--- a/paywall/src/__tests__/hooks/useOptimism.test.js
+++ b/paywall/src/__tests__/hooks/useOptimism.test.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+
+import useOptimism from '../../hooks/useOptimism'
+import useLocksmith from '../../hooks/useLocksmith'
+
+jest.mock('../../hooks/useLocksmith')
+
+describe('useOptimism hook', () => {
+  function MockOptimismn() {
+    const result = useOptimism('0x123')
+
+    return <div>{JSON.stringify(result)}</div>
+  }
+
+  beforeEach(() => {
+    useLocksmith.mockImplementation(() => ({
+      willSucceed: 0,
+    }))
+  })
+
+  it('calls useLocksmith properly', () => {
+    expect.assertions(1)
+
+    rtl.render(<MockOptimismn />)
+
+    expect(useLocksmith).toHaveBeenCalledWith('/transaction/0x123/odds', {
+      willSucceed: 1,
+    })
+  })
+
+  it('returns the result of useLocksmith', () => {
+    expect.assertions(1)
+
+    const wrapper = rtl.render(<MockOptimismn />)
+
+    expect(wrapper.getByText('0')).not.toBeNull()
+  })
+})

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -105,3 +105,5 @@ export const MAX_UINT =
 
 // the number of ms between checking for account changes in walletService
 export const POLLING_INTERVAL = 2000
+// the length of time to consider an optimistic key purchase to have become pessimistic
+export const OPTIMISM_TIME_LIMIT = 30000

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -106,4 +106,4 @@ export const MAX_UINT =
 // the number of ms between checking for account changes in walletService
 export const POLLING_INTERVAL = 2000
 // the length of time to consider an optimistic key purchase to have become pessimistic
-export const OPTIMISM_TIME_LIMIT = 15000
+export const OPTIMISM_POLLING_INTERVAL = 15000

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -106,4 +106,4 @@ export const MAX_UINT =
 // the number of ms between checking for account changes in walletService
 export const POLLING_INTERVAL = 2000
 // the length of time to consider an optimistic key purchase to have become pessimistic
-export const OPTIMISM_TIME_LIMIT = 30000
+export const OPTIMISM_TIME_LIMIT = 15000

--- a/paywall/src/hooks/useLocksmith.js
+++ b/paywall/src/hooks/useLocksmith.js
@@ -10,7 +10,7 @@ export default function useLocksmith(api, defaultValue, active = true) {
   const window = useWindow()
   const { locksmithHost } = useConfig()
   const [result, setResult] = useState(defaultValue)
-  const [reSend, reSendQuery] = useReducer(state => state + 1, 0) // christ rebasing is stew ped
+  const [reSend, reSendQuery] = useReducer(state => state + 1, 0)
 
   const fetch = window.fetch
   // remove double / if there are any

--- a/paywall/src/hooks/useLocksmith.js
+++ b/paywall/src/hooks/useLocksmith.js
@@ -10,7 +10,7 @@ export default function useLocksmith(api, defaultValue, active = true) {
   const window = useWindow()
   const { locksmithHost } = useConfig()
   const [result, setResult] = useState(defaultValue)
-  const [reSend, reSendQuery] = useReducer(state => state + 1, 0)
+  const [reSend, reSendQuery] = useReducer(state => state + 1, 0) // christ rebasing is stew ped
 
   const fetch = window.fetch
   // remove double / if there are any

--- a/paywall/src/hooks/useOptimism.js
+++ b/paywall/src/hooks/useOptimism.js
@@ -4,11 +4,11 @@ import useLocksmith from './useLocksmith'
 import { OPTIMISM_POLLING_INTERVAL } from '../constants'
 
 export default function useOptimism(transaction) {
-  const API = transaction ? `/transaction/${transaction.hash}/odds` : ''
+  const apiEndPoint = transaction ? `/transaction/${transaction.hash}/odds` : ''
   const hash = transaction ? transaction.hash : false
   const status = transaction ? transaction.status : 'inactive'
-  const [locksmithOptimism, resendQuery] = useLocksmith(
-    API,
+  const [locksmithOptimism, reSendQuery] = useLocksmith(
+    apiEndPoint,
     {
       willSucceed: 0,
     },
@@ -28,7 +28,7 @@ export default function useOptimism(transaction) {
   )
   const timeout = useRef()
   const reQuery = () => {
-    resendQuery()
+    reSendQuery()
     setTimeout(reQuery, OPTIMISM_POLLING_INTERVAL)
   }
   const endPolling = () => {

--- a/paywall/src/hooks/useOptimism.js
+++ b/paywall/src/hooks/useOptimism.js
@@ -1,0 +1,7 @@
+import useLocksmith from './useLocksmith'
+
+export default function useOptimism(transactionHash) {
+  return useLocksmith(`/transaction/${transactionHash}/odds`, {
+    willSucceed: 1,
+  }).willSucceed
+}

--- a/paywall/src/hooks/useOptimism.js
+++ b/paywall/src/hooks/useOptimism.js
@@ -1,7 +1,40 @@
+import { useEffect, useReducer, useRef } from 'react'
+
 import useLocksmith from './useLocksmith'
+import { OPTIMISM_TIME_LIMIT } from '../constants'
 
 export default function useOptimism(transactionHash) {
-  return useLocksmith(`/transaction/${transactionHash}/odds`, {
-    willSucceed: 1,
-  }).willSucceed
+  const locksmithOptimism = useLocksmith(
+    `/transaction/${transactionHash}/odds`,
+    {
+      willSucceed: 0,
+    }
+  ).willSucceed
+  const timeout = useRef()
+  const [optimism, setOptimism] = useReducer(
+    (state, newState) => {
+      if (state.current !== newState) {
+        return {
+          current: newState,
+          past: state.current,
+        }
+      }
+      return state
+    },
+    { current: locksmithOptimism, past: 0 }
+  )
+  useEffect(() => {
+    if (!transactionHash) {
+      if (timeout.current) {
+        clearTimeout(timeout.current)
+        timeout.current = undefined
+      }
+    } else {
+      setTimeout(() => {
+        setOptimism(0)
+      }, OPTIMISM_TIME_LIMIT)
+    }
+  }, [transactionHash, locksmithOptimism])
+
+  return optimism
 }


### PR DESCRIPTION
# Description

This PR implements retrieval of the likelihood of success for a key purchase transaction from locksmith.

It uses the `useLocksmith` hook to do the actual API call, and returns a simple object that contains the current likelihood of success and the previous value like `{ current: 1, past: 0 }`. This is used as in this table:


| Past | Current | Outcome                           |
|------|---------|-----------------------------------|
| 0    | 0       | Pessimistic                       |
| 0    | 1       | Optimistic                        |
| 1    | 0       | Pessimistic, displays explanation |
| 1    | 1       | Optimistic                        |
----------------------------

Usage in the code is dirt-simple:

```js
const { current, past } = useOptimism()
```

Then the paywall UI responds as in the table above.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2403
Refs #2404 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
