### PR TITLE
Add signed address to redux

### DIFF
--- a/tickets/src/__tests__/actions/ticket.test.js
+++ b/tickets/src/__tests__/actions/ticket.test.js
@@ -53,6 +53,6 @@ describe('ticket actions', () => {
       signedAddress,
     }
 
-    expect(gotSignedAddress(signedAddress)).toEqual(expectedAction)
+    expect(gotSignedAddress(address, signedAddress)).toEqual(expectedAction)
   })
 })

--- a/tickets/src/__tests__/actions/ticket.test.js
+++ b/tickets/src/__tests__/actions/ticket.test.js
@@ -45,9 +45,11 @@ describe('ticket actions', () => {
 
   it('should create an action emitting an address that has been signed', () => {
     expect.assertions(1)
+    const address = '0x12345678'
     const signedAddress = 'ENCRYPTED'
     const expectedAction = {
       type: GOT_SIGNED_ADDRESS,
+      address,
       signedAddress,
     }
 

--- a/tickets/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/tickets/src/__tests__/middlewares/walletMiddleware.test.js
@@ -282,7 +282,7 @@ describe('Wallet middleware', () => {
       expect.any(Function)
     )
     expect(dispatch).toHaveBeenCalledWith(
-      gotSignedAddress(`ENCRYPTED: ${address}`)
+      gotSignedAddress(address, `ENCRYPTED: ${address}`)
     )
     expect(next).toHaveBeenCalledWith(action)
   })

--- a/tickets/src/__tests__/reducers/ticketsReducer.test.js
+++ b/tickets/src/__tests__/reducers/ticketsReducer.test.js
@@ -1,0 +1,38 @@
+import reducer, { initialState } from '../../reducers/ticketsReducer'
+import { GOT_SIGNED_ADDRESS } from '../../actions/ticket'
+import { SET_PROVIDER } from '../../actions/provider'
+import { SET_NETWORK } from '../../actions/network'
+import { SET_ACCOUNT } from '../../actions/accounts'
+
+describe('tickets reducer', () => {
+  const address = '0x12345678'
+  const signedAddress = 'ENCRYPTED'
+
+  it('should return the initial state', () => {
+    expect.assertions(1)
+    expect(reducer(undefined, {})).toEqual({})
+  })
+
+  it.each([
+    ['SET_PROVIDER', SET_PROVIDER],
+    ['SET_NETWORK', SET_NETWORK],
+    ['SET_ACCOUNT', SET_ACCOUNT],
+  ])('should return the initial state when receiving %s', (name, type) => {
+    expect.assertions(1)
+    expect(reducer({ address: signedAddress }, { type })).toBe(initialState)
+  })
+
+  it('should add a signed address to the state', () => {
+    expect.assertions(1)
+    expect(
+      reducer(
+        {},
+        {
+          type: GOT_SIGNED_ADDRESS,
+          address,
+          signedAddress,
+        }
+      )
+    ).toEqual({ [address]: signedAddress })
+  })
+})

--- a/tickets/src/actions/ticket.js
+++ b/tickets/src/actions/ticket.js
@@ -20,7 +20,7 @@ export const signAddress = address => ({
   address,
 })
 
-export const gotSignedAddress = signedAddress => ({
+export const gotSignedAddress = (address, signedAddress) => ({
   type: GOT_SIGNED_ADDRESS,
   signedAddress,
 })

--- a/tickets/src/actions/ticket.js
+++ b/tickets/src/actions/ticket.js
@@ -22,5 +22,6 @@ export const signAddress = address => ({
 
 export const gotSignedAddress = (address, signedAddress) => ({
   type: GOT_SIGNED_ADDRESS,
+  address,
   signedAddress,
 })

--- a/tickets/src/createUnlockStore.js
+++ b/tickets/src/createUnlockStore.js
@@ -30,6 +30,9 @@ import accountReducer, {
 import walletStatusReducer, {
   initialState as defaultWalletStatus,
 } from './reducers/walletStatusReducer'
+import ticketsReducer, {
+  initialState as defaultTicketAddresses,
+} from './reducers/ticketsReducer'
 
 const config = configure()
 
@@ -44,6 +47,7 @@ export const createUnlockStore = (defaultState = {}, middlewares = []) => {
     currency: currencyReducer,
     errors: errorsReducer,
     walletStatus: walletStatusReducer,
+    tickets: ticketsReducer,
   }
 
   // Cleanup the defaultState to remove all null values so that we do not overwrite existing
@@ -65,6 +69,7 @@ export const createUnlockStore = (defaultState = {}, middlewares = []) => {
       currency: defaultCurrency,
       errors: defaultError,
       walletStatus: defaultWalletStatus,
+      ticketAddresses: defaultTicketAddresses,
     },
     {
       provider: Object.keys(config.providers)[0],

--- a/tickets/src/middlewares/walletMiddleware.js
+++ b/tickets/src/middlewares/walletMiddleware.js
@@ -81,18 +81,15 @@ const walletMiddleware = config => {
 
         if (action.type === SIGN_ADDRESS) {
           const { account } = getState()
-          walletService.signData(
-            account,
-            action.address,
-            (error, signedAddress) => {
-              if (error) {
-                // TODO: Does this need to be handled in the error consumer?
-                dispatch(setError(FAILED_TO_SIGN_ADDRESS, error))
-              } else {
-                dispatch(gotSignedAddress(signedAddress))
-              }
+          const { address } = action
+          walletService.signData(account, address, (error, signedAddress) => {
+            if (error) {
+              // TODO: Does this need to be handled in the error consumer?
+              dispatch(setError(FAILED_TO_SIGN_ADDRESS, error))
+            } else {
+              dispatch(gotSignedAddress(address, signedAddress))
             }
-          )
+          })
         }
         next(action)
       }

--- a/tickets/src/reducers/ticketsReducer.js
+++ b/tickets/src/reducers/ticketsReducer.js
@@ -1,0 +1,16 @@
+import { SET_PROVIDER } from '../actions/provider'
+import { SET_NETWORK } from '../actions/network'
+import { SET_ACCOUNT } from '../actions/accounts'
+import { GOT_SIGNED_ADDRESS } from '../actions/ticket'
+
+export const initialState = {}
+
+const ticketsReducer = (state = initialState, action) => {
+  if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
+    return initialState
+  }
+
+  if (action.type === GOT_SIGNED_ADDRESS) {
+    const { address, signedAddress } = action
+  }
+}

--- a/tickets/src/reducers/ticketsReducer.js
+++ b/tickets/src/reducers/ticketsReducer.js
@@ -12,5 +12,13 @@ const ticketsReducer = (state = initialState, action) => {
 
   if (action.type === GOT_SIGNED_ADDRESS) {
     const { address, signedAddress } = action
+    return {
+      [address]: signedAddress,
+      ...state,
+    }
   }
+
+  return state
 }
+
+export default ticketsReducer


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This resolves #2701. It adds a reducer that will take the output of `gotSignedAddress`, a pair of `(lockAddress, signedLockAddress)`, and add them to the state as key and value of `ticketAddresses`.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
