### PR TITLE
new selector for key status, to be used in paywall

### DIFF
--- a/paywall/src/__tests__/selectors/keys.test.ts
+++ b/paywall/src/__tests__/selectors/keys.test.ts
@@ -1,0 +1,144 @@
+import keyStatus from '../../selectors/keys'
+import {
+  Transaction,
+  TransactionStatus,
+  TransactionType,
+} from '../../unlockTypes'
+
+describe('keys selectors', () => {
+  describe('keyStatus', () => {
+    let transactions: { [key: string]: Transaction }
+
+    beforeEach(() => {
+      transactions = {
+        one: {
+          hash: 'one',
+          status: TransactionStatus.MINED,
+          type: TransactionType.KEY_PURCHASE,
+          confirmations: 2,
+          blockNumber: 1,
+        },
+      }
+    })
+
+    it('returns "none" if the key does not exist', () => {
+      expect.assertions(1)
+
+      expect(keyStatus('', {}, 12)).toBe('none')
+    })
+
+    it('returns "none" if the key does not exist in keys', () => {
+      expect.assertions(1)
+
+      expect(keyStatus('hi', {}, 12)).toBe('none')
+    })
+
+    it('returns "none" if the transaction status is falsy', () => {
+      expect.assertions(1)
+
+      transactions.one.status = TransactionStatus.NONE
+      expect(
+        keyStatus(
+          'hi',
+          {
+            hi: {
+              expiration: new Date().getTime() / 1000 + 10000,
+              transactions,
+            },
+          },
+          12
+        )
+      ).toBe('none')
+    })
+
+    it('returns transactoin status if the transaction status is not "mined"', () => {
+      expect.assertions(2)
+
+      transactions.one.status = TransactionStatus.PENDING
+      expect(
+        keyStatus(
+          'hi',
+          {
+            hi: {
+              expiration: new Date().getTime() / 1000 + 10000,
+              transactions,
+            },
+          },
+          12
+        )
+      ).toBe('pending')
+
+      transactions.one.status = TransactionStatus.SUBMITTED
+      expect(
+        keyStatus(
+          'hi',
+          {
+            hi: {
+              expiration: new Date().getTime() / 1000 + 10000,
+              transactions,
+            },
+          },
+          12
+        )
+      ).toBe('submitted')
+    })
+
+    describe('mined transactions', () => {
+      it('returns "confirming" if the transaction has fewer than the required confirmations', () => {
+        expect.assertions(1)
+
+        transactions.one.status = TransactionStatus.MINED
+        expect(
+          keyStatus(
+            'hi',
+            {
+              hi: {
+                expiration: new Date().getTime() / 1000 + 10000,
+                transactions,
+              },
+            },
+            12
+          )
+        ).toBe('confirming')
+      })
+
+      it('returns "valid" if the transaction has more than the required confirmations', () => {
+        expect.assertions(1)
+
+        transactions.one.status = TransactionStatus.MINED
+        transactions.one.confirmations = 12345
+        expect(
+          keyStatus(
+            'hi',
+            {
+              hi: {
+                expiration: new Date().getTime() / 1000 + 10000,
+                transactions,
+              },
+            },
+            12
+          )
+        ).toBe('valid')
+      })
+
+      it('returns "expired" if the transaction is confirmed and key is old', () => {
+        expect.assertions(1)
+
+        transactions.one.status = TransactionStatus.MINED
+        transactions.one.confirmations = 12345
+        expect(
+          keyStatus(
+            'hi',
+            {
+              hi: {
+                expiration: new Date().getTime() / 1000 - 10000,
+                transactions,
+              },
+            },
+            12
+          )
+        ).toBe('expired')
+      })
+    })
+  })
+})

--- a/paywall/src/selectors/keys.ts
+++ b/paywall/src/selectors/keys.ts
@@ -1,0 +1,44 @@
+import { Transaction, TransactionStatus } from '../unlockTypes'
+
+interface Key {
+  expiration: number
+  transactions: {
+    [key: string]: Transaction
+  }
+}
+
+export enum KeyStatus {
+  NONE = 'none',
+  CONFIRMING = 'confirming',
+  CONFIRMED = 'confirmed',
+  EXPIRED = 'expired',
+  VALID = 'valid',
+}
+
+export default function keyStatus(
+  id: string,
+  keys: { [key: string]: Key },
+  requiredConfirmations: number
+): KeyStatus | TransactionStatus {
+  const key = keys[id]
+
+  if (!key || !key.transactions) {
+    return KeyStatus.NONE
+  }
+  const transactions = Object.values(key.transactions)
+  transactions.sort((a, b) => (a.blockNumber > b.blockNumber ? -1 : 1))
+  const lastTransaction = transactions[0]
+
+  switch (lastTransaction.status) {
+    case 'mined':
+      if (lastTransaction.confirmations < requiredConfirmations) {
+        return KeyStatus.CONFIRMING
+      }
+      if (key.expiration < new Date().getTime() / 1000) {
+        return KeyStatus.EXPIRED
+      }
+      return KeyStatus.VALID
+    default:
+      return lastTransaction.status || KeyStatus.NONE
+  }
+}

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -17,6 +17,7 @@ export enum TransactionStatus {
   SUBMITTED = 'submitted',
   PENDING = 'pending',
   MINED = 'mined',
+  NONE = '', // for testing purposes
 }
 /* eslint-enable no-unused-vars */
 


### PR DESCRIPTION
# Description

This adds a new selector which accepts the current redux state, a key to process, and the number of required confirmations, and returns the status of the key. Statuses are "none", "submitted", "pending", "confirming", "valid", and "expired."

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2725 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
