### PR TITLE
implement _handleMethodCall as an ethers version of _sendTransaction

### DIFF
--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -101,6 +101,31 @@ export default class WalletService extends UnlockService {
   }
 
   /**
+   * This function submits a web3 transaction and will trigger an event as soon as it receives its
+   * hash. We then use the web3Service to handle the ongoing transaction (watch for confirmation
+   * receipt... etc)
+   * @private
+   * @param {Promise} the result of calling a contract method (ethersjs contract)
+   * @param {string} the Unlock protocol transaction type
+   * @param {Function} a standard node callback that accepts the transaction hash
+   */
+  async _handleMethodCall(methodCall, transactionType) {
+    this.emit('transaction.pending', transactionType)
+    const transaction = await methodCall
+    this.emit(
+      'transaction.new',
+      transaction.hash,
+      transaction.from,
+      transaction.to,
+      transaction.data,
+      transactionType,
+      'submitted'
+    )
+    return transaction.hash
+    // errors fall through
+  }
+
+  /**
    * This function submits a web3Transaction and will trigger an event as soon as it receives its
    * hash. We then use the web3Service to handle the ongoing transaction (watch for conformation
    * receipt... etc)


### PR DESCRIPTION
# Description

This introduces the `_handleMethodCall` function, which is the ethers version of `_sendTransaction`. The function can be thought of as having 2 parts. The first is the part that actually does the sending of the transaction to the JSON-RPC server. In the web3 case, this is done inside `_sendTransaction`. Ethers, however, does this inside the logic of the `ethers.Contract` class (https://docs.ethers.io/ethers.js/html/api-contract.html) and so we only need to wait for the promise it returns to resolve and then the second part of the functionality kicks in.

In this second part, we take the transaction hash, emit a few events and then finish. In addition, errors are handled. This functionality is identical between the ethers and the web3 implementation because it is unlock-specific.

Side note: this really showcases the strength of the API design of ethers. The core is significantly shorter, *and* our code using it is shorter and easier to reason through.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
