### PR TITLE
remove all mocking of web3.eth from walletService test

### DIFF
--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -89,11 +89,32 @@ export class NockHelper {
   }
 
   // eth_getCode
-  ethGetCodeAndYield(address, opCode) {
+  ethGetCodeAndYield(address, opCode, error) {
     return this._jsonRpcRequest(
       'eth_getCode',
       [address.toLowerCase(), 'latest'],
-      opCode
+      opCode,
+      error
+    )
+  }
+
+  // eth_getGasPrice
+  ethGetGasPriceAndYield(price) {
+    return this._jsonRpcRequest('eth_gasPrice', [], price)
+  }
+
+  // eth_sendTransaction
+  ethSendTransactionAndYield(transaction, gasPrice, result, error) {
+    return this._jsonRpcRequest(
+      'eth_sendTransaction',
+      [
+        {
+          ...transaction,
+          gasPrice,
+        },
+      ],
+      result,
+      error
     )
   }
 }


### PR DESCRIPTION
# Description

This test removes meddling with the internal details of `web3.eth` using `jest.fn()` from `walletService.test.js`. However, it leaves in place a mock provider, which will need to be updated with all upgrades.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
