### PR TITLE
make optimistic locking fully operational (frontend-side)

### DIFF
--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -6,8 +6,13 @@ import { Paywall, mapStateToProps } from '../../components/Paywall'
 import { ConfigContext } from '../../utils/withConfig'
 import { WindowContext } from '../../hooks/browser/useWindow'
 import { POST_MESSAGE_SCROLL_POSITION } from '../../paywall-builder/constants'
+import { TRANSACTION_TYPES } from '../../constants'
+import useOptimism from '../../hooks/useOptimism'
 
 jest.useFakeTimers()
+jest.mock('../../hooks/useOptimism', () => {
+  return jest.fn(() => ({ current: 1, past: 0 }))
+})
 
 const lock = { address: '0x4983D5ECDc5cc0E499c2D23BF4Ac32B982bAe53a' }
 const locks = {
@@ -42,8 +47,15 @@ const keys = {
   },
 }
 const modals = []
+const transactions = {}
 
-const store = createUnlockStore({ locks, keys, modals, router })
+const store = createUnlockStore({
+  locks,
+  keys,
+  modals,
+  router,
+  transactions,
+})
 
 function renderMockPaywall(props = {}) {
   return rtl.render(
@@ -86,25 +98,49 @@ describe('Paywall', () => {
   describe('mapStateToProps', () => {
     it('should yield the lock which matches the address of the demo page', () => {
       expect.assertions(1)
-      const props = mapStateToProps({ locks, keys, modals, router })
+      const props = mapStateToProps({
+        locks,
+        keys,
+        modals,
+        router,
+        transactions,
+      })
       expect(props.locks[0]).toBe(lock)
     })
 
     it('should be locked when no keys are available', () => {
       expect.assertions(1)
-      const props = mapStateToProps({ locks, keys: {}, modals, router })
+      const props = mapStateToProps({
+        locks,
+        keys: {},
+        modals,
+        router,
+        transactions,
+      })
       expect(props.locked).toBe(true)
     })
 
     it('should not be locked when there is a matching key', () => {
       expect.assertions(1)
-      const props = mapStateToProps({ locks, keys, modals, router })
+      const props = mapStateToProps({
+        locks,
+        keys,
+        modals,
+        router,
+        transactions,
+      })
       expect(props.locked).toBe(false)
     })
 
     it('should pass redirect if present in the URI', () => {
       expect.assertions(1)
-      const props = mapStateToProps({ locks, keys, modals, router })
+      const props = mapStateToProps({
+        locks,
+        keys,
+        modals,
+        router,
+        transactions,
+      })
       expect(props.redirect).toBe('http://example.com')
     })
 
@@ -115,6 +151,7 @@ describe('Paywall', () => {
         keys,
         modals,
         router: noRedirectRouter,
+        transactions,
       })
       expect(props.redirect).toBeFalsy()
     })
@@ -130,8 +167,74 @@ describe('Paywall', () => {
           pathname: `/paywall/${lock.address}/http%3A%2F%2Fexample.com`,
         },
       }
-      const props = mapStateToProps({ locks, router, keys, modals })
+      const props = mapStateToProps({
+        locks,
+        router,
+        keys,
+        modals,
+        transactions,
+      })
       expect(props.redirect).toBe('http://example.com')
+    })
+
+    it('should return the transaction if applicable', () => {
+      expect.assertions(1)
+
+      const transaction = {
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        status: 'pending',
+        hash: '0x777',
+        key: '0x123-0x456',
+      }
+      const newProps = mapStateToProps({
+        account: {
+          address: '0x123',
+        },
+        locks,
+        keys: {
+          '0x123-0x456': {
+            id: '0x123-0x456',
+            lock: lock.address,
+            owner: '0x123',
+            expiration: 0,
+            data: 'hello',
+          },
+        },
+        modals,
+        router,
+        transactions: {
+          '0x777': transaction,
+        },
+      })
+      expect(newProps.transaction).toEqual(transaction)
+    })
+  })
+
+  describe('uses optimism', () => {
+    beforeEach(() => {
+      config = { providers: [], isInIframe: true }
+      fakeWindow = {
+        location: {
+          pathname: `/${lock.address}`,
+          search: '?origin=http%3A%2F%2Fexample.com',
+          hash: '',
+        },
+        parent: { postMessage: jest.fn() },
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        document: {
+          body: {
+            style: {},
+          },
+        },
+      }
+    })
+
+    it('calls the useOptimism hook', () => {
+      expect.assertions(1)
+      renderMockPaywall({ locks: [lock] })
+
+      expect(useOptimism).toHaveBeenCalled()
     })
   })
 

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -17,11 +17,13 @@ import {
 } from '../paywall-builder/constants'
 import { isPositiveNumber } from '../utils/validators'
 import useWindow from '../hooks/browser/useWindow'
