### PR TITLE
Adding UnlockUtils contract with string concat methods

### DIFF
--- a/smart-contracts/contracts/UnlockUtils.sol
+++ b/smart-contracts/contracts/UnlockUtils.sol
@@ -1,0 +1,63 @@
+pragma solidity 0.5.7;
+
+// This contract provides some utility methods for use with the unlock protocol smart contracts.
+// Borrowed from:
+// https://github.com/oraclize/ethereum-api/blob/master/oraclizeAPI_0.5.sol#L943
+
+contract UnlockUtils {
+
+  function strConcat(
+    string memory _a,
+    string memory _b
+  ) internal
+    pure
+    returns(string memory)
+ {
+    bytes memory _ba = bytes(_a);
+    bytes memory _bb = bytes(_b);
+    string memory ab = new string(_ba.length + _bb.length);
+    bytes memory bab = bytes(ab);
+    uint k = 0;
+    for(uint i = 0; i < _ba.length; i++) {
+      bab[k++] = _ba[i];
+    }
+    for(uint i = 0; i < _bb.length; i++) {
+      bab[k++] = _bb[i];
+    }
+    return string(bab);
+  }
+
+  function strConcat(
+    string memory _a,
+    string memory _b
+  ) internal
+    pure
+    returns(string memory)
+  {
+    return strConcat(_a, _b, "", "", "");
+  }
+
+  function uint2str(
+    uint i
+  ) internal
+    pure
+    returns (string memory)
+  {
+    if (i == 0) {
+      return "0";
+    }
+    uint j = i;
+    uint len;
+    while(j != 0) {
+      len++;
+      j /= 10;
+    }
+    bytes memory bstr = new bytes(len);
+    uint k = len - 1;
+    while(i != 0) {
+      bstr[k--] = byte(48 + i % 10);
+      i /= 10;
+    }
+    return string(bstr);
+  }
+}

