### PR TITLE
Adds a check around Lock authorization

### DIFF
--- a/locksmith/__tests__/operations/authorizedLockOperations.test.ts
+++ b/locksmith/__tests__/operations/authorizedLockOperations.test.ts
@@ -1,0 +1,34 @@
+import AuthorizedLockOperations from '../../src/operations/authorizedLockOperations'
+
+const models = require('../../src/models')
+
+let AuthorizedLock: any = models.AuthorizedLock
+
+describe('hasAuthorization', () => {
+  let authorizedLock = '0xDc0731517234d0A13a4Da4572b9caC56d0cF5c29'
+  let unauthorizedLock = '0xAc442c26177a33B255E811Ea2736234bCB4bCf96'
+  AuthorizedLock.count = jest
+    .fn()
+    .mockReturnValueOnce(0)
+    .mockReturnValueOnce(1)
+
+  describe('when the provided address has not been authorized', () => {
+    it('returns false', async () => {
+      expect.assertions(1)
+      let result = await AuthorizedLockOperations.hasAuthorization(
+        authorizedLock
+      )
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('when the provided address has been authorized', () => {
+    it('returns true', async () => {
+      expect.assertions(1)
+      let result = await AuthorizedLockOperations.hasAuthorization(
+        unauthorizedLock
+      )
+      expect(result).toBe(true)
+    })
+  })
+})

--- a/locksmith/migrations/20190408215635-create-authorized-lock.js
+++ b/locksmith/migrations/20190408215635-create-authorized-lock.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('AuthorizedLocks', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      address: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      authorizedAt: {
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('AuthorizedLocks');
+  }
+};

--- a/locksmith/src/controllers/purchaseController.ts
+++ b/locksmith/src/controllers/purchaseController.ts
@@ -1,13 +1,19 @@
 import { Request, Response } from 'express-serve-static-core' // eslint-disable-line no-unused-vars, import/no-unresolved
+import AuthorizedLockOperations from '../operations/authorizedLockOperations'
 
 namespace PurchaseController {
   //eslint-disable-next-line import/prefer-default-export
   export const purchase = async (req: Request, res: Response): Promise<any> => {
     let currentTime = Math.floor(Date.now() / 1000)
     const expiry = req.body.message.purchaseRequest.expiry
+    const lockAddress = req.body.message.purchaseRequest.lock
 
     if (expiry < currentTime) {
       return res.sendStatus(412)
+    }
+
+    if (!(await AuthorizedLockOperations.hasAuthorization(lockAddress))) {
+      return res.sendStatus(451)
     }
 
     return res.sendStatus(202)

--- a/locksmith/src/models/authorizedLock.js
+++ b/locksmith/src/models/authorizedLock.js
@@ -1,0 +1,16 @@
+'use strict'
+module.exports = (sequelize, DataTypes) => {
+  const AuthorizedLock = sequelize.define(
+    'AuthorizedLock',
+    {
+      address: DataTypes.STRING,
+      authorizedAt: DataTypes.DATE,
+    },
+    {}
+  )
+  // AuthorizedLock.associate= function(models) {
+  AuthorizedLock.associate = function() {
+    // associations can be defined here
+  }
+  return AuthorizedLock
+}

--- a/locksmith/src/operations/authorizedLockOperations.ts
+++ b/locksmith/src/operations/authorizedLockOperations.ts
@@ -1,0 +1,25 @@
+import * as Normalizer from '../utils/normalizer'
+
+const models = require('../models')
+
+const { AuthorizedLock } = models
+import Sequelize = require('sequelize')
+
+const Op = Sequelize.Op
+
+namespace AuthorizedLockOperations {
+  // eslint-disable-next-line import/prefer-default-export
+  export const hasAuthorization = async (address: string): Promise<boolean> => {
+    let authorizedLockCount = await AuthorizedLock.count({
+      where: {
+        address: {
+          [Op.eq]: Normalizer.ethereumAddress(address),
+        },
+      },
+    })
+
+    return authorizedLockCount > 0
+  }
+}
+
+export = AuthorizedLockOperations


### PR DESCRIPTION
# Description

As part of the work of being able to purchase keys on a
user's behalf we need to ensure that the Locks being referenced
have been authorized for this premium feature.

This commit adds the boiler plate a well as the evaluation around authorization.

**this shouldn't be merged in until the newer deployment approach has been updated to handle migrations**

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
