### PR TITLE
Replacing createEvent with saveEvent

### DIFF
--- a/tickets/src/__tests__/middlewares/ticketMiddleware.test.js
+++ b/tickets/src/__tests__/middlewares/ticketMiddleware.test.js
@@ -61,12 +61,12 @@ describe('Ticketing middleware', () => {
         data: structuredData,
         signature: 'foo',
       }
-      mockTicketService.createEvent = jest.fn(() => {
+      mockTicketService.saveEvent = jest.fn(() => {
         return Promise.resolve()
       })
       await invoke(action)
 
-      expect(mockTicketService.createEvent).toHaveBeenCalledWith(
+      expect(mockTicketService.saveEvent).toHaveBeenCalledWith(
         structuredData.message.event,
         'foo'
       )

--- a/tickets/src/__tests__/services/ticketService.test.js
+++ b/tickets/src/__tests__/services/ticketService.test.js
@@ -11,8 +11,8 @@ describe('TicketService', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
-  describe('createEvent', () => {
-    describe('when the event can be created', () => {
+  describe('saveEvent', () => {
+    describe('when an event does not exist and can be created', () => {
       it('returns a successful promise', async () => {
         expect.assertions(1)
         const event = {
@@ -24,8 +24,9 @@ describe('TicketService', () => {
           owner: '0x03',
           logo: '',
         }
+        axios.get.mockReturnValue({ status: 404 })
         axios.post.mockReturnValue({})
-        await ticketService.createEvent(event)
+        await ticketService.saveEvent(event)
 
         const payload = UnlockEvent.build(event)
 
@@ -36,7 +37,7 @@ describe('TicketService', () => {
         )
       })
     })
-    describe('when the event cannot be created', () => {
+    describe('when an event does not exist and cannot be created', () => {
       it('returns a rejected promise', async () => {
         expect.assertions(2)
         const event = {
@@ -48,17 +49,72 @@ describe('TicketService', () => {
           owner: '0x03',
           logo: '',
         }
-        axios.post.mockRejectedValue('Hark! An Error')
+        axios.get.mockReturnValue({ status: 404 })
+        axios.post.mockRejectedValue('Oh dear! An Error')
         try {
-          await ticketService.createEvent(event)
+          await ticketService.saveEvent(event)
         } catch (error) {
-          expect(error).toEqual('Hark! An Error')
+          expect(error).toEqual('Oh dear! An Error')
         }
 
         const payload = UnlockEvent.build(event)
 
         expect(axios.post).toHaveBeenCalledWith(
           `${serviceHost}/events/`,
+          payload,
+          {}
+        )
+      })
+    })
+    describe('when an event does exist and can be updated', () => {
+      it('returns a successful promise', async () => {
+        expect.assertions(1)
+        const event = {
+          lockAddress: 'abc123',
+          name: 'Sample event',
+          description: 'Fun times',
+          location: 'On the blockchain',
+          date: new Date().toString(),
+          owner: '0x03',
+          logo: '',
+        }
+        axios.get.mockReturnValue({ status: 200 })
+        axios.put.mockReturnValue({})
+        await ticketService.saveEvent(event)
+
+        const payload = UnlockEvent.build(event)
+
+        expect(axios.put).toHaveBeenCalledWith(
+          `${serviceHost}/events/${event.lockAddress}`,
+          payload,
+          {}
+        )
+      })
+    })
+    describe('when an event does exist and cannot be updated', () => {
+      it('returns a successful promise', async () => {
+        expect.assertions(2)
+        const event = {
+          lockAddress: 'abc123',
+          name: 'Sample event',
+          description: 'Fun times',
+          location: 'On the blockchain',
+          date: new Date().toString(),
+          owner: '0x03',
+          logo: '',
+        }
+        axios.get.mockReturnValue({ status: 200 })
+        axios.put.mockRejectedValue('Crumbs! An Error')
+        try {
+          await ticketService.saveEvent(event)
+        } catch (error) {
+          expect(error).toEqual('Crumbs! An Error')
+        }
+
+        const payload = UnlockEvent.build(event)
+
+        expect(axios.put).toHaveBeenCalledWith(
+          `${serviceHost}/events/${event.lockAddress}`,
           payload,
           {}
         )

--- a/tickets/src/middlewares/ticketMiddleware.js
+++ b/tickets/src/middlewares/ticketMiddleware.js
@@ -48,7 +48,7 @@ const ticketMiddleware = config => {
           action.data.message.event
         ) {
           ticketService
-            .createEvent(action.data.message.event, action.signature)
+            .saveEvent(action.data.message.event, action.signature)
             .catch(error => dispatch(ticketError(error)))
         }
 

--- a/tickets/src/services/ticketService.js
+++ b/tickets/src/services/ticketService.js
@@ -11,12 +11,11 @@ export default class TicketService {
   }
 
   /**
-   * Saves a new event to locksmith
+   * Saves an event to locksmith - either creating a new event or updating an existing record.
    * @param {*} event
-   * @param {*} token
    * @returns {Promise<*>}
    */
-  async createEvent(
+  async saveEvent(
     { lockAddress, name, description, location, date, owner, logo },
     token
   ) {
@@ -34,10 +33,28 @@ export default class TicketService {
       logo,
     })
 
-    try {
-      return await axios.post(`${this.host}/events/`, payload, opts)
-    } catch (error) {
-      return Promise.reject(error)
+    // First check if the event exists
+    const res = await axios.get(`${this.host}/events/${lockAddress}`, {
+      validateStatus: false,
+    })
+    if (res.status === 200) {
+      try {
+        // If so, update the record
+        return await axios.put(
+          `${this.host}/events/${lockAddress}`,
+          payload,
+          opts
+        )
+      } catch (error) {
+        return Promise.reject(error)
+      }
+    } else {
+      try {
+        // Otherwise create it
+        await axios.post(`${this.host}/events/`, payload, opts)
+      } catch (error) {
+        return Promise.reject(error)
+      }
     }
   }
 


### PR DESCRIPTION
# Description

There's no need for separate createEvent and saveEvent methods. There is now just one method to save them all.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
