### PR TITLE
the lock is either submitted or confirming based on the speed of the test suite

### DIFF
--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -91,7 +91,7 @@ describe('The Unlock Dashboard', () => {
       await expect(lockText).toMatch(`${expirationDuration} day`) // we use day as this could be singular!
       await expect(lockText).toMatch(`0/${maxNumberOfKeys}`)
       await expect(lockText).toMatch(keyPrice)
-      await expect(lockText).toMatch('Submitted')
+      await expect(lockText).toMatch(/Confirming|Submitted/) // The lock is either submitted or confirming (depending on when the mining happens in the tests)
     })
 
     // This test requires the test above


### PR DESCRIPTION
This will fix the transient issue we see on integration tests.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread