### PR TITLE
VASTLY simplify the iframe css by using actual css classes

### DIFF
--- a/paywall/src/__tests__/paywall-builder/iframe.test.js
+++ b/paywall/src/__tests__/paywall-builder/iframe.test.js
@@ -1,10 +1,4 @@
-import {
-  getIframe,
-  iframeStyles,
-  add,
-  show,
-  hide,
-} from '../../paywall-builder/iframe'
+import { getIframe, add, show, hide } from '../../paywall-builder/iframe'
 
 describe('iframe', () => {
   it('add appends the iframe to document.body', () => {
@@ -20,15 +14,11 @@ describe('iframe', () => {
 
     expect(getIframe(document, 'hi')).toBe(el)
 
-    expect(el.setAttribute).toHaveBeenCalledTimes(3)
+    expect(el.setAttribute).toHaveBeenCalledTimes(2)
 
-    expect(el.setAttribute).toHaveBeenNthCalledWith(
-      1,
-      'style',
-      iframeStyles.join('; ')
-    )
-    expect(el.setAttribute).toHaveBeenNthCalledWith(2, 'src', 'hi')
-    expect(el.setAttribute).toHaveBeenNthCalledWith(3, 'data-unlock', 'yes')
+    expect(el.className).toBe('unlock start')
+    expect(el.setAttribute).toHaveBeenNthCalledWith(1, 'src', 'hi')
+    expect(el.setAttribute).toHaveBeenNthCalledWith(2, 'data-unlock', 'yes')
   })
 
   describe('add', () => {
@@ -67,11 +57,8 @@ describe('iframe', () => {
   })
 
   it('show', () => {
-    expect.assertions(3)
-    const iframe = {
-      style: {},
-      setAttribute: jest.fn(),
-    }
+    expect.assertions(2)
+    const iframe = {}
     const document = {
       body: {
         style: {},
@@ -79,35 +66,19 @@ describe('iframe', () => {
     }
 
     show(iframe, document)
-    expect(iframe.style).toEqual({
-      display: 'block',
-      'z-index': '2147483647',
-    })
+    expect(iframe.className).toBe('unlock start show')
 
     expect(document.body.style).toEqual({
       overflow: 'hidden',
     })
-
-    expect(iframe.setAttribute).toHaveBeenCalledWith(
-      'style',
-      iframeStyles.join('; ')
-    )
   })
 
   describe('hide', () => {
     it('unlocked', () => {
-      expect.assertions(4)
+      expect.assertions(2)
 
       jest.useFakeTimers()
-      const iframe = {
-        addEventListener: jest.fn(),
-        style: {},
-        contentDocument: {
-          body: {
-            style: {},
-          },
-        },
-      }
+      const iframe = {}
       const document = {
         body: {
           style: { overflow: 'hidden' },
@@ -115,42 +86,17 @@ describe('iframe', () => {
       }
       hide(iframe, document)
 
-      expect(iframe.style).toEqual({
-        backgroundColor: 'transparent',
-        backgroundImage: 'none',
-        overflow: 'hidden',
-        width: '134px',
-        height: '160px',
-        marginRight: 0,
-        left: null,
-        top: null,
-        right: '0',
-        bottom: '105px',
-        transition: 'margin-right 0.4s ease-in',
-      })
-
+      expect(iframe.className).toBe('unlock start show hide')
       expect(document.body.style).toEqual({
         overflow: '',
       })
-
-      expect(setTimeout).toHaveBeenCalled()
-
-      expect(iframe.addEventListener).toHaveBeenCalledTimes(2)
     })
 
     it('optimistic unlocking', () => {
-      expect.assertions(4)
+      expect.assertions(2)
 
       jest.useFakeTimers()
-      const iframe = {
-        addEventListener: jest.fn(),
-        style: {},
-        contentDocument: {
-          body: {
-            style: {},
-          },
-        },
-      }
+      const iframe = {}
       const document = {
         body: {
           style: { overflow: 'hidden' },
@@ -158,25 +104,10 @@ describe('iframe', () => {
       }
       hide(iframe, document, false)
 
-      expect(iframe.style).toEqual({
-        backgroundColor: 'transparent',
-        backgroundImage: 'none',
-        overflow: 'hidden',
-        width: '134px',
-        height: '160px',
-        marginRight: 0,
-        left: null,
-        top: null,
-        right: '0',
-        bottom: '105px',
-      })
-
+      expect(iframe.className).toBe('unlock start show hide optimism')
       expect(document.body.style).toEqual({
         overflow: '',
       })
-      expect(setTimeout).not.toHaveBeenCalled()
-
-      expect(iframe.addEventListener).not.toHaveBeenCalled()
     })
   })
 })

--- a/paywall/src/paywall-builder/iframe.css
+++ b/paywall/src/paywall-builder/iframe.css
@@ -1,0 +1,59 @@
+.unlock.start {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  border: 0;
+  z-index: -2147483647;
+}
+.unlock.show {
+  display: block;
+  z-index: 2147483647;
+}
+.unlock.hide {
+  right: 0;
+  top: initial;
+  left: initial;
+  bottom: 105px;
+  width: 134px;
+  height: 160px;
+  margin-right: -104px;
+  overflow: hidden;
+  transition: margin-right 0.4s ease-in;
+  animation: 2400ms slideout;
+}
+.unlock.optimism {
+  margin-right: 0;
+  animation: none;
+  transition: none;
+}
+.unlock.hide:hover {
+  margin-right: 0px;
+}
+@keyframes slideout {
+  0% {
+    margin-right: 0px;
+  }
+  80% {
+    margin-right: 0px;
+  }
+  100% {
+    margin-right: -104px;
+  }
+}
+@media only screen and (max-width: 763px) {
+  .unlock.hide {
+    display: flex;
+    bottom: 0;
+    width: 100vw;
+    height: 80px;
+    animation: none;
+    transition: none;
+    margin-right: 0;
+  }
+  .unlock.hide:hover {
+    margin-right: 0;
+  }
+}

--- a/paywall/src/paywall-builder/iframe.js
+++ b/paywall/src/paywall-builder/iframe.js
@@ -1,5 +1,3 @@
-import { SHOW_FLAG_FOR } from '../constants'
-
 export const iframeStyles = [
   'display:none',
   'position:fixed',
@@ -14,7 +12,7 @@ export const iframeStyles = [
 export function getIframe(document, src) {
   var s = document.createElement('iframe')
 
-  s.setAttribute('style', iframeStyles.join('; '))
+  s.className = 'unlock start'
   s.setAttribute('src', src)
   s.setAttribute('data-unlock', 'yes')
   return s
@@ -29,53 +27,10 @@ export function add(document, iframe) {
 
 export function show(iframe, document) {
   document.body.style.overflow = 'hidden'
-  iframe.setAttribute('style', iframeStyles.join('; '))
-  iframe.style.display = 'block'
-  iframe.style['z-index'] = '2147483647'
+  iframe.className = 'unlock start show'
 }
 
 export function hide(iframe, document, unlocked = true) {
-  const width = '134px'
-  const height = '160px'
-  const collapsedMargin = '-104px'
-  let open = true
-
-  // general settings
+  iframe.className = `unlock start show hide${unlocked ? '' : ' optimism'}`
   document.body.style.overflow = ''
-  iframe.style.backgroundColor = 'transparent'
-  iframe.style.backgroundImage = 'none'
-  iframe.style.marginRight = 0
-
-  if (unlocked) {
-    setTimeout(() => {
-      open = false
-      iframe.style.marginRight = collapsedMargin
-    }, SHOW_FLAG_FOR)
-  }
-
-  // so that there's no scroll when it goes off the edge
-  iframe.style.overflow = 'hidden'
-
-  // new dimensions
-  iframe.style.width = width
-  iframe.style.height = height
-
-  // positioning
-  iframe.style.left = null
-  iframe.style.top = null
-  iframe.style.right = '0'
-  iframe.style.bottom = '105px'
-
-  if (unlocked) {
-    // Animation
-    iframe.style.transition = 'margin-right 0.4s ease-in'
-
-    iframe.addEventListener('mouseenter', () => {
-      iframe.style.marginRight = '0'
-    })
-    iframe.addEventListener('mouseleave', () => {
-      if (open) return
-      iframe.style.marginRight = collapsedMargin
-    })
-  }
 }

--- a/paywall/src/paywall-builder/index.js
+++ b/paywall/src/paywall-builder/index.js
@@ -1,3 +1,4 @@
+import './iframe.css'
 import listenForNewLocks from './mutationObserver'
 import { getBlocker, addBlocker, removeBlocker } from './blocker'
 import buildPaywall from './build'


### PR DESCRIPTION
# Description

This replaces all the fancy javascript for managing the iframe's position and size and animation with simple CSS. Also, because we are using fancy minimizing of CSS, the resulting `paywall.min.js` file is fully compressed and contains the CSS inline. In addition, because the .css file is external, it can be imported into the paywall app storybook stories to more accurately simulate how the iframe causes our components to look. win-win-win.

*Note: although this has the fixes in place for mobile view, the rest of the app is not fixed yet, so the screencast for that view will be in the subsequent PR.*

![out](https://user-images.githubusercontent.com/98250/55507569-f70b4380-5625-11e9-913d-8579b155ef2a.gif)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2351

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
