### PR TITLE
Tell Netlify where the keyChain is

### DIFF
--- a/unlock-app/src/static/_redirects
+++ b/unlock-app/src/static/_redirects
@@ -3,3 +3,4 @@
 
 /demo/* /demo 200
 /paywall/* /paywall 200
+/keyChain/* /keyChain 200


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
In order to actually visit the keyChain page on staging, we need to let Netlify know where it is. I believe this change should handle that (of course I will check on the draft URL before merging).

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
