### PR TITLE
skipping chromatic on production builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,9 @@ workflows:
       - unlock-app-tests
       - unlock-js-tests
       - unlock-app-chromatic:
+          filters:
+            branches:
+              ignore: production
           requires:
             - unlock-app-tests
       - integration-tests:


### PR DESCRIPTION
There is no need to run chromatic on production builds...

Syntax is detailed there https://circleci.com/docs/2.0/configuration-reference/#branches




- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread