### PR TITLE
Add unlock-app URL to config for use in email links

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -45,6 +45,7 @@ services:
       LOCKSMITH_URI: '${LOCKSMITH_URI}'
       PAYWALL_URL: '${PAYWALL_URL}'
       PAYWALL_SCRIPT_URL: '${PAYWALL_SCRIPT_URL}'
+      UNLOCK_APP_URL: '${UNLOCK_APP_URL}'
     command: ['npm', 'run', 'start']
   unlock-protocol-com:
     image: unlock-protocol-com

--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -19,6 +19,7 @@ let requiredConfigVariables = {
   locksmithHost: process.env.LOCKSMITH_URI,
   wedlocksUri: process.env.WEDLOCKS_URI,
   unlockStaticUrl: process.env.UNLOCK_STATIC_URL,
+  unlockAppUrl: process.env.UNLOCK_APP_URL,
 }
 
 let optionalConfigVariables = {

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -46,6 +46,7 @@ export default function configure(
     runtimeConfig.paywallScriptUrl ||
     'http://localhost:3001/static/paywall.min.js'
   let unlockStaticUrl = runtimeConfig.unlockStaticUrl || 'http://localhost:3002'
+  let unlockAppUrl = runtimeConfig.unlockAppUrl || 'http://localhost:3000'
   let httpProvider = runtimeConfig.httpProvider || '127.0.0.1'
   let blockTime = 8000 // in mseconds.
   let chainExplorerUrlBuilders = {
@@ -116,6 +117,7 @@ export default function configure(
     services['wedlocks'] = { host: runtimeConfig.wedlocksUri }
     paywallUrl = runtimeConfig.paywallUrl
     paywallScriptUrl = runtimeConfig.paywallScriptUrl
+    unlockAppUrl = runtimeConfig.unlockAppUrl
 
     // Address for the Unlock smart contract
     unlockAddress = '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b'
@@ -142,6 +144,7 @@ export default function configure(
     services['wedlocks'] = { host: runtimeConfig.wedlocksUri }
     paywallUrl = runtimeConfig.paywallUrl
     paywallScriptUrl = runtimeConfig.paywallScriptUrl
+    unlockAppUrl = runtimeConfig.unlockAppUrl
 
     // Address for the Unlock smart contract
     unlockAddress = '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'
@@ -177,5 +180,6 @@ export default function configure(
     supportedProviders,
     unlockStaticUrl,
     chainExplorerUrlBuilders,
+    unlockAppUrl,
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Part of #2111 and #2721, this PR adds the URL of the dashboard app to the config so that we can use it to construct links for emails. I *believe* this is all that should be required other than setting the env var itself, but please let me know if I've forgotten anything.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
