### PR TITLE
remove redundant mapStateToProps from UnlockFlag

### DIFF
--- a/paywall/src/__tests__/components/lock/UnlockFlag.test.js
+++ b/paywall/src/__tests__/components/lock/UnlockFlag.test.js
@@ -1,39 +1,12 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
-import {
-  mapStateToProps,
-  LockedFlag,
-  UnlockedFlag,
-} from '../../../components/lock/UnlockFlag'
-
-const lock = { address: '0x4983D5ECDc5cc0E499c2D23BF4Ac32B982bAe53a' }
-const locks = {
-  [lock.address]: lock,
-}
-const router = {
-  location: {
-    pathname: `/paywall/${lock.address}/http%3a%2f%2fexample.com`,
-    search: '?origin=http%3A%2F%2Fexample.com',
-    hash: '',
-  },
-}
-
-const account = { address: '0x1234567890123456789012345678901234567890' }
+import { LockedFlag, UnlockedFlag } from '../../../components/lock/UnlockFlag'
 
 let futureDate = new Date()
 futureDate.setYear(2019)
 futureDate.setMonth(4)
 futureDate.setDate(3)
 futureDate = futureDate.getTime() / 1000
-
-const keys = {
-  aKey: {
-    id: 'aKey',
-    lock: lock.address,
-    owner: account.address,
-    expiration: futureDate,
-  },
-}
 
 describe('UnlockFlag component', () => {
   describe('LockedFlag', () => {
@@ -49,15 +22,5 @@ describe('UnlockFlag component', () => {
     let wrapper = rtl.render(<UnlockedFlag expiration="Next Week" />)
 
     expect(wrapper.getByText('Unlock').target).toBe('_blank')
-  })
-
-  describe('mapStateToProps', () => {
-    it('should return the expiration date of the key, formatted', () => {
-      expect.assertions(1)
-
-      expect(mapStateToProps({ locks, keys, router, account })).toEqual({
-        expiration: 'May 3, 2019',
-      })
-    })
   })
 })

--- a/paywall/src/components/lock/UnlockFlag.js
+++ b/paywall/src/components/lock/UnlockFlag.js
@@ -1,4 +1,3 @@
-import { connect } from 'react-redux'
 import styled from 'styled-components'
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
@@ -7,8 +6,6 @@ import { Colophon } from './LockStyles'
 import { RoundedLogo } from '../interface/Logo'
 import Media from '../../theme/media'
 import { SHOW_FLAG_FOR } from '../../constants'
-import { lockRoute } from '../../utils/routes'
-import { expirationAsDate } from '../../utils/durations'
 
 export function LockedFlag() {
   return (
@@ -54,35 +51,7 @@ UnlockedFlag.propTypes = {
   expiration: PropTypes.string.isRequired,
 }
 
-export const mapStateToProps = ({ locks, keys, router, account }) => {
-  const { lockAddress } = lockRoute(router.location.pathname)
-
-  const lockFromUri = Object.values(locks).find(
-    lock => lock.address === lockAddress
-  )
-
-  let validKeys = []
-  const locksFromUri = lockFromUri ? [lockFromUri] : []
-  locksFromUri.forEach(lock => {
-    for (let k of Object.values(keys)) {
-      if (
-        k.lock === lock.address &&
-        account &&
-        k.owner === account.address &&
-        k.expiration > new Date().getTime() / 1000
-      ) {
-        validKeys.push(k)
-      }
-    }
-  })
-
-  const key = validKeys[0]
-
-  const expiration = expirationAsDate(key.expiration)
-  return { expiration }
-}
-
-export default connect(mapStateToProps)(UnlockedFlag)
+export default UnlockedFlag
 
 const Flag = styled(Colophon).attrs({
   className: 'flag',


### PR DESCRIPTION
# Description

Now that `expiration` is passed from `Paywall` directly to `UnlockFlag`, the entire `mapStateToProps` becomes redundant, and this PR nukes it.

screenshots showing it still works:

<img width="1680" alt="Screen Shot 2019-04-18 at 10 29 04 PM" src="https://user-images.githubusercontent.com/98250/56401992-7b1a1980-6229-11e9-9915-9fd3fc02044c.png">
<img width="1680" alt="Screen Shot 2019-04-18 at 10 28 56 PM" src="https://user-images.githubusercontent.com/98250/56401993-7b1a1980-6229-11e9-9065-077445cd3b6d.png">
<img width="1680" alt="Screen Shot 2019-04-18 at 10 28 36 PM" src="https://user-images.githubusercontent.com/98250/56401994-7b1a1980-6229-11e9-8faa-62fbfde4382e.png">
<img width="1680" alt="Screen Shot 2019-04-18 at 10 28 29 PM" src="https://user-images.githubusercontent.com/98250/56401995-7b1a1980-6229-11e9-9fc2-3fb944e6c20f.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2725 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
