### PR TITLE
using the right method to get the version to use

### DIFF
--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -127,7 +127,7 @@ export default class WalletService extends UnlockService {
    * @param {string} price : new price for the lock
    */
   async updateKeyPrice(lock, account, price) {
-    const version = await this.lockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(lock)
     return version.updateKeyPrice.bind(this)(lock, account, price)
   }
 
@@ -154,7 +154,7 @@ export default class WalletService extends UnlockService {
    * @param {string} account
    */
   async purchaseKey(lock, owner, keyPrice, account, data = '') {
-    const version = await this.lockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(lock)
     return version.purchaseKey.bind(this)(lock, owner, keyPrice, account, data)
   }
 
@@ -167,7 +167,7 @@ export default class WalletService extends UnlockService {
    * @param {Function} callback
    */
   async partialWithdrawFromLock(lock, account, ethAmount, callback) {
-    const version = await this.lockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(lock)
     return version.partialWithdrawFromLock.bind(this)(
       lock,
       account,
@@ -183,7 +183,7 @@ export default class WalletService extends UnlockService {
    * @param {Function} callback TODO: implement...
    */
   async withdrawFromLock(lock, account) {
-    const version = await this.lockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(lock)
     return version.withdrawFromLock.bind(this)(lock, account)
   }
 

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -173,7 +173,7 @@ export default class Web3Service extends UnlockService {
    * @param {*} address
    */
   async getPastLockCreationsTransactionsForUser(address) {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(address)
     return version.getPastLockCreationsTransactionsForUser.bind(this)(address)
   }
 
@@ -183,7 +183,7 @@ export default class Web3Service extends UnlockService {
    * @param {*} lockAddress
    */
   async getPastLockTransactions(lockAddress) {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(lockAddress)
     return version.getPastLockTransactions.bind(this)(lockAddress)
   }
 
@@ -350,7 +350,7 @@ export default class Web3Service extends UnlockService {
    * @return Promise<Lock>
    */
   async getLock(address) {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(address)
     return version.getLock.bind(this)(address)
   }
 
@@ -360,7 +360,7 @@ export default class Web3Service extends UnlockService {
    * @param {PropTypes.string} owner
    */
   async getKeyByLockForOwner(lock, owner) {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(lock)
     return version.getKeyByLockForOwner.bind(this)(lock, owner)
   }
 
@@ -372,7 +372,7 @@ export default class Web3Service extends UnlockService {
    * @return Promise<>
    */
   async _getKeyByLockForOwner(lockContract, owner) {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(lockContract)
     return version._getKeyByLockForOwner.bind(this)(lockContract, owner)
   }
 
@@ -443,7 +443,7 @@ export default class Web3Service extends UnlockService {
    * @param {PropTypes.integer}
    */
   async getKeysForLockOnPage(lock, page, byPage) {
-    const version = await this.unlockContractAbiVersion()
+    const version = await this.lockContractAbiVersion(lock)
     return version.getKeysForLockOnPage.bind(this)(lock, page, byPage)
   }
 }


### PR DESCRIPTION
When handling lock contract we should get the method wich extract the version from it, not from
the unlock contract.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - X ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread