### PR TITLE
enable storage middleware for transactions

### DIFF
--- a/paywall/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,0 +1,121 @@
+import storageMiddleware from '../../middlewares/storageMiddleware'
+import { addTransaction, NEW_TRANSACTION } from '../../actions/transaction'
+import { SET_ACCOUNT } from '../../actions/accounts'
+import configure from '../../config'
+
+/**
+ * This is a "fake" middleware caller
+ * Taken from https://redux.js.org/recipes/writing-tests#middleware
+ */
+
+let state
+let account
+let lock
+let network
+
+const create = () => {
+  const config = configure()
+  const store = {
+    getState: jest.fn(() => state),
+    dispatch: jest.fn(() => true),
+  }
+  const next = jest.fn()
+  const handler = storageMiddleware(config)(store)
+  const invoke = action => handler(next)(action)
+  return { next, invoke, store }
+}
+
+let mockStorageService = {}
+
+jest.mock('../../services/storageService', () => {
+  return function() {
+    return mockStorageService
+  }
+})
+
+describe('Storage middleware', () => {
+  beforeEach(() => {
+    account = {
+      address: '0xabc',
+    }
+    network = {
+      name: 'test',
+    }
+    lock = {
+      address: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      keyPrice: '100',
+      owner: account.address,
+    }
+    state = {
+      account,
+      network,
+      provider: 'HTTP',
+      locks: {
+        [lock.address]: lock,
+      },
+      keys: {},
+    }
+    // reset the mock
+    mockStorageService = {}
+  })
+
+  describe('handling NEW_TRANSACTION', () => {
+    it('should store the transaction', async () => {
+      expect.assertions(2)
+      const { next, invoke } = create()
+      const transaction = {
+        hash: '0x123',
+        to: 'unlock',
+        from: 'julien',
+      }
+      const action = { type: NEW_TRANSACTION, transaction }
+
+      mockStorageService.storeTransaction = jest.fn(() => {
+        return Promise.resolve()
+      })
+      await invoke(action)
+      expect(mockStorageService.storeTransaction).toHaveBeenCalledWith(
+        transaction.hash,
+        transaction.from,
+        transaction.to
+      )
+      expect(next).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('handling SET_ACCOUNT', () => {
+    it('should retrieve the transactions for that user', async () => {
+      expect.assertions(4)
+      const { next, invoke, store } = create()
+      const account = {
+        address: '0x123',
+      }
+      const action = { type: SET_ACCOUNT, account }
+
+      mockStorageService.getTransactionsHashesSentBy = jest.fn(() => {
+        return Promise.resolve(['0xabc', '0xdef'])
+      })
+      await invoke(action)
+
+      expect(
+        mockStorageService.getTransactionsHashesSentBy
+      ).toHaveBeenCalledWith(account.address)
+
+      expect(store.dispatch).toHaveBeenNthCalledWith(
+        1,
+        addTransaction({
+          hash: '0xabc',
+        })
+      )
+
+      expect(store.dispatch).toHaveBeenNthCalledWith(
+        2,
+        addTransaction({
+          hash: '0xdef',
+        })
+      )
+
+      expect(next).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/paywall/src/__tests__/services/storageService.test.js
+++ b/paywall/src/__tests__/services/storageService.test.js
@@ -1,0 +1,50 @@
+import axios from 'axios'
+import StorageService from '../../services/storageService'
+
+jest.mock('axios')
+
+describe('StorageService', () => {
+  const serviceHost = 'http://127.0.0.1:8080'
+  const storageService = new StorageService(serviceHost)
+
+  describe('getTransactionsHashesSentBy', () => {
+    it('should expect a list of transactions hashes', async () => {
+      expect.assertions(2)
+      const sender = '0x123'
+      axios.get.mockReturnValue({
+        data: {
+          transactions: [
+            { transactionHash: '0x123', sender: '0xabc', recipient: '0xcde' },
+            { transactionHash: '0x456', sender: '0xabc', recipient: '0xfgh' },
+          ],
+        },
+      })
+      const hashes = await storageService.getTransactionsHashesSentBy(sender)
+      expect(hashes).toEqual(['0x123', '0x456'])
+      expect(axios.get).toHaveBeenCalledWith(
+        `${serviceHost}/transactions?sender=${sender}`
+      )
+    })
+  })
+
+  describe('storeTransaction', () => {
+    it('returns a successful promise', async () => {
+      expect.assertions(1)
+      const transactionHash = ' 0xhash'
+      const senderAddress = ' 0xsender'
+      const recipientAddress = ' 0xrecipient'
+      axios.post.mockReturnValue({})
+
+      await storageService.storeTransaction(
+        transactionHash,
+        senderAddress,
+        recipientAddress
+      )
+      expect(axios.post).toHaveBeenCalledWith(`${serviceHost}/transaction`, {
+        transactionHash,
+        sender: senderAddress,
+        recipient: recipientAddress,
+      })
+    })
+  })
+})

--- a/paywall/src/middlewares/storageMiddleware.js
+++ b/paywall/src/middlewares/storageMiddleware.js
@@ -1,0 +1,57 @@
+/* eslint promise/prefer-await-to-then: 0 */
+import { batch } from 'react-redux'
+
+import StorageService from '../services/storageService'
+import { storageError } from '../actions/storage'
+
+import { NEW_TRANSACTION, addTransaction } from '../actions/transaction'
+import { SET_ACCOUNT } from '../actions/accounts'
+
+const storageMiddleware = config => {
+  const { services } = config
+  return ({ dispatch }) => {
+    const storageService = new StorageService(services.storage.host)
+
+    return next => {
+      return action => {
+        // TODO: never async/await middlewares
+        if (action.type === SET_ACCOUNT) {
+          // When we set the account, we want to retrieve the list of transactions
+          storageService
+            .getTransactionsHashesSentBy(action.account.address)
+            .then(transactionHashes => {
+              // Dispatch each transaction, but only trigger 1 re-render
+              batch(() =>
+                transactionHashes.forEach(hash => {
+                  dispatch(
+                    addTransaction({
+                      hash,
+                    })
+                  )
+                })
+              )
+            })
+            .catch(error => {
+              dispatch(storageError(error))
+            })
+        }
+
+        if (action.type === NEW_TRANSACTION) {
+          // Storing a new transaction so that we can easoly point to it later on
+          storageService
+            .storeTransaction(
+              action.transaction.hash,
+              action.transaction.from,
+              action.transaction.to
+            )
+            .catch(error => {
+              dispatch(storageError(error))
+            })
+        }
+        next(action)
+      }
+    }
+  }
+}
+
+export default storageMiddleware

--- a/paywall/src/pages/_app.js
+++ b/paywall/src/pages/_app.js
@@ -17,6 +17,7 @@ import currencyConversionMiddleware from '../middlewares/currencyConversionMiddl
 import walletMiddleware from '../middlewares/walletMiddleware'
 import interWindowCommunicationMiddleware from '../middlewares/interWindowCommunicationMiddleware'
 import { WindowContext } from '../hooks/browser/useWindow'
+import storageMiddleware from '../middlewares/storageMiddleware'
 
 const config = configure()
 
@@ -28,6 +29,7 @@ function getOrCreateStore(initialState, history) {
     web3Middleware,
     currencyConversionMiddleware,
     walletMiddleware,
+    storageMiddleware(config),
   ]
 
   // Always make a new store if server, otherwise state is shared between requests

--- a/paywall/src/services/storageService.js
+++ b/paywall/src/services/storageService.js
@@ -1,0 +1,38 @@
+import axios from 'axios'
+
+export default class StorageService {
+  constructor(host) {
+    this.host = host
+  }
+
+  /**
+   * Stores transaction hashes and the sender
+   * @param {*} transactionHash
+   * @param {*} senderAddress
+   * @param {*} recipientAddress
+   */
+  storeTransaction(transactionHash, senderAddress, recipientAddress) {
+    const payload = {
+      transactionHash,
+      sender: senderAddress,
+      recipient: recipientAddress,
+    }
+    return axios.post(`${this.host}/transaction`, payload)
+  }
+
+  /**
+   * Gets all the transactions sent by a given address.
+   * Returns an empty array by default
+   * TODO: consider a more robust url building
+   * @param {*} senderAddress
+   */
+  async getTransactionsHashesSentBy(senderAddress) {
+    const response = await axios.get(
+      `${this.host}/transactions?sender=${senderAddress}`
+    )
+    if (response.data && response.data.transactions) {
+      return response.data.transactions.map(t => t.transactionHash)
+    }
+    return []
+  }
+}


### PR DESCRIPTION
# Description

*(adding Akeem because of the locksmith element)*

This fixes the issue with a refresh not preserving the key purchase transaction by adding in an abbreviated version of the `storageService` and `storageMiddleware`, one that only sends and retrieves transactions from locksmith. Screencast shows starting a key purchase and then refreshing the page, and preserving the transaction in progress.

This is the last PR for optimistic unlocking!

![out](https://user-images.githubusercontent.com/98250/55906967-81622300-5ba3-11e9-9f85-be1c85d86023.gif)


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2571 #1081 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
