### PR TITLE
Add providerReady action

### DIFF
--- a/unlock-app/src/__tests__/actions/provider.test.js
+++ b/unlock-app/src/__tests__/actions/provider.test.js
@@ -1,4 +1,9 @@
-import { setProvider, SET_PROVIDER } from '../../actions/provider'
+import {
+  setProvider,
+  SET_PROVIDER,
+  PROVIDER_READY,
+  providerReady,
+} from '../../actions/provider'
 
 describe('provider actions', () => {
   it('should create an action to set the provider', () => {
@@ -9,5 +14,14 @@ describe('provider actions', () => {
       provider,
     }
     expect(setProvider(provider)).toEqual(expectedAction)
+  })
+
+  it('should create an action to signal the provider is ready', () => {
+    expect.assertions(1)
+    const expectedAction = {
+      type: PROVIDER_READY,
+    }
+
+    expect(providerReady()).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/actions/provider.js
+++ b/unlock-app/src/actions/provider.js
@@ -1,6 +1,11 @@
 export const SET_PROVIDER = 'provider/SET_PROVIDER'
+export const PROVIDER_READY = 'provider/PROVIDER_READY'
 
 export const setProvider = provider => ({
   type: SET_PROVIDER,
   provider,
+})
+
+export const providerReady = () => ({
+  type: PROVIDER_READY,
 })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR adds an action so that we can signal when the provider is ready -- this way the `walletService` will only try to connect when there is a provider that will result in a valid Web3 instantiation.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
