### PR TITLE
using the shared eslint config for tests

### DIFF
--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,40 +1,9 @@
 module.exports = {
-  extends: [
-    'standard',
-    'eslint:recommended',
-    'airbnb-base',
-    'plugin:prettier/recommended',
-  ],
-  plugins: ['prettier'],
-  env: {
-    es6: true,
-    node: true,
-    browser: true,
-    jest: true,
-  },
+  extends: ['../.eslintrc.js'],
   globals: {
     page: true,
     browser: true,
     context: true,
     jestPuppeteer: true,
-  },
-  rules: {
-    'prettier/prettier': 'error',
-    indent: ['error', 2],
-    'linebreak-style': ['error', 'unix'],
-    quotes: ['error', 'single'],
-    semi: ['error', 'never'],
-    'no-multiple-empty-lines': [
-      'error',
-      {
-        max: 1,
-        maxEOF: 0,
-        maxBOF: 0,
-      },
-    ],
-    'brace-style': [2, '1tbs', { allowSingleLine: true }],
-    'comma-dangle': [2, 'always-multiline'],
-    'eol-last': ['error'],
-    'no-console': ['error'],
   },
 }

--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -17,10 +17,12 @@ describe('The Unlock Dashboard', () => {
   })
 
   it('should load the creator dashboard', async () => {
+    expect.assertions(1)
     await expect(page).toMatch('Creator Dashboard')
   })
 
   it('should list the address of the current user', async () => {
+    expect.assertions(1)
     await page.waitForSelector('#UserAddress')
     const userAddress = await page.$eval('#UserAddress', e => e.innerText)
     await expect(userAddress).toMatch(
@@ -29,6 +31,7 @@ describe('The Unlock Dashboard', () => {
   })
 
   it('should have a button allowing the creation of a Lock', async () => {
+    expect.assertions(1)
     const createLockButton = await page.waitFor('#CreateLockButton')
     await expect(createLockButton).toMatch('Create Lock')
   })
@@ -42,6 +45,7 @@ describe('The Unlock Dashboard', () => {
     })
 
     it('should display the lock creation form', async () => {
+      expect.assertions(4)
       await expect(page).toClick('button', { text: 'Create Lock' })
       await expect(page).toMatch('Submit')
       await expect(page).toMatch('Cancel')
@@ -50,6 +54,7 @@ describe('The Unlock Dashboard', () => {
 
     // This test requires the test above to have been executed and pass
     it('should persist the lock', async () => {
+      expect.assertions(11)
       const name = `My lock ${Math.random()
         .toString(36)
         .substring(7)}`
@@ -91,6 +96,7 @@ describe('The Unlock Dashboard', () => {
 
     // This test requires the test above
     it('should be confirming after having been submitted', async () => {
+      expect.assertions(1)
       await wait.untilIsFalse(address => {
         return document
           .querySelector(`[data-address="${address}"]`)
@@ -118,7 +124,6 @@ describe('The Unlock Dashboard', () => {
     beforeAll(async () => {
       await wait.forLoadingDone()
       const existingLocks = await listLocksOnPage()
-      expect(existingLocks.length).toBeGreaterThan(0)
       lockSelector = `[data-address="${existingLocks[0]}"]`
       // Let's make sure the lock is not pending!
       await wait.untilIsFalse(_lockSelector => {
@@ -136,6 +141,7 @@ describe('The Unlock Dashboard', () => {
 
     describe('Data existing after refresh', () => {
       it('should retain the lock address, key price, duration and maximum number of keys', async () => {
+        expect.assertions(1)
         await page.reload({ waitUntil: 'networkidle2' })
         await wait.forLoadingDone()
         await expect(page).toMatchElement(lockSelector)
@@ -144,12 +150,14 @@ describe('The Unlock Dashboard', () => {
 
     describe('Lock Embed Code', () => {
       it('should toggle the embed code', async () => {
+        expect.assertions(2)
         await page.waitForSelector(lockSelector)
         await expect(page).toClick(`${lockSelector} button[title="Embed"]`)
         await expect(page).toMatch('Code snippet')
       })
 
       it('has a Preview lock link', async () => {
+        expect.assertions(1)
         await expect(page).toMatchElement(`${lockSelector} a[title="Preview"]`)
       })
     })
@@ -158,17 +166,18 @@ describe('The Unlock Dashboard', () => {
       let lockToEditSelector
       beforeEach(async () => {
         const existingLocks = await listLocksOnPage()
-        expect(existingLocks.length).toBeGreaterThan(0)
         lockToEditSelector = `[data-address="${existingLocks[0]}"]`
       })
 
       it('a button exists to edit the Lock details', async () => {
+        expect.assertions(1)
         await expect(page).toMatchElement(
           `${lockToEditSelector} button[title="Edit"]`
         )
       })
 
       it('allows the lock owner to update the price of the lock', async () => {
+        expect.assertions(5)
         await expect(page).toClick(`${lockToEditSelector} button[title="Edit"]`)
         const keyPriceInputSelector = 'input[name="keyPrice"]'
         await expect(page).toMatchElement(keyPriceInputSelector)

--- a/tests/test/home.test.js
+++ b/tests/test/home.test.js
@@ -2,20 +2,20 @@ const url = require('../helpers/url').main
 
 describe('The Unlock Homepage', () => {
   it('should display "unlock" text on page', async () => {
-    const page = await browser.newPage()
+    expect.assertions(1)
     await page.goto(url('/'))
     await expect(page).toMatch('Unlock')
   })
 
   it('should display a go to dashboard button on the page', async () => {
-    const page = await browser.newPage()
+    expect.assertions(1)
     await page.goto(url('/'))
     const button = await page.waitFor('button')
     await expect(button).toMatch('Go to Your Dashboard')
   })
 
   it('should display the Terms of Service and Privacy Policy links when tapping through to the dashboard', async () => {
-    const page = await browser.newPage()
+    expect.assertions(2)
     await page.goto(url('/'))
     const button = await page.waitFor('button')
     await button.click()

--- a/tests/test/keychain.test.js
+++ b/tests/test/keychain.test.js
@@ -6,6 +6,7 @@ describe('The Unlock Keychain', () => {
   })
 
   it('should load the key chain', async () => {
+    expect.assertions(1)
     await expect(page).toMatch('Key Chain')
   })
 })

--- a/tests/test/paywall.test.js
+++ b/tests/test/paywall.test.js
@@ -15,12 +15,14 @@ describe.skip('The Unlock Paywall', () => {
   }, 10000)
 
   it('should remove the blocker', async () => {
+    expect.assertions(0)
     await page.waitForFunction(
       () => !document.querySelector('#_unlock_blocker')
     )
   })
 
   it('should display the lock after the blocker is gone', async () => {
+    expect.assertions(0)
     await page.waitForFunction(() => window.frames.length)
     const paywallIframe = page.mainFrame().childFrames()[0]
     await paywallIframe.waitForSelector(lockSelector('Lock'))
@@ -36,6 +38,7 @@ describe.skip('The Unlock Paywall', () => {
   })
 
   it('scrolling is disabled', async () => {
+    expect.assertions(1)
     // scroll the page prior to the paywall displaying
     await page.evaluate(() => {
       window.scrollBy(0, 200)
@@ -55,6 +58,7 @@ describe.skip('The Unlock Paywall', () => {
   })
 
   it('clicking the lock purchases a key', async () => {
+    expect.assertions(1)
     const paywallIframe = page.mainFrame().childFrames()[0]
     const paywallBody = await paywallIframe.$('body')
     await expect(paywallBody).toClick(lockSelector('PurchaseKey'))
@@ -70,6 +74,7 @@ describe.skip('The Unlock Paywall', () => {
   })
 
   it('after key purchase, unlocked flag appears', async () => {
+    expect.assertions(0)
     await page.reload()
     await page.waitForFunction(() => window.frames.length)
     const paywallIframe = page.mainFrame().childFrames()[0]

--- a/tests/test/url-with-defaults.test.js
+++ b/tests/test/url-with-defaults.test.js
@@ -5,10 +5,13 @@ const url = require('../helpers/url')
 
 describe('url test helper, default values', () => {
   it('main', () => {
+    expect.assertions(2)
     expect(url.main()).toBe('http://127.0.0.1:3000/')
     expect(url.main('/path')).toBe('http://127.0.0.1:3000/path')
   })
+
   it('paywall', () => {
+    expect.assertions(2)
     expect(url.paywall()).toBe('http://127.0.0.1:3001/')
     expect(url.paywall('/path')).toBe('http://127.0.0.1:3001/path')
   })

--- a/tests/test/url.test.js
+++ b/tests/test/url.test.js
@@ -5,10 +5,13 @@ const url = require('../helpers/url')
 
 describe('url test helper, from environment', () => {
   it('main', () => {
+    expect.assertions(2)
     expect(url.main()).toBe('http://host:999/')
     expect(url.main('/path')).toBe('http://host:999/path')
   })
+
   it('paywall', () => {
+    expect.assertions(2)
     expect(url.paywall()).toBe('http://whatever/')
     expect(url.paywall('/path')).toBe('http://whatever/path')
   })


### PR DESCRIPTION
Using the shared eslint config for our integration tests as well.
This will fix issues found in https://github.com/unlock-protocol/unlock/pull/2475


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread