### PR TITLE
passing the transaction type and status upon creation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,57 @@
+module.exports = {
+  extends: [
+    'standard',
+    'airbnb',
+    'eslint:recommended',
+    'prettier',
+    'prettier/standard',
+    'plugin:prettier/recommended'
+  ],
+  env: {
+    es6: true,
+    node: true,
+    browser: true,
+    jest: true
+  },
+  plugins: ['jest', 'promise', 'import', '@typescript-eslint', 'prettier'],
+  parser: '@typescript-eslint/parser',
+  settings: {
+    'import/parsers': {
+      '@typescript-eslint/parser': ['.ts', '.tsx']
+    },
+    'import/resolver': {
+      // use <root>/tsconfig.json
+      typescript: {}
+    }
+  },
+  rules: {
+    'prettier/prettier': 'error',
+    'linebreak-style': ['error', 'unix'],
+    quotes: [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    'no-multiple-empty-lines': [
+      'error',
+      {
+        max: 1,
+        maxEOF: 0,
+        maxBOF: 0
+      }
+    ],
+    'brace-style': 0,
+    'import/no-named-as-default': 0,
+    'import/no-named-as-default-member': 0,
+    'standard/computed-property-even-spacing': 0,
+    'standard/object-curly-even-spacing': 0,
+    'standard/array-bracket-even-spacing': 0,
+    'promise/prefer-await-to-then': 'warn',
+    'jest/no-disabled-tests': 'warn',
+    'jest/no-identical-title': 'error',
+    'jest/no-focused-tests': 'error',
+    'jest/prefer-expect-assertions': 'error',
+    'eol-last': ['error'],
+    semi: ['error', 'never']
+  }
+}

--- a/unlock-app/.eslintrc.js
+++ b/unlock-app/.eslintrc.js
@@ -1,46 +1,13 @@
 module.exports = {
-  extends: [
-    'standard',
-    'airbnb',
-    'eslint:recommended',
-    'plugin:react/recommended',
-    'prettier',
-    'prettier/react',
-    'prettier/standard',
-    'plugin:prettier/recommended',
-  ],
-  env: {
-    es6: true,
-    node: true,
-    browser: true,
-    jest: true,
-  },
-  plugins: ['jest', 'mocha', 'promise', 'import', '@typescript-eslint'],
-  parser: '@typescript-eslint/parser',
+  extends: ['../.eslintrc.js', 'plugin:react/recommended', 'prettier/react'],
   settings: {
     react: {
       version: 'detect',
     },
-    'import/parsers': {
-      '@typescript-eslint/parser': ['.ts', '.tsx'],
-    },
-    'import/resolver': {
-      // use <root>/tsconfig.json
-      typescript: {},
-    },
   },
   rules: {
-    'prettier/prettier': 'error',
     'react/prefer-stateless-function': [2],
-    'linebreak-style': ['error', 'unix'],
-    quotes: [
-      'error',
-      'single',
-      { avoidEscape: true, allowTemplateLiterals: false },
-    ],
-    'brace-style': 0,
     'react/forbid-prop-types': 2,
-    indent: 0, // this conflicts with prettier and is not needed
     'jsx-a11y/anchor-is-valid': [
       'error',
       {
@@ -49,18 +16,6 @@ module.exports = {
         aspects: ['invalidHref', 'preferButton'],
       },
     ],
-    'mocha/no-exclusive-tests': 'error',
     'react/jsx-filename-extension': [0, { extensions: ['.js', '.jsx'] }],
-    'import/no-named-as-default': 0,
-    'import/no-named-as-default-member': 0,
-    'standard/computed-property-even-spacing': 0,
-    'standard/object-curly-even-spacing': 0,
-    'standard/array-bracket-even-spacing': 0,
-    'promise/prefer-await-to-then': 'warn',
-    'jest/no-disabled-tests': 'warn',
-    'jest/no-identical-title': 'error',
-    'jest/no-focused-tests': 'error',
-    'jest/prefer-expect-assertions': 'error',
-    'eol-last': ['error'],
   },
 }


### PR DESCRIPTION
The next step will be about using the shared config for other projects.
Consistency!


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread