### PR TITLE
Provider Middleware

### DIFF
--- a/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
@@ -1,0 +1,81 @@
+import providerMiddleware from '../../middlewares/providerMiddleware'
+import { SET_PROVIDER } from '../../actions/provider'
+import { setError } from '../../actions/error'
+import { FATAL_MISSING_PROVIDER } from '../../errors'
+
+const config = {
+  providers: {
+    UNLOCK: {
+      enable: jest.fn(),
+      isUnlock: true,
+    },
+    NUNLOCK: {
+      enable: jest.fn(),
+    },
+  },
+}
+
+const getState = () => ({
+  provider: 'NUNLOCK',
+})
+
+const unlockAction = {
+  type: SET_PROVIDER,
+  provider: 'UNLOCK',
+}
+
+const erroneousAction = {
+  type: SET_PROVIDER,
+  provider: 'HONLOCK',
+}
+
+const sameAction = {
+  type: SET_PROVIDER,
+  provider: 'NUNLOCK',
+}
+
+let dispatch: () => any
+
+describe('provider middleware', () => {
+  beforeEach(() => {
+    config.providers['UNLOCK'].enable = jest.fn()
+    config.providers['NUNLOCK'].enable = jest.fn()
+    dispatch = jest.fn()
+  })
+  describe('SET_PROVIDER', () => {
+    it('should initialize the provider when provider is different from one in state', done => {
+      expect.assertions(2)
+      const next = () => {
+        expect(config.providers['UNLOCK'].enable).toHaveBeenCalled()
+        expect(config.providers['NUNLOCK'].enable).not.toHaveBeenCalled()
+        done()
+      }
+
+      providerMiddleware(config)({ getState, dispatch })(next)(unlockAction)
+    })
+
+    it('should set an error and return if there is no matching provider', done => {
+      expect.assertions(3)
+      const next = () => {
+        expect(config.providers['UNLOCK'].enable).not.toHaveBeenCalled()
+        expect(config.providers['NUNLOCK'].enable).not.toHaveBeenCalled()
+        expect(dispatch).toHaveBeenCalledWith(setError(FATAL_MISSING_PROVIDER))
+        done()
+      }
+
+      providerMiddleware(config)({ getState, dispatch })(next)(erroneousAction)
+    })
+
+    it('should do nothing if provider is the same as in state', done => {
+      expect.assertions(3)
+      const next = () => {
+        expect(config.providers['UNLOCK'].enable).not.toHaveBeenCalled()
+        expect(config.providers['NUNLOCK'].enable).not.toHaveBeenCalled()
+        expect(dispatch).not.toHaveBeenCalled()
+        done()
+      }
+
+      providerMiddleware(config)({ getState, dispatch })(next)(sameAction)
+    })
+  })
+})

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -1,0 +1,51 @@
+import { SET_PROVIDER } from '../actions/provider'
+import { setError } from '../actions/error'
+import { FATAL_MISSING_PROVIDER } from '../errors'
+
+interface Action {
+  type: string
+  [key: string]: any
+}
+
+async function initializeProvider(
+  providerName: string,
+  providers: { [key: string]: any },
+  dispatch: any
+) {
+  const provider = providers[providerName]
+  if (!provider) {
+    // Once Unlock Provider is in place, it should be highly unusual for this error to occur.
+    dispatch(setError(FATAL_MISSING_PROVIDER))
+    return
+  }
+
+  try {
+    if (provider.enable) {
+      // this exists for metamask and other modern dapp wallets and must be
+      // called, see:
+      // https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8
+      // TODO: unlock provider specific code to open communication channels for prompts
+      await provider.enable()
+    }
+  } catch (err) {
+    // do a thing with err
+  }
+}
+
+const providerMiddleware = (config: any) => {
+  return ({ getState, dispatch }: { [key: string]: any }) => {
+    return function(next: any) {
+      return function(action: Action) {
+        if (action.type === SET_PROVIDER) {
+          // Only initialize the provider if we haven't already done so.
+          if (action.provider !== getState().provider) {
+            initializeProvider(action.provider, config.providers, dispatch)
+          }
+          next(action)
+        }
+      }
+    }
+  }
+}
+
+export default providerMiddleware

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -7,18 +7,7 @@ interface Action {
   [key: string]: any
 }
 
-async function initializeProvider(
-  providerName: string,
-  providers: { [key: string]: any },
-  dispatch: any
-) {
-  const provider = providers[providerName]
-  if (!provider) {
-    // Once Unlock Provider is in place, it should be highly unusual for this error to occur.
-    dispatch(setError(FATAL_MISSING_PROVIDER))
-    return
-  }
-
+async function initializeProvider(provider: { enable?: () => any }) {
   try {
     if (provider.enable) {
       // this exists for metamask and other modern dapp wallets and must be
@@ -39,7 +28,12 @@ const providerMiddleware = (config: any) => {
         if (action.type === SET_PROVIDER) {
           // Only initialize the provider if we haven't already done so.
           if (action.provider !== getState().provider) {
-            initializeProvider(action.provider, config.providers, dispatch)
+            const provider = config.providers[action.provider]
+            if (provider) {
+              initializeProvider(provider)
+            } else {
+              dispatch(setError(FATAL_MISSING_PROVIDER))
+            }
           }
           next(action)
         }

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -46,8 +46,8 @@ const providerMiddleware = (config: any) => {
               dispatch(setError(FATAL_MISSING_PROVIDER))
             }
           }
-          next(action)
         }
+        next(action)
       }
     }
   }

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -1,23 +1,34 @@
 import { SET_PROVIDER } from '../actions/provider'
 import { setError } from '../actions/error'
-import { FATAL_MISSING_PROVIDER } from '../errors'
+import {
+  FATAL_MISSING_PROVIDER,
+  FATAL_NOT_ENABLED_IN_PROVIDER,
+} from '../errors'
 
 interface Action {
   type: string
   [key: string]: any
 }
 
-async function initializeProvider(provider: { enable?: () => any }) {
+async function initializeProvider(
+  provider: { enable?: () => any },
+  dispatch: any
+) {
   try {
     if (provider.enable) {
       // this exists for metamask and other modern dapp wallets and must be
       // called, see:
       // https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8
       // TODO: unlock provider specific code to open communication channels for prompts
+      // Prerequisite: unlock provider must exist
       await provider.enable()
     }
   } catch (err) {
-    // do a thing with err
+    // If we fail here, the provider has not been enabled. For example, a user
+    // may not have authorized the connection to our dapp. When using the Unlock
+    // Provider, this should never occur because it should block until there is
+    // a successful authentication.
+    dispatch(setError(FATAL_NOT_ENABLED_IN_PROVIDER))
   }
 }
 
@@ -30,7 +41,7 @@ const providerMiddleware = (config: any) => {
           if (action.provider !== getState().provider) {
             const provider = config.providers[action.provider]
             if (provider) {
-              initializeProvider(provider)
+              initializeProvider(provider, dispatch)
             } else {
               dispatch(setError(FATAL_MISSING_PROVIDER))
             }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This draft PR illustrates the introduction of a middleware to handle providers. Right now, initialization of a provider happens in the wallet middleware in response to the `SET_PROVIDER` action. Conceptually, that isn't very clean. We also need to do some special work for the providers anyway so that we can effectively use the (upcoming) Unlock provider, so now seems like the time to split out management of providers into its own middleware.

The idea here is that the provider will be a resident of the config file, which will be a singleton (ref #2470). The provider middleware will trigger the initialization of the provider (in particular, the `enable` call). The provider will then be passed down through the config to those components that require it.

https://github.com/unlock-protocol/unlock/blob/8c63ea46d388a5e933ef9b4f6d5bac6166825aee/unlock-app/src/services/walletService.js#L54-L95

The `connect` method will still exist on the wallet service, but it will just be the part from line 87 onward, where it creates an instance of Web3 based on the given provider.

This PR needs a little more time to bake, but I wanted to put it up to solicit comments about this approach.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
