### PR TITLE
Removing UTC forcing from datepicker in events page

### DIFF
--- a/tickets/src/__tests__/components/content/CreateContent.test.js
+++ b/tickets/src/__tests__/components/content/CreateContent.test.js
@@ -79,12 +79,15 @@ describe('CreateContent', () => {
     })
     const addEvent = jest.fn()
 
+    const now = new Date('2019-03-02T00:00:00.000') // March 2nd, 2019
+
     const form = rtl.render(
       <Provider store={store}>
         <CreateContent
           account={{ address: 'ben' }}
           locks={['abc123', 'def456']}
           addEvent={addEvent}
+          now={now}
         />
       </Provider>
     )
@@ -106,8 +109,7 @@ describe('CreateContent', () => {
     expect(submit).not.toBeNull()
     rtl.fireEvent.click(submit)
 
-    let date = new Date(2020, 10, 23)
-    date.setUTCHours(0, 0, 0, 0)
+    let date = new Date('2020-11-23T00:00:00.000')
     expect(addEvent).toHaveBeenCalledWith({
       lockAddress: 'abc123',
       name: '',

--- a/tickets/src/__tests__/components/interface/DatePicker.test.js
+++ b/tickets/src/__tests__/components/interface/DatePicker.test.js
@@ -69,12 +69,12 @@ describe('DatePicker', () => {
   it('should let the user pick a day and trigger onChange', () => {
     expect.assertions(1)
     const onChange = jest.fn()
-    const now = new Date('2019-03-02T00:00:00.000Z') // March 2nd, 2019
+    const now = new Date('2019-03-02T00:00:00.000') // March 2nd, 2019
     let wrapper = rtl.render(<DatePicker now={now} onChange={onChange} />)
     rtl.fireEvent.change(wrapper.getByTestId('Pick a day'), {
       target: { value: '3' }, // Changed to the 3rd
     })
-    expect(onChange).toHaveBeenCalledWith(new Date('2019-03-03T00:00:00.000Z'))
+    expect(onChange).toHaveBeenCalledWith(new Date('2019-03-03T00:00:00.000'))
   })
 
   describe('getDaysMonthsAndYearsForSelect', () => {

--- a/tickets/src/components/content/CreateContent.js
+++ b/tickets/src/components/content/CreateContent.js
@@ -63,7 +63,6 @@ export class CreateContent extends Component {
   }
 
   dateChanged(date) {
-    date.setUTCHours(0, 0, 0, 0) // We don't need to store hours
     this.setState(state => {
       return {
         ...state,

--- a/tickets/src/components/interface/DatePicker.js
+++ b/tickets/src/components/interface/DatePicker.js
@@ -38,36 +38,32 @@ export default class DatePicker extends Component {
   onChange(method) {
     const { now } = this.props
     return selected => {
-      this.setState(
-        state => {
-          let date = state.date
-          // Change the date based on the selected value
-          date[method](selected.value)
+      this.setState(state => {
+        let date = state.date
+        // Change the date based on the selected value
+        date[method](selected.value)
 
-          // If the day is in the past, we default to today's date
-          if (date < now) {
-            date = new Date(now)
-          }
-
-          const newState = {
-            ...state,
-            date,
-          }
-
-          // Get the new possible days, months and years
-          const dateState = getDaysMonthsAndYearsForSelect(
-            now,
-            newState.date.getFullYear(),
-            newState.date.getMonth() + 1
-          )
-          return Object.assign(newState, dateState)
-        },
-        () => {
-          const { date } = this.state
-          const { onChange } = this.props
-          onChange(date)
+        // If the day is in the past, we default to today's date
+        if (date < now) {
+          date = new Date(now)
         }
-      )
+
+        const newState = {
+          ...state,
+          date,
+        }
+
+        const { onChange } = this.props
+        onChange(date)
+
+        // Get the new possible days, months and years
+        const dateState = getDaysMonthsAndYearsForSelect(
+          now,
+          newState.date.getFullYear(),
+          newState.date.getMonth() + 1
+        )
+        return Object.assign(newState, dateState)
+      })
     }
   }
 
@@ -88,7 +84,7 @@ export default class DatePicker extends Component {
           className="select-container"
           classNamePrefix="select-option"
           options={months}
-          onChange={this.onChange('setUTCMonth')}
+          onChange={this.onChange('setMonth')}
           value={month}
         />
         <StyledSelect
@@ -96,7 +92,7 @@ export default class DatePicker extends Component {
           className="select-container"
           classNamePrefix="select-option"
           options={days}
-          onChange={this.onChange('setUTCDate')}
+          onChange={this.onChange('setDate')}
           value={day}
         />
         <StyledSelect
@@ -104,7 +100,7 @@ export default class DatePicker extends Component {
           className="select-container"
           classNamePrefix="select-option"
           options={years}
-          onChange={this.onChange('setUTCFullYear')}
+          onChange={this.onChange('setFullYear')}
           value={year}
         />
       </EventDate>


### PR DESCRIPTION
# Description

The datepicker now picks the correct day, relative to the user's timezone. In addition, tests for day picking will reliably pass.

This supersedes #2820.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
