### PR TITLE
renamed transaction to lockCreationTransaction for consistency and clarfication

### DIFF
--- a/unlock-app/src/components/creator/lock/LockIconBar.js
+++ b/unlock-app/src/components/creator/lock/LockIconBar.js
@@ -18,16 +18,17 @@ export function LockIconBar({
   lock,
   priceUpdateTransaction,
   toggleCode,
-  transaction,
+  lockCreationTransaction,
   withdrawalTransaction,
   config,
   edit,
 }) {
   // These 2 transactions, if not mined or confirmed will trigger the display of CreatorLockStatus
   // instead of the regular iconBar
-  const blockingTransactions = [transaction, priceUpdateTransaction].filter(
-    t => !!t
-  )
+  const blockingTransactions = [
+    lockCreationTransaction,
+    priceUpdateTransaction,
+  ].filter(t => !!t)
 
   // TODO: move that logic to mapStateToProps
   for (let i = 0; i < blockingTransactions.length; i++) {
@@ -93,14 +94,14 @@ LockIconBar.propTypes = {
   lock: UnlockPropTypes.lock.isRequired,
   toggleCode: PropTypes.func.isRequired,
   edit: PropTypes.func, // this will be required when we wire it up, no-op for now
-  transaction: UnlockPropTypes.transaction,
+  lockCreationTransaction: UnlockPropTypes.transaction,
   withdrawalTransaction: UnlockPropTypes.transaction,
   priceUpdateTransaction: UnlockPropTypes.transaction,
   config: UnlockPropTypes.configuration.isRequired,
 }
 
 LockIconBar.defaultProps = {
-  transaction: null,
+  lockCreationTransaction: null,
   priceUpdateTransaction: null,
   withdrawalTransaction: null,
   edit: () => {},
@@ -129,11 +130,10 @@ const mapStateToProps = ({ transactions }, { lock }) => {
     }
   })
 
-  // TODO change that to lockCreationTransaction
-  const transaction = transactions[lock.transaction]
+  const lockCreationTransaction = transactions[lock.transaction]
 
   return {
-    transaction,
+    lockCreationTransaction,
     withdrawalTransaction,
     priceUpdateTransaction,
   }


### PR DESCRIPTION
I am doing a larger refactor of the lockIconBar (after I found bug/discrepancies using the integration tests) and wanted to get this out of the way!


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread