### PR TITLE
namespacing the ABI

### DIFF
--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -3,7 +3,7 @@ import Web3 from 'web3'
 import EventEmitter from 'events'
 import nock from 'nock'
 import Web3Utils from 'web3-utils'
-import { PublicLock, Unlock } from 'unlock-abi-0'
+import * as UnlockV0 from 'unlock-abi-0'
 
 import WalletService, { Errors } from '../walletService'
 
@@ -86,7 +86,7 @@ describe('WalletService', () => {
       const netVersion = Math.floor(Math.random() * 100000)
       netVersionAndYield(netVersion)
 
-      Unlock.networks = {
+      UnlockV0.Unlock.networks = {
         [netVersion]: {
           events: {},
           links: {},
@@ -110,7 +110,7 @@ describe('WalletService', () => {
     beforeEach(done => {
       netVersionAndYield(netVersion)
 
-      Unlock.networks = {
+      UnlockV0.Unlock.networks = {
         [netVersion]: {
           events: {},
           links: {},
@@ -357,7 +357,7 @@ describe('WalletService', () => {
 
         const ContractClass = class {
           constructor(abi, address) {
-            expect(abi).toBe(Unlock.abi)
+            expect(abi).toBe(UnlockV0.Unlock.abi)
             expect(address).toBe(walletService.unlockContractAddress)
             this.methods = {
               createLock: (duration, price, numberOfKeys) => {
@@ -381,7 +381,7 @@ describe('WalletService', () => {
             from: owner,
             data,
             gas: WalletService.gasAmountConstants().createLock,
-            contract: Unlock,
+            contract: UnlockV0.Unlock,
           },
           TransactionType.LOCK_CREATION,
           expect.any(Function)
@@ -453,7 +453,7 @@ describe('WalletService', () => {
 
         const ContractClass = class {
           constructor(abi, address) {
-            expect(abi).toBe(PublicLock.abi)
+            expect(abi).toBe(UnlockV0.PublicLock.abi)
             expect(address).toBe(lock)
             this.methods = {
               purchaseFor: (customer, data) => {
@@ -476,7 +476,7 @@ describe('WalletService', () => {
             from: account,
             data,
             gas: WalletService.gasAmountConstants().purchaseKey,
-            contract: PublicLock,
+            contract: UnlockV0.PublicLock,
             value: '100000000000000000000000000', // Web3Utils.toWei(keyPrice, 'ether')
           },
           TransactionType.KEY_PURCHASE,
@@ -520,7 +520,7 @@ describe('WalletService', () => {
 
         const ContractClass = class {
           constructor(abi, address) {
-            expect(abi).toBe(PublicLock.abi)
+            expect(abi).toBe(UnlockV0.PublicLock.abi)
             expect(address).toBe(lock)
             this.methods = {
               updateKeyPrice: newPrice => {
@@ -542,7 +542,7 @@ describe('WalletService', () => {
             from: account,
             data,
             gas: WalletService.gasAmountConstants().updateKeyPrice,
-            contract: PublicLock,
+            contract: UnlockV0.PublicLock,
           },
           TransactionType.UPDATE_KEY_PRICE,
           expect.any(Function)
@@ -665,7 +665,7 @@ describe('WalletService', () => {
 
         const MockContractClass = class {
           constructor(abi, address) {
-            expect(abi).toBe(PublicLock.abi)
+            expect(abi).toBe(UnlockV0.PublicLock.abi)
             expect(address).toBe(lock)
             this.methods = {
               partialWithdraw: () => this,
@@ -686,7 +686,7 @@ describe('WalletService', () => {
             from: account,
             data,
             gas: WalletService.gasAmountConstants().partialWithdrawFromLock,
-            contract: PublicLock,
+            contract: UnlockV0.PublicLock,
           },
           TransactionType.WITHDRAWAL,
           expect.any(Function)
@@ -743,7 +743,7 @@ describe('WalletService', () => {
 
         const ContractClass = class {
           constructor(abi, address) {
-            expect(abi).toBe(PublicLock.abi)
+            expect(abi).toBe(UnlockV0.PublicLock.abi)
             expect(address).toBe(lock)
             this.methods = {
               withdraw: () => {
@@ -764,7 +764,7 @@ describe('WalletService', () => {
             from: account,
             data,
             gas: WalletService.gasAmountConstants().withdrawFromLock,
-            contract: PublicLock,
+            contract: UnlockV0.PublicLock,
           },
           TransactionType.WITHDRAWAL,
           expect.any(Function)

--- a/unlock-js/src/__tests__/web3Service.test.js
+++ b/unlock-js/src/__tests__/web3Service.test.js
@@ -3,7 +3,8 @@
 import Web3Utils from 'web3-utils'
 import Web3EthAbi from 'web3-eth-abi'
 import nock from 'nock'
-import { PublicLock, Unlock } from 'unlock-abi-0'
+import * as UnlockV0 from 'unlock-abi-0'
+
 import Web3Service, { TransactionType, keyId } from '../web3Service'
 
 const nodeAccounts = [
@@ -111,7 +112,7 @@ describe('Web3Service', () => {
       const lockAddress = '0x123'
       class MockContract {
         constructor(abi, address) {
-          expect(abi).toBe(PublicLock.abi)
+          expect(abi).toBe(UnlockV0.PublicLock.abi)
           expect(address).toEqual(lockAddress)
         }
       }
@@ -185,7 +186,7 @@ describe('Web3Service', () => {
 
       class MockContract {
         constructor(abi, address) {
-          expect(abi).toBe(Unlock.abi)
+          expect(abi).toBe(UnlockV0.Unlock.abi)
           expect(address).toEqual(web3Service.unlockAddress)
         }
       }
@@ -343,7 +344,7 @@ describe('Web3Service', () => {
       })
       web3Service.parseTransactionFromInput(
         transaction.hash,
-        Unlock,
+        UnlockV0.Unlock,
         input,
         web3Service.unlockAddress
       )
@@ -684,12 +685,12 @@ describe('Web3Service', () => {
           receipt
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
-          expect(contract).toEqual(Unlock)
+          expect(contract).toEqual(UnlockV0.Unlock)
           expect(receipt.blockNumber).toEqual(344)
           expect(receipt.logs).toEqual([])
           web3Service.unlockAddress = previousAddress
           expect(web3Service.getTransactionType).toHaveBeenCalledWith(
-            Unlock,
+            UnlockV0.Unlock,
             blockTransaction.input
           )
           done()
@@ -720,11 +721,11 @@ describe('Web3Service', () => {
           receipt
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
-          expect(contract).toEqual(PublicLock)
+          expect(contract).toEqual(UnlockV0.PublicLock)
           expect(receipt.blockNumber).toEqual(344)
           expect(receipt.logs).toEqual([])
           expect(web3Service.getTransactionType).toHaveBeenCalledWith(
-            PublicLock,
+            UnlockV0.PublicLock,
             blockTransaction.input
           )
           done()
@@ -854,7 +855,7 @@ describe('Web3Service', () => {
       )
 
       const lockContract = new web3Service.web3.eth.Contract(
-        PublicLock.abi,
+        UnlockV0.PublicLock.abi,
         lockAddress
       )
 
@@ -881,7 +882,7 @@ describe('Web3Service', () => {
       )
 
       const lockContract = new web3Service.web3.eth.Contract(
-        PublicLock.abi,
+        UnlockV0.PublicLock.abi,
         lockAddress
       )
 
@@ -920,36 +921,42 @@ describe('Web3Service', () => {
     it('should return null if there is no matching method', () => {
       expect.assertions(1)
       const data = 'notarealmethod'
-      expect(web3Service.getTransactionType(Unlock, data)).toBe(null)
+      expect(web3Service.getTransactionType(UnlockV0.Unlock, data)).toBe(null)
     })
 
     it('should return the right transaction type on lock creation', () => {
       expect.assertions(1)
-      const unlock = new web3Service.web3.eth.Contract(Unlock.abi, '')
+      const unlock = new web3Service.web3.eth.Contract(UnlockV0.Unlock.abi, '')
       const data = unlock.methods
         .createLock('1000', '1000000000', '1')
         .encodeABI()
-      expect(web3Service.getTransactionType(Unlock, data)).toBe(
+      expect(web3Service.getTransactionType(UnlockV0.Unlock, data)).toBe(
         TransactionType.LOCK_CREATION
       )
     })
 
     it('should return the right transaction type on key purchase', () => {
       expect.assertions(1)
-      const lock = new web3Service.web3.eth.Contract(PublicLock.abi, '')
+      const lock = new web3Service.web3.eth.Contract(
+        UnlockV0.PublicLock.abi,
+        ''
+      )
       const data = lock.methods
         .purchaseFor(nodeAccounts[0], Web3Utils.utf8ToHex(''))
         .encodeABI()
-      expect(web3Service.getTransactionType(PublicLock, data)).toBe(
+      expect(web3Service.getTransactionType(UnlockV0.PublicLock, data)).toBe(
         TransactionType.KEY_PURCHASE
       )
     })
 
     it('should return the right transaction type on withdrawals', () => {
       expect.assertions(1)
-      const lock = new web3Service.web3.eth.Contract(PublicLock.abi, '')
+      const lock = new web3Service.web3.eth.Contract(
+        UnlockV0.PublicLock.abi,
+        ''
+      )
       const data = lock.methods.withdraw().encodeABI()
-      expect(web3Service.getTransactionType(PublicLock, data)).toBe(
+      expect(web3Service.getTransactionType(UnlockV0.PublicLock, data)).toBe(
         TransactionType.WITHDRAWAL
       )
     })

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events'
 import Web3 from 'web3'
 import Web3Utils from 'web3-utils'
-import { PublicLock, Unlock } from 'unlock-abi-0'
+import * as UnlockV0 from 'unlock-abi-0'
 
 export const Errors = {
   FATAL_MISSING_PROVIDER: 'FATAL_MISSING_PROVIDER',
@@ -155,7 +155,10 @@ export default class WalletService extends EventEmitter {
    * @param {string} price : new price for the lock
    */
   updateKeyPrice(lock, account, price) {
-    const lockContract = new this.web3.eth.Contract(PublicLock.abi, lock)
+    const lockContract = new this.web3.eth.Contract(
+      UnlockV0.PublicLock.abi,
+      lock
+    )
     const data = lockContract.methods
       .updateKeyPrice(Web3Utils.toWei(price, 'ether'))
       .encodeABI()
@@ -166,7 +169,7 @@ export default class WalletService extends EventEmitter {
         from: account,
         data,
         gas: WalletService.gasAmountConstants().updateKeyPrice,
-        contract: PublicLock,
+        contract: UnlockV0.PublicLock,
       },
       TransactionType.UPDATE_KEY_PRICE,
       error => {
@@ -187,7 +190,7 @@ export default class WalletService extends EventEmitter {
    */
   createLock(lock, owner) {
     const unlock = new this.web3.eth.Contract(
-      Unlock.abi,
+      UnlockV0.Unlock.abi,
       this.unlockContractAddress
     )
 
@@ -205,7 +208,7 @@ export default class WalletService extends EventEmitter {
         from: owner,
         data,
         gas: WalletService.gasAmountConstants().createLock,
-        contract: Unlock,
+        contract: UnlockV0.Unlock,
       },
       TransactionType.LOCK_CREATION,
       (error, hash) => {
@@ -241,7 +244,10 @@ export default class WalletService extends EventEmitter {
    * @param {string} account
 \   */
   purchaseKey(lock, owner, keyPrice, account, data = '') {
-    const lockContract = new this.web3.eth.Contract(PublicLock.abi, lock)
+    const lockContract = new this.web3.eth.Contract(
+      UnlockV0.PublicLock.abi,
+      lock
+    )
     const abi = lockContract.methods
       .purchaseFor(owner, Web3Utils.utf8ToHex(data || ''))
       .encodeABI()
@@ -253,7 +259,7 @@ export default class WalletService extends EventEmitter {
         data: abi,
         gas: WalletService.gasAmountConstants().purchaseKey,
         value: Web3Utils.toWei(keyPrice, 'ether'),
-        contract: PublicLock,
+        contract: UnlockV0.PublicLock,
       },
       TransactionType.KEY_PURCHASE,
       error => {
@@ -273,7 +279,10 @@ export default class WalletService extends EventEmitter {
    * @param {Function} callback
    */
   partialWithdrawFromLock(lock, account, ethAmount, callback) {
-    const lockContract = new this.web3.eth.Contract(PublicLock.abi, lock)
+    const lockContract = new this.web3.eth.Contract(
+      UnlockV0.PublicLock.abi,
+      lock
+    )
     const weiAmount = Web3Utils.toWei(ethAmount)
     const data = lockContract.methods.partialWithdraw(weiAmount).encodeABI()
 
@@ -283,7 +292,7 @@ export default class WalletService extends EventEmitter {
         from: account,
         data,
         gas: WalletService.gasAmountConstants().partialWithdrawFromLock,
-        contract: PublicLock,
+        contract: UnlockV0.PublicLock,
       },
       TransactionType.WITHDRAWAL,
       error => {
@@ -303,7 +312,10 @@ export default class WalletService extends EventEmitter {
    * @param {Function} callback TODO: implement...
    */
   withdrawFromLock(lock, account) {
-    const lockContract = new this.web3.eth.Contract(PublicLock.abi, lock)
+    const lockContract = new this.web3.eth.Contract(
+      UnlockV0.PublicLock.abi,
+      lock
+    )
     const data = lockContract.methods.withdraw().encodeABI()
 
     return this._sendTransaction(
@@ -312,7 +324,7 @@ export default class WalletService extends EventEmitter {
         from: account,
         data,
         gas: WalletService.gasAmountConstants().withdrawFromLock,
-        contract: PublicLock,
+        contract: UnlockV0.PublicLock,
       },
       TransactionType.WITHDRAWAL,
       error => {

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -2,7 +2,8 @@ import EventEmitter from 'events'
 import Web3 from 'web3'
 import Web3Utils from 'web3-utils'
 import { bufferToHex, generateAddress } from 'ethereumjs-util'
-import { PublicLock, Unlock } from 'unlock-abi-0'
+// import * as UnlockV01 from 'unlock-abi-0-1'
+import * as UnlockV0 from 'unlock-abi-0'
 
 export const keyId = (lock, owner) => [lock, owner].join('-')
 
@@ -220,7 +221,10 @@ export default class Web3Service extends EventEmitter {
    * @param {*} address
    */
   getPastLockCreationsTransactionsForUser(address) {
-    const unlock = new this.web3.eth.Contract(Unlock.abi, this.unlockAddress)
+    const unlock = new this.web3.eth.Contract(
+      UnlockV0.Unlock.abi,
+      this.unlockAddress
+    )
     return this._getPastTransactionsForContract(unlock, 'NewLock', {
       lockOwner: address,
     })
@@ -232,7 +236,10 @@ export default class Web3Service extends EventEmitter {
    * @param {*} lockAddress
    */
   getPastLockTransactions(lockAddress) {
-    const lockContract = new this.web3.eth.Contract(PublicLock.abi, lockAddress)
+    const lockContract = new this.web3.eth.Contract(
+      UnlockV0.PublicLock.abi,
+      lockAddress
+    )
     return this._getPastTransactionsForContract(lockContract, 'allevents')
   }
 
@@ -388,8 +395,8 @@ export default class Web3Service extends EventEmitter {
     if (defaults) {
       const contract =
         this.unlockAddress === Web3Utils.toChecksumAddress(defaults.to)
-          ? Unlock
-          : PublicLock
+          ? UnlockV0.Unlock
+          : UnlockV0.PublicLock
 
       return this.parseTransactionFromInput(
         transactionHash,
@@ -418,8 +425,8 @@ export default class Web3Service extends EventEmitter {
 
     const contract =
       this.unlockAddress === Web3Utils.toChecksumAddress(blockTransaction.to)
-        ? Unlock
-        : PublicLock
+        ? UnlockV0.Unlock
+        : UnlockV0.PublicLock
 
     return this.parseTransactionFromInput(
       blockTransaction.hash,
@@ -460,8 +467,8 @@ export default class Web3Service extends EventEmitter {
 
       const contract =
         this.unlockAddress === Web3Utils.toChecksumAddress(blockTransaction.to)
-          ? Unlock
-          : PublicLock
+          ? UnlockV0.Unlock
+          : UnlockV0.PublicLock
 
       const transactionType = this.getTransactionType(
         contract,
@@ -514,7 +521,10 @@ export default class Web3Service extends EventEmitter {
    * @return Promise<Lock>
    */
   getLock(address) {
-    const contract = new this.web3.eth.Contract(PublicLock.abi, address)
+    const contract = new this.web3.eth.Contract(
+      UnlockV0.PublicLock.abi,
+      address
+    )
     const attributes = {
       keyPrice: x => Web3Utils.fromWei(x, 'ether'),
       expirationDuration: parseInt,
@@ -565,7 +575,10 @@ export default class Web3Service extends EventEmitter {
    * @param {PropTypes.string} owner
    */
   getKeyByLockForOwner(lock, owner) {
-    const lockContract = new this.web3.eth.Contract(PublicLock.abi, lock)
+    const lockContract = new this.web3.eth.Contract(
+      UnlockV0.PublicLock.abi,
+      lock
+    )
     return this._getKeyByLockForOwner(lockContract, owner).then(
       ([expiration, data]) => {
         this.emit('key.updated', keyId(lock, owner), {
@@ -669,7 +682,10 @@ export default class Web3Service extends EventEmitter {
    * @param {PropTypes.integer}
    */
   getKeysForLockOnPage(lock, page, byPage) {
-    const lockContract = new this.web3.eth.Contract(PublicLock.abi, lock)
+    const lockContract = new this.web3.eth.Contract(
+      UnlockV0.PublicLock.abi,
+      lock
+    )
 
     this._genKeyOwnersFromLockContract(lock, lockContract, page, byPage).then(
       keyPromises => {


### PR DESCRIPTION
In order to support multiple versions of Unlock concurrently we need to namespace the versions used.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread