### PR TITLE
Keeping track of the network on transactions

### DIFF
--- a/paywall/src/__tests__/middlewares/web3Middleware.test.js
+++ b/paywall/src/__tests__/middlewares/web3Middleware.test.js
@@ -294,7 +294,10 @@ describe('Web3 middleware', () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: ADD_TRANSACTION,
-        transaction,
+        transaction: {
+          hash: transaction.hash,
+          network: 'test',
+        },
       })
     )
   })
@@ -380,7 +383,9 @@ describe('Web3 middleware', () => {
       invoke(setAccount({ address: 'hi' }))
 
       expect(store.dispatch).toHaveBeenCalledWith(
-        expect.objectContaining(addTransaction({ hash: transaction }))
+        expect.objectContaining(
+          addTransaction({ hash: transaction, network: 'test' })
+        )
       )
     })
 
@@ -419,7 +424,9 @@ describe('Web3 middleware', () => {
         invoke(action('hi'))
 
         expect(store.dispatch).toHaveBeenCalledWith(
-          expect.objectContaining(addTransaction({ hash: transaction }))
+          expect.objectContaining(
+            addTransaction({ hash: transaction, network: 'test' })
+          )
         )
       }
     )
@@ -456,7 +463,9 @@ describe('Web3 middleware', () => {
     mockWeb3Service.getLock = jest.fn()
     invoke(action)
     expect(store.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining(addTransaction({ hash: transaction }))
+      expect.objectContaining(
+        addTransaction({ hash: transaction, network: 'test' })
+      )
     )
     expect(next).toHaveBeenCalledWith(action)
   })

--- a/paywall/src/middlewares/storageMiddleware.js
+++ b/paywall/src/middlewares/storageMiddleware.js
@@ -28,6 +28,7 @@ const storageMiddleware = config => {
                       hash: transaction.transactionHash,
                       to: transaction.recipient,
                       from: transaction.sender,
+                      network: transaction.network,
                     })
                   )
                 })

--- a/paywall/src/middlewares/walletMiddleware.js
+++ b/paywall/src/middlewares/walletMiddleware.js
@@ -73,6 +73,7 @@ const walletMiddleware = config => ({ getState, dispatch }) => {
           input,
           type: transactionTypeMapping(type),
           status,
+          network: getState().network.name,
         })
       )
     }

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -93,6 +93,7 @@ const web3Middleware = config => ({ getState, dispatch }) => {
     dispatch(
       addTransaction({
         hash: transactionHash,
+        network: getState().network.name,
       })
     )
   })
@@ -131,6 +132,7 @@ const web3Middleware = config => ({ getState, dispatch }) => {
           dispatch(
             addTransaction({
               hash: transaction,
+              network: getState().network.name,
             })
           )
         }

--- a/tickets/src/__tests__/middlewares/web3Middleware.test.js
+++ b/tickets/src/__tests__/middlewares/web3Middleware.test.js
@@ -159,7 +159,10 @@ describe('Web3 middleware', () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: ADD_TRANSACTION,
-        transaction,
+        transaction: {
+          hash: transaction.hash,
+          network: 'test',
+        },
       })
     )
   })

--- a/tickets/src/middlewares/web3Middleware.js
+++ b/tickets/src/middlewares/web3Middleware.js
@@ -39,6 +39,7 @@ const web3Middleware = config => {
       dispatch(
         addTransaction({
           hash: transactionHash,
+          network: getState().network.name,
         })
       )
     })

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -118,6 +118,7 @@ describe('Storage middleware', () => {
       expect(store.dispatch).toHaveBeenNthCalledWith(
         3,
         addTransaction({
+          network: null,
           hash: '0xabc',
         })
       )
@@ -126,6 +127,7 @@ describe('Storage middleware', () => {
         4,
         addTransaction({
           hash: '0xdef',
+          network: null,
         })
       )
 

--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -280,7 +280,10 @@ describe('Lock middleware', () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: ADD_TRANSACTION,
-        transaction,
+        transaction: {
+          hash: transaction.hash,
+          network: 'test',
+        },
       })
     )
   })
@@ -363,7 +366,8 @@ describe('Lock middleware', () => {
       await lockCreationTransaction
 
       expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
-        mockTx.transactionHash
+        mockTx.transactionHash,
+        { network: 'test' }
       )
       expect(mockWeb3Service.getKeyByLockForOwner).not.toHaveBeenCalled()
     })
@@ -424,7 +428,8 @@ describe('Lock middleware', () => {
       })
     )
     expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
-      transaction.hash
+      transaction.hash,
+      transaction
     )
     await transactionPromise
     expect(store.dispatch).toHaveBeenCalledWith(

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -35,6 +35,7 @@ const storageMiddleware = config => {
               transactionHashes.forEach(hash => {
                 dispatch(
                   addTransaction({
+                    network: null, // TODO: have storageService yield this!
                     hash,
                   })
                 )

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -86,6 +86,7 @@ const walletMiddleware = config => {
             input,
             type: transactionTypeMapping(type),
             status,
+            network: getState().network.name,
           })
         )
       }

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -99,6 +99,7 @@ const web3Middleware = config => {
       dispatch(
         addTransaction({
           hash: transactionHash,
+          network: getState().network.name,
         })
       )
     })
@@ -126,9 +127,11 @@ const web3Middleware = config => {
 
         if (action.type === ADD_TRANSACTION) {
           dispatch(startLoading())
-          web3Service.getTransaction(action.transaction.hash).then(() => {
-            dispatch(doneLoading())
-          })
+          web3Service
+            .getTransaction(action.transaction.hash, action.transaction)
+            .then(() => {
+              dispatch(doneLoading())
+            })
         }
 
         if (action.type === NEW_TRANSACTION) {
@@ -163,7 +166,9 @@ const web3Middleware = config => {
             .then(lockCreations => {
               dispatch(doneLoading())
               lockCreations.forEach(lockCreation => {
-                web3Service.getTransaction(lockCreation.transactionHash)
+                web3Service.getTransaction(lockCreation.transactionHash, {
+                  network: getState().network.name,
+                })
               })
             })
         }


### PR DESCRIPTION
This will be useful to not try to retrieve on chain the transactions which are not from this network.



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread