### PR TITLE
Resort inheritance order

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -26,21 +26,21 @@ import './mixins/MixinTransfer.sol';
  * https://eips.ethereum.org/EIPS/eip-721
  */
 contract PublicLock is
-  MixinNoFallback,
-  ERC721Holder,
   IERC721,
+  MixinNoFallback,
   ERC165,
   Ownable,
+  ERC721Holder,
+  MixinLockMetadata,
   MixinFunds,
   MixinDisableAndDestroy,
   MixinLockCore,
   MixinKeys,
   MixinGrantKeys,
-  MixinApproval,
-  MixinLockMetadata,
-  MixinRefunds,
   MixinPurchase,
-  MixinTransfer
+  MixinApproval,
+  MixinTransfer,
+  MixinRefunds
 {
   constructor(
     address _owner,

--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -35,7 +35,12 @@ import './mixins/MixinNoFallback.sol';
 
 /// @dev Must list the direct base contracts in the order from “most base-like” to “most derived”.
 /// https://solidity.readthedocs.io/en/latest/contracts.html#multiple-inheritance-and-linearization
-contract Unlock is MixinNoFallback, IUnlock, Initializable, Ownable {
+contract Unlock is
+  IUnlock,
+  MixinNoFallback,
+  Initializable,
+  Ownable
+{
 
   /**
    * The struct for a lock


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Updating the inheritance order to match the best practice of most base-like to most derived. 

For Unlock: the change is about listing all interfaces before concrete contracts.

For Lock: 
 - all interfaces before concrete contracts
 - 165 is next since that could be used by any of the other mixins that follow
 - Ownable before 721Holder since ownable is a common feature used by many contracts while 721holder seems a bit more specific to our use case
 - Metadata moved up since it doesn't actually do anything important to our use case
 - Purchase before approval, since you need a key before it makes sense to consider a transfer
 - Refunds moved down because you can't refund a key before purchasing one.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2178 
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
