### PR TITLE
Initial Key Chain authentication screen

### DIFF
--- a/unlock-app/src/__tests__/components/interface/Authentication.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/Authentication.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { Provider } from 'react-redux'
+import createUnlockStore from '../../../createUnlockStore'
+import { AuthenticationPrompt } from '../../../components/interface/AuthenticationPrompt'
+
+const store = createUnlockStore({})
+
+let wrapper: rtl.RenderResult<typeof rtl.queries>
+let gotCredentials: any
+
+afterEach(rtl.cleanup)
+describe('Authentication Prompt', () => {
+  beforeEach(() => {
+    gotCredentials = jest.fn()
+    wrapper = rtl.render(
+      <Provider store={store}>
+        <AuthenticationPrompt gotCredentials={gotCredentials} />
+      </Provider>
+    )
+  })
+
+  it('should dispatch a GOT_CREDENTIALS action when submit is clicked', () => {
+    expect.assertions(3)
+    const { container } = wrapper
+    const submitButton = container.querySelector('input[type="submit"]')
+    expect(submitButton).not.toBeNull()
+    expect(gotCredentials).not.toHaveBeenCalled()
+    if (submitButton) {
+      rtl.fireEvent.click(submitButton)
+      expect(gotCredentials).toHaveBeenCalledTimes(1)
+    }
+  })
+})

--- a/unlock-app/src/__tests__/components/interface/Authentication.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/Authentication.test.tsx
@@ -1,10 +1,6 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
-import { Provider } from 'react-redux'
-import createUnlockStore from '../../../createUnlockStore'
 import { AuthenticationPrompt } from '../../../components/interface/AuthenticationPrompt'
-
-const store = createUnlockStore({})
 
 let wrapper: rtl.RenderResult<typeof rtl.queries>
 let gotCredentials: any
