### PR TITLE
skipping chromatic on all production branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ workflows:
       - unlock-app-chromatic:
           filters:
             branches:
-              ignore: production
+              ignore: /production.*/
           requires:
             - unlock-app-tests
       - integration-tests:


### PR DESCRIPTION
This should not ask us to validate hundreds of changes on every production deploys...



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread