### PR TITLE
doing public lock version detection from the contract

### DIFF
--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "index.js",
   "scripts": {

--- a/unlock-js/src/__tests__/unlockService.test.js
+++ b/unlock-js/src/__tests__/unlockService.test.js
@@ -1,14 +1,10 @@
 /* eslint no-console: 0 */
 
 import Web3 from 'web3'
-import * as UnlockV0 from 'unlock-abi-0'
-import * as UnlockV01 from 'unlock-abi-0-1'
-import * as UnlockV02 from 'unlock-abi-0-2'
 
-import UnlockService, { Errors } from '../unlockService'
+import UnlockService from '../unlockService'
 import NockHelper from './helpers/nockHelper'
 import v0 from '../v0'
-import v01 from '../v01'
 import v02 from '../v02'
 
 const endpoint = 'http://127.0.0.1:8545'
@@ -68,148 +64,52 @@ describe('UnlockService', () => {
     })
   })
 
-  describe('_getVersionFromContract', () => {
-    it('should return the version number if there is one', async () => {
-      expect.assertions(1)
-
-      nock.ethCallAndYield(
-        '0x4220bd46', //bytes4(keccak256('unlockVersion()'))
-        unlockAddress,
-        '0x0000000000000000000000000000000000000000000000000000000000000002'
-      )
-      const version = await unlockService._getVersionFromContract(unlockAddress)
-      expect(version).toBe(2)
-    })
-
-    it('should return 0 if the contract does not have a version number', async () => {
-      expect.assertions(1)
-
-      nock.ethCallAndYield(
-        '0x4220bd46' /*bytes4(keccak256('unlockVersion()'))*/,
-        unlockAddress,
-        {
-          message:
-            'VM Exception while processing transaction: revert NO_FALLBACK',
-          code: -32000,
-          data: {
-            '0xbf4181f274c0d90e6f0ece0285cb98a13f8816ba09bd8111eec4ffa8fa06d5bb': {
-              error: 'revert',
-              program_counter: 305,
-              return:
-                '0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b4e4f5f46414c4c4241434b000000000000000000000000000000000000000000',
-              reason: 'NO_FALLBACK',
-            },
-            stack:
-              'o: VM Exception while processing transaction: revert NO_FALLBACK\n    at Function.o.fromResults (/Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:10:81931)\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:47:121203\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:61:1833282\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:26124\n    at i (/Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:41179)\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:61:1190532\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:105418\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:32:392\n    at c (/Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:32:5407)\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:32:317\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:61:1851708\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:23237\n    at o (/Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:26646)\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:26124\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:61:1844745\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:61:1842608\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:61:1869821\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:23237\n    at o (/Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:26646)\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:26124\n    at /Users/julien/repos/unlock-shadow/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:5439\n    at FSReqWrap.oncomplete (fs.js:135:15)',
-            name: 'o',
-          },
-        }
-      )
-      const version = await unlockService._getVersionFromContract(unlockAddress)
-      expect(version).toBe(0)
-    })
-  })
-
   describe('lockContractAbiVersion', () => {
-    it('should return UnlockV0 when the opCode matches', async () => {
-      expect.assertions(2)
-      unlockService.web3.eth = {
-        getCode: jest.fn(() => {
-          return Promise.resolve(UnlockV0.PublicLock.deployedBytecode)
-        }),
-      }
+    it('should return UnlockV0 when the version matches', async () => {
+      expect.assertions(3)
+      unlockService._getPublicLockVersionFromContract = jest.fn(() => {
+        return Promise.resolve(0)
+      })
+
       const address = '0xabc'
       const version = await unlockService.lockContractAbiVersion(address)
 
-      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
+      expect(
+        unlockService._getPublicLockVersionFromContract
+      ).toHaveBeenCalledWith(address)
       expect(version).toEqual(v0)
+      expect(unlockService.versionForAddress[address]).toEqual(0)
     })
 
-    it('should return UnlockV01 when the opCode matches', async () => {
-      expect.assertions(2)
-      unlockService.web3.eth = {
-        getCode: jest.fn(() => {
-          return Promise.resolve(UnlockV01.PublicLock.deployedBytecode)
-        }),
-      }
+    it('should return UnlockV01 when the version matches', async () => {
+      expect.assertions(3)
+      unlockService._getPublicLockVersionFromContract = jest.fn(() => {
+        return Promise.resolve(1) // See code for explaination
+      })
+
       const address = '0xabc'
       const version = await unlockService.lockContractAbiVersion(address)
 
-      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
-      expect(version).toEqual(v01)
-    })
-
-    it('should return UnlockV02 when the opCode matches', async () => {
-      expect.assertions(2)
-      unlockService.web3.eth = {
-        getCode: jest.fn(() => {
-          return Promise.resolve(UnlockV02.PublicLock.deployedBytecode)
-        }),
-      }
-      const address = '0xabc'
-      const version = await unlockService.lockContractAbiVersion(address)
-
-      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
+      expect(
+        unlockService._getPublicLockVersionFromContract
+      ).toHaveBeenCalledWith(address)
       expect(version).toEqual(v02)
-    })
-
-    it('should throw NON_DEPLOYED_CONTRACT if the opCode is 0x', async () => {
-      expect.assertions(2)
-      unlockService.web3.eth = {
-        getCode: jest.fn(() => {
-          return Promise.resolve('0x')
-        }),
-      }
-      const address = '0xabc'
-      try {
-        await unlockService.lockContractAbiVersion(address)
-      } catch (error) {
-        expect(error.message).toEqual(Errors.NON_DEPLOYED_CONTRACT)
-      }
-      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
-    })
-
-    // This test should be removed in favor of the next one once we changed the behavior on default
-    it('should default to v0 if the opCode does not match any version', async () => {
-      expect.assertions(2)
-      unlockService.web3.eth = {
-        getCode: jest.fn(() => {
-          return Promise.resolve('0xabc')
-        }),
-      }
-      const address = '0xabc'
-      const version = await unlockService.lockContractAbiVersion(address)
-      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
-      expect(version).toEqual(v0)
-    })
-
-    it.skip('should throw UNKNOWN_CONTRACT if the opCode does not match any version', async () => {
-      expect.assertions(2)
-      unlockService.web3.eth = {
-        getCode: jest.fn(() => {
-          return Promise.resolve('0xabc')
-        }),
-      }
-      const address = '0xabc'
-      try {
-        await unlockService.lockContractAbiVersion(address)
-      } catch (error) {
-        expect(error.message).toEqual(Errors.UNKNOWN_CONTRACT)
-      }
-      expect(unlockService.web3.eth.getCode).toHaveBeenCalledWith(address)
+      expect(unlockService.versionForAddress[address]).toEqual(1)
     })
 
     it('should memoize the result', async () => {
-      expect.assertions(2)
-      unlockService.web3.eth = {
-        getCode: jest.fn(),
-      }
+      expect.assertions(3)
+      unlockService._getPublicLockVersionFromContract = jest.fn(() => {})
+
       const address = '0xabc'
-      unlockService.opCodeForAddress[address] =
-        UnlockV0.PublicLock.deployedBytecode
+      unlockService.versionForAddress[address] = 1
       const version = await unlockService.lockContractAbiVersion(address)
-      expect(unlockService.web3.eth.getCode).not.toHaveBeenCalled()
-      expect(version).toEqual(v0)
+
+      expect(
+        unlockService._getPublicLockVersionFromContract
+      ).not.toHaveBeenCalled()
+      expect(version).toEqual(v02)
+      expect(unlockService.versionForAddress[address]).toEqual(1)
     })
   })
 })

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -1,11 +1,6 @@
 import EventEmitter from 'events'
 
-import * as UnlockV0 from 'unlock-abi-0'
-import * as UnlockV01 from 'unlock-abi-0-1'
-import * as UnlockV02 from 'unlock-abi-0-2'
-
 import v0 from './v0'
-import v01 from './v01'
 import v02 from './v02'
 
 export const Errors = {
@@ -24,12 +19,7 @@ export default class UnlockService extends EventEmitter {
     this.unlockContractAddress = unlockAddress
     this.web3 = null
     /* Memoization for opCode per address */
-    // Used for Locks
-    this.opCodeForAddress = {
-      // '0x123': '0xopCode'
-    }
-
-    // Used for Unlock
+    // Used to cache
     this.versionForAddress = {}
   }
 
@@ -66,31 +56,51 @@ export default class UnlockService extends EventEmitter {
       throw new Error(Errors.MISSING_WEB3)
     }
 
-    let opCode = this.opCodeForAddress[address]
-    if (!opCode) {
+    let version = this.versionForAddress[address]
+    if (!version) {
       // This was not memo-ized
-      opCode = await this.web3.eth.getCode(address)
-      this.opCodeForAddress[address] = opCode
+      version = await this._getPublicLockVersionFromContract(address)
+      this.versionForAddress[address] = version
     }
 
-    if (opCode === '0x') {
-      throw new Error(Errors.NON_DEPLOYED_CONTRACT)
-    }
-
-    if (UnlockV0.PublicLock.deployedBytecode === opCode) {
-      return v0
-    }
-
-    if (UnlockV01.PublicLock.deployedBytecode === opCode) {
-      return v01
-    }
-
-    if (UnlockV02.PublicLock.deployedBytecode === opCode) {
+    // NOTE: we (julien) F'ed up the deploy on the PublicLock and v02 still uses 1 for its version.
+    // The good news (luck) is that no contract was ever deployed as v01
+    if (1 === version) {
       return v02
     }
 
-    // throw new Error(Errors.UNKNOWN_CONTRACT)
-    return v0 // TODO: we currently default to v0 because the deployed version may bot match the content of the npm module. Change this once we have certainty over the deployed contract.
+    // Defaults to v0
+    return v0
+  }
+
+  async _getPublicLockVersionFromContract(address) {
+    const contract = new this.web3.eth.Contract(
+      [
+        {
+          constant: true,
+          inputs: [],
+          name: 'publicLockVersion',
+          outputs: [
+            {
+              name: '',
+              type: 'uint8',
+            },
+          ],
+          payable: false,
+          stateMutability: 'view',
+          type: 'function',
+        },
+      ],
+      address
+    )
+    let version = 0
+    try {
+      const contractVersion = await contract.methods.publicLockVersion().call()
+      version = parseInt(contractVersion, 10) || 0
+    } catch (error) {
+      // This is an older version of Unlock which did not support publicLockVersion
+    }
+    return version
   }
 
   /**


### PR DESCRIPTION
Doing version detection using the opCode is hard... using an actual version function is much cleaner.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread