### PR TITLE
mapping the types from unlock-js

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -196,7 +196,7 @@ describe('Wallet middleware', () => {
     const from = '0xjulien'
     const to = '0xunlock'
     const input = 'input'
-    const type = TransactionType.LOCK_CREATION
+    const type = 'LOCK_CREATION'
     const status = 'submitted'
     mockWalletService.emit(
       'transaction.new',
@@ -218,7 +218,7 @@ describe('Wallet middleware', () => {
           to,
           from,
           input,
-          type,
+          type: 'Lock Creation',
           status,
         }),
       })

--- a/unlock-app/src/__tests__/utils/types.test.js
+++ b/unlock-app/src/__tests__/utils/types.test.js
@@ -1,0 +1,20 @@
+import { transactionTypeMapping } from '../../utils/types'
+import { TransactionType } from '../../unlockTypes'
+
+describe('transactionTypeMapping', () => {
+  it('should map the types from unlock-js', () => {
+    expect.assertions(4)
+    expect(transactionTypeMapping('LOCK_CREATION')).toEqual(
+      TransactionType.LOCK_CREATION
+    )
+    expect(transactionTypeMapping('KEY_PURCHASE')).toEqual(
+      TransactionType.KEY_PURCHASE
+    )
+    expect(transactionTypeMapping('WITHDRAWAL')).toEqual(
+      TransactionType.WITHDRAWAL
+    )
+    expect(transactionTypeMapping('UPDATE_KEY_PRICE')).toEqual(
+      TransactionType.UPDATE_KEY_PRICE
+    )
+  })
+})

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -28,6 +28,7 @@ import {
 import { SIGN_DATA, signedData, signatureError } from '../actions/signature'
 import { TransactionType } from '../unlockTypes'
 import { hideForm } from '../actions/lockFormVisibility'
+import { transactionTypeMapping } from '../utils/types'
 
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
@@ -79,7 +80,7 @@ const walletMiddleware = config => {
             to,
             from,
             input,
-            type,
+            type: transactionTypeMapping(type),
             status,
           })
         )

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -19,6 +19,7 @@ import {
   SET_KEYS_ON_PAGE_FOR_LOCK,
   setKeysOnPageForLock,
 } from '../actions/keysPages'
+import { transactionTypeMapping } from '../utils/types'
 
 const { Web3Service } = UnlockJs
 
@@ -97,6 +98,10 @@ const web3Middleware = config => {
     })
 
     web3Service.on('transaction.updated', (transactionHash, update) => {
+      // Mapping the transaction type
+      if (update.type) {
+        update.type = transactionTypeMapping(update.type)
+      }
       dispatch(updateTransaction(transactionHash, update))
     })
 

--- a/unlock-app/src/utils/types.ts
+++ b/unlock-app/src/utils/types.ts
@@ -1,0 +1,24 @@
+import { TransactionType } from '../unlockTypes'
+
+/**
+ * Mapping function to change the types received from unlock-js into types
+ * used by unlock-app
+ * TODO: use the actual types exported by unlock-js rather than a list of strings!
+ */
+export const transactionTypeMapping = (type: string) => {
+  if (type === 'LOCK_CREATION') {
+    return TransactionType.LOCK_CREATION
+  } else if (type === 'KEY_PURCHASE') {
+    return TransactionType.KEY_PURCHASE
+  } else if (type === 'WITHDRAWAL') {
+    return TransactionType.WITHDRAWAL
+  } else if (type === 'UPDATE_KEY_PRICE') {
+    return TransactionType.UPDATE_KEY_PRICE
+  } else {
+    // Not sure but that should not happen
+  }
+}
+
+export default {
+  transactionTypeMapping,
+}


### PR DESCRIPTION
Unlock.js has different transction types than the application.
This PR introduces a mapping for it in creator dashboard.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread