### PR TITLE
Adding version detection for v01

### DIFF
--- a/unlock-js/src/__tests__/unlockService.test.js
+++ b/unlock-js/src/__tests__/unlockService.test.js
@@ -2,8 +2,10 @@
 
 import nock from 'nock'
 import * as UnlockV0 from 'unlock-abi-0'
+import * as UnlockV01 from 'unlock-abi-0-1'
 import UnlockService, { Errors } from '../unlockService'
 import v0 from '../v0'
+import v01 from '../v01'
 
 // This unlock address smart contract is fake
 const unlockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
@@ -32,6 +34,19 @@ describe('UnlockService', () => {
 
       expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(unlockAddress)
       expect(version).toEqual(v0)
+    })
+
+    it('should return UnlockV01 when the opCode matches', async () => {
+      expect.assertions(2)
+      unlockService.web3.eth = {
+        getCode: jest.fn(() => {
+          return Promise.resolve(UnlockV01.Unlock.deployedBytecode)
+        }),
+      }
+      const version = await unlockService.unlockContractAbiVersion()
+
+      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(unlockAddress)
+      expect(version).toEqual(v01)
     })
 
     it('should throw NON_DEPLOYED_CONTRACT if the opCode is 0x', async () => {

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -1,8 +1,10 @@
 import EventEmitter from 'events'
 
 import * as UnlockV0 from 'unlock-abi-0'
+import * as UnlockV01 from 'unlock-abi-0-1'
 
 import v0 from './v0'
+import v01 from './v01'
 
 export const Errors = {
   MISSING_WEB3: 'MISSING_WEB3',
@@ -48,6 +50,10 @@ export default class UnlockService extends EventEmitter {
 
     if (UnlockV0.Unlock.deployedBytecode === opCode) {
       return v0
+    }
+
+    if (UnlockV01.Unlock.deployedBytecode === opCode) {
+      return v01
     }
 
     throw new Error(Errors.UNKNOWN_CONTRACT)


### PR DESCRIPTION
This adds version detection for v01.
Please review only after https://github.com/unlock-protocol/unlock/pull/2666 has been merged and master has been rebased (or look at latest commit only)



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread