### PR TITLE
pass withConfig in the correct location

### DIFF
--- a/paywall/src/__tests__/components/lock/Overlay.test.js
+++ b/paywall/src/__tests__/components/lock/Overlay.test.js
@@ -95,6 +95,34 @@ describe('Overlay', () => {
         transaction: null,
       })
     })
+    it('should not crash if there are no matching keys yet for a transaction', () => {
+      expect.assertions(1)
+
+      const props = {
+        locks: [
+          {
+            address: '0x123',
+          },
+        ],
+      }
+      const state = {
+        account: {
+          address: 'account',
+        },
+        keys: {},
+        transactions: {
+          transaction: {
+            key: 'key',
+            type: TRANSACTION_TYPES.KEY_PURCHASE,
+          },
+        },
+      }
+
+      expect(mapStateToProps(state, props)).toEqual({
+        openInNewWindow: false,
+        transaction: null,
+      })
+    })
     it('should set openInNewWindow based on the value of account', () => {
       expect.assertions(3)
 

--- a/paywall/src/components/lock/ConfirmingFlag.js
+++ b/paywall/src/components/lock/ConfirmingFlag.js
@@ -83,4 +83,4 @@ export const mapStateToProps = ({ account, keys, transactions }, { lock }) => {
   }
 }
 
-export default withConfig(connect(mapStateToProps)(ConfirmingFlag))
+export default connect(mapStateToProps)(withConfig(ConfirmingFlag))

--- a/paywall/src/components/lock/Lock.js
+++ b/paywall/src/components/lock/Lock.js
@@ -121,9 +121,7 @@ export const mapStateToProps = (state, { lock }) => {
   }
 }
 
-export default withConfig(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(Lock)
-)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withConfig(Lock))

--- a/paywall/src/components/lock/Overlay.js
+++ b/paywall/src/components/lock/Overlay.js
@@ -154,7 +154,7 @@ export const mapStateToProps = ({ account, transactions, keys }, { locks }) => {
   transaction = Object.values(transactions).find(
     transaction =>
       transaction.type === TRANSACTION_TYPES.KEY_PURCHASE &&
-      transaction.key === lockKey.id
+      transaction.key === (lockKey && lockKey.id)
   )
 
   return {
@@ -172,12 +172,10 @@ export const mapDispatchToProps = (dispatch, { locks }) => ({
   },
 })
 
-export default withConfig(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(Overlay)
-)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withConfig(Overlay))
 
 const FullPage = styled.div`
   position: fixed; /* Sit on top of the page content */


### PR DESCRIPTION
# Description

This passes withConfig in the correct location to ensure it is directly available to the component using it, and fixes a crash when transaction is available prior to its key.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2498 
Refs #2351 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
