### PR TITLE
Updating datepicker to display UTC time

### DIFF
--- a/tickets/src/components/interface/DatePicker.js
+++ b/tickets/src/components/interface/DatePicker.js
@@ -78,8 +78,8 @@ export default class DatePicker extends Component {
       value: date.getMonth(),
       label: MONTH_NAMES[date.getMonth()],
     }
-    const day = { value: date.getDate(), label: date.getDate() }
-    const year = { value: date.getFullYear(), label: date.getFullYear() }
+    const day = { value: date.getUTCDate(), label: date.getUTCDate() }
+    const year = { value: date.getUTCFullYear(), label: date.getUTCFullYear() }
 
     return (
       <EventDate>


### PR DESCRIPTION
# Description

The setters are using UTC, so the display should too. Fixes an issue where the displayed date didn't quite correspond with the selected date.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
