### PR TITLE
refresh the lock if provider or network changes on the paywall

### DIFF
--- a/paywall/src/__tests__/middlewares/web3Middleware.test.js
+++ b/paywall/src/__tests__/middlewares/web3Middleware.test.js
@@ -10,6 +10,8 @@ import {
   NEW_TRANSACTION,
 } from '../../actions/transaction'
 import { SET_ERROR } from '../../actions/error'
+import { SET_PROVIDER, setProvider } from '../../actions/provider'
+import { SET_NETWORK, setNetwork } from '../../actions/network'
 
 /**
  * Fake state
@@ -304,6 +306,23 @@ describe('Lock middleware', () => {
         '0x345'
       )
     })
+
+    it.each([[SET_PROVIDER, setProvider], [SET_NETWORK, setNetwork]])(
+      'should refresh the lock if %s is called',
+      async (key, action) => {
+        expect.assertions(1)
+        mockWeb3Service.getLock = jest.fn()
+
+        const lock = '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9'
+        state.router.location.pathname = `/${lock}/`
+
+        const { invoke } = create()
+
+        invoke(action('hi'))
+
+        expect(mockWeb3Service.getLock).toHaveBeenCalledWith(lock)
+      }
+    )
   })
 
   it("should handle LOCATION_CHANGE if a lock is passed by calling web3Service's getLock", () => {

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -16,6 +16,8 @@ import Web3Service from '../services/web3Service'
 import { lockRoute } from '../utils/routes'
 
 import configure from '../config'
+import { SET_PROVIDER } from '../actions/provider'
+import { SET_NETWORK } from '../actions/network'
 
 const {
   readOnlyProvider,
@@ -112,6 +114,14 @@ export default function web3Middleware({ getState, dispatch }) {
       }
 
       next(action)
+
+      if (action.type === SET_PROVIDER || action.type === SET_NETWORK) {
+        // Location was changed, get the matching lock, if we are on a paywall page
+        const { lockAddress } = lockRoute(getState().router.location.pathname)
+        if (lockAddress) {
+          web3Service.getLock(lockAddress)
+        }
+      }
 
       // note: this needs to be after the reducer has seen it, because refreshAccountBalance
       // triggers 'account.update' which dispatches UPDATE_ACCOUNT. The reducer assumes that

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -116,7 +116,8 @@ export default function web3Middleware({ getState, dispatch }) {
       next(action)
 
       if (action.type === SET_PROVIDER || action.type === SET_NETWORK) {
-        // Location was changed, get the matching lock, if we are on a paywall page
+        // for both of these actions, the lock state is invalid, and must be refreshed.
+        // Location was changed, get the matching lock
         const { lockAddress } = lockRoute(getState().router.location.pathname)
         if (lockAddress) {
           web3Service.getLock(lockAddress)


### PR DESCRIPTION
# Description

This fixes the master breakage on the paywall caused by a race condition. If the read-only provider is faster at retrieving a lock than the wallet is at declaring a network and/or provider, it will nuke the state, and not refresh it. This adds the missing refresh needed to keep displaying a lock.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2422

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
