### PR TITLE
handling NO_SUCH_KEY

### DIFF
--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "index.js",
   "scripts": {

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -559,6 +559,14 @@ export default class Web3Service extends UnlockService {
       const expiration = await lockContract.methods
         .keyExpirationTimestampFor(owner)
         .call()
+      // Handling NO_SUCH_KEY
+      // TODO find a more robust approach (apparently the call above should throw, but it does not!)
+      if (
+        expiration ==
+        '3963877391197344453575983046348115674221700746820753546331534351508065746944'
+      ) {
+        return 0
+      }
       return parseInt(expiration, 10)
     } catch (error) {
       return 0


### PR DESCRIPTION
When a user does not have a key, the contract returns NO_SUCH_KEY rather than the number of keys. The Web3Service turns this value into 0.


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread