### PR TITLE
Unlock JS will return entire account now

### DIFF
--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -1,6 +1,6 @@
 import {
   createAccountAndPasswordEncryptKey,
-  getAddressFromPrivateKey,
+  getAccountFromPrivateKey,
 } from '../accounts'
 
 describe('account helpers', () => {
@@ -28,12 +28,20 @@ describe('account helpers', () => {
         passwordEncryptedPrivateKey,
       } = createAccountAndPasswordEncryptKey('guest')
 
-      const decryptedAddress = getAddressFromPrivateKey(
+      const decryptedAddress = getAccountFromPrivateKey(
         passwordEncryptedPrivateKey,
         'guest'
       )
 
-      expect(decryptedAddress).toBe(address)
+      expect(decryptedAddress).toEqual(
+        expect.objectContaining({
+          address: address,
+          privateKey: expect.any(String),
+          encrypt: expect.any(Function),
+          sign: expect.any(Function),
+          signTransaction: expect.any(Function),
+        })
+      )
     })
 
     it('should throw when an incorrect password is given for an account', () => {
@@ -43,7 +51,7 @@ describe('account helpers', () => {
       } = createAccountAndPasswordEncryptKey('guest')
 
       expect(() => {
-        getAddressFromPrivateKey(passwordEncryptedPrivateKey, 'ghost')
+        getAccountFromPrivateKey(passwordEncryptedPrivateKey, 'ghost')
       }).toThrow()
     })
   })

--- a/unlock-js/src/accounts.js
+++ b/unlock-js/src/accounts.js
@@ -21,10 +21,8 @@ export function createAccountAndPasswordEncryptKey(password) {
  * @param {string} password
  * @throws Throws an error if password does not decrypt private key.
  */
-export function getAddressFromPrivateKey(encryptedPrivateKey, password) {
+export function getAccountFromPrivateKey(encryptedPrivateKey, password) {
   const web3 = new Web3()
 
-  const { address } = web3.eth.accounts.decrypt(encryptedPrivateKey, password)
-
-  return address
+  return web3.eth.accounts.decrypt(encryptedPrivateKey, password)
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Per a discussion with Julien, now when `unlock-js` is asked to decrypt a private key, it will return the whole account object rather than just the address. This gives us some greater flexibility, and is necessary so that we can sign transactions, etc. with the account.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
