### PR TITLE
Lift up state into the Paywall's mapStateToProps and pass down as props to child components

### DIFF
--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -42,13 +42,14 @@ let futureDate = new Date()
 futureDate.setYear(futureDate.getFullYear() + 1)
 futureDate = futureDate.getTime() / 1000
 
+const key = {
+  id: 'aKey',
+  lock: lock.address,
+  owner: account.address,
+  expiration: futureDate,
+}
 const keys = {
-  aKey: {
-    id: 'aKey',
-    lock: lock.address,
-    owner: account.address,
-    expiration: futureDate,
-  },
+  aKey: key,
 }
 const modals = []
 const transactions = {}
@@ -135,22 +136,28 @@ describe('Paywall', () => {
 
     it('should be locked when there is a matching key and transaction is not confirmed yet', () => {
       expect.assertions(1)
+      const transactions = {
+        transaction: {
+          id: 'transaction',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          key: 'aKey',
+          lock: lock.address,
+          confirmations: 3,
+        },
+      }
       const props = mapStateToProps(
         {
           locks,
-          keys,
+          keys: {
+            aKey: {
+              ...key,
+              transactions,
+            },
+          },
           modals,
           router,
           account,
-          transactions: {
-            transaction: {
-              id: 'transaction',
-              type: TRANSACTION_TYPES.KEY_PURCHASE,
-              key: 'aKey',
-              lock: lock.address,
-              confirmations: 3,
-            },
-          },
+          transactions,
         },
         { config }
       )
@@ -159,34 +166,26 @@ describe('Paywall', () => {
 
     it('should not be locked when there is a matching key and transaction is confirmed', () => {
       expect.assertions(1)
+      const transactions = {
+        transaction: {
+          id: 'transaction',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          key: 'aKey',
+          lock: lock.address,
+          confirmations: 13,
+          status: 'mined',
+        },
+      }
       const props = mapStateToProps(
         {
           locks,
-          keys,
-          modals,
-          router,
-          account,
-          transactions: {
-            transaction: {
-              id: 'transaction',
-              type: TRANSACTION_TYPES.KEY_PURCHASE,
-              key: 'aKey',
-              lock: lock.address,
-              confirmations: 13,
+          keys: {
+            aKey: {
+              ...key,
+              transactions,
+              expiration: new Date().getTime() / 1000 + 10000,
             },
           },
-        },
-        { config }
-      )
-      expect(props.locked).toBe(false)
-    })
-
-    it('should not be locked when there is a matching key and no transaction', () => {
-      expect.assertions(1)
-      const props = mapStateToProps(
-        {
-          locks,
-          keys,
           modals,
           router,
           account,
@@ -195,6 +194,38 @@ describe('Paywall', () => {
         { config }
       )
       expect(props.locked).toBe(false)
+    })
+
+    it('should be locked when there is a matching expired key and fully confirmed transaction', () => {
+      expect.assertions(1)
+      const transactions = {
+        transaction: {
+          id: 'transaction',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          key: 'aKey',
+          lock: lock.address,
+          confirmations: 13,
+          status: 'mined',
+        },
+      }
+      const props = mapStateToProps(
+        {
+          locks,
+          keys: {
+            aKey: {
+              ...key,
+              expiration: 1234,
+              transactions,
+            },
+          },
+          modals,
+          router,
+          account,
+          transactions,
+        },
+        { config }
+      )
+      expect(props.locked).toBe(true)
     })
 
     it('should pass redirect if present in the URI', () => {
@@ -263,6 +294,9 @@ describe('Paywall', () => {
         hash: '0x777',
         key: '0x123-0x456',
       }
+      const transactions = {
+        '0x777': transaction,
+      }
       const newProps = mapStateToProps(
         {
           account: {
@@ -276,13 +310,12 @@ describe('Paywall', () => {
               owner: '0x123',
               expiration: 0,
               data: 'hello',
+              transactions,
             },
           },
           modals,
           router,
-          transactions: {
-            '0x777': transaction,
-          },
+          transactions,
         },
         { config }
       )

--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -228,6 +228,50 @@ describe('Paywall', () => {
       expect(props.locked).toBe(true)
     })
 
+    it('should be locked and pull in the newest pending transaction with an expired key', () => {
+      expect.assertions(2)
+      const pendingTransaction = {
+        id: 'pendingTransaction',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        key: 'aKey',
+        lock: lock.address,
+        confirmations: 13,
+        status: 'pending',
+        blockNumber: 500,
+      }
+      const transactions = {
+        transaction: {
+          id: 'transaction',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          key: 'aKey',
+          lock: lock.address,
+          confirmations: 13,
+          status: 'mined',
+          blockNumber: 1,
+        },
+        pendingTransaction,
+      }
+      const props = mapStateToProps(
+        {
+          locks,
+          keys: {
+            aKey: {
+              ...key,
+              expiration: 1234,
+              transactions,
+            },
+          },
+          modals,
+          router,
+          account,
+          transactions,
+        },
+        { config }
+      )
+      expect(props.locked).toBe(true)
+      expect(props.transaction).toBe(pendingTransaction)
+    })
+
     it('should pass redirect if present in the URI', () => {
       expect.assertions(1)
       const props = mapStateToProps(

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -18,11 +18,22 @@ import {
 import { isPositiveNumber } from '../utils/validators'
 import useWindow from '../hooks/browser/useWindow'
 import useOptimism from '../hooks/useOptimism'
-import { TRANSACTION_TYPES } from '../constants'
 import withConfig from '../utils/withConfig'
 import './Paywall.css'
+import keyStatus from '../selectors/keys'
+import { expirationAsDate } from '../utils/durations'
 
-export function Paywall({ locks, locked, redirect, account, transaction }) {
+export function Paywall({
+  locks,
+  locked,
+  redirect,
+  account,
+  transaction,
+  requiredConfirmations,
+  keyStatus,
+  lockKey,
+  expiration,
+}) {
   const optimism = useOptimism(transaction)
   const window = useWindow()
   const scrollPosition = useListenForPostMessage({
@@ -66,11 +77,15 @@ export function Paywall({ locks, locked, redirect, account, transaction }) {
           optimism={optimism}
           smallBody={() => smallBody(window.document.body)}
           bigBody={() => bigBody(window.document.body)}
+          requiredConfirmations={requiredConfirmations}
+          keyStatus={keyStatus}
+          lockKey={lockKey}
+          transaction={transaction}
         />
         {optimism.current ? null : <DeveloperOverlay />}
       </ShowWhenLocked>
       <ShowWhenUnlocked locked={locked}>
-        <UnlockedFlag />
+        <UnlockedFlag expiration={expiration} />
       </ShowWhenUnlocked>
     </GlobalErrorProvider>
   )
@@ -82,6 +97,10 @@ Paywall.propTypes = {
   redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   transaction: UnlockPropTypes.transaction,
   account: PropTypes.string,
+  requiredConfirmations: PropTypes.number.isRequired,
+  keyStatus: PropTypes.string.isRequired,
+  lockKey: UnlockPropTypes.key.isRequired,
+  expiration: PropTypes.string.isRequired,
 }
 
 Paywall.defaultProps = {
@@ -91,71 +110,57 @@ Paywall.defaultProps = {
 }
 
 export const mapStateToProps = (
-  { locks, keys, modals, router, account, transactions },
+  { locks, keys, modals, router, account },
   { config: { requiredConfirmations } }
 ) => {
   const { lockAddress, redirect } = lockRoute(router.location.pathname)
-
-  const lockFromUri = Object.values(locks).find(
-    lock => lock.address === lockAddress
-  )
-
-  let validKeys = []
-  const locksFromUri = lockFromUri ? [lockFromUri] : []
-  locksFromUri.forEach(lock => {
-    for (let k of Object.values(keys)) {
-      if (
-        k.lock === lock.address &&
-        k.expiration > new Date().getTime() / 1000
-      ) {
-        validKeys.push(k)
-      }
-    }
-  })
-
-  const lock = locksFromUri.length ? locksFromUri[0] : null
-
+  const accountAddress = account && account.address
   let transaction = null
 
-  const lockKey = Object.values(keys).find(
-    key =>
-      account &&
-      lock &&
-      key.lock === lock.address &&
-      key.owner === account.address
+  const lock = Object.values(locks).find(
+    thisLock => thisLock.address === lockAddress
   )
 
-  // Let's select the transaction corresponding to this key purchase, if it exists
-  // This transaction is of type KEY_PURCHASE
-  transaction = Object.values(transactions).find(
-    transaction =>
-      transaction.type === TRANSACTION_TYPES.KEY_PURCHASE &&
-      transaction.key === (lockKey && lockKey.id)
+  let lockKey = Object.values(keys).find(
+    key => key.lock === lockAddress && key.owner === accountAddress
   )
 
-  const modalShown = !!modals[locksFromUri.map(l => l.address).join('-')]
-  let locked = false
-  if (modalShown) {
-    locked = true
-  }
-  if (!locked && !validKeys.length) {
-    locked = true
-  }
-  if (!locked && transaction) {
-    if (
-      !transaction.confirmations ||
-      transaction.confirmations < requiredConfirmations
-    ) {
-      locked = true
+  if (lockKey) {
+    const keyTransactions = lockKey.transactions
+      ? Object.values(lockKey.transactions)
+      : []
+    if (keyTransactions.length) {
+      keyTransactions.sort((a, b) => (a.blockNumber > b.blockNumber ? -1 : 1))
+      transaction = keyTransactions[0]
+    }
+  } else {
+    lockKey = {
+      id: `${lockAddress}-${accountAddress}`,
+      lock: lockAddress,
+      owner: accountAddress,
+      expired: 0,
+      data: null,
     }
   }
+
+  const currentKeyStatus = keyStatus(lockKey.id, keys, requiredConfirmations)
+
+  const locked =
+    !lockKey ||
+    !!modals[[lock || { address: '' }].map(l => l.address).join('-')] ||
+    currentKeyStatus !== 'valid'
+  const expiration = !lockKey ? '' : expirationAsDate(lockKey.expiration)
 
   return {
     locked,
-    locks: locksFromUri,
+    locks: lock ? [lock] : [],
     redirect,
     transaction,
-    account: account && account.address,
+    account: accountAddress,
+    requiredConfirmations,
+    keyStatus: currentKeyStatus,
+    lockKey,
+    expiration,
   }
 }
 

--- a/paywall/src/stories/Paywall.stories.js
+++ b/paywall/src/stories/Paywall.stories.js
@@ -41,27 +41,33 @@ const lockedState = {
     USD: 195.99,
   },
 }
+const unlockedTransactions = {
+  '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876': {
+    hash: '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876',
+    type: 'KEY_PURCHASE',
+    lock: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+    status: 'mined',
+    confirmations: 200,
+    key: '0xab7c74abc0c4d48d1bdad5dcb26153fc87eeeeee',
+    to: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
+    from: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+  },
+}
 const unlockedState = {
   ...lockedState,
   keys: {
-    '0xab7c74abc0c4d48d1bdad5dcb26153fc87eeeeee': {
+    '0xab7c74abc0c4d48d1bdad5dcb26153fc87eeeeee-0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2': {
+      id:
+        '0xab7c74abc0c4d48d1bdad5dcb26153fc87eeeeee-0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
       lock: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
       owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
       expiration: new Date('December 31, 3000 12:00:00').getTime() / 1000,
       transaction:
         '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876',
+      transactions: unlockedTransactions,
     },
   },
-  transactions: {
-    '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876': {
-      hash:
-        '0x06094207a34b7f1c19b93d337d0c91c357d45ff8e584deb003e67b637db3d876',
-      type: 'LOCK_CREATION',
-      lock: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
-      status: 'mined',
-      confirmations: 200,
-    },
-  },
+  transactions: unlockedTransactions,
   router: {
     location: {
       pathname: '/demo/0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
@@ -78,6 +84,7 @@ const config = {
   providers: {
     HTTP: [],
   },
+  requiredConfirmations: 12,
 }
 
 const fakeWindow = {

--- a/paywall/src/stories/content/PaywallContent.stories.js
+++ b/paywall/src/stories/content/PaywallContent.stories.js
@@ -47,6 +47,7 @@ const config = {
   providers: {
     HTTP: [],
   },
+  requiredConfirmations: 12,
 }
 
 storiesOf('Paywall app page', module)

--- a/paywall/src/stories/interface/StaticDemo.stories.js
+++ b/paywall/src/stories/interface/StaticDemo.stories.js
@@ -44,6 +44,7 @@ const store = createUnlockStore({
 const config = {
   env: 'dev',
   providers: { HTTP: {}, Metamask: {} },
+  requiredConfirmations: 12,
 }
 
 const fakeWindow = {


### PR DESCRIPTION
# Description

This PR is about lifting the logic for extracting a transaction and key for the current user/lock from child `mapStateToProps` up into the `Paywall` component. This will DRY up the source for the paywall even more (stay tuned for imminent PRs!), and reduce surface area for bugs.

The primary new props generated are `keyStatus` which is based on the new `keyStatus` selector, `expiration`, which is a textual description of the key's time to expiry, `lockKey`, which is simply the key for the current lock or the placeholder key which exists even when a purchase has not yet been attempted, and `requiredConfirmations`, which is the value from configuration. By passing `requiredConfirmations` here, we can also eliminate a bevy of `withConfig` calls and convert almost all of the child components into dumb display components for a big win in maintainability.

Internal to the `mapStateToProps`, we now use the `transactions` stored inside the key in redux, instead of attempting to construct the relevant transactions from all of them. This makes the whole thing more robust and simpler to reason through.

screenshots to show it still works:
<img width="1680" alt="Screen Shot 2019-04-18 at 8 53 32 PM" src="https://user-images.githubusercontent.com/98250/56399476-2c19b780-621c-11e9-8957-461f02c24eaa.png">
<img width="1680" alt="Screen Shot 2019-04-18 at 8 51 09 PM" src="https://user-images.githubusercontent.com/98250/56399477-2c19b780-621c-11e9-88bc-aef0ec58b8c4.png">
<img width="1680" alt="Screen Shot 2019-04-18 at 8 51 05 PM" src="https://user-images.githubusercontent.com/98250/56399478-2c19b780-621c-11e9-831b-e56ea5dc0dc4.png">
<img width="1680" alt="Screen Shot 2019-04-18 at 8 51 01 PM" src="https://user-images.githubusercontent.com/98250/56399479-2c19b780-621c-11e9-9985-d3aa2cf6c27d.png">
<img width="1680" alt="Screen Shot 2019-04-18 at 8 50 49 PM" src="https://user-images.githubusercontent.com/98250/56399480-2c19b780-621c-11e9-9af9-0c94fd53f04a.png">


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2725 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
