### PR TITLE
using the shared eslint config

### DIFF
--- a/paywall/.eslintrc.js
+++ b/paywall/.eslintrc.js
@@ -1,39 +1,19 @@
 module.exports = {
   extends: [
-    'standard',
-    'airbnb',
-    'eslint:recommended',
+    '../.eslintrc.js',
     'plugin:react/recommended',
-    'prettier',
     'prettier/react',
-    'prettier/standard',
     'plugin:prettier/recommended',
   ],
-  env: {
-    es6: true,
-    node: true,
-    browser: true,
-    jest: true,
-  },
-  plugins: ['jest', 'mocha', 'promise', 'react-hooks'],
-  parser: 'babel-eslint',
+  plugins: ['react-hooks'],
   settings: {
     react: {
       version: 'detect',
     },
   },
   rules: {
-    'prettier/prettier': 'error',
     'react/prefer-stateless-function': [2],
-    'linebreak-style': ['error', 'unix'],
-    quotes: [
-      'error',
-      'single',
-      { avoidEscape: true, allowTemplateLiterals: false },
-    ],
-    'brace-style': 0,
     'react/forbid-prop-types': 2,
-    indent: 0, // this conflicts with prettier and is not needed
     'jsx-a11y/anchor-is-valid': [
       'error',
       {
@@ -42,18 +22,6 @@ module.exports = {
         aspects: ['invalidHref', 'preferButton'],
       },
     ],
-    'mocha/no-exclusive-tests': 'error',
     'react/jsx-filename-extension': [0, { extensions: ['.js', '.jsx'] }],
-    'import/no-named-as-default': 0,
-    'import/no-named-as-default-member': 0,
-    'standard/computed-property-even-spacing': 0,
-    'standard/object-curly-even-spacing': 0,
-    'standard/array-bracket-even-spacing': 0,
-    'promise/prefer-await-to-then': 'warn',
-    'jest/no-disabled-tests': 'warn',
-    'jest/no-identical-title': 'error',
-    'jest/no-focused-tests': 'error',
-    'jest/prefer-expect-assertions': 'warn', // TODO: fix errors and change into error
-    'eol-last': ['error'],
   },
 }


### PR DESCRIPTION
In an effort to add consistency all eslint config are using the same shared config + custom rules...


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread