### PR TITLE
hiding the form only when the transaction has been sent

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -30,6 +30,7 @@ import {
   SIGNED_DATA,
   SIGNATURE_ERROR,
 } from '../../actions/signature'
+import { HIDE_FORM } from '../../actions/lockFormVisibility'
 
 let mockConfig
 
@@ -156,6 +157,7 @@ describe('Wallet middleware', () => {
       POLLING_INTERVAL
     )
   })
+
   it('on the server, it should not handle account.changed events triggered by the walletService', () => {
     expect.assertions(2)
     setTimeout.mockClear()
@@ -221,7 +223,7 @@ describe('Wallet middleware', () => {
   })
 
   it('it should handle lock.updated events triggered by the walletService', () => {
-    expect.assertions(1)
+    expect.assertions(2)
     const { store } = create()
     const update = {
       transaction: '0x123',
@@ -232,6 +234,11 @@ describe('Wallet middleware', () => {
         type: UPDATE_LOCK,
         address: lock.address,
         update,
+      })
+    )
+    expect(store.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: HIDE_FORM,
       })
     )
   })

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -220,8 +220,6 @@ export class CreatorLockForm extends React.Component {
     this.setState(state => {
       const { valid, errors } = this.sendErrorsToRedux(state)
       if (!valid.formValid) return { valid, errors }
-      const { hideAction } = this.props
-      if (hideAction) hideAction()
       return this.saveLock(state, valid, errors)
     })
   }

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -28,6 +28,7 @@ import {
 import { SIGN_DATA, signedData, signatureError } from '../actions/signature'
 import configure from '../config'
 import { TransactionType } from '../unlock'
+import { hideForm } from '../actions/lockFormVisibility'
 
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
@@ -94,7 +95,9 @@ export default function walletMiddleware({ getState, dispatch }) {
   })
 
   walletService.on('lock.updated', (address, update) => {
+    // This is a new lock!
     dispatch(updateLock(address, update))
+    dispatch(hideForm()) // Close the form
   })
 
   walletService.on('error', (error, transactionHash) => {


### PR DESCRIPTION
This will avoid a flicker which closes the form significantly before the we actually show the newly created lock.

This will help fixing some integration tests.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread