### PR TITLE
Adds endpoints supporting the creation and fetching of Events

### DIFF
--- a/locksmith/__tests__/operations/eventOperations.test.ts
+++ b/locksmith/__tests__/operations/eventOperations.test.ts
@@ -1,0 +1,50 @@
+import * as Sequelize from 'sequelize'
+import EventOperations from '../../src/operations/eventOperations'
+
+const models = require('../../src/models')
+
+const Op = Sequelize.Op
+
+let Event: any = models.Event
+let eventData = {
+  lockAddress: '0x49158d35259e3264ad2a6abb300cda19294d125e',
+  name: 'A Test Event',
+  description: 'A fun event for everyone',
+  location: 'http://example.com/a_sample_location',
+  date: 1744487946000,
+  logo: 'http://example.com/a_logo',
+  owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+}
+
+describe('EventOperations', () => {
+  describe('create', () => {
+    it('dispatches to the event model with normalized addresses', () => {
+      expect.assertions(1)
+      Event.create = jest.fn(() => {})
+      EventOperations.create(eventData)
+      expect(Event.create).toHaveBeenCalledWith({
+        date: 1744487946000,
+        description: 'A fun event for everyone',
+        location: 'http://example.com/a_sample_location',
+        lockAddress: '0x49158d35259E3264Ad2a6aBb300cdA19294D125e',
+        logo: 'http://example.com/a_logo',
+        name: 'A Test Event',
+        owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+      })
+    })
+  })
+  describe('find', () => {
+    it('dispatches to the event model with a normalized address', () => {
+      expect.assertions(1)
+      Event.findOne = jest.fn(() => {})
+      EventOperations.find('0x49158d35259e3264ad2a6abb300cda19294d125e')
+      expect(Event.findOne).toHaveBeenCalledWith({
+        where: {
+          lockAddress: {
+            [Op.eq]: '0x49158d35259E3264Ad2a6aBb300cdA19294D125e',
+          },
+        },
+      })
+    })
+  })
+})

--- a/locksmith/migrations/20190412205611-add_event_owner.js
+++ b/locksmith/migrations/20190412205611-add_event_owner.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const table = 'Events'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(table, 'owner', {
+      type: Sequelize.STRING,
+      allowNull: false,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn(table, 'owner')
+  },
+}

--- a/locksmith/src/app.js
+++ b/locksmith/src/app.js
@@ -11,11 +11,18 @@ var transactionRouter = require('./routes/transaction')
 var lockRouter = require('./routes/lock')
 var blockRouter = require('./routes/block')
 var userRouter = require('./routes/user')
+var eventRouter = require('./routes/event')
 var purchaseRouter = require('./routes/purchase')
 
 let lockSignatureConfiguration = {
   name: 'lock',
   required: ['name', 'owner', 'address'],
+  signee: 'owner',
+}
+
+let eventConfiguration = {
+  name: 'event',
+  required: ['lockAddress', 'name', 'location', 'date', 'owner'],
   signee: 'owner',
 }
 
@@ -29,6 +36,12 @@ app.post(
   /^\/lock$/i,
   signatureValidationMiddleware.generateProcessor(lockSignatureConfiguration)
 )
+
+app.post(
+  /^\/events$/i,
+  signatureValidationMiddleware.generateProcessor(eventConfiguration)
+)
+
 app.post(
   /^\/users$/i,
   signatureValidationMiddleware.generateProcessor({
@@ -59,6 +72,7 @@ app.use('/', router)
 app.use('/', transactionRouter)
 app.use('/', lockRouter)
 app.use('/block', blockRouter)
+app.use('/events', eventRouter)
 app.use('/users', userRouter)
 app.use('/purchase', purchaseRouter)
 

--- a/locksmith/src/controllers/eventController.ts
+++ b/locksmith/src/controllers/eventController.ts
@@ -1,0 +1,31 @@
+// eslint-disable-next-line no-unused-vars, import/no-unresolved
+import { Request, Response } from 'express-serve-static-core'
+
+const eventOperation = require('../operations/eventOperations')
+
+namespace EventController {
+  export const create = async (req: Request, res: Response): Promise<any> => {
+    let event = req.body.message.event
+
+    try {
+      await eventOperation.create(event)
+
+      return res.sendStatus(200)
+    } catch (e) {
+      return res.sendStatus(409)
+    }
+  }
+
+  export const find = async (req: Request, res: Response): Promise<any> => {
+    let lockAddress = req.params.lockAddress
+    let event = await eventOperation.find(lockAddress)
+
+    if (event) {
+      return res.json(event.toJSON())
+    } else {
+      return res.sendStatus(404)
+    }
+  }
+}
+
+export = EventController

--- a/locksmith/src/models/event.js
+++ b/locksmith/src/models/event.js
@@ -9,6 +9,7 @@ module.exports = (sequelize, DataTypes) => {
       location: DataTypes.STRING,
       date: DataTypes.DATE,
       logo: DataTypes.STRING,
+      owner: DataTypes.STRING,
     },
     {}
   )

--- a/locksmith/src/operations/eventOperations.ts
+++ b/locksmith/src/operations/eventOperations.ts
@@ -1,0 +1,26 @@
+import * as Sequelize from 'sequelize'
+import Normalizer from '../utils/normalizer'
+import { EventCreation } from '../types' // eslint-disable-line no-unused-vars
+
+const models = require('../models')
+
+const { Event } = models
+const Op = Sequelize.Op
+
+namespace EventOperations {
+  export const create = (event: EventCreation): Promise<any> => {
+    event.owner = Normalizer.ethereumAddress(event.owner)
+    event.lockAddress = Normalizer.ethereumAddress(event.lockAddress)
+    return Event.create(event)
+  }
+
+  export const find = async (lockAddress: string): Promise<any> => {
+    return Event.findOne({
+      where: {
+        lockAddress: { [Op.eq]: Normalizer.ethereumAddress(lockAddress) },
+      },
+    })
+  }
+}
+
+export = EventOperations

--- a/locksmith/src/routes/event.ts
+++ b/locksmith/src/routes/event.ts
@@ -1,0 +1,9 @@
+import express from 'express'
+
+let router = express.Router()
+let eventController = require('../controllers/eventController')
+
+router.post('/', eventController.create)
+router.get('/:lockAddress', eventController.find)
+
+module.exports = router

--- a/locksmith/src/types.ts
+++ b/locksmith/src/types.ts
@@ -15,3 +15,13 @@ export interface SignatureValidationConfiguration {
   required: string[]
   name: string
 }
+
+export interface EventCreation {
+  lockAddress: string
+  name: string
+  description: string
+  location: string
+  date: number
+  logo: string
+  owner: string
+}


### PR DESCRIPTION
# Description

We are beginning to add backend support for the initial release
of the events application.

adds `POST - /events`
adds `GET - /events/lockAddress`

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
