### PR TITLE
Improving code coverage stats for social tag components

### DIFF
--- a/unlock-app/src/__tests__/components/page/OpenGraphTags.test.js
+++ b/unlock-app/src/__tests__/components/page/OpenGraphTags.test.js
@@ -10,7 +10,14 @@ import OpenGraphTags from '../../../components/page/OpenGraphTags'
 describe('OpenGraphTags', () => {
   it('should render open graph tags based on default values', () => {
     expect.assertions(5)
-    const tags = rtl.render(<OpenGraphTags />)
+    const tags = rtl.render(
+      <OpenGraphTags
+        title={null}
+        description={null}
+        image={null}
+        canonicalPath={null}
+      />
+    )
     expect(
       tags.container.querySelector("meta[property='og:title']").content
     ).toBe(pageTitle())

--- a/unlock-app/src/__tests__/components/page/TwitterTags.test.js
+++ b/unlock-app/src/__tests__/components/page/TwitterTags.test.js
@@ -10,7 +10,9 @@ import TwitterTags from '../../../components/page/TwitterTags'
 describe('TwitterTags', () => {
   it('should render twitter tags based on default values', () => {
     expect.assertions(3)
-    const tags = rtl.render(<TwitterTags />)
+    const tags = rtl.render(
+      <TwitterTags title={null} description={null} image={null} />
+    )
     expect(
       tags.container.querySelector("meta[name='twitter:title']").content
     ).toBe(pageTitle())

--- a/unlock-protocol.com/src/__tests__/components/page/OpenGraphTags.test.js
+++ b/unlock-protocol.com/src/__tests__/components/page/OpenGraphTags.test.js
@@ -4,14 +4,20 @@ import {
   pageTitle,
   PAGE_DESCRIPTION,
   PAGE_DEFAULT_IMAGE,
-  CANONICAL_BASE_URL,
 } from '../../../constants'
 import OpenGraphTags from '../../../components/page/OpenGraphTags'
 
 describe('OpenGraphTags', () => {
   it('should render open graph tags based on default values', () => {
     expect.assertions(5)
-    const tags = rtl.render(<OpenGraphTags />)
+    const tags = rtl.render(
+      <OpenGraphTags
+        title={null}
+        description={null}
+        image={null}
+        canonicalPath={null}
+      />
+    )
     expect(
       tags.container.querySelector("meta[property='og:title']").content
     ).toBe(pageTitle())
@@ -26,7 +32,7 @@ describe('OpenGraphTags', () => {
     ).toBe('website')
     expect(
       tags.container.querySelector("meta[property='og:url']").content
-    ).toBe(CANONICAL_BASE_URL + '/')
+    ).toBe('/')
   })
 
   it('should render open graph tags based on custom values', () => {
@@ -57,6 +63,6 @@ describe('OpenGraphTags', () => {
     ).toBe('website')
     expect(
       tags.container.querySelector("meta[property='og:url']").content
-    ).toBe(CANONICAL_BASE_URL + path)
+    ).toBe(path)
   })
 })

--- a/unlock-protocol.com/src/__tests__/components/page/TwitterTags.test.js
+++ b/unlock-protocol.com/src/__tests__/components/page/TwitterTags.test.js
@@ -10,7 +10,9 @@ import TwitterTags from '../../../components/page/TwitterTags'
 describe('TwitterTags', () => {
   it('should render twitter tags based on default values', () => {
     expect.assertions(3)
-    const tags = rtl.render(<TwitterTags />)
+    const tags = rtl.render(
+      <TwitterTags title={null} description={null} image={null}/>
+    )
     expect(
       tags.container.querySelector("meta[name='twitter:title']").content
     ).toBe(pageTitle())
@@ -28,7 +30,7 @@ describe('TwitterTags', () => {
     let description = 'I am the very model of a model view controller'
     let image = '/some/image.png'
     const tags = rtl.render(
-      <TwitterTags title={title} description={description} image={image} />
+      <TwitterTags title={title} description={description} image={image}/>
     )
     expect(
       tags.container.querySelector("meta[name='twitter:title']").content

--- a/unlock-protocol.com/src/__tests__/components/page/TwitterTags.test.js
+++ b/unlock-protocol.com/src/__tests__/components/page/TwitterTags.test.js
@@ -11,7 +11,7 @@ describe('TwitterTags', () => {
   it('should render twitter tags based on default values', () => {
     expect.assertions(3)
     const tags = rtl.render(
-      <TwitterTags title={null} description={null} image={null}/>
+      <TwitterTags title={null} description={null} image={null} />
     )
     expect(
       tags.container.querySelector("meta[name='twitter:title']").content
@@ -30,7 +30,7 @@ describe('TwitterTags', () => {
     let description = 'I am the very model of a model view controller'
     let image = '/some/image.png'
     const tags = rtl.render(
-      <TwitterTags title={title} description={description} image={image}/>
+      <TwitterTags title={title} description={description} image={image} />
     )
     expect(
       tags.container.querySelector("meta[name='twitter:title']").content

--- a/unlock-protocol.com/src/components/page/OpenGraphTags.js
+++ b/unlock-protocol.com/src/components/page/OpenGraphTags.js
@@ -4,7 +4,6 @@ import {
   pageTitle,
   PAGE_DESCRIPTION,
   PAGE_DEFAULT_IMAGE,
-  CANONICAL_BASE_URL,
 } from '../../constants'
 
 export const OpenGraphTags = ({ title, description, image, canonicalPath }) => {
@@ -18,7 +17,7 @@ export const OpenGraphTags = ({ title, description, image, canonicalPath }) => {
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:type" content="website" />
-      <meta property="og:url" content={CANONICAL_BASE_URL + canonicalPath} />
+      <meta property="og:url" content={canonicalPath} />
       <meta property="og:image" content={image} />
     </React.Fragment>
   )


### PR DESCRIPTION
# Description

In my quest to improve code coverage, this PR tweaks the tests to bring the stats up to 100% for the Twitter and Open Graph tag components. A goal of this PR is not to unify these components in `unlock-app` and `unlock-protocol.com`, although this should probably be done in the future.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
