### PR TITLE
Changing version detection when using a proxy contract.

### DIFF
--- a/unlock-js/src/v0/index.js
+++ b/unlock-js/src/v0/index.js
@@ -32,4 +32,5 @@ export default {
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
+  version: 'v0',
 }

--- a/unlock-js/src/v01/index.js
+++ b/unlock-js/src/v01/index.js
@@ -32,4 +32,5 @@ export default {
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
+  version: 'v01',
 }


### PR DESCRIPTION
We changed it by implementing version lookup through the proxy contracts.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread