### PR TITLE
Not asserting state of lock

### DIFF
--- a/tests/helpers/wait.js
+++ b/tests/helpers/wait.js
@@ -16,6 +16,23 @@ const untilIsFalse = async (statement, ...variables) =>
   })
 
 /**
+ * Helper function which waits for something to be false
+ */
+const untilIsTrue = async (statement, ...variables) =>
+  new Promise(resolve => {
+    const waitIfTrue = async () => {
+      const isTrue = await page.evaluate(statement, variables)
+      if (isTrue) {
+        return resolve()
+      }
+      return setTimeout(async () => {
+        return waitIfTrue()
+      }, 10)
+    }
+    waitIfTrue()
+  })
+
+/**
  * Helper function to ensure that a DOM element is gone.
  */
 const untilIsGone = async selector =>
@@ -36,6 +53,7 @@ const forIframe = async () => {
 
 module.exports = {
   untilIsFalse,
+  untilIsTrue,
   untilIsGone,
   forLoadingDone,
   forIframe,

--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -46,7 +46,7 @@ describe('The Unlock Dashboard', () => {
 
     // This test requires the test above to have been executed and pass
     it('should persist the lock', async () => {
-      expect.assertions(11)
+      expect.assertions(10)
       const name = `My lock ${Math.random()
         .toString(36)
         .substring(7)}`
@@ -76,6 +76,13 @@ describe('The Unlock Dashboard', () => {
       newLock = locks.find(lock => {
         return !existingLocks.includes(lock)
       })
+
+      await wait.untilIsTrue(address => {
+        return !!document
+          .querySelector(`[data-address="${address}"]`)
+          .innerText.match(/Confirming|Submitted/)
+      }, newLock)
+
       // Get the locks' innerText
       const lockText = await page.evaluate(address => {
         return document.querySelector(`[data-address="${address}"]`).innerText
@@ -84,7 +91,9 @@ describe('The Unlock Dashboard', () => {
       await expect(lockText).toMatch(`${expirationDuration} day`) // we use day as this could be singular!
       await expect(lockText).toMatch(`0/${maxNumberOfKeys}`)
       await expect(lockText).toMatch(keyPrice)
-      await expect(lockText).toMatch(/Confirming|Submitted/) // The lock is either submitted or confirming (depending on when the mining happens in the tests)
+      await page.waitForFunction(
+        () => !document.querySelector('#_unlock_blocker')
+      )
     })
 
     // This test requires the test above


### PR DESCRIPTION
This fixes the failing integration tests.
Note that the logic of looking at the state is actually still there in the next test


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread