### PR TITLE
Disallow locks with 0 duration as well as those longer than 100 years

### DIFF
--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -16,7 +16,7 @@ import {
 import {
   INFINITY,
   UNLIMITED_KEYS_COUNT,
-  oneHundredYearsInDays,
+  ONE_HUNDRED_YEARS_IN_DAYS,
 } from '../../../constants'
 
 describe('lockToFormValues', () => {
@@ -180,7 +180,7 @@ describe('CreatorLockForm', () => {
     it('key expiration is greater than 100 years', () => {
       expect.assertions(1)
       const { container } = makeLockForm({
-        expirationDuration: oneHundredYearsInDays + secondsInADay,
+        expirationDuration: ONE_HUNDRED_YEARS_IN_DAYS + 1,
       })
       expect(container.querySelector('.duration > input').dataset.valid).toBe(
         'false'

--- a/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLockForm.test.js
@@ -13,7 +13,11 @@ import {
   FORM_KEY_PRICE_INVALID,
 } from '../../../errors'
 
-import { INFINITY, UNLIMITED_KEYS_COUNT } from '../../../constants'
+import {
+  INFINITY,
+  UNLIMITED_KEYS_COUNT,
+  oneHundredYearsInDays,
+} from '../../../constants'
 
 describe('lockToFormValues', () => {
   it('should return an object with the expirationDuration in the right unit', () => {
@@ -162,10 +166,25 @@ describe('CreatorLockForm', () => {
       expect(wrapper.getByValue('').dataset.valid).toBe('false')
     })
 
-    it('key expiration is a negative number', () => {
-      expect.assertions(1)
+    it('key expiration is not a positive whole number', () => {
+      expect.assertions(2)
       const wrapper = makeLockForm({ expirationDuration: -2 * secondsInADay })
       expect(wrapper.getByValue('-2').dataset.valid).toBe('false')
+
+      const { container } = makeLockForm({ expirationDuration: 0 })
+      expect(container.querySelector('.duration > input').dataset.valid).toBe(
+        'false'
+      )
+    })
+
+    it('key expiration is greater than 100 years', () => {
+      expect.assertions(1)
+      const { container } = makeLockForm({
+        expirationDuration: oneHundredYearsInDays + secondsInADay,
+      })
+      expect(container.querySelector('.duration > input').dataset.valid).toBe(
+        'false'
+      )
     })
 
     it('max number of keys is missing', () => {

--- a/unlock-app/src/__tests__/utils/validators.test.js
+++ b/unlock-app/src/__tests__/utils/validators.test.js
@@ -12,7 +12,7 @@ describe('Form field validators', () => {
     expect(validators.isNotEmpty(false)).toBeFalsy()
   })
   it('isPositiveInteger', () => {
-    expect.assertions(8)
+    expect.assertions(7)
     expect(validators.isPositiveInteger('1')).toBeTruthy()
     expect(
       validators.isPositiveInteger(
@@ -20,7 +20,6 @@ describe('Form field validators', () => {
       )
     ).toBeTruthy()
 
-    expect(validators.isPositiveInteger('0')).toBeTruthy()
     expect(validators.isPositiveInteger('-1')).toBeFalsy()
     expect(validators.isPositiveInteger('1.1')).toBeFalsy()
     expect(validators.isPositiveInteger('av')).toBeFalsy()

--- a/unlock-app/src/__tests__/utils/validators.test.js
+++ b/unlock-app/src/__tests__/utils/validators.test.js
@@ -1,4 +1,5 @@
 import * as validators from '../../utils/validators'
+import { ONE_HUNDRED_YEARS_IN_DAYS } from '../../constants'
 
 describe('Form field validators', () => {
   it('isMissing', () => {
@@ -26,9 +27,10 @@ describe('Form field validators', () => {
     expect(validators.isPositiveInteger(null)).toBeFalsy()
     expect(validators.isPositiveInteger(false)).toBeFalsy()
   })
-  it('isLessThanOneHundredYearsInDays', () => {
+  it('isLTE', () => {
     expect.assertions(6)
-    const { isLTEOneHundredYearsInDays } = validators
+    const { isLTE } = validators
+    const isLTEOneHundredYearsInDays = isLTE(ONE_HUNDRED_YEARS_IN_DAYS)
 
     expect(isLTEOneHundredYearsInDays('-5')).toBeTruthy()
     expect(isLTEOneHundredYearsInDays('0')).toBeTruthy()

--- a/unlock-app/src/__tests__/utils/validators.test.js
+++ b/unlock-app/src/__tests__/utils/validators.test.js
@@ -26,6 +26,17 @@ describe('Form field validators', () => {
     expect(validators.isPositiveInteger(null)).toBeFalsy()
     expect(validators.isPositiveInteger(false)).toBeFalsy()
   })
+  it('isLessThanOneHundredYearsInDays', () => {
+    expect.assertions(6)
+    const { isLTEOneHundredYearsInDays } = validators
+
+    expect(isLTEOneHundredYearsInDays('-5')).toBeTruthy()
+    expect(isLTEOneHundredYearsInDays('0')).toBeTruthy()
+    expect(isLTEOneHundredYearsInDays(null)).toBeFalsy()
+    expect(isLTEOneHundredYearsInDays(false)).toBeFalsy()
+    expect(isLTEOneHundredYearsInDays('36500')).toBeTruthy()
+    expect(isLTEOneHundredYearsInDays('36501')).toBeFalsy()
+  })
   it('isPositiveNumber', () => {
     expect.assertions(7)
     expect(validators.isPositiveNumber('1.3')).toBeTruthy()

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -25,6 +25,7 @@ import {
   isNotEmpty,
   isPositiveInteger,
   isPositiveNumber,
+  isLTEOneHundredYearsInDays,
 } from '../../utils/validators'
 
 import { INFINITY, UNLIMITED_KEYS_COUNT } from '../../constants'
@@ -150,7 +151,9 @@ export class CreatorLockForm extends React.Component {
         }
         break
       case 'expirationDuration':
-        if (!isPositiveInteger(value)) return FORM_EXPIRATION_DURATION_INVALID
+        if (!isPositiveInteger(value) || !isLTEOneHundredYearsInDays(value)) {
+          return FORM_EXPIRATION_DURATION_INVALID
+        }
         break
       case 'maxNumberOfKeys':
         if (value !== INFINITY && !isPositiveInteger(value)) {

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -25,10 +25,14 @@ import {
   isNotEmpty,
   isPositiveInteger,
   isPositiveNumber,
-  isLTEOneHundredYearsInDays,
+  isLTE,
 } from '../../utils/validators'
 
-import { INFINITY, UNLIMITED_KEYS_COUNT } from '../../constants'
+import {
+  INFINITY,
+  UNLIMITED_KEYS_COUNT,
+  ONE_HUNDRED_YEARS_IN_DAYS,
+} from '../../constants'
 
 /**
  * Converts the lock values into form values
@@ -151,7 +155,10 @@ export class CreatorLockForm extends React.Component {
         }
         break
       case 'expirationDuration':
-        if (!isPositiveInteger(value) || !isLTEOneHundredYearsInDays(value)) {
+        if (
+          !isPositiveInteger(value) ||
+          !isLTE(ONE_HUNDRED_YEARS_IN_DAYS)(value)
+        ) {
           return FORM_EXPIRATION_DURATION_INVALID
         }
         break

--- a/unlock-app/src/constants.ts
+++ b/unlock-app/src/constants.ts
@@ -91,6 +91,9 @@ export const MAX_DEVICE_WIDTHS = {
 export const INFINITY = '∞'
 export const UNLIMITED_KEYS_COUNT = -1
 
+// oneHundredYearsInDays -- based on the calculation for max duration in smart contract.
+export const oneHundredYearsInDays = 100 * 365
+
 export const SHOW_FLAG_FOR = 2000 // milliseconds
 
 export const MAX_UINT =

--- a/unlock-app/src/constants.ts
+++ b/unlock-app/src/constants.ts
@@ -92,7 +92,7 @@ export const INFINITY = '∞'
 export const UNLIMITED_KEYS_COUNT = -1
 
 // oneHundredYearsInDays -- based on the calculation for max duration in smart contract.
-export const oneHundredYearsInDays = 100 * 365
+export const ONE_HUNDRED_YEARS_IN_DAYS = 100 * 365
 
 export const SHOW_FLAG_FOR = 2000 // milliseconds
 

--- a/unlock-app/src/utils/validators.js
+++ b/unlock-app/src/utils/validators.js
@@ -1,10 +1,10 @@
 // tests whether a field's value was not entered by the user
 export const isNotEmpty = val => val || val === 0
 
-// tests whether a number is non-negative and not a decimal number
+// tests whether a number is positive and not a decimal number
 export const isPositiveInteger = val => {
   const parsedInt = parseInt(val)
-  return !isNaN(parsedInt) && val == parsedInt && +val >= 0
+  return !isNaN(parsedInt) && val == parsedInt && +val > 0
 }
 
 // tests whether a number is a non-negative real number (decimals allowed)

--- a/unlock-app/src/utils/validators.js
+++ b/unlock-app/src/utils/validators.js
@@ -1,3 +1,5 @@
+import { oneHundredYearsInDays } from '../constants'
+
 // tests whether a field's value was not entered by the user
 export const isNotEmpty = val => val || val === 0
 
@@ -5,6 +7,11 @@ export const isNotEmpty = val => val || val === 0
 export const isPositiveInteger = val => {
   const parsedInt = parseInt(val)
   return !isNaN(parsedInt) && val == parsedInt && +val > 0
+}
+
+export const isLTEOneHundredYearsInDays = val => {
+  const parsedInt = parseInt(val)
+  return parsedInt <= oneHundredYearsInDays
 }
 
 // tests whether a number is a non-negative real number (decimals allowed)

--- a/unlock-app/src/utils/validators.js
+++ b/unlock-app/src/utils/validators.js
@@ -1,5 +1,3 @@
-import { oneHundredYearsInDays } from '../constants'
-
 // tests whether a field's value was not entered by the user
 export const isNotEmpty = val => val || val === 0
 
@@ -9,9 +7,11 @@ export const isPositiveInteger = val => {
   return !isNaN(parsedInt) && val == parsedInt && +val > 0
 }
 
-export const isLTEOneHundredYearsInDays = val => {
-  const parsedInt = parseInt(val)
-  return parsedInt <= oneHundredYearsInDays
+export const isLTE = limit => {
+  return val => {
+    const parsedInt = parseInt(val)
+    return parsedInt <= limit
+  }
 }
 
 // tests whether a number is a non-negative real number (decimals allowed)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR fixes #2758 and fixes #2864 by making the lock form validation reject values of 0 and values greater than 100 years for the duration.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
