### PR TITLE
fix jest for components that import .css files

### DIFF
--- a/paywall/jest.config.js
+++ b/paywall/jest.config.js
@@ -10,6 +10,9 @@ module.exports = {
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
+  moduleNameMapper: {
+    '\\.css$': '<rootDir>/src/__mocks__/styleMocks.js',
+  },
   collectCoverage: true,
   coverageThreshold: {
     global: {

--- a/paywall/src/__mocks__/styleMocks.js
+++ b/paywall/src/__mocks__/styleMocks.js
@@ -1,0 +1,1 @@
+module.exports = {}


### PR DESCRIPTION
# Description

Subject says it all - jest doesn't like imports of .css files, this mocks them out to nothing, as static files are not used directly.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2351

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
