### PR TITLE
enable the createLock ethers version and *actually* test its interaction with walletService

### DIFF
--- a/unlock-js/src/__tests__/v0/createLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v0/createLock.ethers.test.js
@@ -1,6 +1,5 @@
 import * as UnlockV0 from 'unlock-abi-0'
 import * as utils from '../../utils.ethers'
-import createLock from '../../v0/createLock.ethers'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
@@ -36,7 +35,6 @@ describe('v0 (ethers)', () => {
         nock,
         true // this is the Unlock contract, not PublicLock
       )
-      walletService.createLock = createLock.bind(walletService)
 
       const callMethodData = prepContract({
         contract: UnlockV0.Unlock,

--- a/unlock-js/src/__tests__/v01/createLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v01/createLock.ethers.test.js
@@ -1,7 +1,6 @@
 import { ethers } from 'ethers'
 import * as UnlockV01 from 'unlock-abi-0-1'
 import * as utils from '../../utils.ethers'
-import createLock from '../../v01/createLock.ethers'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
@@ -37,7 +36,6 @@ describe('v01 (ethers)', () => {
         nock,
         true // this is the Unlock contract, not PublicLock
       )
-      walletService.createLock = createLock.bind(walletService)
 
       const callMethodData = prepContract({
         contract: UnlockV01.Unlock,

--- a/unlock-js/src/__tests__/v02/createLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v02/createLock.ethers.test.js
@@ -1,7 +1,6 @@
 import { ethers } from 'ethers'
 import * as UnlockV02 from 'unlock-abi-0-2'
 import * as utils from '../../utils.ethers'
-import createLock from '../../v02/createLock.ethers'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
@@ -37,7 +36,6 @@ describe('v02 (ethers)', () => {
         nock,
         true // this is the Unlock contract, not PublicLock
       )
-      walletService.createLock = createLock.bind(walletService)
 
       const callMethodData = prepContract({
         contract: UnlockV02.Unlock,

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -407,36 +407,12 @@ describe('WalletService', () => {
       }
     )
 
-    const versionSpecificUnlockMethods = ['createLock']
-
-    it.each(versionSpecificUnlockMethods)(
-      'should invoke the implementation of the corresponding version of %s',
-      async method => {
-        const args = []
-        const result = {}
-        const version = {
-          [method]: function(_args) {
-            // Needs to be a function because it is bound to walletService
-            expect(this).toBe(walletService)
-            expect(_args).toBe(...args)
-            return result
-          },
-        }
-        walletService.unlockContractAbiVersion = jest.fn(() => version)
-        const r = await walletService[method](...args)
-        expect(r).toBe(result)
-      }
-    )
-
     // for each supported version, let's make sure it implements all methods
     const supportedVersions = [v0, v01, v02]
     it.each(supportedVersions)(
       'should implement all the required methods',
       version => {
         versionSpecificLockMethods.forEach(method => {
-          expect(version[method]).toBeInstanceOf(Function)
-        })
-        versionSpecificUnlockMethods.forEach(method => {
           expect(version[method]).toBeInstanceOf(Function)
         })
       }

--- a/unlock-js/src/v0/index.js
+++ b/unlock-js/src/v0/index.js
@@ -1,5 +1,6 @@
 import { Unlock, PublicLock } from 'unlock-abi-0'
 import createLock from './createLock'
+import ethers_createLock from './createLock.ethers'
 import getLock from './getLock'
 import partialWithdrawFromLock from './partialWithdrawFromLock'
 import purchaseKey from './purchaseKey'
@@ -7,6 +8,7 @@ import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 
 export default {
+  ethers_createLock,
   createLock,
   getLock,
   partialWithdrawFromLock,

--- a/unlock-js/src/v01/index.js
+++ b/unlock-js/src/v01/index.js
@@ -1,5 +1,6 @@
 import { Unlock, PublicLock } from 'unlock-abi-0-1'
 import createLock from './createLock'
+import ethers_createLock from './createLock.ethers'
 import getLock from './getLock'
 import partialWithdrawFromLock from './partialWithdrawFromLock'
 import purchaseKey from './purchaseKey'
@@ -7,6 +8,7 @@ import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 
 export default {
+  ethers_createLock,
   createLock,
   getLock,
   partialWithdrawFromLock,

--- a/unlock-js/src/v02/index.js
+++ b/unlock-js/src/v02/index.js
@@ -1,5 +1,6 @@
 import { Unlock, PublicLock } from 'unlock-abi-0-2'
 import createLock from './createLock'
+import ethers_createLock from './createLock.ethers'
 import getLock from './getLock'
 import partialWithdrawFromLock from './partialWithdrawFromLock'
 import purchaseKey from './purchaseKey'
@@ -7,6 +8,7 @@ import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 
 export default {
+  ethers_createLock,
   createLock,
   getLock,
   partialWithdrawFromLock,

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -178,8 +178,8 @@ export default class WalletService extends UnlockService {
    * @param {PropTypes.address} owner
    */
   async createLock(lock, owner) {
-    const version = await this.unlockContractAbiVersion()
-    return version.createLock.bind(this)(lock, owner)
+    const version = await this.ethers_unlockContractAbiVersion()
+    return version.ethers_createLock.bind(this)(lock, owner)
   }
 
   /**


### PR DESCRIPTION
# Description

The migration of `createLock` to ethers was missing a key element: actually being called. This PR fixes that oversight

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
