### PR TITLE
Modify shouldFail helper to work when auto-mine is disabled

### DIFF
--- a/smart-contracts/test/helpers/shouldFail.js
+++ b/smart-contracts/test/helpers/shouldFail.js
@@ -15,11 +15,19 @@ module.exports = async function shouldFail(promise, expectedRevertReason) {
   } catch (error) {
     // Using `startsWith` as some error.message may include '-- Reason given: ${expectedRevertReason}.'
     if (!error.message.startsWith(expectedMessage)) {
-      throw new Error(
-        `shouldFail reason for revert does not match. Got "${
-          error.message
-        }"; expected "${expectedMessage}"`
-      )
+      // Check for an alternate message format
+      expectedMessage = 'exited with an error (status 0).'
+      if (expectedRevertReason) {
+        expectedMessage += ` Reason given: ${expectedRevertReason}.`
+      }
+
+      if (!error.message.includes(expectedMessage)) {
+        throw new Error(
+          `shouldFail reason for revert does not match. Got "${
+            error.message
+          }"; expected "${expectedMessage}"`
+        )
+      }
     }
     return
   }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

When auto-mine is disabled in Ganache, the message provided when an error thrown is different.  This PR changes the `shouldFail` helper method to support either message format.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #2466

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
