### PR TITLE
Implement mobile-friendly flag and optimistic unlocking UI

### DIFF
--- a/paywall/src/components/lock/FlagStyles.js
+++ b/paywall/src/components/lock/FlagStyles.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import Media from '../../theme/media'
 
 export const OptimisticFlag = styled.div`
   height: 80px;
@@ -12,6 +13,11 @@ export const OptimisticFlag = styled.div`
   align-items: center;
 
   position: relative;
+
+  ${Media.phone`
+    justify-self: center;
+    box-shadow: 14px 0px 40px rgba(0, 0, 0, 0.14);
+  `}
 `
 
 export const OptimisticLogo = styled.div`

--- a/paywall/src/components/lock/LockStyles.js
+++ b/paywall/src/components/lock/LockStyles.js
@@ -131,6 +131,29 @@ export const Colophon = styled.footer`
     color: var(--darkgrey);
   }
   ${Media.phone`
-    display: none;
+    display: flex;
+    flex-direction: column;
+    justify-self: center;
+    background-color: transparent;
+    height: 30px;
+    width: 100%;
+    margin-right: 0;
+
+    grid-row: 3;
+
+    & > p {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      align-self: center;
+      justify-self: center;
+      color: var(--slate);
+      & > a {
+        color: var(--red);
+      }
+    }
+    & > div {
+      display: none;
+    }
   `}
 `

--- a/paywall/src/components/lock/LockStyles.js
+++ b/paywall/src/components/lock/LockStyles.js
@@ -117,6 +117,9 @@ export const Colophon = styled.footer`
     align-self: center;
     margin-left: -14px;
   }
+  & a {
+    color: var(--red);
+  }
   & > p {
     margin-left: auto;
     margin-right: auto;

--- a/paywall/src/components/lock/Overlay.js
+++ b/paywall/src/components/lock/Overlay.js
@@ -12,6 +12,7 @@ import { mapErrorToComponent } from '../creator/FatalError'
 import { FATAL_NO_USER_ACCOUNT, FATAL_MISSING_PROVIDER } from '../../errors'
 import withConfig from '../../utils/withConfig'
 import usePostMessage from '../../hooks/browser/usePostMessage'
+import Media from '../../theme/media'
 
 import ConfirmedFlag from './ConfirmedFlag'
 import ConfirmingFlag from './ConfirmingFlag'
@@ -211,6 +212,9 @@ const Banner = styled.div.attrs(({ scrollPosition }) => ({
   padding-bottom: 100px;
   grid-gap: 24px;
   align-self: center;
+  ${Media.phone`
+    min-height: 390px;
+  `}
 `
 
 const Headline = styled.h1`

--- a/paywall/src/components/lock/UnlockFlag.js
+++ b/paywall/src/components/lock/UnlockFlag.js
@@ -10,7 +10,9 @@ export function LockedFlag() {
   return (
     <Colophon>
       <RoundedLogo size="28px" />
-      <p>Powered by Unlock</p>
+      <p>
+        Powered by&nbsp;<a href="https://paywall.unlock-protocol.com">Unlock</a>
+      </p>
     </Colophon>
   )
 }
@@ -46,5 +48,25 @@ const Flag = styled(Colophon)`
 
   ${Media.phone`
     display: flex;
-`}
+    background-color: var(--white);
+    grid-row: 2;
+    grid-column: 1;
+    width: 120px;
+    height: 80px;
+    margin-right: -33px;
+    flex-direction: row;
+    float: none;
+    margin-right: auto;
+    margin-left: auto;
+  
+    & > div {
+      display: block;
+    }
+    & > p {
+      width: 63px;
+      display: block;
+      grid-row: 2;
+    }
+    opacity: 1;
+  `}
 `

--- a/paywall/src/components/lock/UnlockFlag.js
+++ b/paywall/src/components/lock/UnlockFlag.js
@@ -28,7 +28,10 @@ export const UnlockedFlag = () => {
   return (
     <Flag id="UnlockFlag" hidden={hidden}>
       <RoundedLogo size="28px" />
-      <p>Subscribed with Unlock</p>
+      <p>
+        Subscribed with&nbsp;
+        <a href="https://paywall.unlock-protocol.com">Unlock</a>
+      </p>
     </Flag>
   )
 }
