### PR TITLE
removed the custom eslint packages installed by tests and unlock-js

### DIFF
--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -24,7 +24,6 @@
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.4",
     "@babel/preset-env": "^7.4.2",
-    "babel-jest": "^23.6.0",
-    "eslint": "^5.15.3"
+    "babel-jest": "^23.6.0"
   }
 }


### PR DESCRIPTION
For some reason eslint was installed in duplicate.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->