### PR TITLE
trigger production pull request every weekday at 2:30PM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ workflows:
   promote: # The promote workflow will checkout an old version of master (4 days old) and rebase it onto the production branch
     triggers:
       - schedule:
-          cron: '30 20 * * 2' # use cron syntax to set the schedule trigger on Teusday at 430pm ET (2030 UTC)
+          cron: '30 20 * * 1-4' # use cron syntax to set the scheduled trigger on week days at 230pm ET (1830 UTC).
           filters:
             branches:
               only:


### PR DESCRIPTION
Adding "continuous" in "continous deployment" ;)
A PR will automagically be opened against the production branch every week day at 230PM ET!


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->