### PR TITLE
using the new convention for environment variables

### DIFF
--- a/paywall/src/__tests__/hooks/useLocksmith.test.js
+++ b/paywall/src/__tests__/hooks/useLocksmith.test.js
@@ -70,7 +70,7 @@ describe('useLocksmith hook', () => {
       finishFetch(fetchResponse)
     })
 
-    expect(fakeWindow.fetch).toHaveBeenCalledWith(config.locksmithHost + '/hi')
+    expect(fakeWindow.fetch).toHaveBeenCalledWith(config.locksmithUri + '/hi')
   })
 
   it('returns the response', () => {

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -71,33 +71,34 @@ export default function configure(
   // note: the choice of 127.0.0.1 instead of localhost is deliberate, as it will
   // allow us to test cross-origin requests from localhost/demo
   let paywallUrl = runtimeConfig.paywallUrl || 'http://127.0.0.1:3001'
-  const locksmithHost = runtimeConfig.locksmithHost
-  let paywallScriptPath =
-    runtimeConfig.paywallScriptPath || '/static/paywall.min.js'
+  const locksmithUri = runtimeConfig.locksmithUri || 'http://0.0.0.0:8080'
+  let paywallScriptPath = '/static/paywall.min.js'
+  const httpProvider = runtimeConfig.httpProvider || '127.0.0.1'
   let providers = {}
   let isRequiredNetwork = () => false
   let requiredNetwork = 'Dev'
   let requiredNetworkId = 1984
   let requiredConfirmations = 12
   // Unlock address by default
-  // Smart contract deployments yield the same address on a "clean" node as long as long as the
-  // migration script runs in the same order.
-  let unlockAddress = runtimeConfig.unlockAddress
-  let services = {}
+  // Smart contract deployments yield the same address on a "clean" node as long as long as the migration script runs in the same order.
+  let unlockAddress = '0x885EF47c3439ADE0CB9b33a4D3c534C99964Db93'
+  let services = {
+    storage: {
+      host: locksmithUri,
+    },
+  }
   let supportedProviders = []
   let blockTime = 8000 // in mseconds.
   const readOnlyProviderUrl =
-    runtimeConfig.readOnlyProvider ||
-    `http://${runtimeConfig.httpProvider}:8545`
+    runtimeConfig.readOnlyProvider || `http://${httpProvider}:8545`
 
   if (env === 'test') {
     // In test, we fake the HTTP provider
     providers['HTTP'] = new Web3.providers.HttpProvider(
-      `http://${runtimeConfig.httpProvider}:8545`
+      `http://${httpProvider}:8545`
     )
     blockTime = 10 // in mseconds.
     supportedProviders = ['HTTP']
-    services['storage'] = { host: 'http://127.0.0.1:8080' }
     isRequiredNetwork = networkId => networkId === 1984
   }
 
@@ -105,9 +106,8 @@ export default function configure(
     // In dev, we assume there is a running local ethereum node with unlocked accounts
     // listening to the HTTP endpoint. We can add more providers (Websockets...) if needed.
     providers['HTTP'] = new Web3.providers.HttpProvider(
-      `http://${runtimeConfig.httpProvider}:8545`
+      `http://${httpProvider}:8545`
     )
-    services['storage'] = { host: 'http://127.0.0.1:8080' }
 
     // If there is an existing web3 injected provider, we also add this one to the list of possible providers
     if (typeof environment.web3 !== 'undefined') {
@@ -136,14 +136,9 @@ export default function configure(
     isRequiredNetwork = networkId => networkId === 4
     requiredNetworkId = 4
     supportedProviders = ['Metamask', 'Opera']
-    services['storage'] = { host: runtimeConfig.locksmithHost }
 
     // Address for the Unlock smart contract
     unlockAddress = '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b'
-
-    // Paywall URL for staging
-    paywallUrl =
-      runtimeConfig.paywallUrl || 'https://staging-paywall.unlock-protocol.com'
 
     // rinkeby block time is roughly same as main net
     blockTime = 8000
@@ -165,10 +160,6 @@ export default function configure(
     // Address for the Unlock smart contract
     unlockAddress = '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'
 
-    // Paywall URL for production
-    paywallUrl =
-      runtimeConfig.paywallUrl || 'https://paywall.unlock-protocol.com'
-
     // See https://www.reddit.com/r/ethereum/comments/3c8v2i/what_is_the_expected_block_time/
     blockTime = 8000
   }
@@ -189,7 +180,7 @@ export default function configure(
     env,
     providers,
     isRequiredNetwork,
-    locksmithHost,
+    locksmithUri,
     readOnlyProvider,
     requiredNetworkId,
     requiredNetwork,

--- a/paywall/src/hooks/useLocksmith.js
+++ b/paywall/src/hooks/useLocksmith.js
@@ -8,13 +8,13 @@ import useConfig from './utils/useConfig'
 // It only re-fetches if the api path changes.
 export default function useLocksmith(api, defaultValue, active = true) {
   const window = useWindow()
-  const { locksmithHost } = useConfig()
+  const { locksmithUri } = useConfig()
   const [result, setResult] = useState(defaultValue)
   const [reSend, reSendQuery] = useReducer(state => state + 1, 0)
 
   const fetch = window.fetch
   // remove double / if there are any
-  const url = locksmithHost + ('/' + api).replace(/\/+/g, '/')
+  const url = locksmithUri + ('/' + api).replace(/\/+/g, '/')
 
   useEffect(() => {
     if (!active) return


### PR DESCRIPTION
See https://github.com/unlock-protocol/unlock/wiki/Environment-variables for details.
I discovered that the integration tests did not set some important environment variables.
This should catch that.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread