### PR TITLE
implement keyStatus usage across the paywall

### DIFF
--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -68,7 +68,21 @@ function renderMockPaywall(props = {}) {
     <ConfigContext.Provider value={config}>
       <WindowContext.Provider value={fakeWindow}>
         <Provider store={store}>
-          <Paywall locks={[]} locked redirect={false} {...props} />
+          <Paywall
+            locks={[]}
+            locked
+            redirect={false}
+            transaction={null}
+            account={null}
+            requiredConfirmations={12}
+            keyStatus="none"
+            lockKey={{
+              lock: 'lock',
+              expiration: 12345,
+            }}
+            expiration=""
+            {...props}
+          />
         </Provider>
       </WindowContext.Provider>
     </ConfigContext.Provider>

--- a/paywall/src/__tests__/components/lock/Lock.test.js
+++ b/paywall/src/__tests__/components/lock/Lock.test.js
@@ -132,6 +132,7 @@ describe('Lock', () => {
             hideModal={() => {}}
             showModal={() => {}}
             openInNewWindow={openInNewWindow}
+            keyStatus="none"
           />
         </Provider>
       )

--- a/paywall/src/__tests__/components/lock/Overlay.test.js
+++ b/paywall/src/__tests__/components/lock/Overlay.test.js
@@ -95,6 +95,7 @@ describe('Overlay', () => {
         transaction: null,
       })
     })
+
     it('should not crash if there are no matching keys yet for a transaction', () => {
       expect.assertions(1)
 
@@ -123,6 +124,7 @@ describe('Overlay', () => {
         transaction: null,
       })
     })
