### PR TITLE
attach KEY_PURCHASE transactions to the keys they represent in redux

### DIFF
--- a/paywall/src/__tests__/middlewares/web3Middleware.test.js
+++ b/paywall/src/__tests__/middlewares/web3Middleware.test.js
@@ -2,7 +2,7 @@ import EventEmitter from 'events'
 import { LOCATION_CHANGE } from 'connected-react-router'
 import web3Middleware from '../../middlewares/web3Middleware'
 import { ADD_LOCK, UPDATE_LOCK } from '../../actions/lock'
-import { UPDATE_KEY } from '../../actions/key'
+import { UPDATE_KEY, updateKey, addKey } from '../../actions/key'
 import { UPDATE_ACCOUNT, setAccount } from '../../actions/accounts'
 import {
   ADD_TRANSACTION,
@@ -14,6 +14,7 @@ import { SET_ERROR } from '../../actions/error'
 import { SET_PROVIDER, setProvider } from '../../actions/provider'
 import { SET_NETWORK, setNetwork } from '../../actions/network'
 import configure from '../../config'
+import { TRANSACTION_TYPES } from '../../constants'
 
 const config = configure()
 
@@ -23,6 +24,7 @@ const config = configure()
 let account = {
   address: '0xabc',
 }
+let key
 let lock = {
   address: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
   keyPrice: '100',
@@ -30,7 +32,7 @@ let lock = {
 }
 let state = {}
 
-const transaction = {
+let transaction = {
   hash: '0xf21e9820af34282c8bebb3a191cf615076ca06026a144c9c28e9cb762585472e',
 }
 const network = {
@@ -89,6 +91,16 @@ beforeEach(() => {
     keyPrice: '100',
     owner: account.address,
   }
+  transaction = {
+    hash: '0xf21e9820af34282c8bebb3a191cf615076ca06026a144c9c28e9cb762585472e',
+  }
+  key = {
+    id: `${lock.address}-${account.address}`,
+    lock: lock.address,
+    owner: account.address,
+    expiration: 0,
+    data: null,
+  }
   state = {
     router: {
       location: {
@@ -103,7 +115,9 @@ beforeEach(() => {
       [lock.address]: lock,
     },
     transactions: {},
-    keys: {},
+    keys: {
+      [key.id]: key,
+    },
   }
 })
 
@@ -287,14 +301,26 @@ describe('Web3 middleware', () => {
 
   it('it should handle transaction.updated events triggered by the web3Service', () => {
     expect.assertions(1)
+    state.transactions = {
+      [transaction.hash]: {
+        ...transaction,
+        bar: 'foo',
+      },
+    }
     const { store } = create()
-    const update = {}
+    const update = {
+      foo: 'bar',
+    }
     mockWeb3Service.emit('transaction.updated', transaction.hash, update)
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: UPDATE_TRANSACTION,
         hash: transaction.hash,
-        update,
+        update: {
+          ...transaction,
+          ...update,
+          bar: 'foo',
+        },
       })
     )
   })
@@ -507,8 +533,12 @@ describe('Web3 middleware', () => {
   })
 
   it('should handle NEW_TRANSACTION', () => {
-    expect.assertions(2)
-    const { next, invoke } = create()
+    expect.assertions(3)
+    const {
+      next,
+      invoke,
+      store: { dispatch },
+    } = create()
     const action = { type: NEW_TRANSACTION, transaction }
     mockWeb3Service.getTransaction = jest.fn()
 
@@ -517,6 +547,146 @@ describe('Web3 middleware', () => {
     expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
       transaction.hash,
       transaction
+    )
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('should dispatch key update on NEW_TRANSACTION if it is a key purchase of our lock from us', () => {
+    expect.assertions(3)
+    state.router = {
+      location: {
+        pathname: `/${lock.address}`,
+        hash: '',
+        search: '',
+      },
+    }
+    transaction = {
+      ...transaction,
+      to: lock.address,
+      from: account.address,
+      type: TRANSACTION_TYPES.KEY_PURCHASE,
+    }
+    state.transactions = {
+      [transaction.hash]: transaction,
+    }
+    const {
+      next,
+      invoke,
+      store: { dispatch },
+    } = create()
+    const action = { type: NEW_TRANSACTION, transaction }
+    mockWeb3Service.getTransaction = jest.fn()
+
+    invoke(action)
+    expect(next).toHaveBeenCalled()
+    expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
+      transaction.hash,
+      transaction
+    )
+    expect(dispatch).toHaveBeenCalledWith(
+      updateKey(
+        key.id,
+        expect.objectContaining({
+          ...key,
+          transactions: {
+            [transaction.hash]: transaction,
+          },
+        })
+      )
+    )
+  })
+
+  it('should dispatch key update on UPDATE_TRANSACTION if it is a key purchase of our lock from us and key exists', () => {
+    expect.assertions(2)
+    state.router = {
+      location: {
+        pathname: `/${lock.address}`,
+        hash: '',
+        search: '',
+      },
+    }
+    transaction = {
+      ...transaction,
+      to: lock.address,
+      from: account.address,
+      type: TRANSACTION_TYPES.KEY_PURCHASE,
+      key: key.id,
+      lock: lock.address,
+    }
+    key.expiration = 1234
+    state.transactions = {
+      [transaction.hash]: transaction,
+    }
+    const {
+      next,
+      invoke,
+      store: { dispatch },
+    } = create()
+    const action = {
+      type: UPDATE_TRANSACTION,
+      transaction,
+      hash: transaction.hash,
+    }
+
+    invoke(action)
+    expect(next).toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining(
+        updateKey(key.id, {
+          ...key,
+          transactions: {
+            [transaction.hash]: transaction,
+          },
+        })
+      )
+    )
+  })
+
+  it('should dispatch add key on UPDATE_TRANSACTION if it is a key purchase of our lock from us and key does not exist', () => {
+    expect.assertions(2)
+    state.router = {
+      location: {
+        pathname: `/${lock.address}`,
+        hash: '',
+        search: '',
+      },
+    }
+    transaction = {
+      ...transaction,
+      to: lock.address,
+      from: account.address,
+      type: TRANSACTION_TYPES.KEY_PURCHASE,
+      key: key.id,
+      lock: lock.address,
+    }
+    key.expiration = 1234
+    state.keys = {}
+    state.transactions = {
+      [transaction.hash]: transaction,
+    }
+    const {
+      next,
+      invoke,
+      store: { dispatch },
+    } = create()
+    const action = {
+      type: UPDATE_TRANSACTION,
+      transaction,
+      hash: transaction.hash,
+    }
+
+    invoke(action)
+    expect(next).toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining(
+        addKey(key.id, {
+          ...key,
+          expiration: 0,
+          transactions: {
+            [transaction.hash]: transaction,
+          },
+        })
+      )
     )
   })
 

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -12,6 +12,7 @@ import {
   updateTransaction,
   ADD_TRANSACTION,
   NEW_TRANSACTION,
+  UPDATE_TRANSACTION,
 } from '../actions/transaction'
 
 import { lockRoute } from '../utils/routes'
@@ -79,7 +80,13 @@ const web3Middleware = config => ({ getState, dispatch }) => {
   })
 
   web3Service.on('transaction.updated', (transactionHash, update) => {
-    dispatch(updateTransaction(transactionHash, update))
+    const transaction = getState().transactions[transactionHash]
+    dispatch(
+      updateTransaction(transactionHash, {
+        ...(transaction ? transaction : {}),
+        ...update,
+      })
+    )
   })
 
   web3Service.on('transaction.new', transactionHash => {
@@ -114,7 +121,7 @@ const web3Middleware = config => ({ getState, dispatch }) => {
         locks,
       } = getState()
       const { lockAddress, transaction } = lockRoute(pathname + hash)
-
+      const accountAddress = account && account.address
       if (
         [SET_PROVIDER, SET_NETWORK, SET_ACCOUNT, LOCATION_CHANGE].includes(
           action.type
@@ -165,6 +172,65 @@ const web3Middleware = config => ({ getState, dispatch }) => {
         // Location was changed, get the matching lock
         if (lockAddress) {
           web3Service.getLock(lockAddress)
+        }
+      }
+
+      const keyId = `${lockAddress}-${accountAddress}`
+      if (action.type === NEW_TRANSACTION) {
+        // when the web3Service is retrieving transactions, only transactionHash is set
+        // this line checks to see if we are instead getting the transaction with all the stuff we need
+        if (
+          action.transaction.to === lockAddress &&
+          action.transaction.from === accountAddress
+        ) {
+          // this is key purchase transaction from us to the lock!
+          const key = getState().keys[keyId]
+
+          dispatch(
+            updateKey(keyId, {
+              ...key,
+              transactions: {
+                ...key.transactions,
+                [action.transaction.hash]: action.transaction,
+              },
+            })
+          )
+        }
+      }
+      if (action.type === UPDATE_TRANSACTION) {
+        const existingTransaction = getState().transactions[action.hash]
+        if (
+          (existingTransaction.to === lockAddress &&
+            existingTransaction.from === accountAddress) ||
+          existingTransaction.key === keyId
+        ) {
+          // this is key purchase transaction from us to the lock!
+          const key = getState().keys[keyId]
+
+          if (key) {
+            dispatch(
+              updateKey(keyId, {
+                ...key,
+                transactions: {
+                  ...key.transactions,
+                  [action.hash]: existingTransaction,
+                },
+              })
+            )
+          } else {
+            dispatch(
+              addKey(keyId, {
+                lock: lockAddress,
+                owner: accountAddress,
+                expiration: 0,
+                data: null,
+                id: keyId,
+                transactions: {
+                  [action.hash]: existingTransaction,
+                },
+              })
+            )
+          }
         }
       }
     }


### PR DESCRIPTION
# Description

This adds the missing information needed to determine the status of a key directly to the key object in the redux store. This will make it possible to distinguish between expired keys and a pending key purchase transaction, which is currently very difficult to do accurately.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2725 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
