### PR TITLE
add plumbing to hook up ethers in web3Service and walletService

### DIFF
--- a/unlock-js/src/__tests__/walletService.ethers.test.js
+++ b/unlock-js/src/__tests__/walletService.ethers.test.js
@@ -1,0 +1,83 @@
+import { ethers } from 'ethers'
+import http from 'http'
+import NockHelper from './helpers/nockHelper'
+
+import WalletService from '../walletService'
+
+const endpoint = 'http://127.0.0.1:8545'
+const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
+
+let walletService
+
+let unlockAddress = '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b'
+describe('WalletService (ethers)', () => {
+  function resetTests() {
+    nock.cleanAll()
+    walletService = new WalletService({
+      unlockAddress,
+    })
+  }
+  const netVersion = Math.floor(Math.random() * 100000)
+  async function resetTestsAndConnect(provider = endpoint) {
+    nock.cleanAll()
+    walletService = new WalletService({
+      unlockAddress,
+    })
+    nock.netVersionAndYield(netVersion)
+
+    await walletService.ethers_connect(provider)
+    await nock.resolveWhenAllNocksUsed()
+  }
+
+  describe('ethers_connect', () => {
+    beforeEach(() => {
+      resetTests()
+    })
+
+    it('properly connects to the ethers jsonRpcProvider', async () => {
+      expect.assertions(1)
+
+      await resetTestsAndConnect()
+      expect(walletService.provider).toBeInstanceOf(
+        ethers.providers.JsonRpcProvider
+      )
+    })
+
+    it('properly connects to the ethers Web3Provider', async () => {
+      expect.assertions(1)
+
+      await resetTestsAndConnect({
+        sendAsync(params, callback) {
+          const data = JSON.stringify(params)
+          const options = {
+            host: '127.0.0.1',
+            port: 8545,
+            method: 'POST',
+            path: '/',
+            headers: {
+              'Content-Type': 'application/json',
+              'Content-Length': data.length,
+            },
+          }
+          const req = http.request(options, res => {
+            var responseString = ''
+
+            res.on('data', data => {
+              responseString += data
+              // save all the data from response
+            })
+            res.on('end', () => {
+              callback(null, JSON.parse(responseString))
+              // print to console when response ends
+            })
+          })
+          req.write(JSON.stringify(params))
+          req.end()
+        }, // a web3 provider must have sendAsync as a minimum
+      })
+      expect(walletService.provider).toBeInstanceOf(
+        ethers.providers.Web3Provider
+      )
+    })
+  })
+})

--- a/unlock-js/src/__tests__/web3Service.ethers.test.js
+++ b/unlock-js/src/__tests__/web3Service.ethers.test.js
@@ -1,0 +1,79 @@
+import { ethers } from 'ethers'
+import http from 'http'
+
+import NockHelper from './helpers/nockHelper'
+import Web3Service from '../web3Service'
+
+const blockTime = 3
+const readOnlyProvider = 'http://127.0.0.1:8545'
+const requiredConfirmations = 12
+const unlockAddress = '0xc43efE2C7116CB94d563b5A9D68F260CCc44256F'
+
+const nock = new NockHelper(
+  readOnlyProvider,
+  false /** debug */,
+  true /** ethers */
+)
+let web3Service
+
+describe('Web3Service', () => {
+  async function nockBeforeEach(endpoint = readOnlyProvider) {
+    nock.cleanAll()
+    nock.netVersionAndYield(1)
+    web3Service = new Web3Service({
+      readOnlyProvider: endpoint,
+      unlockAddress,
+      blockTime,
+      requiredConfirmations,
+      useEthers: true,
+    })
+    return nock.resolveWhenAllNocksUsed()
+  }
+
+  describe('ethers_setup', () => {
+    it('should set up a JsonRpcProvider for a string end point', async () => {
+      expect.assertions(1)
+
+      await nockBeforeEach()
+
+      expect(web3Service.provider).toBeInstanceOf(
+        ethers.providers.JsonRpcProvider
+      )
+    })
+
+    it('should set up a Web3Provider for a web3 provider end point', async () => {
+      expect.assertions(1)
+
+      await nockBeforeEach({
+        send(params, callback) {
+          const data = JSON.stringify(params)
+          const options = {
+            host: '127.0.0.1',
+            port: 8545,
+            method: 'POST',
+            path: '/',
+            headers: {
+              'Content-Type': 'application/json',
+              'Content-Length': data.length,
+            },
+          }
+          const req = http.request(options, res => {
+            var responseString = ''
+
+            res.on('data', data => {
+              responseString += data
+              // save all the data from response
+            })
+            res.on('end', () => {
+              callback(null, JSON.parse(responseString))
+              // print to console when response ends
+            })
+          })
+          req.write(JSON.stringify(params))
+          req.end()
+        }, // a web3 provider must have sendAsync as a minimum
+      })
+      expect(web3Service.provider).toBeInstanceOf(ethers.providers.Web3Provider)
+    })
+  })
+})

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -1,4 +1,5 @@
 import Web3 from 'web3'
+import { providers as ethersProviders } from 'ethers'
 import { bufferToHex, generateAddress } from 'ethereumjs-util'
 import Web3Utils from './utils'
 import TransactionTypes from './transactionTypes'
@@ -15,10 +16,15 @@ export default class Web3Service extends UnlockService {
     unlockAddress,
     blockTime,
     requiredConfirmations,
+    useEthers,
   }) {
     super({ unlockAddress })
 
-    this.web3 = new Web3(readOnlyProvider)
+    if (useEthers) {
+      this.ethers_setup(readOnlyProvider)
+    } else {
+      this.web3 = new Web3(readOnlyProvider)
+    }
     this.blockTime = blockTime
     this.requiredConfirmations = requiredConfirmations
 
@@ -108,6 +114,19 @@ export default class Web3Service extends UnlockService {
           owner,
         })
       },
+    }
+  }
+
+  /**
+   * Temporary function that allows us to use ethers functionality
+   * without interfering with web3. This will be moved to the constructor when
+   * we remove web3
+   */
+  ethers_setup(readOnlyProvider) {
+    if (typeof readOnlyProvider === 'string') {
+      this.provider = new ethersProviders.JsonRpcProvider(readOnlyProvider)
+    } else if (readOnlyProvider.send) {
+      this.provider = new ethersProviders.Web3Provider(readOnlyProvider)
     }
   }
 


### PR DESCRIPTION
# Description

This sets up the ethers providers we will need to use in migrating the rest of the service methods over to ethers.

Continuing with the last PR, all new ethers-based content is prefixed with `ethers_` to make the final migration step simpler

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
