### PR TITLE
if transaction is passed in hash on paywall, retrieve it

### DIFF
--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -160,9 +160,14 @@ export default function web3Middleware({ getState, dispatch }) {
         action.payload.location.pathname
       ) {
         // Location was changed, get the matching lock, if we are on a paywall page
-        const { lockAddress } = lockRoute(action.payload.location.pathname)
+        const { lockAddress, transaction } = lockRoute(
+          action.payload.location.pathname + action.payload.location.hash
+        )
         if (lockAddress) {
           web3Service.getLock(lockAddress)
+        }
+        if (transaction) {
+          web3Service.getTransaction(transaction)
         }
       }
     }


### PR DESCRIPTION
# Description

In preparation for enabling optimistic unlocking in coinbase wallet and company, this adds functionality to retrieve the transaction when it is passed in the URL

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2351

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
