### PR TITLE
Add everything to the contract gas report

### DIFF
--- a/smart-contracts/test/helpers/lockApi.js
+++ b/smart-contracts/test/helpers/lockApi.js
@@ -62,6 +62,40 @@ module.exports = function lockApi(lockContract) {
       })
     },
 
+    async transferFrom(from, recipient, tokenId, transferFee, sender = from) {
+      const call = web3.eth.abi.encodeFunctionCall(
+        lockContract.abi.find(e => e.name === 'transferFrom'),
+        [from, recipient, tokenId]
+      )
+      return web3.eth.sendTransaction({
+        to: lockContract.address,
+        data: call,
+        from: sender,
+        value: transferFee,
+        gas: walletService.gasAmountConstants().withdrawFromLock,
+      })
+    },
+
+    async safeTransferFrom(
+      from,
+      recipient,
+      tokenId,
+      transferFee,
+      sender = from
+    ) {
+      const call = web3.eth.abi.encodeFunctionCall(
+        lockContract.abi.find(e => e.name === 'safeTransferFrom'),
+        [from, recipient, tokenId]
+      )
+      return web3.eth.sendTransaction({
+        to: lockContract.address,
+        data: call,
+        from: sender,
+        value: transferFee,
+        gas: walletService.gasAmountConstants().withdrawFromLock,
+      })
+    },
+
     async withdraw(from) {
       const call = web3.eth.abi.encodeFunctionCall(
         lockContract.abi.find(e => e.name === 'withdraw'),

--- a/smart-contracts/test/reports/gas.js
+++ b/smart-contracts/test/reports/gas.js
@@ -147,9 +147,11 @@ contract('reports / gas', accounts => {
     const grantKey = await getGasFor(lock.grantKey(accounts[8], 9999999999))
 
     const partialWithdrawEth = await getGasFor(lock.partialWithdraw(1))
-    const partialWithdrawErc20 = new BigNumber(0) //TODO await getGasFor(lockErc20.partialWithdraw(1))
+    const partialWithdrawErc20 = await getGasFor(
+      lockApi.partialWithdraw(1, accounts[0])
+    )
     const withdrawEth = await getGasFor(lock.withdraw())
-    const withdrawErc20 = new BigNumber(0) // TODO await getGasFor(lockErc20.withdraw())
+    const withdrawErc20 = await getGasFor(lockApi.withdraw(accounts[0]))
 
     const updateLockName = await getGasFor(lock.updateLockName('Unlock Blog'))
     // Put some more money back in

--- a/smart-contracts/test/reports/gas.js
+++ b/smart-contracts/test/reports/gas.js
@@ -3,56 +3,199 @@ const Web3Utils = require('web3-utils')
 const BigNumber = require('bignumber.js')
 const deployLocks = require('../helpers/deployLocks')
 const getUnlockProxy = require('../helpers/proxy')
+const LockApi = require('../helpers/lockApi')
+
+const TestErc20Token = artifacts.require('TestErc20Token.sol')
 
 const Unlock = artifacts.require('Unlock.sol')
 
-let unlock, lock
+let unlock, locks, lock, lockErc20, token, lockApi
 
 contract('reports / gas', accounts => {
   beforeEach(async () => {
     unlock = await getUnlockProxy(Unlock)
-    const locks = await deployLocks(unlock, accounts[0])
+    locks = await deployLocks(unlock, accounts[0])
     lock = locks['FIRST']
+    token = await TestErc20Token.new()
+    // Mint one token so it appears to be a valid ERC20
+    await token.mint(accounts[0], 1)
+
+    const locksErc20 = await deployLocks(unlock, accounts[0], token.address)
+    lockErc20 = locksErc20['FIRST']
+    for (let i = 0; i < 10; i++) {
+      await token.mint(accounts[i], '1000000000000000000000000000000000', {
+        from: accounts[0],
+      })
+      await token.approve(lockErc20.address, -1, { from: accounts[i] })
+    }
+    lockApi = new LockApi(lockErc20)
 
     // First usage costs more, skip it
     await lock.purchaseFor(accounts[0], {
       value: Units.convert('0.01', 'eth', 'wei'),
     })
+    await lockApi.purchaseFor(accounts[0])
+    await lock.purchaseFor(accounts[9], {
+      value: Units.convert('0.01', 'eth', 'wei'),
+    })
+    await lockApi.purchaseFor(accounts[9])
   })
 
   it('gas usage report', async () => {
-    let tx = await unlock.createLock(
-      60 * 60 * 24 * 30, // expirationDuration: 30 days
-      Web3Utils.padLeft(0, 40),
-      Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
-      100, // maxNumberOfKeys
-      {
-        from: accounts[0],
-      }
+    const approve = await getGasFor(
+      lock.approve(accounts[5], await lock.getTokenIdFor(accounts[0]))
     )
-    const createLock = new BigNumber(tx.receipt.gasUsed)
+    const createLock = await getGasFor(
+      unlock.createLock(
+        60 * 60 * 24 * 30, // expirationDuration: 30 days
+        Web3Utils.padLeft(0, 40),
+        Units.convert(1, 'eth', 'wei'), // keyPrice: in wei
+        100, // maxNumberOfKeys
+        {
+          from: accounts[0],
+        }
+      )
+    )
 
-    tx = await lock.purchaseFor(accounts[2], {
+    const purchaseForEth = await getGasFor(
+      lock.purchaseFor(accounts[2], {
+        value: Units.convert('0.01', 'eth', 'wei'),
+      })
+    )
+    const purchaseForErc20 = await getGasFor(lockApi.purchaseFor(accounts[2]))
+    const purchaseForFromEth = await getGasFor(
+      lock.purchaseForFrom(accounts[7], accounts[2], {
+        value: Units.convert('0.01', 'eth', 'wei'),
+      })
+    )
+    const purchaseForFromErc20 = await getGasFor(
+      lockApi.purchaseForFrom(accounts[7], accounts[2])
+    )
+
+    const setApprovalForAll = await getGasFor(
+      lock.setApprovalForAll(accounts[1], true)
+    )
+
+    // Turn on fees before the transfer tests
+    const updateTransferFee = await getGasFor(lock.updateTransferFee(1, 1))
+    const updateRefundPenalty = await getGasFor(lock.updateRefundPenalty(1, 1))
+    await lockErc20.updateTransferFee(1, 1)
+    await lockErc20.updateRefundPenalty(1, 1)
+
+    const estimatedTransferFee = await lock.getTransferFee.call(accounts[2])
+    const transferFromEth = await getGasFor(
+      lock.transferFrom(
+        accounts[2],
+        accounts[4],
+        await lock.getTokenIdFor.call(accounts[2]),
+        {
+          from: accounts[2],
+          value: estimatedTransferFee,
+        }
+      )
+    )
+    const transferFromErc20 = new BigNumber(0) // TODO
+    // await getGasFor(
+    //   lockErc20.transferFrom(
+    //     accounts[2],
+    //     accounts[4],
+    //     await lockErc20.getTokenIdFor.call(accounts[2]),
+    //     {
+    //       from: accounts[2],
+    //     }
+    //   )
+    // )
+    const safeTransferFromEth = await getGasFor(
+      lock.safeTransferFrom(
+        accounts[4],
+        accounts[2],
+        await lock.getTokenIdFor.call(accounts[4]),
+        {
+          from: accounts[4],
+          value: estimatedTransferFee,
+        }
+      )
+    )
+    const safeTransferFromErc20 = new BigNumber(0) // todo
+    // await getGasFor(
+    //   lockErc20.safeTransferFrom(
+    //     accounts[4],
+    //     accounts[2],
+    //     await lockErc20.getTokenIdFor.call(accounts[2]),
+    //     {
+    //       from: accounts[4],
+    //       value: estimatedTransferFee,
+    //     }
+    //   )
+    // )
+
+    const cancelAndRefundEth = await getGasFor(lock.cancelAndRefund())
+    const cancelAndRefundErc20 = await getGasFor(lockErc20.cancelAndRefund())
+
+    const expireKeyFor = await getGasFor(lock.expireKeyFor(accounts[9]))
+
+    const updateKeyPrice = await getGasFor(lock.updateKeyPrice(12))
+
+    const grantKeys = await getGasFor(
+      lock.grantKeys([accounts[5], accounts[6]], 9999999999)
+    )
+    const grantKey = await getGasFor(lock.grantKey(accounts[7], 9999999999))
+
+    const partialWithdrawEth = await getGasFor(lock.partialWithdraw(1))
+    const partialWithdrawErc20 = new BigNumber(0) //TODO await getGasFor(lockErc20.partialWithdraw(1))
+    const withdrawEth = await getGasFor(lock.withdraw())
+    const withdrawErc20 = new BigNumber(0) // TODO await getGasFor(lockErc20.withdraw())
+
+    const updateLockName = await getGasFor(lock.updateLockName('Unlock Blog'))
+    // Put some more money back in
+    await lock.purchaseFor(accounts[0], {
       value: Units.convert('0.01', 'eth', 'wei'),
     })
-    const purchaseFor = new BigNumber(tx.receipt.gasUsed)
-    const estimatedTransferFee = await lock.getTransferFee.call(accounts[2])
+    await lockApi.purchaseFor(accounts[0])
 
-    tx = await lock.transferFrom(
-      accounts[2],
-      accounts[4],
-      await lock.getTokenIdFor.call(accounts[2]),
-      {
-        from: accounts[2],
-        value: estimatedTransferFee,
-      }
+    const disableLock = await getGasFor(lock.disableLock())
+    await lockErc20.disableLock()
+
+    const destroyLockEth = await getGasFor(lock.destroyLock())
+    const destroyLockErc20 = await getGasFor(lockErc20.destroyLock())
+
+    const transferOwnership = await getGasFor(
+      locks['SECOND'].transferOwnership(accounts[2])
     )
-    const transferFrom = new BigNumber(tx.receipt.gasUsed)
+    const renounceOwnership = await getGasFor(
+      locks['SECOND'].renounceOwnership({ from: accounts[2] })
+    )
 
     // eslint-disable-next-line no-console
-    console.log(`Gas Usage
-  createLock: ${createLock.toFormat()}
-  purchaseFor: ${purchaseFor.toFormat()}
-  transferFrom: ${transferFrom.toFormat()}`)
+    console.log(`Gas Usage (slightly more gas may be required than what you see below)
+  Key owner functions
+    approve: ${approve.toFormat()}
+    cancelAndRefund: ${cancelAndRefundEth.toFormat()} ETH / ${cancelAndRefundErc20.toFormat()} ERC20
+    expireKeyFor: ${expireKeyFor.toFormat()}
+    purchaseFor: ${purchaseForEth.toFormat()} ETH / ${purchaseForErc20.toFormat()} ERC20
+    purchaseForFrom: ${purchaseForFromEth.toFormat()} ETH / ${purchaseForFromErc20.toFormat()} ERC20
+    safeTransferFrom: ${safeTransferFromEth.toFormat()} ETH / ${safeTransferFromErc20.toFormat()} ERC20
+    setApprovalForAll: ${setApprovalForAll.toFormat()}
+    transferFrom: ${transferFromEth.toFormat()} ETH / ${transferFromErc20.toFormat()} ERC20
+    updateKeyPrice: ${updateKeyPrice.toFormat()}
+  Lock owner functions
+    createLock: ${createLock.toFormat()}
+    destroyLock: ${destroyLockEth.toFormat()} ETH / ${destroyLockErc20.toFormat()} ERC20
+    disableLock: ${disableLock.toFormat()}
+    grantKey: ${grantKey.toFormat()}
+    grantKeys: ${grantKeys.toFormat()}
+    partialWithdraw: ${partialWithdrawEth.toFormat()} ETH / ${partialWithdrawErc20.toFormat()} ERC20
+    renounceOwnership: ${renounceOwnership.toFormat()}
+    transferOwnership: ${transferOwnership.toFormat()}
+    updateLockName: ${updateLockName.toFormat()}
+    updateRefundPenalty: ${updateRefundPenalty.toFormat()}
+    updateTransferFee: ${updateTransferFee.toFormat()}
+    withdraw: ${withdrawEth.toFormat()} ETH / ${withdrawErc20.toFormat()} ERC20`)
   })
 })
+
+async function getGasFor(tx) {
+  const result = await tx
+  const receipt = result.receipt || result
+  return new BigNumber(receipt.gasUsed)
+}

--- a/smart-contracts/test/reports/gas.js
+++ b/smart-contracts/test/reports/gas.js
@@ -144,7 +144,7 @@ contract('reports / gas', accounts => {
     const grantKeys = await getGasFor(
       lock.grantKeys([accounts[5], accounts[6]], 9999999999)
     )
-    const grantKey = await getGasFor(lock.grantKey(accounts[7], 9999999999))
+    const grantKey = await getGasFor(lock.grantKey(accounts[8], 9999999999))
 
     const partialWithdrawEth = await getGasFor(lock.partialWithdraw(1))
     const partialWithdrawErc20 = new BigNumber(0) //TODO await getGasFor(lockErc20.partialWithdraw(1))

--- a/smart-contracts/test/reports/gas.js
+++ b/smart-contracts/test/reports/gas.js
@@ -94,17 +94,25 @@ contract('reports / gas', accounts => {
         }
       )
     )
-    const transferFromErc20 = new BigNumber(0) // TODO
-    // await getGasFor(
-    //   lockErc20.transferFrom(
-    //     accounts[2],
-    //     accounts[4],
-    //     await lockErc20.getTokenIdFor.call(accounts[2]),
-    //     {
-    //       from: accounts[2],
-    //     }
-    //   )
-    // )
+    const transferFromErc20 = await getGasFor(
+      lockApi.transferFrom(
+        accounts[2],
+        accounts[4],
+        (await lockErc20.getTokenIdFor.call(accounts[2])).toString(),
+        estimatedTransferFee,
+        accounts[2]
+      )
+    )
+
+    const safeTransferFromErc20 = await getGasFor(
+      lockApi.safeTransferFrom(
+        accounts[4],
+        accounts[2],
+        (await lockErc20.getTokenIdFor.call(accounts[2])).toString(),
+        estimatedTransferFee,
+        accounts[4]
+      )
+    )
     const safeTransferFromEth = await getGasFor(
       lock.safeTransferFrom(
         accounts[4],
@@ -116,26 +124,12 @@ contract('reports / gas', accounts => {
         }
       )
     )
-    const safeTransferFromErc20 = new BigNumber(0) // todo
-    // await getGasFor(
-    //   lockErc20.safeTransferFrom(
-    //     accounts[4],
-    //     accounts[2],
-    //     await lockErc20.getTokenIdFor.call(accounts[2]),
-    //     {
-    //       from: accounts[4],
-    //       value: estimatedTransferFee,
-    //     }
-    //   )
-    // )
-
     const cancelAndRefundEth = await getGasFor(
       lock.cancelAndRefund({ from: accounts[7] })
     )
-    const cancelAndRefundErc20 = new BigNumber(0) // todo
-    // await getGasFor(
-    //   lockErc20.cancelAndRefund({ from: accounts[7] })
-    // )
+    const cancelAndRefundErc20 = await getGasFor(
+      lockApi.cancelAndRefund(accounts[7])
+    )
 
     const expireKeyFor = await getGasFor(lock.expireKeyFor(accounts[9]))
 
@@ -150,10 +144,18 @@ contract('reports / gas', accounts => {
     const partialWithdrawErc20 = await getGasFor(
       lockApi.partialWithdraw(1, accounts[0])
     )
+
+    // Put some more money back in
+    await lock.purchaseFor(accounts[1], {
+      value: Units.convert('0.01', 'eth', 'wei'),
+    })
+    await lockApi.purchaseFor(accounts[1])
+
     const withdrawEth = await getGasFor(lock.withdraw())
     const withdrawErc20 = await getGasFor(lockApi.withdraw(accounts[0]))
 
     const updateLockName = await getGasFor(lock.updateLockName('Unlock Blog'))
+
     // Put some more money back in
     await lock.purchaseFor(accounts[0], {
       value: Units.convert('0.01', 'eth', 'wei'),

--- a/smart-contracts/test/reports/gas.js
+++ b/smart-contracts/test/reports/gas.js
@@ -77,10 +77,10 @@ contract('reports / gas', accounts => {
     )
 
     // Turn on fees before the transfer tests
-    const updateTransferFee = await getGasFor(lock.updateTransferFee(1, 1))
-    const updateRefundPenalty = await getGasFor(lock.updateRefundPenalty(1, 1))
-    await lockErc20.updateTransferFee(1, 1)
-    await lockErc20.updateRefundPenalty(1, 1)
+    const updateTransferFee = await getGasFor(lock.updateTransferFee(1, 10))
+    const updateRefundPenalty = await getGasFor(lock.updateRefundPenalty(1, 10))
+    await lockErc20.updateTransferFee(1, 10)
+    await lockErc20.updateRefundPenalty(1, 10)
 
     const estimatedTransferFee = await lock.getTransferFee.call(accounts[2])
     const transferFromEth = await getGasFor(
@@ -129,8 +129,13 @@ contract('reports / gas', accounts => {
     //   )
     // )
 
-    const cancelAndRefundEth = await getGasFor(lock.cancelAndRefund())
-    const cancelAndRefundErc20 = await getGasFor(lockErc20.cancelAndRefund())
+    const cancelAndRefundEth = await getGasFor(
+      lock.cancelAndRefund({ from: accounts[7] })
+    )
+    const cancelAndRefundErc20 = new BigNumber(0) // todo
+    // await getGasFor(
+    //   lockErc20.cancelAndRefund({ from: accounts[7] })
+    // )
 
     const expireKeyFor = await getGasFor(lock.expireKeyFor(accounts[9]))
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Updates the gas report printed in the CI build to the following:

```
Gas Usage (slightly more gas may be required than what you see below)
  Key owner functions
    approve: 46,762
    cancelAndRefund: 38,501 ETH / 50,662 ERC20
    expireKeyFor: 29,971
    purchaseFor: 137,111 ETH / 164,295 ERC20
    purchaseForFrom: 138,825 ETH / 166,009 ERC20
    safeTransferFrom: 75,092 ETH / 102,285 ERC20
    setApprovalForAll: 45,724
    transferFrom: 107,747 ETH / 134,943 ERC20
    updateKeyPrice: 28,788
  Lock owner functions
    createLock: 3,016,010
    destroyLock: 14,414 ETH / 14,414 ERC20
    disableLock: 14,021
    grantKey: 118,122
    grantKeys: 214,684
    partialWithdraw: 32,303 ETH / 46,546 ERC20
    renounceOwnership: 14,365
    transferOwnership: 30,326
    updateLockName: 43,709
    updateRefundPenalty: 34,521
    updateTransferFee: 49,587
    withdraw: 32,063 ETH / 31,306 ERC20
```

...we should circle back to refactor the lock helper (and then maybe the gas report itself).  It's very confusing having multiple web3 like APIs in the same file.  I ended up burning a number of hours investigating an issue I thought was a contract bug but was actually because of API differences.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
