### PR TITLE
implement ethers-ready versions of unlockService

### DIFF
--- a/unlock-js/src/__tests__/unlockService.ethers.test..js
+++ b/unlock-js/src/__tests__/unlockService.ethers.test..js
@@ -26,12 +26,12 @@ describe('UnlockService', () => {
   describe('ethers_unlockContractAbiVersion', () => {
     it('should return the v2 implementation when the opCode matches', async () => {
       expect.assertions(3)
-      unlockService.ethers_getVersionFromContract = jest.fn(() => {
+      unlockService._ethers_getVersionFromContract = jest.fn(() => {
         return Promise.resolve(2)
       })
       const version = await unlockService.ethers_unlockContractAbiVersion()
 
-      expect(unlockService.ethers_getVersionFromContract).toHaveBeenCalledWith(
+      expect(unlockService._ethers_getVersionFromContract).toHaveBeenCalledWith(
         unlockAddress
       )
       expect(version).toEqual(v02)
@@ -40,13 +40,13 @@ describe('UnlockService', () => {
 
     it('should return v0 by default', async () => {
       expect.assertions(3)
-      unlockService.ethers_getVersionFromContract = jest.fn(() => {
+      unlockService._ethers_getVersionFromContract = jest.fn(() => {
         return Promise.resolve(0)
       })
 
       const version = await unlockService.ethers_unlockContractAbiVersion()
 
-      expect(unlockService.ethers_getVersionFromContract).toHaveBeenCalledWith(
+      expect(unlockService._ethers_getVersionFromContract).toHaveBeenCalledWith(
         unlockAddress
       )
       expect(version).toEqual(v0)
@@ -55,10 +55,12 @@ describe('UnlockService', () => {
 
     it('should used the memoized the result', async () => {
       expect.assertions(2)
-      unlockService.ethers_getVersionFromContract = jest.fn(() => {})
+      unlockService._ethers_getVersionFromContract = jest.fn(() => {})
       unlockService.ethers_versionForAddress[unlockAddress] = 2
       const version = await unlockService.ethers_unlockContractAbiVersion()
-      expect(unlockService.ethers_getVersionFromContract).not.toHaveBeenCalled()
+      expect(
+        unlockService._ethers_getVersionFromContract
+      ).not.toHaveBeenCalled()
       expect(version).toEqual(v02)
     })
   })
@@ -66,7 +68,7 @@ describe('UnlockService', () => {
   describe('lockContractAbiVersion', () => {
     it('should return UnlockV0 when the version matches', async () => {
       expect.assertions(3)
-      unlockService.ethers_getPublicLockVersionFromContract = jest.fn(() => {
+      unlockService._ethers_getPublicLockVersionFromContract = jest.fn(() => {
         return Promise.resolve(0)
       })
 
@@ -74,7 +76,7 @@ describe('UnlockService', () => {
       const version = await unlockService.ethers_lockContractAbiVersion(address)
 
       expect(
-        unlockService.ethers_getPublicLockVersionFromContract
+        unlockService._ethers_getPublicLockVersionFromContract
       ).toHaveBeenCalledWith(address)
       expect(version).toEqual(v0)
       expect(unlockService.ethers_versionForAddress[address]).toEqual(0)
@@ -82,7 +84,7 @@ describe('UnlockService', () => {
 
     it('should return UnlockV01 when the version matches', async () => {
       expect.assertions(3)
-      unlockService.ethers_getPublicLockVersionFromContract = jest.fn(() => {
+      unlockService._ethers_getPublicLockVersionFromContract = jest.fn(() => {
         return Promise.resolve(1) // See code for explaination
       })
 
@@ -90,7 +92,7 @@ describe('UnlockService', () => {
       const version = await unlockService.ethers_lockContractAbiVersion(address)
 
       expect(
-        unlockService.ethers_getPublicLockVersionFromContract
+        unlockService._ethers_getPublicLockVersionFromContract
       ).toHaveBeenCalledWith(address)
       expect(version).toEqual(v02)
       expect(unlockService.ethers_versionForAddress[address]).toEqual(1)
@@ -98,14 +100,14 @@ describe('UnlockService', () => {
 
     it('should memoize the result', async () => {
       expect.assertions(3)
-      unlockService.ethers_getPublicLockVersionFromContract = jest.fn(() => {})
+      unlockService._ethers_getPublicLockVersionFromContract = jest.fn(() => {})
 
       const address = '0xabc'
       unlockService.ethers_versionForAddress[address] = 1
       const version = await unlockService.ethers_lockContractAbiVersion(address)
 
       expect(
-        unlockService.ethers_getPublicLockVersionFromContract
+        unlockService._ethers_getPublicLockVersionFromContract
       ).not.toHaveBeenCalled()
       expect(version).toEqual(v02)
       expect(unlockService.ethers_versionForAddress[address]).toEqual(1)

--- a/unlock-js/src/__tests__/unlockService.ethers.test..js
+++ b/unlock-js/src/__tests__/unlockService.ethers.test..js
@@ -1,0 +1,114 @@
+/* eslint no-console: 0 */
+
+import { providers as ethersProviders } from 'ethers'
+
+import UnlockService from '../unlockService'
+import NockHelper from './helpers/nockHelper'
+import v0 from '../v0'
+import v02 from '../v02'
+
+const endpoint = 'http://127.0.0.1:8545'
+const nock = new NockHelper(endpoint, false /** debug */)
+
+// This unlock address smart contract is fake
+let unlockAddress = '0x885ef47c3439ade0cb9b33a4d3c534c99964db93'
+let unlockService
+
+describe('UnlockService', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+    unlockService = new UnlockService({
+      unlockAddress,
+    })
+    unlockService.provider = new ethersProviders.JsonRpcProvider(endpoint)
+  })
+
+  describe('ethers_unlockContractAbiVersion', () => {
+    it('should return the v2 implementation when the opCode matches', async () => {
+      expect.assertions(3)
+      unlockService.ethers_getVersionFromContract = jest.fn(() => {
+        return Promise.resolve(2)
+      })
+      const version = await unlockService.ethers_unlockContractAbiVersion()
+
+      expect(unlockService.ethers_getVersionFromContract).toHaveBeenCalledWith(
+        unlockAddress
+      )
+      expect(version).toEqual(v02)
+      expect(unlockService.ethers_versionForAddress[unlockAddress]).toEqual(2)
+    })
+
+    it('should return v0 by default', async () => {
+      expect.assertions(3)
+      unlockService.ethers_getVersionFromContract = jest.fn(() => {
+        return Promise.resolve(0)
+      })
+
+      const version = await unlockService.ethers_unlockContractAbiVersion()
+
+      expect(unlockService.ethers_getVersionFromContract).toHaveBeenCalledWith(
+        unlockAddress
+      )
+      expect(version).toEqual(v0)
+      expect(unlockService.ethers_versionForAddress[unlockAddress]).toEqual(0)
+    })
+
+    it('should used the memoized the result', async () => {
+      expect.assertions(2)
+      unlockService.ethers_getVersionFromContract = jest.fn(() => {})
+      unlockService.ethers_versionForAddress[unlockAddress] = 2
+      const version = await unlockService.ethers_unlockContractAbiVersion()
+      expect(unlockService.ethers_getVersionFromContract).not.toHaveBeenCalled()
+      expect(version).toEqual(v02)
+    })
+  })
+
+  describe('lockContractAbiVersion', () => {
+    it('should return UnlockV0 when the version matches', async () => {
+      expect.assertions(3)
+      unlockService.ethers_getPublicLockVersionFromContract = jest.fn(() => {
+        return Promise.resolve(0)
+      })
+
+      const address = '0xabc'
+      const version = await unlockService.ethers_lockContractAbiVersion(address)
+
+      expect(
+        unlockService.ethers_getPublicLockVersionFromContract
+      ).toHaveBeenCalledWith(address)
+      expect(version).toEqual(v0)
+      expect(unlockService.ethers_versionForAddress[address]).toEqual(0)
+    })
+
+    it('should return UnlockV01 when the version matches', async () => {
+      expect.assertions(3)
+      unlockService.ethers_getPublicLockVersionFromContract = jest.fn(() => {
+        return Promise.resolve(1) // See code for explaination
+      })
+
+      const address = '0xabc'
+      const version = await unlockService.ethers_lockContractAbiVersion(address)
+
+      expect(
+        unlockService.ethers_getPublicLockVersionFromContract
+      ).toHaveBeenCalledWith(address)
+      expect(version).toEqual(v02)
+      expect(unlockService.ethers_versionForAddress[address]).toEqual(1)
+    })
+
+    it('should memoize the result', async () => {
+      expect.assertions(3)
+      unlockService.ethers_getPublicLockVersionFromContract = jest.fn(() => {})
+
+      const address = '0xabc'
+      unlockService.ethers_versionForAddress[address] = 1
+      const version = await unlockService.ethers_lockContractAbiVersion(address)
+
+      expect(
+        unlockService.ethers_getPublicLockVersionFromContract
+      ).not.toHaveBeenCalled()
+      expect(version).toEqual(v02)
+      expect(unlockService.ethers_versionForAddress[address]).toEqual(1)
+    })
+  })
+})

--- a/unlock-js/src/__tests__/unlockService.ethers.test..js
+++ b/unlock-js/src/__tests__/unlockService.ethers.test..js
@@ -1,31 +1,110 @@
 /* eslint no-console: 0 */
 
-import { providers as ethersProviders } from 'ethers'
+import { providers as ethersProviders, ethers } from 'ethers'
 
-import UnlockService from '../unlockService'
+import UnlockService, { Errors } from '../unlockService'
 import NockHelper from './helpers/nockHelper'
 import v0 from '../v0'
+import v01 from '../v01'
 import v02 from '../v02'
 
 const endpoint = 'http://127.0.0.1:8545'
-const nock = new NockHelper(endpoint, false /** debug */)
+const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
 
 // This unlock address smart contract is fake
 let unlockAddress = '0x885ef47c3439ade0cb9b33a4d3c534c99964db93'
 let unlockService
 
 describe('UnlockService', () => {
-  beforeEach(() => {
+  async function nockBeforeEach() {
     nock.cleanAll()
+    nock.netVersionAndYield(0)
+
     unlockService = new UnlockService({
       unlockAddress,
     })
     unlockService.provider = new ethersProviders.JsonRpcProvider(endpoint)
+    await nock.resolveWhenAllNocksUsed()
+  }
+
+  describe('errors', () => {
+    it('ethers_unlockContractAbiVersion throws if provider is not set', async () => {
+      expect.assertions(1)
+      await nockBeforeEach()
+      unlockService.provider = null
+
+      try {
+        await unlockService.ethers_unlockContractAbiVersion()
+      } catch (e) {
+        expect(e.message).toBe(Errors.MISSING_WEB3)
+      }
+    })
+
+    it('ethers_lockContractAbiVersion throws if provider is not set', async () => {
+      expect.assertions(1)
+      await nockBeforeEach()
+      unlockService.provider = null
+
+      try {
+        await unlockService.ethers_lockContractAbiVersion(1)
+      } catch (e) {
+        expect(e.message).toBe(Errors.MISSING_WEB3)
+      }
+    })
+  })
+
+  describe('_ethers_getPublicLockVersionFromContract', () => {
+    it('calls publicLockVersion', async () => {
+      expect.assertions(1)
+      await nockBeforeEach()
+      const metadata = new ethers.utils.Interface(v02.PublicLock.abi)
+      const coder = ethers.utils.defaultAbiCoder
+
+      nock.ethGetCodeAndYield(unlockAddress, v02.PublicLock.deployedBytecode)
+      nock.ethCallAndYield(
+        metadata.functions['publicLockVersion()'].encode([]),
+        ethers.utils.getAddress(unlockAddress),
+        coder.encode(['uint256'], [ethers.utils.bigNumberify(1)])
+      )
+
+      const result = await unlockService._ethers_getPublicLockVersionFromContract(
+        unlockAddress
+      )
+
+      // this test fails if the call does not occur
+      await nock.resolveWhenAllNocksUsed()
+      expect(result).toBe(1)
+    })
+  })
+
+  describe('_ethers_getVersionFromContract', () => {
+    it('calls publicLockVersion', async () => {
+      expect.assertions(1)
+      await nockBeforeEach()
+      const metadata = new ethers.utils.Interface(v02.Unlock.abi)
+      const coder = ethers.utils.defaultAbiCoder
+
+      nock.ethGetCodeAndYield(unlockAddress, v02.Unlock.deployedBytecode)
+      nock.ethCallAndYield(
+        metadata.functions['unlockVersion()'].encode([]),
+        ethers.utils.getAddress(unlockAddress),
+        coder.encode(['uint256'], [ethers.utils.bigNumberify(1)])
+      )
+
+      const result = await unlockService._ethers_getVersionFromContract(
+        unlockAddress
+      )
+
+      // this test fails if the call does not occur
+      await nock.resolveWhenAllNocksUsed()
+      expect(result).toBe(1)
+    })
   })
 
   describe('ethers_unlockContractAbiVersion', () => {
     it('should return the v2 implementation when the opCode matches', async () => {
       expect.assertions(3)
+      await nockBeforeEach()
       unlockService._ethers_getVersionFromContract = jest.fn(() => {
         return Promise.resolve(2)
       })
@@ -40,6 +119,7 @@ describe('UnlockService', () => {
 
     it('should return v0 by default', async () => {
       expect.assertions(3)
+      await nockBeforeEach()
       unlockService._ethers_getVersionFromContract = jest.fn(() => {
         return Promise.resolve(0)
       })
@@ -53,8 +133,25 @@ describe('UnlockService', () => {
       expect(unlockService.ethers_versionForAddress[unlockAddress]).toEqual(0)
     })
 
+    it('should return v01 if version is 1', async () => {
+      expect.assertions(3)
+      await nockBeforeEach()
+      unlockService._ethers_getVersionFromContract = jest.fn(() => {
+        return Promise.resolve(1)
+      })
+
+      const version = await unlockService.ethers_unlockContractAbiVersion()
+
+      expect(unlockService._ethers_getVersionFromContract).toHaveBeenCalledWith(
+        unlockAddress
+      )
+      expect(version).toEqual(v01)
+      expect(unlockService.ethers_versionForAddress[unlockAddress]).toEqual(1)
+    })
+
     it('should used the memoized the result', async () => {
       expect.assertions(2)
+      await nockBeforeEach()
       unlockService._ethers_getVersionFromContract = jest.fn(() => {})
       unlockService.ethers_versionForAddress[unlockAddress] = 2
       const version = await unlockService.ethers_unlockContractAbiVersion()
@@ -68,6 +165,7 @@ describe('UnlockService', () => {
   describe('lockContractAbiVersion', () => {
     it('should return UnlockV0 when the version matches', async () => {
       expect.assertions(3)
+      await nockBeforeEach()
       unlockService._ethers_getPublicLockVersionFromContract = jest.fn(() => {
         return Promise.resolve(0)
       })
@@ -84,6 +182,7 @@ describe('UnlockService', () => {
 
     it('should return UnlockV01 when the version matches', async () => {
       expect.assertions(3)
+      await nockBeforeEach()
       unlockService._ethers_getPublicLockVersionFromContract = jest.fn(() => {
         return Promise.resolve(1) // See code for explaination
       })
@@ -100,6 +199,7 @@ describe('UnlockService', () => {
 
     it('should memoize the result', async () => {
       expect.assertions(3)
+      await nockBeforeEach()
       unlockService._ethers_getPublicLockVersionFromContract = jest.fn(() => {})
 
       const address = '0xabc'
@@ -111,6 +211,120 @@ describe('UnlockService', () => {
       ).not.toHaveBeenCalled()
       expect(version).toEqual(v02)
       expect(unlockService.ethers_versionForAddress[address]).toEqual(1)
+    })
+  })
+
+  describe('getContract', () => {
+    it('returns a writable contract if service is writable', async () => {
+      expect.assertions(1)
+      await nockBeforeEach()
+      unlockService.writable = true
+      unlockService.getWritableContract = jest.fn()
+
+      unlockService.getContract('address', 'contract')
+      expect(unlockService.getWritableContract).toHaveBeenCalledWith(
+        'address',
+        'contract'
+      )
+    })
+
+    it('creates a new ethers.Contract', async () => {
+      expect.assertions(3)
+      await nockBeforeEach()
+
+      const fakeContract = {
+        abi: ['booboo(uint256)'],
+      }
+      const contract = await unlockService.getContract(
+        '0x1234567890123456789012345678901234567890',
+        fakeContract
+      )
+      expect(contract).toBeInstanceOf(ethers.Contract)
+      expect(contract.signer).toBeNull()
+      expect(contract.provider).toBe(unlockService.provider)
+    })
+  })
+
+  describe('getWritableContract', () => {
+    it('creates a new writable ethers.Contract', async () => {
+      expect.assertions(3)
+      await nockBeforeEach()
+
+      const fakeContract = {
+        abi: ['booboo(uint256)'],
+      }
+      const contract = await unlockService.getWritableContract(
+        '0x1234567890123456789012345678901234567890',
+        fakeContract
+      )
+      expect(contract).toBeInstanceOf(ethers.Contract)
+      expect(contract.signer).not.toBeNull()
+      expect(contract.provider).toBe(unlockService.provider)
+    })
+  })
+
+  describe('getLockContract', () => {
+    it('returns and memoizes the lock contract', async () => {
+      expect.assertions(3)
+      await nockBeforeEach()
+      const lockAddress = '0x1234567890123456789012345678901234567890'
+
+      unlockService.ethers_lockContractAbiVersion = jest.fn(() => v02)
+
+      const contract = await unlockService.getLockContract(lockAddress)
+
+      expect(unlockService.lockContracts[lockAddress]).toBeInstanceOf(
+        ethers.Contract
+      )
+      expect(contract).toBeInstanceOf(ethers.Contract)
+      expect(contract.interface.abi).toEqual(v02.PublicLock.abi)
+    })
+
+    it('retrieves memoized lock contract', async () => {
+      expect.assertions(2)
+      await nockBeforeEach()
+      const lockAddress = '0x1234567890123456789012345678901234567890'
+
+      unlockService.ethers_lockContractAbiVersion = jest.fn(() => v02)
+      unlockService.lockContracts = {
+        [lockAddress]: 'hi',
+      }
+
+      const contract = await unlockService.getLockContract(lockAddress)
+
+      expect(unlockService.ethers_lockContractAbiVersion).not.toHaveBeenCalled()
+      expect(contract).toBe('hi')
+    })
+  })
+
+  describe('getUnlockContract', () => {
+    it('returns and memoizes the unlock contract', async () => {
+      expect.assertions(3)
+      await nockBeforeEach()
+
+      unlockService.ethers_unlockContractAbiVersion = jest.fn(() => v02)
+
+      const contract = await unlockService.getUnlockContract()
+
+      expect(unlockService.unlockContract).toBeInstanceOf(ethers.Contract)
+      expect(contract).toBeInstanceOf(ethers.Contract)
+      expect(contract.interface.abi).toEqual(v02.Unlock.abi)
+    })
+
+    it('retrieves memoized unlock contract', async () => {
+      expect.assertions(2)
+      await nockBeforeEach()
+
+      unlockService.ethers_unlockContractAbiVersion = jest.fn(() => v02)
+
+      unlockService.unlockContract = 'hi'
+
+      const contract = await unlockService.getUnlockContract()
+
+      expect(
+        unlockService.ethers_unlockContractAbiVersion
+      ).not.toHaveBeenCalled()
+      expect(contract).toBe('hi')
     })
   })
 })

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -161,7 +161,7 @@ export default class UnlockService extends EventEmitter {
     let version = this.ethers_versionForAddress[this.unlockContractAddress]
     if (version === undefined) {
       // This was not memo-ized
-      version = await this.ethers_getVersionFromContract(
+      version = await this._ethers_getVersionFromContract(
         this.unlockContractAddress
       )
       this.ethers_versionForAddress[this.unlockContractAddress] = version
@@ -191,7 +191,7 @@ export default class UnlockService extends EventEmitter {
     let version = this.ethers_versionForAddress[address.toLowerCase()]
     if (version === undefined) {
       // This was not memo-ized
-      version = await this.ethers_getPublicLockVersionFromContract(address)
+      version = await this._ethers_getPublicLockVersionFromContract(address)
       this.ethers_versionForAddress[address.toLowerCase()] = version
     }
 
@@ -205,7 +205,7 @@ export default class UnlockService extends EventEmitter {
     return v0
   }
 
-  async ethers_getPublicLockVersionFromContract(address) {
+  async _ethers_getPublicLockVersionFromContract(address) {
     const contract = new Contract(
       address,
       ['function publicLockVersion() view returns (uint8)'],
@@ -225,7 +225,7 @@ export default class UnlockService extends EventEmitter {
    * Private method, which given an address will query the contract and return the corresponding method
    * @param {*} address
    */
-  async ethers_getVersionFromContract(address) {
+  async _ethers_getVersionFromContract(address) {
     const contract = new Contract(
       address,
       ['function unlockVersion() view returns (uint8)'],

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -257,26 +257,28 @@ export default class UnlockService extends EventEmitter {
   async getLockContract(lockAddress) {
     if (this.lockContracts[lockAddress]) {
       return this.lockContracts[lockAddress]
+    } else {
+      const version = await this.ethers_lockContractAbiVersion(lockAddress)
+      this.lockContracts[lockAddress] = this.getContract(
+        lockAddress,
+        version.PublicLock,
+        this.provider
+      )
+      return this.lockContracts[lockAddress]
     }
-    const version = await this.ethers_lockContractAbiVersion(lockAddress)
-    this.lockContracts[lockAddress] = this.getContract(
-      lockAddress,
-      version.PublicLock,
-      this.provider
-    )
-    return this.lockContracts[lockAddress]
   }
 
   async getUnlockContract() {
     if (this.unlockContract) {
       return this.unlockContract
+    } else {
+      const version = await this.ethers_unlockContractAbiVersion()
+      this.unlockContract = this.getContract(
+        this.unlockContractAddress,
+        version.Unlock,
+        this.provider
+      )
+      return this.unlockContract
     }
-    const version = await this.ethers_unlockContractAbiVersion()
-    this.unlockContract = this.getContract(
-      this.unlockContractAddress,
-      version.Unlock,
-      this.provider
-    )
-    return this.unlockContract
   }
 }

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -1,6 +1,8 @@
 import EventEmitter from 'events'
+import { Contract } from 'ethers'
 
 import v0 from './v0'
+import v01 from './v01'
 import v02 from './v02'
 
 export const Errors = {
@@ -14,13 +16,19 @@ export const Errors = {
  * It is not meant to be instantiated (only subclasses should)
  */
 export default class UnlockService extends EventEmitter {
-  constructor({ unlockAddress }) {
+  constructor({ unlockAddress, writable = false }) {
     super()
+    this.writable = writable
     this.unlockContractAddress = unlockAddress
     this.web3 = null
+    this.provider = null
     /* Memoization for opCode per address */
     // Used to cache
     this.versionForAddress = {}
+    this.ethers_versionForAddress = {}
+    this.unlockContract = null
+    // this will populate on-demand as locks are accessed
+    this.lockContracts = {}
   }
 
   /**
@@ -33,10 +41,14 @@ export default class UnlockService extends EventEmitter {
     }
 
     let version = this.versionForAddress[this.unlockContractAddress]
-    if (!version) {
-      // This was no memo-ized
+    if (version === undefined) {
+      // This was not memo-ized
       version = await this._getVersionFromContract(this.unlockContractAddress)
       this.versionForAddress[this.unlockContractAddress] = version
+    }
+
+    if (1 === version) {
+      return v01
     }
 
     if (2 === version) {
@@ -56,11 +68,11 @@ export default class UnlockService extends EventEmitter {
       throw new Error(Errors.MISSING_WEB3)
     }
 
-    let version = this.versionForAddress[address]
-    if (!version) {
+    let version = this.versionForAddress[address.toLowerCase()]
+    if (version === undefined) {
       // This was not memo-ized
       version = await this._getPublicLockVersionFromContract(address)
-      this.versionForAddress[address] = version
+      this.versionForAddress[address.toLowerCase()] = version
     }
 
     // NOTE: we (julien) F'ed up the deploy on the PublicLock and v02 still uses 1 for its version.
@@ -135,5 +147,133 @@ export default class UnlockService extends EventEmitter {
       // This is an older version of Unlock which did not support unlockVersion
     }
     return version
+  }
+
+  /**
+   * Returns the implementation based on the deployed version
+   * @param {*} address
+   */
+  async ethers_unlockContractAbiVersion() {
+    if (!this.provider) {
+      throw new Error(Errors.MISSING_WEB3)
+    }
+
+    let version = this.ethers_versionForAddress[this.unlockContractAddress]
+    if (version === undefined) {
+      // This was not memo-ized
+      version = await this.ethers_getVersionFromContract(
+        this.unlockContractAddress
+      )
+      this.ethers_versionForAddress[this.unlockContractAddress] = version
+    }
+
+    if (1 === version) {
+      return v01
+    }
+
+    if (2 === version) {
+      return v02
+    }
+
+    // Defaults to v0
+    return v0
+  }
+
+  /**
+   * Returns the ABI for the Lock contract deployed at the provided address
+   * @param {*} address
+   */
+  async ethers_lockContractAbiVersion(address) {
+    if (!this.provider) {
+      throw new Error(Errors.MISSING_WEB3)
+    }
+
+    let version = this.ethers_versionForAddress[address.toLowerCase()]
+    if (version === undefined) {
+      // This was not memo-ized
+      version = await this.ethers_getPublicLockVersionFromContract(address)
+      this.ethers_versionForAddress[address.toLowerCase()] = version
+    }
+
+    // NOTE: we (julien) F'ed up the deploy on the PublicLock and v02 still uses 1 for its version.
+    // The good news (luck) is that no contract was ever deployed as v01
+    if (1 === version) {
+      return v02
+    }
+
+    // Defaults to v0
+    return v0
+  }
+
+  async ethers_getPublicLockVersionFromContract(address) {
+    const contract = new Contract(
+      address,
+      ['function publicLockVersion() view returns (uint8)'],
+      this.provider
+    )
+    let version = 0
+    try {
+      const contractVersion = await contract.publicLockVersion()
+      version = parseInt(contractVersion, 10) || 0
+    } catch (error) {
+      // This is an older version of Unlock which did not support publicLockVersion
+    }
+    return version
+  }
+
+  /**
+   * Private method, which given an address will query the contract and return the corresponding method
+   * @param {*} address
+   */
+  async ethers_getVersionFromContract(address) {
+    const contract = new Contract(
+      address,
+      ['function unlockVersion() view returns (uint8)'],
+      this.provider
+    )
+    let version = 0
+    try {
+      const contractVersion = await contract.unlockVersion()
+      version = parseInt(contractVersion, 10) || 0
+    } catch (error) {
+      // This is an older version of Unlock which did not support unlockVersion
+    }
+    return version
+  }
+
+  getContract(address, contract) {
+    if (this.writable) return this.getWritableContract(address, contract)
+    return new Contract(address, contract.abi, this.provider)
+  }
+
+  async getWritableContract(address, contract) {
+    const signer = this.provider.getSigner()
+    return new Contract(address, contract.abi, signer)
+  }
+
+  async getLockContract(lockAddress) {
+    if (this.lockContracts[lockAddress]) {
+      return this.lockContracts[lockAddress]
+    }
+    const version = await this.lockContractAbiVersion(lockAddress)
+    this.lockContracts[lockAddress] = this.getContract(
+      lockAddress,
+      version.PublicLock,
+      this.provider
+    )
+    return this.lockContracts[lockAddress]
+  }
+
+  async getUnlockContract() {
+    if (this.unlockContract) {
+      return this.unlockContract
+    }
+    const version = await this.ethers_unlockContractAbiVersion()
+    this.unlockContract = this.getContract(
+      this.unlockContractAddress,
+      version.Unlock,
+      this.provider
+    )
+    return this.unlockContract
   }
 }

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -1,9 +1,12 @@
 import EventEmitter from 'events'
-import { Contract } from 'ethers'
+import { Contract, errors } from 'ethers'
 
 import v0 from './v0'
 import v01 from './v01'
 import v02 from './v02'
+
+// mute warnings from overloaded smart contract methods (https://github.com/ethers-io/ethers.js/issues/499)
+errors.setLogLevel('error')
 
 export const Errors = {
   MISSING_WEB3: 'MISSING_WEB3',
@@ -255,7 +258,7 @@ export default class UnlockService extends EventEmitter {
     if (this.lockContracts[lockAddress]) {
       return this.lockContracts[lockAddress]
     }
-    const version = await this.lockContractAbiVersion(lockAddress)
+    const version = await this.ethers_lockContractAbiVersion(lockAddress)
     this.lockContracts[lockAddress] = this.getContract(
       lockAddress,
       version.PublicLock,

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -157,6 +157,9 @@ export default class UnlockService extends EventEmitter {
       throw new Error(Errors.MISSING_WEB3)
     }
 
+    // ethereum has 2 kinds of addresses, this ensures we don't
+    // accidentally store the same contract twice
+    // see https://docs.ethers.io/ethers.js/html/notes.html#checksum-address
     const contractAddress = address.toLowerCase()
     let version = this.ethers_versionForAddress[contractAddress]
     if (version === undefined) {

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -257,28 +257,26 @@ export default class UnlockService extends EventEmitter {
   async getLockContract(lockAddress) {
     if (this.lockContracts[lockAddress]) {
       return this.lockContracts[lockAddress]
-    } else {
-      const version = await this.ethers_lockContractAbiVersion(lockAddress)
-      this.lockContracts[lockAddress] = this.getContract(
-        lockAddress,
-        version.PublicLock,
-        this.provider
-      )
-      return this.lockContracts[lockAddress]
     }
+    const version = await this.ethers_lockContractAbiVersion(lockAddress)
+    this.lockContracts[lockAddress] = this.getContract(
+      lockAddress,
+      version.PublicLock,
+      this.provider
+    )
+    return this.lockContracts[lockAddress]
   }
 
   async getUnlockContract() {
     if (this.unlockContract) {
       return this.unlockContract
-    } else {
-      const version = await this.ethers_unlockContractAbiVersion()
-      this.unlockContract = this.getContract(
-        this.unlockContractAddress,
-        version.Unlock,
-        this.provider
-      )
-      return this.unlockContract
     }
+    const version = await this.ethers_unlockContractAbiVersion()
+    this.unlockContract = this.getContract(
+      this.unlockContractAddress,
+      version.Unlock,
+      this.provider
+    )
+    return this.unlockContract
   }
 }

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -152,6 +152,10 @@ export default class UnlockService extends EventEmitter {
     return version
   }
 
+  /**
+   * @param {string} address contract address
+   * @param {string} versionRetrievalMethodName the method to call to retrieve the contract version
+   */
   async contractAbiVersion(address, versionRetrievalMethodName) {
     if (!this.provider) {
       throw new Error(Errors.MISSING_WEB3)
@@ -179,10 +183,7 @@ export default class UnlockService extends EventEmitter {
     // Defaults to v0
     return v0
   }
-  /**
-   * Returns the implementation based on the deployed version
-   * @param {*} address
-   */
+
   async ethers_unlockContractAbiVersion() {
     return this.contractAbiVersion(
       this.unlockContractAddress,
@@ -201,6 +202,10 @@ export default class UnlockService extends EventEmitter {
     )
   }
 
+  /**
+   * Private method, which given an address will query the lock and return the version of the lock
+   * @param {*} address
+   */
   async _ethers_getPublicLockVersionFromContract(address) {
     const contract = new Contract(
       address,
@@ -227,7 +232,7 @@ export default class UnlockService extends EventEmitter {
   }
 
   /**
-   * Private method, which given an address will query the contract and return the corresponding method
+   * Private method, which given an address will query the unlock contract to get its version
    * @param {*} address
    */
   async _ethers_getVersionFromContract(address) {


### PR DESCRIPTION
# Description

In order to implement the ethers-based version of unlockService, this PR uses the `ethers_` prefix for any methods that are modified. All changes are at the bottom of the file. The existing methods:

```
unlockContractAbiVersion()
lockContractAbiVersion()
_getPublicLockVersionFromContract()
_getVersionFromContract()
```

are all prefixed to become:

```
ethers_unlockContractAbiVersion()
ethers_lockContractAbiVersion()
_ethers_getPublicLockVersionFromContract()
_ethers_getVersionFromContract()
```

new methods added are:

```
getContract
getWritableContract
getLockContract
getUnlockContract
```

These are ethers-specific. In ethers, contracts are first-class citizens (https://docs.ethers.io/ethers.js/html/api-contract.html) and have providers assigned to them. Ethers additionally makes a strong separation between readable contracts and writable contracts.

Providers or signers must be connected to contracts before they can be used on-chain. There are 2 ways to do this. One is to create a contract, and then call `connect`. This PR chooses the other option, which is to create a new contract by passing the provider, or the signer, as the 3rd parameter.

This logic is handled by `getContract`, which uses the `writable` property (set in the constructor) to determine whether to make a read-only (web3Service) or a write-only (walletService) contract.

After this PR is approved and merged, the next steps are:

1. pass `writable: true` to `unlockService` from `walletService` to ensure we get a writable contract
2. set up `this.provider` in both `web3Service` and `walletService`, and add `_handleMethodCall` to walletService
3. migrate the stuff in `v0/`, `v01/`, and `v02/` over to use ethers. (this we can collaborate on really easily)
4. migrate the remaining `walletService` and `web3Service` methods
5. migrate `deploy.js` and `account.js` and `providers`
6. profit

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
