### PR TITLE
Event page with key won't ask to sign on every page load

### DIFF
--- a/tickets/src/components/content/EventContent.js
+++ b/tickets/src/components/content/EventContent.js
@@ -36,13 +36,26 @@ export class EventContent extends Component {
   }
 
   componentDidUpdate() {
-    const { lock, loadEvent, signAddress, event, keyStatus } = this.props
+    const {
+      lock,
+      loadEvent,
+      signAddress,
+      event,
+      keyStatus,
+      signedEventAddress,
+    } = this.props
     const { loaded, signed } = this.state
     if (lock.address && !event.lockAddress && !loaded) {
       loadEvent(lock.address)
       this.setAsLoaded() // To prevent multiple loads
     }
-    if (keyStatus === KeyStatus.VALID && !signed) {
+    if (signedEventAddress && !signed) {
+      this.setAsSigned()
+    } else if (
+      keyStatus === KeyStatus.VALID &&
+      !signed &&
+      !signedEventAddress
+    ) {
       signAddress(lock.address)
       this.setAsSigned()
     }


### PR DESCRIPTION
# Description

If the data is already in redux, we don't need to ask for it again ...

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
