### PR TITLE
Adds the ability to add chain id to Transactions stored in Locksmith

### DIFF
--- a/locksmith/__tests__/controllers/transactionController.test.js
+++ b/locksmith/__tests__/controllers/transactionController.test.js
@@ -66,10 +66,11 @@ describe('transactionController', () => {
             transactionHash: '0xsdbegjkbg,egf',
             sender: '0xSDgErGR',
             recipient: '0xSdaG433r',
+            chain: 42,
           })
 
         let record = await Transaction.findOne({
-          where: { sender: '0xSDgErGR', recipient: '0xSdaG433r' },
+          where: { sender: '0xSDgErGR', recipient: '0xSdaG433r', chain: 42 },
         })
         expect(record.sender).toBe('0xSDgErGR')
         expect(response.statusCode).toBe(202)

--- a/locksmith/__tests__/operations/transactionOperations.test.js
+++ b/locksmith/__tests__/operations/transactionOperations.test.js
@@ -17,11 +17,12 @@ beforeEach(() => {
 describe('lockOperations', () => {
   describe('findOrCreateTransaction', () => {
     it('should call findOrCreate on the transaction object', async () => {
-      expect.assertions(5)
+      expect.assertions(6)
       const transactionHash =
         '0x7d6289db59c3434b6a034b4f211be52ca34f05e2aa856fc3e69b8af101355842'
       const sender = '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
       const recipient = '0xca750f9232c1c38e34d27e77534e1631526ec99e'
+      const chain = 1984
       Transaction.findOrCreate = jest.fn(query => {
         expect(query.where).toEqual({
           transactionHash,
@@ -33,11 +34,14 @@ describe('lockOperations', () => {
         expect(query.defaults.recipient).toEqual(
           '0xCA750f9232C1c38e34D27e77534e1631526eC99e'
         )
+
+        expect(query.defaults.chain).toEqual(1984)
       })
       await findOrCreateTransaction({
         transactionHash,
         sender,
         recipient,
+        chain,
       })
       expect(Transaction.findOrCreate).toHaveBeenCalled()
     })

--- a/locksmith/migrations/20190419150046-add_chain_to_transactions.js
+++ b/locksmith/migrations/20190419150046-add_chain_to_transactions.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const table = 'Transactions'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(table, 'chain', {
+      type: Sequelize.INTEGER,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn(table, 'chain')
+  },
+}

--- a/locksmith/src/models/transaction.ts
+++ b/locksmith/src/models/transaction.ts
@@ -4,11 +4,14 @@ import { Table, Model, Column } from 'sequelize-typescript'
 // eslint-disable-next-line import/prefer-default-export
 export class Transaction extends Model<Transaction> {
   @Column
-  transactionHash!: string
+  public transactionHash!: string
 
   @Column
-  sender!: string
+  public sender!: string
 
   @Column
-  recipient!: string
+  public recipient!: string
+
+  @Column
+  public chain!: number
 }

--- a/locksmith/src/operations/transactionOperations.ts
+++ b/locksmith/src/operations/transactionOperations.ts
@@ -1,15 +1,15 @@
+import { Transaction } from '../models/transaction'
+
 const ethJsUtil = require('ethereumjs-util')
 const Sequelize = require('sequelize')
-const models = require('../models')
 
 const Op = Sequelize.Op
-const { Transaction } = models
 
 /**
  * Finds a transaction by its hash or creates it
  * @param {*} transaction
  */
-const findOrCreateTransaction = async transaction => {
+export const findOrCreateTransaction = async (transaction: Transaction) => {
   return await Transaction.findOrCreate({
     where: {
       transactionHash: transaction.transactionHash,
@@ -18,6 +18,7 @@ const findOrCreateTransaction = async transaction => {
       transactionHash: transaction.transactionHash,
       sender: ethJsUtil.toChecksumAddress(transaction.sender),
       recipient: ethJsUtil.toChecksumAddress(transaction.recipient),
+      chain: transaction.chain,
     },
   })
 }
@@ -26,16 +27,11 @@ const findOrCreateTransaction = async transaction => {
  * get all the transactions sent by a given address
  * @param {*} _sender
  */
-const getTransactionsBySender = async _sender => {
+export const getTransactionsBySender = async (_sender: string) => {
   const sender = ethJsUtil.toChecksumAddress(_sender)
   return await Transaction.findAll({
     where: {
       sender: { [Op.eq]: sender },
     },
   })
-}
-
-module.exports = {
-  findOrCreateTransaction,
-  getTransactionsBySender,
 }


### PR DESCRIPTION
# Description

This addresses an issues raised by consuming application not being able to filter irrelevant transactions for their running context

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
