### PR TITLE
if the key has no transactions, use its expiration as the determinant…

### DIFF
--- a/paywall/src/__tests__/selectors/keys.test.ts
+++ b/paywall/src/__tests__/selectors/keys.test.ts
@@ -33,7 +33,7 @@ describe('keys selectors', () => {
       expect(keyStatus('hi', {}, 12)).toBe('none')
     })
 
-    it('returns "none" if the transaction status is falsy', () => {
+    it('returns "valid" if the transaction status is falsy and the key is not expired', () => {
       expect.assertions(1)
 
       transactions.one.status = TransactionStatus.NONE
@@ -43,7 +43,23 @@ describe('keys selectors', () => {
           {
             hi: {
               expiration: new Date().getTime() / 1000 + 10000,
-              transactions,
+            },
+          },
+          12
+        )
+      ).toBe('valid')
+    })
+
+    it('returns "none" if there are no transactions and the key is expired', () => {
+      expect.assertions(1)
+
+      transactions.one.status = TransactionStatus.NONE
+      expect(
+        keyStatus(
+          'hi',
+          {
+            hi: {
+              expiration: 0,
             },
           },
           12

--- a/paywall/src/selectors/keys.ts
+++ b/paywall/src/selectors/keys.ts
@@ -2,7 +2,7 @@ import { Transaction, TransactionStatus } from '../unlockTypes'
 
 interface Key {
   expiration: number
-  transactions: {
+  transactions?: {
     [key: string]: Transaction
   }
 }
@@ -22,7 +22,13 @@ export default function keyStatus(
 ): KeyStatus | TransactionStatus {
   const key = keys[id]
 
-  if (!key || !key.transactions) {
+  if (!key) {
+    return KeyStatus.NONE
+  }
+  if (!key.transactions) {
+    if (key.expiration > new Date().getTime() / 1000) {
+      return KeyStatus.VALID
+    }
     return KeyStatus.NONE
   }
   const transactions = Object.values(key.transactions)


### PR DESCRIPTION
… of validity

# Description

Integration tests for #2764 caught a bug in the `keyStatus` function, which is that if there is no transaction present, we were always assuming the key was invalid, when in reality we should fall back to the simple test: is the key expired or not?

This PR fixes that oversight

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2725 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
