### PR TITLE
Improve provider middleware

### DIFF
--- a/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
@@ -1,10 +1,7 @@
 import providerMiddleware from '../../middlewares/providerMiddleware'
 import { SET_PROVIDER } from '../../actions/provider'
 import { setError } from '../../actions/error'
-import {
-  FATAL_MISSING_PROVIDER,
-  FATAL_NOT_ENABLED_IN_PROVIDER,
-} from '../../errors'
+import { FATAL_MISSING_PROVIDER } from '../../errors'
 
 const config = {
   providers: {
@@ -72,7 +69,7 @@ describe('provider middleware', () => {
     })
 
     it('should set an error and return if the call to enable fails', done => {
-      expect.assertions(3)
+      expect.assertions(2)
       config.providers['UNLOCK'].enable = jest.fn(() => {
         // eslint-disable-next-line promise/param-names
         return new Promise((_, reject) => {
@@ -83,9 +80,6 @@ describe('provider middleware', () => {
       const next = () => {
         expect(config.providers['UNLOCK'].enable).toHaveBeenCalled()
         expect(config.providers['NUNLOCK'].enable).not.toHaveBeenCalled()
-        expect(dispatch).toHaveBeenCalledWith(
-          setError(FATAL_NOT_ENABLED_IN_PROVIDER)
-        )
         done()
       }
 

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -31,11 +31,7 @@ const providerMiddleware = (config: any) => {
             if (provider) {
               initializeProvider(provider)
                 .then(() => dispatch(providerReady()))
-                .catch(
-                  // This awful hack makes it so that jest will recognize that dispatch is called
-                  () => (() => {})(),
-                  dispatch(setError(FATAL_NOT_ENABLED_IN_PROVIDER))
-                )
+                .catch(() => dispatch(setError(FATAL_NOT_ENABLED_IN_PROVIDER)))
             } else {
               dispatch(setError(FATAL_MISSING_PROVIDER))
             }

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -31,8 +31,8 @@ const providerMiddleware = (config: any) => {
             if (provider) {
               initializeProvider(provider)
                 .then(() => dispatch(providerReady()))
-                // This awful hack makes it so that jest will recognize that dispatch is called
                 .catch(
+                  // This awful hack makes it so that jest will recognize that dispatch is called
                   () => (() => {})(),
                   dispatch(setError(FATAL_NOT_ENABLED_IN_PROVIDER))
                 )


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR makes some needed adjustments to the provider middleware.

1. No more async/await (should have caught this before committing the last one)
2. Once the provider is enabled, the middleware dispatches a `providerReady` action. Middlewares can listen for this, and upon receipt they can then instantiate a Web3 with the provider.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
