### PR TITLE
refactor useLocksmith to allow re-sending queries

### DIFF
--- a/paywall/src/__tests__/hooks/useLocksmith.test.js
+++ b/paywall/src/__tests__/hooks/useLocksmith.test.js
@@ -15,12 +15,14 @@ describe('useLocksmith hook', () => {
   let fakeWindow
   let fakeResponse
   let finishFetch
+  let triggerNewFetch
   const fetchResponse = {
     json: () => fakeResponse,
   }
 
   function MockLocksmither({ api = '/hi' }) {
-    const result = useLocksmith(api)
+    const [result, reQuery] = useLocksmith(api)
+    triggerNewFetch = reQuery
 
     return <div>{JSON.stringify(result)}</div>
   }
@@ -90,5 +92,29 @@ describe('useLocksmith hook', () => {
     })
 
     expect(wrapper.getByText(JSON.stringify(fakeResponse))).not.toBeNull()
+  })
+
+  it('triggers a new fetch if refetch is called', () => {
+    expect.assertions(1)
+
+    rtl.act(() => {
+      rtl.render(
+        <WindowProvider value={fakeWindow}>
+          <ConfigProvider value={config}>
+            <MockLocksmither />
+          </ConfigProvider>
+        </WindowProvider>
+      )
+    })
+
+    rtl.act(() => {
+      finishFetch(fetchResponse)
+    })
+
+    rtl.act(() => {
+      triggerNewFetch()
+    })
+
+    expect(fakeWindow.fetch).toHaveBeenCalledTimes(2)
   })
 })

--- a/paywall/src/hooks/useLocksmith.js
+++ b/paywall/src/hooks/useLocksmith.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useReducer } from 'react'
 import useWindow from './browser/useWindow'
 import useConfig from './utils/useConfig'
 
@@ -6,19 +6,21 @@ import useConfig from './utils/useConfig'
 // It takes a default value to return prior to the API success, and then
 // replaces it upon receiving a result with the result.
 // It only re-fetches if the api path changes.
-export default function useLocksmith(api, defaultValue) {
+export default function useLocksmith(api, defaultValue, active = true) {
   const window = useWindow()
   const { locksmithHost } = useConfig()
   const [result, setResult] = useState(defaultValue)
+  const [reSend, reSendQuery] = useReducer(state => state + 1, 0)
 
   const fetch = window.fetch
   // remove double / if there are any
   const url = locksmithHost + ('/' + api).replace(/\/+/g, '/')
 
   useEffect(() => {
+    if (!active) return
     fetch(url)
       .then(response => setResult(response.json()))
       .catch(error => console.error(error)) // eslint-disable-line no-console
-  }, [api])
-  return result
+  }, [api, reSend, active])
+  return [result, reSendQuery]
 }


### PR DESCRIPTION
# Description

This PR pulls off the refactor of `useLocksmith` from #2415 into its own PR. It also includes reviewer feedback to camelCase `reSendQuery` internally to `useLocksmith`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2404 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
