### PR TITLE
Fixing the missing types

### DIFF
--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "index.js",
   "scripts": {

--- a/unlock-js/src/__tests__/web3Service.test.js
+++ b/unlock-js/src/__tests__/web3Service.test.js
@@ -372,6 +372,29 @@ describe('Web3Service', () => {
   })
 
   describe('_getTransactionType', () => {
+    it('should compute the method signature to compare it with the inputs', () => {
+      expect.assertions(1)
+      const data =
+        '0xf6e4641f00000000000000000000000033ab07df7f09e793ddd1e9a25b079989a557119a'
+      const Contract = {
+        contractName: 'PublicLock',
+        abi: [
+          {
+            constant: false,
+            inputs: [{ name: '_recipient', type: 'address' }],
+            name: 'purchaseFor',
+            outputs: [],
+            payable: true,
+            stateMutability: 'payable',
+            type: 'function',
+          },
+        ],
+      }
+      expect(web3Service._getTransactionType(Contract, data)).toBe(
+        'KEY_PURCHASE'
+      )
+    })
+
     describe('v0', () => {
       it('should return null if there is no matching method', () => {
         expect.assertions(1)
@@ -1953,7 +1976,7 @@ describe('Web3Service', () => {
     })
   })
 
-  describe('_getKeyByLockForOwner', async () => {
+  describe('_getKeyByLockForOwner', () => {
     describe('v0', () => {
       it('should update the expiration date', async () => {
         expect.assertions(1)

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -142,7 +142,13 @@ export default class Web3Service extends UnlockService {
    */
   _getTransactionType(contract, data) {
     const method = contract.abi.find(binaryInterface => {
-      return data.startsWith(binaryInterface.signature)
+      if (binaryInterface.type !== 'function') {
+        return false
+      }
+      const signature = this.web3.eth.abi.encodeFunctionSignature(
+        binaryInterface
+      )
+      return data.startsWith(signature)
     })
 
     // If there is no matching method, return null


### PR DESCRIPTION
For some reason, web3.js does not consistently set the `signature` field, so we now compute it ourselves!



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread