### PR TITLE
send the current ethereum account to the iframe when it is ready

### DIFF
--- a/paywall/src/__tests__/components/Paywall.test.js
+++ b/paywall/src/__tests__/components/Paywall.test.js
@@ -486,6 +486,38 @@ describe('Paywall', () => {
       )
     })
 
+    it('should accept account, and dispatch setAccount if iframe has no account', () => {
+      expect.assertions(1)
+
+      const anotherAccount = '0x1234567890123456789012345678901234567890'
+      state.account = null
+      store = createUnlockStore(state)
+      store.dispatch = jest.fn()
+      rtl.act(() => {
+        renderMockPaywall()
+      })
+      const listener = getAccountPostmessageEventListener()
+
+      rtl.act(() => {
+        listener({
+          origin: 'http://example.com',
+          source: fakeWindow.parent,
+          data: { type: POST_MESSAGE_ACCOUNT, payload: anotherAccount },
+        })
+        jest.runAllTimers()
+      })
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining(
+          setAccount({
+            address: anotherAccount,
+            fromLocalStorage: true,
+            fromMainWindow: true,
+          })
+        )
+      )
+    })
+
     it('should ignore account if it is unchanged', () => {
       expect.assertions(1)
 

--- a/paywall/src/__tests__/paywall-builder/config.test.js
+++ b/paywall/src/__tests__/paywall-builder/config.test.js
@@ -89,12 +89,14 @@ describe('paywall configuration inter-window communication', () => {
       it('should enable the ethereum provider', done => {
         expect.assertions(1)
 
-        window.ethereum = {
-          enable: jest.fn(() => ({
-            then() {
-              done()
-            },
-          })),
+        window.web3 = {
+          currentProvider: {
+            enable: jest.fn(() => ({
+              then() {
+                done()
+              },
+            })),
+          },
         }
 
         const event = {
@@ -108,25 +110,27 @@ describe('paywall configuration inter-window communication', () => {
 
         listener(event)
 
-        expect(window.ethereum.enable).toHaveBeenCalled()
+        expect(window.web3.currentProvider.enable).toHaveBeenCalled()
       })
 
       it('should request accounts once enabled', done => {
         expect.assertions(1)
 
-        window.ethereum = {
-          enable: () => Promise.resolve(),
-          send: jest.fn(content => {
-            expect(content).toEqual(
-              expect.objectContaining({
-                method: 'eth_accounts',
-                params: [],
-                jsonrpc: '2.0',
-                id: expect.any(Number),
-              })
-            )
-            done()
-          }),
+        window.web3 = {
+          currentProvider: {
+            enable: () => Promise.resolve(),
+            send: jest.fn(content => {
+              expect(content).toEqual(
+                expect.objectContaining({
+                  method: 'eth_accounts',
+                  params: [],
+                  jsonrpc: '2.0',
+                  id: expect.any(Number),
+                })
+              )
+              done()
+            }),
+          },
         }
 
         const event = {
@@ -143,13 +147,15 @@ describe('paywall configuration inter-window communication', () => {
       it('should not post anything on error', done => {
         expect.assertions(1)
 
-        window.ethereum = {
-          enable: () => Promise.resolve(),
-          send: (content, callbackFunc) => {
-            callbackFunc(true, false)
+        window.web3 = {
+          currentProvider: {
+            enable: () => Promise.resolve(),
+            send: (content, callbackFunc) => {
+              callbackFunc(true, false)
 
-            expect(iframe.contentWindow.postMessage).not.toHaveBeenCalled()
-            done()
+              expect(iframe.contentWindow.postMessage).not.toHaveBeenCalled()
+              done()
+            },
           },
         }
 
@@ -168,19 +174,21 @@ describe('paywall configuration inter-window communication', () => {
       it('should post the first account retrieved to the parent window', done => {
         expect.assertions(1)
 
-        window.ethereum = {
-          enable: () => Promise.resolve(),
-          send: (content, callbackFunc) => {
-            callbackFunc(null, { result: ['hi'] })
+        window.web3 = {
+          currentProvider: {
+            enable: () => Promise.resolve(),
+            send: (content, callbackFunc) => {
+              callbackFunc(null, { result: ['hi'] })
 
-            expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
-              expect.objectContaining({
-                type: POST_MESSAGE_ACCOUNT,
-                payload: 'hi',
-              }),
-              'origin'
-            )
-            done()
+              expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  type: POST_MESSAGE_ACCOUNT,
+                  payload: 'hi',
+                }),
+                'origin'
+              )
+              done()
+            },
           },
         }
 

--- a/paywall/src/__tests__/paywall-builder/config.test.js
+++ b/paywall/src/__tests__/paywall-builder/config.test.js
@@ -89,14 +89,12 @@ describe('paywall configuration inter-window communication', () => {
       it('should enable the ethereum provider', done => {
         expect.assertions(1)
 
-        window.web3 = {
-          currentProvider: {
-            enable: jest.fn(() => ({
-              then() {
-                done()
-              },
-            })),
-          },
+        window.ethereum = {
+          enable: jest.fn(() => ({
+            then() {
+              done()
+            },
+          })),
         }
 
         const event = {
@@ -110,23 +108,48 @@ describe('paywall configuration inter-window communication', () => {
 
         listener(event)
 
-        expect(window.web3.currentProvider.enable).toHaveBeenCalled()
+        expect(window.ethereum.enable).toHaveBeenCalled()
       })
 
+      it('should request accounts once enabled', done => {
+        expect.assertions(1)
+
+        window.ethereum = {
+          enable: () => Promise.resolve(),
+          sendAsync: jest.fn(content => {
+            expect(content).toEqual(
+              expect.objectContaining({
+                method: 'eth_accounts',
+                params: [],
+                jsonrpc: '2.0',
+                id: expect.any(Number),
+              })
+            )
+            done()
+          }),
+        }
+
+        const event = {
+          origin: 'origin',
+          source: iframe.contentWindow,
+          data: POST_MESSAGE_READY,
+        }
+        setupReadyListener(window, iframe, 'origin')
+
+        const listener = getListener()
+
+        listener(event)
+      })
       it('should not post anything on error', done => {
         expect.assertions(1)
 
-        window.web3 = {
-          eth: {
-            getAccounts(callbackFunc) {
-              callbackFunc(true, false)
+        window.ethereum = {
+          enable: () => Promise.resolve(),
+          sendAsync: (content, callbackFunc) => {
+            callbackFunc(true, false)
 
-              expect(iframe.contentWindow.postMessage).not.toHaveBeenCalled()
-              done()
-            },
-          },
-          currentProvider: {
-            enable: () => Promise.resolve(),
+            expect(iframe.contentWindow.postMessage).not.toHaveBeenCalled()
+            done()
           },
         }
 
@@ -145,23 +168,19 @@ describe('paywall configuration inter-window communication', () => {
       it('should post the first account retrieved to the parent window', done => {
         expect.assertions(1)
 
-        window.web3 = {
-          eth: {
-            getAccounts(callbackFunc) {
-              callbackFunc(null, { result: ['hi'] })
+        window.ethereum = {
+          enable: () => Promise.resolve(),
+          sendAsync: (content, callbackFunc) => {
+            callbackFunc(null, { result: ['hi'] })
 
-              expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
-                expect.objectContaining({
-                  type: POST_MESSAGE_ACCOUNT,
-                  payload: 'hi',
-                }),
-                'origin'
-              )
-              done()
-            },
-          },
-          currentProvider: {
-            enable: () => Promise.resolve(),
+            expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+              expect.objectContaining({
+                type: POST_MESSAGE_ACCOUNT,
+                payload: 'hi',
+              }),
+              'origin'
+            )
+            done()
           },
         }
 

--- a/paywall/src/__tests__/paywall-builder/config.test.js
+++ b/paywall/src/__tests__/paywall-builder/config.test.js
@@ -116,7 +116,7 @@ describe('paywall configuration inter-window communication', () => {
 
         window.ethereum = {
           enable: () => Promise.resolve(),
-          sendAsync: jest.fn(content => {
+          send: jest.fn(content => {
             expect(content).toEqual(
               expect.objectContaining({
                 method: 'eth_accounts',
@@ -145,7 +145,7 @@ describe('paywall configuration inter-window communication', () => {
 
         window.ethereum = {
           enable: () => Promise.resolve(),
-          sendAsync: (content, callbackFunc) => {
+          send: (content, callbackFunc) => {
             callbackFunc(true, false)
 
             expect(iframe.contentWindow.postMessage).not.toHaveBeenCalled()
@@ -170,7 +170,7 @@ describe('paywall configuration inter-window communication', () => {
 
         window.ethereum = {
           enable: () => Promise.resolve(),
-          sendAsync: (content, callbackFunc) => {
+          send: (content, callbackFunc) => {
             callbackFunc(null, { result: ['hi'] })
 
             expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(

--- a/paywall/src/__tests__/paywall-builder/config.test.js
+++ b/paywall/src/__tests__/paywall-builder/config.test.js
@@ -2,6 +2,7 @@ import { sendConfig, setupReadyListener } from '../../paywall-builder/config'
 import {
   POST_MESSAGE_CONFIG,
   POST_MESSAGE_READY,
+  POST_MESSAGE_ACCOUNT,
 } from '../../paywall-builder/constants'
 
 describe('paywall configuration inter-window communication', () => {
@@ -82,6 +83,118 @@ describe('paywall configuration inter-window communication', () => {
         }),
         'origin'
       )
+    })
+
+    describe('sending ethereum account', () => {
+      it('should enable the ethereum provider', done => {
+        expect.assertions(1)
+
+        window.ethereum = {
+          enable: jest.fn(() => ({
+            then() {
+              done()
+            },
+          })),
+        }
+
+        const event = {
+          origin: 'origin',
+          source: iframe.contentWindow,
+          data: POST_MESSAGE_READY,
+        }
+        setupReadyListener(window, iframe, 'origin')
+
+        const listener = getListener()
+
+        listener(event)
+
+        expect(window.ethereum.enable).toHaveBeenCalled()
+      })
+
+      it('should request accounts once enabled', done => {
+        expect.assertions(1)
+
+        window.ethereum = {
+          enable: () => Promise.resolve(),
+          sendAsync: jest.fn(content => {
+            expect(content).toEqual(
+              expect.objectContaining({
+                method: 'eth_accounts',
+                params: [],
+                jsonrpc: '2.0',
+                id: expect.any(Number),
+              })
+            )
+            done()
+          }),
+        }
+
+        const event = {
+          origin: 'origin',
+          source: iframe.contentWindow,
+          data: POST_MESSAGE_READY,
+        }
+        setupReadyListener(window, iframe, 'origin')
+
+        const listener = getListener()
+
+        listener(event)
+      })
+      it('should not post anything on error', done => {
+        expect.assertions(1)
+
+        window.ethereum = {
+          enable: () => Promise.resolve(),
+          sendAsync: (content, callbackFunc) => {
+            callbackFunc(true, false)
+
+            expect(iframe.contentWindow.postMessage).not.toHaveBeenCalled()
+            done()
+          },
+        }
+
+        const event = {
+          origin: 'origin',
+          source: iframe.contentWindow,
+          data: POST_MESSAGE_READY,
+        }
+        setupReadyListener(window, iframe, 'origin')
+
+        const listener = getListener()
+
+        listener(event)
+      })
+
+      it('should post the first account retrieved to the parent window', done => {
+        expect.assertions(1)
+
+        window.ethereum = {
+          enable: () => Promise.resolve(),
+          sendAsync: (content, callbackFunc) => {
+            callbackFunc(null, { result: ['hi'] })
+
+            expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+              expect.objectContaining({
+                type: POST_MESSAGE_ACCOUNT,
+                payload: 'hi',
+              }),
+              'origin'
+            )
+            done()
+          },
+        }
+
+        const event = {
+          origin: 'origin',
+          source: iframe.contentWindow,
+          data: POST_MESSAGE_READY,
+        }
+        setupReadyListener(window, iframe, 'origin')
+
+        const listener = getListener()
+
+        listener(event)
+      })
     })
 
     describe('failures', () => {

--- a/paywall/src/__tests__/paywall-builder/config.test.js
+++ b/paywall/src/__tests__/paywall-builder/config.test.js
@@ -52,6 +52,7 @@ describe('paywall configuration inter-window communication', () => {
     }
     beforeEach(() => {
       window = {
+        Promise: global.Promise,
         addEventListener: jest.fn(),
       }
       iframe = {

--- a/paywall/src/components/Paywall.js
+++ b/paywall/src/components/Paywall.js
@@ -64,9 +64,9 @@ export function Paywall({
     body.className = 'big'
   }
   useEffect(() => {
-    if (fullAccount && fullAccount.fromLocalStorage) {
+    if (!fullAccount || fullAccount.fromLocalStorage) {
       if (mainWindowAccount) {
-        if (mainWindowAccount !== fullAccount.address) {
+        if (!fullAccount || mainWindowAccount !== fullAccount.address) {
           setAccount({
             address: mainWindowAccount,
             fromLocalStorage: true,

--- a/paywall/src/paywall-builder/config.js
+++ b/paywall/src/paywall-builder/config.js
@@ -17,13 +17,22 @@ export function sendConfig(config, iframe, origin) {
 }
 
 function getAccount(window, iframe, origin) {
-  window.web3.eth.getAccounts((error, result) => {
-    if (error) return
-    iframe.contentWindow.postMessage(
-      { type: POST_MESSAGE_ACCOUNT, payload: result.result[0] },
-      origin
-    )
-  })
+  const id = new Date().getTime()
+  window.ethereum.sendAsync(
+    {
+      method: 'eth_accounts',
+      params: [],
+      jsonrpc: '2.0',
+      id,
+    },
+    (error, result) => {
+      if (error) return
+      iframe.contentWindow.postMessage(
+        { type: POST_MESSAGE_ACCOUNT, payload: result.result[0] },
+        origin
+      )
+    }
+  )
 }
 // this listens for the "ready" message from the iframe
 export function setupReadyListener(window, iframe, origin) {
@@ -39,9 +48,9 @@ export function setupReadyListener(window, iframe, origin) {
       // <script type="text/javascript">window.unlockConfig = {...}</script>
       // immediately before paywall.min.js is loaded
       sendConfig(window.unlockConfig, iframe, origin)
-      if (window.web3) {
-        if (window.web3.currentProvider && window.web3.currentProvider.enable) {
-          window.web3.currentProvider.enable().then(() => {
+      if (window.ethereum) {
+        if (window.ethereum.enable) {
+          window.ethereum.enable().then(() => {
             getAccount(window, iframe, origin)
           })
         } else {

--- a/paywall/src/paywall-builder/config.js
+++ b/paywall/src/paywall-builder/config.js
@@ -17,7 +17,7 @@ export function sendConfig(config, iframe, origin) {
 }
 
 function enable(window) {
-  return new Promise((resolve, reject) => {
+  return new window.Promise((resolve, reject) => {
     if (!window.web3 || !window.web3.currentProvider) return reject()
     if (!window.web3.currentProvider.enable) return resolve()
     window.web3.currentProvider.enable().then(resolve)

--- a/paywall/src/paywall-builder/config.js
+++ b/paywall/src/paywall-builder/config.js
@@ -18,7 +18,7 @@ export function sendConfig(config, iframe, origin) {
 
 function getAccount(window, iframe, origin) {
   const id = new Date().getTime()
-  window.ethereum.sendAsync(
+  window.ethereum.send(
     {
       method: 'eth_accounts',
       params: [],

--- a/paywall/src/paywall-builder/config.js
+++ b/paywall/src/paywall-builder/config.js
@@ -16,6 +16,14 @@ export function sendConfig(config, iframe, origin) {
   )
 }
 
+function enable(window) {
+  return new Promise((resolve, reject) => {
+    if (!window.web3 || !window.web3.currentProvider) return reject()
+    if (!window.web3.currentProvider.enable) return resolve()
+    window.web3.currentProvider.enable().then(resolve)
+  })
+}
+
 function getAccount(window, iframe, origin) {
   const id = new Date().getTime()
   window.web3.currentProvider.send(
@@ -48,15 +56,9 @@ export function setupReadyListener(window, iframe, origin) {
       // <script type="text/javascript">window.unlockConfig = {...}</script>
       // immediately before paywall.min.js is loaded
       sendConfig(window.unlockConfig, iframe, origin)
-      if (window.web3 && window.web3.currentProvider) {
-        if (window.web3.currentProvider.enable) {
-          window.web3.currentProvider.enable().then(() => {
-            getAccount(window, iframe, origin)
-          })
-        } else {
-          getAccount(window, iframe, origin)
-        }
-      }
+      enable(window)
+        .then(() => getAccount(window, iframe, origin))
+        .catch(() => {}) // no web3, don't retrieve account
     }
   })
 }

--- a/paywall/src/paywall-builder/config.js
+++ b/paywall/src/paywall-builder/config.js
@@ -17,22 +17,13 @@ export function sendConfig(config, iframe, origin) {
 }
 
 function getAccount(window, iframe, origin) {
-  const id = new Date().getTime()
-  window.ethereum.sendAsync(
-    {
-      method: 'eth_accounts',
-      params: [],
-      jsonrpc: '2.0',
-      id,
-    },
-    (error, result) => {
-      if (error) return
-      iframe.contentWindow.postMessage(
-        { type: POST_MESSAGE_ACCOUNT, payload: result.result[0] },
-        origin
-      )
-    }
-  )
+  window.web3.eth.getAccounts((error, result) => {
+    if (error) return
+    iframe.contentWindow.postMessage(
+      { type: POST_MESSAGE_ACCOUNT, payload: result.result[0] },
+      origin
+    )
+  })
 }
 // this listens for the "ready" message from the iframe
 export function setupReadyListener(window, iframe, origin) {
@@ -48,9 +39,9 @@ export function setupReadyListener(window, iframe, origin) {
       // <script type="text/javascript">window.unlockConfig = {...}</script>
       // immediately before paywall.min.js is loaded
       sendConfig(window.unlockConfig, iframe, origin)
-      if (window.ethereum) {
-        if (window.ethereum.enable) {
-          window.ethereum.enable().then(() => {
+      if (window.web3) {
+        if (window.web3.currentProvider && window.web3.currentProvider.enable) {
+          window.web3.currentProvider.enable().then(() => {
             getAccount(window, iframe, origin)
           })
         } else {

--- a/paywall/src/paywall-builder/config.js
+++ b/paywall/src/paywall-builder/config.js
@@ -1,4 +1,8 @@
-import { POST_MESSAGE_READY, POST_MESSAGE_CONFIG } from './constants'
+import {
+  POST_MESSAGE_READY,
+  POST_MESSAGE_CONFIG,
+  POST_MESSAGE_ACCOUNT,
+} from './constants'
 
 export function sendConfig(config, iframe, origin) {
   const payload = config
@@ -26,6 +30,26 @@ export function setupReadyListener(window, iframe, origin) {
       // <script type="text/javascript">window.unlockConfig = {...}</script>
       // immediately before paywall.min.js is loaded
       sendConfig(window.unlockConfig, iframe, origin)
+      if (window.ethereum) {
+        window.ethereum.enable().then(() => {
+          const id = new Date().getTime()
+          window.ethereum.sendAsync(
+            {
+              method: 'eth_accounts',
+              params: [],
+              jsonrpc: '2.0',
+              id,
+            },
+            (error, result) => {
+              if (error) return
+              iframe.contentWindow.postMessage(
+                { type: POST_MESSAGE_ACCOUNT, payload: result.result[0] },
+                origin
+              )
+            }
+          )
+        })
+      }
     }
   })
 }

--- a/paywall/src/paywall-builder/config.js
+++ b/paywall/src/paywall-builder/config.js
@@ -18,7 +18,7 @@ export function sendConfig(config, iframe, origin) {
 
 function getAccount(window, iframe, origin) {
   const id = new Date().getTime()
-  window.ethereum.send(
+  window.web3.currentProvider.send(
     {
       method: 'eth_accounts',
       params: [],
@@ -48,9 +48,9 @@ export function setupReadyListener(window, iframe, origin) {
       // <script type="text/javascript">window.unlockConfig = {...}</script>
       // immediately before paywall.min.js is loaded
       sendConfig(window.unlockConfig, iframe, origin)
-      if (window.ethereum) {
-        if (window.ethereum.enable) {
-          window.ethereum.enable().then(() => {
+      if (window.web3 && window.web3.currentProvider) {
+        if (window.web3.currentProvider.enable) {
+          window.web3.currentProvider.enable().then(() => {
             getAccount(window, iframe, origin)
           })
         } else {


### PR DESCRIPTION
# Description

Sending the current account will allow the iframe to look at its account saved in localStorage and change it if it is stale.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2902

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
