### PR TITLE
migrate partialWithdrawFromLock to ethers

### DIFF
--- a/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
+++ b/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
@@ -92,12 +92,7 @@ export const prepContract = ({
   return (...args) => {
     const encodedValue = value ? utils.toWei(value, 'ether') : 0
     const testParams = {
-      gas: utils.hexStripZeros(
-        utils.hexlify(
-          // handles partialWithDrawFromLock and withdrawFromLock
-          GAS_AMOUNTS[functionName] || GAS_AMOUNTS[`${functionName}FromLock`]
-        )
-      ),
+      gas: utils.hexStripZeros(utils.hexlify(GAS_AMOUNTS[functionName])),
       to: checksumContractAddress,
       data: unlockInterface.functions[`${functionName}(${signature})`].encode(
         args

--- a/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
+++ b/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
@@ -92,7 +92,12 @@ export const prepContract = ({
   return (...args) => {
     const encodedValue = value ? utils.toWei(value, 'ether') : 0
     const testParams = {
-      gas: utils.hexStripZeros(utils.hexlify(GAS_AMOUNTS[functionName])),
+      gas: utils.hexStripZeros(
+        utils.hexlify(
+          // handles partialWithDrawFromLock and withdrawFromLock
+          GAS_AMOUNTS[functionName] || GAS_AMOUNTS[`${functionName}FromLock`]
+        )
+      ),
       to: checksumContractAddress,
       data: unlockInterface.functions[`${functionName}(${signature})`].encode(
         args

--- a/unlock-js/src/__tests__/v0/partialWithdrawFromLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v0/partialWithdrawFromLock.ethers.test.js
@@ -1,0 +1,129 @@
+import * as UnlockV0 from 'unlock-abi-0'
+import * as utils from '../../utils.ethers'
+import Errors from '../../errors'
+import TransactionTypes from '../../transactionTypes'
+import NockHelper from '../helpers/nockHelper'
+import {
+  prepWalletService,
+  prepContract,
+} from '../helpers/walletServiceHelper.ethers'
+
+const { FAILED_TO_WITHDRAW_FROM_LOCK } = Errors
+const endpoint = 'http://127.0.0.1:8545'
+const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
+
+let walletService
+let transaction
+let transactionResult
+let setupSuccess
+let setupFail
+
+describe('v0 (ethers)', () => {
+  describe('partialWithdrawFromLock', () => {
+    const lock = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+    const account = '0xdeadbeef'
+    const amount = '3'
+
+    async function nockBeforeEach() {
+      nock.cleanAll()
+      walletService = await prepWalletService(
+        UnlockV0.PublicLock,
+        endpoint,
+        nock
+      )
+
+      const callMethodData = prepContract({
+        contract: UnlockV0.PublicLock,
+        functionName: 'partialWithdraw',
+        signature: 'uint256',
+        nock,
+      })
+
+      const {
+        testTransaction,
+        testTransactionResult,
+        success,
+        fail,
+      } = callMethodData(utils.toWei(amount, 'ether'))
+
+      transaction = testTransaction
+      transactionResult = testTransactionResult
+      setupSuccess = success
+      setupFail = fail
+    }
+
+    it('should invoke _handleMethodCall with the right params', async () => {
+      expect.assertions(2)
+      const callback = jest.fn()
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      walletService._handleMethodCall = jest.fn(() =>
+        Promise.resolve(transaction.hash)
+      )
+      const mock = walletService._handleMethodCall
+
+      await walletService.partialWithdrawFromLock(
+        lock,
+        account,
+        amount,
+        callback
+      )
+
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(Promise),
+        TransactionTypes.WITHDRAWAL
+      )
+
+      // verify that the promise passed to _handleMethodCall actually resolves
+      // to the result the chain returns from a sendTransaction call to createLock
+      const result = await mock.mock.calls[0][0]
+      expect(result).toEqual(transactionResult)
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should emit an error if the transaction cannot be sent', async () => {
+      expect.assertions(1)
+      const callback = jest.fn()
+
+      const error = { code: 404, data: 'oops' }
+      await nockBeforeEach()
+      setupFail(error)
+
+      walletService.on('error', error => {
+        expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
+      })
+
+      await walletService.partialWithdrawFromLock(
+        lock,
+        account,
+        amount,
+        callback
+      )
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should not emit an error when `error` is falsy', async () => {
+      expect.assertions(1)
+      const callback = jest.fn()
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      walletService._handleMethodCall = jest.fn(() =>
+        Promise.resolve(transaction.hash)
+      )
+
+      await walletService.partialWithdrawFromLock(
+        lock,
+        account,
+        amount,
+        callback
+      )
+
+      await nock.resolveWhenAllNocksUsed()
+      expect(callback).toHaveBeenCalled()
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v01/partialWithdrawFromLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v01/partialWithdrawFromLock.ethers.test.js
@@ -1,0 +1,129 @@
+import * as UnlockV01 from 'unlock-abi-0-1'
+import * as utils from '../../utils.ethers'
+import Errors from '../../errors'
+import TransactionTypes from '../../transactionTypes'
+import NockHelper from '../helpers/nockHelper'
+import {
+  prepWalletService,
+  prepContract,
+} from '../helpers/walletServiceHelper.ethers'
+
+const { FAILED_TO_WITHDRAW_FROM_LOCK } = Errors
+const endpoint = 'http://127.0.0.1:8545'
+const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
+
+let walletService
+let transaction
+let transactionResult
+let setupSuccess
+let setupFail
+
+describe('v01 (ethers)', () => {
+  describe('partialWithdrawFromLock', () => {
+    const lock = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+    const account = '0xdeadbeef'
+    const amount = '3'
+
+    async function nockBeforeEach() {
+      nock.cleanAll()
+      walletService = await prepWalletService(
+        UnlockV01.PublicLock,
+        endpoint,
+        nock
+      )
+
+      const callMethodData = prepContract({
+        contract: UnlockV01.PublicLock,
+        functionName: 'partialWithdraw',
+        signature: 'uint256',
+        nock,
+      })
+
+      const {
+        testTransaction,
+        testTransactionResult,
+        success,
+        fail,
+      } = callMethodData(utils.toWei(amount, 'ether'))
+
+      transaction = testTransaction
+      transactionResult = testTransactionResult
+      setupSuccess = success
+      setupFail = fail
+    }
+
+    it('should invoke _handleMethodCall with the right params', async () => {
+      expect.assertions(2)
+      const callback = jest.fn()
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      walletService._handleMethodCall = jest.fn(() =>
+        Promise.resolve(transaction.hash)
+      )
+      const mock = walletService._handleMethodCall
+
+      await walletService.partialWithdrawFromLock(
+        lock,
+        account,
+        amount,
+        callback
+      )
+
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(Promise),
+        TransactionTypes.WITHDRAWAL
+      )
+
+      // verify that the promise passed to _handleMethodCall actually resolves
+      // to the result the chain returns from a sendTransaction call to createLock
+      const result = await mock.mock.calls[0][0]
+      expect(result).toEqual(transactionResult)
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should emit an error if the transaction cannot be sent', async () => {
+      expect.assertions(1)
+      const callback = jest.fn()
+
+      const error = { code: 404, data: 'oops' }
+      await nockBeforeEach()
+      setupFail(error)
+
+      walletService.on('error', error => {
+        expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
+      })
+
+      await walletService.partialWithdrawFromLock(
+        lock,
+        account,
+        amount,
+        callback
+      )
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should not emit an error when `error` is falsy', async () => {
+      expect.assertions(1)
+      const callback = jest.fn()
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      walletService._handleMethodCall = jest.fn(() =>
+        Promise.resolve(transaction.hash)
+      )
+
+      await walletService.partialWithdrawFromLock(
+        lock,
+        account,
+        amount,
+        callback
+      )
+
+      await nock.resolveWhenAllNocksUsed()
+      expect(callback).toHaveBeenCalled()
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v02/partialWithdrawFromLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v02/partialWithdrawFromLock.ethers.test.js
@@ -1,0 +1,129 @@
+import * as UnlockV02 from 'unlock-abi-0-2'
+import * as utils from '../../utils.ethers'
+import Errors from '../../errors'
+import TransactionTypes from '../../transactionTypes'
+import NockHelper from '../helpers/nockHelper'
+import {
+  prepWalletService,
+  prepContract,
+} from '../helpers/walletServiceHelper.ethers'
+
+const { FAILED_TO_WITHDRAW_FROM_LOCK } = Errors
+const endpoint = 'http://127.0.0.1:8545'
+const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
+
+let walletService
+let transaction
+let transactionResult
+let setupSuccess
+let setupFail
+
+describe('v02 (ethers)', () => {
+  describe('partialWithdrawFromLock', () => {
+    const lock = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+    const account = '0xdeadbeef'
+    const amount = '3'
+
+    async function nockBeforeEach() {
+      nock.cleanAll()
+      walletService = await prepWalletService(
+        UnlockV02.PublicLock,
+        endpoint,
+        nock
+      )
+
+      const callMethodData = prepContract({
+        contract: UnlockV02.PublicLock,
+        functionName: 'partialWithdraw',
+        signature: 'uint256',
+        nock,
+      })
+
+      const {
+        testTransaction,
+        testTransactionResult,
+        success,
+        fail,
+      } = callMethodData(utils.toWei(amount, 'ether'))
+
+      transaction = testTransaction
+      transactionResult = testTransactionResult
+      setupSuccess = success
+      setupFail = fail
+    }
+
+    it('should invoke _handleMethodCall with the right params', async () => {
+      expect.assertions(2)
+      const callback = jest.fn()
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      walletService._handleMethodCall = jest.fn(() =>
+        Promise.resolve(transaction.hash)
+      )
+      const mock = walletService._handleMethodCall
+
+      await walletService.partialWithdrawFromLock(
+        lock,
+        account,
+        amount,
+        callback
+      )
+
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(Promise),
+        TransactionTypes.WITHDRAWAL
+      )
+
+      // verify that the promise passed to _handleMethodCall actually resolves
+      // to the result the chain returns from a sendTransaction call to createLock
+      const result = await mock.mock.calls[0][0]
+      expect(result).toEqual(transactionResult)
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should emit an error if the transaction cannot be sent', async () => {
+      expect.assertions(1)
+      const callback = jest.fn()
+
+      const error = { code: 404, data: 'oops' }
+      await nockBeforeEach()
+      setupFail(error)
+
+      walletService.on('error', error => {
+        expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
+      })
+
+      await walletService.partialWithdrawFromLock(
+        lock,
+        account,
+        amount,
+        callback
+      )
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should not emit an error when `error` is falsy', async () => {
+      expect.assertions(1)
+      const callback = jest.fn()
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      walletService._handleMethodCall = jest.fn(() =>
+        Promise.resolve(transaction.hash)
+      )
+
+      await walletService.partialWithdrawFromLock(
+        lock,
+        account,
+        amount,
+        callback
+      )
+
+      await nock.resolveWhenAllNocksUsed()
+      expect(callback).toHaveBeenCalled()
+    })
+  })
+})

--- a/unlock-js/src/__tests__/walletService.ethers.test.js
+++ b/unlock-js/src/__tests__/walletService.ethers.test.js
@@ -184,6 +184,26 @@ describe('WalletService (ethers)', () => {
         expect(r).toBe(result)
       }
     )
+    const versionSpecificLockMethods = ['partialWithdrawFromLock']
+
+    it.each(versionSpecificLockMethods)(
+      'should invoke the implementation of the corresponding version of %s',
+      async method => {
+        const args = []
+        const result = {}
+        const version = {
+          [`ethers_${method}`]: function(_args) {
+            // Needs to be a function because it is bound to walletService
+            expect(this).toBe(walletService)
+            expect(_args).toBe(...args)
+            return result
+          },
+        }
+        walletService.ethers_lockContractAbiVersion = jest.fn(() => version)
+        const r = await walletService[method](...args)
+        expect(r).toBe(result)
+      }
+    )
 
     // for each supported version, let's make sure it implements all methods
     const supportedVersions = [v0, v01, v02]
@@ -191,6 +211,9 @@ describe('WalletService (ethers)', () => {
       'should implement all the required methods',
       version => {
         versionSpecificUnlockMethods.forEach(method => {
+          expect(version[method]).toBeInstanceOf(Function)
+        })
+        versionSpecificLockMethods.forEach(method => {
           expect(version[method]).toBeInstanceOf(Function)
         })
       }

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -384,7 +384,6 @@ describe('WalletService', () => {
     const versionSpecificLockMethods = [
       'updateKeyPrice',
       'purchaseKey',
-      'partialWithdrawFromLock',
       'withdrawFromLock',
     ]
 

--- a/unlock-js/src/v0/index.js
+++ b/unlock-js/src/v0/index.js
@@ -3,6 +3,7 @@ import createLock from './createLock'
 import ethers_createLock from './createLock.ethers'
 import getLock from './getLock'
 import partialWithdrawFromLock from './partialWithdrawFromLock'
+import ethers_partialWithdrawFromLock from './partialWithdrawFromLock.ethers'
 import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
@@ -12,6 +13,7 @@ export default {
   createLock,
   getLock,
   partialWithdrawFromLock,
+  ethers_partialWithdrawFromLock,
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,

--- a/unlock-js/src/v0/partialWithdrawFromLock.ethers.js
+++ b/unlock-js/src/v0/partialWithdrawFromLock.ethers.js
@@ -17,7 +17,7 @@ export default async function(lockAddress, account, ethAmount, callback) {
   let transactionPromise
   try {
     transactionPromise = lockContract['partialWithdraw(uint256)'](weiAmount, {
-      gasLimit: GAS_AMOUNTS.partialWithdrawFromLock, // overrides default value for transaction gas price
+      gasLimit: GAS_AMOUNTS.partialWithdraw, // overrides default value for transaction gas price
     })
     const hash = await this._handleMethodCall(
       transactionPromise,

--- a/unlock-js/src/v0/partialWithdrawFromLock.ethers.js
+++ b/unlock-js/src/v0/partialWithdrawFromLock.ethers.js
@@ -1,0 +1,32 @@
+import utils from '../utils.ethers'
+import { GAS_AMOUNTS } from '../constants'
+import TransactionTypes from '../transactionTypes'
+import Errors from '../errors'
+
+/**
+ * Triggers a transaction to withdraw some funds from the lock and assign them
+ * to the owner.
+ * @param {PropTypes.address} lock
+ * @param {PropTypes.address} account
+ * @param {string} ethAmount
+ * @param {Function} callback
+ */
+export default async function(lockAddress, account, ethAmount, callback) {
+  const lockContract = await this.getLockContract(lockAddress)
+  const weiAmount = utils.toWei(ethAmount)
+  let transactionPromise
+  try {
+    transactionPromise = lockContract['partialWithdraw(uint256)'](weiAmount, {
+      gasLimit: GAS_AMOUNTS.partialWithdrawFromLock, // overrides default value for transaction gas price
+    })
+    const hash = await this._handleMethodCall(
+      transactionPromise,
+      TransactionTypes.WITHDRAWAL
+    )
+    callback()
+    return hash
+  } catch (error) {
+    this.emit('error', new Error(Errors.FAILED_TO_WITHDRAW_FROM_LOCK))
+    callback(error)
+  }
+}

--- a/unlock-js/src/v01/index.js
+++ b/unlock-js/src/v01/index.js
@@ -3,6 +3,7 @@ import createLock from './createLock'
 import ethers_createLock from './createLock.ethers'
 import getLock from './getLock'
 import partialWithdrawFromLock from './partialWithdrawFromLock'
+import ethers_partialWithdrawFromLock from './partialWithdrawFromLock.ethers'
 import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
@@ -12,6 +13,7 @@ export default {
   createLock,
   getLock,
   partialWithdrawFromLock,
+  ethers_partialWithdrawFromLock,
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,

--- a/unlock-js/src/v01/partialWithdrawFromLock.ethers.js
+++ b/unlock-js/src/v01/partialWithdrawFromLock.ethers.js
@@ -17,7 +17,7 @@ export default async function(lockAddress, account, ethAmount, callback) {
   let transactionPromise
   try {
     transactionPromise = lockContract['partialWithdraw(uint256)'](weiAmount, {
-      gasLimit: GAS_AMOUNTS.partialWithdrawFromLock, // overrides default value for transaction gas price
+      gasLimit: GAS_AMOUNTS.partialWithdraw, // overrides default value for transaction gas price
     })
     const hash = await this._handleMethodCall(
       transactionPromise,

--- a/unlock-js/src/v01/partialWithdrawFromLock.ethers.js
+++ b/unlock-js/src/v01/partialWithdrawFromLock.ethers.js
@@ -1,0 +1,32 @@
+import utils from '../utils.ethers'
+import { GAS_AMOUNTS } from '../constants'
+import TransactionTypes from '../transactionTypes'
+import Errors from '../errors'
+
+/**
+ * Triggers a transaction to withdraw some funds from the lock and assign them
+ * to the owner.
+ * @param {PropTypes.address} lock
+ * @param {PropTypes.address} account
+ * @param {string} ethAmount
+ * @param {Function} callback
+ */
+export default async function(lockAddress, account, ethAmount, callback) {
+  const lockContract = await this.getLockContract(lockAddress)
+  const weiAmount = utils.toWei(ethAmount)
+  let transactionPromise
+  try {
+    transactionPromise = lockContract['partialWithdraw(uint256)'](weiAmount, {
+      gasLimit: GAS_AMOUNTS.partialWithdrawFromLock, // overrides default value for transaction gas price
+    })
+    const hash = await this._handleMethodCall(
+      transactionPromise,
+      TransactionTypes.WITHDRAWAL
+    )
+    callback()
+    return hash
+  } catch (error) {
+    this.emit('error', new Error(Errors.FAILED_TO_WITHDRAW_FROM_LOCK))
+    callback(error)
+  }
+}

--- a/unlock-js/src/v02/index.js
+++ b/unlock-js/src/v02/index.js
@@ -3,6 +3,7 @@ import createLock from './createLock'
 import ethers_createLock from './createLock.ethers'
 import getLock from './getLock'
 import partialWithdrawFromLock from './partialWithdrawFromLock'
+import ethers_partialWithdrawFromLock from './partialWithdrawFromLock.ethers'
 import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
@@ -12,6 +13,7 @@ export default {
   createLock,
   getLock,
   partialWithdrawFromLock,
+  ethers_partialWithdrawFromLock,
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,

--- a/unlock-js/src/v02/partialWithdrawFromLock.ethers.js
+++ b/unlock-js/src/v02/partialWithdrawFromLock.ethers.js
@@ -17,7 +17,7 @@ export default async function(lockAddress, account, ethAmount, callback) {
   let transactionPromise
   try {
     transactionPromise = lockContract['partialWithdraw(uint256)'](weiAmount, {
-      gasLimit: GAS_AMOUNTS.partialWithdrawFromLock, // overrides default value for transaction gas price
+      gasLimit: GAS_AMOUNTS.partialWithdraw, // overrides default value for transaction gas price
     })
     const hash = await this._handleMethodCall(
       transactionPromise,

--- a/unlock-js/src/v02/partialWithdrawFromLock.ethers.js
+++ b/unlock-js/src/v02/partialWithdrawFromLock.ethers.js
@@ -1,0 +1,32 @@
+import utils from '../utils.ethers'
+import { GAS_AMOUNTS } from '../constants'
+import TransactionTypes from '../transactionTypes'
+import Errors from '../errors'
+
+/**
+ * Triggers a transaction to withdraw some funds from the lock and assign them
+ * to the owner.
+ * @param {PropTypes.address} lock
+ * @param {PropTypes.address} account
+ * @param {string} ethAmount
+ * @param {Function} callback
+ */
+export default async function(lockAddress, account, ethAmount, callback) {
+  const lockContract = await this.getLockContract(lockAddress)
+  const weiAmount = utils.toWei(ethAmount)
+  let transactionPromise
+  try {
+    transactionPromise = lockContract['partialWithdraw(uint256)'](weiAmount, {
+      gasLimit: GAS_AMOUNTS.partialWithdrawFromLock, // overrides default value for transaction gas price
+    })
+    const hash = await this._handleMethodCall(
+      transactionPromise,
+      TransactionTypes.WITHDRAWAL
+    )
+    callback()
+    return hash
+  } catch (error) {
+    this.emit('error', new Error(Errors.FAILED_TO_WITHDRAW_FROM_LOCK))
+    callback(error)
+  }
+}

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -208,8 +208,8 @@ export default class WalletService extends UnlockService {
    * @param {Function} callback
    */
   async partialWithdrawFromLock(lock, account, ethAmount, callback) {
-    const version = await this.lockContractAbiVersion(lock)
-    return version.partialWithdrawFromLock.bind(this)(
+    const version = await this.ethers_lockContractAbiVersion(lock)
+    return version.ethers_partialWithdrawFromLock.bind(this)(
       lock,
       account,
       ethAmount,


### PR DESCRIPTION
# Description

This PR migrates the `partialWithdrawFromLock` function to ethers. To support the slight differences in behavior with `PublicLock` methods, some changes to the `walletServiceHelper.ethers.js` needed to be made.

1. the inconsistency in the publicLockVersion returned from v01 is handled properly
2. the extra calls to `getCode` in order to differentiate between v0 and v01 is inserted
3. the inconsistency in `GAS_AMOUNTS` naming (withdraws append `FromLock`) is addressed

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
