### PR TITLE
Add actions related to signup flow

### DIFF
--- a/unlock-app/src/__tests__/actions/signUp.test.js
+++ b/unlock-app/src/__tests__/actions/signUp.test.js
@@ -1,0 +1,60 @@
+import * as s from '../../actions/signUp'
+
+describe('signup actions', () => {
+  it('should create an action indicating an email has been submitted', () => {
+    expect.assertions(1)
+    const emailAddress = 'ray@smuckles.escalade'
+    const expectedAction = {
+      type: s.SIGNUP_EMAIL,
+      emailAddress,
+    }
+
+    expect(s.signupEmail(emailAddress)).toEqual(expectedAction)
+  })
+
+  it('should create an action indicating a password has been submitted', () => {
+    expect.assertions(1)
+    const password = 'entropy9'
+    const expectedAction = {
+      type: s.SIGNUP_PASSWORD,
+      password,
+    }
+
+    expect(s.signupPassword(password)).toEqual(expectedAction)
+  })
+
+  it('should create an action indicating a bundle of credentials has been submitted', () => {
+    expect.assertions(1)
+    const password = 'entropy9'
+    const emailAddress = 'ray@smuckles.escalade'
+    const expectedAction = {
+      type: s.SIGNUP_CREDENTIALS,
+      password,
+      emailAddress,
+    }
+
+    expect(s.signupCredentials({ password, emailAddress })).toEqual(
+      expectedAction
+    )
+  })
+
+  it('should create an action indicating a signup has failed', () => {
+    expect.assertions(1)
+    const reason = 'The email is already in use.'
+    const expectedAction = {
+      type: s.SIGNUP_FAILED,
+      reason,
+    }
+
+    expect(s.signupFailed(reason)).toEqual(expectedAction)
+  })
+
+  it('should create an action indicating a signup has succeeded', () => {
+    expect.assertions(1)
+    const expectedAction = {
+      type: s.SIGNUP_SUCCEEDED,
+    }
+
+    expect(s.signupSucceeded()).toEqual(expectedAction)
+  })
+})

--- a/unlock-app/src/actions/signUp.js
+++ b/unlock-app/src/actions/signUp.js
@@ -1,0 +1,32 @@
+export const SIGNUP_EMAIL = 'signup/GOT_EMAIL'
+export const SIGNUP_PASSWORD = 'signup/GOT_PASSWORD'
+export const SIGNUP_CREDENTIALS = 'signup/GOT_CREDENTIALS'
+export const SIGNUP_FAILED = 'signup/FAILED'
+export const SIGNUP_SUCCEEDED = 'signup/SUCCESS'
+
+export const signupEmail = emailAddress => ({
+  type: SIGNUP_EMAIL,
+  emailAddress,
+})
+
+export const signupPassword = password => ({
+  type: SIGNUP_PASSWORD,
+  password,
+})
+
+export const signupCredentials = ({ emailAddress, password }) => ({
+  type: SIGNUP_CREDENTIALS,
+  emailAddress,
+  password,
+})
+
+// Should be triggered when signup fails for any reason (email already in use...)
+export const signupFailed = reason => ({
+  type: SIGNUP_FAILED,
+  reason,
+})
+
+// TODO: Determine if this action requires a payload. Depends on exact way signup works.
+export const signupSucceeded = () => ({
+  type: SIGNUP_SUCCEEDED,
+})


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Related to #2111, we need actions to dispatch when we get credentials from a user. This PR adds them.

- got password
- got email
- got email/password combo
- signup failed (with a reason)
- signup succeeded

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
