### PR TITLE
add functionality to unlock-js to remove all web3 from the other apps

### DIFF
--- a/unlock-js/index.js
+++ b/unlock-js/index.js
@@ -1,8 +1,8 @@
 const Web3Service = require('./lib/web3Service')
 const WalletService = require('./lib/walletService')
-const { createAccountAndPasswordEncryptKey } = require('./lib/accounts')
+const createAccountAndPasswordEncryptKey = require('./lib/accounts').default
 const { getCurrentProvider, getWeb3Provider } = require('./lib/providers')
-const { deploy } = require('./lib/deploy')
+const deploy = require('./lib/deploy').default
 
 module.exports = {
   Web3Service: Web3Service.default,

--- a/unlock-js/index.js
+++ b/unlock-js/index.js
@@ -1,7 +1,14 @@
 const Web3Service = require('./lib/web3Service')
 const WalletService = require('./lib/walletService')
+const { createAccountAndPasswordEncryptKey } = require('./lib/accounts')
+const { getCurrentProvider, getWeb3Provider } = require('./lib/providers')
+const { deploy } = require('./lib/deploy')
 
 module.exports = {
   Web3Service: Web3Service.default,
   WalletService: WalletService.default,
+  createAccountAndPasswordEncryptKey,
+  getCurrentProvider,
+  getWeb3Provider,
+  deploy,
 }

--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -1,4 +1,4 @@
-import { createAccountAndPasswordEncryptKey } from '../accounts'
+import createAccountAndPasswordEncryptKey from '../accounts'
 
 describe('web3 accounts creation', () => {
   it('should call web3.accounts.create', () => {

--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -1,0 +1,17 @@
+import { createAccountAndPasswordEncryptKey } from '../accounts'
+
+describe('web3 accounts creation', () => {
+  it('should call web3.accounts.create', () => {
+    expect.assertions(2)
+
+    const {
+      address,
+      passwordEncryptedPrivateKey,
+    } = createAccountAndPasswordEncryptKey('hello')
+
+    expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/)
+    expect(passwordEncryptedPrivateKey.address).toBe(
+      address.substring(2).toLowerCase()
+    )
+  })
+})

--- a/unlock-js/src/__tests__/deploy.test.js
+++ b/unlock-js/src/__tests__/deploy.test.js
@@ -1,0 +1,202 @@
+import nock from 'nock'
+import Web3 from 'web3'
+
+import { deploy } from '../deploy'
+import { Unlock } from 'unlock-abi-0'
+
+const host = '127.0.0.1'
+const port = 8545
+const readOnlyProvider = `http://${host}:${port}`
+
+const nockScope = nock(readOnlyProvider, { encodedQueryParams: true })
+
+let rpcRequestId = 0
+
+let debug = false // set to true to see more logging statements
+
+function logNock(...args) {
+  if (debug) {
+    console.log(...args)
+  }
+}
+
+// Generic call
+const jsonRpcRequest = (method, params, result, error) => {
+  rpcRequestId += 1
+  nockScope
+    .post('/', { jsonrpc: '2.0', id: rpcRequestId, method, params })
+    .reply(200, { id: rpcRequestId, jsonrpc: '2.0', result, error })
+    .log(logNock)
+}
+
+// eth_getBalance
+const getBalanceForAccountAndYieldBalance = (account, balance) => {
+  return jsonRpcRequest(
+    'eth_getBalance',
+    [account.toLowerCase(), 'latest'],
+    balance
+  )
+}
+
+// eth_call
+const ethCallAndYield = (data, to, result) => {
+  return jsonRpcRequest('eth_call', [{ data, to }, 'latest'], result)
+}
+
+// eth_accounts
+const accountsAndYield = accounts => {
+  return jsonRpcRequest('eth_accounts', [], accounts)
+}
+
+// eth_gasPrice
+const ethGasPriceAndYield = () => {
+  return jsonRpcRequest('eth_gasPrice', [], 8000000)
+}
+
+// eth_sendTransaction
+const sendTransactionAndYield = (
+  from,
+  result,
+  data = Unlock.bytecode,
+  to = false,
+  gas = '0x3d0900'
+) => {
+  return jsonRpcRequest(
+    'eth_sendTransaction',
+    [
+      {
+        ...(to ? { to } : {}),
+        from,
+        gas,
+        data,
+        gasPrice: 8000000,
+      },
+    ],
+    result
+  )
+}
+
+// eth_getTransactionReceipt
+const ethGetTransactionReceiptAndYield = (hash, result) => {
+  return jsonRpcRequest('eth_getTransactionReceipt', [hash], result)
+}
+
+// eth_getCode
+const ethGetCodeAndYield = (address, tag) => {
+  return jsonRpcRequest(
+    'eth_getCode',
+    [address, tag],
+    '0x6000357c0100000000000000000000000000000000000000000000000000000000900480633284fd791461004557806370a0823114610059578063ccb767ae1461006e57005b610053600435602435610082565b60006000f35b6100646004356100f8565b8060005260206000f35b61007c600435602435610136565b60006000f35b60015473ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16146100bc576100f3565b80600060008473ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000209081540190819060000155505b5b5050565b6000600060008373ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205463ffffffff169050610131565b919050565b8063ffffffff16600060003373ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205463ffffffff16106101775761017c565b6101e9565b80600060003373ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090815403908190600001555080600060008473ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000209081540190819060000155505b505056'
+  )
+}
+
+const ethCallAndFail = (data, to, error) => {
+  return jsonRpcRequest('eth_call', [{ data, to }, 'latest'], undefined, error)
+}
+
+nock.emitter.on('no match', function(clientRequestObject, options, body) {
+  if (debug) {
+    console.log(`NO HTTP MOCK EXISTS FOR THAT REQUEST\n${body}`)
+  }
+})
+
+describe('contract deployer', () => {
+  const unlockAccountsOnNode = ['0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2']
+  const transaction = {
+    hash: '0x83f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
+    nonce: '0x04',
+    blockHash:
+      '0xdc7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
+    blockNumber: `0x${(14).toString('16')}`,
+    transactionIndex: '0x00',
+    from: unlockAccountsOnNode[0],
+    to: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+    value: '0x0',
+    gas: '0x16e360',
+    gasPrice: '0x04a817c800',
+    input:
+      '0x2bc888bf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000278d00000000000000000000000000000000000000000000000000002386f26fc10000000000000000000000000000000000000000000000000000000000000000000a',
+  }
+  const transactionReceipt = {
+    transactionIndex: '0x3',
+    blockHash:
+      '0xdc7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
+    blockNumber: `0x${(14).toString('16')}`,
+    gasUsed: '0x2ea84',
+    cumulativeGasUsed: '0x3a525',
+    contractAddress: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+    logs: [],
+    status: '0x1',
+  }
+  beforeEach(() => {
+    accountsAndYield(unlockAccountsOnNode)
+    ethGasPriceAndYield()
+    sendTransactionAndYield(unlockAccountsOnNode[0], transaction.hash)
+    ethGetTransactionReceiptAndYield(transaction.hash, transactionReceipt)
+    ethGetCodeAndYield('0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2', 'latest')
+    ethGasPriceAndYield()
+    sendTransactionAndYield(
+      unlockAccountsOnNode[0],
+      transaction.hash,
+      '0xc4d66de8000000000000000000000000aaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2', // data (no idea what this is, but there it is)
+      '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2', // contract address
+      '0xf4240' // gas
+    )
+    ethGetTransactionReceiptAndYield(transaction.hash, transactionReceipt)
+  })
+  it('retrieves accounts', async () => {
+    expect.assertions(1)
+    const web3 = new Web3(`http://${host}:${port}`)
+    const getAccounts = web3.eth.getAccounts
+    web3.eth.getAccounts = jest.fn(() => getAccounts())
+
+    await deploy(host, port, 'unlock-abi-0', () => {}, web3)
+    expect(web3.eth.getAccounts).toHaveBeenCalled()
+  })
+
+  it('passes the new contract instance to onNewContractInstance', async () => {
+    expect.assertions(1)
+    const deployed = jest.fn()
+
+    await deploy(host, port, 'unlock-abi-0', deployed)
+
+    expect(deployed.mock.calls[0][0].options.address).toBe(
+      '0xBbBDeed4C0b861cb36f4Ce006A9c90bA2E43fDc2' // fancified by web3-utils
+    )
+  })
+
+  it('calls initialize on the contract', async () => {
+    expect.assertions(1)
+    const web3 = new Web3(`http://${host}:${port}`)
+    const sendTransaction = web3.eth.sendTransaction
+    web3.eth.sendTransaction = jest.fn(t => sendTransaction(t))
+
+    await deploy(host, port, 'unlock-abi-0', () => {}, web3)
+    expect(web3.eth.sendTransaction).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        to: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+        from: unlockAccountsOnNode[0],
+        data: expect.any(String),
+        gas: '0xf4240',
+      })
+    )
+  })
+
+  it('returns the result of the contract initialization transaction', async () => {
+    expect.assertions(1)
+
+    const returnValue = await deploy(host, port, 'unlock-abi-0')
+
+    expect(returnValue).toEqual({
+      blockHash:
+        '0xdc7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
+      blockNumber: 14,
+      contractAddress: '0xBbBDeed4C0b861cb36f4Ce006A9c90bA2E43fDc2',
+      cumulativeGasUsed: 238885,
+      gasUsed: 191108,
+      logs: [],
+      status: true,
+      transactionIndex: 3,
+    })
+  })
+})

--- a/unlock-js/src/__tests__/deploy.test.js
+++ b/unlock-js/src/__tests__/deploy.test.js
@@ -1,8 +1,8 @@
 import nock from 'nock'
 import Web3 from 'web3'
-
-import { deploy } from '../deploy'
 import { Unlock } from 'unlock-abi-0'
+
+import deploy from '../deploy'
 
 const host = '127.0.0.1'
 const port = 8545
@@ -16,6 +16,7 @@ let debug = false // set to true to see more logging statements
 
 function logNock(...args) {
   if (debug) {
+    /* eslint-disable-next-line */
     console.log(...args)
   }
 }
@@ -27,20 +28,6 @@ const jsonRpcRequest = (method, params, result, error) => {
     .post('/', { jsonrpc: '2.0', id: rpcRequestId, method, params })
     .reply(200, { id: rpcRequestId, jsonrpc: '2.0', result, error })
     .log(logNock)
-}
-
-// eth_getBalance
-const getBalanceForAccountAndYieldBalance = (account, balance) => {
-  return jsonRpcRequest(
-    'eth_getBalance',
-    [account.toLowerCase(), 'latest'],
-    balance
-  )
-}
-
-// eth_call
-const ethCallAndYield = (data, to, result) => {
-  return jsonRpcRequest('eth_call', [{ data, to }, 'latest'], result)
 }
 
 // eth_accounts
@@ -90,12 +77,9 @@ const ethGetCodeAndYield = (address, tag) => {
   )
 }
 
