### PR TITLE
Remove notion of signature from createUser

### DIFF
--- a/locksmith/__tests__/controllers/userController.test.ts
+++ b/locksmith/__tests__/controllers/userController.test.ts
@@ -52,10 +52,6 @@ describe('User Controller', () => {
     }
     let typedData = generateTypedData(message)
 
-    const sig = sigUtil.signTypedData(privateKey, {
-      data: typedData,
-    })
-
     describe('when a user matching the public key does not exist', () => {
       it('creates the appropriate records', async () => {
         expect.assertions(3)
@@ -63,7 +59,6 @@ describe('User Controller', () => {
         let response = await request(app)
           .post('/users')
           .set('Accept', /json/)
-          .set('Authorization', `Bearer ${Base64.encode(sig)}`)
           .send(typedData)
         expect(response.statusCode).toBe(200)
         expect(
@@ -87,7 +82,6 @@ describe('User Controller', () => {
         let response = await request(app)
           .post('/users')
           .set('Accept', /json/)
-          .set('Authorization', `Bearer ${Base64.encode(sig)}`)
           .send(typedData)
 
         expect(response.statusCode).toBe(200)

--- a/locksmith/src/routes/user.ts
+++ b/locksmith/src/routes/user.ts
@@ -8,17 +8,8 @@ let passwordEncryptedPrivateKeyPathRegex = new RegExp(
   '^/users/S+/passwordEncryptedPrivateKey/?$',
   'i'
 )
-let userCreationPathRegex = new RegExp('^/users/?$', 'i')
 let userUpdatePathRegex = new RegExp('^/users/?$', 'i')
 
-router.post(
-  userCreationPathRegex,
-  signatureValidationMiddleware.generateProcessor({
-    name: 'user',
-    required: ['emailAddress', 'publicKey', 'passwordEncryptedPrivateKey'],
-    signee: 'publicKey',
-  })
-)
 router.put(
   userUpdatePathRegex,
   signatureValidationMiddleware.generateProcessor({

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -133,6 +133,7 @@ const storageMiddleware = config => {
           storageService
             .createUser(user) // TODO: Now what?
             .then(() => dispatch(setAccount({ address })))
+            // TODO: This isn't the right way to handle the error
             .catch(err => dispatch(setError(err)))
         }
 

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -113,12 +113,8 @@ export default class StorageService {
    * @param {*} user
    * @returns {Promise<*>}
    */
-  async createUser(user, token) {
+  async createUser(user) {
     const opts = {}
-    if (token) {
-      // TODO: Tokens aren't optional
-      opts.headers = this.genAuthorizationHeader(token)
-    }
     try {
       return await axios.post(`${this.host}/users/`, user, opts)
     } catch (error) {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
We realized that the API for creating a user implied that a signed token was necessary for the call to succeed. We then realized that calls succeeded without any signed tokens. Then we realized that there was no way to sign a request for an account without already having an account. Then we realized that there was no real benefit to having the initial account creation require a signature, so we removed it. And that's this PR.

# Issues
Refs #2111

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
