### PR TITLE
rename GAS_AMOUNTS to match the contract function name

### DIFF
--- a/unlock-js/src/__tests__/v0/partialWithdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v0/partialWithdrawFromLock.test.js
@@ -73,7 +73,7 @@ describe('v0', () => {
           to: lock,
           from: account,
           data,
-          gas: GAS_AMOUNTS.partialWithdrawFromLock,
+          gas: GAS_AMOUNTS.partialWithdraw,
           contract: UnlockV0.PublicLock,
         },
         TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/__tests__/v0/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v0/purchaseKey.test.js
@@ -77,7 +77,7 @@ describe('v0', () => {
           to: lock,
           from: account,
           data,
-          gas: GAS_AMOUNTS.purchaseKey,
+          gas: GAS_AMOUNTS.purchaseFor,
           contract: UnlockV0.PublicLock,
           value: '100000000000000000000000000', // Web3Utils.toWei(keyPrice, 'ether')
         },

--- a/unlock-js/src/__tests__/v0/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v0/withdrawFromLock.test.js
@@ -69,7 +69,7 @@ describe('v0', () => {
           to: lock,
           from: account,
           data,
-          gas: GAS_AMOUNTS.withdrawFromLock,
+          gas: GAS_AMOUNTS.withdraw,
           contract: UnlockV0.PublicLock,
         },
         TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/__tests__/v01/partialWithdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v01/partialWithdrawFromLock.test.js
@@ -73,7 +73,7 @@ describe('v01', () => {
           to: lock,
           from: account,
           data,
-          gas: GAS_AMOUNTS.partialWithdrawFromLock,
+          gas: GAS_AMOUNTS.partialWithdraw,
           contract: UnlockV01.PublicLock,
         },
         TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/__tests__/v01/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v01/purchaseKey.test.js
@@ -74,7 +74,7 @@ describe('v01', () => {
           to: lock,
           from: account,
           data,
-          gas: GAS_AMOUNTS.purchaseKey,
+          gas: GAS_AMOUNTS.purchaseFor,
           contract: UnlockV01.PublicLock,
           value: '100000000000000000000000000', // Web3Utils.toWei(keyPrice, 'ether')
         },

--- a/unlock-js/src/__tests__/v01/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v01/withdrawFromLock.test.js
@@ -69,7 +69,7 @@ describe('v01', () => {
           to: lock,
           from: account,
           data,
-          gas: GAS_AMOUNTS.withdrawFromLock,
+          gas: GAS_AMOUNTS.withdraw,
           contract: UnlockV01.PublicLock,
         },
         TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/__tests__/v02/partialWithdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v02/partialWithdrawFromLock.test.js
@@ -73,7 +73,7 @@ describe('v02', () => {
           to: lock,
           from: account,
           data,
-          gas: GAS_AMOUNTS.partialWithdrawFromLock,
+          gas: GAS_AMOUNTS.partialWithdraw,
           contract: UnlockV02.PublicLock,
         },
         TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/__tests__/v02/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v02/purchaseKey.test.js
@@ -74,7 +74,7 @@ describe('v02', () => {
           to: lock,
           from: account,
           data,
-          gas: GAS_AMOUNTS.purchaseKey,
+          gas: GAS_AMOUNTS.purchaseFor,
           contract: UnlockV02.PublicLock,
           value: '100000000000000000000000000', // Web3Utils.toWei(keyPrice, 'ether')
         },

--- a/unlock-js/src/__tests__/v02/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v02/withdrawFromLock.test.js
@@ -69,7 +69,7 @@ describe('v02', () => {
           to: lock,
           from: account,
           data,
-          gas: GAS_AMOUNTS.withdrawFromLock,
+          gas: GAS_AMOUNTS.withdraw,
           contract: UnlockV02.PublicLock,
         },
         TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/constants.js
+++ b/unlock-js/src/constants.js
@@ -3,9 +3,9 @@ import { constants } from 'ethers'
 export const GAS_AMOUNTS = {
   createLock: 3500000,
   updateKeyPrice: 1000000,
-  purchaseKey: 300000,
-  withdrawFromLock: 1000000,
-  partialWithdrawFromLock: 1000000,
+  purchaseFor: 300000, // purchaseKey in walletService
+  withdraw: 1000000, // withdrawFromLock in walletService
+  partialWithdraw: 1000000, // partialWithdrawFromLock in walletService
   deployContract: 6000000,
 }
 

--- a/unlock-js/src/v0/partialWithdrawFromLock.js
+++ b/unlock-js/src/v0/partialWithdrawFromLock.js
@@ -22,7 +22,7 @@ export default function(lock, account, ethAmount, callback) {
       to: lock,
       from: account,
       data,
-      gas: GAS_AMOUNTS.partialWithdrawFromLock,
+      gas: GAS_AMOUNTS.partialWithdraw,
       contract: UnlockV0.PublicLock,
     },
     TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/v0/purchaseKey.js
+++ b/unlock-js/src/v0/purchaseKey.js
@@ -27,7 +27,7 @@ export default function(lock, owner, keyPrice, account, data = '') {
       to: lock,
       from: account,
       data: abi,
-      gas: GAS_AMOUNTS.purchaseKey,
+      gas: GAS_AMOUNTS.purchaseFor,
       value: Web3Utils.toWei(keyPrice, 'ether'),
       contract: UnlockV0.PublicLock,
     },

--- a/unlock-js/src/v0/withdrawFromLock.js
+++ b/unlock-js/src/v0/withdrawFromLock.js
@@ -18,7 +18,7 @@ export default function(lock, account) {
       to: lock,
       from: account,
       data,
-      gas: GAS_AMOUNTS.withdrawFromLock,
+      gas: GAS_AMOUNTS.withdraw,
       contract: UnlockV0.PublicLock,
     },
     TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/v01/partialWithdrawFromLock.js
+++ b/unlock-js/src/v01/partialWithdrawFromLock.js
@@ -25,7 +25,7 @@ export default function(lock, account, ethAmount, callback) {
       to: lock,
       from: account,
       data,
-      gas: GAS_AMOUNTS.partialWithdrawFromLock,
+      gas: GAS_AMOUNTS.partialWithdraw,
       contract: UnlockV01.PublicLock,
     },
     TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/v01/purchaseKey.js
+++ b/unlock-js/src/v01/purchaseKey.js
@@ -33,7 +33,7 @@ export default function(lock, owner, keyPrice, account, data = '') {
       to: lock,
       from: account,
       data: abi,
-      gas: GAS_AMOUNTS.purchaseKey,
+      gas: GAS_AMOUNTS.purchaseFor,
       value: Web3Utils.toWei(keyPrice, 'ether'),
       contract: UnlockV01.PublicLock,
     },

--- a/unlock-js/src/v01/withdrawFromLock.js
+++ b/unlock-js/src/v01/withdrawFromLock.js
@@ -21,7 +21,7 @@ export default function(lock, account) {
       to: lock,
       from: account,
       data,
-      gas: GAS_AMOUNTS.withdrawFromLock,
+      gas: GAS_AMOUNTS.withdraw,
       contract: UnlockV01.PublicLock,
     },
     TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/v02/partialWithdrawFromLock.js
+++ b/unlock-js/src/v02/partialWithdrawFromLock.js
@@ -25,7 +25,7 @@ export default function(lock, account, ethAmount, callback) {
       to: lock,
       from: account,
       data,
-      gas: GAS_AMOUNTS.partialWithdrawFromLock,
+      gas: GAS_AMOUNTS.partialWithdraw,
       contract: UnlockV02.PublicLock,
     },
     TransactionTypes.WITHDRAWAL,

--- a/unlock-js/src/v02/purchaseKey.js
+++ b/unlock-js/src/v02/purchaseKey.js
@@ -33,7 +33,7 @@ export default function(lock, owner, keyPrice, account, data = '') {
       to: lock,
       from: account,
       data: abi,
-      gas: GAS_AMOUNTS.purchaseKey,
+      gas: GAS_AMOUNTS.purchaseFor,
       value: Web3Utils.toWei(keyPrice, 'ether'),
       contract: UnlockV02.PublicLock,
     },

--- a/unlock-js/src/v02/withdrawFromLock.js
+++ b/unlock-js/src/v02/withdrawFromLock.js
@@ -21,7 +21,7 @@ export default function(lock, account) {
       to: lock,
       from: account,
       data,
-      gas: GAS_AMOUNTS.withdrawFromLock,
+      gas: GAS_AMOUNTS.withdraw,
       contract: UnlockV02.PublicLock,
     },
     TransactionTypes.WITHDRAWAL,


### PR DESCRIPTION
# Description

Currently, the `GAS_AMOUNTS` constants match the `walletService` function call they represent. This PR renames them to instead match the smart contract method name they represent. This has a couple of benefits, the most immediate of which is that the `walletService.helper.ethers` helper can correctly guess the gas amount to use based on the smart contract function name it will be called with.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
