### PR TITLE
Add wedlocks address to config

### DIFF
--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -14,6 +14,7 @@ let requiredConfigVariables = {
   paywallScriptUrl: process.env.PAYWALL_SCRIPT_URL,
   readOnlyProvider: process.env.READ_ONLY_PROVIDER,
   locksmithHost: process.env.LOCKSMITH_URI,
+  wedlocksHost: process.env.WEDLOCKS_URI,
 }
 
 let optionalConfigVariables = {

--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -14,7 +14,7 @@ let requiredConfigVariables = {
   paywallScriptUrl: process.env.PAYWALL_SCRIPT_URL,
   readOnlyProvider: process.env.READ_ONLY_PROVIDER,
   locksmithHost: process.env.LOCKSMITH_URI,
-  wedlocksHost: process.env.WEDLOCKS_URI,
+  wedlocksUri: process.env.WEDLOCKS_URI,
 }
 
 let optionalConfigVariables = {

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -102,6 +102,9 @@ export default function configure(
     services['storage'] = {
       host: runtimeConfig.locksmithHost || 'http://127.0.0.1:8080',
     }
+    services['wedlocks'] = {
+      host: runtimeConfig.wedlocksHost || 'http://127.0.0.1:1337',
+    }
     isRequiredNetwork = networkId => networkId === 1984
   }
 
@@ -113,6 +116,9 @@ export default function configure(
     )
     services['storage'] = {
       host: runtimeConfig.locksmithHost || 'http://127.0.0.1:8080',
+    }
+    services['wedlocks'] = {
+      host: runtimeConfig.wedlocksHost || 'http://127.0.0.1:1337',
     }
 
     // If there is an existing web3 injected provider, we also add this one to the list of possible providers
@@ -146,6 +152,7 @@ export default function configure(
     paywallUrl = 'https://'
     supportedProviders = ['Metamask', 'Opera']
     services['storage'] = { host: runtimeConfig.locksmithHost }
+    services['wedlocks'] = { host: runtimeConfig.wedlocksHost }
     paywallUrl = runtimeConfig.paywallUrl
     paywallScriptUrl = runtimeConfig.paywallScriptUrl
 
@@ -171,6 +178,7 @@ export default function configure(
 
     supportedProviders = ['Metamask', 'Opera']
     services['storage'] = { host: runtimeConfig.locksmithHost }
+    services['wedlocks'] = { host: runtimeConfig.wedlocksHost }
     paywallUrl = runtimeConfig.paywallUrl
     paywallScriptUrl = runtimeConfig.paywallScriptUrl
 

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -103,7 +103,7 @@ export default function configure(
       host: runtimeConfig.locksmithHost || 'http://127.0.0.1:8080',
     }
     services['wedlocks'] = {
-      host: runtimeConfig.wedlocksHost || 'http://127.0.0.1:1337',
+      host: runtimeConfig.wedlocksUri || 'http://127.0.0.1:1337',
     }
     isRequiredNetwork = networkId => networkId === 1984
   }
@@ -118,7 +118,7 @@ export default function configure(
       host: runtimeConfig.locksmithHost || 'http://127.0.0.1:8080',
     }
     services['wedlocks'] = {
-      host: runtimeConfig.wedlocksHost || 'http://127.0.0.1:1337',
+      host: runtimeConfig.wedlocksUri || 'http://127.0.0.1:1337',
     }
 
     // If there is an existing web3 injected provider, we also add this one to the list of possible providers
@@ -152,7 +152,7 @@ export default function configure(
     paywallUrl = 'https://'
     supportedProviders = ['Metamask', 'Opera']
     services['storage'] = { host: runtimeConfig.locksmithHost }
-    services['wedlocks'] = { host: runtimeConfig.wedlocksHost }
+    services['wedlocks'] = { host: runtimeConfig.wedlocksUri }
     paywallUrl = runtimeConfig.paywallUrl
     paywallScriptUrl = runtimeConfig.paywallScriptUrl
 
@@ -178,7 +178,7 @@ export default function configure(
 
     supportedProviders = ['Metamask', 'Opera']
     services['storage'] = { host: runtimeConfig.locksmithHost }
-    services['wedlocks'] = { host: runtimeConfig.wedlocksHost }
+    services['wedlocks'] = { host: runtimeConfig.wedlocksUri }
     paywallUrl = runtimeConfig.paywallUrl
     paywallScriptUrl = runtimeConfig.paywallScriptUrl
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Part of #2111, we need to fire off emails to confirm users during the signup process. To do that, we need to talk to `wedlocks`. To do that, we need to know where `wedlocks` is. This PR adds configuration to locate it.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
