### PR TITLE
refresh transaction from URL if needed, fix crash on key save if account is null

### DIFF
--- a/paywall/src/__tests__/middlewares/web3Middleware.test.js
+++ b/paywall/src/__tests__/middlewares/web3Middleware.test.js
@@ -8,6 +8,7 @@ import {
   ADD_TRANSACTION,
   UPDATE_TRANSACTION,
   NEW_TRANSACTION,
+  addTransaction,
 } from '../../actions/transaction'
 import { SET_ERROR } from '../../actions/error'
 import { SET_PROVIDER, setProvider } from '../../actions/provider'
@@ -212,6 +213,29 @@ describe('Lock middleware', () => {
         state.account
       )
     })
+
+    it('it should not refresh account balance if the account is not currently set', () => {
+      expect.assertions(3)
+      create()
+
+      const key = {
+        id: '0xabc',
+        lock: lock.address,
+        owner: state.account.address,
+      }
+      mockWeb3Service.getLock = jest.fn()
+      mockWeb3Service.refreshAccountBalance = jest.fn()
+      mockWeb3Service.getKeyByLockForOwner = jest.fn()
+
+      state.account = null
+      mockWeb3Service.emit('key.saved', '0xabc', key)
+      expect(mockWeb3Service.getLock).toHaveBeenCalledWith(lock.address)
+      expect(mockWeb3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
+        lock.address,
+        key.owner
+      )
+      expect(mockWeb3Service.refreshAccountBalance).not.toHaveBeenCalled()
+    })
   })
 
   describe('when handling the key.updated events triggered by the web3Service', () => {
@@ -310,6 +334,27 @@ describe('Lock middleware', () => {
       )
     })
 
+    it('for SET_ACCOUNT calls, should retrieve transaction if present in the URL', () => {
+      expect.assertions(1)
+      mockWeb3Service.refreshAccountBalance = jest.fn()
+      mockWeb3Service.getKeyByLockForOwner = jest.fn()
+
+      const transaction =
+        '0x1234567890123456789012345678901234567890123456789012345678901234'
+      state.router.location = {
+        pathname: `/${lock.address}`,
+        hash: `#${transaction}`,
+      }
+
+      const { invoke, store } = create()
+
+      invoke(setAccount({ address: 'hi' }))
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining(addTransaction({ hash: transaction }))
+      )
+    })
+
     it.each([[SET_PROVIDER, setProvider], [SET_NETWORK, setNetwork]])(
       'should refresh the lock if %s is called',
       async (key, action) => {
@@ -326,6 +371,29 @@ describe('Lock middleware', () => {
         expect(mockWeb3Service.getLock).toHaveBeenCalledWith(lock)
       }
     )
+
+    it.each([[SET_PROVIDER, setProvider], [SET_NETWORK, setNetwork]])(
+      'should dispatch ADD_TRANSACTION if %s is called and transaction is in the URL',
+      async (key, action) => {
+        expect.assertions(1)
+        mockWeb3Service.getLock = jest.fn()
+
+        const transaction =
+          '0x1234567890123456789012345678901234567890123456789012345678901234'
+        state.router.location = {
+          pathname: `/${lock.address}`,
+          hash: `#${transaction}`,
+        }
+
+        const { invoke, store } = create()
+
+        invoke(action('hi'))
+
+        expect(store.dispatch).toHaveBeenCalledWith(
+          expect.objectContaining(addTransaction({ hash: transaction }))
+        )
+      }
+    )
   })
 
   it("should handle LOCATION_CHANGE if a lock is passed by calling web3Service's getLock", () => {
@@ -335,15 +403,16 @@ describe('Lock middleware', () => {
       type: LOCATION_CHANGE,
       payload: { location: { pathname: `/${lock.address}` }, hash: '' },
     }
+    state.router.location = action.payload.location
     mockWeb3Service.getLock = jest.fn()
     invoke(action)
     expect(mockWeb3Service.getLock).toHaveBeenCalled()
     expect(next).toHaveBeenCalledWith(action)
   })
 
-  it("should handle LOCATION_CHANGE if a transaction is passed by calling web3Service's getTransaction", () => {
+  it('should handle LOCATION_CHANGE if a transaction is passed by dispatching ADD_TRANSACTION', () => {
     expect.assertions(2)
-    const { next, invoke } = create()
+    const { next, invoke, store } = create()
     // transaction hashes are 64 digits long
     const transaction =
       '0x1234567890123456789012345678901234567890123456789012345678901234'
@@ -353,10 +422,13 @@ describe('Lock middleware', () => {
         location: { pathname: `/${lock.address}`, hash: `#${transaction}` },
       },
     }
+    state.router.location = action.payload.location
     mockWeb3Service.getTransaction = jest.fn()
     mockWeb3Service.getLock = jest.fn()
     invoke(action)
-    expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(transaction)
+    expect(store.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining(addTransaction({ hash: transaction }))
+    )
     expect(next).toHaveBeenCalledWith(action)
   })
 

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -149,7 +149,7 @@ export default function web3Middleware({ getState, dispatch }) {
 
       // note: this needs to be after the reducer has seen it, because refreshAccountBalance
       // triggers 'account.update' which dispatches UPDATE_ACCOUNT. The reducer assumes that
-      // ADD_ACCOUNT has reached it first, and throws an exception. Putting it after the
+      // SET_ACCOUNT has reached it first, and throws an exception. Putting it after the
       // reducer has a chance to populate state removes this race condition.
       if (action.type === SET_ACCOUNT) {
         // TODO: when the account has been updated we should reset web3Service and remove all listeners
@@ -163,6 +163,8 @@ export default function web3Middleware({ getState, dispatch }) {
 
       if (action.type === ADD_LOCK || action.type == UPDATE_LOCK) {
         const lock = locks[action.address]
+        // this is quite different from the code on line 160, as it uses the lock from the action
+        // line 160 uses the lock from the current URL
         if (account) {
           web3Service.getKeyByLockForOwner(lock.address, account.address)
         }
@@ -171,7 +173,7 @@ export default function web3Middleware({ getState, dispatch }) {
         action.payload.location &&
         action.payload.location.pathname
       ) {
-        // Location was changed, get the matching lock, if we are on a paywall page
+        // Location was changed, get the matching lock
         if (lockAddress) {
           web3Service.getLock(lockAddress)
         }


### PR DESCRIPTION
# Description

If account changes, network changes, provider changes, or the actual URL changes, we need to refresh the transaction state.

In addition, if a `key.save` is emitted, there is a chance that the account is not yet set (race condition), so this removes a crash.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2505 
Fixes #2506 
Refs #2351

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
