### PR TITLE
Return unwrapped key from storageService

### DIFF
--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -292,13 +292,19 @@ describe('StorageService', () => {
   describe('Retrieve a private key for a user', () => {
     describe('When a private key can be retrieved', () => {
       it('returns a successful promise', async () => {
-        expect.assertions(1)
-        axios.get.mockReturnValue({})
+        expect.assertions(2)
+        axios.get.mockReturnValue({
+          data: {
+            passwordEncryptedPrivateKey: 'Private Key  reporting for duty',
+          },
+        })
 
-        await storageService.getUserPrivateKey(
+        const key = await storageService.getUserPrivateKey(
           'hello@unlock-protocol.com',
           null
         )
+
+        expect(key).toBe('Private Key  reporting for duty')
 
         expect(axios.get).toHaveBeenCalledWith(
           `${serviceHost}/users/${encodeURIComponent(

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -162,11 +162,14 @@ export default class StorageService {
   async getUserPrivateKey(emailAddress) {
     const opts = {}
     try {
-      return await axios.get(
+      const response = await axios.get(
         `${this.host}/users/${encodeURIComponent(emailAddress)}/privatekey`,
         null,
         opts
       )
+      if (response.data && response.data.passwordEncryptedPrivateKey) {
+        return response.data.passwordEncryptedPrivateKey
+      }
     } catch (error) {
       return Promise.reject(error)
     }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Replacing #2937, this PR ensures that `storageService` returns just the unwrapped `passwordEncryptedPrivateKey`  to callers of `getUserPrivateKey`

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
