### PR TITLE
Add actions needed to coordinate authentication

### DIFF
--- a/unlock-app/src/__tests__/actions/authentication.test.js
+++ b/unlock-app/src/__tests__/actions/authentication.test.js
@@ -1,0 +1,51 @@
+import * as auth from '../../actions/authentication'
+
+describe('authentication actions', () => {
+  it('should create an action to signal receipt of an email', () => {
+    expect.assertions(1)
+    const email = 'geoff@bitconnect.gov'
+    const expectedAction = {
+      type: auth.GOT_EMAIL,
+      emailAddress: email,
+    }
+
+    expect(auth.gotEmail(email)).toEqual(expectedAction)
+  })
+
+  it('should create an action to signal receipt of a password', () => {
+    expect.assertions(1)
+    const password = 'guest'
+    const expectedAction = {
+      type: auth.GOT_PASSWORD,
+      password,
+    }
+
+    expect(auth.gotPassword(password)).toEqual(expectedAction)
+  })
+
+  it('should create an action to signal receipt of both credentials', () => {
+    expect.assertions(1)
+    const password = 'guest'
+    const emailAddress = 'geoff@bitconnect.gov'
+    const expectedAction = {
+      type: auth.GOT_CREDENTIALS,
+      emailAddress,
+      password,
+    }
+
+    expect(auth.gotCredentials({ emailAddress, password })).toEqual(
+      expectedAction
+    )
+  })
+
+  it('should create an action to signal when authentication fails', () => {
+    expect.assertions(1)
+    const reason = 'Could not decrypt private key.'
+    const expectedAction = {
+      type: auth.AUTHENTICATION_FAILED,
+      reason,
+    }
+
+    expect(auth.authenticationFailed(reason)).toEqual(expectedAction)
+  })
+})

--- a/unlock-app/src/actions/authentication.js
+++ b/unlock-app/src/actions/authentication.js
@@ -1,0 +1,29 @@
+export const GOT_EMAIL = 'authentication/GOT_EMAIL'
+export const GOT_PASSWORD = 'authentication/GOT_PASSWORD'
+export const GOT_CREDENTIALS = 'authentication/GOT_CREDENTIALS'
+export const AUTHENTICATION_FAILED = 'authentication/FAILED'
+
+export const gotEmail = emailAddress => ({
+  type: GOT_EMAIL,
+  emailAddress,
+})
+
+export const gotPassword = password => ({
+  type: GOT_PASSWORD,
+  password,
+})
+
+export const gotCredentials = ({ emailAddress, password }) => ({
+  type: GOT_CREDENTIALS,
+  emailAddress,
+  password,
+})
+
+// Should be triggered when the given password can't decrypt the
+// password-encrypted-private-key associated with the given email. We don't need
+// an action for success, because that will be implicit when SET_ACCOUNT is
+// triggered.
+export const authenticationFailed = reason => ({
+  type: AUTHENTICATION_FAILED,
+  reason,
+})


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Another piece of #2414, this PR adds some actions that we can use to coordinate authentication among the various components that may be involved.

New actions for:

- receipt of email address
- receipt of password
- receipt of bundle containing both of above
- failure to authenticate with given credentials

My intention is that these actions should be used only for communication--credentials should not end up in Redux or localStorage.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
