### PR TITLE
Allow wedlocks to respond to OPTIONS

### DIFF
--- a/wedlocks/src/__tests__/handler.test.js
+++ b/wedlocks/src/__tests__/handler.test.js
@@ -17,7 +17,7 @@ describe('handler', () => {
       }
     )
   })
-  
+
   it('should render 405 if the method is not a POST', done => {
     expect.assertions(2)
     handler(

--- a/wedlocks/src/__tests__/handler.test.js
+++ b/wedlocks/src/__tests__/handler.test.js
@@ -4,6 +4,20 @@ import { route } from '../route'
 jest.mock('../route')
 
 describe('handler', () => {
+  it('should render 204 if the method is OPTIONS', done => {
+    expect.assertions(1)
+    handler(
+      {
+        httpMethod: 'OPTIONS',
+      },
+      {},
+      (error, response) => {
+        expect(response.statusCode).toBe(204)
+        done()
+      }
+    )
+  })
+  
   it('should render 405 if the method is not a POST', done => {
     expect.assertions(2)
     handler(

--- a/wedlocks/src/handler.js
+++ b/wedlocks/src/handler.js
@@ -17,6 +17,13 @@ export const handler = (event, context, responseCallback) => {
       },
     })
   }
+
+  if (event.httpMethod === 'OPTIONS') {
+    return callback(null, {
+      statusCode: 204,
+    })
+  }
+  
   if (event.httpMethod != 'POST') {
     return callback(null, {
       statusCode: 405,

--- a/wedlocks/src/handler.js
+++ b/wedlocks/src/handler.js
@@ -23,7 +23,7 @@ export const handler = (event, context, responseCallback) => {
       statusCode: 204,
     })
   }
-  
+
   if (event.httpMethod != 'POST') {
     return callback(null, {
       statusCode: 405,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
In user account creation testing this past Friday, we realized that `wedlocks` fails on the HTTP `OPTIONS` method, which prevented emails from sending. This updates the handler to return `204` on an `OPTIONS` method, indicating success.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #2111 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
