### PR TITLE
adding the transaction status type

### DIFF
--- a/unlock-app/src/__tests__/components/content/LogContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/LogContent.test.tsx
@@ -14,7 +14,7 @@ const transactions = {
   '0x12345678': {
     hash: '0x12345678',
     confirmations: 12,
-    status: 'mined',
+    status: UnlockTypes.TransactionStatus.MINED,
     lock: '0x12345678a',
     blockNumber: 1,
     type: UnlockTypes.TransactionType.LOCK_CREATION,
@@ -23,7 +23,7 @@ const transactions = {
   '0x56781234': {
     hash: '0x56781234',
     confirmations: 4,
-    status: 'mined',
+    status: UnlockTypes.TransactionStatus.MINED,
     lock: '0x56781234a',
     blockNumber: 2,
     type: UnlockTypes.TransactionType.LOCK_CREATION,
@@ -32,7 +32,7 @@ const transactions = {
   '0x9abcdef0': {
     hash: '0x9abcdef0',
     confirmations: 2,
-    status: 'mined',
+    status: UnlockTypes.TransactionStatus.MINED,
     lock: '0x9abcdef0a',
     blockNumber: 3,
     type: UnlockTypes.TransactionType.LOCK_CREATION,

--- a/unlock-app/src/__tests__/components/creator/CreatorLog.test.tsx
+++ b/unlock-app/src/__tests__/components/creator/CreatorLog.test.tsx
@@ -5,7 +5,7 @@ import * as UnlockTypes from '../../../unlockTypes'
 
 const transactionFeed: UnlockTypes.Transaction[] = [
   {
-    status: 'mined',
+    status: UnlockTypes.TransactionStatus.MINED,
     confirmations: 3,
     hash: '0x123',
     name: 'empty',

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -12,8 +12,16 @@ export enum TransactionType {
 }
 /* eslint-enable no-unused-vars */
 
+/* eslint-disable no-unused-vars */
+export enum TransactionStatus {
+  SUBMITTED = 'submitted',
+  PENDING = 'pending',
+  MINED = 'mined',
+}
+/* eslint-enable no-unused-vars */
+
 export interface Transaction {
-  status: string
+  status: TransactionStatus
   confirmations: number
   hash: string
   lock: string


### PR DESCRIPTION
At some point this will be useful when we typescriptify some components which ise the status.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread