### PR TITLE
Storage middleware now ready to handle user creation

### DIFF
--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -7,6 +7,7 @@ import { SIGNED_DATA } from '../../actions/signature'
 import UnlockLock from '../../structured_data/unlockLock'
 import { startLoading, doneLoading } from '../../actions/loading'
 import configure from '../../config'
+import { SIGNUP_CREDENTIALS } from '../../actions/signUp'
 
 /**
  * This is a "fake" middleware caller
@@ -250,6 +251,26 @@ describe('Storage middleware', () => {
         data,
         type: 'signature/SIGN_DATA',
       })
+    })
+  })
+
+  describe('SIGNUP_CREDENTIALS', () => {
+    it('should create a user and then set the account', () => {
+      expect.assertions(1)
+      const emailAddress = 'tim@cern.ch'
+      const password = 'guest'
+      const { invoke } = create()
+
+      const action = {
+        type: SIGNUP_CREDENTIALS,
+        emailAddress,
+        password,
+      }
+
+      mockStorageService.createUser = jest.fn(() => Promise.resolve(true))
+
+      invoke(action)
+      expect(mockStorageService.createUser).toHaveBeenCalled()
     })
   })
 })

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -1,5 +1,6 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
+import Web3 from 'web3'
 import { UPDATE_LOCK, updateLock, UPDATE_LOCK_NAME } from '../actions/lock'
 
 import { startLoading, doneLoading } from '../actions/loading'
@@ -8,9 +9,12 @@ import StorageService from '../services/storageService'
 import { STORE_LOCK_NAME, storageError } from '../actions/storage'
 
 import { NEW_TRANSACTION, addTransaction } from '../actions/transaction'
-import { SET_ACCOUNT } from '../actions/accounts'
+import { SET_ACCOUNT, setAccount } from '../actions/accounts'
 import UnlockLock from '../structured_data/unlockLock'
 import { SIGNED_DATA, signData } from '../actions/signature'
+import { SIGNUP_CREDENTIALS } from '../actions/signUp'
+import UnlockUser from '../structured_data/unlockUser'
+import { setError } from '../actions/error'
 
 const storageMiddleware = config => {
   const { services } = config
@@ -103,6 +107,28 @@ const storageMiddleware = config => {
                 dispatch(storageError(error))
               })
           }
+        }
+
+        if (action.type === SIGNUP_CREDENTIALS) {
+          const web3 = new Web3()
+          const { address, privateKey } = web3.eth.accounts.create()
+          const { emailAddress, password } = action
+
+          const passwordEncryptedPrivateKey = web3.eth.accounts.encrypt(
+            privateKey,
+            password
+          )
+
+          const user = UnlockUser.build({
+            emailAddress,
+            publicKey: address,
+            passwordEncryptedPrivateKey,
+          })
+
+          storageService
+            .createUser(user) // TODO: Now what?
+            .then(() => dispatch(setAccount({ address })))
+            .catch(err => dispatch(setError(err)))
         }
 
         next(action)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Part of #2111, this PR has the storage middleware listen for events triggered by the signup process. Upon receiving a set of credentials, storage service creates a user account and then sets the account in state.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
