### PR TITLE
Example of using screenshotOnFail [DRAFT NOT A REAL PR]

### DIFF
--- a/tests/helpers/debugging.js
+++ b/tests/helpers/debugging.js
@@ -74,7 +74,7 @@ module.exports = {
     const runTest = async () => {
       try {
         // await will do nothing for non-async code, and make async tests work
-        module.exports.debugPage(page, true, true)
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await
         await code()
         // if the code does not throw, we did not fail
       } catch (e) {

--- a/tests/helpers/debugging.js
+++ b/tests/helpers/debugging.js
@@ -1,30 +1,51 @@
 /* eslint no-console: 0 */
 
 /**
- * debugPage
- ***********
+ * debugPage [local dev only]
  *
- * debugPage is used to turn on the display of console.log calls within the browser context.
- * This includes calls within page.evaluate and page.waitForFunction.
- *
- * Usage:
+ * Use debugPage() to display the output of console.log from within the page context.
+ * It should be called at the point you would like logging to begin with:
  *
  * debugPage(page, true)
  *
- * screenshot
- ************
+ * ****************************
+ * screenshot [local or CI dev]
  *
- * screenshot is used to take a screenshot. It will work both locally when run with the
- * scripts/local-docker-integration-tests.sh script or on CI. Screenshots locally are
- * placed in the current directory. In CI, they are found in the artifacts on CircleCI.
+ * screenshot() will immediately take a screenshot and save it. It accepts
+ * an optional filename prefix, which defaults to 'test'. With each call to
+ * screenshot, the file generated has a unique name based on a counter. The
+ * counter increments every time screenshot is called regardless of the filename
+ * prefix. These calls:
  *
- * Usage:
+ * screenshot(page)
+ * screenshot(page, 'different')
+ * screenshot(page)
  *
- * await screenshot(page) // creates test-1.jpg
- * await screenshot(page) // creates test-2.jpg
- * await screenshot(page, 'another') // creates another-3.jpg
+ * will generate files '/screenshots/test-1.png', '/screenshots/different-2.png', and
+ * '/screenshots/test-3.png'
  *
- * The numeric prefix is always unique and represents the order of the screenshot.
+ * screenshot can be used either in development or production. Be aware that on Mac
+ * OS X screenshots take a minimum of 1/6 second, and can distort timing results, so
+ * should only be used for development of integration tests.
+ *
+ * screenshots are saved into /tmp/screenshots
+ *
+ * ****************************
+ * screenshotOnFail [local and CI]
+ *
+ * screenshotOnFail() is designed to be a replacement for jest's "it"
+ * that is used to take a screenshot on any test failure. It is a factory
+ * that returns the replacement for "it." Usage:
+ *
+ * const it = screenshotOnFail(page)
+ *
+ * Note that there is no requirement that it replace "it", and one could just as easily use:
+ *
+ * const itWithScreenshot = screenshotOnFail(page)
+ *
+ * screenshots are saved into /tmp/screenshots for local dev, and will appear on CircleCI
+ * in the Artifacts section of integration tests for viewing when the tests conplete.
+ * Screenshot names are based on the test description.
  */
 let counter = 1
 module.exports = {

--- a/tests/helpers/debugging.js
+++ b/tests/helpers/debugging.js
@@ -44,9 +44,34 @@ module.exports = {
   },
   async screenshot(page, file = 'test') {
     await page.screenshot({
-      path: `/screenshots/${file}-${counter}.jpg`,
+      path: `/screenshots/${file}-${counter}.png`,
       fullPage: true,
     })
     counter += 1
+  },
+  screenshotOnFail: page => (testDescription, code) => {
+    const runTest = async () => {
+      try {
+        // await will do nothing for non-async code, and make async tests work
+        module.exports.debugPage(page, true, true)
+        await code()
+        // if the code does not throw, we did not fail
+      } catch (e) {
+        // locally, we use the volume mounted at /screenshots
+        // on CI, we use the /home/unlock/screenshots directory used to retrieve artifacts
+        const screenshotPath = `/screenshots/${testDescription.replace(
+          /[ ,/"'^$\\]+/g,
+          '-'
+        )}.png`
+        console.error(`writing screenshot to ${screenshotPath}`)
+        try {
+          await page.screenshot({ path: screenshotPath, fullPage: true })
+        } catch (screenshotError) {
+          console.error(screenshotError)
+        }
+        throw e
+      }
+    }
+    it(testDescription, runTest)
   },
 }


### PR DESCRIPTION
# Description

This PR is an example showing how to use screenshotOnFail with a fake failing test that takes a screenshot. The screenshot will be available in the "Artifacts" tab on Circle which is:

[Artifacts](https://circleci.com/gh/unlock-protocol/unlock/26489#artifacts/containers/0)

Click on the `screenshots/` directory to see the image, which can be viewed [here](https://26489-112683472-gh.circle-artifacts.com/0/tmp/screenshots/after-key-purchase-unlocked-flag-appears.png)

<img width="886" alt="Screen Shot 2019-04-12 at 9 59 50 AM" src="https://user-images.githubusercontent.com/98250/56042745-c1dbb100-5d09-11e9-85cb-4f95dfa65af0.png">
<img width="886" alt="Screen Shot 2019-04-12 at 9 56 11 AM" src="https://user-images.githubusercontent.com/98250/56042747-c1dbb100-5d09-11e9-8268-9ae59f884e20.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2191 

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
