### PR TITLE
use natural value for PAYWALL_URL on paywall

### DIFF
--- a/paywall/next.config.js
+++ b/paywall/next.config.js
@@ -18,7 +18,6 @@ const copyFile = promisify(fs.copyFile)
 const requiredConfigVariables = {
   unlockEnv: process.env.UNLOCK_ENV || 'dev',
   readOnlyProvider: process.env.READ_ONLY_PROVIDER,
-  paywallUrl: process.env.PAYWALL_URL,
   locksmithUri: process.env.LOCKSMITH_URI,
 }
 

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -40,6 +40,7 @@ export default function configure(
   } else if (global.window) {
     paywallUrl = window.origin
   } else {
+    // server-side, it doesn't matter what we render
     paywallUrl = ''
   }
   const locksmithUri = runtimeConfig.locksmithUri || 'http://0.0.0.0:8080'

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -34,8 +34,14 @@ export default function configure(
 
   // note: the choice of 127.0.0.1 instead of localhost is deliberate, as it will
   // allow us to test cross-origin requests from localhost/demo
-  let paywallUrl =
-    runtimeConfig.paywallUrl || (global.window ? window.origin : '')
+  let paywallUrl
+  if (global.window && window.origin === 'http://localhost:3001') {
+    paywallUrl = 'http://127.0.0.1:3001'
+  } else if (global.window) {
+    paywallUrl = window.origin
+  } else {
+    paywallUrl = ''
+  }
   const locksmithUri = runtimeConfig.locksmithUri || 'http://0.0.0.0:8080'
   let paywallScriptPath = '/static/paywall.min.js'
   const httpProvider = runtimeConfig.httpProvider || '127.0.0.1'

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -34,7 +34,8 @@ export default function configure(
 
   // note: the choice of 127.0.0.1 instead of localhost is deliberate, as it will
   // allow us to test cross-origin requests from localhost/demo
-  let paywallUrl = runtimeConfig.paywallUrl || 'http://127.0.0.1:3001'
+  let paywallUrl =
+    runtimeConfig.paywallUrl || (global.window ? window.origin : '')
   const locksmithUri = runtimeConfig.locksmithUri || 'http://0.0.0.0:8080'
   let paywallScriptPath = '/static/paywall.min.js'
   const httpProvider = runtimeConfig.httpProvider || '127.0.0.1'

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -31,20 +31,7 @@ export default function configure(
   const isInIframe = inIframe(useWindow)
 
   const env = runtimeConfig.unlockEnv
-
-  // note: the choice of 127.0.0.1 instead of localhost is deliberate, as it will
-  // allow us to test cross-origin requests from localhost/demo
-  let paywallUrl
-  if (global.window && window.origin === 'http://localhost:3001') {
-    paywallUrl = 'http://127.0.0.1:3001'
-  } else if (global.window) {
-    paywallUrl = window.origin
-  } else {
-    // server-side, it doesn't matter what we render
-    paywallUrl = ''
-  }
   const locksmithUri = runtimeConfig.locksmithUri || 'http://0.0.0.0:8080'
-  let paywallScriptPath = '/static/paywall.min.js'
   const httpProvider = runtimeConfig.httpProvider || '127.0.0.1'
   let providers = {}
   let isRequiredNetwork = () => false
@@ -156,7 +143,5 @@ export default function configure(
     unlockAddress,
     services,
     supportedProviders,
-    paywallScriptPath,
-    paywallUrl,
   }
 }


### PR DESCRIPTION
# Description

This PR addresses a subtle issue discovered while trying to test a draft PR. Because the paywall sets its url for the script in the paywall demo based on the `PAYWALL_URL` env variable, draft PR deploys on netlify were loading the paywall from `https://staging-paywall.unlock-protocol.com`.

This PR addresses that issue while preserving the ability to test cross-domain concerns in development. It responds to 3 environments:

1. client-side, running in local development (sets paywall url to `http://127.0.0.1:3001` to ensure we have a different domain from `localhost`)
2. everywhere else, use the current origin as the paywall URL
3. server-side, when we have no window object, just use a relative path

This change will make it possible to test the paywall in a PR netlify deploy

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2902 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
