### PR TITLE
Event page adjusts to key and transaction status

### DIFF
--- a/tickets/src/__tests__/components/content/EventContent.test.js
+++ b/tickets/src/__tests__/components/content/EventContent.test.js
@@ -5,10 +5,12 @@ import {
   EventContent,
   mapStateToProps,
 } from '../../../components/content/EventContent'
-import { MONTH_NAMES } from '../../../constants'
+import { MONTH_NAMES, TRANSACTION_TYPES } from '../../../constants'
 import createUnlockStore from '../../../createUnlockStore'
 import configure from '../../../config'
 import { ConfigContext } from '../../../utils/withConfig'
+import { KeyStatus } from '../../../selectors/keys'
+import { transactionTypeMapping } from '../../../utils/types'
 
 const store = createUnlockStore({})
 const config = configure({})
@@ -66,22 +68,48 @@ describe('EventContent', () => {
 describe('mapStateToProps', () => {
   it('sets a value from initial state', () => {
     expect.hasAssertions()
-    const props = mapStateToProps({
-      locks: {
-        abc123: { address: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9' },
-      },
-      tickets: { event },
-      keys: {},
-      account: {
-        address: 'foo',
-      },
-      transactions: {},
-      router: {
-        location: {
-          pathname: '/event/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
+    const keyDate = new Date('2038-01-17')
+    const props = mapStateToProps(
+      {
+        locks: {
+          abc123: { address: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9' },
+        },
+        tickets: { event },
+        keys: {
+          '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9-foo': {
+            lock: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
+            id: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9-foo',
+            owner: 'foo',
+            expiration: keyDate,
+            transactions: {
+              def234: {
+                type: transactionTypeMapping(TRANSACTION_TYPES.KEY_PURCHASE),
+                key: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9-foo',
+                confirmations: 3,
+                status: 'mined',
+              },
+            },
+          },
+        },
+        account: {
+          address: 'foo',
+        },
+        transactions: {
+          def234: {
+            type: transactionTypeMapping(TRANSACTION_TYPES.KEY_PURCHASE),
+            key: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9-foo',
+            confirmations: 3,
+            status: 'mined',
+          },
+        },
+        router: {
+          location: {
+            pathname: '/event/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
+          },
         },
       },
-    })
+      { config }
+    )
 
     const expectedProps = {
       event: {
@@ -95,13 +123,26 @@ describe('mapStateToProps', () => {
         address: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
       },
       lockKey: {
-        data: null,
-        expired: 0,
+        expiration: keyDate,
         id: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9-foo',
         lock: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
         owner: 'foo',
+        transactions: {
+          def234: {
+            type: transactionTypeMapping(TRANSACTION_TYPES.KEY_PURCHASE),
+            key: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9-foo',
+            confirmations: 3,
+            status: 'mined',
+          },
+        },
       },
-      transaction: undefined,
+      transaction: {
+        type: transactionTypeMapping(TRANSACTION_TYPES.KEY_PURCHASE),
+        key: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9-foo',
+        confirmations: 3,
+        status: 'mined',
+      },
+      keyStatus: KeyStatus.CONFIRMING,
     }
 
     expect(props).toEqual(expectedProps)

--- a/tickets/src/__tests__/components/content/PayButton.test.js
+++ b/tickets/src/__tests__/components/content/PayButton.test.js
@@ -3,6 +3,7 @@ import * as rtl from 'react-testing-library'
 
 import configure from '../../../config'
 import { PayButton } from '../../../components/content/purchase/PayButton'
+import { KeyStatus } from '../../../selectors/keys'
 
 const config = configure({})
 
@@ -42,7 +43,7 @@ describe('PayButton', () => {
     rtl.fireEvent.click(button)
     expect(purchaseKey).not.toHaveBeenCalled()
   })
-  it('should not trigger purchasekey when the button is clicked and the key is confirming', () => {
+  it('should not trigger purchasekey when the button is clicked and the key transaction is confirming', () => {
     expect.assertions(2)
     const purchaseKey = jest.fn()
     const transaction = {
@@ -61,7 +62,22 @@ describe('PayButton', () => {
     rtl.fireEvent.click(button)
     expect(purchaseKey).not.toHaveBeenCalled()
   })
-  it('should not trigger purchasekey when the button is clicked and the key is confirmed', () => {
+  it('should not trigger purchasekey when the button is clicked and the key is confirming', () => {
+    expect.assertions(2)
+    const purchaseKey = jest.fn()
+    const wrapper = rtl.render(
+      <PayButton
+        config={config}
+        keyStatus={KeyStatus.CONFIRMING}
+        purchaseKey={purchaseKey}
+      />
+    )
+    let button = wrapper.queryByText('Confirming Payment', { exact: false })
+    expect(button).not.toBeNull()
+    rtl.fireEvent.click(button)
+    expect(purchaseKey).not.toHaveBeenCalled()
+  })
+  it('should not trigger purchasekey when the button is clicked and the key transaction is confirmed', () => {
     expect.assertions(2)
     const purchaseKey = jest.fn()
     const transaction = {
@@ -72,6 +88,21 @@ describe('PayButton', () => {
       <PayButton
         config={config}
         transaction={transaction}
+        purchaseKey={purchaseKey}
+      />
+    )
+    let button = wrapper.getByText('Confirmed')
+    expect(button).not.toBeNull()
+    rtl.fireEvent.click(button)
+    expect(purchaseKey).not.toHaveBeenCalled()
+  })
+  it('should not trigger purchasekey when the button is clicked and the key is confirmed', () => {
+    expect.assertions(2)
+    const purchaseKey = jest.fn()
+    const wrapper = rtl.render(
+      <PayButton
+        config={config}
+        keyStatus={KeyStatus.VALID}
         purchaseKey={purchaseKey}
       />
     )

--- a/tickets/src/__tests__/selectors/keys.test.ts
+++ b/tickets/src/__tests__/selectors/keys.test.ts
@@ -1,0 +1,160 @@
+import keyStatus from '../../selectors/keys'
+import {
+  Transaction,
+  TransactionStatus,
+  TransactionType,
+} from '../../unlockTypes'
+
+describe('keys selectors', () => {
+  describe('keyStatus', () => {
+    let transactions: { [key: string]: Transaction }
+
+    beforeEach(() => {
+      transactions = {
+        one: {
+          hash: 'one',
+          status: TransactionStatus.MINED,
+          type: TransactionType.KEY_PURCHASE,
+          confirmations: 2,
+          blockNumber: 1,
+        },
+      }
+    })
+
+    it('returns "none" if the key does not exist', () => {
+      expect.assertions(1)
+
+      expect(keyStatus('', {}, 12)).toBe('none')
+    })
+
+    it('returns "none" if the key does not exist in keys', () => {
+      expect.assertions(1)
+
+      expect(keyStatus('hi', {}, 12)).toBe('none')
+    })
+
+    it('returns "valid" if the transaction status is falsy and the key is not expired', () => {
+      expect.assertions(1)
+
+      transactions.one.status = TransactionStatus.NONE
+      expect(
+        keyStatus(
+          'hi',
+          {
+            hi: {
+              expiration: new Date().getTime() / 1000 + 10000,
+            },
+          },
+          12
+        )
+      ).toBe('valid')
+    })
+
+    it('returns "none" if there are no transactions and the key is expired', () => {
+      expect.assertions(1)
+
+      transactions.one.status = TransactionStatus.NONE
+      expect(
+        keyStatus(
+          'hi',
+          {
+            hi: {
+              expiration: 0,
+            },
+          },
+          12
+        )
+      ).toBe('none')
+    })
+
+    it('returns transactoin status if the transaction status is not "mined"', () => {
+      expect.assertions(2)
+
+      transactions.one.status = TransactionStatus.PENDING
+      expect(
+        keyStatus(
+          'hi',
+          {
+            hi: {
+              expiration: new Date().getTime() / 1000 + 10000,
+              transactions,
+            },
+          },
+          12
+        )
+      ).toBe('pending')
+
+      transactions.one.status = TransactionStatus.SUBMITTED
+      expect(
+        keyStatus(
+          'hi',
+          {
+            hi: {
+              expiration: new Date().getTime() / 1000 + 10000,
+              transactions,
+            },
+          },
+          12
+        )
+      ).toBe('submitted')
+    })
+
+    describe('mined transactions', () => {
+      it('returns "confirming" if the transaction has fewer than the required confirmations', () => {
+        expect.assertions(1)
+
+        transactions.one.status = TransactionStatus.MINED
+        expect(
+          keyStatus(
+            'hi',
+            {
+              hi: {
+                expiration: new Date().getTime() / 1000 + 10000,
+                transactions,
+              },
+            },
+            12
+          )
+        ).toBe('confirming')
+      })
+
+      it('returns "valid" if the transaction has more than the required confirmations', () => {
+        expect.assertions(1)
+
+        transactions.one.status = TransactionStatus.MINED
+        transactions.one.confirmations = 12345
+        expect(
+          keyStatus(
+            'hi',
+            {
+              hi: {
+                expiration: new Date().getTime() / 1000 + 10000,
+                transactions,
+              },
+            },
+            12
+          )
+        ).toBe('valid')
+      })
+
+      it('returns "expired" if the transaction is confirmed and key is old', () => {
+        expect.assertions(1)
+
+        transactions.one.status = TransactionStatus.MINED
+        transactions.one.confirmations = 12345
+        expect(
+          keyStatus(
+            'hi',
+            {
+              hi: {
+                expiration: new Date().getTime() / 1000 - 10000,
+                transactions,
+              },
+            },
+            12
+          )
+        ).toBe('expired')
+      })
+    })
+  })
+})

--- a/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5626,7 +5626,1183 @@ Join us for an hour or two of fine entertainment.
 }
 `;
 
+exports[`Storyshots Event RSVP page Event RSVP page with confirmed key transaction 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c21 {
+  background-color: var(--brand);
+  height: 28px;
+  width: 28px;
+  border-radius: 50%;
+}
+
+.c21 > svg {
+  fill: white;
+}
+
+.c0 {
+  display: grid;
+  height: 100%;
+  grid-template-columns: 1fr minmax(280px,4fr) 1fr;
+}
+
+.c1 {
+  display: grid;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  height: 24px;
+}
+
+.c20 {
+  position: relative;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  padding: 20px;
+  font-weight: bold;
+  font-size: 20px;
+  color: var(--brand);
+}
+
+.c4 {
+  cursor: pointer;
+  color: var(--brand);
+}
+
+.c2 {
+  color: var(--darkgrey);
+  display: grid;
+  row-gap: 24px;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 25px auto;
+  -webkit-align-items: top;
+  -webkit-box-align: top;
+  -ms-flex-align: top;
+  align-items: top;
+}
+
+.c11 {
+  font-size: 13px;
+  color: var(--darkgrey);
+}
+
+.c7 {
+  background-color: var(--green);
+  border: none;
+  font-size: 16px;
+  color: var(--white);
+  font-family: 'IBM Plex Sans',sans-serif;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+  outline: none;
+  -webkit-transition: background-color 200ms ease;
+  transition: background-color 200ms ease;
+  height: 60px;
+  text-align: center;
+  padding-top: 20px;
+  border: 2px solid var(--green);
+  color: var(--green);
+  border-radius: 4px;
+  background-color: var(--white);
+}
+
+.c7:hover {
+  background-color: var(--activegreen);
+}
+
+.c7:hover {
+  background-color: var(--white);
+}
+
+.c5 {
+  font-family: 'IBM Plex Serif',serif;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 30px;
+  line-height: normal;
+  color: var(--dimgrey);
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.c12 {
+  display: grid;
+  grid-template-columns: repeat(2,1fr);
+  grid-gap: 10px;
+}
+
+.c13 {
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-weight: bold;
+  font-size: 30px;
+  line-height: 39px;
+  color: var(--dimgrey);
+}
+
+.c14 {
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 20px;
+  line-height: 27px;
+  text-align: right;
+  color: var(--grey);
+}
+
+.c15 {
+  padding: 0;
+  border: none;
+  margin-bottom: 30px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.c6 {
+  padding: 0;
+  border: none;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.c16 {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 25px auto;
+  -webkit-align-items: top;
+  -webkit-box-align: top;
+  -ms-flex-align: top;
+  align-items: top;
+  grid-template-rows: 35px auto;
+}
+
+.c16 > .c10 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c17 {
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 24px;
+  line-height: 32px;
+  color: var(--red);
+}
+
+.c18 {
+  font-size: 20px;
+  font-family: 'IBM Plex Serif',serif;
+}
+
+.c19 {
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 20px;
+  margin-top: 30px;
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c9 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c21 {
+    height: 16px;
+    width: 16px;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c1 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c22 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c20 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c3 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c8 {
+    margin-bottom: 15px;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c15 {
+    display: grid;
+    grid-gap: 30px;
+    grid-template-columns: repeat(2,1fr);
+    -webkit-align-items: top;
+    -webkit-box-align: top;
+    -ms-flex-align: top;
+    align-items: top;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c6 {
+    display: grid;
+    grid-gap: 30px;
+    grid-template-columns: repeat(2,1fr);
+    -webkit-align-items: top;
+    -webkit-box-align: top;
+    -ms-flex-align: top;
+    align-items: top;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c16 {
+    margin-bottom: 15px;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <div
+          class="c1"
+        />
+        <div
+          class="c2"
+        >
+          <div
+            class="c3"
+          >
+            <span
+              class="c4"
+              href="/"
+            >
+              Unlock Tickets
+            </span>
+          </div>
+          <h1
+            class="c5"
+          >
+            My Doctor Who party
+          </h1>
+          <div
+            class="c6"
+          >
+            <div
+              class="c7"
+            >
+              Confirmed
+            </div>
+            <div
+              class="c8"
+            >
+              <div
+                class="c9"
+              >
+                <label
+                  class="c10 c11"
+                >
+                  Ticket Price
+                </label>
+              </div>
+              <div
+                class="c12"
+              >
+                <div
+                  class="c13"
+                >
+                  0.01
+                   ETH
+                </div>
+                <div
+                  class="c14"
+                >
+                  $
+                  ---
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="c15"
+          >
+            <div
+              class="c16"
+            >
+              <div
+                class="c17"
+              >
+                Nov 23, 2063
+              </div>
+              <div
+                class="c18"
+              >
+                Unbelievably, it's been 100 years since it first came to our screens.
+    
+Join us for an hour or two of fine entertainment.
+              </div>
+              <div
+                class="c19"
+              >
+                Totters Lane, London
+              </div>
+            </div>
+            <div
+              class="c16"
+            >
+              <div />
+            </div>
+          </div>
+          <div
+            class="c20"
+          >
+            <div
+              class="c21"
+            >
+              <svg
+                viewBox="0 0 56 56"
+              >
+                <title />
+                <path
+                  d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                />
+              </svg>
+            </div>
+            <p>
+              Powered by Unlock
+            </p>
+          </div>
+        </div>
+        <div
+          class="c22"
+        />
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="b9ke0k-0 kUnmag"
+    >
+      <div
+        class="b9ke0k-1 jDykuE"
+      />
+      <div
+        class="b9ke0k-6 kLtGVO"
+      >
+        <div
+          class="b9ke0k-4 kmengs"
+        >
+          <span
+            class="b9ke0k-5 bDmGKS"
+            href="/"
+          >
+            Unlock Tickets
+          </span>
+        </div>
+        <h1
+          class="sc-1fq9sck-0 esJxvf"
+        >
+          My Doctor Who party
+        </h1>
+        <div
+          class="sc-1xgodx9-4 sc-1fq9sck-5 eyUQpb"
+        >
+          <div
+            class="sc-1uk9h2s-0 sc-1uk9h2s-1 jXrtxI"
+          >
+            Confirmed
+          </div>
+          <div
+            class="sc-1xgodx9-5 hKuMTX"
+          >
+            <div
+              class="sc-8fuwpj-0 btHddm"
+            >
+              <label
+                class="sc-1xgodx9-6 loqXYl"
+              >
+                Ticket Price
+              </label>
+            </div>
+            <div
+              class="sc-1fq9sck-1 vveei"
+            >
+              <div
+                class="sc-1fq9sck-2 fFmRNK"
+              >
+                0.01
+                 ETH
+              </div>
+              <div
+                class="sc-1fq9sck-3 dwRewx"
+              >
+                $
+                ---
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="sc-1xgodx9-4 sc-1fq9sck-4 eqlEGi"
+        >
+          <div
+            class="sc-1xgodx9-5 sc-1fq9sck-6 dDmCuX"
+          >
+            <div
+              class="sc-1fq9sck-7 hswCiG"
+            >
+              Nov 23, 2063
+            </div>
+            <div
+              class="sc-1fq9sck-8 clEMWd"
+            >
+              Unbelievably, it's been 100 years since it first came to our screens.
+    
+Join us for an hour or two of fine entertainment.
+            </div>
+            <div
+              class="sc-1fq9sck-9 iJXTq"
+            >
+              Totters Lane, London
+            </div>
+          </div>
+          <div
+            class="sc-1xgodx9-5 sc-1fq9sck-6 dDmCuX"
+          >
+            <div />
+          </div>
+        </div>
+        <div
+          class="b9ke0k-3 dhAsVa"
+        >
+          <div
+            class="oj0wpp-0 lguXZd"
+          >
+            <svg
+              viewBox="0 0 56 56"
+            >
+              <title />
+              <path
+                d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+              />
+            </svg>
+          </div>
+          <p>
+            Powered by Unlock
+          </p>
+        </div>
+      </div>
+      <div
+        class="b9ke0k-2 khwivT"
+      />
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots Event RSVP page Event RSVP page with confirming key 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c21 {
+  background-color: var(--brand);
+  height: 28px;
+  width: 28px;
+  border-radius: 50%;
+}
+
+.c21 > svg {
+  fill: white;
+}
+
+.c0 {
+  display: grid;
+  height: 100%;
+  grid-template-columns: 1fr minmax(280px,4fr) 1fr;
+}
+
+.c1 {
+  display: grid;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  height: 24px;
+}
+
+.c20 {
+  position: relative;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  padding: 20px;
+  font-weight: bold;
+  font-size: 20px;
+  color: var(--brand);
+}
+
+.c4 {
+  cursor: pointer;
+  color: var(--brand);
+}
+
+.c2 {
+  color: var(--darkgrey);
+  display: grid;
+  row-gap: 24px;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 25px auto;
+  -webkit-align-items: top;
+  -webkit-box-align: top;
+  -ms-flex-align: top;
+  align-items: top;
+}
+
+.c11 {
+  font-size: 13px;
+  color: var(--darkgrey);
+}
+
+.c7 {
+  background-color: var(--green);
+  border: none;
+  font-size: 16px;
+  color: var(--white);
+  font-family: 'IBM Plex Sans',sans-serif;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+  outline: none;
+  -webkit-transition: background-color 200ms ease;
+  transition: background-color 200ms ease;
+  height: 60px;
+  text-align: center;
+  padding-top: 20px;
+  border: 2px solid var(--green);
+  color: var(--green);
+  border-radius: 4px;
+  background-color: var(--white);
+}
+
+.c7:hover {
+  background-color: var(--activegreen);
+}
+
+.c7:hover {
+  background-color: var(--white);
+}
+
+.c5 {
+  font-family: 'IBM Plex Serif',serif;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 30px;
+  line-height: normal;
+  color: var(--dimgrey);
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.c12 {
+  display: grid;
+  grid-template-columns: repeat(2,1fr);
+  grid-gap: 10px;
+}
+
+.c13 {
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-weight: bold;
+  font-size: 30px;
+  line-height: 39px;
+  color: var(--dimgrey);
+}
+
+.c14 {
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 20px;
+  line-height: 27px;
+  text-align: right;
+  color: var(--grey);
+}
+
+.c15 {
+  padding: 0;
+  border: none;
+  margin-bottom: 30px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.c6 {
+  padding: 0;
+  border: none;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.c16 {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 25px auto;
+  -webkit-align-items: top;
+  -webkit-box-align: top;
+  -ms-flex-align: top;
+  align-items: top;
+  grid-template-rows: 35px auto;
+}
+
+.c16 > .c10 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c17 {
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 24px;
+  line-height: 32px;
+  color: var(--red);
+}
+
+.c18 {
+  font-size: 20px;
+  font-family: 'IBM Plex Serif',serif;
+}
+
+.c19 {
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 20px;
+  margin-top: 30px;
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c9 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c21 {
+    height: 16px;
+    width: 16px;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c1 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c22 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c20 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c3 {
+    display: none;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c8 {
+    margin-bottom: 15px;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c15 {
+    display: grid;
+    grid-gap: 30px;
+    grid-template-columns: repeat(2,1fr);
+    -webkit-align-items: top;
+    -webkit-box-align: top;
+    -ms-flex-align: top;
+    align-items: top;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c6 {
+    display: grid;
+    grid-gap: 30px;
+    grid-template-columns: repeat(2,1fr);
+    -webkit-align-items: top;
+    -webkit-box-align: top;
+    -ms-flex-align: top;
+    align-items: top;
+  }
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c16 {
+    margin-bottom: 15px;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <div
+          class="c1"
+        />
+        <div
+          class="c2"
+        >
+          <div
+            class="c3"
+          >
+            <span
+              class="c4"
+              href="/"
+            >
+              Unlock Tickets
+            </span>
+          </div>
+          <h1
+            class="c5"
+          >
+            My Doctor Who party
+          </h1>
+          <div
+            class="c6"
+          >
+            <div
+              class="c7"
+            >
+              Confirming Payment
+            </div>
+            <div
+              class="c8"
+            >
+              <div
+                class="c9"
+              >
+                <label
+                  class="c10 c11"
+                >
+                  Ticket Price
+                </label>
+              </div>
+              <div
+                class="c12"
+              >
+                <div
+                  class="c13"
+                >
+                  0.01
+                   ETH
+                </div>
+                <div
+                  class="c14"
+                >
+                  $
+                  ---
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="c15"
+          >
+            <div
+              class="c16"
+            >
+              <div
+                class="c17"
+              >
+                Nov 23, 2063
+              </div>
+              <div
+                class="c18"
+              >
+                Unbelievably, it's been 100 years since it first came to our screens.
+    
+Join us for an hour or two of fine entertainment.
+              </div>
+              <div
+                class="c19"
+              >
+                Totters Lane, London
+              </div>
+            </div>
+            <div
+              class="c16"
+            >
+              <div />
+            </div>
+          </div>
+          <div
+            class="c20"
+          >
+            <div
+              class="c21"
+            >
+              <svg
+                viewBox="0 0 56 56"
+              >
+                <title />
+                <path
+                  d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+                />
+              </svg>
+            </div>
+            <p>
+              Powered by Unlock
+            </p>
+          </div>
+        </div>
+        <div
+          class="c22"
+        />
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="b9ke0k-0 kUnmag"
+    >
+      <div
+        class="b9ke0k-1 jDykuE"
+      />
+      <div
+        class="b9ke0k-6 kLtGVO"
+      >
+        <div
+          class="b9ke0k-4 kmengs"
+        >
+          <span
+            class="b9ke0k-5 bDmGKS"
+            href="/"
+          >
+            Unlock Tickets
+          </span>
+        </div>
+        <h1
+          class="sc-1fq9sck-0 esJxvf"
+        >
+          My Doctor Who party
+        </h1>
+        <div
+          class="sc-1xgodx9-4 sc-1fq9sck-5 eyUQpb"
+        >
+          <div
+            class="sc-1uk9h2s-0 sc-1uk9h2s-1 jXrtxI"
+          >
+            Confirming Payment
+          </div>
+          <div
+            class="sc-1xgodx9-5 hKuMTX"
+          >
+            <div
+              class="sc-8fuwpj-0 btHddm"
+            >
+              <label
+                class="sc-1xgodx9-6 loqXYl"
+              >
+                Ticket Price
+              </label>
+            </div>
+            <div
+              class="sc-1fq9sck-1 vveei"
+            >
+              <div
+                class="sc-1fq9sck-2 fFmRNK"
+              >
+                0.01
+                 ETH
+              </div>
+              <div
+                class="sc-1fq9sck-3 dwRewx"
+              >
+                $
+                ---
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="sc-1xgodx9-4 sc-1fq9sck-4 eqlEGi"
+        >
+          <div
+            class="sc-1xgodx9-5 sc-1fq9sck-6 dDmCuX"
+          >
+            <div
+              class="sc-1fq9sck-7 hswCiG"
+            >
+              Nov 23, 2063
+            </div>
+            <div
+              class="sc-1fq9sck-8 clEMWd"
+            >
+              Unbelievably, it's been 100 years since it first came to our screens.
+    
+Join us for an hour or two of fine entertainment.
+            </div>
+            <div
+              class="sc-1fq9sck-9 iJXTq"
+            >
+              Totters Lane, London
+            </div>
+          </div>
+          <div
+            class="sc-1xgodx9-5 sc-1fq9sck-6 dDmCuX"
+          >
+            <div />
+          </div>
+        </div>
+        <div
+          class="b9ke0k-3 dhAsVa"
+        >
+          <div
+            class="oj0wpp-0 lguXZd"
+          >
+            <svg
+              viewBox="0 0 56 56"
+            >
+              <title />
+              <path
+                d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+              />
+            </svg>
+          </div>
+          <p>
+            Powered by Unlock
+          </p>
+        </div>
+      </div>
+      <div
+        class="b9ke0k-2 khwivT"
+      />
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Event RSVP page Event RSVP page with confirming key transaction 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -8601,6 +9777,130 @@ Object {
 }
 `;
 
+exports[`Storyshots PayButton Confirming (key, no transaction) 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c0 {
+  background-color: var(--green);
+  border: none;
+  font-size: 16px;
+  color: var(--white);
+  font-family: 'IBM Plex Sans',sans-serif;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+  outline: none;
+  -webkit-transition: background-color 200ms ease;
+  transition: background-color 200ms ease;
+  height: 60px;
+  text-align: center;
+  padding-top: 20px;
+  border: 2px solid var(--green);
+  color: var(--green);
+  border-radius: 4px;
+  background-color: var(--white);
+}
+
+.c0:hover {
+  background-color: var(--activegreen);
+}
+
+.c0:hover {
+  background-color: var(--white);
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c0 {
+    margin-bottom: 20px;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        Confirming Payment
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-1uk9h2s-0 sc-1uk9h2s-1 jXrtxI"
+    >
+      Confirming Payment
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots PayButton Confirming 1`] = `
 Object {
   "asFragment": [Function],
@@ -8911,6 +10211,130 @@ Object {
       class="sc-1uk9h2s-0 sc-1uk9h2s-1 jXrtxI"
     >
       Payment Sent ...
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots PayButton Valid (key, no transaction) 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c0 {
+  background-color: var(--green);
+  border: none;
+  font-size: 16px;
+  color: var(--white);
+  font-family: 'IBM Plex Sans',sans-serif;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+  outline: none;
+  -webkit-transition: background-color 200ms ease;
+  transition: background-color 200ms ease;
+  height: 60px;
+  text-align: center;
+  padding-top: 20px;
+  border: 2px solid var(--green);
+  color: var(--green);
+  border-radius: 4px;
+  background-color: var(--white);
+}
+
+.c0:hover {
+  background-color: var(--activegreen);
+}
+
+.c0:hover {
+  background-color: var(--white);
+}
+
+@media only screen and (min-width:135px) and (max-width:736px) {
+  .c0 {
+    margin-bottom: 20px;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        Confirmed
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-1uk9h2s-0 sc-1uk9h2s-1 jXrtxI"
+    >
+      Confirmed
     </div>
   </div>,
   "debug": [Function],

--- a/tickets/src/selectors/keys.ts
+++ b/tickets/src/selectors/keys.ts
@@ -1,0 +1,50 @@
+import { Transaction, TransactionStatus } from '../unlockTypes'
+
+interface Key {
+  expiration: number
+  transactions?: {
+    [key: string]: Transaction
+  }
+}
+
+export enum KeyStatus {
+  NONE = 'none',
+  CONFIRMING = 'confirming',
+  CONFIRMED = 'confirmed',
+  EXPIRED = 'expired',
+  VALID = 'valid',
+}
+
+export default function keyStatus(
+  id: string,
+  keys: { [key: string]: Key },
+  requiredConfirmations: number
+): KeyStatus | TransactionStatus {
+  const key = keys[id]
+
+  if (!key) {
+    return KeyStatus.NONE
+  }
+  if (!key.transactions) {
+    if (key.expiration > new Date().getTime() / 1000) {
+      return KeyStatus.VALID
+    }
+    return KeyStatus.NONE
+  }
+  const transactions = Object.values(key.transactions)
+  transactions.sort((a, b) => (a.blockNumber > b.blockNumber ? -1 : 1))
+  const lastTransaction = transactions[0]
+
+  switch (lastTransaction.status) {
+    case 'mined':
+      if (lastTransaction.confirmations < requiredConfirmations) {
+        return KeyStatus.CONFIRMING
+      }
+      if (key.expiration < new Date().getTime() / 1000) {
+        return KeyStatus.EXPIRED
+      }
+      return KeyStatus.VALID
+    default:
+      return lastTransaction.status || KeyStatus.NONE
+  }
+}

--- a/tickets/src/stories/content/EventContent.stories.js
+++ b/tickets/src/stories/content/EventContent.stories.js
@@ -6,6 +6,7 @@ import { EventContent } from '../../components/content/EventContent'
 import createUnlockStore from '../../createUnlockStore'
 import configure from '../../config'
 import { ConfigContext } from '../../utils/withConfig'
+import { KeyStatus } from '../../selectors/keys'
 
 const store = createUnlockStore({})
 
@@ -67,7 +68,7 @@ storiesOf('Event RSVP page', module)
       </ConfigProvider>
     )
   })
-  .add('Event RSVP page with confirming key', () => {
+  .add('Event RSVP page with confirming key transaction', () => {
     const transaction = {
       status: 'mined',
       confirmations: 3,
@@ -86,7 +87,7 @@ storiesOf('Event RSVP page', module)
       </ConfigProvider>
     )
   })
-  .add('Event RSVP page with confirmed key', () => {
+  .add('Event RSVP page with confirmed key transaction', () => {
     const transaction = {
       status: 'mined',
       confirmations: 14,
@@ -101,6 +102,34 @@ storiesOf('Event RSVP page', module)
           purchaseKey={purchaseKey}
           loadEvent={loadEvent}
           transaction={transaction}
+        />
+      </ConfigProvider>
+    )
+  })
+  .add('Event RSVP page with confirming key', () => {
+    return (
+      <ConfigProvider value={config}>
+        <EventContent
+          event={event}
+          lock={lock}
+          config={config}
+          purchaseKey={purchaseKey}
+          loadEvent={loadEvent}
+          keyStatus={KeyStatus.CONFIRMING}
+        />
+      </ConfigProvider>
+    )
+  })
+  .add('Event RSVP page with confirmed key', () => {
+    return (
+      <ConfigProvider value={config}>
+        <EventContent
+          event={event}
+          lock={lock}
+          config={config}
+          purchaseKey={purchaseKey}
+          loadEvent={loadEvent}
+          keyStatus={KeyStatus.VALID}
         />
       </ConfigProvider>
     )

--- a/tickets/src/stories/content/PayButton.stories.js
+++ b/tickets/src/stories/content/PayButton.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { PayButton } from '../../components/content/purchase/PayButton'
+import { KeyStatus } from '../../selectors/keys'
 
 const config = {
   requiredConfirmations: 12,
@@ -37,6 +38,20 @@ storiesOf('PayButton', module)
     <PayButton
       transaction={confirmedTx}
       purchaseKey={purchaseKey}
+      config={config}
+    />
+  ))
+  .add('Confirming (key, no transaction)', () => (
+    <PayButton
+      purchaseKey={purchaseKey}
+      keyStatus={KeyStatus.CONFIRMING}
+      config={config}
+    />
+  ))
+  .add('Valid (key, no transaction)', () => (
+    <PayButton
+      purchaseKey={purchaseKey}
+      keyStatus={KeyStatus.VALID}
       config={config}
     />
   ))

--- a/tickets/src/unlockTypes.ts
+++ b/tickets/src/unlockTypes.ts
@@ -17,6 +17,7 @@ export enum TransactionStatus {
   SUBMITTED = 'submitted',
   PENDING = 'pending',
   MINED = 'mined',
+  NONE = '', // for testing purposes
 }
 /* eslint-enable no-unused-vars */
 
@@ -24,11 +25,11 @@ export interface Transaction {
   status: TransactionStatus
   confirmations: number
   hash: string
-  lock: string
-  name: string
   type: TransactionType
   blockNumber: number
 
+  lock?: string
+  name?: string
   key?: string // TODO: tighten up our types, hopefully we won't have too many
   // optional properties.
 }


### PR DESCRIPTION
# Description

The event page now reacts properly to key status. It will show as confirmed if you've bought a key, confirming if this is in progress, etc.

**Please only evaluate latest commit.** There will be one more cascading commit tonight, to produce the QR code that sits on the event page itself. Obviously this should be rebased before it's merged in, with the QR code component coming first. [There is a configuration change here, which will disappear when rebased. Please ignore.]

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
