### PR TITLE
refactor paywall Overlay: remove redundant mapStateToProps

### DIFF
--- a/paywall/src/__tests__/components/lock/Overlay.test.js
+++ b/paywall/src/__tests__/components/lock/Overlay.test.js
@@ -254,12 +254,20 @@ describe('Overlay', () => {
       expect(wrapper.getByText('Need account')).not.toBeNull()
     })
   })
+
   describe('error replacement', () => {
     const lock = {
+      id: 'lock',
       name: 'Monthly',
       address: '0xdeadbeef',
       keyPrice: '100000',
       expirationDuration: 123456789,
+    }
+    const lockKey = {
+      id: 'key',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 10000,
     }
     let store
     beforeEach(() => (store = createUnlockStore()))
@@ -281,6 +289,7 @@ describe('Overlay', () => {
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
                 keyStatus="none"
+                lockKey={lockKey}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -313,6 +322,7 @@ describe('Overlay', () => {
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
                 keyStatus="none"
+                lockKey={lockKey}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -348,6 +358,7 @@ describe('Overlay', () => {
                 locks={[lock]}
                 openInNewWindow={false}
                 keyStatus="none"
+                lockKey={lockKey}
               />
             </ConfigProvider>
           </ErrorProvider>
@@ -370,6 +381,12 @@ describe('Overlay', () => {
       address: '0xdeadbeef',
       keyPrice: '100000',
       expirationDuration: 123456789,
+    }
+    const lockKey = {
+      id: 'key',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 10000,
     }
     let state
     beforeEach(() => {
@@ -413,6 +430,7 @@ describe('Overlay', () => {
                 optimism={{ current: 1, past: 0 }}
                 locks={[lock]}
                 keyStatus="confirming"
+                lockKey={lockKey}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -443,6 +461,7 @@ describe('Overlay', () => {
                 optimism={{ current: 1, past: 0 }}
                 locks={[lock]}
                 keyStatus="valid"
+                lockKey={lockKey}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -489,6 +508,7 @@ describe('Overlay', () => {
                     optimism={{ current: 1, past: 0 }}
                     locks={[lock]}
                     keyStatus="confirming"
+                    lockKey={lockKey}
                   />
                 </ErrorProvider>
               </ConfigProvider>
@@ -536,6 +556,7 @@ describe('Overlay', () => {
                     optimism={{ current: 0, past: 0 }}
                     locks={[lock]}
                     keyStatus="confirming"
+                    lockKey={lockKey}
                   />
                 </ErrorProvider>
               </ConfigProvider>
@@ -552,15 +573,29 @@ describe('Overlay', () => {
     })
   })
 
-  describe('message displayed to user (pessimistic unlocking', () => {
+  describe('message displayed to user (pessimistic unlocking)', () => {
     const lock = {
       name: 'Monthly',
       address: '0xdeadbeef',
       keyPrice: '100000',
       expirationDuration: 123456789,
     }
+    const lockKey = {
+      id: 'key',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 10000,
+    }
     let state
     beforeEach(() => {
+      const transactions = {
+        transaction: {
+          key: 'key',
+          status: 'mined',
+          confirmations: 4,
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+        },
+      }
       state = {
         account: {
           address: 'account',
@@ -570,15 +605,10 @@ describe('Overlay', () => {
             lock: '0xdeadbeef',
             owner: 'account',
             id: 'key',
+            transactions,
           },
         },
-        transactions: {
-          transaction: {
-            key: 'key',
-            confirmations: 4,
-            type: TRANSACTION_TYPES.KEY_PURCHASE,
-          },
-        },
+        transactions,
       }
     })
 
@@ -601,6 +631,7 @@ describe('Overlay', () => {
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
                 keyStatus="none"
+                lockKey={lockKey}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -634,6 +665,7 @@ describe('Overlay', () => {
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
                 keyStatus="confirming"
+                lockKey={lockKey}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -664,6 +696,7 @@ describe('Overlay', () => {
                 optimism={{ current: 0, past: 0 }}
                 locks={[lock]}
                 keyStatus="valid"
+                lockKey={lockKey}
               />
             </ErrorProvider>
           </ConfigProvider>

--- a/paywall/src/__tests__/components/lock/Overlay.test.js
+++ b/paywall/src/__tests__/components/lock/Overlay.test.js
@@ -44,87 +44,6 @@ describe('Overlay', () => {
   })
 
   describe('mapStateToProps', () => {
-    it('should set transaction', () => {
-      expect.assertions(2)
-
-      const props = {
-        locks: [
-          {
-            address: '0x123',
-          },
-        ],
-      }
-      const state = {
-        account: {
-          address: 'account',
-        },
-        keys: {
-          key: {
-            lock: '0x123',
-            owner: 'account',
-            id: 'key',
-          },
-        },
-        transactions: {
-          transaction: {
-            key: 'key',
-            type: TRANSACTION_TYPES.KEY_PURCHASE,
-          },
-        },
-      }
-      const state2 = {
-        account: {
-          address: 'account',
-        },
-        keys: {
-          key: {
-            lock: '0x123',
-            owner: 'account',
-            id: 'key',
-          },
-        },
-        transactions: {},
-      }
-
-      expect(mapStateToProps(state, props)).toEqual({
-        openInNewWindow: false,
-        transaction: state.transactions.transaction,
-      })
-      expect(mapStateToProps(state2, props)).toEqual({
-        openInNewWindow: false,
-        transaction: null,
-      })
-    })
-
-    it('should not crash if there are no matching keys yet for a transaction', () => {
-      expect.assertions(1)
-
-      const props = {
-        locks: [
-          {
-            address: '0x123',
-          },
-        ],
-      }
-      const state = {
-        account: {
-          address: 'account',
-        },
-        keys: {},
-        transactions: {
-          transaction: {
-            key: 'key',
-            type: TRANSACTION_TYPES.KEY_PURCHASE,
-          },
-        },
-      }
-
-      expect(mapStateToProps(state, props)).toEqual({
-        openInNewWindow: false,
-        transaction: null,
-      })
-    })
-
     it('should set openInNewWindow based on the value of account', () => {
       expect.assertions(3)
 
@@ -167,18 +86,15 @@ describe('Overlay', () => {
       }
 
       expect(mapStateToProps(state1, props)).toEqual({
-        transaction: null,
         openInNewWindow: true,
       })
 
       expect(mapStateToProps(state2, props)).toEqual({
         openInNewWindow: false,
-        transaction: null,
       })
 
       expect(mapStateToProps(state3, props)).toEqual({
         openInNewWindow: true,
-        transaction: null,
       })
     })
   })
@@ -389,7 +305,13 @@ describe('Overlay', () => {
       expiration: new Date().getTime() / 1000 + 10000,
     }
     let state
+    let transaction
     beforeEach(() => {
+      transaction = {
+        key: 'key',
+        confirmations: 4,
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+      }
       state = {
         account: {
           address: 'account',
@@ -402,11 +324,7 @@ describe('Overlay', () => {
           },
         },
         transactions: {
-          transaction: {
-            key: 'key',
-            confirmations: 4,
-            type: TRANSACTION_TYPES.KEY_PURCHASE,
-          },
+          transaction,
         },
       }
     })
@@ -431,6 +349,7 @@ describe('Overlay', () => {
                 locks={[lock]}
                 keyStatus="confirming"
                 lockKey={lockKey}
+                transaction={transaction}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -462,6 +381,7 @@ describe('Overlay', () => {
                 locks={[lock]}
                 keyStatus="valid"
                 lockKey={lockKey}
+                transaction={transaction}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -509,6 +429,7 @@ describe('Overlay', () => {
                     locks={[lock]}
                     keyStatus="confirming"
                     lockKey={lockKey}
+                    transaction={transaction}
                   />
                 </ErrorProvider>
               </ConfigProvider>
@@ -557,6 +478,7 @@ describe('Overlay', () => {
                     locks={[lock]}
                     keyStatus="confirming"
                     lockKey={lockKey}
+                    transaction={transaction}
                   />
                 </ErrorProvider>
               </ConfigProvider>
@@ -587,14 +509,16 @@ describe('Overlay', () => {
       expiration: new Date().getTime() / 1000 + 10000,
     }
     let state
+    let transaction
     beforeEach(() => {
+      transaction = {
+        key: 'key',
+        status: 'mined',
+        confirmations: 4,
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+      }
       const transactions = {
-        transaction: {
-          key: 'key',
-          status: 'mined',
-          confirmations: 4,
-          type: TRANSACTION_TYPES.KEY_PURCHASE,
-        },
+        transaction,
       }
       state = {
         account: {
@@ -632,6 +556,7 @@ describe('Overlay', () => {
                 locks={[lock]}
                 keyStatus="none"
                 lockKey={lockKey}
+                transaction={transaction}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -666,6 +591,7 @@ describe('Overlay', () => {
                 locks={[lock]}
                 keyStatus="confirming"
                 lockKey={lockKey}
+                transaction={transaction}
               />
             </ErrorProvider>
           </ConfigProvider>
@@ -697,6 +623,7 @@ describe('Overlay', () => {
                 locks={[lock]}
                 keyStatus="valid"
                 lockKey={lockKey}
+                transaction={transaction}
               />
             </ErrorProvider>
           </ConfigProvider>

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -29,7 +29,6 @@ export function Paywall({
   redirect,
   account,
   transaction,
-  requiredConfirmations,
   keyStatus,
   lockKey,
   expiration,
@@ -77,7 +76,6 @@ export function Paywall({
           optimism={optimism}
           smallBody={() => smallBody(window.document.body)}
           bigBody={() => bigBody(window.document.body)}
-          requiredConfirmations={requiredConfirmations}
           keyStatus={keyStatus}
           lockKey={lockKey}
           transaction={transaction}
@@ -97,7 +95,6 @@ Paywall.propTypes = {
   redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   transaction: UnlockPropTypes.transaction,
   account: PropTypes.string,
-  requiredConfirmations: PropTypes.number.isRequired,
   keyStatus: PropTypes.string.isRequired,
   lockKey: UnlockPropTypes.key.isRequired,
   expiration: PropTypes.string.isRequired,
@@ -157,7 +154,6 @@ export const mapStateToProps = (
     redirect,
     transaction,
     account: accountAddress,
-    requiredConfirmations,
     keyStatus: currentKeyStatus,
     lockKey,
     expiration,

--- a/paywall/src/components/lock/Overlay.js
+++ b/paywall/src/components/lock/Overlay.js
@@ -16,7 +16,6 @@ import Media from '../../theme/media'
 
 import ConfirmedFlag from './ConfirmedFlag'
 import ConfirmingFlag from './ConfirmingFlag'
-import { TRANSACTION_TYPES } from '../../constants'
 import {
   POST_MESSAGE_GET_OPTIMISTIC,
   POST_MESSAGE_GET_PESSIMISTIC,
@@ -157,34 +156,8 @@ Overlay.defaultProps = {
   transaction: null,
   account: null,
 }
-export const mapStateToProps = ({ account, transactions, keys }, { locks }) => {
-  const lock = locks.length ? locks[0] : {}
-
-  // If there is no account (probably not loaded yet), we do not want to create a key
-  // similarly, if there is no lock
-  if (!account || !lock) {
-    return {
-      transaction: null,
-      openInNewWindow: !account || !!account.fromLocalStorage,
-    }
-  }
-
-  let transaction = null
-
-  const lockKey = Object.values(keys).find(
-    key => key.lock === lock.address && key.owner === account.address
-  )
-
-  // Let's select the transaction corresponding to this key purchase, if it exists
-  // This transaction is of type KEY_PURCHASE
-  transaction = Object.values(transactions).find(
-    transaction =>
-      transaction.type === TRANSACTION_TYPES.KEY_PURCHASE &&
-      transaction.key === (lockKey && lockKey.id)
-  )
-
+export const mapStateToProps = ({ account }) => {
   return {
-    transaction: transaction ? transaction : null,
     openInNewWindow: !account || !!account.fromLocalStorage,
   }
 }

--- a/paywall/src/stories/lock/Overlay-Optimistic.stories.js
+++ b/paywall/src/stories/lock/Overlay-Optimistic.stories.js
@@ -67,6 +67,15 @@ const defaultState = {
       id: '0x1234567890123456789012345678901234567890-0x456',
       lock: '0x1234567890123456789012345678901234567890',
       owner: '0x456',
+      transactions: {
+        transaction: {
+          id: 'transaction',
+          status: 'pending',
+          confirmations: 0,
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          key: '0x1234567890123456789012345678901234567890-0x456',
+        },
+      },
     },
   },
 }
@@ -142,6 +151,13 @@ const render = (
                 openInNewWindow={false}
                 optimism={optimism}
                 keyStatus={keyStatus}
+                lockKey={{
+                  lock: locks[0].address,
+                  owner: 'account',
+                  expiration:
+                    new Date('January 30, 3000, 00:00:00').getTime() / 1000,
+                }}
+                account="account"
               />
             </FakeIframe>
           </ErrorProvider>
@@ -189,7 +205,7 @@ storiesOf('Overlay/Optimistic Unlocking', module)
   })
   .add('beginning purchase (pessimistic)', () => {
     makeStore()
-    return render(locks, 'pending', undefined, undefined, {
+    return render(locks, 'submitted', undefined, undefined, {
       current: 0,
       past: 1,
     })

--- a/paywall/src/stories/lock/Overlay-Optimistic.stories.js
+++ b/paywall/src/stories/lock/Overlay-Optimistic.stories.js
@@ -194,8 +194,8 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         ...transaction,
         confirmations: 5,
       },
-      undefined,
-      undefined,
+      undefined /* errors */,
+      undefined /* thisConfig */,
       {
         current: 1,
         past: 0,
@@ -218,8 +218,8 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         ...transaction,
         confirmations: 12,
       },
-      undefined,
-      undefined,
+      undefined /* errors */,
+      undefined /* thisConfig */,
       {
         current: 1,
         past: 0,
@@ -228,10 +228,17 @@ storiesOf('Overlay/Optimistic Unlocking', module)
   })
   .add('beginning purchase (pessimistic)', () => {
     makeStore()
-    return render(locks, 'submitted', transaction, undefined, undefined, {
-      current: 0,
-      past: 1,
-    })
+    return render(
+      locks,
+      'submitted',
+      transaction,
+      undefined /* errors */,
+      undefined /* thisConfig */,
+      {
+        current: 0,
+        past: 1,
+      }
+    )
   })
   .add('some confirmations (pessimistic)', () => {
     makeStore({
@@ -251,8 +258,8 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         status: 'mined',
         confirmations: 5,
       },
-      undefined,
-      undefined,
+      undefined /* errors */,
+      undefined /* thisConfig */,
       {
         current: 0,
         past: 1,
@@ -277,8 +284,8 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         status: 'mined',
         confirmations: 12,
       },
-      undefined,
-      undefined,
+      undefined /* errors */,
+      undefined /* thisConfig */,
       {
         current: 0,
         past: 1,

--- a/paywall/src/stories/lock/Overlay-Optimistic.stories.js
+++ b/paywall/src/stories/lock/Overlay-Optimistic.stories.js
@@ -40,6 +40,13 @@ const locks = [
   },
 ]
 
+const transaction = {
+  id: 'transaction',
+  status: 'pending',
+  confirmations: 0,
+  type: TRANSACTION_TYPES.KEY_PURCHASE,
+  key: '0x1234567890123456789012345678901234567890-0x456',
+}
 const defaultState = {
   currency: {
     USD: 195.99,
@@ -54,13 +61,7 @@ const defaultState = {
     balance: '2',
   },
   transactions: {
-    transaction: {
-      id: 'transaction',
-      status: 'pending',
-      confirmations: 0,
-      type: TRANSACTION_TYPES.KEY_PURCHASE,
-      key: '0x1234567890123456789012345678901234567890-0x456',
-    },
+    transaction,
   },
   keys: {
     '0x1234567890123456789012345678901234567890-0x456': {
@@ -91,6 +92,7 @@ function makeStore(state = {}) {
 const render = (
   locks,
   keyStatus,
+  transaction,
   errors = { error: false, errorMetadata: {} },
   thisConfig = config,
   optimism = { current: 0, past: 0 }
@@ -157,6 +159,7 @@ const render = (
                   expiration:
                     new Date('January 30, 3000, 00:00:00').getTime() / 1000,
                 }}
+                transaction={transaction}
                 account="account"
               />
             </FakeIframe>
@@ -170,7 +173,7 @@ const render = (
 storiesOf('Overlay/Optimistic Unlocking', module)
   .add('beginning purchase', () => {
     makeStore()
-    return render(locks, 'pending', undefined, undefined, {
+    return render(locks, 'pending', transaction, undefined, undefined, {
       current: 1,
       past: 0,
     })
@@ -184,10 +187,20 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         },
       },
     })
-    return render(locks, 'confirming', undefined, undefined, {
-      current: 1,
-      past: 0,
-    })
+    return render(
+      locks,
+      'confirming',
+      {
+        ...transaction,
+        confirmations: 5,
+      },
+      undefined,
+      undefined,
+      {
+        current: 1,
+        past: 0,
+      }
+    )
   })
   .add('confirmed', () => {
     makeStore({
@@ -198,14 +211,24 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         },
       },
     })
-    return render(locks, 'confirmed', undefined, undefined, {
-      current: 1,
-      past: 0,
-    })
+    return render(
+      locks,
+      'confirmed',
+      {
+        ...transaction,
+        confirmations: 12,
+      },
+      undefined,
+      undefined,
+      {
+        current: 1,
+        past: 0,
+      }
+    )
   })
   .add('beginning purchase (pessimistic)', () => {
     makeStore()
-    return render(locks, 'submitted', undefined, undefined, {
+    return render(locks, 'submitted', transaction, undefined, undefined, {
       current: 0,
       past: 1,
     })
@@ -220,10 +243,21 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         },
       },
     })
-    return render(locks, 'confirming', undefined, undefined, {
-      current: 0,
-      past: 1,
-    })
+    return render(
+      locks,
+      'confirming',
+      {
+        ...transaction,
+        status: 'mined',
+        confirmations: 5,
+      },
+      undefined,
+      undefined,
+      {
+        current: 0,
+        past: 1,
+      }
+    )
   })
   .add('confirmed (pessimistic)', () => {
     makeStore({
@@ -235,8 +269,19 @@ storiesOf('Overlay/Optimistic Unlocking', module)
         },
       },
     })
-    return render(locks, 'confirmed', undefined, undefined, {
-      current: 0,
-      past: 1,
-    })
+    return render(
+      locks,
+      'confirmed',
+      {
+        ...transaction,
+        status: 'mined',
+        confirmations: 12,
+      },
+      undefined,
+      undefined,
+      {
+        current: 0,
+        past: 1,
+      }
+    )
   })

--- a/paywall/src/stories/lock/Overlay.stories.js
+++ b/paywall/src/stories/lock/Overlay.stories.js
@@ -93,6 +93,12 @@ const render = (
             openInNewWindow={false}
             optimism={optimism}
             keyStatus="none"
+            lockKey={{
+              lock: locks[0].address,
+              owner: 'account',
+              expiration:
+                new Date('January 30, 3000, 00:00:00').getTime() / 1000,
+            }}
             account="account"
           />
         </ErrorProvider>


### PR DESCRIPTION
# Description

This PR refactors `Overlay` to remove its `mapStateToProps`. As part of the refactor, I caught a small section that still used `transaction` instead of `keyStatus` and fixed that. Also, the `'submitted'` key status was not being handled, so that is fixed.

`requiredConfirmations` is pulled in by `withConfig` to Overlay, so redundant passing of the value to `Overlay` from `Paywall` is removed.

There are no changes to any storybook rendered stories.

Note that `Paywall` is already passing down `account` and `expired` and `transaction` and `lockKey`, which is why behavior is seamlessly the same.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2725 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
