### PR TITLE
Middlewares now have config passed to them

### DIFF
--- a/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
@@ -1,4 +1,5 @@
 import { setConversionRate } from '../../actions/currencyConvert'
+import configure from '../../config'
 
 jest.mock('../../services/currencyLookupService', () => () => ({
   lookupPrice: jest
@@ -12,6 +13,7 @@ describe('Currency conversion service retrieval middleware', () => {
   it('service called, action dispatched to set currency conversion rate', async () => {
     expect.assertions(2)
     jest.useFakeTimers()
+    const config = configure()
     const middleware = require('../../middlewares/currencyConversionMiddleware')
       .default
     const store = {
@@ -21,7 +23,7 @@ describe('Currency conversion service retrieval middleware', () => {
       },
     }
 
-    await middleware(store)
+    await middleware(config)(store)
 
     expect(store.dispatch).toHaveBeenCalledWith(
       setConversionRate('USD', '195.99')
@@ -38,13 +40,14 @@ describe('Currency conversion service retrieval middleware', () => {
   it("service called, values are the same, so don't dispatch", async () => {
     expect.assertions(1)
     jest.useFakeTimers()
+    const config = configure()
     const middleware = require('../../middlewares/currencyConversionMiddleware')
       .default
     const store = {
       dispatch: jest.fn(),
     }
 
-    await middleware(store)
+    await middleware(config)(store)
     store.dispatch = jest.fn() // reset
     store.getState = () => ({ currency: { USD: 195.99 } })
     jest.advanceTimersByTime(10000) // test the setInterval

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -11,6 +11,7 @@ import { SET_ACCOUNT } from '../../actions/accounts'
 import { SIGNED_DATA } from '../../actions/signature'
 import UnlockLock from '../../structured_data/unlockLock'
 import { startLoading, doneLoading } from '../../actions/loading'
+import configure from '../../config'
 
 /**
  * This is a "fake" middleware caller
@@ -23,12 +24,13 @@ let lock
 let network
 
 const create = () => {
+  const config = configure()
   const store = {
     getState: jest.fn(() => state),
     dispatch: jest.fn(() => true),
   }
   const next = jest.fn()
-  const handler = storageMiddleware(store)
+  const handler = storageMiddleware(config)(store)
   const invoke = action => handler(next)(action)
   return { next, invoke, store }
 }

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -74,7 +74,7 @@ const create = () => {
   }
   const next = jest.fn()
 
-  const handler = walletMiddleware(store)
+  const handler = walletMiddleware(mockConfig)(store)
 
   const invoke = action => handler(next)(action)
 

--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -13,6 +13,7 @@ import { SET_ERROR } from '../../actions/error'
 import { SET_KEYS_ON_PAGE_FOR_LOCK } from '../../actions/keysPages'
 import { PGN_ITEMS_PER_PAGE, UNLIMITED_KEYS_COUNT } from '../../constants'
 import { START_LOADING, DONE_LOADING } from '../../actions/loading'
+import configure from '../../config'
 
 /**
  * Fake state
@@ -39,13 +40,14 @@ const network = {
  * Taken from https://redux.js.org/recipes/writing-tests#middleware
  */
 const create = () => {
+  const config = configure()
   const store = {
     getState: jest.fn(() => state),
     dispatch: jest.fn(() => true),
   }
   const next = jest.fn()
 
-  const handler = web3Middleware(store)
+  const handler = web3Middleware(config)(store)
 
   const invoke = action => handler(next)(action)
 

--- a/unlock-app/src/middlewares/currencyConversionMiddleware.js
+++ b/unlock-app/src/middlewares/currencyConversionMiddleware.js
@@ -1,29 +1,31 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import { setConversionRate } from '../actions/currencyConvert'
-import configure from '../config'
 import CurrencyLookupService from '../services/currencyLookupService'
 import { CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL } from '../constants'
 
-const { services } = configure(global)
-const currencyPriceLookupURI = services.currencyPriceLookup
+export default config => {
+  const { services } = config
+  const currencyPriceLookupURI = services.currencyPriceLookup
+  return store => {
+    const currencyLookupService = new CurrencyLookupService(
+      currencyPriceLookupURI
+    )
 
-export default store => {
-  const currencyLookupService = new CurrencyLookupService(
-    currencyPriceLookupURI
-  )
+    currencyLookupService
+      .lookupPrice('ETH', 'USD')
+      .then(info =>
+        store.dispatch(setConversionRate(info.currency, info.amount))
+      )
 
-  currencyLookupService
-    .lookupPrice('ETH', 'USD')
-    .then(info => store.dispatch(setConversionRate(info.currency, info.amount)))
+    setInterval(() => {
+      currencyLookupService.lookupPrice('ETH', 'USD').then(info => {
+        const current = store.getState().currency[info.currency]
+        if (current === info.amount) return
 
-  setInterval(() => {
-    currencyLookupService.lookupPrice('ETH', 'USD').then(info => {
-      const current = store.getState().currency[info.currency]
-      if (current === info.amount) return
-
-      store.dispatch(setConversionRate(info.currency, info.amount))
-    })
-  }, CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL)
-  return next => action => next(action)
+        store.dispatch(setConversionRate(info.currency, info.amount))
+      })
+    }, CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL)
+    return next => action => next(action)
+  }
 }

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -12,118 +12,120 @@ import { startLoading, doneLoading } from '../actions/loading'
 import StorageService from '../services/storageService'
 import { STORE_LOCK_NAME, storageError } from '../actions/storage'
 
-import configure from '../config'
 import { NEW_TRANSACTION, addTransaction } from '../actions/transaction'
 import { SET_ACCOUNT } from '../actions/accounts'
 import UnlockLock from '../structured_data/unlockLock'
 import { SIGNED_DATA, signData } from '../actions/signature'
 
-const { services } = configure(global)
+const storageMiddleware = config => {
+  const { services } = config
+  return ({ getState, dispatch }) => {
+    const storageService = new StorageService(services.storage.host)
 
-export default function storageMiddleware({ getState, dispatch }) {
-  const storageService = new StorageService(services.storage.host)
-
-  return next => {
-    return action => {
-      // TODO: never async/await middlewares
-      if (action.type === SET_ACCOUNT) {
-        dispatch(startLoading())
-        // When we set the account, we want to retrieve the list of transactions
-        storageService
-          .getTransactionsHashesSentBy(action.account.address)
-          .then(transactionHashes => {
-            dispatch(doneLoading())
-            // Dispatch each lock. Greg probably wants to a batch action?
-            transactionHashes.forEach(hash => {
-              dispatch(
-                addTransaction({
-                  hash,
-                })
-              )
-            })
-          })
-          .catch(error => {
-            dispatch(doneLoading())
-            dispatch(storageError(error))
-          })
-      }
-
-      if (action.type === NEW_TRANSACTION) {
-        // Storing a new transaction so that we can easoly point to it later on
-        storageService
-          .storeTransaction(
-            action.transaction.hash,
-            action.transaction.from,
-            action.transaction.to
-          )
-          .catch(error => {
-            dispatch(storageError(error))
-          })
-      }
-
-      if (
-        action.type === SIGNED_DATA &&
-        action.data.message &&
-        action.data.message.lock
-      ) {
-        // Once signed, let's save it!
-        storageService
-          .storeLockDetails(action.data, action.signature)
-          .catch(error => {
-            dispatch(storageError(error))
-          })
-      }
-
-      // TODO: isolate the logic below so we can also make it happen on lock updates
-      if (action.type === CREATE_LOCK && action.lock.address) {
-        // Build the data to sign
-        let data = UnlockLock.build({
-          name: action.lock.name,
-          owner: action.lock.owner,
-          address: action.lock.address,
-        })
-        // Ask someone to sign it!
-        dispatch(signData(data))
-      }
-
-      if (action.type === UPDATE_LOCK_NAME) {
-        const lock = getState().locks[action.address]
-        // Build the data to sign
-        let data = UnlockLock.build({
-          name: action.name,
-          owner: lock.owner,
-          address: lock.address,
-        })
-        // Ask someone to sign it!
-        dispatch(signData(data))
-      }
-
-      // TODO : remove me because it is not needed anymore
-      if (action.type === STORE_LOCK_NAME) {
-        // A new lock has been created
-        storageService
-          .storeLockDetails(action.lock, action.token)
-          .catch(error => {
-            dispatch(storageError(error))
-          })
-      }
-
-      if (action.type === UPDATE_LOCK) {
-        // Only look up the name for a lock for which the name is empty/not-set
-        const lock = getState().locks[action.address]
-        if (lock && !lock.name) {
+    return next => {
+      return action => {
+        // TODO: never async/await middlewares
+        if (action.type === SET_ACCOUNT) {
+          dispatch(startLoading())
+          // When we set the account, we want to retrieve the list of transactions
           storageService
-            .lockLookUp(action.address)
-            .then(name => {
-              dispatch(updateLock(action.address, { name }))
+            .getTransactionsHashesSentBy(action.account.address)
+            .then(transactionHashes => {
+              dispatch(doneLoading())
+              // Dispatch each lock. Greg probably wants to a batch action?
+              transactionHashes.forEach(hash => {
+                dispatch(
+                  addTransaction({
+                    hash,
+                  })
+                )
+              })
             })
+            .catch(error => {
+              dispatch(doneLoading())
+              dispatch(storageError(error))
+            })
+        }
+
+        if (action.type === NEW_TRANSACTION) {
+          // Storing a new transaction so that we can easoly point to it later on
+          storageService
+            .storeTransaction(
+              action.transaction.hash,
+              action.transaction.from,
+              action.transaction.to
+            )
             .catch(error => {
               dispatch(storageError(error))
             })
         }
-      }
 
-      next(action)
+        if (
+          action.type === SIGNED_DATA &&
+          action.data.message &&
+          action.data.message.lock
+        ) {
+          // Once signed, let's save it!
+          storageService
+            .storeLockDetails(action.data, action.signature)
+            .catch(error => {
+              dispatch(storageError(error))
+            })
+        }
+
+        // TODO: isolate the logic below so we can also make it happen on lock updates
+        if (action.type === CREATE_LOCK && action.lock.address) {
+          // Build the data to sign
+          let data = UnlockLock.build({
+            name: action.lock.name,
+            owner: action.lock.owner,
+            address: action.lock.address,
+          })
+          // Ask someone to sign it!
+          dispatch(signData(data))
+        }
+
+        if (action.type === UPDATE_LOCK_NAME) {
+          const lock = getState().locks[action.address]
+          // Build the data to sign
+          let data = UnlockLock.build({
+            name: action.name,
+            owner: lock.owner,
+            address: lock.address,
+          })
+          // Ask someone to sign it!
+          dispatch(signData(data))
+        }
+
+        // TODO : remove me because it is not needed anymore
+        if (action.type === STORE_LOCK_NAME) {
+          // A new lock has been created
+          storageService
+            .storeLockDetails(action.lock, action.token)
+            .catch(error => {
+              dispatch(storageError(error))
+            })
+        }
+
+        if (action.type === UPDATE_LOCK) {
+          // Only look up the name for a lock for which the name is empty/not-set
+          const lock = getState().locks[action.address]
+          if (lock && !lock.name) {
+            storageService
+              .lockLookUp(action.address)
+              .then(name => {
+                dispatch(updateLock(action.address, { name }))
+              })
+              .catch(error => {
+                dispatch(storageError(error))
+              })
+          }
+        }
+
+        next(action)
+      }
     }
   }
 }
+
+export default storageMiddleware

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -26,192 +26,194 @@ import {
   FATAL_NON_DEPLOYED_CONTRACT,
 } from '../errors'
 import { SIGN_DATA, signedData, signatureError } from '../actions/signature'
-import configure from '../config'
 import { TransactionType } from '../unlockTypes'
 import { hideForm } from '../actions/lockFormVisibility'
 
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
 
-export default function walletMiddleware({ getState, dispatch }) {
-  const config = configure()
-  const walletService = new WalletService(config)
+const walletMiddleware = config => {
+  return ({ getState, dispatch }) => {
+    const walletService = new WalletService(config)
 
-  /**
-   * Helper function which ensures that the walletService is ready
-   * before calling it or dispatches an error
-   * @param {*} callback
-   */
-  const ensureReadyBefore = callback => {
-    if (!walletService.ready) {
-      return dispatch(setError(FATAL_NO_USER_ACCOUNT))
-    }
-    return callback()
-  }
-
-  /**
-   * When an account was changed, we dispatch the corresponding action
-   * The setAccount action will reset other relevant redux state
-   */
-  walletService.on('account.changed', account => {
-    if (config.isServer) return
-    // Let's poll to detect account changes
-    setTimeout(walletService.getAccount.bind(walletService), POLLING_INTERVAL)
-
-    // If the account is actually different
-    if (!getState().account || getState().account.address !== account) {
-      dispatch(
-        setAccount({
-          address: account,
-        })
-      )
-    }
-  })
-
-  walletService.on(
-    'transaction.new',
-    (transactionHash, from, to, input, type, status) => {
-      // At this point we know that a wallet was found, because a new transaction
-      // cannot be created without it
-      dispatch(gotWallet())
-      dispatch(
-        newTransaction({
-          hash: transactionHash,
-          to,
-          from,
-          input,
-          type,
-          status,
-        })
-      )
-    }
-  )
-
-  // A transaction has started, now we need to signal that we're waiting for
-  // interaction with the wallet
-  walletService.on('transaction.pending', () => {
-    dispatch(waitForWallet())
-  })
-
-  // The wallet check overlay may be manually dismissed. When that event is
-  // signaled, clear the overlay.
-  walletService.on('overlay.dismissed', () => {
-    dispatch(dismissWalletCheck())
-  })
-
-  walletService.on('lock.updated', (address, update) => {
-    // This is a new lock!
-    dispatch(updateLock(address, update))
-    dispatch(hideForm()) // Close the form
-  })
-
-  walletService.on('error', (error, transactionHash) => {
-    // If we didn't successfully interact with the wallet, we need to clear the
-    // overlay
-    dispatch(dismissWalletCheck())
-    const transaction = getState().transactions[transactionHash]
-    if (transaction && transaction.type === TransactionType.LOCK_CREATION) {
-      // delete the lock
-      dispatch(deleteLock(transaction.lock))
-      return dispatch(
-        setError('Failed to create lock. Did you decline the transaction?')
-      )
-    }
-    dispatch(setError(error.message))
-  })
-
-  /**
-   * When the network has changed, we need to ensure Unlock has been deployed there and
-   * get a new account as well as reset all the reducers
-   */
-  walletService.on('network.changed', networkId => {
-    // Set the new network, which should also clean up all reducers
-    dispatch(setNetwork(networkId))
-
-    // Let's check if we're on the right network
-    if (config.isRequiredNetwork && !config.isRequiredNetwork(networkId)) {
-      const currentNetwork = ETHEREUM_NETWORKS_NAMES[networkId]
-        ? ETHEREUM_NETWORKS_NAMES[networkId][0]
-        : 'Unknown Network'
-      return dispatch(
-        setError(FATAL_WRONG_NETWORK, {
-          currentNetwork: currentNetwork,
-          requiredNetworkId: config.requiredNetworkId,
-        })
-      )
-    }
-
-    // Check if the smart contract exists
-    walletService.isUnlockContractDeployed((error, isDeployed) => {
-      if (error) {
-        return dispatch(setError(error.message))
+    /**
+     * Helper function which ensures that the walletService is ready
+     * before calling it or dispatches an error
+     * @param {*} callback
+     */
+    const ensureReadyBefore = callback => {
+      if (!walletService.ready) {
+        return dispatch(setError(FATAL_NO_USER_ACCOUNT))
       }
-      if (!isDeployed) {
-        return dispatch(setError(FATAL_NON_DEPLOYED_CONTRACT))
-      }
-      // We need a new account!
-      return walletService.getAccount(true /* createIfNone */)
-    })
-  })
+      return callback()
+    }
 
-  return function(next) {
-    // Connect to the current provider
-    // We connect once the middleware has been initialized, using setTimout (warning: fragile?)
-    setTimeout(() => {
-      walletService.connect(getState().provider)
+    /**
+     * When an account was changed, we dispatch the corresponding action
+     * The setAccount action will reset other relevant redux state
+     */
+    walletService.on('account.changed', account => {
+      if (config.isServer) return
+      // Let's poll to detect account changes
+      setTimeout(walletService.getAccount.bind(walletService), POLLING_INTERVAL)
+
+      // If the account is actually different
+      if (!getState().account || getState().account.address !== account) {
+        dispatch(
+          setAccount({
+            address: account,
+          })
+        )
+      }
     })
 
-    return function(action) {
-      if (action.type === SET_PROVIDER) {
-        walletService.connect(action.provider)
-      } else if (action.type === CREATE_LOCK && action.lock.address) {
-        ensureReadyBefore(() => {
-          walletService.createLock(action.lock, getState().account.address)
-        })
-      } else if (action.type === PURCHASE_KEY) {
-        ensureReadyBefore(() => {
-          const account = getState().account
-          // find the lock to get its keyPrice
-          const lock = Object.values(getState().locks).find(
-            lock => lock.address === action.key.lock
-          )
-          walletService.purchaseKey(
-            action.key.lock,
-            action.key.owner,
-            lock.keyPrice,
-            account.address,
-            action.key.data
-          )
-        })
-      } else if (action.type === WITHDRAW_FROM_LOCK) {
-        ensureReadyBefore(() => {
-          const account = getState().account
-          walletService.withdrawFromLock(action.lock.address, account.address)
-        })
-      } else if (action.type === UPDATE_LOCK_KEY_PRICE) {
-        ensureReadyBefore(() => {
-          const account = getState().account
-          walletService.updateKeyPrice(
-            action.address,
-            account.address,
-            action.price
-          )
-        })
-      } else if (action.type === SIGN_DATA) {
-        const account = getState().account
-        walletService.signData(
-          account.address,
-          action.data,
-          (error, signature) => {
-            if (error) {
-              dispatch(signatureError(error))
-            }
-            dispatch(signedData(action.data, signature))
-          }
+    walletService.on(
+      'transaction.new',
+      (transactionHash, from, to, input, type, status) => {
+        // At this point we know that a wallet was found, because a new transaction
+        // cannot be created without it
+        dispatch(gotWallet())
+        dispatch(
+          newTransaction({
+            hash: transactionHash,
+            to,
+            from,
+            input,
+            type,
+            status,
+          })
+        )
+      }
+    )
+
+    // A transaction has started, now we need to signal that we're waiting for
+    // interaction with the wallet
+    walletService.on('transaction.pending', () => {
+      dispatch(waitForWallet())
+    })
+
+    // The wallet check overlay may be manually dismissed. When that event is
+    // signaled, clear the overlay.
+    walletService.on('overlay.dismissed', () => {
+      dispatch(dismissWalletCheck())
+    })
+
+    walletService.on('lock.updated', (address, update) => {
+      // This is a new lock!
+      dispatch(updateLock(address, update))
+      dispatch(hideForm()) // Close the form
+    })
+
+    walletService.on('error', (error, transactionHash) => {
+      // If we didn't successfully interact with the wallet, we need to clear the
+      // overlay
+      dispatch(dismissWalletCheck())
+      const transaction = getState().transactions[transactionHash]
+      if (transaction && transaction.type === TransactionType.LOCK_CREATION) {
+        // delete the lock
+        dispatch(deleteLock(transaction.lock))
+        return dispatch(
+          setError('Failed to create lock. Did you decline the transaction?')
+        )
+      }
+      dispatch(setError(error.message))
+    })
+
+    /**
+     * When the network has changed, we need to ensure Unlock has been deployed there and
+     * get a new account as well as reset all the reducers
+     */
+    walletService.on('network.changed', networkId => {
+      // Set the new network, which should also clean up all reducers
+      dispatch(setNetwork(networkId))
+
+      // Let's check if we're on the right network
+      if (config.isRequiredNetwork && !config.isRequiredNetwork(networkId)) {
+        const currentNetwork = ETHEREUM_NETWORKS_NAMES[networkId]
+          ? ETHEREUM_NETWORKS_NAMES[networkId][0]
+          : 'Unknown Network'
+        return dispatch(
+          setError(FATAL_WRONG_NETWORK, {
+            currentNetwork: currentNetwork,
+            requiredNetworkId: config.requiredNetworkId,
+          })
         )
       }
 
-      next(action)
+      // Check if the smart contract exists
+      walletService.isUnlockContractDeployed((error, isDeployed) => {
+        if (error) {
+          return dispatch(setError(error.message))
+        }
+        if (!isDeployed) {
+          return dispatch(setError(FATAL_NON_DEPLOYED_CONTRACT))
+        }
+        // We need a new account!
+        return walletService.getAccount(true /* createIfNone */)
+      })
+    })
+
+    return function(next) {
+      // Connect to the current provider
+      // We connect once the middleware has been initialized, using setTimout (warning: fragile?)
+      setTimeout(() => {
+        walletService.connect(getState().provider)
+      })
+
+      return function(action) {
+        if (action.type === SET_PROVIDER) {
+          walletService.connect(action.provider)
+        } else if (action.type === CREATE_LOCK && action.lock.address) {
+          ensureReadyBefore(() => {
+            walletService.createLock(action.lock, getState().account.address)
+          })
+        } else if (action.type === PURCHASE_KEY) {
+          ensureReadyBefore(() => {
+            const account = getState().account
+            // find the lock to get its keyPrice
+            const lock = Object.values(getState().locks).find(
+              lock => lock.address === action.key.lock
+            )
+            walletService.purchaseKey(
+              action.key.lock,
+              action.key.owner,
+              lock.keyPrice,
+              account.address,
+              action.key.data
+            )
+          })
+        } else if (action.type === WITHDRAW_FROM_LOCK) {
+          ensureReadyBefore(() => {
+            const account = getState().account
+            walletService.withdrawFromLock(action.lock.address, account.address)
+          })
+        } else if (action.type === UPDATE_LOCK_KEY_PRICE) {
+          ensureReadyBefore(() => {
+            const account = getState().account
+            walletService.updateKeyPrice(
+              action.address,
+              account.address,
+              action.price
+            )
+          })
+        } else if (action.type === SIGN_DATA) {
+          const account = getState().account
+          walletService.signData(
+            account.address,
+            action.data,
+            (error, signature) => {
+              if (error) {
+                dispatch(signatureError(error))
+              }
+              dispatch(signedData(action.data, signature))
+            }
+          )
+        }
+
+        next(action)
+      }
     }
   }
 }
+
+export default walletMiddleware

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -19,160 +19,162 @@ import {
   SET_KEYS_ON_PAGE_FOR_LOCK,
   setKeysOnPageForLock,
 } from '../actions/keysPages'
-import configure from '../config'
 
 const { Web3Service } = UnlockJs
 
-const {
-  readOnlyProvider,
-  unlockAddress,
-  blockTime,
-  requiredConfirmations,
-} = configure()
-
 // This middleware listen to redux events and invokes the web3Service API.
 // It also listen to events from web3Service and dispatches corresponding actions
-export default function web3Middleware({ getState, dispatch }) {
-  const web3Service = new Web3Service({
+const web3Middleware = config => {
+  const {
     readOnlyProvider,
     unlockAddress,
     blockTime,
     requiredConfirmations,
-  })
+  } = config
+  return ({ getState, dispatch }) => {
+    const web3Service = new Web3Service({
+      readOnlyProvider,
+      unlockAddress,
+      blockTime,
+      requiredConfirmations,
+    })
 
-  web3Service.on('account.updated', (account, update) => {
-    dispatch(updateAccount(update))
-  })
+    web3Service.on('account.updated', (account, update) => {
+      dispatch(updateAccount(update))
+    })
 
-  /**
-   * When a lock was saved, we update it, as well as its transaction and
-   * refresh the balance of its owner and refresh its content
-   */
-  web3Service.on('lock.saved', (lock, address) => {
-    web3Service.refreshAccountBalance(getState().account)
-    web3Service.getLock(address)
-    web3Service.getPastLockTransactions(address) // This is costly and not useful for the paywall app...
-  })
-
-  /**
-   * The Lock was changed.
-   * Should we get the balance of the lock owner?
-   */
-  web3Service.on('lock.updated', (address, update) => {
-    const lock = getState().locks[address]
-
-    // Our app defines a unlimitedKeys boolean
-    if (update.maxNumberOfKeys) {
-      update.unlimitedKeys = update.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
-    }
-
-    if (lock) {
-      // Only dispatch the updates which are more recent than the current value
-      if (!lock.asOf || lock.asOf < update.asOf) {
-        dispatch(updateLock(lock.address, update))
-      }
-    } else {
-      dispatch(addLock(address, update))
-    }
-  })
-
-  /**
-   * When a key was saved, we reload the corresponding lock because
-   * it might have been updated (balance, outstanding keys...)
-   */
-  web3Service.on('key.saved', (keyId, key) => {
-    web3Service.getLock(key.lock)
-    if (getState().account.address === key.owner) {
+    /**
+     * When a lock was saved, we update it, as well as its transaction and
+     * refresh the balance of its owner and refresh its content
+     */
+    web3Service.on('lock.saved', (lock, address) => {
       web3Service.refreshAccountBalance(getState().account)
-    }
-    web3Service.getKeyByLockForOwner(key.lock, key.owner)
-  })
+      web3Service.getLock(address)
+      web3Service.getPastLockTransactions(address) // This is costly and not useful for the paywall app...
+    })
 
-  web3Service.on('key.updated', (id, update) => {
-    if (getState().keys[id]) {
-      dispatch(updateKey(id, update))
-    } else {
-      // That key does not exist yet
-      dispatch(addKey(id, update))
-    }
-  })
+    /**
+     * The Lock was changed.
+     * Should we get the balance of the lock owner?
+     */
+    web3Service.on('lock.updated', (address, update) => {
+      const lock = getState().locks[address]
 
-  web3Service.on('transaction.updated', (transactionHash, update) => {
-    dispatch(updateTransaction(transactionHash, update))
-  })
+      // Our app defines a unlimitedKeys boolean
+      if (update.maxNumberOfKeys) {
+        update.unlimitedKeys = update.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
+      }
 
-  web3Service.on('transaction.new', transactionHash => {
-    dispatch(
-      addTransaction({
-        hash: transactionHash,
-      })
-    )
-  })
-
-  web3Service.on('error', error => {
-    dispatch(setError(error.message))
-  })
-
-  web3Service.on('keys.page', (lock, page, keys) => {
-    dispatch(setKeysOnPageForLock(page, lock, keys))
-  })
-
-  return function(next) {
-    return function(action) {
-      // When the keys for a lock are loaded on the dashboard
-      if (action.type === SET_KEYS_ON_PAGE_FOR_LOCK) {
-        if (!action.keys) {
-          web3Service.getKeysForLockOnPage(
-            action.lock,
-            action.page,
-            PGN_ITEMS_PER_PAGE
-          )
+      if (lock) {
+        // Only dispatch the updates which are more recent than the current value
+        if (!lock.asOf || lock.asOf < update.asOf) {
+          dispatch(updateLock(lock.address, update))
         }
+      } else {
+        dispatch(addLock(address, update))
       }
+    })
 
-      if (action.type === ADD_TRANSACTION) {
-        dispatch(startLoading())
-        web3Service.getTransaction(action.transaction.hash).then(() => {
-          dispatch(doneLoading())
+    /**
+     * When a key was saved, we reload the corresponding lock because
+     * it might have been updated (balance, outstanding keys...)
+     */
+    web3Service.on('key.saved', (keyId, key) => {
+      web3Service.getLock(key.lock)
+      if (getState().account.address === key.owner) {
+        web3Service.refreshAccountBalance(getState().account)
+      }
+      web3Service.getKeyByLockForOwner(key.lock, key.owner)
+    })
+
+    web3Service.on('key.updated', (id, update) => {
+      if (getState().keys[id]) {
+        dispatch(updateKey(id, update))
+      } else {
+        // That key does not exist yet
+        dispatch(addKey(id, update))
+      }
+    })
+
+    web3Service.on('transaction.updated', (transactionHash, update) => {
+      dispatch(updateTransaction(transactionHash, update))
+    })
+
+    web3Service.on('transaction.new', transactionHash => {
+      dispatch(
+        addTransaction({
+          hash: transactionHash,
         })
-      }
+      )
+    })
 
-      if (action.type === NEW_TRANSACTION) {
-        dispatch(startLoading())
-        web3Service
-          .getTransaction(action.transaction.hash, action.transaction)
-          .then(() => {
+    web3Service.on('error', error => {
+      dispatch(setError(error.message))
+    })
+
+    web3Service.on('keys.page', (lock, page, keys) => {
+      dispatch(setKeysOnPageForLock(page, lock, keys))
+    })
+
+    return function(next) {
+      return function(action) {
+        // When the keys for a lock are loaded on the dashboard
+        if (action.type === SET_KEYS_ON_PAGE_FOR_LOCK) {
+          if (!action.keys) {
+            web3Service.getKeysForLockOnPage(
+              action.lock,
+              action.page,
+              PGN_ITEMS_PER_PAGE
+            )
+          }
+        }
+
+        if (action.type === ADD_TRANSACTION) {
+          dispatch(startLoading())
+          web3Service.getTransaction(action.transaction.hash).then(() => {
             dispatch(doneLoading())
           })
-      }
+        }
 
-      if (action.type === CREATE_LOCK && !action.lock.address) {
-        web3Service.generateLockAddress().then(address => {
-          action.lock.address = address
-          dispatch(createLock(action.lock))
-        })
-      }
-
-      next(action)
-
-      // note: this needs to be after the reducer has seen it, because refreshAccountBalance
-      // triggers 'account.update' which dispatches UPDATE_ACCOUNT. The reducer assumes that
-      // ADD_ACCOUNT has reached it first, and throws an exception. Putting it after the
-      // reducer has a chance to populate state removes this race condition.
-      if (action.type === SET_ACCOUNT) {
-        // TODO: when the account has been updated we should reset web3Service and remove all listeners
-        // So that pending API calls do not interract with our "new" state.
-        web3Service.refreshAccountBalance(action.account)
-        dispatch(startLoading())
-        web3Service
-          .getPastLockCreationsTransactionsForUser(action.account.address)
-          .then(lockCreations => {
-            dispatch(doneLoading())
-            lockCreations.forEach(lockCreation => {
-              web3Service.getTransaction(lockCreation.transactionHash)
+        if (action.type === NEW_TRANSACTION) {
+          dispatch(startLoading())
+          web3Service
+            .getTransaction(action.transaction.hash, action.transaction)
+            .then(() => {
+              dispatch(doneLoading())
             })
+        }
+
+        if (action.type === CREATE_LOCK && !action.lock.address) {
+          web3Service.generateLockAddress().then(address => {
+            action.lock.address = address
+            dispatch(createLock(action.lock))
           })
+        }
+
+        next(action)
+
+        // note: this needs to be after the reducer has seen it, because refreshAccountBalance
+        // triggers 'account.update' which dispatches UPDATE_ACCOUNT. The reducer assumes that
+        // ADD_ACCOUNT has reached it first, and throws an exception. Putting it after the
+        // reducer has a chance to populate state removes this race condition.
+        if (action.type === SET_ACCOUNT) {
+          // TODO: when the account has been updated we should reset web3Service and remove all listeners
+          // So that pending API calls do not interract with our "new" state.
+          web3Service.refreshAccountBalance(action.account)
+          dispatch(startLoading())
+          web3Service
+            .getPastLockCreationsTransactionsForUser(action.account.address)
+            .then(lockCreations => {
+              dispatch(doneLoading())
+              lockCreations.forEach(lockCreation => {
+                web3Service.getTransaction(lockCreation.transactionHash)
+              })
+            })
+        }
       }
     }
   }
 }
+
+export default web3Middleware

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -22,9 +22,9 @@ const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
 
 function getOrCreateStore(initialState, path) {
   const middlewares = [
-    web3Middleware,
-    currencyConversionMiddleware,
-    walletMiddleware,
+    web3Middleware(config),
+    currencyConversionMiddleware(config),
+    walletMiddleware(config),
   ]
 
   if (config.services.storage) {

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -28,7 +28,7 @@ function getOrCreateStore(initialState, path) {
   ]
 
   if (config.services.storage) {
-    middlewares.push(storageMiddleware)
+    middlewares.push(storageMiddleware(config))
   }
 
   // Always make a new store if server, otherwise state is shared between requests


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR is a bit of cleanup work around the usage of the config in middlewares. Currently, they each instantiate the config on their own. This is unnecessary, and actually inhibits some of our plans for the future (which require the config object to be a singleton).

Now just one single config file is made, and it is passed to each middleware in `_app.js` so that they each share the same object.

# Issues
Refs #2414 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
