### PR TITLE
paywall.min.js side of optimistic unlocking

### DIFF
--- a/paywall/src/__tests__/paywall-builder/build.test.js
+++ b/paywall/src/__tests__/paywall-builder/build.test.js
@@ -5,12 +5,9 @@ import {
   POST_MESSAGE_LOCKED,
   POST_MESSAGE_UNLOCKED,
   POST_MESSAGE_REDIRECT,
+  POST_MESSAGE_GET_OPTIMISTIC,
+  POST_MESSAGE_GET_PESSIMISTIC,
 } from '../../paywall-builder/constants'
-
-global.window = {} // this is fun...
-global.MutationObserver = function() {
-  this.observe = () => {}
-}
 
 const fakeLockAddress = 'lockaddress'
 
@@ -345,6 +342,40 @@ describe('buildPaywall', () => {
         expect(mockHide).toHaveBeenCalledWith(iframe, document)
         expect(mockHide).toHaveBeenCalledTimes(1)
         expect(mockShow).toHaveBeenCalledTimes(1)
+      })
+
+      it('calls hide on optimistic event', () => {
+        expect.assertions(1)
+
+        callbacks.message({
+          data: POST_MESSAGE_LOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
+        callbacks.message({
+          data: POST_MESSAGE_GET_OPTIMISTIC,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
+
+        expect(mockHide).toHaveBeenLastCalledWith(iframe, document, false)
+      })
+
+      it('calls show on pessimistic event', () => {
+        expect.assertions(1)
+
+        callbacks.message({
+          data: POST_MESSAGE_LOCKED,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
+        callbacks.message({
+          data: POST_MESSAGE_GET_PESSIMISTIC,
+          origin: 'origin',
+          source: iframe.contentWindow,
+        })
+
+        expect(mockShow).toHaveBeenLastCalledWith(iframe, document)
       })
 
       it('bails out on error in redirect event', () => {

--- a/paywall/src/__tests__/paywall-builder/build.test.js
+++ b/paywall/src/__tests__/paywall-builder/build.test.js
@@ -82,6 +82,7 @@ describe('buildPaywall', () => {
         },
         style: {},
         remove: jest.fn(),
+        setAttribute: jest.fn(),
       }
 
       mockAdd = jest.spyOn(iframeManager, 'add')

--- a/paywall/src/__tests__/paywall-builder/iframe.test.js
+++ b/paywall/src/__tests__/paywall-builder/iframe.test.js
@@ -94,40 +94,89 @@ describe('iframe', () => {
     )
   })
 
-  it('hide', () => {
-    expect.assertions(2)
-    const iframe = {
-      style: {},
-      contentDocument: {
-        body: {
-          style: {},
-        },
-      },
-      addEventListener: () => {},
-    }
-    const document = {
-      body: {
-        style: { overflow: 'hidden' },
-      },
-    }
-    hide(iframe, document)
+  describe('hide', () => {
+    it('unlocked', () => {
+      expect.assertions(4)
 
-    expect(iframe.style).toEqual({
-      backgroundColor: 'transparent',
-      backgroundImage: 'none',
-      overflow: 'hidden',
-      width: '134px',
-      height: '160px',
-      marginRight: 0,
-      left: null,
-      top: null,
-      right: '0',
-      bottom: '105px',
-      transition: 'margin-right 0.4s ease-in',
+      jest.useFakeTimers()
+      const iframe = {
+        addEventListener: jest.fn(),
+        style: {},
+        contentDocument: {
+          body: {
+            style: {},
+          },
+        },
+      }
+      const document = {
+        body: {
+          style: { overflow: 'hidden' },
+        },
+      }
+      hide(iframe, document)
+
+      expect(iframe.style).toEqual({
+        backgroundColor: 'transparent',
+        backgroundImage: 'none',
+        overflow: 'hidden',
+        width: '134px',
+        height: '160px',
+        marginRight: 0,
+        left: null,
+        top: null,
+        right: '0',
+        bottom: '105px',
+        transition: 'margin-right 0.4s ease-in',
+      })
+
+      expect(document.body.style).toEqual({
+        overflow: '',
+      })
+
+      expect(setTimeout).toHaveBeenCalled()
+
+      expect(iframe.addEventListener).toHaveBeenCalledTimes(2)
     })
 
-    expect(document.body.style).toEqual({
-      overflow: '',
+    it('optimistic unlocking', () => {
+      expect.assertions(4)
+
+      jest.useFakeTimers()
+      const iframe = {
+        addEventListener: jest.fn(),
+        style: {},
+        contentDocument: {
+          body: {
+            style: {},
+          },
+        },
+      }
+      const document = {
+        body: {
+          style: { overflow: 'hidden' },
+        },
+      }
+      hide(iframe, document, false)
+
+      expect(iframe.style).toEqual({
+        backgroundColor: 'transparent',
+        backgroundImage: 'none',
+        overflow: 'hidden',
+        width: '134px',
+        height: '160px',
+        marginRight: 0,
+        left: null,
+        top: null,
+        right: '0',
+        bottom: '105px',
+      })
+
+      expect(document.body.style).toEqual({
+        overflow: '',
+      })
+      expect(setTimeout).not.toHaveBeenCalled()
+
+      expect(iframe.addEventListener).not.toHaveBeenCalled()
     })
   })
 })

--- a/paywall/src/__tests__/paywall-builder/iframe.test.js
+++ b/paywall/src/__tests__/paywall-builder/iframe.test.js
@@ -67,9 +67,10 @@ describe('iframe', () => {
   })
 
   it('show', () => {
-    expect.assertions(2)
+    expect.assertions(3)
     const iframe = {
       style: {},
+      setAttribute: jest.fn(),
     }
     const document = {
       body: {
@@ -86,6 +87,11 @@ describe('iframe', () => {
     expect(document.body.style).toEqual({
       overflow: 'hidden',
     })
+
+    expect(iframe.setAttribute).toHaveBeenCalledWith(
+      'style',
+      iframeStyles.join('; ')
+    )
   })
 
   it('hide', () => {

--- a/paywall/src/paywall-builder/build.js
+++ b/paywall/src/paywall-builder/build.js
@@ -4,6 +4,8 @@ import {
   POST_MESSAGE_LOCKED,
   POST_MESSAGE_UNLOCKED,
   POST_MESSAGE_REDIRECT,
+  POST_MESSAGE_GET_OPTIMISTIC,
+  POST_MESSAGE_GET_PESSIMISTIC,
 } from './constants'
 import { disableScrollPolling, enableScrollPolling, scrollLoop } from './scroll'
 
@@ -56,6 +58,16 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
             scrollLoop(window, document, iframe, origin)
             show(iframe, document)
             blocker.remove()
+          }
+          if (event.data === POST_MESSAGE_GET_OPTIMISTIC && locked) {
+            disableScrollPolling()
+            hide(iframe, document, false)
+          }
+          if (event.data === POST_MESSAGE_GET_PESSIMISTIC && locked) {
+            enableScrollPolling()
+
+            scrollLoop(window, document, iframe, origin)
+            show(iframe, document)
           }
           if (event.data === POST_MESSAGE_UNLOCKED && locked) {
             locked = false

--- a/paywall/src/paywall-builder/build.js
+++ b/paywall/src/paywall-builder/build.js
@@ -61,6 +61,7 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
           }
           if (event.data === POST_MESSAGE_GET_OPTIMISTIC && locked) {
             disableScrollPolling()
+
             hide(iframe, document, false)
           }
           if (event.data === POST_MESSAGE_GET_PESSIMISTIC && locked) {
@@ -72,6 +73,7 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
           if (event.data === POST_MESSAGE_UNLOCKED && locked) {
             locked = false
             disableScrollPolling()
+
             hide(iframe, document)
             blocker.remove()
           }

--- a/paywall/src/paywall-builder/iframe.js
+++ b/paywall/src/paywall-builder/iframe.js
@@ -29,11 +29,12 @@ export function add(document, iframe) {
 
 export function show(iframe, document) {
   document.body.style.overflow = 'hidden'
+  iframe.setAttribute('style', iframeStyles.join('; '))
   iframe.style.display = 'block'
   iframe.style['z-index'] = '2147483647'
 }
 
-export function hide(iframe, document) {
+export function hide(iframe, document, unlocked = true) {
   const width = '134px'
   const height = '160px'
   const collapsedMargin = '-104px'
@@ -45,10 +46,12 @@ export function hide(iframe, document) {
   iframe.style.backgroundImage = 'none'
   iframe.style.marginRight = 0
 
-  setTimeout(() => {
-    open = false
-    iframe.style.marginRight = collapsedMargin
-  }, SHOW_FLAG_FOR)
+  if (unlocked) {
+    setTimeout(() => {
+      open = false
+      iframe.style.marginRight = collapsedMargin
+    }, SHOW_FLAG_FOR)
+  }
 
   // so that there's no scroll when it goes off the edge
   iframe.style.overflow = 'hidden'
@@ -63,14 +66,16 @@ export function hide(iframe, document) {
   iframe.style.right = '0'
   iframe.style.bottom = '105px'
 
-  // Animation
-  iframe.style.transition = 'margin-right 0.4s ease-in'
+  if (unlocked) {
+    // Animation
+    iframe.style.transition = 'margin-right 0.4s ease-in'
 
-  iframe.addEventListener('mouseenter', () => {
-    iframe.style.marginRight = '0'
-  })
-  iframe.addEventListener('mouseleave', () => {
-    if (open) return
-    iframe.style.marginRight = collapsedMargin
-  })
+    iframe.addEventListener('mouseenter', () => {
+      iframe.style.marginRight = '0'
+    })
+    iframe.addEventListener('mouseleave', () => {
+      if (open) return
+      iframe.style.marginRight = collapsedMargin
+    })
+  }
 }


### PR DESCRIPTION
# Description

This PR implements the `paywall.min.js` response to optimistic and pessimistic unlocking. Its primary job is to respond to the `POST_MESSAGE_GET_OPTIMISTIC` and `POST_MESSAGE_GET_PESSIMISTIC` messages, and resize and style the iframe accordingly.

Since this doesn't actually do anything without the PRs to enable optimistic locking in the paywall, there are no screenshots to show yet.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2393 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
