### PR TITLE
Contract bug fix: transferFrom with 0 fee on an ERC20 Lock fails

### DIFF
--- a/smart-contracts/contracts/mixins/MixinFunds.sol
+++ b/smart-contracts/contracts/mixins/MixinFunds.sol
@@ -38,17 +38,19 @@ contract MixinFunds
     uint _price
   ) internal
   {
-    if(tokenAddress == address(0)) {
-      require(msg.value >= _price, 'NOT_ENOUGH_FUNDS');
-    } else {
-      IERC20 token = IERC20(tokenAddress);
-      uint balanceBefore = token.balanceOf(address(this));
-      token.transferFrom(msg.sender, address(this), _price);
+    if(_price > 0) {
+      if(tokenAddress == address(0)) {
+        require(msg.value >= _price, 'NOT_ENOUGH_FUNDS');
+      } else {
+        IERC20 token = IERC20(tokenAddress);
+        uint balanceBefore = token.balanceOf(address(this));
+        token.transferFrom(msg.sender, address(this), _price);
 
-      // There are known bugs in popular ERC20 implements which means we cannot
-      // trust the return value of `transferFrom`.  This require statement ensures
-      // that a transfer occurred.
-      require(token.balanceOf(address(this)) > balanceBefore, 'TRANSFER_FAILED');
+        // There are known bugs in popular ERC20 implements which means we cannot
+        // trust the return value of `transferFrom`.  This require statement ensures
+        // that a transfer occurred.
+        require(token.balanceOf(address(this)) > balanceBefore, 'TRANSFER_FAILED');
+      }
     }
   }
 
@@ -62,17 +64,19 @@ contract MixinFunds
     uint _amount
   ) internal
   {
-    if(tokenAddress == address(0)) {
-      address(uint160(_to)).transfer(_amount);
-    } else {
-      IERC20 token = IERC20(tokenAddress);
-      uint balanceBefore = token.balanceOf(_to);
-      token.transfer(_to, _amount);
+    if(_amount > 0) {
+      if(tokenAddress == address(0)) {
+        address(uint160(_to)).transfer(_amount);
+      } else {
+        IERC20 token = IERC20(tokenAddress);
+        uint balanceBefore = token.balanceOf(_to);
+        token.transfer(_to, _amount);
 
-      // There are known bugs in popular ERC20 implements which means we cannot
-      // trust the return value of `transferFrom`.  This require statement ensures
-      // that a transfer occurred.
-      require(token.balanceOf(_to) > balanceBefore, 'TRANSFER_FAILED');
+        // There are known bugs in popular ERC20 implements which means we cannot
+        // trust the return value of `transferFrom`.  This require statement ensures
+        // that a transfer occurred.
+        require(token.balanceOf(_to) > balanceBefore, 'TRANSFER_FAILED');
+      }
     }
   }
 

--- a/smart-contracts/test/Lock/erc20.js
+++ b/smart-contracts/test/Lock/erc20.js
@@ -106,6 +106,17 @@ contract('Lock / erc20', accounts => {
         const balance = new BigNumber(await token.balanceOf(keyOwner2))
         assert.equal(balance.toFixed(), balanceBefore.minus(keyPrice).toFixed())
       })
+
+      it('can transfer the key to another user', async () => {
+        await lock.transferFrom(
+          accounts[2],
+          accounts[4],
+          await lock.getTokenIdFor.call(accounts[2]),
+          {
+            from: accounts[2],
+          }
+        )
+      })
     })
 
     it('purchaseKey fails when the user does not have enough funds', async () => {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

The contract has missing an `if > 0` check, causing the ERC20 transfer flow to throw an exception when attempting to transfer 0 tokens.   This would break any scenario which attempts to charge 0 - namely `transferFrom` which has a default transfer fee of 0.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
