### PR TITLE
don't mutate state in reducers, don't reset transaction info on the paywall on SET_ACCOUNT

### DIFF
--- a/paywall/src/__tests__/reducers/accountReducer.test.js
+++ b/paywall/src/__tests__/reducers/accountReducer.test.js
@@ -57,4 +57,17 @@ describe('account reducer', () => {
       balance: '1337',
     })
   })
+
+  it('should not mutate existing account state', () => {
+    expect.assertions(1)
+    const update = {
+      balance: '1337',
+    }
+    expect(
+      reducer(account, {
+        type: UPDATE_ACCOUNT,
+        update,
+      })
+    ).not.toBe(account)
+  })
 })

--- a/paywall/src/__tests__/reducers/transactionsReducer.test.js
+++ b/paywall/src/__tests__/reducers/transactionsReducer.test.js
@@ -7,6 +7,7 @@ import {
 } from '../../actions/transaction'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
+import { SET_ACCOUNT } from '../../actions/accounts'
 
 describe('transaction reducer', () => {
   it('should return the initial state', () => {
@@ -51,6 +52,27 @@ describe('transaction reducer', () => {
           type: SET_NETWORK,
         }
       )
+    ).toBe(initialState)
+  })
+
+  // Upon changing account, we need to clear the existing transaction. The web3 middleware will
+  // re-populate them
+  it('should clear the transactions when receiving SET_ACCOUNT', () => {
+    expect.assertions(1)
+    const account = {}
+    const transaction = {
+      status: 'pending',
+      confirmations: 0,
+      hash: '0x123',
+    }
+    const state = {
+      [transaction.id]: transaction,
+    }
+    expect(
+      reducer(state, {
+        type: SET_ACCOUNT,
+        account,
+      })
     ).toBe(initialState)
   })
 

--- a/paywall/src/__tests__/reducers/transactionsReducer.test.js
+++ b/paywall/src/__tests__/reducers/transactionsReducer.test.js
@@ -7,7 +7,6 @@ import {
 } from '../../actions/transaction'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
-import { SET_ACCOUNT } from '../../actions/accounts'
 
 describe('transaction reducer', () => {
   it('should return the initial state', () => {
@@ -15,7 +14,7 @@ describe('transaction reducer', () => {
     expect(initialState).toEqual({})
   })
 
-  it('should return the initial state when receveing SET_PROVIDER', () => {
+  it('should return the initial state when receiving SET_PROVIDER', () => {
     expect.assertions(1)
     const transaction = {
       status: 'pending',
@@ -35,7 +34,7 @@ describe('transaction reducer', () => {
     ).toBe(initialState)
   })
 
-  it('should return the initial state when receveing SET_NETWORK', () => {
+  it('should return the initial state when receiving SET_NETWORK', () => {
     expect.assertions(1)
     const transaction = {
       status: 'pending',
@@ -52,27 +51,6 @@ describe('transaction reducer', () => {
           type: SET_NETWORK,
         }
       )
-    ).toBe(initialState)
-  })
-
-  // Upon changing account, we need to clear the existing transaction. The web3 middleware will
-  // re-populate them
-  it('should clear the transactions when receiving SET_ACCOUNT', () => {
-    expect.assertions(1)
-    const account = {}
-    const transaction = {
-      status: 'pending',
-      confirmations: 0,
-      hash: '0x123',
-    }
-    const state = {
-      [transaction.id]: transaction,
-    }
-    expect(
-      reducer(state, {
-        type: SET_ACCOUNT,
-        account,
-      })
     ).toBe(initialState)
   })
 
@@ -221,6 +199,29 @@ describe('transaction reducer', () => {
           hash: '0x123',
         },
       })
+    })
+
+    it('should not mutate state of existing transactions', () => {
+      expect.assertions(1)
+      const transaction = {
+        status: 'pending',
+        confirmations: 0,
+        hash: '0x123',
+      }
+
+      const state = {
+        [transaction.hash]: transaction,
+      }
+      const action = {
+        type: UPDATE_TRANSACTION,
+        hash: transaction.hash,
+        update: {
+          status: 'mined',
+          confirmations: 3,
+        },
+      }
+
+      expect(reducer(state, action)['0x123']).not.toBe(transaction)
     })
   })
 

--- a/paywall/src/reducers/accountReducer.js
+++ b/paywall/src/reducers/accountReducer.js
@@ -14,7 +14,7 @@ const accountReducer = (state = initialState, action) => {
   }
 
   if (action.type === UPDATE_ACCOUNT) {
-    return Object.assign(state, action.update)
+    return { ...state, ...action.update }
   }
 
   return state

--- a/paywall/src/reducers/transactionsReducer.js
+++ b/paywall/src/reducers/transactionsReducer.js
@@ -7,11 +7,12 @@ import {
 
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
+import { SET_ACCOUNT } from '../actions/accounts'
 
 export const initialState = {}
 
 const transactionsReducer = (transactions = initialState, action) => {
-  if ([SET_PROVIDER, SET_NETWORK].indexOf(action.type) > -1) {
+  if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
     return initialState
   }
 

--- a/paywall/src/reducers/transactionsReducer.js
+++ b/paywall/src/reducers/transactionsReducer.js
@@ -7,12 +7,11 @@ import {
 
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
-import { SET_ACCOUNT } from '../actions/accounts'
 
 export const initialState = {}
 
 const transactionsReducer = (transactions = initialState, action) => {
-  if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
+  if ([SET_PROVIDER, SET_NETWORK].indexOf(action.type) > -1) {
     return initialState
   }
 
@@ -38,7 +37,6 @@ const transactionsReducer = (transactions = initialState, action) => {
       // 'Could not change the transaction hash' => Let's not change state
       return transactions
     }
-
     if (!transactions[action.hash]) {
       // 'Could not update missing transaction' => Let's not change state
       return transactions
@@ -46,7 +44,10 @@ const transactionsReducer = (transactions = initialState, action) => {
 
     return {
       ...transactions,
-      [action.hash]: Object.assign(transactions[action.hash], action.update),
+      [action.hash]: {
+        ...transactions[action.hash],
+        ...action.update,
+      },
     }
   }
 


### PR DESCRIPTION
# Description

This fixes 2 issues in the `transactionReducer`, 1 in `accountReducer`. In both reducers, `Object.assign` was mutating state, which can cause redux not to re-render on changes.

In the `transactionReducer`, our transactions were being nuked by `SET_ACCOUNT` but on the paywall we don't care. The transaction is always going to be a key purchase transaction, so we don't want to nuke them, as it causes annoying UI flickering on each transaction confirmation.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2502 
Fixes #2504 
Refs #2351 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
