### PR TITLE
Rejecting signatures accompanying purchase requests that have expired

### DIFF
--- a/locksmith/__tests__/controllers/purchaseController.test.js
+++ b/locksmith/__tests__/controllers/purchaseController.test.js
@@ -67,5 +67,30 @@ describe('Purchase Controller', () => {
         expect(response.statusCode).toBe(202)
       })
     })
+
+    describe('when the purchase request is past its expiry window', () => {
+      let message = {
+        purchaseRequest: {
+          recipient: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+          lock: '0xe4906CE8a8E861339F75611c129b9679EDAe7bBD',
+          expiry: 702764221,
+        },
+      }
+
+      let typedData = generateTypedData(message)
+
+      const sig = sigUtil.signTypedData(privateKey, {
+        data: typedData,
+      })
+      it('responds with a 412', async () => {
+        expect.assertions(1)
+        let response = await request(app)
+          .post('/purchase')
+          .set('Accept', /json/)
+          .set('Authorization', `Bearer ${Base64.encode(sig)}`)
+          .send(typedData)
+        expect(response.statusCode).toBe(412)
+      })
+    })
   })
 })

--- a/locksmith/src/controllers/purchaseController.ts
+++ b/locksmith/src/controllers/purchaseController.ts
@@ -2,10 +2,14 @@ import { Request, Response } from 'express-serve-static-core' // eslint-disable-
 
 namespace PurchaseController {
   //eslint-disable-next-line import/prefer-default-export
-  export const purchase = async (
-    _req: Request,
-    res: Response
-  ): Promise<any> => {
+  export const purchase = async (req: Request, res: Response): Promise<any> => {
+    let currentTime = Math.floor(Date.now() / 1000)
+    const expiry = req.body.message.purchaseRequest.expiry
+
+    if (expiry < currentTime) {
+      return res.sendStatus(412)
+    }
+
     return res.sendStatus(202)
   }
 }


### PR DESCRIPTION
# Description

Signatures with out an expiry check are subject to replay. The associated risk is attached to the use case of the signature.

In our case, we would like to avoid signature replay here.
It may be worth moving this to middleware but let's see if we have a further use case first.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
