### PR TITLE
fix the height of the body in mobile unlocked flag view

### DIFF
--- a/paywall/src/components/Paywall.css
+++ b/paywall/src/components/Paywall.css
@@ -19,6 +19,6 @@ body.big {
 /* if you change this, also change the value in src/themes/media.js */
 @media only screen and (min-width: 257px) and (max-width: 763px) {
   body.small {
-    height: 43px;
+    height: 60px;
   }
 }


### PR DESCRIPTION
# Description

The body size was 43px, but the height of the paywall flag is 60px, so this created a small gap at the bottom of the screen.

![Screenshot_20190415-143542](https://user-images.githubusercontent.com/98250/56156917-3cb3fe80-5f8c-11e9-8dd9-5112e11c6481.png)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2652

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
