### PR TITLE
refactor to accept a contract and to initialize web3 if it is not passed

### DIFF
--- a/unlock-js/src/__tests__/deploy.test.js
+++ b/unlock-js/src/__tests__/deploy.test.js
@@ -134,7 +134,7 @@ describe('contract deployer', () => {
     const getAccounts = web3.eth.getAccounts
     web3.eth.getAccounts = jest.fn(() => getAccounts())
 
-    await deploy(host, port, 'unlock-abi-0', () => {}, web3)
+    await deploy(host, port, Unlock, () => {}, web3)
     expect(web3.eth.getAccounts).toHaveBeenCalled()
   })
 
@@ -142,7 +142,7 @@ describe('contract deployer', () => {
     expect.assertions(1)
     const deployed = jest.fn()
 
-    await deploy(host, port, 'unlock-abi-0', deployed)
+    await deploy(host, port, Unlock, deployed)
 
     expect(deployed.mock.calls[0][0].options.address).toBe(
       '0xBbBDeed4C0b861cb36f4Ce006A9c90bA2E43fDc2' // fancified by web3-utils
@@ -155,7 +155,7 @@ describe('contract deployer', () => {
     const sendTransaction = web3.eth.sendTransaction
     web3.eth.sendTransaction = jest.fn(t => sendTransaction(t))
 
-    await deploy(host, port, 'unlock-abi-0', () => {}, web3)
+    await deploy(host, port, Unlock, () => {}, web3)
     expect(web3.eth.sendTransaction).toHaveBeenLastCalledWith(
       expect.objectContaining({
         to: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
@@ -169,7 +169,7 @@ describe('contract deployer', () => {
   it('returns the result of the contract initialization transaction', async () => {
     expect.assertions(1)
 
-    const returnValue = await deploy(host, port, 'unlock-abi-0')
+    const returnValue = await deploy(host, port, Unlock)
 
     expect(returnValue).toEqual({
       blockHash:

--- a/unlock-js/src/deploy.js
+++ b/unlock-js/src/deploy.js
@@ -3,12 +3,11 @@ const Web3 = require('web3')
 export default async function deploy(
   host,
   port,
-  unlockVersion = 'unlock-abi-0',
+  Unlock,
   onNewContractInstance = () => {},
-  web3 = new Web3(`http://${host}:${port}`)
+  web3Object
 ) {
-  /* eslint-disable-next-line import/no-dynamic-require */
-  const Unlock = require(unlockVersion).Unlock
+  const web3 = web3Object || new Web3(`http://${host}:${port}`)
   const unlock = new web3.eth.Contract(Unlock.abi)
 
   const accounts = await web3.eth.getAccounts()


### PR DESCRIPTION
# Description

In unrelated research, I discovered dynamic require will not be supported by es modules, and is frowned upon. This PR removes that and instead has the contract passed in. It also removes the `new Web3` call from the default arguments, as that causes webpack to warn about importing an expression.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
