### PR TITLE
use .css for Paywall body instead of styles

### DIFF
--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -373,28 +373,15 @@ describe('Paywall', () => {
         'http://example.com'
       )
     })
-    describe('updating body css', () => {
-      it.each([
-        // TODO: update mobile CSS
-        ['mobile', 412, { display: 'flex', height: '160px' }],
-        ['desktop', 1000, { display: 'flex', height: '160px' }],
-      ])('%s', (type, size, expected) => {
-        expect.assertions(1)
+    it('updating body css', () => {
+      expect.assertions(1)
 
-        fakeWindow.innerWidth = size
-        config.isInIframe = true
-        rtl.act(() => {
-          renderMockPaywall({ locked: false })
-        })
-
-        expect(fakeWindow.document.body.style).toEqual({
-          ...expected,
-          flexDirection: 'column',
-          justifyContent: 'center',
-          margin: '0',
-          overflow: 'hidden',
-        })
+      config.isInIframe = true
+      rtl.act(() => {
+        renderMockPaywall({ locked: false })
       })
+
+      expect(fakeWindow.document.body.className).toBe('small')
     })
   })
 
@@ -449,17 +436,17 @@ describe('Paywall', () => {
   describe('the unlocked flag', () => {
     it('should be present when the paywall is unlocked', () => {
       expect.assertions(1)
-      const { queryByText } = renderMockPaywall({ locked: false })
+      const component = renderMockPaywall({ locked: false })
 
-      const flagText = queryByText('Subscribed with Unlock')
+      const flagText = component.getByText('Subscribed with Unlock')
       expect(flagText).not.toBeNull()
     })
 
     it('should not be present when the paywall is locked', () => {
       expect.assertions(1)
-      const { queryByText } = renderMockPaywall({ locked: true })
+      const component = renderMockPaywall({ locked: true })
 
-      const flagText = queryByText('Subscribed with Unlock')
+      const flagText = component.queryByText('Subscribed with Unlock')
       expect(flagText).toBeNull()
     })
   })

--- a/paywall/src/components/Paywall.css
+++ b/paywall/src/components/Paywall.css
@@ -1,0 +1,21 @@
+body.small {
+  margin: 0;
+  height: 160px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+}
+body.big {
+  margin: 0;
+  height: 100vh;
+  width: 100vw;
+  display: fixed;
+  overflow: initial;
+}
+
+@media only screen and (min-width: 135px) and (max-width: 763px) {
+  body.small {
+    height: 80px;
+  }
+}

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -20,8 +20,8 @@ import useWindow from '../hooks/browser/useWindow'
 import useOptimism from '../hooks/useOptimism'
 import { TRANSACTION_TYPES } from '../constants'
 import withConfig from '../utils/withConfig'
+import './Paywall.css'
 
-// TODO: mobile formatting for unlocked and optimistic unlocking views
 export function Paywall({ locks, locked, redirect, account, transaction }) {
   const optimism = useOptimism(transaction)
   const window = useWindow()
@@ -31,21 +31,11 @@ export function Paywall({ locks, locked, redirect, account, transaction }) {
     validator: isPositiveNumber,
   })
   const { postMessage } = usePostMessage()
-  const height = '160px'
   const smallBody = body => {
-    body.style.margin = '0'
-    body.style.height = height
-    body.style.display = 'flex'
-    body.style.flexDirection = 'column'
-    body.style.justifyContent = 'center'
-    body.style.overflow = 'hidden'
+    body.className = 'small'
   }
   const bigBody = body => {
-    body.style.margin = '0'
-    body.style.height = '100vh'
-    body.style.width = '100vw'
-    body.style.display = 'fixed'
-    body.style.overflow = 'initial'
+    body.className = 'big'
   }
   useEffect(() => {
     if (locked) {


### PR DESCRIPTION
# Description

*NOTE: the mobile layout in the screenshots is broken, this is intentional, as subsequent PRs fix it.*

This is a split-off of the original full UI for mobile styling on the paywall.

<img width="1680" alt="Screen Shot 2019-04-08 at 10 52 36 AM" src="https://user-images.githubusercontent.com/98250/55733947-b1b39100-59ec-11e9-88ee-5646258a593b.png">
<img width="1680" alt="Screen Shot 2019-04-08 at 10 52 32 AM" src="https://user-images.githubusercontent.com/98250/55733948-b24c2780-59ec-11e9-802d-2232e8b78070.png">
<img width="1680" alt="Screen Shot 2019-04-08 at 10 52 28 AM" src="https://user-images.githubusercontent.com/98250/55733949-b24c2780-59ec-11e9-8ccb-27335f767061.png">
<img width="1680" alt="Screen Shot 2019-04-08 at 10 52 06 AM" src="https://user-images.githubusercontent.com/98250/55733951-b2e4be00-59ec-11e9-85fd-927b59da2cd4.png">
<img width="1680" alt="Screen Shot 2019-04-08 at 10 52 00 AM" src="https://user-images.githubusercontent.com/98250/55733952-b2e4be00-59ec-11e9-8bed-e263685e09c0.png">
<img width="1680" alt="Screen Shot 2019-04-08 at 10 51 55 AM" src="https://user-images.githubusercontent.com/98250/55733954-b2e4be00-59ec-11e9-9c91-b176deb47038.png">
<img width="1680" alt="Screen Shot 2019-04-08 at 10 51 51 AM" src="https://user-images.githubusercontent.com/98250/55733955-b2e4be00-59ec-11e9-88f4-cea4dcd5a5ad.png">


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2351 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
