### PR TITLE
migrate getAddressBalance to ethers

### DIFF
--- a/unlock-js/src/__tests__/utils.ethers.test.js
+++ b/unlock-js/src/__tests__/utils.ethers.test.js
@@ -1,0 +1,39 @@
+import { utils } from 'ethers'
+import ethersUtils from '../utils.ethers'
+
+describe('ethers utils', () => {
+  it('toWei', () => {
+    expect.assertions(2)
+
+    expect(ethersUtils.toWei('1000', 'ether')).toEqual(
+      utils.bigNumberify('1000000000000000000000')
+    )
+
+    expect(ethersUtils.toWei('1000000000000', 'gwei')).toEqual(
+      utils.bigNumberify('1000000000000000000000')
+    )
+  })
+
+  it('hexToNumberString', () => {
+    expect.assertions(2)
+
+    const bigNumber = 132654781356418
+
+    expect(ethersUtils.hexToNumberString('0x00')).toBe('0')
+    expect(ethersUtils.hexToNumberString('0x' + bigNumber.toString(16))).toBe(
+      `${bigNumber}`
+    )
+  })
+
+  it('fromWei', () => {
+    expect.assertions(2)
+
+    expect(ethersUtils.fromWei('1000000000000000000000', 'ether')).toEqual(
+      '1000'
+    )
+
+    expect(ethersUtils.fromWei('1000000000000000000000', 'gwei')).toEqual(
+      '1000000000000'
+    )
+  })
+})

--- a/unlock-js/src/__tests__/web3Service.ethers.test.js
+++ b/unlock-js/src/__tests__/web3Service.ethers.test.js
@@ -84,11 +84,13 @@ describe('Web3Service', () => {
       await nockBeforeEach()
       const balance = '0xdeadbeef'
       const inWei = utils.hexToNumberString(balance)
+      const expectedBalance = utils.fromWei(inWei, 'ether')
       const address = '0x1df62f291b2e969fb0849d99d9ce41e2f137006e'
+
       nock.getBalanceForAccountAndYieldBalance(address, '0xdeadbeef')
 
       let addressBalance = await web3Service.ethers_getAddressBalance(address)
-      expect(addressBalance).toEqual(utils.fromWei(inWei, 'ether'))
+      expect(addressBalance).toEqual(expectedBalance)
     })
   })
 })

--- a/unlock-js/src/__tests__/web3Service.ethers.test.js
+++ b/unlock-js/src/__tests__/web3Service.ethers.test.js
@@ -3,6 +3,7 @@ import http from 'http'
 
 import NockHelper from './helpers/nockHelper'
 import Web3Service from '../web3Service'
+import utils from '../utils.ethers'
 
 const blockTime = 3
 const readOnlyProvider = 'http://127.0.0.1:8545'
@@ -74,6 +75,20 @@ describe('Web3Service', () => {
         }, // a web3 provider must have sendAsync as a minimum
       })
       expect(web3Service.provider).toBeInstanceOf(ethers.providers.Web3Provider)
+    })
+  })
+
+  describe('getAddressBalance', () => {
+    it('should return the balance of the address', async () => {
+      expect.assertions(1)
+      await nockBeforeEach()
+      const balance = '0xdeadbeef'
+      const inWei = utils.hexToNumberString(balance)
+      const address = '0x1df62f291b2e969fb0849d99d9ce41e2f137006e'
+      nock.getBalanceForAccountAndYieldBalance(address, '0xdeadbeef')
+
+      let addressBalance = await web3Service.ethers_getAddressBalance(address)
+      expect(addressBalance).toEqual(utils.fromWei(inWei, 'ether'))
     })
   })
 })

--- a/unlock-js/src/utils.ethers.js
+++ b/unlock-js/src/utils.ethers.js
@@ -7,4 +7,7 @@ module.exports = {
   hexlify: utils.hexlify,
   hexStripZeros: utils.hexStripZeros,
   bigNumberify: utils.bigNumberify,
+  hexToNumberString: num =>
+    utils.formatUnits(utils.bigNumberify(num), 'wei').replace('.0', ''),
+  fromWei: (num, units) => utils.formatUnits(utils.bigNumberify(num), units),
 }

--- a/unlock-js/src/utils.ethers.js
+++ b/unlock-js/src/utils.ethers.js
@@ -9,5 +9,6 @@ module.exports = {
   bigNumberify: utils.bigNumberify,
   hexToNumberString: num =>
     utils.formatUnits(utils.bigNumberify(num), 'wei').replace('.0', ''),
-  fromWei: (num, units) => utils.formatUnits(utils.bigNumberify(num), units),
+  fromWei: (num, units) =>
+    utils.formatUnits(utils.bigNumberify(num), units).replace('.0', ''),
 }

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -2,6 +2,7 @@ import Web3 from 'web3'
 import { providers as ethersProviders } from 'ethers'
 import { bufferToHex, generateAddress } from 'ethereumjs-util'
 import Web3Utils from './utils'
+import ethers_utils from './utils.ethers'
 import TransactionTypes from './transactionTypes'
 import UnlockService from './unlockService'
 import { MAX_UINT, UNLIMITED_KEYS_COUNT, KEY_ID } from './constants'
@@ -268,6 +269,20 @@ export default class Web3Service extends UnlockService {
       .catch(error => {
         this.emit('error', error)
       })
+  }
+
+  /**
+   * This retrieves the balance of an address (contract or account)
+   * and formats it to a string of ether.
+   * Returns a promise with the balance
+   */
+  async ethers_getAddressBalance(address) {
+    try {
+      const balance = await this.provider.getBalance(address)
+      return ethers_utils.fromWei(balance, 'ether')
+    } catch (error) {
+      this.emit('error', error)
+    }
   }
 
   /**


### PR DESCRIPTION
# Description

This migrates `getAddressBalance` to ethers. The test is literally copy/pasted from the existing web3Service test, to show 1-1 parity on features.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
