### PR TITLE
add new nock helpers, prepare for ethers migration

### DIFF
--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -2,12 +2,14 @@
 import nock from 'nock'
 
 export class NockHelper {
-  constructor(endpoint, debug = false) {
+  constructor(endpoint, debug = false, isEthers = false) {
     this.nockScope = nock(endpoint, { encodedQueryParams: true })
 
+    this.anyRequestSetUp = false
     this.debug = debug
-    this._rpcRequestId = 0
+    this._rpcRequestId = isEthers ? 42 : 0
     this._noMatches = []
+    this._isEthers = isEthers
 
     // In order to monitor traffic without intercepting it (so that mocks can be built). uncomment the line below
     // nock.recorder.rec()
@@ -15,6 +17,19 @@ export class NockHelper {
     nock.emitter.on('no match', (clientRequestObject, options, body) => {
       this._noMatches.push(body)
       if (debug) {
+        if (!this.anyRequestSetUp) {
+          console.log(
+            new Error('No mocks have been set up, but a request was made!')
+          )
+        }
+        if (!body) {
+          console.log(
+            new Error(
+              'no body? (is there a jest.fakeTimers call? you must reset mocks' +
+                ', see https://github.com/sapegin/jest-cheat-sheet#clearing-and-restoring-mocks'
+            )
+          )
+        }
         console.log(`NO HTTP MOCK EXISTS FOR THAT REQUEST\n${body}`)
       }
     })
@@ -37,31 +52,61 @@ export class NockHelper {
     this._noMatches = []
   }
 
+  resolveWhenAllNocksUsed() {
+    return new Promise((resolve, reject) => {
+      let counter = 0
+      setTimeout(() => {
+        if (nock.isDone()) {
+          resolve()
+        }
+        if (counter++ > 100) {
+          try {
+            this.ensureAllNocksUsed()
+          } catch (e) {
+            reject(e)
+          }
+        }
+      }, 10)
+    })
+  }
+
+  getUnusedNocks() {
+    if (nock.isDone()) return []
+    const unused = Object.values(this.nockScope.keyedInterceptors).map(
+      interceptors =>
+        interceptors
+          .map(interceptor => {
+            return (
+              interceptor.interceptionCounter === 0 && {
+                api: interceptor._requestBody,
+                reply: interceptor.body,
+              }
+            )
+          })
+          .filter(a => a)
+    )
+    unused.sort((a, b) => {
+      return a.api.id < b.api.id ? -1 : 1
+    })
+    return unused[0]
+  }
+
+  displayUnusedNocks() {
+    const unused = this.getUnusedNocks()
+    console.log(`${unused.length} Unused nocks:`)
+    unused.forEach(info => {
+      console.log('API call', info.api)
+      console.log('return', info.reply)
+    })
+  }
+
+  nockCount() {
+    console.log(`${this.getUnusedNocks().length} Unused nocks`)
+  }
+
   ensureAllNocksUsed() {
     if (!nock.isDone()) {
-      const unused = Object.values(this.nockScope.keyedInterceptors).map(
-        interceptors =>
-          interceptors
-            .map(interceptor => {
-              return (
-                interceptor.interceptionCounter === 0 && {
-                  api: interceptor._requestBody,
-                  reply: interceptor.body,
-                }
-              )
-            })
-            .filter(a => a)
-      )
-      unused.sort((a, b) => {
-        return a.api.id < b.api.id ? -1 : 1
-      })
-      console.log('Unused nocks:')
-      unused.forEach(infos => {
-        infos.forEach(info => {
-          console.log('API call', info.api)
-          console.log('return', info.reply)
-        })
-      })
+      this.displayUnusedNocks()
       throw new Error('Not all JSON-RPC call mocks were used!')
     }
     if (this._noMatches.length) {
@@ -71,7 +116,8 @@ export class NockHelper {
 
   // Generic call
   _jsonRpcRequest(method, params, result, error) {
-    this._rpcRequestId += 1
+    this.anyRequestSetUp = true // detect http calls made before any mocks setup
+    if (!this._isEthers) this._rpcRequestId += 1 // web3 only, ethers uses 42
     const cb = (...args) => this.logNock(args)
     return this.nockScope
       .post('/', { jsonrpc: '2.0', id: this._rpcRequestId, method, params })
@@ -155,12 +201,16 @@ export class NockHelper {
       [
         {
           ...transaction,
-          gasPrice,
+          ...(gasPrice ? { gasPrice } : {}),
         },
       ],
       result,
       error
     )
+  }
+
+  personalSignAndYield(hash, account, result, error) {
+    return this._jsonRpcRequest('personal_sign', [hash, account], result, error)
   }
 }
 


### PR DESCRIPTION
# Description

This pulls in `nockHelper` from the ethers migration branch. It also provides a flexibility. A test file may opt in to ether.js behavior (all JSON-RPC requests have ID 42, apparently he's a Douglas Adams fan), or web3 behavior, which is monotonically incrementing JSON-RPC id.

It updates `sendTransactionAndYield` to support ethers-style transactions, which do not include a gas price, but do include a gas limit.

It also adds a good deal of debugging helpers, and a nock call for `personal_sign`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
