### PR TITLE
enable typescript in the next app

### DIFF
--- a/paywall/next.config.js
+++ b/paywall/next.config.js
@@ -3,7 +3,6 @@
 const fs = require('fs')
 const { join } = require('path')
 const { promisify } = require('util')
-const withSourceMaps = require('@zeit/next-source-maps')
 const withCSS = require('@zeit/next-css')
 const withTypescript = require('@zeit/next-typescript')
 
@@ -34,46 +33,44 @@ Object.keys(requiredConfigVariables).forEach(configVariableName => {
 })
 
 module.exports = withTypescript(
-  withSourceMaps(
-    withCSS({
-      publicRuntimeConfig: {
-        ...optionalConfigVariables,
-        ...requiredConfigVariables,
-      },
-      webpack: config => {
-        // Fixes npm packages that depend on `fs` module
-        config.node = {
-          fs: 'empty',
-        }
+  withCSS({
+    publicRuntimeConfig: {
+      ...optionalConfigVariables,
+      ...requiredConfigVariables,
+    },
+    webpack: config => {
+      // Fixes npm packages that depend on `fs` module
+      config.node = {
+        fs: 'empty',
+      }
 
-        return config
-      },
-      exportPathMap: async (defaultPathMap, { dev, dir, outDir }) => {
-        // Export robots.txt and humans.txt in non-dev environments
-        if (!dev && outDir) {
-          await copyFile(
-            join(dir, 'static', 'robots.txt'),
-            join(outDir, 'robots.txt')
-          )
+      return config
+    },
+    exportPathMap: async (defaultPathMap, { dev, dir, outDir }) => {
+      // Export robots.txt and humans.txt in non-dev environments
+      if (!dev && outDir) {
+        await copyFile(
+          join(dir, 'static', 'robots.txt'),
+          join(outDir, 'robots.txt')
+        )
 
-          await copyFile(
-            join(dir, 'static', 'humans.txt'),
-            join(outDir, 'humans.txt')
-          )
+        await copyFile(
+          join(dir, 'static', 'humans.txt'),
+          join(outDir, 'humans.txt')
+        )
 
-          // Export _redirects which is used by netlify for URL rewrites
-          await copyFile(
-            join(dir, 'static', '_redirects'),
-            join(outDir, '_redirects')
-          )
-        }
+        // Export _redirects which is used by netlify for URL rewrites
+        await copyFile(
+          join(dir, 'static', '_redirects'),
+          join(outDir, '_redirects')
+        )
+      }
 
-        return {
-          '/': { page: '/home' },
-          '/paywall': { page: '/paywall' },
-          '/demo': { page: '/demo' },
-        }
-      },
-    })
-  )
+      return {
+        '/': { page: '/home' },
+        '/paywall': { page: '/paywall' },
+        '/demo': { page: '/demo' },
+      }
+    },
+  })
 )

--- a/paywall/next.config.js
+++ b/paywall/next.config.js
@@ -5,6 +5,7 @@ const { join } = require('path')
 const { promisify } = require('util')
 const withSourceMaps = require('@zeit/next-source-maps')
 const withCSS = require('@zeit/next-css')
+const withTypescript = require('@zeit/next-typescript')
 
 const copyFile = promisify(fs.copyFile)
 
@@ -32,45 +33,47 @@ Object.keys(requiredConfigVariables).forEach(configVariableName => {
   }
 })
 
-module.exports = withSourceMaps(
-  withCSS({
-    publicRuntimeConfig: {
-      ...optionalConfigVariables,
-      ...requiredConfigVariables,
-    },
-    webpack: config => {
-      // Fixes npm packages that depend on `fs` module
-      config.node = {
-        fs: 'empty',
-      }
+module.exports = withTypescript(
+  withSourceMaps(
+    withCSS({
+      publicRuntimeConfig: {
+        ...optionalConfigVariables,
+        ...requiredConfigVariables,
+      },
+      webpack: config => {
+        // Fixes npm packages that depend on `fs` module
+        config.node = {
+          fs: 'empty',
+        }
 
-      return config
-    },
-    exportPathMap: async (defaultPathMap, { dev, dir, outDir }) => {
-      // Export robots.txt and humans.txt in non-dev environments
-      if (!dev && outDir) {
-        await copyFile(
-          join(dir, 'static', 'robots.txt'),
-          join(outDir, 'robots.txt')
-        )
+        return config
+      },
+      exportPathMap: async (defaultPathMap, { dev, dir, outDir }) => {
+        // Export robots.txt and humans.txt in non-dev environments
+        if (!dev && outDir) {
+          await copyFile(
+            join(dir, 'static', 'robots.txt'),
+            join(outDir, 'robots.txt')
+          )
 
-        await copyFile(
-          join(dir, 'static', 'humans.txt'),
-          join(outDir, 'humans.txt')
-        )
+          await copyFile(
+            join(dir, 'static', 'humans.txt'),
+            join(outDir, 'humans.txt')
+          )
 
-        // Export _redirects which is used by netlify for URL rewrites
-        await copyFile(
-          join(dir, 'static', '_redirects'),
-          join(outDir, '_redirects')
-        )
-      }
+          // Export _redirects which is used by netlify for URL rewrites
+          await copyFile(
+            join(dir, 'static', '_redirects'),
+            join(outDir, '_redirects')
+          )
+        }
 
-      return {
-        '/': { page: '/home' },
-        '/paywall': { page: '/paywall' },
-        '/demo': { page: '/demo' },
-      }
-    },
-  })
+        return {
+          '/': { page: '/home' },
+          '/paywall': { page: '/paywall' },
+          '/demo': { page: '/demo' },
+        }
+      },
+    })
+  )
 )


### PR DESCRIPTION
# Description

This adds the `withTypescript` decorator to `next.config.js`, which is needed in order to run any typescript inside paywall/

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2571

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
