### PR TITLE
minor refactor of ConfirmingFlag

### DIFF
--- a/paywall/src/components/lock/ConfirmingFlag.js
+++ b/paywall/src/components/lock/ConfirmingFlag.js
@@ -45,18 +45,20 @@ export function ConfirmingFlag({
 
 ConfirmingFlag.propTypes = {
   config: UnlockPropTypes.configuration.isRequired,
-  transaction: UnlockPropTypes.transaction.isRequired,
+  transaction: UnlockPropTypes.transaction,
 }
 
-export const mapStateToProps = (state, { lock }) => {
-  const account = state.account
+ConfirmingFlag.defaultProps = {
+  transaction: null,
+}
 
+export const mapStateToProps = ({ account, keys, transactions }, { lock }) => {
   // If there is no account (probably not loaded yet), we do not want to create a key
   if (!account) {
     return {}
   }
 
-  let lockKey = Object.values(state.keys).find(
+  let lockKey = Object.values(keys).find(
     key => key.lock === lock.address && key.owner === account.address
   )
   let transaction = null
@@ -70,7 +72,7 @@ export const mapStateToProps = (state, { lock }) => {
 
   // Let's select the transaction corresponding to this key purchase, if it exists
   // This transaction is of type KEY_PURCHASE
-  transaction = Object.values(state.transactions).find(
+  transaction = Object.values(transactions).find(
     transaction =>
       transaction.type === TRANSACTION_TYPES.KEY_PURCHASE &&
       transaction.key === lockKey.id


### PR DESCRIPTION
# Description

This refactor fixes some prop types warnings when transaction is null, and cleans up `mapStateToProps` to use destructuring. There is no visual or functional change.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2393 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
