### PR TITLE
Integrate providerMiddleware

### DIFF
--- a/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
@@ -6,11 +6,11 @@ import { FATAL_MISSING_PROVIDER } from '../../errors'
 const config = {
   providers: {
     UNLOCK: {
-      enable: jest.fn(() => new Promise(resolve => resolve('lol'))),
+      enable: jest.fn(() => new Promise(resolve => resolve(true))),
       isUnlock: true,
     },
     NUNLOCK: {
-      enable: jest.fn(),
+      enable: jest.fn(() => new Promise(resolve => resolve(true))),
     },
   },
 }
@@ -41,7 +41,9 @@ describe('provider middleware', () => {
     config.providers['UNLOCK'].enable = jest.fn(
       () => new Promise(resolve => resolve(true))
     )
-    config.providers['NUNLOCK'].enable = jest.fn()
+    config.providers['NUNLOCK'].enable = jest.fn(
+      () => new Promise(resolve => resolve(true))
+    )
     dispatch = jest.fn()
   })
   describe('SET_PROVIDER', () => {

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -15,7 +15,7 @@ import {
 import { PURCHASE_KEY } from '../../actions/key'
 import { SET_ACCOUNT } from '../../actions/accounts'
 import { SET_NETWORK } from '../../actions/network'
-import { SET_PROVIDER } from '../../actions/provider'
+import { PROVIDER_READY } from '../../actions/provider'
 import { NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ERROR } from '../../actions/error'
 import { POLLING_INTERVAL } from '../../constants'
@@ -61,7 +61,6 @@ const transaction = {
 const network = {
   name: 'test',
 }
-const provider = 'Toshi'
 
 /**
  * This is a "fake" middleware caller
@@ -411,13 +410,15 @@ describe('Wallet middleware', () => {
     })
   })
 
-  it('should handle SET_PROVIDER and re connect', () => {
+  it('should handle PROVIDER_READY and connect', () => {
     expect.assertions(2)
     const { next, invoke } = create()
-    const action = { type: SET_PROVIDER, provider }
+    const action = { type: PROVIDER_READY }
     mockWalletService.connect = jest.fn()
     invoke(action)
-    expect(mockWalletService.connect).toHaveBeenCalledWith(provider)
+    expect(mockWalletService.connect).toHaveBeenCalledWith(
+      mockConfig.providers[state.provider]
+    )
     expect(next).toHaveBeenCalledWith(action)
   })
 

--- a/unlock-app/src/__tests__/services/walletService.test.js
+++ b/unlock-app/src/__tests__/services/walletService.test.js
@@ -9,8 +9,6 @@ import configure from '../../config'
 import WalletService, { Errors } from '../../services/walletService'
 
 const {
-  FATAL_NOT_ENABLED_IN_PROVIDER,
-  FATAL_MISSING_PROVIDER,
   FAILED_TO_CREATE_LOCK,
   FAILED_TO_PURCHASE_KEY,
   FAILED_TO_UPDATE_KEY_PRICE,
@@ -105,83 +103,7 @@ describe('WalletService', () => {
         return done()
       })
 
-      walletService.connect('HTTP')
-    })
-
-    it('should trigger an error if the provider is not set', done => {
-      expect.assertions(1)
-
-      walletService.on('error', error => {
-        expect(error.message).toEqual(FATAL_MISSING_PROVIDER)
-        return done()
-      })
-
-      walletService.connect('AnotherProvider')
-    })
-
-    it('should silently ignore requests to connect again to the same provider', done => {
-      expect.assertions(1)
-
-      walletService.once('error', error => {
-        expect(error.message).toBe(FATAL_MISSING_PROVIDER)
-
-        walletService.once('error', () => {
-          // This should not trigger
-          expect(false).toBe(true)
-        })
-
-        setTimeout(done, 1000) // wait 1 second
-
-        // connect again
-        walletService.connect('CLOUD')
-      })
-      walletService.connect('CLOUD')
-    })
-
-    it('should call enable on a provider that supplies it', done => {
-      expect.assertions(3)
-
-      expect(walletService.ready).toBe(false)
-      Unlock.networks = {}
-
-      const netVersion = Math.floor(Math.random() * 100000)
-      netVersionAndYield(netVersion)
-      Unlock.networks = {
-        [netVersion]: {
-          events: {},
-          links: {},
-          address: '0x3f313221a2af33fd8a430891291370632cb471bf',
-          transactionHash:
-            '0x8545541749873b42c96e1699c2e62f0f4062ca57f3398270423c1089232ef7dd',
-        },
-      }
-      const enable = (providers.HTTP.enable = jest.fn(() => Promise.resolve()))
-
-      expect(walletService.ready).toBe(false)
-      walletService.once('network.changed', () => {
-        expect(enable).toHaveBeenCalled()
-        done()
-      })
-
-      walletService.connect('HTTP')
-    })
-
-    it('should fail if a user rejects access', done => {
-      expect.assertions(4)
-
-      expect(walletService.ready).toBe(false)
-      Unlock.networks = {}
-
-      const enable = (providers.HTTP.enable = jest.fn(() => Promise.reject()))
-
-      expect(walletService.ready).toBe(false)
-      walletService.once('error', error => {
-        expect(enable).toHaveBeenCalled()
-        expect(error.message).toBe(FATAL_NOT_ENABLED_IN_PROVIDER)
-        done()
-      })
-
-      walletService.connect('HTTP')
+      walletService.connect(providers['HTTP'])
     })
   })
 
@@ -204,7 +126,7 @@ describe('WalletService', () => {
       walletService.on('network.changed', () => {
         done()
       })
-      return walletService.connect('HTTP')
+      return walletService.connect(providers['HTTP'])
     })
 
     describe('isUnlockContractDeployed', () => {

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'timers'
 import { SET_PROVIDER, providerReady } from '../actions/provider'
 import { setError } from '../actions/error'
 import {
@@ -10,31 +11,40 @@ interface Action {
   [key: string]: any
 }
 
-function initializeProvider(provider: { enable?: () => any }) {
+function initializeProvider(provider: { enable?: () => any }, dispatch: any) {
+  if (!provider) {
+    dispatch(setError(FATAL_MISSING_PROVIDER))
+    return
+  }
+
   // provider.enable exists for metamask and other modern dapp wallets and must be called, see:
   // https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8
   if (provider.enable) {
-    return provider.enable()
+    provider
+      .enable()
+      .then(() => dispatch(providerReady()))
+      .catch(() => dispatch(setError(FATAL_NOT_ENABLED_IN_PROVIDER)))
+  } else {
+    // Default case, provider doesn't have an enable method, so it must already be ready
+    dispatch(providerReady())
   }
-  // Default case, provider doesn't have an enable method, so it must already be ready
-  return Promise.resolve(true)
 }
 
 const providerMiddleware = (config: any) => {
   return ({ getState, dispatch }: { [key: string]: any }) => {
     return function(next: any) {
+      // Initialize provider based on the one grabbed in the state. Fragile?
+      setTimeout(() => {
+        const provider = config.providers[getState().provider]
+        initializeProvider(provider, dispatch)
+      }, 0)
+
       return function(action: Action) {
         if (action.type === SET_PROVIDER) {
           // Only initialize the provider if we haven't already done so.
           if (action.provider !== getState().provider) {
             const provider = config.providers[action.provider]
-            if (provider) {
-              initializeProvider(provider)
-                .then(() => dispatch(providerReady()))
-                .catch(() => dispatch(setError(FATAL_NOT_ENABLED_IN_PROVIDER)))
-            } else {
-              dispatch(setError(FATAL_MISSING_PROVIDER))
-            }
+            initializeProvider(provider, dispatch)
           }
         }
         next(action)

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -1,4 +1,3 @@
-import { setTimeout } from 'timers'
 import { SET_PROVIDER, providerReady } from '../actions/provider'
 import { setError } from '../actions/error'
 import {

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -155,12 +155,6 @@ const walletMiddleware = config => {
     })
 
     return function(next) {
-      // Connect to the current provider
-      // We connect once the middleware has been initialized, using setTimout (warning: fragile?)
-      setTimeout(() => {
-        walletService.connect(getState().provider)
-      })
-
       return function(action) {
         if (action.type === PROVIDER_READY) {
           walletService.connect(config.providers[getState().provider])

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -10,7 +10,7 @@ import { PURCHASE_KEY } from '../actions/key'
 import { setAccount } from '../actions/accounts'
 import { setNetwork } from '../actions/network'
 import { setError } from '../actions/error'
-import { SET_PROVIDER } from '../actions/provider'
+import { PROVIDER_READY } from '../actions/provider'
 import { newTransaction } from '../actions/transaction'
 import {
   waitForWallet,
@@ -162,8 +162,8 @@ const walletMiddleware = config => {
       })
 
       return function(action) {
-        if (action.type === SET_PROVIDER) {
-          walletService.connect(action.provider)
+        if (action.type === PROVIDER_READY) {
+          walletService.connect(config.providers[getState().provider])
         } else if (action.type === CREATE_LOCK && action.lock.address) {
           ensureReadyBefore(() => {
             walletService.createLock(action.lock, getState().account.address)

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -15,6 +15,7 @@ import web3Middleware from '../middlewares/web3Middleware'
 import currencyConversionMiddleware from '../middlewares/currencyConversionMiddleware'
 import storageMiddleware from '../middlewares/storageMiddleware'
 import walletMiddleware from '../middlewares/walletMiddleware'
+import providerMiddleware from '../middlewares/providerMiddleware'
 
 const config = configure()
 
@@ -22,6 +23,7 @@ const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
 
 function getOrCreateStore(initialState, path) {
   const middlewares = [
+    providerMiddleware(config),
     web3Middleware(config),
     currencyConversionMiddleware(config),
     walletMiddleware(config),

--- a/unlock-app/src/services/walletService.js
+++ b/unlock-app/src/services/walletService.js
@@ -28,12 +28,10 @@ export const keyId = (lock, owner) => [lock, owner].join('-')
  * actually retrieving the data from the chain/smart contracts
  */
 export default class WalletService extends EventEmitter {
-  constructor({ providers, unlockAddress }) {
+  constructor({ unlockAddress }) {
     super()
     this.unlockContractAddress = unlockAddress
-    this.providers = providers
     this.ready = false
-    this.providerName = null
     this.web3 = null
 
     this.on('ready', () => {
@@ -61,33 +59,9 @@ export default class WalletService extends EventEmitter {
    * @param {string} providerName
    * @return
    */
-  async connect(providerName) {
-    if (providerName && providerName === this.providerName) {
-      // If the provider is set and did not really change, no need to reset it
-      return
-    }
-
-    // Keep track of the provider
-    this.providerName = providerName
-    // And reset the connection
+  async connect(provider) {
+    // Reset the connection
     this.ready = false
-
-    const provider = this.providers[providerName]
-
-    // We fail: it appears that we are trying to connect but do not have a provider available...
-    if (!provider) {
-      return this.emit('error', new Error(Errors.FATAL_MISSING_PROVIDER))
-    }
-
-    try {
-      if (provider.enable) {
-        // this exists for metamask and other modern dapp wallets and must be called,
-        // see: https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8
-        await provider.enable()
-      }
-    } catch (error) {
-      return this.emit('error', new Error(Errors.FATAL_NOT_ENABLED_IN_PROVIDER))
-    }
 
     this.web3 = new Web3(provider)
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Following on #2479, this PR integrates the `providerMiddleware` with the rest of the app, making it solely responsible for instantiating providers and signaling when they are ready for interaction.

Changes include:

1. Add `providerMiddleware` to app
2. Change `walletMiddleware` to respond to the `PROVIDER_READY` action
3. Change `walletService` to simply instantiate Web3 with a ready-to-use provider that is passed to it
4. Update various tests to work with this new way of handling providers

Verified working locally with:
- [x] HTTP Provider
- [x] Metamask
- [x] No provider (triggers error)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
