### PR TITLE
migrate deploy script to ethers

### DIFF
--- a/unlock-js/src/__tests__/deploy.test.js
+++ b/unlock-js/src/__tests__/deploy.test.js
@@ -1,4 +1,5 @@
-import Web3 from 'web3'
+import { ethers } from 'ethers'
+import { getContractAddress } from 'ethers/utils'
 import { Unlock } from 'unlock-abi-0'
 
 import deploy from '../deploy'
@@ -9,14 +10,14 @@ const host = '127.0.0.1'
 const port = 8545
 
 const endpoint = 'http://127.0.0.1:8545'
-const nock = new NockHelper(endpoint, false /** debug */)
+const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
 const gasPrice = `0x${(8000000).toString(16)}`
 
 describe('contract deployer', () => {
   const unlockAccountsOnNode = ['0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2']
   const transaction = {
     hash: '0x83f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
-    nonce: '0x04',
+    nonce: '0x0',
     blockHash:
       '0xdc7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
     blockNumber: `0x${(14).toString('16')}`,
@@ -29,26 +30,29 @@ describe('contract deployer', () => {
     input:
       '0x2bc888bf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000278d00000000000000000000000000000000000000000000000000002386f26fc10000000000000000000000000000000000000000000000000000000000000000000a',
   }
+  const contractAddress = getContractAddress(transaction)
   const transactionReceipt = {
-    transactionIndex: '0x3',
+    transactionHash:
+      '0x83f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
+    transactionIndex: '0x00',
     blockHash:
       '0xdc7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
     blockNumber: `0x${(14).toString('16')}`,
     gasUsed: '0x2ea84',
     cumulativeGasUsed: '0x3a525',
-    contractAddress: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+    contractAddress,
     logs: [],
     status: '0x1',
   }
   const transaction2 = {
     hash: '0x93f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
-    nonce: '0x05',
+    nonce: '0x01',
     blockHash:
       '0xec7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
     blockNumber: `0x${(15).toString('16')}`,
     transactionIndex: '0x00',
     from: unlockAccountsOnNode[0],
-    to: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+    to: contractAddress,
     value: '0x0',
     gas: '0x16e360',
     gasPrice: '0x04a817c800',
@@ -56,13 +60,14 @@ describe('contract deployer', () => {
       '0xc4d66de8000000000000000000000000aaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
   }
   const transaction2Receipt = {
+    transactionHash:
+      '0x93f3e76db42dfd5ebba894e6ff462b3ae30b5f7bfb7a6fec3888e0ed88377f64',
     transactionIndex: '0x4',
     blockHash:
       '0xec7c95899e030f3104871a597866767ec296e948a24e99b12e0b251011d11c36',
     blockNumber: `0x${(15).toString('16')}`,
     gasUsed: '0x2ea84',
     cumulativeGasUsed: '0x3a525',
-    contractAddress: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
     logs: [],
     status: '0x1',
   }
@@ -71,12 +76,13 @@ describe('contract deployer', () => {
   })
 
   async function deployContract(Contract) {
-    const web3 = new Web3(`http://${host}:${port}`)
-    const unlock = new web3.eth.Contract(Contract.abi)
+    const unlock = new ethers.utils.Interface(Contract.abi)
 
     nock.cleanAll()
     nock.accountsAndYield(unlockAccountsOnNode)
-    nock.ethGasPriceAndYield(gasPrice)
+    nock.netVersionAndYield(1984) // ethers.js-only call
+    // nock.ethGasPriceAndYield(gasPrice) (web3-only call)
+    nock.accountsAndYield(unlockAccountsOnNode) // ethers.js-only call
 
     // contract deploy call
     nock.ethSendTransactionAndYield(
@@ -85,30 +91,36 @@ describe('contract deployer', () => {
         data: Unlock.bytecode,
         gas: '0x' + GAS_AMOUNTS.deployContract.toString(16),
       },
-      gasPrice,
+      false, // ethers.js does not use gasPrice
       transaction.hash
     )
+    nock.ethGetTransactionByHash(transaction.hash, transaction)
+    nock.ethBlockNumber(`0x${(14).toString('16')}`)
     nock.ethGetTransactionReceipt(transaction.hash, transactionReceipt)
-    // get the contract bytecode
-    nock.ethGetCodeAndYield(
+    nock.ethGetTransactionReceipt(transaction.hash, transactionReceipt)
+    // get the contract bytecode (web3-only)
+    /*nock.ethGetCodeAndYield(
       '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
       'latest',
       Contract.deployedByteCode
-    )
+    )*/
 
     // initialize call
-    nock.ethGasPriceAndYield(gasPrice)
+    // nock.ethGasPriceAndYield(gasPrice) // web3-only
     nock.ethSendTransactionAndYield(
       {
-        to: '0xbbbdeed4c0b861cb36f4ce006a9c90ba2e43fdc2', // contract address
+        to: contractAddress,
         from: unlockAccountsOnNode[0],
-        data: unlock.methods.initialize(unlockAccountsOnNode[0]).encodeABI(),
+        data: unlock.functions['initialize(address)'].encode([
+          unlockAccountsOnNode[0],
+        ]),
         gas: '0xf4240',
       },
-      gasPrice,
+      false, // gasPrice, // web3-only
       transaction2.hash
     )
-    nock.ethGetTransactionReceipt(transaction2.hash, transaction2Receipt)
+    nock.ethGetTransactionByHash(transaction2.hash, transaction2)
+    // nock.ethGetTransactionReceipt(transaction2.hash, transaction2Receipt) // web3-only
   }
 
   describe('all JSON-RPC calls happen in expected order', () => {
@@ -200,9 +212,10 @@ describe('contract deployer', () => {
     it('passes the new contract instance to onNewContractInstance', async () => {
       expect.assertions(1)
 
-      expect(deployed.mock.calls[0][0].options.address).toBe(
-        '0xBbBDeed4C0b861cb36f4Ce006A9c90bA2E43fDc2' // fancified by web3-utils
-      )
+      // const contractAddress = deployed.mock.calls[0][0].options.address // web3
+      const sentAddress = deployed.mock.calls[0][0].address // ethers.js
+
+      expect(sentAddress).toBe(contractAddress)
     })
   })
 
@@ -216,16 +229,12 @@ describe('contract deployer', () => {
     it('returns the result of the contract initialization transaction', async () => {
       expect.assertions(1)
 
-      expect(returnValue).toEqual({
-        blockHash: transaction2Receipt.blockHash,
-        blockNumber: parseInt(transaction2Receipt.blockNumber, 16),
-        contractAddress: '0xBbBDeed4C0b861cb36f4Ce006A9c90bA2E43fDc2',
-        cumulativeGasUsed: 238885,
-        gasUsed: 191108,
-        logs: [],
-        status: true,
-        transactionIndex: parseInt(transaction2Receipt.transactionIndex, 16),
-      })
+      expect(returnValue).toEqual(
+        expect.objectContaining({
+          blockHash: transaction2Receipt.blockHash,
+          blockNumber: parseInt(transaction2Receipt.blockNumber, 16),
+        })
+      )
     })
   })
 })

--- a/unlock-js/src/deploy.js
+++ b/unlock-js/src/deploy.js
@@ -19,13 +19,14 @@ export default async function deploy(
   )
   const accounts = await provider.listAccounts()
   const unlockContract = await factory.deploy({ gasLimit: gas.deployContract })
-  onNewContractInstance(unlockContract)
 
   await unlockContract.deployed()
 
   const writableUnlockContract = unlockContract.connect(wallet)
   // Initialize
-  return writableUnlockContract.initialize(accounts[0], {
+  const result = await writableUnlockContract.initialize(accounts[0], {
     gasLimit: 1000000,
   })
+  onNewContractInstance(unlockContract)
+  return result
 }


### PR DESCRIPTION
# Description

This PR migrates the contract deploy script for local dev to ethers. Note that this is the only place that introduces a backwards-compatibility break. The contract address was `contract.options.address` with web3, and is `contract.address` in ethers, so `deploy-unlock.js` will need to be updated when upgrading to the next version of unlock-js

Also, this really shows where ethers shines. The code is concise and easy to reason through, as well as easy to debug (in my experience)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