--- a/smart-contracts/contracts/UnlockUtils.sol
+++ b/smart-contracts/contracts/UnlockUtils.sol
@@ -9,7 +9,7 @@ contract UnlockUtils {
   function strConcat(
     string memory _a,
     string memory _b
-  ) internal
+  ) public
     pure
     returns(string memory)
  {
@@ -29,7 +29,7 @@ contract UnlockUtils {
 
   function uint2str(
     uint _i
-  ) internal
+  ) public
     pure
     returns (string memory _uintAsString)
   {

--- a/smart-contracts/contracts/UnlockUtils.sol
+++ b/smart-contracts/contracts/UnlockUtils.sol
@@ -27,36 +27,26 @@ contract UnlockUtils {
     return string(bab);
   }
 
-  function strConcat(
-    string memory _a,
-    string memory _b
-  ) internal
-    pure
-    returns(string memory)
-  {
-    return strConcat(_a, _b);
-  }
-
   function uint2str(
-    uint i
+    uint _i
   ) internal
     pure
-    returns (string memory)
+    returns (string memory _uintAsString)
   {
-    if (i == 0) {
-      return "0";
+    if (_i == 0) {
+        return "0";
     }
-    uint j = i;
+    uint j = _i;
     uint len;
-    while(j != 0) {
-      len++;
-      j /= 10;
+    while (j != 0) {
+        len++;
+        j /= 10;
     }
     bytes memory bstr = new bytes(len);
     uint k = len - 1;
-    while(i != 0) {
-      bstr[k--] = byte(48 + i % 10);
-      i /= 10;
+    while (_i != 0) {
+        bstr[k--] = byte(uint8(48 + _i % 10));
+        _i /= 10;
     }
     return string(bstr);
   }

--- a/smart-contracts/contracts/UnlockUtils.sol
+++ b/smart-contracts/contracts/UnlockUtils.sol
@@ -34,7 +34,7 @@ contract UnlockUtils {
     pure
     returns(string memory)
   {
-    return strConcat(_a, _b, "", "", "");
+    return strConcat(_a, _b);
   }
 
   function uint2str(

--- a/smart-contracts/contracts/UnlockUtils.sol
+++ b/smart-contracts/contracts/UnlockUtils.sol
@@ -33,20 +33,22 @@ contract UnlockUtils {
     pure
     returns (string memory _uintAsString)
   {
+    // make a copy of the param to avoid security/no-assign-params error
+    uint c = _i;
     if (_i == 0) {
-        return "0";
+      return '0';
     }
     uint j = _i;
     uint len;
     while (j != 0) {
-        len++;
-        j /= 10;
+      len++;
+      j /= 10;
     }
     bytes memory bstr = new bytes(len);
     uint k = len - 1;
-    while (_i != 0) {
-        bstr[k--] = byte(uint8(48 + _i % 10));
-        _i /= 10;
+    while (c != 0) {
+      bstr[k--] = byte(uint8(48 + c % 10));
+      c /= 10;
     }
     return string(bstr);
   }

--- a/smart-contracts/contracts/UnlockUtils.sol
+++ b/smart-contracts/contracts/UnlockUtils.sol
@@ -27,7 +27,7 @@ contract UnlockUtils {
     return string(bab);
   }
 
-  function uint2str(
+  function uint2Str(
     uint _i
   ) public
     pure
@@ -51,5 +51,23 @@ contract UnlockUtils {
       c /= 10;
     }
     return string(bstr);
+  }
+
+  function address2Str(
+    address _addr
+  ) public
+    pure
+    returns(string memory)
+  {
+    bytes32 value = bytes32(uint256(_addr));
+    bytes memory alphabet = '0123456789abcdef';
+    bytes memory str = new bytes(42);
+    str[0] = '0';
+    str[1] = 'x';
+    for (uint i = 0; i < 20; i++) {
+      str[2+i*2] = alphabet[uint8(value[i + 12] >> 4)];
+      str[3+i*2] = alphabet[uint8(value[i + 12] & 0x0f)];
+    }
+    return string(str);
   }
 }

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -2,6 +2,7 @@ pragma solidity 0.5.7;
 
 import 'openzeppelin-eth/contracts/ownership/Ownable.sol';
 import '../interfaces/IERC721.sol';
+import '../UnlockUtils.sol';
 
 
 /**
@@ -12,7 +13,8 @@ import '../interfaces/IERC721.sol';
  */
 contract MixinLockMetadata is
   IERC721,
-  Ownable
+  Ownable,
+  UnlockUtils
 {
   /// A descriptive name for a collection of NFTs in this contract
   string private lockName;

--- a/smart-contracts/test/Lock/unlockUtils.js
+++ b/smart-contracts/test/Lock/unlockUtils.js
@@ -1,0 +1,51 @@
+const deployLocks = require('../helpers/deployLocks')
+// const shouldFail = require('../helpers/shouldFail')
+
+const unlockContract = artifacts.require('../Unlock.sol')
+const getUnlockProxy = require('../helpers/proxy')
+
+let unlock, lock
+
+contract('Lock / erc721 / unlockUtils', accounts => {
+  before(async () => {
+    unlock = await getUnlockProxy(unlockContract)
+    const locks = await deployLocks(unlock, accounts[0])
+    lock = locks['FIRST']
+  })
+
+  describe('function uint2str', () => {
+    let str1, str2
+    it('should convert a uint to a string', async () => {
+      str1 = await lock.uint2str.call(0)
+      assert.equal(str1, '0')
+      str2 = await lock.uint2str.call(42)
+      assert.equal(str2, '42')
+    })
+  })
+
+  describe('function strConcat', () => {
+    let resultingStr1, resultingStr2, resultingStr3, moreThan2Str
+    it('should concatenate 2 strings', async () => {
+      resultingStr1 = await lock.strConcat.call('hello', ' unlock')
+      resultingStr2 = await lock.strConcat.call('4', '2')
+      resultingStr3 = await lock.strConcat.call(
+        'https://locksmith.unlock-protocol.com/api/key/',
+        '11'
+      )
+      assert.equal(resultingStr1, 'hello unlock')
+      assert.equal(resultingStr2, '42')
+      assert.equal(
+        resultingStr3,
+        'https://locksmith.unlock-protocol.com/api/key/11'
+      )
+    })
+
+    it('should concatenate more than 2 strings', async () => {
+      moreThan2Str = await lock.strConcat.call(
+        await lock.strConcat.call('1', '2'),
+        '3'
+      )
+      assert.equal(moreThan2Str, '123')
+    })
+  })
+})

--- a/smart-contracts/test/Lock/unlockUtils.js
+++ b/smart-contracts/test/Lock/unlockUtils.js
@@ -16,9 +16,9 @@ contract('Lock / erc721 / unlockUtils', accounts => {
   describe('function uint2str', () => {
     let str1, str2
     it('should convert a uint to a string', async () => {
-      str1 = await lock.uint2str.call(0)
+      str1 = await lock.uint2Str.call(0)
       assert.equal(str1, '0')
-      str2 = await lock.uint2str.call(42)
+      str2 = await lock.uint2Str.call(42)
       assert.equal(str2, '42')
     })
   })
@@ -46,6 +46,15 @@ contract('Lock / erc721 / unlockUtils', accounts => {
         '3'
       )
       assert.equal(moreThan2Str, '123')
+    })
+  })
+
+  describe('function address2Str', () => {
+    let senderAddress
+    // currently returns the address as a string with all chars in lowercase
+    it('should convert an ethereum address to an ASCII string', async () => {
+      senderAddress = await lock.address2Str.call(accounts[0])
+      assert.equal(senderAddress, '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2')
     })
   })
 })


### PR DESCRIPTION
# Description

This is to support the erc721 metadata spec. It allows us to construct unique URI's for each token by concatenating the `tokenID` onto the base tokenURI.
Tests to come with a PR which allows Locks to start using these methods.

The code waws borrowed from here:
https://github.com/oraclize/ethereum-api/blob/master/oraclizeAPI_0.5.sol#L943

Note that I've simplified it to accept only 2 strings (instead of 5 as in the original), but it might be best to make this 3 strings, as we then have an easy way to add the lock address to the URI.

Not sure about how to go about accrediting the original author or if I need to be concerned? Here's a link to the License:
https://github.com/oraclize/ethereum-api/blob/master/LICENSE

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #1764

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
