### PR TITLE
refactor deploy test to remove web3-specific code

### DIFF
--- a/unlock-js/src/__tests__/deploy.test.js
+++ b/unlock-js/src/__tests__/deploy.test.js
@@ -1,3 +1,4 @@
+import Web3 from 'web3'
 import { Unlock } from 'unlock-abi-0'
 
 import deploy from '../deploy'
@@ -39,9 +40,44 @@ describe('contract deployer', () => {
     logs: [],
     status: '0x1',
   }
+  const transaction2 = {
+    hash: '0x93f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
+    nonce: '0x05',
+    blockHash:
+      '0xec7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
+    blockNumber: `0x${(15).toString('16')}`,
+    transactionIndex: '0x00',
+    from: unlockAccountsOnNode[0],
+    to: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+    value: '0x0',
+    gas: '0x16e360',
+    gasPrice: '0x04a817c800',
+    input:
+      '0xc4d66de8000000000000000000000000aaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+  }
+  const transaction2Receipt = {
+    transactionIndex: '0x4',
+    blockHash:
+      '0xec7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
+    blockNumber: `0x${(15).toString('16')}`,
+    gasUsed: '0x2ea84',
+    cumulativeGasUsed: '0x3a525',
+    contractAddress: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+    logs: [],
+    status: '0x1',
+  }
   beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  async function deployContract(Contract) {
+    const web3 = new Web3(`http://${host}:${port}`)
+    const unlock = new web3.eth.Contract(Contract.abi)
+
+    nock.cleanAll()
     nock.accountsAndYield(unlockAccountsOnNode)
     nock.ethGasPriceAndYield(gasPrice)
+
     // contract deploy call
     nock.ethSendTransactionAndYield(
       {
@@ -57,57 +93,72 @@ describe('contract deployer', () => {
     nock.ethGetCodeAndYield(
       '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
       'latest',
-      Unlock.bytecode
+      Contract.deployedByteCode
     )
-    nock.ethGasPriceAndYield(gasPrice)
+
     // initialize call
+    nock.ethGasPriceAndYield(gasPrice)
     nock.ethSendTransactionAndYield(
       {
         to: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2', // contract address
         from: unlockAccountsOnNode[0],
-        data:
-          '0xc4d66de8000000000000000000000000aaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2', // data (no idea what this is, but there it is)
+        data: unlock.methods.initialize(unlockAccountsOnNode[0]).encodeABI(),
         gas: '0xf4240',
       },
       gasPrice,
-      transaction.hash
+      transaction2.hash
     )
-    nock.ethGetTransactionReceipt(transaction.hash, transactionReceipt)
+    nock.ethGetTransactionReceipt(transaction2.hash, transaction2Receipt)
+  }
+
+  describe('all JSON-RPC calls happen in expected order', () => {
+    it('does not throw exception (json-rpc calls are accurate)', async () => {
+      expect.assertions(0)
+
+      await deployContract(Unlock)
+
+      await deploy(host, port, Unlock)
+      nock.ensureAllNocksUsed()
+    })
   })
 
-  it('does not throw exception (json-rpc calls are accurate)', async () => {
-    // beforeEach fails if this is untrue
-    expect.assertions(0)
+  describe('callback', () => {
+    let deployed
+    beforeEach(async () => {
+      deployed = jest.fn()
+      deployContract(Unlock)
+      await deploy(host, port, Unlock, deployed)
+    })
 
-    await deploy(host, port, Unlock)
+    it('passes the new contract instance to onNewContractInstance', async () => {
+      expect.assertions(1)
+
+      expect(deployed.mock.calls[0][0].options.address).toBe(
+        '0xBbBDeed4C0b861cb36f4Ce006A9c90bA2E43fDc2' // fancified by web3-utils
+      )
+    })
   })
 
-  it('passes the new contract instance to onNewContractInstance', async () => {
-    expect.assertions(1)
-    const deployed = jest.fn()
+  describe('return value', () => {
+    let returnValue
+    beforeEach(async () => {
+      deployContract(Unlock)
+      returnValue = await deploy(host, port, Unlock)
+    })
 
-    await deploy(host, port, Unlock, deployed)
+    it('returns the result of the contract initialization transaction', async () => {
+      expect.assertions(1)
 
-    expect(deployed.mock.calls[0][0].options.address).toBe(
-      '0xBbBDeed4C0b861cb36f4Ce006A9c90bA2E43fDc2' // fancified by web3-utils
-    )
-  })
-
-  it('returns the result of the contract initialization transaction', async () => {
-    expect.assertions(1)
-
-    const returnValue = await deploy(host, port, Unlock)
-
-    expect(returnValue).toEqual({
-      blockHash:
-        '0xdc7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
-      blockNumber: 14,
-      contractAddress: '0xBbBDeed4C0b861cb36f4Ce006A9c90bA2E43fDc2',
-      cumulativeGasUsed: 238885,
-      gasUsed: 191108,
-      logs: [],
-      status: true,
-      transactionIndex: 3,
+      expect(returnValue).toEqual({
+        blockHash: transaction2Receipt.blockHash,
+        blockNumber: parseInt(transaction2Receipt.blockNumber, 16),
+        contractAddress: '0xBbBDeed4C0b861cb36f4Ce006A9c90bA2E43fDc2',
+        cumulativeGasUsed: 238885,
+        gasUsed: 191108,
+        logs: [],
+        status: true,
+        transactionIndex: parseInt(transaction2Receipt.transactionIndex, 16),
+      })
     })
   })
 })

--- a/unlock-js/src/__tests__/deploy.test.js
+++ b/unlock-js/src/__tests__/deploy.test.js
@@ -122,6 +122,33 @@ describe('contract deployer', () => {
     })
   })
 
+  describe('failure is reported properly', () => {
+    it('throws on failure', async () => {
+      expect.assertions(1)
+      nock.accountsAndYield(unlockAccountsOnNode)
+      nock.ethGasPriceAndYield(gasPrice)
+
+      // contract deploy call
+      nock.ethSendTransactionAndYield(
+        {
+          from: unlockAccountsOnNode[0],
+          data: Unlock.bytecode,
+          gas: '0x' + GAS_AMOUNTS.deployContract.toString(16),
+        },
+        gasPrice,
+        transaction.hash,
+        new Error('ran out of gas, you miser')
+      )
+
+      try {
+        await deploy(host, port, Unlock)
+      } catch (e) {
+        // this is intentionally vague, since the actual error content will change with other frameworks
+        expect(e.message).toBeInstanceOf(Error)
+      }
+    })
+  })
+
   describe('callback', () => {
     let deployed
     beforeEach(async () => {

--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -8,7 +8,6 @@ export class NockHelper {
     this.debug = debug
     this._rpcRequestId = 0
     this._noMatches = []
-    this._pendingMocks = []
 
     // In order to monitor traffic without intercepting it (so that mocks can be built). uncomment the line below
     // nock.recorder.rec()
@@ -36,7 +35,6 @@ export class NockHelper {
     nock.restore()
     nock.activate()
     this._noMatches = []
-    this._pendingMocks = []
   }
 
   ensureAllNocksUsed() {

--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -8,6 +8,7 @@ export class NockHelper {
     this.debug = debug
     this._rpcRequestId = 0
     this._noMatches = []
+    this._pendingMocks = []
 
     // In order to monitor traffic without intercepting it (so that mocks can be built). uncomment the line below
     // nock.recorder.rec()
@@ -35,6 +36,7 @@ export class NockHelper {
     nock.restore()
     nock.activate()
     this._noMatches = []
+    this._pendingMocks = []
   }
 
   ensureAllNocksUsed() {

--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -138,26 +138,6 @@ export class NockHelper {
     )
   }
 
-  // eth_getGasPrice
-  ethGetGasPriceAndYield(price) {
-    return this._jsonRpcRequest('eth_gasPrice', [], price)
-  }
-
-  // eth_sendTransaction
-  ethSendTransactionAndYield(transaction, gasPrice, result, error) {
-    return this._jsonRpcRequest(
-      'eth_sendTransaction',
-      [
-        {
-          ...transaction,
-          gasPrice,
-        },
-      ],
-      result,
-      error
-    )
-  }
-
   // eth_gasPrice
   ethGasPriceAndYield(price) {
     return this._jsonRpcRequest('eth_gasPrice', [], price)

--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -111,8 +111,13 @@ export class NockHelper {
   }
 
   // eth_getTransactionReceipt
-  ethGetTransactionReceipt(hash, result) {
-    return this._jsonRpcRequest('eth_getTransactionReceipt', [hash], result)
+  ethGetTransactionReceipt(hash, result, error) {
+    return this._jsonRpcRequest(
+      'eth_getTransactionReceipt',
+      [hash],
+      result,
+      error
+    )
   }
 
   // eth_call

--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -157,6 +157,26 @@ export class NockHelper {
       error
     )
   }
+
+  // eth_gasPrice
+  ethGasPriceAndYield(price) {
+    return this._jsonRpcRequest('eth_gasPrice', [], price)
+  }
+
+  // eth_sendTransaction
+  ethSendTransactionAndYield(transaction, gasPrice, result, error) {
+    return this._jsonRpcRequest(
+      'eth_sendTransaction',
+      [
+        {
+          ...transaction,
+          gasPrice,
+        },
+      ],
+      result,
+      error
+    )
+  }
 }
 
 export default NockHelper

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -169,7 +169,7 @@ describe('WalletService', () => {
       it('should handle cases where the transaction is sent via a provider', async () => {
         expect.assertions(0)
 
-        nock.ethGetGasPriceAndYield('0x123')
+        nock.ethGasPriceAndYield('0x123')
         nock.ethSendTransactionAndYield(
           { to, from, data, value: '0x0', gas },
           '0x123',
@@ -202,7 +202,7 @@ describe('WalletService', () => {
 
       describe('success', () => {
         beforeEach(() => {
-          nock.ethGetGasPriceAndYield('0x123')
+          nock.ethGasPriceAndYield('0x123')
           nock.ethSendTransactionAndYield(
             { to, from, data, value: '0x0', gas },
             '0x123',
@@ -271,7 +271,7 @@ describe('WalletService', () => {
       describe('failure', () => {
         const error = new Error('oops')
         beforeEach(() => {
-          nock.ethGetGasPriceAndYield('0x123')
+          nock.ethGasPriceAndYield('0x123')
           nock.ethSendTransactionAndYield(
             { to, from, data, value: '0x0', gas },
             '0x123',


### PR DESCRIPTION
# Description

This removes usage of `web3` inside the deploy test, and instead relies upon the correct JSON-RPC calls being made to the node, which will allow us to verify deployment after swapping implementations without changing the test.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
