### PR TITLE
only show the lock owned by the current account

### DIFF
--- a/unlock-app/src/__tests__/components/content/DashboardContent.test.js
+++ b/unlock-app/src/__tests__/components/content/DashboardContent.test.js
@@ -40,6 +40,7 @@ const locks = {
     maxNumberOfKeys: 800,
     outstandingKeys: 32,
     transaction: '0x5678',
+    owner: '0x12345678',
   },
   '0x12345678a': {
     address: '0x12345678a',
@@ -49,6 +50,7 @@ const locks = {
     maxNumberOfKeys: 240,
     outstandingKeys: 3,
     transaction: '0x1234',
+    owner: '0x12345678',
   },
   '0x9abcdef0a': {
     address: '0x9abcdef0',
@@ -58,8 +60,20 @@ const locks = {
     maxNumberOfKeys: 0,
     outstandingKeys: 10,
     transaction: '0x89ab',
+    owner: '0x12345678',
+  },
+  '0x9abcdef0b': {
+    address: '0x9abcdef0',
+    name: 'The Gamma Blog',
+    keyPrice: '27000000000000000',
+    expirationDuration: 172800,
+    maxNumberOfKeys: 0,
+    outstandingKeys: 10,
+    transaction: '0x89ab',
+    owner: '0x987654',
   },
 }
+
 const locksMinusATransaction = {
   '0x56781234a': {
     address: '0x56781234a',
@@ -68,6 +82,7 @@ const locksMinusATransaction = {
     expirationDuration: 86400,
     maxNumberOfKeys: 800,
     outstandingKeys: 32,
+    owner: '0x12345678',
   },
   '0x12345678a': {
     address: '0x12345678a',
@@ -77,6 +92,7 @@ const locksMinusATransaction = {
     maxNumberOfKeys: 240,
     outstandingKeys: 3,
     transaction: '0x1234',
+    owner: '0x12345678',
   },
   '0x9abcdef0a': {
     address: '0x9abcdef0',
@@ -86,6 +102,7 @@ const locksMinusATransaction = {
     maxNumberOfKeys: 0,
     outstandingKeys: 10,
     transaction: '0x89ab',
+    owner: '0x12345678',
   },
 }
 
@@ -107,6 +124,25 @@ const ConfigProvider = ConfigContext.Provider
 
 describe('DashboardContent', () => {
   describe('mapStateToProps', () => {
+    it('should filter locks for that owner', () => {
+      expect.assertions(5)
+      const state = {
+        account,
+        network,
+        locks,
+        transactions,
+        lockFormStatus,
+      }
+
+      const props = mapStateToProps(state)
+      const lockFeed = props.lockFeed
+      expect(Object.keys(locks)).toHaveLength(4)
+      expect(lockFeed).toHaveLength(3)
+      expect(lockFeed[0].owner).toEqual(account.address)
+      expect(lockFeed[1].owner).toEqual(account.address)
+      expect(lockFeed[2].owner).toEqual(account.address)
+    })
+
     it('should sort locks in descending order by blockNumber', () => {
       expect.assertions(4)
       const state = {

--- a/unlock-app/src/components/content/DashboardContent.js
+++ b/unlock-app/src/components/content/DashboardContent.js
@@ -87,7 +87,16 @@ export const mapStateToProps = ({
       transactions[a.transaction].blockNumber
     )
   }
-  const lockFeed = Object.values(locks).sort(locksComparator)
+
+  // Only show the current account's locks
+  const locksFilter = lock => {
+    return lock.owner === account.address
+  }
+
+  const lockFeed = Object.values(locks)
+    .filter(locksFilter)
+    .sort(locksComparator)
+
   return {
     account: account,
     network: network,

--- a/unlock-app/src/stories/creator/Dashboard.stories.js
+++ b/unlock-app/src/stories/creator/Dashboard.stories.js
@@ -49,6 +49,7 @@ const locks = {
     maxNumberOfKeys: 800,
     outstandingKeys: 32,
     transaction: '0x5678',
+    owner: account.address,
   },
   '0x12345678a': {
     address: '0x12345678a',
@@ -58,6 +59,7 @@ const locks = {
     maxNumberOfKeys: 240,
     outstandingKeys: 3,
     transaction: '0x1234',
+    owner: account.address,
   },
   '0x9abcdef0a': {
     address: '0x9abcdef0',
@@ -67,6 +69,7 @@ const locks = {
     maxNumberOfKeys: 0,
     outstandingKeys: 10,
     transaction: '0x89ab',
+    owner: account.address,
   },
 }
 


### PR DESCRIPTION
This should fix the "submitted" lock issue!



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread