### PR TITLE
Lock name signature

### DIFF
--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,10 +1,5 @@
 import storageMiddleware from '../../middlewares/storageMiddleware'
-import {
-  UPDATE_LOCK,
-  updateLock,
-  CREATE_LOCK,
-  UPDATE_LOCK_NAME,
-} from '../../actions/lock'
+import { UPDATE_LOCK, updateLock, UPDATE_LOCK_NAME } from '../../actions/lock'
 import { STORE_LOCK_NAME } from '../../actions/storage'
 import { addTransaction, NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ACCOUNT } from '../../actions/accounts'
@@ -220,36 +215,6 @@ describe('Storage middleware', () => {
     })
   })
 
-  describe('handling CREATE_LOCK', () => {
-    it('should dispatch an action to sign message to change the name of a lock', () => {
-      expect.assertions(3)
-      const lock = {
-        address: '0x123',
-        name: 'my lock',
-        owner: '0xabc',
-      }
-      const data = {
-        message: {
-          lock: {},
-        },
-      }
-
-      UnlockLock.build = jest.fn(() => {
-        return data
-      })
-      const { next, invoke, store } = create()
-      const action = { type: CREATE_LOCK, lock }
-
-      invoke(action)
-      expect(UnlockLock.build).toHaveBeenCalledWith(lock)
-      expect(next).toHaveBeenCalledTimes(1)
-      expect(store.dispatch).toHaveBeenCalledWith({
-        data,
-        type: 'signature/SIGN_DATA',
-      })
-    })
-  })
-
   describe('UPDATE_LOCK_NAME', () => {
     it('should dispatch an action to sign message to update the name of a lock', () => {
       expect.assertions(3)
@@ -272,9 +237,14 @@ describe('Storage middleware', () => {
         address: lock.address,
         name: newName,
       }
-
+      UnlockLock.build = jest.fn(() => data)
       invoke(action)
-      expect(UnlockLock.build).toHaveBeenCalledWith(lock)
+      expect(UnlockLock.build).toHaveBeenCalledWith({
+        name: action.name,
+        owner: lock.owner,
+        address: lock.address,
+      })
+
       expect(next).toHaveBeenCalledTimes(1)
       expect(store.dispatch).toHaveBeenCalledWith({
         data,

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -6,6 +6,7 @@ import {
   WITHDRAW_FROM_LOCK,
   UPDATE_LOCK_KEY_PRICE,
   UPDATE_LOCK,
+  UPDATE_LOCK_NAME,
 } from '../../actions/lock'
 import {
   WAIT_FOR_WALLET,
@@ -235,12 +236,22 @@ describe('Wallet middleware', () => {
   })
 
   it('it should handle lock.updated events triggered by the walletService', () => {
-    expect.assertions(2)
+    expect.assertions(3)
     const { store } = create()
     const update = {
       transaction: '0x123',
     }
+
     mockWalletService.emit('lock.updated', lock.address, update)
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: UPDATE_LOCK_NAME,
+        address: lock.address,
+        name: lock.name,
+      })
+    )
+
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: UPDATE_LOCK,

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -1,11 +1,6 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
-import {
-  UPDATE_LOCK,
-  updateLock,
-  CREATE_LOCK,
-  UPDATE_LOCK_NAME,
-} from '../actions/lock'
+import { UPDATE_LOCK, updateLock, UPDATE_LOCK_NAME } from '../actions/lock'
 
 import { startLoading, doneLoading } from '../actions/loading'
 
@@ -71,18 +66,6 @@ const storageMiddleware = config => {
             .catch(error => {
               dispatch(storageError(error))
             })
-        }
-
-        // TODO: isolate the logic below so we can also make it happen on lock updates
-        if (action.type === CREATE_LOCK && action.lock.address) {
-          // Build the data to sign
-          let data = UnlockLock.build({
-            name: action.lock.name,
-            owner: action.lock.owner,
-            address: action.lock.address,
-          })
-          // Ask someone to sign it!
-          dispatch(signData(data))
         }
 
         if (action.type === UPDATE_LOCK_NAME) {

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -5,6 +5,7 @@ import {
   deleteLock,
   UPDATE_LOCK_KEY_PRICE,
   updateLock,
+  updateLockName,
 } from '../actions/lock'
 import { PURCHASE_KEY } from '../actions/key'
 import { setAccount } from '../actions/accounts'
@@ -100,7 +101,12 @@ const walletMiddleware = config => {
     })
 
     walletService.on('lock.updated', (address, update) => {
-      // This is a new lock!
+      // This lock is beeing saved to the chain (that is what the update is about)
+      // So we should be able to get its name from the redux store
+      const lock = getState().locks[address]
+      if (lock) {
+        dispatch(updateLockName(address, lock.name))
+      }
       dispatch(updateLock(address, update))
       dispatch(hideForm()) // Close the form
     })


### PR DESCRIPTION
only save the lock name when it has been actually created. This fixes #2322


Fixes #2322


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread