### PR TITLE
walletService yields the full lock object

### DIFF
--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -474,6 +474,12 @@ describe('WalletService', () => {
           expect(lockAddress).toBe(lock.address)
           expect(update).toEqual({
             transaction: hash,
+            balance: '0',
+            expirationDuration: lock.expirationDuration,
+            keyPrice: lock.keyPrice,
+            maxNumberOfKeys: lock.maxNumberOfKeys,
+            outstandingKeys: 0,
+            owner,
           })
           done()
         })

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -234,7 +234,15 @@ export default class WalletService extends EventEmitter {
         // Let's update the lock to reflect that it is linked to this
         // This is an exception because, until we are able to determine the lock address
         // before the transaction is mined, we need to link the lock and transaction.
-        return this.emit('lock.updated', lock.address, { transaction: hash })
+        return this.emit('lock.updated', lock.address, {
+          expirationDuration: lock.expirationDuration,
+          keyPrice: lock.keyPrice, // Must be expressed in Eth!
+          maxNumberOfKeys: lock.maxNumberOfKeys,
+          owner: owner,
+          outstandingKeys: 0,
+          balance: '0',
+          transaction: hash,
+        })
       }
     )
   }


### PR DESCRIPTION
this will fix that integration test transient issue which shows the data from a new lock was not
fully loaded...



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread