### PR TITLE
walletMiddleware handles signAddress [tickets]

### DIFF
--- a/tickets/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/tickets/src/__tests__/middlewares/walletMiddleware.test.js
@@ -6,6 +6,7 @@ import { PROVIDER_READY } from '../../actions/provider'
 import { SET_ERROR } from '../../actions/error'
 import { POLLING_INTERVAL } from '../../constants'
 import { FATAL_NON_DEPLOYED_CONTRACT, FATAL_WRONG_NETWORK } from '../../errors'
+import { SIGN_ADDRESS, gotSignedAddress } from '../../actions/ticket'
 
 let mockConfig
 
@@ -56,6 +57,7 @@ class MockWalletService extends EventEmitter {
     this.ready = true
   }
   connect() {}
+  signData() {}
 }
 
 let mockWalletService = new MockWalletService()
@@ -254,6 +256,33 @@ describe('Wallet middleware', () => {
     invoke(action)
     expect(mockWalletService.connect).toHaveBeenCalledWith(
       mockConfig.providers[state.provider]
+    )
+    expect(next).toHaveBeenCalledWith(action)
+  })
+
+  it('should handle SIGN_ADDRESS and emit a signed address', () => {
+    expect.assertions(3)
+    const {
+      next,
+      invoke,
+      store: { dispatch, getState },
+    } = create()
+    const address = '0x12345678'
+    const action = {
+      type: SIGN_ADDRESS,
+      address,
+    }
+    mockWalletService.signData = jest.fn((_, address, cb) =>
+      cb(null, `ENCRYPTED: ${address}`)
+    )
+    invoke(action)
+    expect(mockWalletService.signData).toHaveBeenCalledWith(
+      getState().account,
+      address,
+      expect.any(Function)
+    )
+    expect(dispatch).toHaveBeenCalledWith(
+      gotSignedAddress(`ENCRYPTED: ${address}`)
     )
     expect(next).toHaveBeenCalledWith(action)
   })

--- a/tickets/src/errors.js
+++ b/tickets/src/errors.js
@@ -12,3 +12,6 @@ export const NO_USER_ACCOUNT = 'NO_USER_ACCOUNT'
 
 // Transaction failures
 export const FAILED_TO_PURCHASE_KEY = 'FAILED_TO_PURCHASE_KEY'
+
+// Ticket failure
+export const FAILED_TO_SIGN_ADDRESS = 'FAILED_TO_SIGN_ADDRESS'


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Part 2 of #2701, now `walletMiddleware` handles `signAddress` and produces an action containing the signed data. The next PR will take this action and use it to update the state.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