-const ethCallAndFail = (data, to, error) => {
-  return jsonRpcRequest('eth_call', [{ data, to }, 'latest'], undefined, error)
-}
-
 nock.emitter.on('no match', function(clientRequestObject, options, body) {
   if (debug) {
+    /* eslint-disable-next-line */
     console.log(`NO HTTP MOCK EXISTS FOR THAT REQUEST\n${body}`)
   }
 })

--- a/unlock-js/src/__tests__/providers.test.js
+++ b/unlock-js/src/__tests__/providers.test.js
@@ -1,0 +1,12 @@
+import { getWeb3Provider } from '../providers'
+
+describe('web3 provider creator', () => {
+  it('getWeb3Provider returns a valid web3 provider for a URL', () => {
+    expect.assertions(2)
+
+    // using ws so that the test will still pass when we move to WebSocketProvider
+    const provider = getWeb3Provider('ws://1.2.3.4:1234')
+    expect(provider.send).toBeInstanceOf(Function)
+    expect(provider.disconnect).toBeInstanceOf(Function)
+  })
+})

--- a/unlock-js/src/accounts.js
+++ b/unlock-js/src/accounts.js
@@ -1,6 +1,6 @@
 const Web3 = require('web3')
 
-export function createAccountAndPasswordEncryptKey(password) {
+export default function createAccountAndPasswordEncryptKey(password) {
   const web3 = new Web3()
   const { address, privateKey } = web3.eth.accounts.create()
 

--- a/unlock-js/src/accounts.js
+++ b/unlock-js/src/accounts.js
@@ -1,0 +1,12 @@
+export function createAccountAndPasswordEncryptKey(password) {
+  const { address, privateKey } = web3.eth.accounts.create()
+
+  const passwordEncryptedPrivateKey = web3.eth.accounts.encrypt(
+    privateKey,
+    password
+  )
+  return {
+    address,
+    passwordEncryptedPrivateKey,
+  }
+}

--- a/unlock-js/src/accounts.js
+++ b/unlock-js/src/accounts.js
@@ -1,4 +1,7 @@
+const Web3 = require('web3')
+
 export function createAccountAndPasswordEncryptKey(password) {
+  const web3 = new Web3()
   const { address, privateKey } = web3.eth.accounts.create()
 
   const passwordEncryptedPrivateKey = web3.eth.accounts.encrypt(

--- a/unlock-js/src/deploy.js
+++ b/unlock-js/src/deploy.js
@@ -1,8 +1,13 @@
 const Web3 = require('web3')
-const Unlock = require('unlock-abi-0').Unlock
 
-export async function deploy(host, port, onNewContractInstance = () => {}) {
-  const web3 = new Web3(`http://${host}:${port}`)
+export async function deploy(
+  host,
+  port,
+  unlockVersion = 'unlock-abi-0',
+  onNewContractInstance = () => {},
+  web3 = new Web3(`http://${host}:${port}`)
+) {
+  const Unlock = require(unlockVersion).Unlock
   const unlock = new web3.eth.Contract(Unlock.abi)
 
   const accounts = await web3.eth.getAccounts()

--- a/unlock-js/src/deploy.js
+++ b/unlock-js/src/deploy.js
@@ -1,0 +1,27 @@
+const Web3 = require('web3')
+const Unlock = require('unlock-abi-0').Unlock
+
+export async function deploy(host, port, onNewContractInstance = () => {}) {
+  const web3 = new Web3(`http://${host}:${port}`)
+  const unlock = new web3.eth.Contract(Unlock.abi)
+
+  const accounts = await web3.eth.getAccounts()
+  const newContractInstance = await unlock
+    .deploy({
+      data: Unlock.bytecode,
+    })
+    .send({
+      from: accounts[0],
+      gas: 4000000,
+    })
+  onNewContractInstance(newContractInstance)
+
+  // Initialize
+  const data = unlock.methods.initialize(accounts[0]).encodeABI()
+  return web3.eth.sendTransaction({
+    to: newContractInstance.options.address,
+    from: accounts[0],
+    data,
+    gas: 1000000,
+  })
+}

--- a/unlock-js/src/deploy.js
+++ b/unlock-js/src/deploy.js
@@ -1,12 +1,13 @@
 const Web3 = require('web3')
 
-export async function deploy(
+export default async function deploy(
   host,
   port,
   unlockVersion = 'unlock-abi-0',
   onNewContractInstance = () => {},
   web3 = new Web3(`http://${host}:${port}`)
 ) {
+  /* eslint-disable-next-line import/no-dynamic-require */
   const Unlock = require(unlockVersion).Unlock
   const unlock = new web3.eth.Contract(Unlock.abi)
 

--- a/unlock-js/src/providers.js
+++ b/unlock-js/src/providers.js
@@ -1,0 +1,42 @@
+import Web3 from 'web3'
+
+// There is no standard way to detect the provider name...
+export function getCurrentProvider(environment) {
+  if (
+    environment.ethereum &&
+    environment.ethereum.constructor.name === 'Object'
+  )
+    return 'Opera'
+
+  if (environment.web3.currentProvider.isMetaMask) return 'Metamask'
+
+  if (environment.web3.currentProvider.isTrust) return 'Trust'
+
+  if (environment.web3.currentProvider.isToshi) return 'Coinbase Wallet'
+
+  if (environment.web3.currentProvider.isCipher) return 'Cipher'
+
+  if (environment.web3.currentProvider.constructor.name === 'EthereumProvider')
+    return 'Mist'
+
+  if (environment.web3.currentProvider.constructor.name === 'Web3FrameProvider')
+    return 'Parity'
+
+  if (
+    environment.web3.currentProvider.host &&
+    environment.web3.currentProvider.host.indexOf('infura') !== -1
+  )
+    return 'Infura'
+
+  if (
+    environment.web3.currentProvider.host &&
+    environment.web3.currentProvider.host.indexOf('localhost') !== -1
+  )
+    return 'localhost'
+
+  return 'UnknownProvider'
+}
+
+export function getWeb3HTTPProvider(url) {
+  return new Web3.providers.HttpProvider(url)
+}

--- a/unlock-js/src/providers.js
+++ b/unlock-js/src/providers.js
@@ -1,6 +1,7 @@
 import Web3 from 'web3'
 
 // There is no standard way to detect the provider name...
+// TODO: remove? this convenience function is unused
 export function getCurrentProvider(environment) {
   if (
     environment.ethereum &&
@@ -37,6 +38,7 @@ export function getCurrentProvider(environment) {
   return 'UnknownProvider'
 }
 
-export function getWeb3HTTPProvider(url) {
+export function getWeb3Provider(url) {
+  // TODO: use websocket provider
   return new Web3.providers.HttpProvider(url)
 }


### PR DESCRIPTION
# Description

This PR adds a few new exports to `unlock-js` that can replace all uses of `web3` inside the `unlock-app`, `unlock-protocol-com` app, `paywall` app, and `tickets` app.

Most of the features are within `config.js`, which instantiates an HTTP provider. For that, we now export `getWeb3Provider` and `getCurrentProvider` (the latter is unused, but could be potentially?).

For the usage in `storageMiddleware` to create a new account, we export `createAccountAndPasswordEncryptKey`, which accepts a password and returns the new address and encrypted private key.

For the `deploy-unlock.js` script, we provide a new async function `deploy` which accepts a host and port for the running ethereum node, and a contract abi package name, defaulting to `unlock-abi-0`. This also accepts a callback which is called with the new contract (used to console.error the new address out in the deploy script), and then returns the result of the deploy initialization transaction.

This reduces the deploy script to:

```js
const net = require('net')
const { deploy } = require('@unlock-protocol/unlock-js')


/*
 * This script is meant to be used in dev environment to deploy a version of the Unlock smart
 * contract from the packaged version to the local ganache server.
 */

const host = process.env.HTTP_PROVIDER || '127.0.0.1'
const port = 8545
const serverIsUp = (delay, maxAttempts) =>
  new Promise((resolve, reject) => {
    let attempts = 1
    const tryConnecting = () => {
      const socket = net.connect(port, host, () => {
        resolve()
        return socket.end() // clean-up
      })

      socket.on('error', error => {
        if (error.code === 'ECONNREFUSED') {
          if (attempts < maxAttempts) {
            attempts += 1
            return setTimeout(tryConnecting, delay)
          }
          return reject(error)
        }
        return reject(error)
      })
    }
    tryConnecting()
  })
serverIsUp(1000 /* every second */, 120 /* up to 2 minutes */)
  .then(() => {
    return deploy(host, port, 'unlock-abi-0', newContractInstance => console.log(newContractInstance.options.address))
  })
  .catch(error => {
    console.error(error)
    process.exit(1)
  })
  
```

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
