### PR TITLE
Correctly index into return value of getUserPrivateKey

### DIFF
--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,7 +1,4 @@
-import {
-  createAccountAndPasswordEncryptKey,
-  getAccountFromPrivateKey,
-} from '@unlock-protocol/unlock-js'
+import * as UnlockJS from '@unlock-protocol/unlock-js'
 import storageMiddleware from '../../middlewares/storageMiddleware'
 import { UPDATE_LOCK, updateLock, UPDATE_LOCK_NAME } from '../../actions/lock'
 import { STORE_LOCK_NAME } from '../../actions/storage'
@@ -13,8 +10,6 @@ import { startLoading, doneLoading } from '../../actions/loading'
 import configure from '../../config'
 import { SIGNUP_CREDENTIALS } from '../../actions/signUp'
 import { LOGIN_CREDENTIALS } from '../../actions/login'
-
-jest.mock('@unlock-protocol/unlock-js')
 
 /**
  * This is a "fake" middleware caller
@@ -269,10 +264,6 @@ describe('Storage middleware', () => {
   describe('SIGNUP_CREDENTIALS', () => {
     it('should create a user and then set the account', () => {
       expect.assertions(2)
-      createAccountAndPasswordEncryptKey.mockReturnValue({
-        address: '',
-        passwordEncryptedPrivateKey: '',
-      })
       const emailAddress = 'tim@cern.ch'
       const password = 'guest'
       const { next, invoke } = create()
@@ -312,11 +303,13 @@ describe('Storage middleware', () => {
         })
       })
 
+      const spy = jest.spyOn(UnlockJS, 'getAccountFromPrivateKey')
+
       await invoke(action)
       expect(mockStorageService.getUserPrivateKey).toHaveBeenCalledWith(
         emailAddress
       )
-      expect(getAccountFromPrivateKey).toHaveBeenCalledWith(
+      expect(spy).toHaveBeenCalledWith(
         'Private Key reporting for duty',
         'guest'
       )

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,4 +1,7 @@
-import { getAccountFromPrivateKey } from '@unlock-protocol/unlock-js'
+import {
+  createAccountAndPasswordEncryptKey,
+  getAccountFromPrivateKey,
+} from '@unlock-protocol/unlock-js'
 import storageMiddleware from '../../middlewares/storageMiddleware'
 import { UPDATE_LOCK, updateLock, UPDATE_LOCK_NAME } from '../../actions/lock'
 import { STORE_LOCK_NAME } from '../../actions/storage'
@@ -10,6 +13,8 @@ import { startLoading, doneLoading } from '../../actions/loading'
 import configure from '../../config'
 import { SIGNUP_CREDENTIALS } from '../../actions/signUp'
 import { LOGIN_CREDENTIALS } from '../../actions/login'
+
+jest.mock('@unlock-protocol/unlock-js')
 
 /**
  * This is a "fake" middleware caller
@@ -42,8 +47,6 @@ jest.mock('../../services/storageService', () => {
 })
 
 jest.mock('../../structured_data/unlockLock.js')
-
-jest.mock(getAccountFromPrivateKey, () => true)
 
 describe('Storage middleware', () => {
   beforeEach(() => {
@@ -266,6 +269,10 @@ describe('Storage middleware', () => {
   describe('SIGNUP_CREDENTIALS', () => {
     it('should create a user and then set the account', () => {
       expect.assertions(2)
+      createAccountAndPasswordEncryptKey.mockReturnValue({
+        address: '',
+        passwordEncryptedPrivateKey: '',
+      })
       const emailAddress = 'tim@cern.ch'
       const password = 'guest'
       const { next, invoke } = create()
@@ -285,8 +292,8 @@ describe('Storage middleware', () => {
   })
 
   describe('LOGIN_CREDENTIALS', () => {
-    it('', () => {
-      expect.assertions(2)
+    it('Should call getAccountFromPrivateKey with correct data', async () => {
+      expect.assertions(3)
       const emailAddress = 'tim@cern.ch'
       const password = 'guest'
       const { next, invoke } = create()
@@ -305,7 +312,7 @@ describe('Storage middleware', () => {
         })
       })
 
-      invoke(action)
+      await invoke(action)
       expect(mockStorageService.getUserPrivateKey).toHaveBeenCalledWith(
         emailAddress
       )

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,3 +1,4 @@
+import { getAccountFromPrivateKey } from '@unlock-protocol/unlock-js'
 import storageMiddleware from '../../middlewares/storageMiddleware'
 import { UPDATE_LOCK, updateLock, UPDATE_LOCK_NAME } from '../../actions/lock'
 import { STORE_LOCK_NAME } from '../../actions/storage'
@@ -41,6 +42,8 @@ jest.mock('../../services/storageService', () => {
 })
 
 jest.mock('../../structured_data/unlockLock.js')
+
+jest.mock(getAccountFromPrivateKey, () => true)
 
 describe('Storage middleware', () => {
   beforeEach(() => {
@@ -294,12 +297,19 @@ describe('Storage middleware', () => {
         password,
       }
 
-      mockStorageService.getUserPrivateKey = jest.fn(() =>
-        Promise.resolve(true)
-      )
+      mockStorageService.getUserPrivateKey = jest.fn(() => {
+        return Promise.resolve({
+          data: {
+            passwordEncryptedPrivateKey: 'Private Key reporting for duty',
+          },
+        })
+      })
 
       invoke(action)
-      expect(mockStorageService.getUserPrivateKey).toHaveBeenCalled()
+      expect(mockStorageService.getUserPrivateKey).toHaveBeenCalledWith(
+        emailAddress
+      )
+      expect()
       expect(next).toHaveBeenCalledTimes(1)
     })
   })

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -309,7 +309,10 @@ describe('Storage middleware', () => {
       expect(mockStorageService.getUserPrivateKey).toHaveBeenCalledWith(
         emailAddress
       )
-      expect()
+      expect(getAccountFromPrivateKey).toHaveBeenCalledWith(
+        'Private Key reporting for duty',
+        'guest'
+      )
       expect(next).toHaveBeenCalledTimes(1)
     })
   })

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -140,7 +140,8 @@ const storageMiddleware = config => {
           const { emailAddress, password } = action
           storageService
             .getUserPrivateKey(emailAddress)
-            .then(key => {
+            .then(result => {
+              const key = result.data.passwordEncryptedPrivateKey
               try {
                 // TODO: store more than just the account address (encrypted key, etc.)
                 const account = getAccountFromPrivateKey(key, password)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR corrects how `storageMiddleware` accessed the account data provided by `locksmith`. Once this is merged, the end-to-end account creation and login milestone will be complete 🎉

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2721 
Refs #2111 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