@@ -45,14 +48,20 @@ const Flag = styled(Colophon)`
     opacity: 1;
     transition: opacity 0.4s ease-in;
   }
+  & a {
+    color: var(--red);
+  }
 
   ${Media.phone`
     display: flex;
     background-color: var(--white);
+    box-shadow: 14px 0px 40px rgba(0, 0, 0, 0.08);
     grid-row: 2;
     grid-column: 1;
     width: 120px;
-    height: 80px;
+    align-self: center;
+    justify-self: center;
+    height: 50px;
     margin-right: -33px;
     flex-direction: row;
     float: none;

--- a/paywall/src/stories/Paywall.stories.js
+++ b/paywall/src/stories/Paywall.stories.js
@@ -1,11 +1,11 @@
 import { Provider } from 'react-redux'
-import React, { useRef } from 'react'
+import React, { useRef, useEffect, useReducer } from 'react'
 import PropTypes from 'prop-types'
 import { storiesOf } from '@storybook/react'
 import Paywall from '../components/Paywall'
 import createUnlockStore from '../createUnlockStore'
 import { ConfigContext } from '../utils/withConfig'
-import { WindowContext } from '../hooks/browser/useWindow'
+import useWindow, { WindowContext } from '../hooks/browser/useWindow'
 
 const lock = {
   address: '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e',
@@ -82,21 +82,48 @@ const config = {
 
 function FakeItTillYouMakeIt({ children }) {
   const divit = useRef()
+  const [{ styles, enter, leave }, dispatch] = useReducer(
+    (state, isPhone) => {
+      if (isPhone) {
+        return {
+          styles: {
+            position: 'fixed',
+            bottom: 0,
+            width: '100vw',
+            height: '80px',
+          },
+          enter: () => {},
+          leave: () => {},
+        }
+      }
+      return {
+        styles: {
+          position: 'fixed',
+          right: 0,
+          bottom: '105px',
+          width: '134px',
+          height: '160px',
+          marginRight: '-104px',
+          transition: 'margin-right 0.4s ease-in',
+        },
+        enter: () => (divit.current.style.marginRight = 0),
+        leave: () => (divit.current.style.marginRight = '-104px'),
+      }
+    },
+    { styles: {}, enter() {}, leave() {} }
+  )
+  const window = useWindow()
+  const resizeListener = mql => {
+    dispatch(mql.matches)
+  }
+  useEffect(() => {
+    const queryList = window.matchMedia('(max-width: 736px)')
+    queryList.addListener(resizeListener)
+    resizeListener(queryList)
+    return () => queryList.removeListener(resizeListener)
+  }, [])
   return (
-    <div
-      ref={divit}
-      style={{
-        position: 'absolute',
-        right: 0,
-        bottom: '105px',
-        width: '134px',
-        height: '160px',
-        marginRight: '-104px',
-        transition: 'margin-right 0.4s ease-in',
-      }}
-      onMouseEnter={() => (divit.current.style.marginRight = 0)}
-      onMouseLeave={() => (divit.current.style.marginRight = '-104px')}
-    >
+    <div ref={divit} style={styles} onMouseEnter={enter} onMouseLeave={leave}>
       {children}
     </div>
   )
@@ -114,6 +141,12 @@ storiesOf('Paywall', module)
         value={{
           document: { body: { style: {} } },
           location: { pathname: '/0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e' },
+          matchMedia: global.window
+            ? window.matchMedia.bind(window)
+            : () => ({
+                addListener: () => {},
+                removeListener: () => {},
+              }),
         }}
       >
         <FakeItTillYouMakeIt>{getStory()}</FakeItTillYouMakeIt>

--- a/paywall/src/stories/interface/StaticDemo.stories.js
+++ b/paywall/src/stories/interface/StaticDemo.stories.js
@@ -46,21 +46,21 @@ const config = {
   providers: { HTTP: {}, Metamask: {} },
 }
 
+const fakeWindow = {
+  document: { body: { style: {} } },
+  location: { pathname: '/0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e' },
+  matchMedia: global.window
+    ? window.matchMedia.bind(window)
+    : () => ({
+        addListener: () => {},
+        removeListener: () => {},
+      }),
+}
+
 storiesOf('StaticDemo', module)
   .addDecorator(getStory => (
     <ConfigContext.Provider value={config}>
-      <WindowContext.Provider
-        value={{
-          document: { body: { style: {} } },
-          location: { pathname: '/0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e' },
-          matchMedia: global.window
-            ? window.matchMedia.bind(window)
-            : () => ({
-                addListener: () => {},
-                removeListener: () => {},
-              }),
-        }}
-      >
+      <WindowContext.Provider value={fakeWindow}>
         <Provider store={store}>{getStory()}</Provider>
       </WindowContext.Provider>
     </ConfigContext.Provider>

--- a/paywall/src/stories/interface/StaticDemo.stories.js
+++ b/paywall/src/stories/interface/StaticDemo.stories.js
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react'
 import StaticDemo from '../../components/interface/StaticDemo'
 import createUnlockStore from '../../createUnlockStore'
 import { ConfigContext } from '../../utils/withConfig'
+import { WindowContext } from '../../hooks/browser/useWindow'
 
 const myLock = {
   address: '0xaaaaaaaaa0c4d48d1bdad5dcb26153fc8780f83e',
@@ -48,7 +49,20 @@ const config = {
 storiesOf('StaticDemo', module)
   .addDecorator(getStory => (
     <ConfigContext.Provider value={config}>
-      <Provider store={store}>{getStory()}</Provider>
+      <WindowContext.Provider
+        value={{
+          document: { body: { style: {} } },
+          location: { pathname: '/0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e' },
+          matchMedia: global.window
+            ? window.matchMedia.bind(window)
+            : () => ({
+                addListener: () => {},
+                removeListener: () => {},
+              }),
+        }}
+      >
+        <Provider store={store}>{getStory()}</Provider>
+      </WindowContext.Provider>
     </ConfigContext.Provider>
   ))
   .add('the demo', () => {

--- a/paywall/src/stories/lock/Overlay-Optimistic.stories.js
+++ b/paywall/src/stories/lock/Overlay-Optimistic.stories.js
@@ -7,6 +7,7 @@ import { GlobalErrorContext } from '../../utils/GlobalErrorProvider'
 import { ConfigContext } from '../../utils/withConfig'
 import { WindowContext } from '../../hooks/browser/useWindow'
 import { TRANSACTION_TYPES } from '../../constants'
+import FakeIframe from '../../utils/FakeIframe'
 
 const ErrorProvider = GlobalErrorContext.Provider
 const ConfigProvider = ConfigContext.Provider
@@ -20,6 +21,12 @@ const fakeWindow = {
     hash: '',
   },
   document: { body: { style: {} } },
+  matchMedia: global.window
+    ? window.matchMedia.bind(window)
+    : () => ({
+        addListener: () => {},
+        removeListener: () => {},
+      }),
 }
 
 const config = {
@@ -129,16 +136,18 @@ const render = (
       <ConfigProvider value={thisConfig}>
         <WindowProvider value={fakeWindow}>
           <ErrorProvider value={errors}>
-            <Overlay
-              scrollPosition={0}
-              locks={locks}
-              hideModal={() => {}}
-              showModal={() => {}}
-              smallBody={() => {}}
-              bigBody={() => {}}
-              openInNewWindow={false}
-              optimism={optimism}
-            />
+            <FakeIframe hide={false}>
+              <Overlay
+                scrollPosition={0}
+                locks={locks}
+                hideModal={() => {}}
+                showModal={() => {}}
+                smallBody={() => {}}
+                bigBody={() => {}}
+                openInNewWindow={false}
+                optimism={optimism}
+              />
+            </FakeIframe>
           </ErrorProvider>
         </WindowProvider>
       </ConfigProvider>

--- a/paywall/src/utils/FakeIframe.js
+++ b/paywall/src/utils/FakeIframe.js
@@ -1,0 +1,80 @@
+import React, { useRef, useEffect, useReducer, useCallback } from 'react'
+import PropTypes from 'prop-types'
+
+import useWindow from '../hooks/browser/useWindow'
+import { SHOW_FLAG_FOR } from '../constants'
+
+export default function FakeIframe({ children, hide }) {
+  const divit = useRef()
+  const [{ styles, isPhone }, dispatch] = useReducer(
+    (state, isPhone) => {
+      if (isPhone) {
+        return {
+          styles: {
+            position: 'fixed',
+            display: 'flex',
+            bottom: 0,
+            width: '100vw',
+            height: '80px',
+          },
+          isPhone,
+        }
+      }
+      return {
+        styles: {
+          position: 'fixed',
+          right: 0,
+          bottom: '105px',
+          width: '134px',
+          height: '160px',
+          marginRight: 0,
+          transition: 'margin-right 0.4s ease-in',
+        },
+        isPhone,
+      }
+    },
+    { styles: {}, isPhone: false }
+  )
+  const enter = useCallback(() => {
+    if (isPhone || !hide) return
+    divit.current.style.marginRight = 0
+  }, [isPhone, hide])
+  const leave = useCallback(() => {
+    if (isPhone || !hide) return
+    divit.current.style.marginRight = '-104px'
+  }, [isPhone, hide])
+  const window = useWindow()
+  const resizeListener = mql => {
+    dispatch(mql.matches)
+  }
+  useEffect(() => {
+    const queryList = window.matchMedia('(max-width: 736px)')
+    queryList.addListener(resizeListener)
+    dispatch(queryList.matches)
+    let timeout = setTimeout(() => {
+      leave()
+    }, SHOW_FLAG_FOR)
+
+    return () => {
+      queryList.removeListener(resizeListener)
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+    }
+  }, [])
+  return (
+    <div
+      ref={divit}
+      style={styles}
+      onMouseEnter={() => enter()}
+      onMouseLeave={() => leave()}
+    >
+      {children}
+    </div>
+  )
+}
+
+FakeIframe.propTypes = {
+  children: PropTypes.node.isRequired,
+  hide: PropTypes.bool.isRequired,
+}


### PR DESCRIPTION
# Description

This PR adds the mobile-friendly view for the unlock app and optimistic unlocking flags.

Note that because a small portion of the unlocking UI will be handled by resizing the iframe, the storybook stories have a `FakeIframe` utility (formerly known as `FakeItTillYouMakeIt`) which has been extracted in order to share between stories. It simply provides the ability to respond to viewport changes by providing different CSS for the "iframe" (a wrapper div in the storybook stories), and `mouseenter` `mouseleave` handling for the unlocked flag (non-mobile view).

The PR adds the following:

1. a link to `https://paywall.unlock-protocol.com`, enabling the landing page as a link from the word `Unlock`
2. mobile styles for the locked flag, unlocked flag, and optimistic unlocking flags
3. storybook stories to reflect these changes

<img width="1677" alt="Screen Shot 2019-04-02 at 5 35 03 PM" src="https://user-images.githubusercontent.com/98250/55438194-fb285a00-556e-11e9-9d6c-ef300a9f0110.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 5 35 00 PM" src="https://user-images.githubusercontent.com/98250/55438196-fb285a00-556e-11e9-8dc2-ac22a4f7c429.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 5 34 44 PM" src="https://user-images.githubusercontent.com/98250/55438197-fbc0f080-556e-11e9-94f2-c74db636b2d7.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 5 34 40 PM" src="https://user-images.githubusercontent.com/98250/55438198-fbc0f080-556e-11e9-84a0-50f25d1bef50.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 5 30 45 PM" src="https://user-images.githubusercontent.com/98250/55438199-fbc0f080-556e-11e9-834c-762bd8533cc2.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 5 30 31 PM" src="https://user-images.githubusercontent.com/98250/55438200-fbc0f080-556e-11e9-9714-524dc1b7dac2.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 5 30 24 PM" src="https://user-images.githubusercontent.com/98250/55438201-fbc0f080-556e-11e9-809a-01e9fc5a2991.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 3 29 25 PM" src="https://user-images.githubusercontent.com/98250/55438202-fbc0f080-556e-11e9-9f42-53d64effc1e1.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 3 29 01 PM" src="https://user-images.githubusercontent.com/98250/55438203-fbc0f080-556e-11e9-964a-f7449231af8a.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 3 27 50 PM" src="https://user-images.githubusercontent.com/98250/55438204-fbc0f080-556e-11e9-8770-a33e60eda6ed.png">
<img width="1677" alt="Screen Shot 2019-04-02 at 3 27 35 PM" src="https://user-images.githubusercontent.com/98250/55438205-fc598700-556e-11e9-82f4-66ef665462dd.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2351 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
