### PR TITLE
update the walletHelper for ethers to work for PublicLock methods

### DIFF
--- a/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
+++ b/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
@@ -31,16 +31,16 @@ export const prepWalletService = async (
   let unlockVersion
   switch (contract) {
     case UnlockV01.Unlock:
-    case UnlockV01.PublicLock:
       unlockVersion =
         '0x0000000000000000000000000000000000000000000000000000000000000001'
       break
-    case UnlockV02.PublicLock:
     case UnlockV02.Unlock:
+    case UnlockV02.PublicLock:
       unlockVersion =
         '0x0000000000000000000000000000000000000000000000000000000000000002'
       break
     default:
+    case UnlockV01.PublicLock: // version 0 is version 1 (oops)
     case UnlockV0.Unlock:
     case UnlockV0.PublicLock:
       unlockVersion =
@@ -60,8 +60,15 @@ export const prepWalletService = async (
     await walletService.getUnlockContract()
   } else {
     // is PublicLock
-    // this is "Contract.publicLockVersion()" with params [] (0x4220bd46)
+    // this is "Contract.publicLockVersion()" with params [] (0xd1bbd49c)
+
     nock.ethCallAndYield('0xd1bbd49c', checksumContractAddress, unlockVersion)
+    if (!unlockVersion) {
+      nock.ethGetCodeAndYield(contractAddress, contract.deployedBytecode)
+    }
+    if (unlockVersion < 2) {
+      nock.ethGetCodeAndYield(contractAddress, contract.deployedBytecode)
+    }
     await walletService.getLockContract(contractAddress)
   }
 


### PR DESCRIPTION
# Description

This extracts the `walletHelper.ethers.js` from #2944 as it is used in all the subsequent PRs and is not directly related to the PR. The test-facing API is unchanged, this only changes the internals. Changes are:

1. PublicLock v01 incorrectly returns version 0 for `publicLockVersion()`, the helper is updated to reflect this.
2. cosmetic consistency: in the switch statement for v02, PublicLock was before Unlock, but in all the other cases it was after
3. fixed the comment for `publicLockVersion` nock used the hex from `unlockVersion` (line above)
4. For public lock version 0, we need to retrieve the byte code to determine the actual version, so 2 new nock calls are added. The first happens when we get 0, and `unlockService` says "uh oh, this could be either version 0 or version 1, let's get the bytecode." The second call happens internally to ethers.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
