### PR TITLE
match transaction if passed in the hash of paywall URL

### DIFF
--- a/paywall/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
@@ -307,7 +307,8 @@ describe('interWindowCommunicationMiddleware', () => {
                   account: null,
                   router: {
                     location: {
-                      pathname: `/paywall/${lock}#${account}`,
+                      pathname: `/paywall/${lock}`,
+                      hash: `#${account}`,
                     },
                   },
                 }

--- a/paywall/src/__tests__/utils/routes.test.js
+++ b/paywall/src/__tests__/utils/routes.test.js
@@ -6,6 +6,7 @@ describe('route utilities', () => {
     prefix: null,
     redirect: null,
     account: null,
+    transaction: null,
     origin: null,
   }
   describe('lockRoute', () => {
@@ -98,12 +99,54 @@ describe('route utilities', () => {
         origin: 'origin/',
       })
     })
+    it('should return the correct transaction parameter when it matches', () => {
+      expect.assertions(2)
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere?origin=origin%2F#0xd22ddf19c1ef9631e6c150b9260f9a4f2f7d4105fabf41d114eef2f0f1ae58d3'
+        )
+      ).toEqual({
+        ...baseRoute,
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+        transaction:
+          '0xd22ddf19c1ef9631e6c150b9260f9a4f2f7d4105fabf41d114eef2f0f1ae58d3',
+        origin: 'origin/',
+      })
+      expect(
+        lockRoute(
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/?origin=origin%2F#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+        )
+      ).toEqual({
+        ...baseRoute,
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        account: '0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        origin: 'origin/',
+      })
+    })
     it('should ignore malformed account parameter', () => {
       expect.assertions(1)
       expect(
         lockRoute(
           // address is too short
           '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere?origin=origin%2F#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb'
+        )
+      ).toEqual({
+        ...baseRoute,
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
+        prefix: 'demo',
+        redirect: 'http://hithere',
+        origin: 'origin/',
+      })
+    })
+    it('should ignore malformed transaction parameter', () => {
+      expect.assertions(1)
+      expect(
+        lockRoute(
+          // address is too short
+          '/demo/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/http%3a%2f%2fhithere?origin=origin%2F#0xd22ddf19c1ef9631e6c150b9260f9a4f2f7d4105fabf41d114eef2f0f1ae58dz'
         )
       ).toEqual({
         ...baseRoute,

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -36,11 +36,17 @@ export const TRANSACTION_TYPES = {
 
 // used in defining the helpers for LOCK_PATH_NAME_REGEXP and ACCOUNT_REGEXP
 const accountRegex = '0x[a-fA-F0-9]{40}'
+const transactionRegex = '0x[a-fA-F0-9]{64}'
 
 /**
  * Matches any valid ethereum account address
  */
-export const ACCOUNT_REGEXP = new RegExp(accountRegex)
+export const ACCOUNT_REGEXP = new RegExp(accountRegex + '$')
+
+/**
+ * Matches any valid ethereum transaction hash
+ */
+export const TRANSACTION_REGEXP = new RegExp(transactionRegex + '$')
 
 // private helpers for the LOCK_PATH_NAME_REGEXP
 const prefix = '[a-z0-9]+'

--- a/paywall/src/utils/routes.js
+++ b/paywall/src/utils/routes.js
@@ -1,4 +1,8 @@
-import { LOCK_PATH_NAME_REGEXP, ACCOUNT_REGEXP } from '../constants'
+import {
+  LOCK_PATH_NAME_REGEXP,
+  ACCOUNT_REGEXP,
+  TRANSACTION_REGEXP,
+} from '../constants'
 
 if (!global.URL) {
   // polyfill for server
@@ -28,19 +32,24 @@ export const lockRoute = path => {
       prefix: null,
       redirect: null,
       account: null,
+      transaction: null,
       origin: null,
     }
   }
 
   let account = url.hash && url.hash.substring(1)
+  let transaction = url.hash && url.hash.substring(1)
   const matchAccount = account.match(ACCOUNT_REGEXP)
-  account = matchAccount && matchAccount[0]
+  const matchTransaction = account.match(TRANSACTION_REGEXP)
+  account = matchAccount ? matchAccount[0] : null
+  transaction = matchTransaction ? matchTransaction[0] : null
 
   return {
     lockAddress: match[2] || null,
     prefix: match[1] || null,
     redirect: (match[3] && decodeURIComponent(match[3])) || null,
     account,
+    transaction,
     origin: url.searchParams.has('origin')
       ? url.searchParams.get('origin')
       : null,


### PR DESCRIPTION
# Description

In preparation for fixing #2351, this extends the URL parsing capability of the paywall to allow passing a transaction hash instead of an account. This will allow us to do a couple of key things:

1) account and lock address can both be retrieved from the transaction hash
2) the retrieved account can be saved in local storage to speed up future returns to any site with a key we have purchased
3) the retrieved lock address can be compared to the address in the URL as an additional sanity check
4) if the user refreshes the page, the transaction is not lost, and we can continue where we left off.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2351

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
