### PR TITLE
fix ethers fromWei, add test

### DIFF
--- a/unlock-js/src/__tests__/utils.ethers.test.js
+++ b/unlock-js/src/__tests__/utils.ethers.test.js
@@ -26,7 +26,7 @@ describe('ethers utils', () => {
   })
 
   it('fromWei', () => {
-    expect.assertions(2)
+    expect.assertions(3)
 
     expect(ethersUtils.fromWei('1000000000000000000000', 'ether')).toEqual(
       '1000'
@@ -35,6 +35,8 @@ describe('ethers utils', () => {
     expect(ethersUtils.fromWei('1000000000000000000000', 'gwei')).toEqual(
       '1000000000000'
     )
+
+    expect(ethersUtils.fromWei('100000000', 'ether')).toEqual('0.0000000001')
   })
 
   it('isInfiniteKeys', () => {

--- a/unlock-js/src/utils.ethers.js
+++ b/unlock-js/src/utils.ethers.js
@@ -11,7 +11,7 @@ module.exports = {
     utils.formatUnits(utils.bigNumberify(num), 'wei').replace('.0', ''),
   toChecksumAddress: utils.getAddress,
   fromWei: (num, units) => {
-    return utils.formatUnits(utils.bigNumberify(num), units).replace('.0', '')
+    return utils.formatUnits(utils.bigNumberify(num), units).replace(/\.0$/, '')
   },
   isInfiniteKeys: value => {
     return utils.bigNumberify(value).eq(constants.MaxUint256)


### PR DESCRIPTION
# Description

`fromWei` was incorrectly stripping the decimal from the start of the value if it matched `0.` anywhere, so `0.01` would become `01` and `0.002` would become `002`. This fixes that major bug and adds a regression test

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