+
     it('should set openInNewWindow based on the value of account', () => {
       expect.assertions(3)
 
@@ -278,6 +280,7 @@ describe('Overlay', () => {
                 bigBody={() => {}}
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
+                keyStatus="none"
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -309,6 +312,7 @@ describe('Overlay', () => {
                 bigBody={() => {}}
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
+                keyStatus="none"
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -343,6 +347,7 @@ describe('Overlay', () => {
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
                 openInNewWindow={false}
+                keyStatus="none"
               />
             </ConfigProvider>
           </ErrorProvider>
@@ -407,6 +412,7 @@ describe('Overlay', () => {
                 bigBody={() => {}}
                 optimism={{ current: 1, past: 0 }}
                 locks={[lock]}
+                keyStatus="confirming"
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -436,6 +442,7 @@ describe('Overlay', () => {
                 bigBody={() => {}}
                 optimism={{ current: 1, past: 0 }}
                 locks={[lock]}
+                keyStatus="valid"
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -481,6 +488,7 @@ describe('Overlay', () => {
                     bigBody={() => {}}
                     optimism={{ current: 1, past: 0 }}
                     locks={[lock]}
+                    keyStatus="confirming"
                   />
                 </ErrorProvider>
               </ConfigProvider>
@@ -527,6 +535,7 @@ describe('Overlay', () => {
                     bigBody={bigBody}
                     optimism={{ current: 0, past: 0 }}
                     locks={[lock]}
+                    keyStatus="confirming"
                   />
                 </ErrorProvider>
               </ConfigProvider>
@@ -591,13 +600,14 @@ describe('Overlay', () => {
                 bigBody={() => {}}
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
+                keyStatus="none"
               />
             </ErrorProvider>
           </ConfigProvider>
         </Provider>
       )
 
-      expect(wrapper.queryByText('100000.00 Eth')).not.toBeNull()
+      expect(wrapper.getByText('100000.00 Eth')).not.toBeNull()
       expect(
         wrapper.getByText(
           'You have reached your limit of free articles. Please purchase access'
@@ -623,13 +633,14 @@ describe('Overlay', () => {
                 bigBody={() => {}}
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
+                keyStatus="confirming"
               />
             </ErrorProvider>
           </ConfigProvider>
         </Provider>
       )
 
-      expect(wrapper.queryByText('100000.00 Eth')).not.toBeNull()
+      expect(wrapper.getByText('100000.00 ETH')).not.toBeNull()
       expect(wrapper.getByText('Purchase pending...')).not.toBeNull()
     })
 
@@ -652,13 +663,14 @@ describe('Overlay', () => {
                 bigBody={() => {}}
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
+                keyStatus="valid"
               />
             </ErrorProvider>
           </ConfigProvider>
         </Provider>
       )
 
-      expect(wrapper.queryByText('100000.00 Eth')).not.toBeNull()
+      expect(wrapper.getByText('100000.00 ETH')).not.toBeNull()
       expect(
         wrapper.getByText('Purchase confirmed, content unlocked!')
       ).not.toBeNull()

--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5931,7 +5931,7 @@ Object {
             <footer
               class="c7 c8"
             >
-              Sold Out
+              Insufficient funds
             </footer>
           </div>
         </div>
@@ -5987,7 +5987,7 @@ Object {
           <footer
             class="sc-1549ebs-2 sc-5sgq84-1 frvQEr"
           >
-            Sold Out
+            Insufficient funds
           </footer>
         </div>
       </div>

--- a/paywall/src/components/lock/Overlay.js
+++ b/paywall/src/components/lock/Overlay.js
@@ -61,17 +61,25 @@ export const Overlay = ({
   optimism,
   smallBody,
   bigBody,
+  keyStatus,
 }) => {
   let message
-  if (transaction) {
-    if (transaction.confirmations < requiredConfirmations) {
+  switch (keyStatus) {
+    case 'confirming':
+    case 'pending':
       message = 'Purchase pending...'
-    } else {
+      break
+    case 'valid':
+    case 'confirmed':
       message = 'Purchase confirmed, content unlocked!'
-    }
-  } else {
-    message =
-      'You have reached your limit of free articles. Please purchase access'
+      break
+    case 'expired':
+      message =
+        'Your subscription has expired, please purchase a new key to continue'
+      break
+    default:
+      message =
+        'You have reached your limit of free articles. Please purchase access'
   }
   const { postMessage } = usePostMessage()
   useEffect(() => {
@@ -109,6 +117,7 @@ export const Overlay = ({
                 hideModal={hideModal}
                 showModal={showModal}
                 openInNewWindow={openInNewWindow}
+                keyStatus={keyStatus}
               />
             ))}
           </GlobalErrorConsumer>
@@ -133,6 +142,7 @@ Overlay.propTypes = {
     current: PropTypes.oneOf([0, 1]).isRequired,
     past: PropTypes.oneOf([0, 1]).isRequired,
   }).isRequired,
+  keyStatus: PropTypes.string.isRequired,
 }
 
 Overlay.defaultProps = {

--- a/paywall/src/stories/lock/Lock.stories.js
+++ b/paywall/src/stories/lock/Lock.stories.js
@@ -52,6 +52,8 @@ const WindowProvider = WindowContext.Provider
 
 const storyConfig = {
   requiredConfirmations: 12,
+  isInIframe: false,
+  isServer: false,
 }
 
 storiesOf('Lock', module)
@@ -75,9 +77,9 @@ storiesOf('Lock', module)
         lock={shortLock}
         transaction={null}
         lockKey={null}
-        config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="none"
       />
     )
   })
@@ -87,9 +89,9 @@ storiesOf('Lock', module)
         lock={lock}
         transaction={null}
         lockKey={null}
-        config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="none"
       />
     )
   })
@@ -100,9 +102,9 @@ storiesOf('Lock', module)
         lock={lock}
         transaction={null}
         lockKey={null}
-        config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="none"
       />
     )
   })
@@ -112,25 +114,25 @@ storiesOf('Lock', module)
         lock={soldOutLock}
         transaction={null}
         lockKey={null}
-        config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="none"
       />
     )
   })
   .add('disabled - too expensive for current user', () => {
     const account = {
-      balance: lock.keyPrice,
+      balance: '0',
     }
     return (
       <Lock
         account={account}
-        lock={soldOutLock}
+        lock={lock}
         transaction={null}
         lockKey={null}
-        config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="none"
       />
     )
   })
@@ -149,6 +151,7 @@ storiesOf('Lock', module)
         config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="submitted"
       />
     )
   })
@@ -168,6 +171,7 @@ storiesOf('Lock', module)
         config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="confirming"
       />
     )
   })
@@ -187,6 +191,7 @@ storiesOf('Lock', module)
         config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="valid"
       />
     )
   })
@@ -207,6 +212,7 @@ storiesOf('Lock', module)
         config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="none"
       />
     )
   })
