### PR TITLE
Don't automatically create account when there isn't one available

### DIFF
--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -113,33 +113,14 @@ describe('WalletService', () => {
       })
 
       describe('when the node has no unlocked account', () => {
-        it('should create an account and emit the ready event', done => {
-          expect.assertions(2)
+        it('should leave the service in a non-ready state', () => {
+          expect.assertions(1)
 
           // this test checks to make sure we create a new account if the node
           // returns no accounts, and so the accountsAndYield call must return []
           nock.accountsAndYield([])
 
-          walletService.once('ready', () => {
-            expect(walletService.ready).toBe(true)
-            done()
-          })
-
-          walletService.on('account.changed', account => {
-            // ensure we get a valid account hash back
-            expect(account).toMatch(/^0x[a-fA-F0-9]{40}$/)
-          })
-
-          return walletService.getAccount(true)
-        })
-      })
-
-      describe('when the node has no unlocked account and when preventing from creating one', () => {
-        it('should fail and mark the walletService is not ready', async () => {
-          expect.assertions(1)
-          walletService.ready = true
-          nock.accountsAndYield([])
-          await walletService.getAccount(false)
+          walletService.getAccount(true)
           expect(walletService.ready).toBe(false)
         })
       })

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -120,7 +120,7 @@ describe('WalletService', () => {
           // returns no accounts, and so the accountsAndYield call must return []
           nock.accountsAndYield([])
 
-          walletService.getAccount(true)
+          walletService.getAccount()
           expect(walletService.ready).toBe(false)
         })
       })

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -60,24 +60,17 @@ export default class WalletService extends UnlockService {
   }
 
   /**
-   * Function which yields the address of the account on the provider or creates a key pair.
+   * Function which yields the address of the account on the provider
    */
-  async getAccount(createIfNone = false) {
+  async getAccount() {
     const accounts = await this.web3.eth.getAccounts()
-    let address
 
-    if (!accounts.length && !createIfNone) {
-      // We do not have an account and were not asked to create one!
-      // Not sure how that could happen?
+    if (!accounts.length) {
+      // We do not have an account, can't do anything until we have one.
       return (this.ready = false)
     }
 
-    if (accounts.length) {
-      address = accounts[0] // We have an account.
-    } else if (createIfNone) {
-      let newAccount = await this.web3.eth.accounts.create()
-      address = newAccount.address
-    }
+    let address = accounts[0]
 
     this.emit('account.changed', address)
     this.emit('ready')


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Existing behavior in the `walletService` is to automatically create an account if none are available. This isn't consistent with our logic for how user accounts should work, which relies on the absence of an account to trigger the login form (so with the existing behavior in place, the form never appears). This PR removes the automatic account creation from `walletService`.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #2111 #2721 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
