### PR TITLE
Add getAddressFromPrivateKey helper

### DIFF
--- a/unlock-js/index.js
+++ b/unlock-js/index.js
@@ -1,6 +1,9 @@
 const Web3Service = require('./lib/web3Service')
 const WalletService = require('./lib/walletService')
-const createAccountAndPasswordEncryptKey = require('./lib/accounts').default
+const {
+  createAccountAndPasswordEncryptKey,
+  getAddressFromPrivateKey,
+} = require('./lib/accounts')
 const { getCurrentProvider, getWeb3Provider } = require('./lib/providers')
 const deploy = require('./lib/deploy').default
 
@@ -8,6 +11,7 @@ module.exports = {
   Web3Service: Web3Service.default,
   WalletService: WalletService.default,
   createAccountAndPasswordEncryptKey,
+  getAddressFromPrivateKey,
   getCurrentProvider,
   getWeb3Provider,
   deploy,

--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -1,17 +1,50 @@
-import createAccountAndPasswordEncryptKey from '../accounts'
+import {
+  createAccountAndPasswordEncryptKey,
+  getAddressFromPrivateKey,
+} from '../accounts'
 
-describe('web3 accounts creation', () => {
-  it('should call web3.accounts.create', () => {
-    expect.assertions(2)
+describe('account helpers', () => {
+  describe('web3 accounts creation', () => {
+    it('should call web3.accounts.create', () => {
+      expect.assertions(2)
 
-    const {
-      address,
-      passwordEncryptedPrivateKey,
-    } = createAccountAndPasswordEncryptKey('hello')
+      const {
+        address,
+        passwordEncryptedPrivateKey,
+      } = createAccountAndPasswordEncryptKey('hello')
 
-    expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/)
-    expect(passwordEncryptedPrivateKey.address).toBe(
-      address.substring(2).toLowerCase()
-    )
+      expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/)
+      expect(passwordEncryptedPrivateKey.address).toBe(
+        address.substring(2).toLowerCase()
+      )
+    })
+  })
+
+  describe('web3 account decryption', () => {
+    it('should decrypt an account given the correct password', () => {
+      expect.assertions(1)
+      const {
+        address,
+        passwordEncryptedPrivateKey,
+      } = createAccountAndPasswordEncryptKey('guest')
+
+      const decryptedAddress = getAddressFromPrivateKey(
+        passwordEncryptedPrivateKey,
+        'guest'
+      )
+
+      expect(decryptedAddress).toBe(address)
+    })
+
+    it('should throw when an incorrect password is given for an account', () => {
+      expect.assertions(1)
+      const {
+        passwordEncryptedPrivateKey,
+      } = createAccountAndPasswordEncryptKey('guest')
+
+      expect(() => {
+        getAddressFromPrivateKey(passwordEncryptedPrivateKey, 'ghost')
+      }).toThrow()
+    })
   })
 })

--- a/unlock-js/src/accounts.js
+++ b/unlock-js/src/accounts.js
@@ -1,6 +1,6 @@
 const Web3 = require('web3')
 
-export default function createAccountAndPasswordEncryptKey(password) {
+export function createAccountAndPasswordEncryptKey(password) {
   const web3 = new Web3()
   const { address, privateKey } = web3.eth.accounts.create()
 
@@ -12,4 +12,19 @@ export default function createAccountAndPasswordEncryptKey(password) {
     address,
     passwordEncryptedPrivateKey,
   }
+}
+
+/**
+ * Given an encrypted private key and a password, decrypts the private key and
+ * gets the public address from it.
+ * @param {*} encryptedPrivateKey
+ * @param {string} password
+ * @throws Throws an error if password does not decrypt private key.
+ */
+export function getAddressFromPrivateKey(encryptedPrivateKey, password) {
+  const web3 = new Web3()
+
+  const { address } = web3.eth.accounts.decrypt(encryptedPrivateKey, password)
+
+  return address
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
For dealing with user accounts, it will help us to have a consistent method for decrypting private keys. This method does that and just returns the address as a string.

# Issues
Refs #2721 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
