### PR TITLE
migrate accounts to ethers

### DIFF
--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -5,13 +5,13 @@ import {
 
 describe('account helpers', () => {
   describe('web3 accounts creation', () => {
-    it('should call web3.accounts.create', () => {
+    it('should call ethers.createRandom', async () => {
       expect.assertions(2)
 
       const {
         address,
         passwordEncryptedPrivateKey,
-      } = createAccountAndPasswordEncryptKey('hello')
+      } = await createAccountAndPasswordEncryptKey('hello')
 
       expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/)
       expect(passwordEncryptedPrivateKey.address).toBe(
@@ -21,14 +21,14 @@ describe('account helpers', () => {
   })
 
   describe('web3 account decryption', () => {
-    it('should decrypt an account given the correct password', () => {
+    it('should decrypt an account given the correct password', async () => {
       expect.assertions(1)
       const {
         address,
         passwordEncryptedPrivateKey,
-      } = createAccountAndPasswordEncryptKey('guest')
+      } = await createAccountAndPasswordEncryptKey('guest')
 
-      const decryptedAddress = getAccountFromPrivateKey(
+      const decryptedAddress = await getAccountFromPrivateKey(
         passwordEncryptedPrivateKey,
         'guest'
       )
@@ -37,22 +37,24 @@ describe('account helpers', () => {
         expect.objectContaining({
           address: address,
           privateKey: expect.any(String),
-          encrypt: expect.any(Function),
-          sign: expect.any(Function),
-          signTransaction: expect.any(Function),
+          publicKey: expect.any(String),
+          signDigest: expect.any(Function),
+          computeSharedSecret: expect.any(Function),
         })
       )
     })
 
-    it('should throw when an incorrect password is given for an account', () => {
+    it('should throw when an incorrect password is given for an account', async () => {
       expect.assertions(1)
       const {
         passwordEncryptedPrivateKey,
-      } = createAccountAndPasswordEncryptKey('guest')
+      } = await createAccountAndPasswordEncryptKey('guest')
 
-      expect(() => {
-        getAccountFromPrivateKey(passwordEncryptedPrivateKey, 'ghost')
-      }).toThrow()
+      try {
+        await getAccountFromPrivateKey(passwordEncryptedPrivateKey, 'ghost')
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error)
+      }
     })
   })
 })

--- a/unlock-js/src/accounts.js
+++ b/unlock-js/src/accounts.js
@@ -1,13 +1,12 @@
-const Web3 = require('web3')
+const Wallet = require('ethers').Wallet
 
-export function createAccountAndPasswordEncryptKey(password) {
-  const web3 = new Web3()
-  const { address, privateKey } = web3.eth.accounts.create()
-
-  const passwordEncryptedPrivateKey = web3.eth.accounts.encrypt(
-    privateKey,
-    password
+export async function createAccountAndPasswordEncryptKey(password) {
+  const newWallet = Wallet.createRandom()
+  const address = await newWallet.getAddress()
+  const passwordEncryptedPrivateKey = JSON.parse(
+    await newWallet.encrypt(password)
   )
+
   return {
     address,
     passwordEncryptedPrivateKey,
@@ -21,8 +20,10 @@ export function createAccountAndPasswordEncryptKey(password) {
  * @param {string} password
  * @throws Throws an error if password does not decrypt private key.
  */
-export function getAccountFromPrivateKey(encryptedPrivateKey, password) {
-  const web3 = new Web3()
-
-  return web3.eth.accounts.decrypt(encryptedPrivateKey, password)
+export async function getAccountFromPrivateKey(encryptedPrivateKey, password) {
+  const wallet = await Wallet.fromEncryptedJson(
+    JSON.stringify(encryptedPrivateKey),
+    password
+  )
+  return wallet.signingKey
 }


### PR DESCRIPTION
# Description

This migrates the accounts portion to ethers. *WARNING!* Major BC break here. `web3` was synchronous, `ethers` is async. Otherwise the API is very similar. @cnasc you will want to take a very close look at this one prior to approving.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
