### PR TITLE
getting the lock's txt again after waiting for it to have been on the Submitted state

### DIFF
--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -115,6 +115,11 @@ describe('The Unlock Dashboard', () => {
             .querySelector(`[data-address="${address}"]`)
             .innerText.includes('Submitted')
         }, newLock)
+
+        // Get the next again now
+        lockText = await page.evaluate(address => {
+          return document.querySelector(`[data-address="${address}"]`).innerText
+        }, newLock)
       }
 
       // If the lock is submitted


### PR DESCRIPTION
This should fix the flakiness of the integration tests...



- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread