### PR TITLE
restore the web3 versions of smart contract methods

### DIFF
--- a/unlock-js/src/__tests__/v0/createLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v0/createLock.ethers.test.js
@@ -71,7 +71,7 @@ describe('v0 (ethers)', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.createLock(lock, owner)
+      await walletService.ethers_createLock(lock, owner)
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -104,7 +104,7 @@ describe('v0 (ethers)', () => {
         })
       })
 
-      await walletService.createLock(lock, owner)
+      await walletService.ethers_createLock(lock, owner)
       await nock.resolveWhenAllNocksUsed()
     })
 
@@ -119,7 +119,7 @@ describe('v0 (ethers)', () => {
         expect(error.message).toBe(FAILED_TO_CREATE_LOCK)
       })
 
-      await walletService.createLock(lock, owner)
+      await walletService.ethers_createLock(lock, owner)
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v0/getLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v0/getLock.ethers.test.js
@@ -114,7 +114,7 @@ describe('v0', () => {
         })
       })
 
-      await web3Service.getLock(lockAddress)
+      await web3Service.ethers_getLock(lockAddress)
     })
 
     it('should successfully yield a lock with an unlimited number of keys', async () => {
@@ -132,7 +132,7 @@ describe('v0', () => {
         })
       })
 
-      return web3Service.getLock(lockAddress)
+      return web3Service.ethers_getLock(lockAddress)
     })
   })
 })

--- a/unlock-js/src/__tests__/v0/partialWithdrawFromLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v0/partialWithdrawFromLock.ethers.test.js
@@ -64,7 +64,7 @@ describe('v0 (ethers)', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.partialWithdrawFromLock(
+      await walletService.ethers_partialWithdrawFromLock(
         lock,
         account,
         amount,
@@ -95,7 +95,7 @@ describe('v0 (ethers)', () => {
         expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
       })
 
-      await walletService.partialWithdrawFromLock(
+      await walletService.ethers_partialWithdrawFromLock(
         lock,
         account,
         amount,
@@ -115,7 +115,7 @@ describe('v0 (ethers)', () => {
         Promise.resolve(transaction.hash)
       )
 
-      await walletService.partialWithdrawFromLock(
+      await walletService.ethers_partialWithdrawFromLock(
         lock,
         account,
         amount,

--- a/unlock-js/src/__tests__/v0/purchaseKey.ethers.test.js
+++ b/unlock-js/src/__tests__/v0/purchaseKey.ethers.test.js
@@ -1,6 +1,5 @@
 import * as UnlockV0 from 'unlock-abi-0'
 import * as utils from '../../utils.ethers'
-import purchaseKey from '../../v0/purchaseKey.ethers'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
@@ -34,7 +33,6 @@ describe('v0 (ethers)', () => {
         endpoint,
         nock
       )
-      walletService.purchaseKey = purchaseKey.bind(walletService)
 
       const callMethodData = prepContract({
         contract: UnlockV0.PublicLock,
@@ -68,7 +66,7 @@ describe('v0 (ethers)', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.purchaseKey(
+      await walletService.ethers_purchaseKey(
         lockAddress,
         owner,
         keyPrice,
@@ -99,7 +97,7 @@ describe('v0 (ethers)', () => {
         expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
       })
 
-      await walletService.purchaseKey(
+      await walletService.ethers_purchaseKey(
         lockAddress,
         owner,
         keyPrice,

--- a/unlock-js/src/__tests__/v01/createLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v01/createLock.ethers.test.js
@@ -73,7 +73,7 @@ describe('v01 (ethers)', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.createLock(lock, owner)
+      await walletService.ethers_createLock(lock, owner)
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -106,7 +106,7 @@ describe('v01 (ethers)', () => {
         })
       })
 
-      await walletService.createLock(lock, owner)
+      await walletService.ethers_createLock(lock, owner)
       await nock.resolveWhenAllNocksUsed()
     })
 
@@ -121,7 +121,7 @@ describe('v01 (ethers)', () => {
         expect(error.message).toBe(FAILED_TO_CREATE_LOCK)
       })
 
-      await walletService.createLock(lock, owner)
+      await walletService.ethers_createLock(lock, owner)
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v01/getLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v01/getLock.ethers.test.js
@@ -124,7 +124,7 @@ describe('v0', () => {
         })
       })
 
-      await web3Service.getLock(lockAddress)
+      await web3Service.ethers_getLock(lockAddress)
     })
 
     it('should successfully yield a lock with an unlimited number of keys', async () => {
@@ -142,7 +142,7 @@ describe('v0', () => {
         })
       })
 
-      return web3Service.getLock(lockAddress)
+      return web3Service.ethers_getLock(lockAddress)
     })
   })
 })

--- a/unlock-js/src/__tests__/v01/partialWithdrawFromLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v01/partialWithdrawFromLock.ethers.test.js
@@ -64,7 +64,7 @@ describe('v01 (ethers)', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.partialWithdrawFromLock(
+      await walletService.ethers_partialWithdrawFromLock(
         lock,
         account,
         amount,
@@ -95,7 +95,7 @@ describe('v01 (ethers)', () => {
         expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
       })
 
-      await walletService.partialWithdrawFromLock(
+      await walletService.ethers_partialWithdrawFromLock(
         lock,
         account,
         amount,
@@ -115,7 +115,7 @@ describe('v01 (ethers)', () => {
         Promise.resolve(transaction.hash)
       )
 
-      await walletService.partialWithdrawFromLock(
+      await walletService.ethers_partialWithdrawFromLock(
         lock,
         account,
         amount,

--- a/unlock-js/src/__tests__/v01/purchaseKey.ethers.test.js
+++ b/unlock-js/src/__tests__/v01/purchaseKey.ethers.test.js
@@ -1,5 +1,4 @@
 import * as UnlockV01 from 'unlock-abi-0-1'
-import purchaseKey from '../../v01/purchaseKey.ethers'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
@@ -31,7 +30,6 @@ describe('v01 (ethers)', () => {
         endpoint,
         nock
       )
-      walletService.purchaseKey = purchaseKey.bind(walletService)
 
       const callMethodData = prepContract({
         contract: UnlockV01.PublicLock,
@@ -65,7 +63,7 @@ describe('v01 (ethers)', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.purchaseKey(lockAddress, owner, keyPrice)
+      await walletService.ethers_purchaseKey(lockAddress, owner, keyPrice)
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -90,7 +88,7 @@ describe('v01 (ethers)', () => {
         expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
       })
 
-      await walletService.purchaseKey(lockAddress, owner, keyPrice)
+      await walletService.ethers_purchaseKey(lockAddress, owner, keyPrice)
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v02/createLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v02/createLock.ethers.test.js
@@ -73,7 +73,7 @@ describe('v02 (ethers)', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.createLock(lock, owner)
+      await walletService.ethers_createLock(lock, owner)
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -106,7 +106,7 @@ describe('v02 (ethers)', () => {
         })
       })
 
-      await walletService.createLock(lock, owner)
+      await walletService.ethers_createLock(lock, owner)
       await nock.resolveWhenAllNocksUsed()
     })
 
@@ -121,7 +121,7 @@ describe('v02 (ethers)', () => {
         expect(error.message).toBe(FAILED_TO_CREATE_LOCK)
       })
 
-      await walletService.createLock(lock, owner)
+      await walletService.ethers_createLock(lock, owner)
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v02/getLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v02/getLock.ethers.test.js
@@ -124,7 +124,7 @@ describe('v0', () => {
         })
       })
 
-      await web3Service.getLock(lockAddress)
+      await web3Service.ethers_getLock(lockAddress)
     })
 
     it('should successfully yield a lock with an unlimited number of keys', async () => {
@@ -142,7 +142,7 @@ describe('v0', () => {
         })
       })
 
-      return web3Service.getLock(lockAddress)
+      return web3Service.ethers_getLock(lockAddress)
     })
   })
 })

--- a/unlock-js/src/__tests__/v02/partialWithdrawFromLock.ethers.test.js
+++ b/unlock-js/src/__tests__/v02/partialWithdrawFromLock.ethers.test.js
@@ -64,7 +64,7 @@ describe('v02 (ethers)', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.partialWithdrawFromLock(
+      await walletService.ethers_partialWithdrawFromLock(
         lock,
         account,
         amount,
@@ -95,7 +95,7 @@ describe('v02 (ethers)', () => {
         expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
       })
 
-      await walletService.partialWithdrawFromLock(
+      await walletService.ethers_partialWithdrawFromLock(
         lock,
         account,
         amount,
@@ -115,7 +115,7 @@ describe('v02 (ethers)', () => {
         Promise.resolve(transaction.hash)
       )
 
-      await walletService.partialWithdrawFromLock(
+      await walletService.ethers_partialWithdrawFromLock(
         lock,
         account,
         amount,

--- a/unlock-js/src/__tests__/v02/purchaseKey.ethers.test.js
+++ b/unlock-js/src/__tests__/v02/purchaseKey.ethers.test.js
@@ -1,5 +1,4 @@
 import * as UnlockV02 from 'unlock-abi-0-2'
-import purchaseKey from '../../v02/purchaseKey.ethers'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
@@ -31,7 +30,6 @@ describe('v02 (ethers)', () => {
         endpoint,
         nock
       )
-      walletService.purchaseKey = purchaseKey.bind(walletService)
 
       const callMethodData = prepContract({
         contract: UnlockV02.PublicLock,
@@ -65,7 +63,7 @@ describe('v02 (ethers)', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.purchaseKey(lockAddress, owner, keyPrice)
+      await walletService.ethers_purchaseKey(lockAddress, owner, keyPrice)
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -90,7 +88,7 @@ describe('v02 (ethers)', () => {
         expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
       })
 
-      await walletService.purchaseKey(lockAddress, owner, keyPrice)
+      await walletService.ethers_purchaseKey(lockAddress, owner, keyPrice)
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/walletService.ethers.test.js
+++ b/unlock-js/src/__tests__/walletService.ethers.test.js
@@ -180,10 +180,11 @@ describe('WalletService (ethers)', () => {
           },
         }
         walletService.ethers_unlockContractAbiVersion = jest.fn(() => version)
-        const r = await walletService[method](...args)
+        const r = await walletService[`ethers_${method}`](...args)
         expect(r).toBe(result)
       }
     )
+
     const versionSpecificLockMethods = [
       'partialWithdrawFromLock',
       'purchaseKey',
@@ -203,7 +204,7 @@ describe('WalletService (ethers)', () => {
           },
         }
         walletService.ethers_lockContractAbiVersion = jest.fn(() => version)
-        const r = await walletService[method](...args)
+        const r = await walletService[`ethers_${method}`](...args)
         expect(r).toBe(result)
       }
     )
@@ -214,10 +215,10 @@ describe('WalletService (ethers)', () => {
       'should implement all the required methods',
       version => {
         versionSpecificUnlockMethods.forEach(method => {
-          expect(version[method]).toBeInstanceOf(Function)
+          expect(version[`ethers_${method}`]).toBeInstanceOf(Function)
         })
         versionSpecificLockMethods.forEach(method => {
-          expect(version[method]).toBeInstanceOf(Function)
+          expect(version[`ethers_${method}`]).toBeInstanceOf(Function)
         })
       }
     )

--- a/unlock-js/src/__tests__/web3Service.ethers.test.js
+++ b/unlock-js/src/__tests__/web3Service.ethers.test.js
@@ -432,7 +432,7 @@ describe('Web3Service', () => {
           },
         }
         web3Service.ethers_lockContractAbiVersion = jest.fn(() => version)
-        const r = await web3Service[method](...args)
+        const r = await web3Service[`ethers_${method}`](...args)
         expect(r).toBe(result)
       }
     )

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -178,6 +178,16 @@ export default class WalletService extends UnlockService {
    * @param {PropTypes.address} owner
    */
   async createLock(lock, owner) {
+    const version = await this.unlockContractAbiVersion()
+    return version.createLock.bind(this)(lock, owner)
+  }
+
+  /**
+   * Creates a lock on behalf of the user.
+   * @param {PropTypes.lock} lock
+   * @param {PropTypes.address} owner
+   */
+  async ethers_createLock(lock, owner) {
     const version = await this.ethers_unlockContractAbiVersion()
     return version.ethers_createLock.bind(this)(lock, owner)
   }
@@ -195,6 +205,23 @@ export default class WalletService extends UnlockService {
    * @param {string} account
    */
   async purchaseKey(lock, owner, keyPrice, account, data = '') {
+    const version = await this.lockContractAbiVersion(lock)
+    return version.purchaseKey.bind(this)(lock, owner, keyPrice, account, data)
+  }
+
+  /**
+   * Purchase a key to a lock by account.
+   * The key object is passed so we can kepe track of it from the application
+   * The lock object is required to get the price data
+   * We pass both the owner and the account because at some point, these may be different (someone
+   * purchases a key for someone else)
+   * @param {PropTypes.address} lock
+   * @param {PropTypes.address} owner
+   * @param {string} keyPrice
+   * @param {string} data
+   * @param {string} account
+   */
+  async ethers_purchaseKey(lock, owner, keyPrice, account, data = '') {
     const version = await this.ethers_lockContractAbiVersion(lock)
     return version.ethers_purchaseKey.bind(this)(
       lock,
@@ -214,6 +241,24 @@ export default class WalletService extends UnlockService {
    * @param {Function} callback
    */
   async partialWithdrawFromLock(lock, account, ethAmount, callback) {
+    const version = await this.lockContractAbiVersion(lock)
+    return version.partialWithdrawFromLock.bind(this)(
+      lock,
+      account,
+      ethAmount,
+      callback
+    )
+  }
+
+  /**
+   * Triggers a transaction to withdraw some funds from the lock and assign them
+   * to the owner.
+   * @param {PropTypes.address} lock
+   * @param {PropTypes.address} account
+   * @param {string} ethAmount
+   * @param {Function} callback
+   */
+  async ethers_partialWithdrawFromLock(lock, account, ethAmount, callback) {
     const version = await this.ethers_lockContractAbiVersion(lock)
     return version.ethers_partialWithdrawFromLock.bind(this)(
       lock,

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -660,6 +660,16 @@ export default class Web3Service extends UnlockService {
    * @return Promise<Lock>
    */
   async getLock(address) {
+    const version = await this.lockContractAbiVersion(address)
+    return version.getLock.bind(this)(address)
+  }
+
+  /**
+   * Refresh the lock's data.
+   * We use the block version
+   * @return Promise<Lock>
+   */
+  async ethers_getLock(address) {
     const version = await this.ethers_lockContractAbiVersion(address)
     return version.ethers_getLock.bind(this)(address)
   }


### PR DESCRIPTION
# Description

@akeem discovered that we still need the web3 doppelgängers of the smart contract methods in `walletService` and `web3Service`. This restores the old versions, and creates ethers doubles.

Note: it also removes 2 lines from the `purchaseKey` tests that were obsolete and unnecessary

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
