### PR TITLE
Wrapping EventContent in the error consumer

### DIFF
--- a/tickets/src/components/content/EventContent.js
+++ b/tickets/src/components/content/EventContent.js
@@ -11,7 +11,6 @@ import BalanceProvider from '../helpers/BalanceProvider'
 import { lockRoute } from '../../utils/routes'
 import BrowserOnly from '../helpers/BrowserOnly'
 import Layout from '../interface/Layout'
-import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import { purchaseKey } from '../../actions/key'
 import { loadEvent, signAddress } from '../../actions/ticket'
 import PayButton from './purchase/PayButton'
@@ -92,52 +91,50 @@ export class EventContent extends Component {
       date.getFullYear()
 
     return (
-      <GlobalErrorConsumer>
-        <BrowserOnly>
-          <Layout forContent>
-            <Head>
-              <title>{pageTitle(name)}</title>
-            </Head>
-            <Title>{name}</Title>
-            <PaymentFieldset>
-              <PayButton
-                transaction={transaction}
-                keyStatus={keyStatus}
-                purchaseKey={() => purchaseKey(lockKey)}
+      <BrowserOnly>
+        <Layout forContent>
+          <Head>
+            <title>{pageTitle(name)}</title>
+          </Head>
+          <Title>{name}</Title>
+          <PaymentFieldset>
+            <PayButton
+              transaction={transaction}
+              keyStatus={keyStatus}
+              purchaseKey={() => purchaseKey(lockKey)}
+            />
+            <Field>
+              <NoPhone>
+                <Label>Ticket Price</Label>
+              </NoPhone>
+              <BalanceProvider
+                amount={lock.keyPrice}
+                render={(ethWithPresentation, convertedUSDValue) => (
+                  <Price>
+                    <Eth>{ethWithPresentation} ETH</Eth>
+                    <Fiat>${convertedUSDValue}</Fiat>
+                  </Price>
+                )}
               />
-              <Field>
-                <NoPhone>
-                  <Label>Ticket Price</Label>
-                </NoPhone>
-                <BalanceProvider
-                  amount={lock.keyPrice}
-                  render={(ethWithPresentation, convertedUSDValue) => (
-                    <Price>
-                      <Eth>{ethWithPresentation} ETH</Eth>
-                      <Fiat>${convertedUSDValue}</Fiat>
-                    </Price>
-                  )}
-                />
-              </Field>
-            </PaymentFieldset>
-            <DetailsFieldset>
-              <DetailsField>
-                <DisplayDate>{dateString}</DisplayDate>
-                <Description>{description}</Description>
-                <Location>{location}</Location>
-              </DetailsField>
-              <DetailsField>
-                <TicketCode
-                  publicKey={account.address}
-                  signedAddress={signedEventAddress}
-                  eventAddress={lock.address}
-                />
-              </DetailsField>
-            </DetailsFieldset>
-          </Layout>
-          <DeveloperOverlay />
-        </BrowserOnly>
-      </GlobalErrorConsumer>
+            </Field>
+          </PaymentFieldset>
+          <DetailsFieldset>
+            <DetailsField>
+              <DisplayDate>{dateString}</DisplayDate>
+              <Description>{description}</Description>
+              <Location>{location}</Location>
+            </DetailsField>
+            <DetailsField>
+              <TicketCode
+                publicKey={account.address}
+                signedAddress={signedEventAddress}
+                eventAddress={lock.address}
+              />
+            </DetailsField>
+          </DetailsFieldset>
+        </Layout>
+        <DeveloperOverlay />
+      </BrowserOnly>
     )
   }
 }

--- a/tickets/src/pages/event.js
+++ b/tickets/src/pages/event.js
@@ -1,8 +1,13 @@
 import React from 'react'
 import EventContent from '../components/content/EventContent'
+import GlobalErrorConsumer from '../components/interface/GlobalErrorConsumer'
 
 const Event = () => {
-  return <EventContent />
+  return (
+    <GlobalErrorConsumer>
+      <EventContent />
+    </GlobalErrorConsumer>
+  )
 }
 
 export default Event


### PR DESCRIPTION
# Description

This small change will allow the error consumer to wrap the event content page, displaying an error i we're on the wrong network. Stories exist for the page and componetn.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
