### PR TITLE
remove retrieval of past lock creation transactions on paywall (#2293)

### DIFF
--- a/paywall/src/__tests__/middlewares/web3Middleware.test.js
+++ b/paywall/src/__tests__/middlewares/web3Middleware.test.js
@@ -302,57 +302,11 @@ describe('Lock middleware', () => {
     })
   })
 
-  describe('not on the paywall', () => {
-    it('should handle SET_ACCOUNT by refreshing balance and retrieving historical unlock transactions', async () => {
-      expect.assertions(4)
-      const mockTx = {
-        returnValues: {
-          newLockAddress: '0x0',
-        },
-      }
-      const lockCreationTransaction = Promise.resolve([mockTx])
-      mockWeb3Service.refreshAccountBalance = jest.fn()
-      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn(
-        () => lockCreationTransaction
-      )
-      mockWeb3Service.getKeyByLockForOwner = jest.fn()
-      mockWeb3Service.getPastLockTransactions = jest.fn()
-
-      const { invoke } = create()
-
-      const newAccount = {
-        address: '0x345',
-      }
-      invoke(setAccount(newAccount))
-
-      expect(mockWeb3Service.refreshAccountBalance).toHaveBeenCalledWith(
-        newAccount
-      )
-      expect(
-        mockWeb3Service.getPastLockCreationsTransactionsForUser
-      ).toHaveBeenCalledWith(newAccount.address)
-      await lockCreationTransaction
-      // We need to await this for the next assertion to work
-      expect(mockWeb3Service.getPastLockTransactions).toHaveBeenCalled()
-      expect(mockWeb3Service.getKeyByLockForOwner).not.toHaveBeenCalled()
-    })
-  })
-
   describe('on the paywall', () => {
     it('should handle SET_ACCOUNT by getting all keys for the owner of that account', async () => {
-      expect.assertions(4)
-      const mockTx = {
-        returnValues: {
-          newLockAddress: '0x0',
-        },
-      }
-      const lockCreationTransaction = Promise.resolve([mockTx])
+      expect.assertions(2)
       mockWeb3Service.refreshAccountBalance = jest.fn()
-      mockWeb3Service.getPastLockCreationsTransactionsForUser = jest.fn(
-        () => lockCreationTransaction
-      )
       mockWeb3Service.getKeyByLockForOwner = jest.fn()
-      mockWeb3Service.getPastLockTransactions = jest.fn()
 
       const lock = '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9'
       state.router.location.pathname = `/${lock}/`
@@ -365,12 +319,7 @@ describe('Lock middleware', () => {
       invoke(setAccount(newAccount))
 
       expect(mockWeb3Service.refreshAccountBalance).toHaveBeenCalled()
-      expect(
-        mockWeb3Service.getPastLockCreationsTransactionsForUser
-      ).toHaveBeenCalled()
       // We need to await this for the next assertion to work
-      await lockCreationTransaction
-      expect(mockWeb3Service.getPastLockTransactions).toHaveBeenCalled()
       expect(mockWeb3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
         lock,
         '0x345'

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -155,20 +155,7 @@ export default function web3Middleware({ getState, dispatch }) {
         // TODO: when the account has been updated we should reset web3Service and remove all listeners
         // So that pending API calls do not interract with our "new" state.
         web3Service.refreshAccountBalance(action.account)
-        web3Service
-          .getPastLockCreationsTransactionsForUser(action.account.address)
-          .then(lockCreations => {
-            // For each lock this user created, go get the history of
-            // interactions with that lock. TODO: Only get the lock interactions
-            // (such as key price update, withdrawals) done by the user. Very
-            // popular locks in the future may have thousands of key purchases,
-            // and we almost certainly don't want to pull them all down here.
-            lockCreations.forEach(lockCreation => {
-              web3Service.getPastLockTransactions(
-                lockCreation.returnValues.newLockAddress
-              )
-            })
-          })
+
         const {
           router: {
             location: { pathname },


### PR DESCRIPTION
This is a test of our "emergency" deploy system.
Since I wanted this test to be a "real" world test, I cherry-picked a commit which was published just after our current "production" deploy.

If approved (please approve!), and if tests pass (they should because this was already tested previously), then I'll merge to the production branch.

Once merged, CircleCI should run our main workflow and actually deploy to production!