### PR TITLE
Add href to link on event creation page

### DIFF
--- a/tickets/src/__tests__/components/content/CreateContent.test.js
+++ b/tickets/src/__tests__/components/content/CreateContent.test.js
@@ -118,6 +118,28 @@ describe('CreateContent', () => {
       date,
     })
   })
+
+  it('should have an href on the call to action', () => {
+    expect.assertions(1)
+    const store = createUnlockStore({
+      account: { address: 'ben' },
+      locks: inputLocks,
+    })
+    const addEvent = jest.fn()
+
+    const { container } = rtl.render(
+      <Provider store={store}>
+        <CreateContent
+          account={{ address: 'ben' }}
+          locks={['abc123', 'def456']}
+          addEvent={addEvent}
+        />
+      </Provider>
+    )
+
+    const theLink = container.querySelector('a')
+    expect(theLink).toHaveAttribute('href')
+  })
 })
 
 describe('mapStateToProps', () => {

--- a/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2260,6 +2260,7 @@ Object {
                     <br />
                     <a
                       class="c11"
+                      href="abc123"
                     >
                       <span>
                         https://tickets.unlock-protocol.com/event/
@@ -2711,6 +2712,7 @@ Object {
                   <br />
                   <a
                     class="sc-1xgodx9-8 lnYSDG"
+                    href="abc123"
                   >
                     <span>
                       https://tickets.unlock-protocol.com/event/

--- a/tickets/src/components/content/CreateContent.js
+++ b/tickets/src/components/content/CreateContent.js
@@ -163,7 +163,7 @@ export class CreateContent extends Component {
                     <SaveButton type="submit">Save Event</SaveButton>
                     <Text>
                       Your event link: <br />
-                      <Cta>
+                      <Cta href={lockAddress}>
                         <EventUrl address={lockAddress} />
                       </Cta>
                     </Text>


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
The link on the event creation page wasn't clickable because it didn't have an href property. This PR adds that and a regression test.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
