### PR TITLE
Remove duplicate stories for LockIconBar

### DIFF
--- a/unlock-app/src/stories/creator/LockIconBar.stories.js
+++ b/unlock-app/src/stories/creator/LockIconBar.stories.js
@@ -236,54 +236,6 @@ storiesOf('LockIconBar', module)
   })
   .add('LockIconBar, mined withdrawal transaction', () => {
     const lock = {
-      address: '0xminedPriceChange',
-    }
-    return (
-      <LockIconBar
-        lock={lock}
-        toggleCode={action('toggleCode')}
-        edit={action('edit')}
-      />
-    )
-  })
-  .add('LockIconBar, pending withdrawal transaction', () => {
-    const lock = {
-      address: '0xpendingWithdrawalLock',
-    }
-    return (
-      <LockIconBar
-        lock={lock}
-        toggleCode={action('toggleCode')}
-        edit={action('edit')}
-      />
-    )
-  })
-  .add('LockIconBar, submitted withdrawal transaction', () => {
-    const lock = {
-      address: '0xsubmittedWithdrawalLock',
-    }
-    return (
-      <LockIconBar
-        lock={lock}
-        toggleCode={action('toggleCode')}
-        edit={action('edit')}
-      />
-    )
-  })
-  .add('LockIconBar, confirming withdrawal transaction', () => {
-    const lock = {
-      address: '0xconfirmingWithdrawalLock',
-    }
-    return (
-      <LockIconBar
-        lock={lock}
-        toggleCode={action('toggleCode')}
-        edit={action('edit')}
-      />
-    )
-  })
-  .add('LockIconBar, mined withdrawal transaction', () => {
-    const lock = {
       address: '0xminedWithdrawal',
     }
     return (


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
While working on another PR I noticed that Storybook threw some warnings about duplicate story IDs. Looks like there was a copy/paste error in some early refactoring that led to these dupes, which I have removed in this PR.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
