### PR TITLE
confirmation always starts at 0. fixes #2367

### DIFF
--- a/unlock-js/src/__tests__/v0/getTransaction.test.js
+++ b/unlock-js/src/__tests__/v0/getTransaction.test.js
@@ -88,6 +88,43 @@ describe('v0', () => {
       })
     })
 
+    describe('when the transaction has been mined in the next block', () => {
+      beforeEach(() => {
+        nock.ethBlockNumber(`0x${(17).toString('16')}`)
+        nock.ethGetTransactionByHash(transaction.hash, {
+          hash:
+            '0x83f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
+          nonce: '0x04',
+          blockHash:
+            '0xdc7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
+          blockNumber: `0x${(18).toString('16')}`,
+          transactionIndex: '0x0d',
+          from: '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1',
+          to: '0xcfeb869f69431e42cdb54a4f4f105c19c080a601',
+          value: '0x0',
+          gas: '0x16e360',
+          gasPrice: '0x04a817c800',
+          input:
+            '0x2bc888bf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000278d00000000000000000000000000000000000000000000000000002386f26fc10000000000000000000000000000000000000000000000000000000000000000000a',
+        })
+        web3Service.web3.eth.getTransactionReceipt = jest.fn(
+          () => new Promise(() => {})
+        )
+        web3Service._watchTransaction = jest.fn()
+        web3Service.getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
+      })
+
+      it('should emit a transaction.updated event with 0 confirmations', done => {
+        expect.assertions(1)
+        web3Service.on('transaction.updated', (hash, update) => {
+          expect(update.confirmations).toEqual(0) // 0 > -1 [17-18]
+          done()
+        })
+
+        web3Service.getTransaction(transaction.hash)
+      })
+    })
+
     describe('when the transaction has been mined but not fully confirmed', () => {
       beforeEach(() => {
         nock.ethBlockNumber(`0x${(17).toString('16')}`)

--- a/unlock-js/src/__tests__/v01/getTransaction.test.js
+++ b/unlock-js/src/__tests__/v01/getTransaction.test.js
@@ -88,6 +88,43 @@ describe('v01', () => {
       })
     })
 
+    describe('when the transaction has been mined in the next block', () => {
+      beforeEach(() => {
+        nock.ethBlockNumber(`0x${(17).toString('16')}`)
+        nock.ethGetTransactionByHash(transaction.hash, {
+          hash:
+            '0x83f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
+          nonce: '0x04',
+          blockHash:
+            '0xdc7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
+          blockNumber: `0x${(18).toString('16')}`,
+          transactionIndex: '0x0d',
+          from: '0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1',
+          to: '0xcfeb869f69431e42cdb54a4f4f105c19c080a601',
+          value: '0x0',
+          gas: '0x16e360',
+          gasPrice: '0x04a817c800',
+          input:
+            '0x2bc888bf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000278d00000000000000000000000000000000000000000000000000002386f26fc10000000000000000000000000000000000000000000000000000000000000000000a',
+        })
+        web3Service.web3.eth.getTransactionReceipt = jest.fn(
+          () => new Promise(() => {})
+        )
+        web3Service._watchTransaction = jest.fn()
+        web3Service.getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
+      })
+
+      it('should emit a transaction.updated event with 0 confirmations', done => {
+        expect.assertions(1)
+        web3Service.on('transaction.updated', (hash, update) => {
+          expect(update.confirmations).toEqual(0) // 0 > -1 [17-18]
+          done()
+        })
+
+        web3Service.getTransaction(transaction.hash)
+      })
+    })
+
     describe('when the transaction has been mined but not fully confirmed', () => {
       beforeEach(() => {
         nock.ethBlockNumber(`0x${(17).toString('16')}`)

--- a/unlock-js/src/v0/getTransaction.js
+++ b/unlock-js/src/v0/getTransaction.js
@@ -53,7 +53,7 @@ export default function(transactionHash, defaults) {
     this.emit('transaction.updated', transactionHash, {
       status: 'mined',
       type: transactionType,
-      confirmations: blockNumber - blockTransaction.blockNumber,
+      confirmations: Math.max(blockNumber - blockTransaction.blockNumber, 0), // sometimes we get the block before getBlockNumber yields it.
       blockNumber: blockTransaction.blockNumber,
     })
 

--- a/unlock-js/src/v01/getTransaction.js
+++ b/unlock-js/src/v01/getTransaction.js
@@ -53,7 +53,7 @@ export default function(transactionHash, defaults) {
     this.emit('transaction.updated', transactionHash, {
       status: 'mined',
       type: transactionType,
-      confirmations: blockNumber - blockTransaction.blockNumber,
+      confirmations: Math.max(blockNumber - blockTransaction.blockNumber, 0), // sometimes we get the block before getBlockNumber yields it.
       blockNumber: blockTransaction.blockNumber,
     })
 


### PR DESCRIPTION
For some reason we sometimes get the transaction receipt and its block before it is reflected in the block height.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread