### PR TITLE
new usePaywallConfig hook

### DIFF
--- a/paywall/src/__tests__/hooks/usePaywallConfig.test.js
+++ b/paywall/src/__tests__/hooks/usePaywallConfig.test.js
@@ -1,0 +1,103 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import usePaywallConfig from '../../hooks/usePaywallConfig'
+import { WindowContext } from '../../hooks/browser/useWindow'
+import { ConfigContext } from '../../utils/withConfig'
+import {
+  POST_MESSAGE_READY,
+  POST_MESSAGE_CONFIG,
+} from '../../paywall-builder/constants'
+
+describe('usePaywallConfig hook', () => {
+  let fakeWindow
+  let config
+  const lock = '0x1234567890123456789012345678901234567890'
+
+  function MockPaywallConfig() {
+    const paywallConfig = usePaywallConfig()
+
+    return <div data-testid="config">{JSON.stringify(paywallConfig)}</div>
+  }
+
+  function Wrapper() {
+    return (
+      <WindowContext.Provider value={fakeWindow}>
+        <ConfigContext.Provider value={config}>
+          <MockPaywallConfig />
+        </ConfigContext.Provider>
+      </WindowContext.Provider>
+    )
+  }
+
+  function getListener() {
+    return fakeWindow.addEventListener.mock.calls[0][1]
+  }
+
+  beforeEach(() => {
+    config = {
+      isInIframe: true,
+      isServer: false,
+    }
+    fakeWindow = {
+      location: {
+        pathname: `/${lock}`,
+        search: '?origin=origin',
+        hash: '',
+      },
+      parent: {
+        postMessage: jest.fn(),
+      },
+      addEventListener: jest.fn(),
+      removeEventListener: () => {},
+    }
+    fakeWindow.self = fakeWindow
+    fakeWindow.top = {}
+  })
+
+  it('sends POST_MESSAGE_READY on startup', () => {
+    expect.assertions(1)
+
+    rtl.render(<Wrapper />)
+
+    expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith(
+      POST_MESSAGE_READY,
+      'origin'
+    )
+  })
+
+  it('does not send POST_MESSAGE_STARTUP more than once', () => {
+    expect.assertions(1)
+
+    const { rerender } = rtl.render(<Wrapper />)
+
+    rerender(<Wrapper foo="bar" />)
+
+    expect(fakeWindow.parent.postMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('listens for POST_MESSAGE_CONFIG', () => {
+    expect.assertions(1)
+
+    let wrapper
+    rtl.act(() => {
+      wrapper = rtl.render(<Wrapper />)
+    })
+
+    const listener = getListener()
+
+    rtl.act(() => {
+      listener({
+        source: fakeWindow.parent,
+        origin: 'origin',
+        data: {
+          type: POST_MESSAGE_CONFIG,
+          payload: { wow: 'it worked!' },
+        },
+      })
+    })
+
+    expect(wrapper.getByTestId('config')).toHaveTextContent(
+      JSON.stringify({ wow: 'it worked!' })
+    )
+  })
+})

--- a/paywall/src/hooks/usePaywallConfig.js
+++ b/paywall/src/hooks/usePaywallConfig.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+import {
+  POST_MESSAGE_CONFIG,
+  POST_MESSAGE_READY,
+} from '../paywall-builder/constants'
+import useListenForPostMessage from './browser/useListenForPostMessage'
+import usePostMessage from './browser/usePostMessage'
+
+export default function usePaywallConfig() {
+  const { postMessage } = usePostMessage()
+  const paywallConfig = useListenForPostMessage({
+    type: POST_MESSAGE_CONFIG,
+  })
+  useEffect(() => {
+    postMessage(POST_MESSAGE_READY)
+  }, []) // only send this once, on startup
+  return paywallConfig
+}


### PR DESCRIPTION
# Description

This introduces the mechanism that the paywall will get the config from `paywall.min.js`. The hook can be used in multiple, independent components. On mount of the component using the hook, it sends a "ready" message to the paywall.min.js script, which then replies with the config.

Because `useListenForPostMessage` accepts a validator, we can use that to validate the input, although this PR does not implement that phase yet. In addition, in the future the `useListenForPostMessage` callback could also be used to sanitize/transform the input into the format desired. Again, not implemented in this PR, just pointing out the possible paths to be trodden upon.

In the future this behavior may change, so that the config is parsed once at the top, and passed down through context, but this will definitely work for now.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2394 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
