### PR TITLE
paywall: pass the to and from fields from locksmith transactions into redux store

### DIFF
--- a/paywall/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/storageMiddleware.test.js
@@ -93,7 +93,18 @@ describe('Storage middleware', () => {
       const action = { type: SET_ACCOUNT, account }
 
       mockStorageService.getTransactionsHashesSentBy = jest.fn(() => {
-        return Promise.resolve(['0xabc', '0xdef'])
+        return Promise.resolve([
+          {
+            transactionHash: '0xabc',
+            sender: 'hi',
+            recipient: 'there',
+          },
+          {
+            transactionHash: '0xdef',
+            sender: 'bye',
+            recipient: 'person',
+          },
+        ])
       })
       await invoke(action)
 
@@ -105,6 +116,8 @@ describe('Storage middleware', () => {
         1,
         addTransaction({
           hash: '0xabc',
+          from: 'hi',
+          to: 'there',
         })
       )
 
@@ -112,6 +125,8 @@ describe('Storage middleware', () => {
         2,
         addTransaction({
           hash: '0xdef',
+          from: 'bye',
+          to: 'person',
         })
       )
 

--- a/paywall/src/__tests__/services/storageService.test.js
+++ b/paywall/src/__tests__/services/storageService.test.js
@@ -20,7 +20,10 @@ describe('StorageService', () => {
         },
       })
       const hashes = await storageService.getTransactionsHashesSentBy(sender)
-      expect(hashes).toEqual(['0x123', '0x456'])
+      expect(hashes).toEqual([
+        { transactionHash: '0x123', sender: '0xabc', recipient: '0xcde' },
+        { transactionHash: '0x456', sender: '0xabc', recipient: '0xfgh' },
+      ])
       expect(axios.get).toHaveBeenCalledWith(
         `${serviceHost}/transactions?sender=${sender}`
       )

--- a/paywall/src/middlewares/storageMiddleware.js
+++ b/paywall/src/middlewares/storageMiddleware.js
@@ -22,10 +22,12 @@ const storageMiddleware = config => {
             .then(transactionHashes => {
               // Dispatch each transaction, but only trigger 1 re-render
               batch(() =>
-                transactionHashes.forEach(hash => {
+                transactionHashes.forEach(transaction => {
                   dispatch(
                     addTransaction({
-                      hash,
+                      hash: transaction.transactionHash,
+                      to: transaction.recipient,
+                      from: transaction.sender,
                     })
                   )
                 })

--- a/paywall/src/services/storageService.js
+++ b/paywall/src/services/storageService.js
@@ -31,7 +31,7 @@ export default class StorageService {
       `${this.host}/transactions?sender=${senderAddress}`
     )
     if (response.data && response.data.transactions) {
-      return response.data.transactions.map(t => t.transactionHash)
+      return response.data.transactions
     }
     return []
   }


### PR DESCRIPTION
# Description

As part of the process of fixing the paywall when purchasing expired keys, we need to store more information about the key purchase transactions saved in locksmith, specifically who purchased the key, and which lock it was for.

# Issues

Refs #2725 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
