### PR TITLE
listen for SET_ACCOUNT from main window

### DIFF
--- a/paywall/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/interWindowCommunicationMiddleware.test.js
@@ -42,6 +42,62 @@ describe('interWindowCommunicationMiddleware', () => {
           window.top = {}
         })
 
+        describe('an account is passed in via postMessage to the main window', () => {
+          beforeEach(() => {
+            state = {
+              account: {
+                address: 'mine',
+                fromLocalStorage: true,
+              },
+              router: {
+                location: {
+                  pathname: `/${lock}`,
+                  hash: '',
+                },
+              },
+            }
+            store.dispatch = jest.fn()
+            window = {
+              localStorage: {
+                setItem: jest.fn(),
+                getItem: jest.fn(() => null),
+              },
+            }
+            window.self = window
+            window.top = {}
+          })
+          it('account is the same as what we have', () => {
+            expect.assertions(1)
+
+            const middleware = interWindowCommunicationMiddleware(window)
+            middleware(store)(() => {})(
+              setAccount({
+                address: 'mine',
+                fromLocalStorage: true,
+                fromMainWindow: true,
+              })
+            )
+
+            expect(window.localStorage.setItem).not.toHaveBeenCalled()
+          })
+          it('account is different from what we have', () => {
+            expect.assertions(1)
+
+            const middleware = interWindowCommunicationMiddleware(window)
+            middleware(store)(() => {})(
+              setAccount({
+                address: 'theirs',
+                fromLocalStorage: true,
+                fromMainWindow: true,
+              })
+            )
+
+            expect(window.localStorage.setItem).toHaveBeenCalledWith(
+              '__unlock__account__',
+              'theirs'
+            )
+          })
+        })
         describe('a transaction is passed in the URL hash', () => {
           beforeEach(() => {
             state = {


### PR DESCRIPTION
# Description

In a subsequent PR, when the ethereum account is posted from the main window, it will dispatch `SET_ACCOUNT` with the value. It will only dispatch if the address is different, but this PR also contains a fail-safe on its side, and won't update localStorage unless the account is actually different.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2902

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
