### PR TITLE
merge providerMiddleware to paywall

### DIFF
--- a/paywall/src/__tests__/actions/provider.test.js
+++ b/paywall/src/__tests__/actions/provider.test.js
@@ -1,4 +1,9 @@
-import { setProvider, SET_PROVIDER } from '../../actions/provider'
+import {
+  setProvider,
+  SET_PROVIDER,
+  PROVIDER_READY,
+  providerReady,
+} from '../../actions/provider'
 
 describe('provider actions', () => {
   it('should create an action to set the provider', () => {
@@ -9,5 +14,14 @@ describe('provider actions', () => {
       provider,
     }
     expect(setProvider(provider)).toEqual(expectedAction)
+  })
+
+  it('should create an action to signal the provider is ready', () => {
+    expect.assertions(1)
+    const expectedAction = {
+      type: PROVIDER_READY,
+    }
+
+    expect(providerReady()).toEqual(expectedAction)
   })
 })

--- a/paywall/src/__tests__/middlewares/providerMiddleware.test.ts
+++ b/paywall/src/__tests__/middlewares/providerMiddleware.test.ts
@@ -1,0 +1,103 @@
+import providerMiddleware from '../../middlewares/providerMiddleware'
+import { SET_PROVIDER } from '../../actions/provider'
+import { setError } from '../../actions/error'
+import { FATAL_MISSING_PROVIDER } from '../../errors'
+
+const config = {
+  providers: {
+    UNLOCK: {
+      enable: jest.fn(() => new Promise(resolve => resolve(true))),
+      isUnlock: true,
+    },
+    NUNLOCK: {
+      enable: jest.fn(() => new Promise(resolve => resolve(true))),
+    },
+  },
+}
+
+const getState = () => ({
+  provider: 'NUNLOCK',
+})
+
+const unlockAction = {
+  type: SET_PROVIDER,
+  provider: 'UNLOCK',
+}
+
+const erroneousAction = {
+  type: SET_PROVIDER,
+  provider: 'HONLOCK',
+}
+
+const sameAction = {
+  type: SET_PROVIDER,
+  provider: 'NUNLOCK',
+}
+
+let dispatch: () => any
+
+describe('provider middleware', () => {
+  beforeEach(() => {
+    config.providers['UNLOCK'].enable = jest.fn(
+      () => new Promise(resolve => resolve(true))
+    )
+    config.providers['NUNLOCK'].enable = jest.fn(
+      () => new Promise(resolve => resolve(true))
+    )
+    dispatch = jest.fn()
+  })
+  describe('SET_PROVIDER', () => {
+    it('should initialize the provider when provider is different from one in state', done => {
+      expect.assertions(2)
+      const next = () => {
+        expect(config.providers['UNLOCK'].enable).toHaveBeenCalled()
+        expect(config.providers['NUNLOCK'].enable).not.toHaveBeenCalled()
+        done()
+      }
+
+      providerMiddleware(config)({ getState, dispatch })(next)(unlockAction)
+    })
+
+    it('should set an error and return if there is no matching provider', done => {
+      expect.assertions(3)
+      const next = () => {
+        expect(config.providers['UNLOCK'].enable).not.toHaveBeenCalled()
+        expect(config.providers['NUNLOCK'].enable).not.toHaveBeenCalled()
+        expect(dispatch).toHaveBeenCalledWith(setError(FATAL_MISSING_PROVIDER))
+        done()
+      }
+
+      providerMiddleware(config)({ getState, dispatch })(next)(erroneousAction)
+    })
+
+    it('should set an error and return if the call to enable fails', done => {
+      expect.assertions(2)
+      config.providers['UNLOCK'].enable = jest.fn(() => {
+        // eslint-disable-next-line promise/param-names
+        return new Promise((_, reject) => {
+          reject('The front fell off.')
+        })
+      })
+
+      const next = () => {
+        expect(config.providers['UNLOCK'].enable).toHaveBeenCalled()
+        expect(config.providers['NUNLOCK'].enable).not.toHaveBeenCalled()
+        done()
+      }
+
+      providerMiddleware(config)({ getState, dispatch })(next)(unlockAction)
+    })
+
+    it('should do nothing if provider is the same as in state', done => {
+      expect.assertions(3)
+      const next = () => {
+        expect(config.providers['UNLOCK'].enable).not.toHaveBeenCalled()
+        expect(config.providers['NUNLOCK'].enable).not.toHaveBeenCalled()
+        expect(dispatch).not.toHaveBeenCalled()
+        done()
+      }
+
+      providerMiddleware(config)({ getState, dispatch })(next)(sameAction)
+    })
+  })
+})

--- a/paywall/src/actions/provider.js
+++ b/paywall/src/actions/provider.js
@@ -1,6 +1,11 @@
 export const SET_PROVIDER = 'provider/SET_PROVIDER'
+export const PROVIDER_READY = 'provider/PROVIDER_READY'
 
 export const setProvider = provider => ({
   type: SET_PROVIDER,
   provider,
+})
+
+export const providerReady = () => ({
+  type: PROVIDER_READY,
 })

--- a/paywall/src/middlewares/providerMiddleware.ts
+++ b/paywall/src/middlewares/providerMiddleware.ts
@@ -1,0 +1,66 @@
+import { SET_PROVIDER, providerReady } from '../actions/provider'
+import { setError } from '../actions/error'
+import {
+  FATAL_MISSING_PROVIDER,
+  FATAL_NOT_ENABLED_IN_PROVIDER,
+} from '../errors'
+
+interface Action {
+  type: string
+  [key: string]: any
+}
+
+type dispatcher = (action: Action) => void
+
+function initializeProvider(
+  provider: { enable?: () => any },
+  dispatch: dispatcher
+) {
+  if (!provider) {
+    dispatch(setError(FATAL_MISSING_PROVIDER))
+    return
+  }
+
+  // provider.enable exists for metamask and other modern dapp wallets and must be called, see:
+  // https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8
+  if (provider.enable) {
+    provider
+      .enable()
+      .then(() => dispatch(providerReady()))
+      .catch(() => dispatch(setError(FATAL_NOT_ENABLED_IN_PROVIDER)))
+  } else {
+    // Default case, provider doesn't have an enable method, so it must already be ready
+    dispatch(providerReady())
+  }
+}
+
+const providerMiddleware = (config: any) => {
+  return ({
+    getState,
+    dispatch,
+  }: {
+    getState: () => any
+    dispatch: dispatcher
+  }) => {
+    return function(next: dispatcher) {
+      // Initialize provider based on the one grabbed in the state. Fragile?
+      setTimeout(() => {
+        const provider = config.providers[getState().provider]
+        initializeProvider(provider, dispatch)
+      }, 0)
+
+      return function(action: Action) {
+        if (action.type === SET_PROVIDER) {
+          // Only initialize the provider if we haven't already done so.
+          if (action.provider !== getState().provider) {
+            const provider = config.providers[action.provider]
+            initializeProvider(provider, dispatch)
+          }
+        }
+        next(action)
+      }
+    }
+  }
+}
+
+export default providerMiddleware


### PR DESCRIPTION
# Description

This ports the `providerMiddleware` from `unlock-app` to `paywall`.

Note: @cnasc I added some types to replace some of the `any`, for things like `dispatch`, `next`, and `getState`. Didn't seem to cause any issues, but would love your take on it.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2591

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
