### PR TITLE
don't dispatch SET_NETWORK unless the network has changed

### DIFF
--- a/paywall/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/walletMiddleware.test.js
@@ -286,7 +286,7 @@ describe('Wallet middleware', () => {
         })
       })
 
-      it('should dispatch a SET_NETWORK action', () => {
+      it('should dispatch a SET_NETWORK action if the network has changed', () => {
         expect.assertions(1)
         const { store } = create()
         const networkId = 1984
@@ -301,6 +301,18 @@ describe('Wallet middleware', () => {
             network: networkId,
           })
         )
+      })
+
+      it('should not dispatch a SET_NETWORK action if the network has not changed', () => {
+        expect.assertions(1)
+        const { store } = create()
+        const networkId = 1984
+
+        state.network.name = 1984
+        mockWalletService.getAccount = jest.fn()
+        mockWalletService.isUnlockContractDeployed = jest.fn()
+        mockWalletService.emit('network.changed', networkId)
+        expect(store.dispatch).not.toHaveBeenCalled()
       })
     })
   })

--- a/paywall/src/middlewares/walletMiddleware.js
+++ b/paywall/src/middlewares/walletMiddleware.js
@@ -98,7 +98,13 @@ export default function walletMiddleware({ getState, dispatch }) {
    */
   walletService.on('network.changed', networkId => {
     // Set the new network, which should also clean up all reducers
-    dispatch(setNetwork(networkId))
+    const {
+      network: { name },
+    } = getState()
+    if (name !== networkId) {
+      // this resets a whole bunch of values, so only change it if it really changed
+      dispatch(setNetwork(networkId))
+    }
     // Check if the smart contract exists
     walletService.isUnlockContractDeployed((error, isDeployed) => {
       if (error) {


### PR DESCRIPTION
# Description

Because `SET_NETWORK` resets transaction and key state, this can wipe out information retrieved by the read-only provider. This PR ensures we only dispatch if the network has actually changed.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2501
Refs #2351 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
