### PR TITLE
Pass confirmLink to wedlocks

### DIFF
--- a/unlock-app/src/__tests__/services/wedlockService.test.js
+++ b/unlock-app/src/__tests__/services/wedlockService.test.js
@@ -15,10 +15,12 @@ describe('Wedlocks Service', () => {
     const expectedPayload = {
       template: emailTemplate.signupConfirmation,
       recipient,
-      params: {},
+      params: {
+        confirmLink: 'https://mcdonalds.gov',
+      },
     }
     axios.post.mockReturnValue()
-    await w.confirmEmail(recipient)
+    await w.confirmEmail(recipient, 'https://mcdonalds.gov')
 
     expect(axios.post).toHaveBeenCalledWith(
       'http://notareal.host',

--- a/unlock-app/src/middlewares/wedlocksMiddleware.ts
+++ b/unlock-app/src/middlewares/wedlocksMiddleware.ts
@@ -11,7 +11,7 @@ const wedlocksMiddleware = (config: any) => {
       return (action: Action) => {
         if (action.type === SIGNUP_EMAIL) {
           // TODO: then and catch? I think we really only need to worry about errors.
-          wedlockService.confirmEmail(action.emailAddress)
+          wedlockService.confirmEmail(action.emailAddress, '')
         }
         next(action)
       }

--- a/unlock-app/src/middlewares/wedlocksMiddleware.ts
+++ b/unlock-app/src/middlewares/wedlocksMiddleware.ts
@@ -9,7 +9,10 @@ const wedlocksMiddleware = (config: any) => {
   return (_: any) => {
     return (next: any) => {
       return (action: Action) => {
-        if (action.type === SIGNUP_EMAIL) {
+        // Check that window is defined before attempting to access it. It would
+        // be pretty bizarre if this event were to appear without window already
+        // existing, so it's safe to simply do nothing in that case.
+        if (action.type === SIGNUP_EMAIL && window && window.location) {
           const { origin } = window.location
           // TODO: then and catch? I think we really only need to worry about errors.
           wedlockService.confirmEmail(

--- a/unlock-app/src/middlewares/wedlocksMiddleware.ts
+++ b/unlock-app/src/middlewares/wedlocksMiddleware.ts
@@ -10,8 +10,12 @@ const wedlocksMiddleware = (config: any) => {
     return (next: any) => {
       return (action: Action) => {
         if (action.type === SIGNUP_EMAIL) {
+          const { origin } = window.location
           // TODO: then and catch? I think we really only need to worry about errors.
-          wedlockService.confirmEmail(action.emailAddress, '')
+          wedlockService.confirmEmail(
+            action.emailAddress,
+            `${origin}/keychain#${action.emailAddress}`
+          )
         }
         next(action)
       }

--- a/unlock-app/src/services/wedlockService.ts
+++ b/unlock-app/src/services/wedlockService.ts
@@ -36,7 +36,9 @@ export default class WedlockService {
     return result
   }
 
-  confirmEmail = (recipient: string) => {
-    return this.sendEmail(emailTemplate.signupConfirmation, recipient)
+  confirmEmail = (recipient: string, confirmLink: string) => {
+    return this.sendEmail(emailTemplate.signupConfirmation, recipient, {
+      confirmLink,
+    })
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Part of #2111 and #2721, this PR adds the confirmation link href to the call to wedlocks, which will allow us to actually use account creation end-to-end.

Example email from signup:

<img width="695" alt="image" src="https://user-images.githubusercontent.com/9300702/57023149-4cc01500-6bff-11e9-9f07-1814abe97261.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
