### PR TITLE
adding version detection mechanism for locks, independently of the deployed unlock version

### DIFF
--- a/unlock-js/src/__tests__/unlockService.test.js
+++ b/unlock-js/src/__tests__/unlockService.test.js
@@ -1,8 +1,8 @@
 /* eslint no-console: 0 */
 
-import nock from 'nock'
 import * as UnlockV0 from 'unlock-abi-0'
 import * as UnlockV01 from 'unlock-abi-0-1'
+
 import UnlockService, { Errors } from '../unlockService'
 import v0 from '../v0'
 import v01 from '../v01'
@@ -14,7 +14,6 @@ let unlockService
 
 describe('UnlockService', () => {
   beforeEach(() => {
-    nock.cleanAll()
     unlockService = new UnlockService({
       unlockAddress,
     })
@@ -87,6 +86,81 @@ describe('UnlockService', () => {
       unlockService.opCodeForAddress[unlockAddress] =
         UnlockV0.Unlock.deployedBytecode
       const version = await unlockService.unlockContractAbiVersion()
+      expect(unlockService.web3.eth.getCode).not.toHaveBeenCalled()
+      expect(version).toEqual(v0)
+    })
+  })
+
+  describe('lockContractAbiVersion', () => {
+    it('should return UnlockV0 when the opCode matches', async () => {
+      expect.assertions(2)
+      unlockService.web3.eth = {
+        getCode: jest.fn(() => {
+          return Promise.resolve(UnlockV0.PublicLock.deployedBytecode)
+        }),
+      }
+      const address = '0xabc'
+      const version = await unlockService.lockContractAbiVersion(address)
+
+      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
+      expect(version).toEqual(v0)
+    })
+
+    it('should return UnlockV01 when the opCode matches', async () => {
+      expect.assertions(2)
+      unlockService.web3.eth = {
+        getCode: jest.fn(() => {
+          return Promise.resolve(UnlockV01.PublicLock.deployedBytecode)
+        }),
+      }
+      const address = '0xabc'
+      const version = await unlockService.lockContractAbiVersion(address)
+
+      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
+      expect(version).toEqual(v01)
+    })
+
+    it('should throw NON_DEPLOYED_CONTRACT if the opCode is 0x', async () => {
+      expect.assertions(2)
+      unlockService.web3.eth = {
+        getCode: jest.fn(() => {
+          return Promise.resolve('0x')
+        }),
+      }
+      const address = '0xabc'
+      try {
+        await unlockService.lockContractAbiVersion(address)
+      } catch (error) {
+        expect(error.message).toEqual(Errors.NON_DEPLOYED_CONTRACT)
+      }
+      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
+    })
+
+    it('should throw UNKNOWN_CONTRACT if the opCode does not match any version', async () => {
+      expect.assertions(2)
+      unlockService.web3.eth = {
+        getCode: jest.fn(() => {
+          return Promise.resolve('0xabc')
+        }),
+      }
+      const address = '0xabc'
+      try {
+        await unlockService.lockContractAbiVersion(address)
+      } catch (error) {
+        expect(error.message).toEqual(Errors.UNKNOWN_CONTRACT)
+      }
+      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
+    })
+
+    it('should memoize the result', async () => {
+      expect.assertions(2)
+      unlockService.web3.eth = {
+        getCode: jest.fn(),
+      }
+      const address = '0xabc'
+      unlockService.opCodeForAddress[address] =
+        UnlockV0.PublicLock.deployedBytecode
+      const version = await unlockService.lockContractAbiVersion(address)
       expect(unlockService.web3.eth.getCode).not.toHaveBeenCalled()
       expect(version).toEqual(v0)
     })

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -29,7 +29,6 @@ export default class UnlockService extends EventEmitter {
 
   /**
    * Returns the ABI for the Unlock contract deployed
-   * Another approach might be to look at the opCode
    * @param {*} address
    */
   async unlockContractAbiVersion() {
@@ -53,6 +52,37 @@ export default class UnlockService extends EventEmitter {
     }
 
     if (UnlockV01.Unlock.deployedBytecode === opCode) {
+      return v01
+    }
+
+    throw new Error(Errors.UNKNOWN_CONTRACT)
+  }
+
+  /**
+   * Returns the ABI for the Lock contract deployed at the provided address
+   * @param {*} address
+   */
+  async lockContractAbiVersion(address) {
+    if (!this.web3) {
+      throw new Error(Errors.MISSING_WEB3)
+    }
+
+    let opCode = this.opCodeForAddress[address]
+    if (!opCode) {
+      // This was not memo-ized
+      opCode = await this.web3.eth.getCode(address)
+      this.opCodeForAddress[address] = opCode
+    }
+
+    if (opCode === '0x') {
+      throw new Error(Errors.NON_DEPLOYED_CONTRACT)
+    }
+
+    if (UnlockV0.PublicLock.deployedBytecode === opCode) {
+      return v0
+    }
+
+    if (UnlockV01.PublicLock.deployedBytecode === opCode) {
       return v01
     }
 

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -127,7 +127,7 @@ export default class WalletService extends UnlockService {
    * @param {string} price : new price for the lock
    */
   async updateKeyPrice(lock, account, price) {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion()
     return version.updateKeyPrice.bind(this)(lock, account, price)
   }
 
@@ -154,7 +154,7 @@ export default class WalletService extends UnlockService {
    * @param {string} account
    */
   async purchaseKey(lock, owner, keyPrice, account, data = '') {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion()
     return version.purchaseKey.bind(this)(lock, owner, keyPrice, account, data)
   }
 
@@ -167,7 +167,7 @@ export default class WalletService extends UnlockService {
    * @param {Function} callback
    */
   async partialWithdrawFromLock(lock, account, ethAmount, callback) {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion()
     return version.partialWithdrawFromLock.bind(this)(
       lock,
       account,
@@ -183,7 +183,7 @@ export default class WalletService extends UnlockService {
    * @param {Function} callback TODO: implement...
    */
   async withdrawFromLock(lock, account) {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion()
     return version.withdrawFromLock.bind(this)(lock, account)
   }
 


### PR DESCRIPTION
Lock versions are independent of the Unlock version, because they could have been deployed from a previous version.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread