### PR TITLE
Initial version of Unlock Provider

### DIFF
--- a/unlock-app/src/__tests__/services/unlockProvider.test.js
+++ b/unlock-app/src/__tests__/services/unlockProvider.test.js
@@ -1,0 +1,22 @@
+import UnlockProvider from '../../services/unlockProvider'
+
+describe('Unlock Provider', () => {
+  let provider
+  beforeEach(() => {
+    provider = new UnlockProvider({})
+  })
+  it('should respond to eth_accounts with an empty array before being initialized', done => {
+    expect.assertions(1)
+    provider.send(
+      {
+        id: 1,
+        jsonrpc: 3,
+        method: 'eth_accounts',
+      },
+      (_, data) => {
+        expect(data.result).toHaveLength(0)
+        done()
+      }
+    )
+  })
+})

--- a/unlock-app/src/__tests__/services/unlockProvider.test.js
+++ b/unlock-app/src/__tests__/services/unlockProvider.test.js
@@ -1,5 +1,11 @@
 import UnlockProvider from '../../services/unlockProvider'
 
+const rpc = method => ({
+  id: 1, // except for `method` these are just dummy values of no import
+  jsonrpc: 3,
+  method,
+})
+
 describe('Unlock Provider', () => {
   let provider
   beforeEach(() => {
@@ -7,16 +13,19 @@ describe('Unlock Provider', () => {
   })
   it('should respond to eth_accounts with an empty array before being initialized', done => {
     expect.assertions(1)
-    provider.send(
-      {
-        id: 1,
-        jsonrpc: 3,
-        method: 'eth_accounts',
-      },
-      (_, data) => {
-        expect(data.result).toHaveLength(0)
-        done()
-      }
-    )
+    provider.send(rpc('eth_accounts'), (_, data) => {
+      expect(data.result).toHaveLength(0)
+      done()
+    })
+  })
+
+  it('should respond to eth_account with an array containing only `this.address` after being initialized', done => {
+    expect.assertions(2)
+    provider.setAddress('0x12345678')
+    provider.send(rpc('eth_accounts'), (_, data) => {
+      expect(data.result).toHaveLength(1)
+      expect(data.result[0]).toBe('0x12345678')
+      done()
+    })
   })
 })

--- a/unlock-app/src/__tests__/services/unlockProvider.test.js
+++ b/unlock-app/src/__tests__/services/unlockProvider.test.js
@@ -9,7 +9,8 @@ const rpc = method => ({
 describe('Unlock Provider', () => {
   let provider
   beforeEach(() => {
-    provider = new UnlockProvider({})
+    const send = jest.fn((_, cb) => cb(null, 'a response'))
+    provider = new UnlockProvider({ send })
   })
   it('should respond to eth_accounts with an empty array before being initialized', done => {
     expect.assertions(1)
@@ -25,6 +26,14 @@ describe('Unlock Provider', () => {
     provider.send(rpc('eth_accounts'), (_, data) => {
       expect(data.result).toHaveLength(1)
       expect(data.result[0]).toBe('0x12345678')
+      done()
+    })
+  })
+
+  it('should call the fallback provider for any method it does not implement', done => {
+    expect.assertions(1)
+    provider.send(rpc('not_a_real_method'), () => {
+      expect(provider.fallbackProvider.send).toHaveBeenCalled()
       done()
     })
   })

--- a/unlock-app/src/services/unlockProvider.js
+++ b/unlock-app/src/services/unlockProvider.js
@@ -1,0 +1,45 @@
+// UnlockProvider implements a subset of Web3 provider functionality, sufficient
+// to allow us to use it as a stand-in for MetaMask or other Web3 integration in
+// the browser.
+export default class UnlockProvider {
+  constructor(fallbackProvider) {
+    this.fallbackProvider = fallbackProvider
+    this.address = ''
+  }
+
+  disconnect = () => true
+
+  async eth_accounts(respond) {
+    // Must always return an array of addresses
+    if (this.address) {
+      respond([this.address])
+    } else {
+      respond([])
+    }
+  }
+
+  setAddress(newAddress) {
+    this.address = newAddress
+  }
+
+  send(args, cb) {
+    const { id, jsonrpc, method } = args
+    // Calling respond with some argument will call the callback with
+    // a "fake" JSON-RPC response constructed by the provider.
+    const respond = result => {
+      cb(null, {
+        id,
+        jsonrpc,
+        result,
+      })
+    }
+
+    try {
+      return this[method](respond)
+    } catch (err) {
+      // We haven't implemented this method, defer to the fallback provider.
+      // TODO: Catch methods we don't want to dispatch and throw an error
+      return this.fallbackProvider.send(args, cb)
+    }
+  }
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR is a piece of #2414. It adds a very early version of the Unlock Provider to the app.

Here's how it works:
- Right now it delegates most calls to another provider. This will be tightened up/whitelisted in the future.
- It responds to `eth_accounts` with either an empty array (if the provider hasn't been initialized with a login) or an array containing one address (the address derived from the login).

This will need to be iterated on to be more useful, but putting it in the app in this state will allow me to reference and extend it in future PRs. Note: it is not hooked up to anything right now, and it won't be until it is more feature complete and other surrounding infrastructure is made.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
