### PR TITLE
Making more of next.config.js testable

### DIFF
--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -1,11 +1,7 @@
 /* eslint no-console: 0 */
 
-const fs = require('fs')
-const { join } = require('path')
-const { promisify } = require('util')
 const withTypescript = require('@zeit/next-typescript')
-
-const copyFile = promisify(fs.copyFile)
+const { exportPaths } = require('./src/utils/exportStatic')
 
 // TODO renames these: URLs need to be URLs, hosts need to be hosts... etc
 let requiredConfigVariables = {
@@ -43,35 +39,5 @@ module.exports = withTypescript({
   webpack(config) {
     return config
   },
-  exportPathMap: async (defaultPathMap, { dev, dir, outDir }) => {
-    // Export robots.txt and humans.txt in non-dev environments
-    if (!dev && outDir) {
-      await copyFile(
-        join(dir, 'static', 'robots.txt'),
-        join(outDir, 'robots.txt')
-      )
-      await copyFile(
-        join(dir, 'static', 'humans.txt'),
-        join(outDir, 'humans.txt')
-      )
-
-      // Export _redirects which is used by netlify for URL rewrites
-      await copyFile(
-        join(dir, 'static', '_redirects'),
-        join(outDir, '_redirects')
-      )
-    }
-
-    // Our statically-defined pages to export
-    return {
-      '/': { page: '/home' },
-      '/about': { page: '/about' },
-      '/jobs': { page: '/jobs' },
-      '/dashboard': { page: '/dashboard' },
-      '/keychain': { page: '/keyChain' },
-      '/terms': { page: '/terms' },
-      '/privacy': { page: '/privacy' },
-      '/log': { page: '/log' },
-    }
-  },
+  exportPathMap: exportPaths,
 })

--- a/unlock-app/src/__tests__/utils/exportStatic.test.js
+++ b/unlock-app/src/__tests__/utils/exportStatic.test.js
@@ -1,0 +1,53 @@
+describe('exportStatic', () => {
+  beforeEach(() => {
+    jest.resetModules()
+
+    jest.mock('fs', () => ({
+      copyFileSync: jest.fn(() => {}),
+    }))
+  })
+
+  it('should copy files when not in dev mode', async () => {
+    expect.assertions(7)
+
+    const { copyFileSync } = require('fs')
+    const { moveStaticFiles } = require('../../utils/exportStatic')
+    moveStaticFiles(false, '/foo/bar', '/alice/bob')
+
+    expect(copyFileSync.mock.calls.length).toBe(3)
+    expect(copyFileSync.mock.calls[0][0]).toBe('/foo/bar/static/robots.txt')
+    expect(copyFileSync.mock.calls[0][1]).toBe('/alice/bob/robots.txt')
+    expect(copyFileSync.mock.calls[1][0]).toBe('/foo/bar/static/humans.txt')
+    expect(copyFileSync.mock.calls[1][1]).toBe('/alice/bob/humans.txt')
+    expect(copyFileSync.mock.calls[2][0]).toBe('/foo/bar/static/_redirects')
+    expect(copyFileSync.mock.calls[2][1]).toBe('/alice/bob/_redirects')
+  })
+
+  it('should not copy files when in dev mode', () => {
+    expect.assertions(1)
+
+    const { copyFileSync } = require('fs')
+    const { moveStaticFiles } = require('../../utils/exportStatic')
+    moveStaticFiles(true, '/foo/bar', '/alice/bob')
+
+    expect(copyFileSync.mock.calls.length).toBe(0)
+  })
+
+  it('should generate path map', () => {
+    expect.assertions(1)
+    const { exportPaths } = require('../../utils/exportStatic')
+
+    const paths = exportPaths({}, { dev: true, dir: '/foo', outDir: '/bar' })
+
+    expect(paths).toEqual({
+      '/': { page: '/home' },
+      '/about': { page: '/about' },
+      '/jobs': { page: '/jobs' },
+      '/dashboard': { page: '/dashboard' },
+      '/keychain': { page: '/keyChain' },
+      '/terms': { page: '/terms' },
+      '/privacy': { page: '/privacy' },
+      '/log': { page: '/log' },
+    })
+  })
+})

--- a/unlock-app/src/utils/exportStatic.js
+++ b/unlock-app/src/utils/exportStatic.js
@@ -1,0 +1,57 @@
+const { copyFileSync } = require('fs')
+const { join } = require('path')
+
+/**
+ * Exports useful files from the static folder to the root deployment
+ * @param {bool} dev Are we in dev mode or not?
+ * @param {string} inDir The incoming root folder
+ * @param {string} outDir The outgoing root folder
+ * @returns {Promise<void>}
+ */
+const moveStaticFiles = async (dev, inDir, outDir) => {
+  // Export robots.txt and humans.txt in non-dev environments
+  if (!dev && outDir) {
+    copyFileSync(
+      join(inDir, 'static', 'robots.txt'),
+      join(outDir, 'robots.txt')
+    )
+    copyFileSync(
+      join(inDir, 'static', 'humans.txt'),
+      join(outDir, 'humans.txt')
+    )
+    // Export _redirects which is used by netlify for URL rewrites
+    copyFileSync(
+      join(inDir, 'static', '_redirects'),
+      join(outDir, '_redirects')
+    )
+  }
+}
+
+/**
+ * Exports static files and generates a path map, as used by next.config.js
+ * @param {{}} defaultPathMap
+ * @param {bool} dev
+ * @param {string} dir
+ * @param {string} outDir
+ * @returns {{}}
+ */
+const exportPaths = (defaultPathMap, { dev, dir, outDir }) => {
+  moveStaticFiles(dev, dir, outDir)
+
+  // Our statically-defined pages to export
+  return {
+    '/': { page: '/home' },
+    '/about': { page: '/about' },
+    '/jobs': { page: '/jobs' },
+    '/dashboard': { page: '/dashboard' },
+    '/keychain': { page: '/keyChain' },
+    '/terms': { page: '/terms' },
+    '/privacy': { page: '/privacy' },
+    '/log': { page: '/log' },
+  }
+}
+
+module.exports = {
+  moveStaticFiles,
+  exportPaths,
+}


### PR DESCRIPTION
# Description

Test coverage on next.config.js has been kind of a pain and doesn't help with our overall test coverage score. This PR moves more of the code outside into a module that can be tested.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
