### PR TITLE
paywall body height in mobile view should be 43px (bad rebase)

### DIFF
--- a/paywall/src/components/Paywall.css
+++ b/paywall/src/components/Paywall.css
@@ -16,6 +16,6 @@ body.big {
 
 @media only screen and (min-width: 135px) and (max-width: 763px) {
   body.small {
-    height: 80px;
+    height: 43px;
   }
 }


### PR DESCRIPTION
# Description

1 more PR, a bad rebase blew away the `43px` size for body in mobile view, causing the flag to be below the screen.

<img width="498" alt="Screen Shot 2019-04-08 at 5 55 42 PM" src="https://user-images.githubusercontent.com/98250/55759606-c5301d80-5a27-11e9-8b04-659cd6f65440.png">
<img width="498" alt="Screen Shot 2019-04-08 at 5 55 15 PM" src="https://user-images.githubusercontent.com/98250/55759609-c6614a80-5a27-11e9-87d3-db0fb37e76e3.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2344 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
