### PR TITLE
renamed createLock into saveLock as it is used both for new locks and existing locks

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -95,14 +95,14 @@ describe('CreatorLockForm', () => {
   function makeLockForm(
     lock = {},
     {
-      createLock = jest.fn(),
+      saveLock = jest.fn(),
       hideAction = jest.fn(),
       setError = jest.fn(),
       resetError = jest.fn(),
     } = {}
   ) {
     actions = {
-      createLock,
+      saveLock,
       hideAction,
       setError,
       resetError,
@@ -110,7 +110,7 @@ describe('CreatorLockForm', () => {
     const ret = rtl.render(
       <CreatorLockForm
         account={{ address: 'hi' }}
-        createLock={createLock}
+        saveLock={saveLock}
         hideAction={hideAction}
         setError={setError}
         resetError={resetError}
@@ -355,7 +355,7 @@ describe('CreatorLockForm', () => {
       const submit = wrapper.getByText('Submit')
       expect(submit).not.toBeNull()
       rtl.fireEvent.click(submit)
-      expect(actions.createLock).toHaveBeenCalledWith(
+      expect(actions.saveLock).toHaveBeenCalledWith(
         expect.objectContaining({
           expirationDuration: 2592000,
           keyPrice: '0.01',
@@ -379,26 +379,26 @@ describe('CreatorLockForm', () => {
   describe('saving', () => {
     it('should skip saving locks when the price is not changed', () => {
       expect.assertions(2)
-      const createLock = jest.fn()
+      const saveLock = jest.fn()
       const lock = {
         keyPrice: '999',
         address: '0x123',
       }
-      const wrapper = makeLockForm({ createLock, lock })
+      const wrapper = makeLockForm({ saveLock, lock })
       const submit = wrapper.getByText('Submit')
       expect(submit).not.toBeNull()
       rtl.fireEvent.click(submit)
-      expect(createLock).not.toHaveBeenCalled()
+      expect(saveLock).not.toHaveBeenCalled()
     })
 
     it('should save the lock when the price has been updated', () => {
       expect.assertions(2)
-      const createLock = jest.fn()
+      const saveLock = jest.fn()
       const lock = {
         keyPrice: '999',
         address: '0x123',
       }
-      const wrapper = makeLockForm(lock, { createLock })
+      const wrapper = makeLockForm(lock, { saveLock })
 
       // Change the keyPrice
       const input = wrapper.getByValue('999')
@@ -411,7 +411,7 @@ describe('CreatorLockForm', () => {
       const submit = wrapper.getByText('Submit')
       expect(submit).not.toBeNull()
       rtl.fireEvent.click(submit)
-      expect(createLock).toHaveBeenCalledWith(
+      expect(saveLock).toHaveBeenCalledWith(
         expect.objectContaining({
           address: '0x123',
           keyPrice: '1000',
@@ -421,13 +421,13 @@ describe('CreatorLockForm', () => {
 
     it('should save a new lock', () => {
       expect.assertions(2)
-      const createLock = jest.fn()
-      const wrapper = makeLockForm({} /* lock */, { createLock })
+      const saveLock = jest.fn()
+      const wrapper = makeLockForm({} /* lock */, { saveLock })
 
       const submit = wrapper.getByText('Submit')
       expect(submit).not.toBeNull()
       rtl.fireEvent.click(submit)
-      expect(createLock).toHaveBeenCalledWith(
+      expect(saveLock).toHaveBeenCalledWith(
         expect.objectContaining({
           keyPrice: '0.01',
           maxNumberOfKeys: 10,

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -79,7 +79,7 @@ export class CreatorLock extends React.Component {
         <CreatorLockForm
           lock={lock}
           hideAction={() => this.setState({ editing: false })}
-          createLock={newLock => updateLock(newLock)}
+          saveLock={newLock => updateLock(newLock)}
         />
       )
     }

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -167,10 +167,9 @@ export class CreatorLockForm extends React.Component {
   }
 
   saveLock() {
-    const { account, createLock } = this.props
+    const { account, saveLock } = this.props
     const newLock = formValuesToLock(this.state)
-    // TODO: createLock is not a great name, because it is actually also being used to update an existing lock
-    createLock({
+    saveLock({
       ...newLock,
       owner: account.address,
     })
@@ -314,7 +313,7 @@ export class CreatorLockForm extends React.Component {
 CreatorLockForm.propTypes = {
   account: UnlockPropTypes.account.isRequired,
   hideAction: PropTypes.func.isRequired,
-  createLock: PropTypes.func.isRequired,
+  saveLock: PropTypes.func.isRequired,
   setError: PropTypes.func.isRequired,
   resetError: PropTypes.func.isRequired,
   lock: UnlockPropTypes.lock,

--- a/unlock-app/src/components/creator/CreatorLocks.js
+++ b/unlock-app/src/components/creator/CreatorLocks.js
@@ -31,11 +31,7 @@ export const CreatorLocks = props => {
       </LockHeaderRow>
       <Errors />
       {formIsVisible && (
-        <CreatorLockForm
-          hideAction={hideForm}
-          createLock={createLock}
-          pending
-        />
+        <CreatorLockForm hideAction={hideForm} saveLock={createLock} pending />
       )}
       {lockFeed.length > 0 &&
         lockFeed.map(lock => {

--- a/unlock-app/src/stories/creator/CreatorLockForm-errors.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm-errors.stories.js
@@ -26,7 +26,7 @@ storiesOf('CreatorLockForm/invalid', module)
         lock={lock}
         hideAction={action('hide')}
         setError={action('setError')}
-        createLock={action('createLock')}
+        saveLock={action('saveLock')}
       />
     )
   })
@@ -40,7 +40,7 @@ storiesOf('CreatorLockForm/invalid', module)
         lock={lock}
         hideAction={action('hide')}
         setError={action('setError')}
-        createLock={action('createLock')}
+        saveLock={action('saveLock')}
       />
     )
   })
@@ -54,7 +54,7 @@ storiesOf('CreatorLockForm/invalid', module)
         lock={lock}
         hideAction={action('hide')}
         setError={action('setError')}
-        createLock={action('createLock')}
+        saveLock={action('saveLock')}
       />
     )
   })
@@ -68,7 +68,7 @@ storiesOf('CreatorLockForm/invalid', module)
         lock={lock}
         hideAction={action('hide')}
         setError={action('setError')}
-        createLock={action('createLock')}
+        saveLock={action('saveLock')}
       />
     )
   })

--- a/unlock-app/src/stories/creator/CreatorLockForm.stories.js
+++ b/unlock-app/src/stories/creator/CreatorLockForm.stories.js
@@ -20,7 +20,7 @@ storiesOf('CreatorLockForm', module)
     const lock = {}
     return (
       <CreatorLockForm
-        createLock={action('createLock')}
+        saveLock={action('saveLock')}
         hideAction={action('hide')}
         setError={action('setError')}
         lock={lock}
@@ -40,7 +40,7 @@ storiesOf('CreatorLockForm', module)
     return (
       <CreatorLockForm
         lock={lock}
-        createLock={action('createLock')}
+        saveLock={action('saveLock')}
         hideAction={action('hide')}
         setError={action('setError')}
       />


### PR DESCRIPTION
Again part of the refactors, cleanups for integration tests I wated to get that out of the way!


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread