### PR TITLE
on paywall, don't set account unless we need to (in iframe, not on SET_ACCOUNT)

### DIFF
--- a/paywall/src/middlewares/interWindowCommunicationMiddleware.js
+++ b/paywall/src/middlewares/interWindowCommunicationMiddleware.js
@@ -16,6 +16,8 @@ const interWindowCommunicationMiddleware = window => ({
   const isInIframe = inIframe(window)
   return next => {
     return action => {
+      next(action)
+
       const { router, account } = getState()
       // TODO: remove the checking for account in
       // the URL hash as soon as the paywall stops sending it
@@ -57,12 +59,11 @@ const interWindowCommunicationMiddleware = window => ({
         }
       }
 
-      next(action)
-
       // this needs to be after the reducer is called
       if (
-        (isInIframe && action.type === UPDATE_KEY) ||
-        (action.type === ADD_KEY && !account)
+        isInIframe &&
+        (action.type === UPDATE_KEY || action.type === ADD_KEY) &&
+        !account
       ) {
         const { transactions, keys } = getState()
         const { lockAddress, transaction } = lockRoute(


### PR DESCRIPTION
# Description

This PR addresses the 2 issues in `interWindowCommunicationMiddleware`, the fact that account can be incorrectly identified as non-existing when a `SET_ACCOUNT` action is about to set it, and the incorrect logic for identifying when to set account from localStorage when transaction hash is passed in the URL.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2499
Fixes #2500 
Refs #2351 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