+import useOptimism from '../hooks/useOptimism'
+import { TRANSACTION_TYPES } from '../constants'
 
 // TODO: mobile formatting for unlocked and optimistic unlocking views
-export function Paywall({ locks, locked, redirect, account }) {
+export function Paywall({ locks, locked, redirect, account, transaction }) {
   // TODO: use the useOptimism hook here instead of hard-coding it
-  const optimism = { current: 1, past: 0 }
+  const optimism = useOptimism(transaction)
   const window = useWindow()
   const scrollPosition = useListenForPostMessage({
     type: 'scrollPosition',
@@ -82,15 +84,24 @@ Paywall.propTypes = {
   locks: PropTypes.arrayOf(UnlockPropTypes.lock).isRequired,
   locked: PropTypes.bool.isRequired,
   redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  transaction: UnlockPropTypes.transaction,
   account: PropTypes.string,
 }
 
 Paywall.defaultProps = {
   redirect: false,
   account: null,
+  transaction: null,
 }
 
-export const mapStateToProps = ({ locks, keys, modals, router, account }) => {
+export const mapStateToProps = ({
+  locks,
+  keys,
+  modals,
+  router,
+  account,
+  transactions,
+}) => {
   const { lockAddress, redirect } = lockRoute(router.location.pathname)
 
   const lockFromUri = Object.values(locks).find(
@@ -110,12 +121,29 @@ export const mapStateToProps = ({ locks, keys, modals, router, account }) => {
     }
   })
 
+  const lock = locksFromUri.length ? locksFromUri[0] : { address: 0 }
+
+  let transaction = null
+
+  const lockKey = Object.values(keys).find(
+    key => account && key.lock === lock.address && key.owner === account.address
+  )
+
+  // Let's select the transaction corresponding to this key purchase, if it exists
+  // This transaction is of type KEY_PURCHASE
+  transaction = Object.values(transactions).find(
+    transaction =>
+      transaction.type === TRANSACTION_TYPES.KEY_PURCHASE &&
+      transaction.key === (lockKey && lockKey.id)
+  )
+
   const modalShown = !!modals[locksFromUri.map(l => l.address).join('-')]
   const locked = validKeys.length === 0 || modalShown
   return {
     locked,
     locks: locksFromUri,
     redirect,
+    transaction,
     account: account && account.address,
   }
 }

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -121,12 +121,16 @@ export const mapStateToProps = ({
     }
   })
 
-  const lock = locksFromUri.length ? locksFromUri[0] : { address: 0 }
+  const lock = locksFromUri.length ? locksFromUri[0] : null
 
   let transaction = null
 
   const lockKey = Object.values(keys).find(
-    key => account && key.lock === lock.address && key.owner === account.address
+    key =>
+      account &&
+      lock &&
+      key.lock === lock.address &&
+      key.owner === account.address
   )
 
   // Let's select the transaction corresponding to this key purchase, if it exists

--- a/paywall/src/stories/Paywall.stories.js
+++ b/paywall/src/stories/Paywall.stories.js
@@ -112,6 +112,11 @@ storiesOf('Paywall', module)
     <ConfigContext.Provider value={config}>
       <WindowContext.Provider
         value={{
+          fetch: () => ({
+            // dummy to prevent errors on CI
+            // this is the expected shape of returns from locksmith for optimism
+            json: Promise.resolve({ willSucceed: 0 }),
+          }),
           document: { body: { style: {} } },
           location: { pathname: '/0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e' },
         }}

--- a/paywall/src/stories/interface/StaticDemo.stories.js
+++ b/paywall/src/stories/interface/StaticDemo.stories.js
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react'
 import StaticDemo from '../../components/interface/StaticDemo'
 import createUnlockStore from '../../createUnlockStore'
 import { ConfigContext } from '../../utils/withConfig'
+import { WindowContext } from '../../hooks/browser/useWindow'
 
 const myLock = {
   address: '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e',
@@ -48,7 +49,19 @@ const config = {
 storiesOf('StaticDemo', module)
   .addDecorator(getStory => (
     <ConfigContext.Provider value={config}>
-      <Provider store={store}>{getStory()}</Provider>
+      <WindowContext.Provider
+        value={{
+          fetch: () => ({
+            // dummy to prevent errors on CI
+            // this is the expected shape of returns from locksmith for optimism
+            json: Promise.resolve({ willSucceed: 0 }),
+          }),
+          document: { body: { style: {} } },
+          location: { pathname: '/0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e' },
+        }}
+      >
+        <Provider store={store}>{getStory()}</Provider>
+      </WindowContext.Provider>
     </ConfigContext.Provider>
   ))
   .add('the demo', () => {


### PR DESCRIPTION
# Description

This enables the `useOptimism` hook in the paywall, so that it actively retrieves the current optimistic success from locksmith, and the past value from cache, in order to update the UI accordingly

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2393 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
