### PR TITLE
stringifying the error message

### DIFF
--- a/wedlocks/src/__tests__/handler.test.js
+++ b/wedlocks/src/__tests__/handler.test.js
@@ -106,10 +106,12 @@ describe('handler', () => {
     const body = {
       hello: 'world',
     }
-    const error = 'Could not send email'
+    const error = {
+      error: 'Could not send email',
+    }
     route.mockImplementationOnce((_body, _callback) => {
       expect(_body).toEqual(body)
-      return _callback('Could not send email')
+      return _callback(error)
     })
 
     handler(
@@ -123,7 +125,7 @@ describe('handler', () => {
       {},
       (_error, response) => {
         expect(response.statusCode).toBe(400)
-        expect(response.body).toBe(error)
+        expect(response.body).toBe(JSON.stringify(error))
         done()
       }
     )

--- a/wedlocks/src/handler.js
+++ b/wedlocks/src/handler.js
@@ -32,7 +32,7 @@ export const handler = (event, context, callback) => {
       if (error) {
         return callback(null, {
           statusCode: 400,
-          body: error,
+          body: JSON.stringify(error),
         })
       }
       return callback(null, {


### PR DESCRIPTION
This is a very minor fix for wedlocks which lets us see error messages on exceptions.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread