### PR TITLE
Events now populate properly via reducer

### DIFF
--- a/tickets/src/__tests__/components/content/EventContent.test.js
+++ b/tickets/src/__tests__/components/content/EventContent.test.js
@@ -1,35 +1,41 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
 import { Provider } from 'react-redux'
-import { EventContent } from '../../../components/content/EventContent'
+import {
+  EventContent,
+  mapStateToProps,
+} from '../../../components/content/EventContent'
 import { MONTH_NAMES } from '../../../constants'
 import createUnlockStore from '../../../createUnlockStore'
 import configure from '../../../config'
 import { ConfigContext } from '../../../utils/withConfig'
 
 const store = createUnlockStore({})
+const config = configure({})
 const ConfigProvider = ConfigContext.Provider
+
+const event = {
+  date: new Date(2063, 10, 23),
+  name: 'My Doctor Who party',
+  description: `Unbelievably, it's been 100 years since it first came to our screens.
+    
+Join us for an hour or two of fine entertainment.`,
+  location: 'Totters Lane, London',
+  lockAddress: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
+}
+
+const lock = {
+  keyPrice: '0.01',
+  expirationDuration: 172800,
+  maxNumberOfKeys: 240,
+  outstandingKeys: 3,
+  address: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
+  transaction: 'deployedid',
+}
 
 describe('EventContent', () => {
   it('should display an event when given appropriate properties', () => {
     expect.assertions(3)
-    const lock = {
-      keyPrice: '0.01',
-      expirationDuration: 172800,
-      maxNumberOfKeys: 240,
-      outstandingKeys: 3,
-      address: '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e',
-      transaction: 'deployedid',
-    }
-    const event = {
-      date: new Date(2063, 10, 23),
-      name: 'My Doctor Who party',
-      description: `Unbelievably, it's been 100 years since it first came to our screens.
-    
-Join us for an hour or two of fine entertainment.`,
-      location: 'Totters Lane, London',
-    }
-    const config = configure({})
 
     const wrapper = rtl.render(
       <Provider store={store}>
@@ -54,5 +60,50 @@ Join us for an hour or two of fine entertainment.`,
       ', ' +
       event.date.getFullYear()
     expect(wrapper.getByText(dateString)).not.toBeNull()
+  })
+})
+
+describe('mapStateToProps', () => {
+  it('sets a value from initial state', () => {
+    expect.hasAssertions()
+    const props = mapStateToProps({
+      locks: {
+        abc123: { address: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9' },
+      },
+      tickets: { event },
+      keys: {},
+      account: {
+        address: 'foo',
+      },
+      transactions: {},
+      router: {
+        location: {
+          pathname: '/event/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
+        },
+      },
+    })
+
+    const expectedProps = {
+      event: {
+        name: event.name,
+        date: event.date,
+        description: event.description,
+        location: event.location,
+        lockAddress: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
+      },
+      lock: {
+        address: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
+      },
+      lockKey: {
+        data: null,
+        expired: 0,
+        id: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9-foo',
+        lock: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
+        owner: 'foo',
+      },
+      transaction: undefined,
+    }
+
+    expect(props).toEqual(expectedProps)
   })
 })

--- a/tickets/src/__tests__/reducers/ticketsReducer.test.js
+++ b/tickets/src/__tests__/reducers/ticketsReducer.test.js
@@ -1,5 +1,5 @@
 import reducer, { initialState } from '../../reducers/ticketsReducer'
-import { GOT_SIGNED_ADDRESS } from '../../actions/ticket'
+import { GOT_SIGNED_ADDRESS, UPDATE_EVENT } from '../../actions/ticket'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
 import { SET_ACCOUNT } from '../../actions/accounts'
@@ -34,5 +34,18 @@ describe('tickets reducer', () => {
         }
       )
     ).toEqual({ [address]: signedAddress })
+  })
+
+  it('should add an event to the state', () => {
+    expect.assertions(1)
+    expect(
+      reducer(
+        {},
+        {
+          type: UPDATE_EVENT,
+          event,
+        }
+      )
+    ).toEqual({ event })
   })
 })

--- a/tickets/src/__tests__/reducers/ticketsReducer.test.js
+++ b/tickets/src/__tests__/reducers/ticketsReducer.test.js
@@ -38,6 +38,9 @@ describe('tickets reducer', () => {
 
   it('should add an event to the state', () => {
     expect.assertions(1)
+    const event = {
+      name: 'I am a dummy event',
+    }
     expect(
       reducer(
         {},

--- a/tickets/src/components/content/EventContent.js
+++ b/tickets/src/components/content/EventContent.js
@@ -20,23 +20,28 @@ export class EventContent extends Component {
   constructor(props) {
     super(props)
 
-    let { event } = this.props
-    if (!event) event = {}
-
     this.state = {
-      event: event,
+      loaded: false,
     }
+
+    this.setAsLoaded.bind(this)
   }
 
   componentDidUpdate() {
-    const { lock, loadEvent } = this.props
-    const { event } = this.state
-    if (lock.address && !event.lockAddress) loadEvent(lock.address)
+    const { lock, loadEvent, event } = this.props
+    const { loaded } = this.state
+    if (lock.address && !event.lockAddress && !loaded) {
+      loadEvent(lock.address)
+      this.setAsLoaded() // To prevent multiple loads
+    }
+  }
+
+  setAsLoaded() {
+    this.setState({ loaded: true })
   }
 
   render() {
-    const { lock, lockKey, purchaseKey, transaction } = this.props
-    const { event } = this.state
+    const { lock, lockKey, purchaseKey, transaction, event } = this.props
 
     if (!lock.address || !event.name) return null // Wait for the lock and event to load
 
@@ -124,6 +129,7 @@ export const mapStateToProps = ({
   keys,
   account,
   transactions,
+  tickets: { event },
 }) => {
   if (!account) {
     return {}
@@ -151,6 +157,18 @@ export const mapStateToProps = ({
     }
   }
 
+  let processedEvent
+  if (event) {
+    const { name, date, lockAddress, description, location } = event
+    processedEvent = {
+      name,
+      date: new Date(date),
+      lockAddress,
+      description,
+      location,
+    }
+  }
+
   let transaction = null
   transaction = Object.values(transactions).find(
     transaction =>
@@ -162,6 +180,7 @@ export const mapStateToProps = ({
     lock,
     lockKey,
     transaction,
+    event: processedEvent,
   }
 }
 

--- a/tickets/src/middlewares/ticketMiddleware.js
+++ b/tickets/src/middlewares/ticketMiddleware.js
@@ -1,11 +1,16 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import TicketService from '../services/ticketService'
-import { ADD_EVENT, LOAD_EVENT, ticketError } from '../actions/ticket'
+import {
+  ADD_EVENT,
+  LOAD_EVENT,
+  updateEvent,
+  ticketError,
+} from '../actions/ticket'
 
 const ticketMiddleware = config => {
   const { services } = config
-  return ({ setState, dispatch }) => {
+  return ({ dispatch }) => {
     const ticketService = new TicketService(services.storage.host)
 
     return next => {
@@ -25,7 +30,7 @@ const ticketMiddleware = config => {
               description,
               location,
             }
-            setState({ event })
+            dispatch(updateEvent(event))
           })
         }
         next(action)

--- a/tickets/src/reducers/ticketsReducer.js
+++ b/tickets/src/reducers/ticketsReducer.js
@@ -1,7 +1,7 @@
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 import { SET_ACCOUNT } from '../actions/accounts'
-import { GOT_SIGNED_ADDRESS } from '../actions/ticket'
+import { GOT_SIGNED_ADDRESS, UPDATE_EVENT } from '../actions/ticket'
 
 export const initialState = {}
 
@@ -14,6 +14,14 @@ const ticketsReducer = (state = initialState, action) => {
     const { address, signedAddress } = action
     return {
       [address]: signedAddress,
+      ...state,
+    }
+  }
+
+  if (action.type === UPDATE_EVENT) {
+    const { event } = action
+    return {
+      event,
       ...state,
     }
   }


### PR DESCRIPTION
# Description

Oops! My PR surgery earlier broke the events and an update event wasn't being properly called to send a loaded event object down the wire. Now it is.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
