### PR TITLE
remove web3 and web3-utils from all web apps

### DIFF
--- a/paywall/package-lock.json
+++ b/paywall/package-lock.json
@@ -1668,14 +1668,6 @@
         "loader-utils": "^1.2.3"
       }
     },
-    "@types/bn.js": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
-      "integrity": "sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -1750,11 +1742,6 @@
         "redux": "^4.0.0"
       }
     },
-    "@types/underscore": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.14.tgz",
-      "integrity": "sha512-xbzi6UaATVKupInG3D65/EPQ3qkJCvG2ZAzmlIYt6x93ACOEX2Y0fHW4/e8TF3G7q5KB2l7wTZgzfNjyYDMuZw=="
-    },
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
@@ -1777,15 +1764,6 @@
       "requires": {
         "@types/node": "*",
         "@types/unist": "*"
-      }
-    },
-    "@types/web3": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.0.18.tgz",
-      "integrity": "sha512-uXQL0LDszt2f476LEmYM6AvSv9F4vU4hWQvlUhwfLHNlIB6OyBXoYsCzWAIhhnc5U0HA7ZBcPybxRJ/yfA6THg==",
-      "requires": {
-        "@types/bn.js": "*",
-        "@types/underscore": "*"
       }
     },
     "@types/yargs": {

--- a/paywall/package.json
+++ b/paywall/package.json
@@ -30,7 +30,6 @@
     "@types/react": "16.8.13",
     "@types/react-dom": "^16.8.3",
     "@types/react-redux": "^7.0.8",
-    "@types/web3": "^1.0.18",
     "@unlock-protocol/unlock-js": "0.0.16",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-source-maps": "0.0.3",
@@ -68,8 +67,7 @@
     "storybook-react-router": "^1.0.5",
     "styled-components": "^4.2.0",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.4.3",
-    "web3": "1.0.0-beta.37"
+    "typescript": "^3.4.3"
   },
   "devDependencies": {
     "@svgr/cli": "4.2.0",

--- a/tickets/package.json
+++ b/tickets/package.json
@@ -54,9 +54,7 @@
     "run-script-os": "1.0.5",
     "styled-components": "4.2.0",
     "ts-jest": "24.0.2",
-    "typescript": "3.4.3",
-    "web3": "1.0.0-beta.37",
-    "web3-utils": "1.0.0-beta.37"
+    "typescript": "3.4.3"
   },
   "devDependencies": {
     "@svgr/cli": "4.2.0",

--- a/unlock-app/package-lock.json
+++ b/unlock-app/package-lock.json
@@ -1703,14 +1703,6 @@
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
     },
-    "@types/bn.js": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
-      "integrity": "sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -1858,11 +1850,6 @@
         }
       }
     },
-    "@types/underscore": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.14.tgz",
-      "integrity": "sha512-xbzi6UaATVKupInG3D65/EPQ3qkJCvG2ZAzmlIYt6x93ACOEX2Y0fHW4/e8TF3G7q5KB2l7wTZgzfNjyYDMuZw=="
-    },
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
@@ -1885,15 +1872,6 @@
       "requires": {
         "@types/node": "*",
         "@types/unist": "*"
-      }
-    },
-    "@types/web3": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.0.18.tgz",
-      "integrity": "sha512-uXQL0LDszt2f476LEmYM6AvSv9F4vU4hWQvlUhwfLHNlIB6OyBXoYsCzWAIhhnc5U0HA7ZBcPybxRJ/yfA6THg==",
-      "requires": {
-        "@types/bn.js": "*",
-        "@types/underscore": "*"
       }
     },
     "@types/webpack": {

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -16,7 +16,6 @@
     "@types/react-redux": "7.0.8",
     "@types/storybook__react": "^4.0.1",
     "@types/styled-components": "4.1.14",
-    "@types/web3": "^1.0.18",
     "@unlock-protocol/unlock-js": "0.0.16",
     "@zeit/next-source-maps": "0.0.3",
     "@zeit/next-typescript": "^1.1.1",
@@ -53,9 +52,7 @@
     "ts-jest": "24.0.2",
     "typescript": "3.4.3",
     "unlock-abi-0-1": "^1.0.0",
-    "unlock-abi-0-2": "^1.0.0",
-    "web3": "1.0.0-beta.37",
-    "web3-utils": "1.0.0-beta.37"
+    "unlock-abi-0-2": "^1.0.0"
   },
   "devDependencies": {
     "@svgr/cli": "4.2.0",


### PR DESCRIPTION
# Description

This removes the deadweight of web3 and web3-utils from all apps, as this is now encapsulated within `unlock-js`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2663 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
