### PR TITLE
increase timeout for accounts test so they don't fail on CI

### DIFF
--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -42,7 +42,7 @@ describe('account helpers', () => {
           computeSharedSecret: expect.any(Function),
         })
       )
-    })
+    }, 10000)
 
     it('should throw when an incorrect password is given for an account', async () => {
       expect.assertions(1)
@@ -56,5 +56,5 @@ describe('account helpers', () => {
         expect(e).toBeInstanceOf(Error)
       }
     })
-  })
+  }, 10000)
 })


### PR DESCRIPTION
# Description

It turns out that accounts tests sometimes take longer than 5 seconds, this PR doubles the timeout so we don't get random CI failures as a result.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
