### PR TITLE
migrate purchaseKey to ethers

### DIFF
--- a/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
+++ b/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
@@ -92,12 +92,7 @@ export const prepContract = ({
   return (...args) => {
     const encodedValue = value ? utils.toWei(value, 'ether') : 0
     const testParams = {
-      gas: utils.hexStripZeros(
-        utils.hexlify(
-          // handles partialWithDrawFromLock and withdrawFromLock
-          GAS_AMOUNTS[functionName] || GAS_AMOUNTS[`${functionName}FromLock`]
-        )
-      ),
+      gas: utils.hexStripZeros(utils.hexlify(GAS_AMOUNTS[functionName])),
       to: checksumContractAddress,
       data: unlockInterface.functions[`${functionName}(${signature})`].encode(
         args

--- a/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
+++ b/unlock-js/src/__tests__/helpers/walletServiceHelper.ethers.js
@@ -92,7 +92,12 @@ export const prepContract = ({
   return (...args) => {
     const encodedValue = value ? utils.toWei(value, 'ether') : 0
     const testParams = {
-      gas: utils.hexStripZeros(utils.hexlify(GAS_AMOUNTS[functionName])),
+      gas: utils.hexStripZeros(
+        utils.hexlify(
+          // handles partialWithDrawFromLock and withdrawFromLock
+          GAS_AMOUNTS[functionName] || GAS_AMOUNTS[`${functionName}FromLock`]
+        )
+      ),
       to: checksumContractAddress,
       data: unlockInterface.functions[`${functionName}(${signature})`].encode(
         args

--- a/unlock-js/src/__tests__/utils.ethers.test.js
+++ b/unlock-js/src/__tests__/utils.ethers.test.js
@@ -75,4 +75,13 @@ describe('ethers utils', () => {
       '0x0000000000000000000000000000000000000000000000000000000000012345'
     )
   })
+
+  it('utf8ToHex', () => {
+    expect.assertions(2)
+
+    expect(ethersUtils.utf8ToHex('hi there')).toBe('0x6869207468657265')
+    expect(ethersUtils.utf8ToHex('I like turtles')).toBe(
+      '0x49206c696b6520747572746c6573'
+    )
+  })
 })

--- a/unlock-js/src/__tests__/v0/purchaseKey.ethers.test.js
+++ b/unlock-js/src/__tests__/v0/purchaseKey.ethers.test.js
@@ -1,0 +1,112 @@
+import * as UnlockV0 from 'unlock-abi-0'
+import * as utils from '../../utils.ethers'
+import purchaseKey from '../../v0/purchaseKey.ethers'
+import Errors from '../../errors'
+import TransactionTypes from '../../transactionTypes'
+import NockHelper from '../helpers/nockHelper'
+import {
+  prepWalletService,
+  prepContract,
+} from '../helpers/walletServiceHelper.ethers'
+
+const { FAILED_TO_PURCHASE_KEY } = Errors
+const endpoint = 'http://127.0.0.1:8545'
+const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
+
+let walletService
+let transaction
+let transactionResult
+let setupSuccess
+let setupFail
+
+describe('v0 (ethers)', () => {
+  describe('purchaseKey', () => {
+    const keyPrice = '0.01'
+    const owner = '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e'
+    const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+    const account = '0xdeadbeef'
+    const data = 'key data'
+
+    async function nockBeforeEach() {
+      nock.cleanAll()
+      walletService = await prepWalletService(
+        UnlockV0.PublicLock,
+        endpoint,
+        nock
+      )
+      walletService.purchaseKey = purchaseKey.bind(walletService)
+
+      const callMethodData = prepContract({
+        contract: UnlockV0.PublicLock,
+        functionName: 'purchaseFor',
+        signature: 'address,bytes',
+        nock,
+        value: keyPrice,
+      })
+
+      const {
+        testTransaction,
+        testTransactionResult,
+        success,
+        fail,
+      } = callMethodData(owner, utils.utf8ToHex(data))
+
+      transaction = testTransaction
+      transactionResult = testTransactionResult
+      setupSuccess = success
+      setupFail = fail
+    }
+
+    it('should invoke _handleMethodCall with the right params', async () => {
+      expect.assertions(2)
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      walletService._handleMethodCall = jest.fn(() =>
+        Promise.resolve(transaction.hash)
+      )
+      const mock = walletService._handleMethodCall
+
+      await walletService.purchaseKey(
+        lockAddress,
+        owner,
+        keyPrice,
+        account,
+        data
+      )
+
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(Promise),
+        TransactionTypes.KEY_PURCHASE
+      )
+
+      // verify that the promise passed to _handleMethodCall actually resolves
+      // to the result the chain returns from a sendTransaction call to createLock
+      const result = await mock.mock.calls[0][0]
+      expect(result).toEqual(transactionResult)
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should emit an error if the transaction could not be sent', async () => {
+      expect.assertions(1)
+
+      const error = { code: 404, data: 'oops' }
+      await nockBeforeEach()
+      setupFail(error)
+
+      walletService.on('error', error => {
+        expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
+      })
+
+      await walletService.purchaseKey(
+        lockAddress,
+        owner,
+        keyPrice,
+        account,
+        data
+      )
+      await nock.resolveWhenAllNocksUsed()
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v01/purchaseKey.ethers.test.js
+++ b/unlock-js/src/__tests__/v01/purchaseKey.ethers.test.js
@@ -1,0 +1,97 @@
+import * as UnlockV01 from 'unlock-abi-0-1'
+import purchaseKey from '../../v01/purchaseKey.ethers'
+import Errors from '../../errors'
+import TransactionTypes from '../../transactionTypes'
+import NockHelper from '../helpers/nockHelper'
+import {
+  prepWalletService,
+  prepContract,
+} from '../helpers/walletServiceHelper.ethers'
+
+const { FAILED_TO_PURCHASE_KEY } = Errors
+const endpoint = 'http://127.0.0.1:8545'
+const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
+
+let walletService
+let transaction
+let transactionResult
+let setupSuccess
+let setupFail
+
+describe('v01 (ethers)', () => {
+  describe('purchaseKey', () => {
+    const keyPrice = '0.01'
+    const owner = '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e'
+    const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+
+    async function nockBeforeEach() {
+      nock.cleanAll()
+      walletService = await prepWalletService(
+        UnlockV01.PublicLock,
+        endpoint,
+        nock
+      )
+      walletService.purchaseKey = purchaseKey.bind(walletService)
+
+      const callMethodData = prepContract({
+        contract: UnlockV01.PublicLock,
+        functionName: 'purchaseFor',
+        signature: 'address',
+        nock,
+        value: keyPrice,
+      })
+
+      const {
+        testTransaction,
+        testTransactionResult,
+        success,
+        fail,
+      } = callMethodData(owner)
+
+      transaction = testTransaction
+      transactionResult = testTransactionResult
+      setupSuccess = success
+      setupFail = fail
+    }
+
+    it('should invoke _handleMethodCall with the right params', async () => {
+      expect.assertions(2)
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      walletService._handleMethodCall = jest.fn(() =>
+        Promise.resolve(transaction.hash)
+      )
+      const mock = walletService._handleMethodCall
+
+      await walletService.purchaseKey(lockAddress, owner, keyPrice)
+
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(Promise),
+        TransactionTypes.KEY_PURCHASE
+      )
+
+      // verify that the promise passed to _handleMethodCall actually resolves
+      // to the result the chain returns from a sendTransaction call to createLock
+      const result = await mock.mock.calls[0][0]
+      expect(result).toEqual(transactionResult)
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should emit an error if the transaction could not be sent', async () => {
+      expect.assertions(1)
+
+      const error = { code: 404, data: 'oops' }
+      await nockBeforeEach()
+      setupFail(error)
+
+      walletService.on('error', error => {
+        expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
+      })
+
+      await walletService.purchaseKey(lockAddress, owner, keyPrice)
+      await nock.resolveWhenAllNocksUsed()
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v02/purchaseKey.ethers.test.js
+++ b/unlock-js/src/__tests__/v02/purchaseKey.ethers.test.js
@@ -1,0 +1,97 @@
+import * as UnlockV02 from 'unlock-abi-0-2'
+import purchaseKey from '../../v02/purchaseKey.ethers'
+import Errors from '../../errors'
+import TransactionTypes from '../../transactionTypes'
+import NockHelper from '../helpers/nockHelper'
+import {
+  prepWalletService,
+  prepContract,
+} from '../helpers/walletServiceHelper.ethers'
+
+const { FAILED_TO_PURCHASE_KEY } = Errors
+const endpoint = 'http://127.0.0.1:8545'
+const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
+
+let walletService
+let transaction
+let transactionResult
+let setupSuccess
+let setupFail
+
+describe('v02 (ethers)', () => {
+  describe('purchaseKey', () => {
+    const keyPrice = '0.01'
+    const owner = '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e'
+    const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+
+    async function nockBeforeEach() {
+      nock.cleanAll()
+      walletService = await prepWalletService(
+        UnlockV02.PublicLock,
+        endpoint,
+        nock
+      )
+      walletService.purchaseKey = purchaseKey.bind(walletService)
+
+      const callMethodData = prepContract({
+        contract: UnlockV02.PublicLock,
+        functionName: 'purchaseFor',
+        signature: 'address',
+        nock,
+        value: keyPrice,
+      })
+
+      const {
+        testTransaction,
+        testTransactionResult,
+        success,
+        fail,
+      } = callMethodData(owner)
+
+      transaction = testTransaction
+      transactionResult = testTransactionResult
+      setupSuccess = success
+      setupFail = fail
+    }
+
+    it('should invoke _handleMethodCall with the right params', async () => {
+      expect.assertions(2)
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      walletService._handleMethodCall = jest.fn(() =>
+        Promise.resolve(transaction.hash)
+      )
+      const mock = walletService._handleMethodCall
+
+      await walletService.purchaseKey(lockAddress, owner, keyPrice)
+
+      expect(mock).toHaveBeenCalledWith(
+        expect.any(Promise),
+        TransactionTypes.KEY_PURCHASE
+      )
+
+      // verify that the promise passed to _handleMethodCall actually resolves
+      // to the result the chain returns from a sendTransaction call to createLock
+      const result = await mock.mock.calls[0][0]
+      expect(result).toEqual(transactionResult)
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should emit an error if the transaction could not be sent', async () => {
+      expect.assertions(1)
+
+      const error = { code: 404, data: 'oops' }
+      await nockBeforeEach()
+      setupFail(error)
+
+      walletService.on('error', error => {
+        expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
+      })
+
+      await walletService.purchaseKey(lockAddress, owner, keyPrice)
+      await nock.resolveWhenAllNocksUsed()
+    })
+  })
+})

--- a/unlock-js/src/__tests__/walletService.ethers.test.js
+++ b/unlock-js/src/__tests__/walletService.ethers.test.js
@@ -184,7 +184,10 @@ describe('WalletService (ethers)', () => {
         expect(r).toBe(result)
       }
     )
-    const versionSpecificLockMethods = ['partialWithdrawFromLock']
+    const versionSpecificLockMethods = [
+      'partialWithdrawFromLock',
+      'purchaseKey',
+    ]
 
     it.each(versionSpecificLockMethods)(
       'should invoke the implementation of the corresponding version of %s',

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -381,11 +381,7 @@ describe('WalletService', () => {
   })
 
   describe('versions', () => {
-    const versionSpecificLockMethods = [
-      'updateKeyPrice',
-      'purchaseKey',
-      'withdrawFromLock',
-    ]
+    const versionSpecificLockMethods = ['updateKeyPrice', 'withdrawFromLock']
 
     it.each(versionSpecificLockMethods)(
       'should invoke the implementation of the corresponding version of %s',

--- a/unlock-js/src/utils.ethers.js
+++ b/unlock-js/src/utils.ethers.js
@@ -23,4 +23,5 @@ module.exports = {
     const num = utils.hexlify(utils.bigNumberify(number))
     return utils.hexZeroPad(num, 32)
   },
+  utf8ToHex: str => utils.hexlify(str.length ? utils.toUtf8Bytes(str) : 0),
 }

--- a/unlock-js/src/v0/index.js
+++ b/unlock-js/src/v0/index.js
@@ -6,6 +6,7 @@ import ethers_getLock from './getLock.ethers'
 import partialWithdrawFromLock from './partialWithdrawFromLock'
 import ethers_partialWithdrawFromLock from './partialWithdrawFromLock.ethers'
 import purchaseKey from './purchaseKey'
+import ethers_purchaseKey from './purchaseKey.ethers'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 
@@ -17,6 +18,7 @@ export default {
   partialWithdrawFromLock,
   ethers_partialWithdrawFromLock,
   purchaseKey,
+  ethers_purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
   version: 'v0',

--- a/unlock-js/src/v0/purchaseKey.ethers.js
+++ b/unlock-js/src/v0/purchaseKey.ethers.js
@@ -1,0 +1,44 @@
+import utils from '../utils.ethers'
+import { GAS_AMOUNTS } from '../constants'
+import TransactionTypes from '../transactionTypes'
+import Errors from '../errors'
+
+/**
+ * Purchase a key to a lock by account.
+ * The key object is passed so we can kepe track of it from the application
+ * The lock object is required to get the price data
+ * We pass both the owner and the account because at some point, these may be different (someone
+ * purchases a key for someone else)
+ * @param {PropTypes.address} lock
+ * @param {PropTypes.address} owner
+ * @param {string} keyPrice
+ * @param {string} data
+ * @param {string} account
+ */
+export default async function(
+  lockAddress,
+  owner,
+  keyPrice,
+  account,
+  data = ''
+) {
+  const lockContract = await this.getLockContract(lockAddress)
+  let transactionPromise
+  try {
+    transactionPromise = lockContract['purchaseFor(address,bytes)'](
+      owner,
+      utils.utf8ToHex(data || ''),
+      {
+        gasLimit: GAS_AMOUNTS.purchaseFor, // overrides default value for transaction gas price
+        value: utils.toWei(keyPrice, 'ether'), // overrides default value
+      }
+    )
+    const ret = await this._handleMethodCall(
+      transactionPromise,
+      TransactionTypes.KEY_PURCHASE
+    )
+    return ret
+  } catch (error) {
+    this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
+  }
+}

--- a/unlock-js/src/v01/index.js
+++ b/unlock-js/src/v01/index.js
@@ -6,6 +6,7 @@ import ethers_getLock from './getLock.ethers'
 import partialWithdrawFromLock from './partialWithdrawFromLock'
 import ethers_partialWithdrawFromLock from './partialWithdrawFromLock.ethers'
 import purchaseKey from './purchaseKey'
+import ethers_purchaseKey from './purchaseKey.ethers'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 
@@ -17,6 +18,7 @@ export default {
   partialWithdrawFromLock,
   ethers_partialWithdrawFromLock,
   purchaseKey,
+  ethers_purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
   version: 'v01',

--- a/unlock-js/src/v01/purchaseKey.ethers.js
+++ b/unlock-js/src/v01/purchaseKey.ethers.js
@@ -1,0 +1,34 @@
+import Web3Utils from '../utils.ethers'
+import { GAS_AMOUNTS } from '../constants'
+import TransactionTypes from '../transactionTypes'
+import Errors from '../errors'
+
+/**
+ * Purchase a key to a lock by account.
+ * The key object is passed so we can kepe track of it from the application
+ * The lock object is required to get the price data
+ * We pass both the owner and the account because at some point, these may be different (someone
+ * purchases a key for someone else)
+ * @param {PropTypes.address} lock
+ * @param {PropTypes.address} owner
+ * @param {string} keyPrice
+ * @param {string} data
+ * @param {string} account
+ */
+export default async function(lockAddress, owner, keyPrice) {
+  const lockContract = await this.getLockContract(lockAddress)
+  let transactionPromise
+  try {
+    transactionPromise = lockContract['purchaseFor(address)'](owner, {
+      gasLimit: GAS_AMOUNTS.purchaseFor, // overrides default value for transaction gas price
+      value: Web3Utils.toWei(keyPrice, 'ether'), // overrides default value
+    })
+    const ret = await this._handleMethodCall(
+      transactionPromise,
+      TransactionTypes.KEY_PURCHASE
+    )
+    return ret
+  } catch (error) {
+    this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
+  }
+}

--- a/unlock-js/src/v02/index.js
+++ b/unlock-js/src/v02/index.js
@@ -6,6 +6,7 @@ import ethers_getLock from './getLock.ethers'
 import partialWithdrawFromLock from './partialWithdrawFromLock'
 import ethers_partialWithdrawFromLock from './partialWithdrawFromLock.ethers'
 import purchaseKey from './purchaseKey'
+import ethers_purchaseKey from './purchaseKey.ethers'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 
@@ -17,6 +18,7 @@ export default {
   partialWithdrawFromLock,
   ethers_partialWithdrawFromLock,
   purchaseKey,
+  ethers_purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
   version: 'v02',

--- a/unlock-js/src/v02/purchaseKey.ethers.js
+++ b/unlock-js/src/v02/purchaseKey.ethers.js
@@ -1,0 +1,34 @@
+import Web3Utils from '../utils.ethers'
+import { GAS_AMOUNTS } from '../constants'
+import TransactionTypes from '../transactionTypes'
+import Errors from '../errors'
+
+/**
+ * Purchase a key to a lock by account.
+ * The key object is passed so we can kepe track of it from the application
+ * The lock object is required to get the price data
+ * We pass both the owner and the account because at some point, these may be different (someone
+ * purchases a key for someone else)
+ * @param {PropTypes.address} lock
+ * @param {PropTypes.address} owner
+ * @param {string} keyPrice
+ * @param {string} data
+ * @param {string} account
+ */
+export default async function(lockAddress, owner, keyPrice) {
+  const lockContract = await this.getLockContract(lockAddress)
+  let transactionPromise
+  try {
+    transactionPromise = lockContract['purchaseFor(address)'](owner, {
+      gasLimit: GAS_AMOUNTS.purchaseFor, // overrides default value for transaction gas price
+      value: Web3Utils.toWei(keyPrice, 'ether'), // overrides default value
+    })
+    const ret = await this._handleMethodCall(
+      transactionPromise,
+      TransactionTypes.KEY_PURCHASE
+    )
+    return ret
+  } catch (error) {
+    this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
+  }
+}

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -195,8 +195,14 @@ export default class WalletService extends UnlockService {
    * @param {string} account
    */
   async purchaseKey(lock, owner, keyPrice, account, data = '') {
-    const version = await this.lockContractAbiVersion(lock)
-    return version.purchaseKey.bind(this)(lock, owner, keyPrice, account, data)
+    const version = await this.ethers_lockContractAbiVersion(lock)
+    return version.ethers_purchaseKey.bind(this)(
+      lock,
+      owner,
+      keyPrice,
+      account,
+      data
+    )
   }
 
   /**


### PR DESCRIPTION
# Description

Migrates `purchaseKey` to ethers. In order to work, this adds a new `utf8ToHex` util and tests it as well.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
