### PR TITLE
Keep track of whether event creation form is submitted

### DIFF
--- a/tickets/src/components/content/CreateContent.js
+++ b/tickets/src/components/content/CreateContent.js
@@ -36,6 +36,7 @@ export class CreateContent extends Component {
       description: '',
       location: '',
       date: now,
+      submitted: false,
     }
 
     this.onChange = this.onChange.bind(this)
@@ -46,6 +47,7 @@ export class CreateContent extends Component {
   onSubmit(e) {
     e.preventDefault()
     this.saveEvent()
+    this.setState(state => ({ ...state, submitted: true }))
     return
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR adds one piece of state to the Event creation form in the tickets app. Right now there is no visual impact, but we can use this state to change the page once the form is submitted. This should help us make a nice UX improvement once we have an idea what we'd like to do to indicate that the form was submitted.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