@@ -223,6 +229,7 @@ storiesOf('Lock', module)
         config={config}
         {...lockActions}
         openInNewWindow={false}
+        keyStatus="none"
       />
     )
   })

--- a/paywall/src/stories/lock/Overlay-Optimistic.stories.js
+++ b/paywall/src/stories/lock/Overlay-Optimistic.stories.js
@@ -81,6 +81,7 @@ function makeStore(state = {}) {
 
 const render = (
   locks,
+  keyStatus,
   errors = { error: false, errorMetadata: {} },
   thisConfig = config,
   optimism = { current: 0, past: 0 }
@@ -140,6 +141,7 @@ const render = (
                 bigBody={() => {}}
                 openInNewWindow={false}
                 optimism={optimism}
+                keyStatus={keyStatus}
               />
             </FakeIframe>
           </ErrorProvider>
@@ -152,7 +154,10 @@ const render = (
 storiesOf('Overlay/Optimistic Unlocking', module)
   .add('beginning purchase', () => {
     makeStore()
-    return render(locks, undefined, undefined, { current: 1, past: 0 })
+    return render(locks, 'pending', undefined, undefined, {
+      current: 1,
+      past: 0,
+    })
   })
   .add('some confirmations', () => {
     makeStore({
@@ -163,7 +168,10 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         },
       },
     })
-    return render(locks, undefined, undefined, { current: 1, past: 0 })
+    return render(locks, 'confirming', undefined, undefined, {
+      current: 1,
+      past: 0,
+    })
   })
   .add('confirmed', () => {
     makeStore({
@@ -174,11 +182,17 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         },
       },
     })
-    return render(locks, undefined, undefined, { current: 1, past: 0 })
+    return render(locks, 'confirmed', undefined, undefined, {
+      current: 1,
+      past: 0,
+    })
   })
   .add('beginning purchase (pessimistic)', () => {
     makeStore()
-    return render(locks, undefined, undefined, { current: 0, past: 1 })
+    return render(locks, 'pending', undefined, undefined, {
+      current: 0,
+      past: 1,
+    })
   })
   .add('some confirmations (pessimistic)', () => {
     makeStore({
@@ -190,7 +204,10 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         },
       },
     })
-    return render(locks, undefined, undefined, { current: 0, past: 1 })
+    return render(locks, 'confirming', undefined, undefined, {
+      current: 0,
+      past: 1,
+    })
   })
   .add('confirmed (pessimistic)', () => {
     makeStore({
@@ -202,5 +219,8 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         },
       },
     })
-    return render(locks, undefined, undefined, { current: 0, past: 1 })
+    return render(locks, 'confirmed', undefined, undefined, {
+      current: 0,
+      past: 1,
+    })
   })

--- a/paywall/src/stories/lock/Overlay.stories.js
+++ b/paywall/src/stories/lock/Overlay.stories.js
@@ -92,6 +92,8 @@ const render = (
             bigBody={() => {}}
             openInNewWindow={false}
             optimism={optimism}
+            keyStatus="none"
+            account="account"
           />
         </ErrorProvider>
       </WindowProvider>


### PR DESCRIPTION
# Description

This refactors the app to use `keyStatus` instead of a series of complex checks for interaction between transaction and key to control the UI of the paywall. It fixes one faulty story that was using the wrong lock and displaying `Sold Out` instead of `Insufficient Funds`, and 2 tests that were searching for `Eth` instead of `ETH` (how did they pass before??), but otherwise, as the snapshots attest, has no effect on the generated code.

<img width="1680" alt="Screen Shot 2019-04-19 at 12 59 41 PM" src="https://user-images.githubusercontent.com/98250/56434719-c7a23b00-62a3-11e9-912e-e67be5b673b1.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2725 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