@@ -14,9 +10,7 @@ describe('Authentication Prompt', () => {
   beforeEach(() => {
     gotCredentials = jest.fn()
     wrapper = rtl.render(
-      <Provider store={store}>
-        <AuthenticationPrompt gotCredentials={gotCredentials} />
-      </Provider>
+      <AuthenticationPrompt gotCredentials={gotCredentials} />
     )
   })
 

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -866,6 +866,197 @@ Object {
 }
 `;
 
+exports[`Storyshots Authentication Prompt The Prompt 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c1 {
+  display: block;
+  text-transform: uppercase;
+  font-size: 10px;
+  color: var(--darkgrey);
+  margin-top: 10px;
+  margin-bottom: 5px;
+}
+
+.c2 {
+  height: 60px;
+  width: 385px;
+  border: none;
+  background-color: var(--lightgrey);
+  border-radius: 4px;
+  padding: 10px;
+  font-size: 16px;
+}
+
+.c0 {
+  font-family: IBM Plex Serif,sans-serif;
+  font-size: 24px;
+  color: var(--darkgrey);
+}
+
+.c3 {
+  height: 60px;
+  width: 385px;
+  border: none;
+  background-color: var(--green);
+  border-radius: 4px;
+  margin-top: 25px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <form>
+        <div
+          class="c0"
+        >
+          Please Log In to Continue
+        </div>
+        <label
+          class="c1"
+          for="emailAddress"
+        >
+          Email address
+        </label>
+        <input
+          class="c2"
+          name="emailAddress"
+          placeholder="Email Address"
+          type="email"
+        />
+        <br />
+        <label
+          class="c1"
+          for="password"
+        >
+          Password
+        </label>
+        <input
+          class="c2"
+          name="password"
+          placeholder="Password"
+          type="password"
+        />
+        <br />
+        <input
+          class="c3"
+          type="submit"
+          value="Submit"
+        />
+      </form>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <form>
+      <div
+        class="sc-kpOJdX iOuKVo"
+      >
+        Please Log In to Continue
+      </div>
+      <label
+        class="sc-kgoBCf ekHVMw"
+        for="emailAddress"
+      >
+        Email address
+      </label>
+      <input
+        class="sc-kGXeez dzsfcf"
+        name="emailAddress"
+        placeholder="Email Address"
+        type="email"
+      />
+      <br />
+      <label
+        class="sc-kgoBCf ekHVMw"
+        for="password"
+      >
+        Password
+      </label>
+      <input
+        class="sc-kGXeez dzsfcf"
+        name="password"
+        placeholder="Password"
+        type="password"
+      />
+      <br />
+      <input
+        class="sc-dxgOiQ ZLgEM"
+        type="submit"
+        value="Submit"
+      />
+    </form>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots Buttons/Layout Buttons About 1`] = `
 Object {
   "asFragment": [Function],
@@ -45470,6 +45661,7 @@ Object {
 .c16 {
   font-family: IBM Plex Serif,sans-serif;
   font-size: 24px;
+  color: var(--darkgrey);
 }
 
 .c19 {
@@ -45480,6 +45672,7 @@ Object {
   border-radius: 4px;
   margin-top: 25px;
   font-size: 16px;
+  cursor: pointer;
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
@@ -45996,7 +46189,7 @@ Object {
         </header>
         <form>
           <div
-            class="sc-kpOJdX cfhpkt"
+            class="sc-kpOJdX iOuKVo"
           >
             Please Log In to Continue
           </div>
@@ -46027,7 +46220,7 @@ Object {
           />
           <br />
           <input
-            class="sc-dxgOiQ eRjgVl"
+            class="sc-dxgOiQ ZLgEM"
             type="submit"
             value="Submit"
           />

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -45722,6 +45722,32 @@ Object {
               class="c15"
             />
           </header>
+          <form>
+            <label
+              for="emailAddress"
+            >
+              Email address:
+              <input
+                name="emailAddress"
+                type="email"
+              />
+            </label>
+            <br />
+            <label
+              for="password"
+            >
+              Password:
+              <input
+                name="password"
+                type="password"
+              />
+            </label>
+            <br />
+            <input
+              type="submit"
+              value="Submit"
+            />
+          </form>
         </div>
         <div
           class="c16"
@@ -45922,6 +45948,32 @@ Object {
             class="sc-1glv5oz-5 bjHPyP"
           />
         </header>
+        <form>
+          <label
+            for="emailAddress"
+          >
+            Email address:
+            <input
+              name="emailAddress"
+              type="email"
+            />
+          </label>
+          <br />
+          <label
+            for="password"
+          >
+            Password:
+            <input
+              name="password"
+              type="password"
+            />
+          </label>
+          <br />
+          <input
+            type="submit"
+            value="Submit"
+          />
+        </form>
       </div>
       <div
         class="hm3mhg-2 dBxAQT"

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -45448,6 +45448,40 @@ Object {
   width: 100%;
 }
 
+.c17 {
+  display: block;
+  text-transform: uppercase;
+  font-size: 10px;
+  color: var(--darkgrey);
+  margin-top: 10px;
+  margin-bottom: 5px;
+}
+
+.c18 {
+  height: 60px;
+  width: 385px;
+  border: none;
+  background-color: var(--lightgrey);
+  border-radius: 4px;
+  padding: 10px;
+  font-size: 16px;
+}
+
+.c16 {
+  font-family: IBM Plex Serif,sans-serif;
+  font-size: 24px;
+}
+
+.c19 {
+  height: 60px;
+  width: 385px;
+  border: none;
+  background-color: var(--green);
+  border-radius: 4px;
+  margin-top: 25px;
+  font-size: 16px;
+}
+
 @media only screen and (min-width:0px) and (max-width:736px) {
   .c4 {
     grid-template-columns: [first] 1fr [second] 48px;
@@ -45524,7 +45558,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c16 {
+  .c20 {
     display: none;
   }
 }
@@ -45723,34 +45757,46 @@ Object {
             />
           </header>
           <form>
+            <div
+              class="c16"
+            >
+              Please Log In to Continue
+            </div>
             <label
+              class="c17"
               for="emailAddress"
             >
-              Email address:
-              <input
-                name="emailAddress"
-                type="email"
-              />
+              Email address
             </label>
+            <input
+              class="c18"
+              name="emailAddress"
+              placeholder="Email Address"
+              type="email"
+            />
             <br />
             <label
+              class="c17"
               for="password"
             >
-              Password:
-              <input
-                name="password"
-                type="password"
-              />
+              Password
             </label>
+            <input
+              class="c18"
+              name="password"
+              placeholder="Password"
+              type="password"
+            />
             <br />
             <input
+              class="c19"
               type="submit"
               value="Submit"
             />
           </form>
         </div>
         <div
-          class="c16"
+          class="c20"
         />
       </div>
     </div>
@@ -45949,27 +45995,39 @@ Object {
           />
         </header>
         <form>
+          <div
+            class="sc-kpOJdX cfhpkt"
+          >
+            Please Log In to Continue
+          </div>
           <label
+            class="sc-kgoBCf ekHVMw"
             for="emailAddress"
           >
-            Email address:
-            <input
-              name="emailAddress"
-              type="email"
-            />
+            Email address
           </label>
+          <input
+            class="sc-kGXeez dzsfcf"
+            name="emailAddress"
+            placeholder="Email Address"
+            type="email"
+          />
           <br />
           <label
+            class="sc-kgoBCf ekHVMw"
             for="password"
           >
-            Password:
-            <input
-              name="password"
-              type="password"
-            />
+            Password
           </label>
+          <input
+            class="sc-kGXeez dzsfcf"
+            name="password"
+            placeholder="Password"
+            type="password"
+          />
           <br />
           <input
+            class="sc-dxgOiQ eRjgVl"
             type="submit"
             value="Submit"
           />

--- a/unlock-app/src/components/content/KeyChainContent.js
+++ b/unlock-app/src/components/content/KeyChainContent.js
@@ -44,7 +44,7 @@ KeyChainContent.defaultProps = {
 
 export const mapStateToProps = state => {
   return {
-    account: null, //state.account,
+    account: state.account,
     network: state.network,
   }
 }

--- a/unlock-app/src/components/content/KeyChainContent.js
+++ b/unlock-app/src/components/content/KeyChainContent.js
@@ -8,6 +8,7 @@ import DeveloperOverlay from '../developer/DeveloperOverlay'
 import Layout from '../interface/Layout'
 import Account from '../interface/Account'
 import { pageTitle } from '../../constants'
+import AuthenticationPrompt from '../interface/AuthenticationPrompt'
 
 export const KeyChainContent = ({ account, network }) => {
   return (
@@ -20,6 +21,11 @@ export const KeyChainContent = ({ account, network }) => {
           <BrowserOnly>
             <Account network={network} account={account} />
             <DeveloperOverlay />
+          </BrowserOnly>
+        )}
+        {!account && (
+          <BrowserOnly>
+            <AuthenticationPrompt />
           </BrowserOnly>
         )}
       </Layout>
@@ -38,7 +44,7 @@ KeyChainContent.defaultProps = {
 
 export const mapStateToProps = state => {
   return {
-    account: state.account,
+    account: null, //state.account,
     network: state.network,
   }
 }

--- a/unlock-app/src/components/interface/AuthenticationPrompt.tsx
+++ b/unlock-app/src/components/interface/AuthenticationPrompt.tsx
@@ -18,8 +18,15 @@ export default class AuthenticationPrompt extends React.Component {
     })
   }
 
+  handleSubmit = (event: any) => {
+    // TODO: dispatch an event here to indicate that we have received credentials
+    // TODO: handle failure -> bad password and/or email. Communicate from storageService to here so we can prompt.
+    event.preventDefault()
+  }
+
   render = () => (
-    <form>
+    // TODO: This form needs an actual design.
+    <form onSubmit={this.handleSubmit}>
       <label htmlFor="emailAddress">
         Email address:
         <input
@@ -37,6 +44,8 @@ export default class AuthenticationPrompt extends React.Component {
           onChange={this.handleInputChange}
         />
       </label>
+      <br />
+      <input type="submit" value="Submit" />
     </form>
   )
 }

--- a/unlock-app/src/components/interface/AuthenticationPrompt.tsx
+++ b/unlock-app/src/components/interface/AuthenticationPrompt.tsx
@@ -1,8 +1,24 @@
 import React from 'react'
 import styled from 'styled-components'
+import { connect } from 'react-redux'
+import { gotCredentials } from '../../actions/authentication'
 
-export default class AuthenticationPrompt extends React.Component {
-  constructor(props: any) {
+interface Credentials {
+  emailAddress: string
+  password: string
+}
+
+interface Props {
+  gotCredentials: (credentials: Credentials) => any
+}
+
+interface State {
+  emailAddress: string
+  password: string
+}
+
+class AuthenticationPrompt extends React.Component<Props, State> {
+  constructor(props: Props) {
     super(props)
     this.state = {
       emailAddress: '', // eslint-disable-line react/no-unused-state
@@ -14,14 +30,19 @@ export default class AuthenticationPrompt extends React.Component {
     const { target } = event
     const { value, name } = target
 
-    this.setState({
+    this.setState(prevState => ({
+      ...prevState,
       [name]: value,
-    })
+    }))
   }
 
   handleSubmit = (event: any) => {
-    // TODO: dispatch an event here to indicate that we have received credentials
+    // TODO: Add validation to this form (basic: just ensure that fields are not empty)
+    // TODO: Add loading indicator to cover time between submission and response from storageService
     // TODO: handle failure -> bad password and/or email. Communicate from storageService to here so we can prompt.
+    const { emailAddress, password } = this.state
+    const { gotCredentials } = this.props
+    gotCredentials({ emailAddress, password })
     event.preventDefault()
   }
 
@@ -49,6 +70,17 @@ export default class AuthenticationPrompt extends React.Component {
   )
 }
 
+const mapDispatchToProps = (dispatch: any) => ({
+  gotCredentials: (credentials: Credentials) =>
+    dispatch(gotCredentials(credentials)),
+})
+
+// Only use dispatch, not state
+export default connect(
+  null,
+  mapDispatchToProps
+)(AuthenticationPrompt)
+
 const Label = styled.label`
   display: block;
   text-transform: uppercase;
@@ -71,6 +103,7 @@ const Input = styled.input`
 const Greeting = styled.div`
   font-family: IBM Plex Serif, sans-serif;
   font-size: 24px;
+  color: var(--darkgrey);
 `
 
 const SubmitButton = styled.input`
@@ -81,4 +114,5 @@ const SubmitButton = styled.input`
   border-radius: 4px;
   margin-top: 25px;
   font-size: 16px;
+  cursor: pointer;
 `

--- a/unlock-app/src/components/interface/AuthenticationPrompt.tsx
+++ b/unlock-app/src/components/interface/AuthenticationPrompt.tsx
@@ -17,7 +17,7 @@ interface State {
   password: string
 }
 
-class AuthenticationPrompt extends React.Component<Props, State> {
+export class AuthenticationPrompt extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {

--- a/unlock-app/src/components/interface/AuthenticationPrompt.tsx
+++ b/unlock-app/src/components/interface/AuthenticationPrompt.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'styled-components'
 
 export default class AuthenticationPrompt extends React.Component {
   constructor(props: any) {
@@ -25,27 +26,59 @@ export default class AuthenticationPrompt extends React.Component {
   }
 
   render = () => (
-    // TODO: This form needs an actual design.
     <form onSubmit={this.handleSubmit}>
-      <label htmlFor="emailAddress">
-        Email address:
-        <input
-          name="emailAddress"
-          type="email"
-          onChange={this.handleInputChange}
-        />
-      </label>
+      <Greeting>Please Log In to Continue</Greeting>
+      <Label htmlFor="emailAddress">Email address</Label>
+      <Input
+        name="emailAddress"
+        type="email"
+        placeholder="Email Address"
+        onChange={this.handleInputChange}
+      />
       <br />
-      <label htmlFor="password">
-        Password:
-        <input
-          name="password"
-          type="password"
-          onChange={this.handleInputChange}
-        />
-      </label>
+      <Label htmlFor="password">Password</Label>
+      <Input
+        name="password"
+        type="password"
+        placeholder="Password"
+        onChange={this.handleInputChange}
+      />
       <br />
-      <input type="submit" value="Submit" />
+      <SubmitButton type="submit" value="Submit" />
     </form>
   )
 }
+
+const Label = styled.label`
+  display: block;
+  text-transform: uppercase;
+  font-size: 10px;
+  color: var(--darkgrey);
+  margin-top: 10px;
+  margin-bottom: 5px;
+`
+
+const Input = styled.input`
+  height: 60px;
+  width: 385px;
+  border: none;
+  background-color: var(--lightgrey);
+  border-radius: 4px;
+  padding: 10px;
+  font-size: 16px;
+`
+
+const Greeting = styled.div`
+  font-family: IBM Plex Serif, sans-serif;
+  font-size: 24px;
+`
+
+const SubmitButton = styled.input`
+  height: 60px;
+  width: 385px;
+  border: none;
+  background-color: var(--green);
+  border-radius: 4px;
+  margin-top: 25px;
+  font-size: 16px;
+`

--- a/unlock-app/src/components/interface/AuthenticationPrompt.tsx
+++ b/unlock-app/src/components/interface/AuthenticationPrompt.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+export default class AuthenticationPrompt extends React.Component {
+  constructor(props: any) {
+    super(props)
+    this.state = {
+      emailAddress: '', // eslint-disable-line react/no-unused-state
+      password: '', // eslint-disable-line react/no-unused-state
+    }
+  }
+
+  handleInputChange = (event: any) => {
+    const { target } = event
+    const { value, name } = target
+
+    this.setState({
+      [name]: value,
+    })
+  }
+
+  render = () => (
+    <form>
+      <label htmlFor="emailAddress">
+        Email address:
+        <input
+          name="emailAddress"
+          type="email"
+          onChange={this.handleInputChange}
+        />
+      </label>
+      <br />
+      <label htmlFor="password">
+        Password:
+        <input
+          name="password"
+          type="password"
+          onChange={this.handleInputChange}
+        />
+      </label>
+    </form>
+  )
+}

--- a/unlock-app/src/stories/interface/AuthenticationPrompt.stories.js
+++ b/unlock-app/src/stories/interface/AuthenticationPrompt.stories.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Provider } from 'react-redux'
+
+import AuthenticationPrompt from '../../components/interface/AuthenticationPrompt'
+import createUnlockStore from '../../createUnlockStore'
+
+const store = createUnlockStore({})
+
+storiesOf('Authentication Prompt', module)
+  .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
+  .add('The Prompt', () => {
+    return <AuthenticationPrompt />
+  })

--- a/unlock-app/src/stories/interface/AuthenticationPrompt.stories.js
+++ b/unlock-app/src/stories/interface/AuthenticationPrompt.stories.js
@@ -1,14 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Provider } from 'react-redux'
 
-import AuthenticationPrompt from '../../components/interface/AuthenticationPrompt'
-import createUnlockStore from '../../createUnlockStore'
+import { AuthenticationPrompt } from '../../components/interface/AuthenticationPrompt'
 
-const store = createUnlockStore({})
-
-storiesOf('Authentication Prompt', module)
-  .addDecorator(getStory => <Provider store={store}>{getStory()}</Provider>)
-  .add('The Prompt', () => {
-    return <AuthenticationPrompt />
-  })
+storiesOf('Authentication Prompt', module).add('The Prompt', () => {
+  return <AuthenticationPrompt />
+})


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
As part of the user accounts epic, we need a way to get input from a user so that we can authenticate their account. This PR creates a form component to handle that process and adds it to the key chain page.

- The form is only visible when there is no account
- The key chain page is currently not accessible
- Submitting this form does nothing at the moment because we don't have the infrastructure necessary to actually log someone in.

I'll keep this as a draft for the moment, unless we think it's OK to merge it given the caveats above.


<img width="1250" alt="image" src="https://user-images.githubusercontent.com/9300702/55730621-9ba2d200-59e6-11e9-88c0-3ec406399fc0.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
