### PR TITLE
new isAccount validator

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -11,6 +11,7 @@ describe('Form field validators', () => {
     expect(validators.isNotEmpty(null)).toBeFalsy()
     expect(validators.isNotEmpty(false)).toBeFalsy()
   })
+
   it('isPositiveInteger', () => {
     expect.assertions(8)
     expect(validators.isPositiveInteger('1')).toBeTruthy()
@@ -27,6 +28,7 @@ describe('Form field validators', () => {
     expect(validators.isPositiveInteger(null)).toBeFalsy()
     expect(validators.isPositiveInteger(false)).toBeFalsy()
   })
+
   it('isPositiveNumber', () => {
     expect.assertions(7)
     expect(validators.isPositiveNumber('1.3')).toBeTruthy()
@@ -37,5 +39,22 @@ describe('Form field validators', () => {
     expect(validators.isPositiveNumber('av')).toBeFalsy()
     expect(validators.isPositiveNumber(null)).toBeFalsy()
     expect(validators.isPositiveNumber(false)).toBeFalsy()
+  })
+
+  it('isAccount', () => {
+    expect.assertions(4)
+
+    expect(
+      validators.isAccount('0x12345678901234567890abcdef0123ABCDEF0123')
+    ).toBeTruthy()
+    expect(
+      validators.isAccount('00x12345678901234567890abcdef0123ABCDEF0123')
+    ).toBeFalsy()
+    expect(
+      validators.isAccount('0x12345678901234567890abcdef0123ABCDEF01234')
+    ).toBeFalsy()
+    expect(
+      validators.isAccount('0X12345678901234567890abcdef0123ABCDEF0123')
+    ).toBeFalsy()
   })
 })

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -41,12 +41,12 @@ const transactionRegex = '0x[a-fA-F0-9]{64}'
 /**
  * Matches any valid ethereum account address
  */
-export const ACCOUNT_REGEXP = new RegExp(accountRegex + '$')
+export const ACCOUNT_REGEXP = new RegExp('^' + accountRegex + '$')
 
 /**
  * Matches any valid ethereum transaction hash
  */
-export const TRANSACTION_REGEXP = new RegExp(transactionRegex + '$')
+export const TRANSACTION_REGEXP = new RegExp('^' + transactionRegex + '$')
 
 // private helpers for the LOCK_PATH_NAME_REGEXP
 const prefix = '[a-z0-9]+'

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -1,3 +1,5 @@
+import { ACCOUNT_REGEXP } from '../constants'
+
 // tests whether a field's value was not entered by the user
 export const isNotEmpty = val => val || val === 0
 
@@ -11,4 +13,8 @@ export const isPositiveInteger = val => {
 export const isPositiveNumber = val => {
   const parsedFloat = parseFloat(val)
   return !isNaN(parsedFloat) && +parsedFloat >= 0
+}
+
+export const isAccount = val => {
+  return val.match(ACCOUNT_REGEXP)
 }


### PR DESCRIPTION
# Description

This validator will be used to ensure an account passed in from the main window to the iframe resembles an ethereum account on a superficial level. It also fixes the regexps for account and transaction hash, which erroneously would allow stuff before an account or transaction hash to match.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #2902

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
