### PR TITLE
refactor nockHelper to fix issues and make it better for debugging

### DIFF
--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -8,7 +8,6 @@ export class NockHelper {
     this.debug = debug
     this._rpcRequestId = 0
     this._noMatches = []
-    this._pendingMocks = []
 
     // In order to monitor traffic without intercepting it (so that mocks can be built). uncomment the line below
     // nock.recorder.rec()
@@ -36,7 +35,6 @@ export class NockHelper {
     nock.restore()
     nock.activate()
     this._noMatches = []
-    this._pendingMocks = []
   }
 
   ensureAllNocksUsed() {


### PR DESCRIPTION
# Description

While developing, I found 3 issues:

1) the `on('nomatch')` callback needs to be an arrow function to retain `this` (or bound, but arrow is simpler). Without this fix, it never logs anything.
2) the unused mocks helper didn't actually display anything useful. This adds some (potentially fragile) reliance on internals of nock, because (annoyingly) they don't expose anything we can use to introspect which calls fail, and so we just see a list of URLs, which in our case are all `http://127.0.0.1:8545`. This now displays both the request and the return so we can see if the bug is in our code or the nock helper.
3) to fully clear nock state, we need to deactivate (restore) and then re-activate it.

In addition, because we log non-matching data, the no match error is simply there to prevent a test from passing, so we no longer display the array of non-matching URLs (again, all 127.0.0.1:8545)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
