### PR TITLE
migrate key paging to ethers

### DIFF
--- a/unlock-js/src/__tests__/web3Service.ethers.test.js
+++ b/unlock-js/src/__tests__/web3Service.ethers.test.js
@@ -1459,29 +1459,6 @@ describe('Web3Service', () => {
         })
       })
     })
-  })
-
-  describe.each([
-    ['v0', UnlockV0, v0, 0],
-    //['v01', UnlockV01, v01, 1],
-    //['v02', UnlockV02, v02, 2],
-  ])('%s', (version, UnlockVersion, LockVersion, actualVersion) => {
-    async function versionedNockBeforeEach(endpoint = readOnlyProvider) {
-      nock.cleanAll()
-      nock.netVersionAndYield(1)
-      web3Service = new Web3Service({
-        readOnlyProvider: endpoint,
-        unlockAddress,
-        blockTime,
-        requiredConfirmations,
-        useEthers: true,
-      })
-      web3Service._ethers_getPublicLockVersionFromContract = jest.fn(
-        () => actualVersion
-      )
-      web3Service._ethers_getVersionFromContract = jest.fn(() => actualVersion)
-      return nock.resolveWhenAllNocksUsed()
-    }
 
     describe('_genKeyOwnersFromLockContractIterative', () => {
       it('calls owners with the correct index', async () => {

--- a/unlock-js/src/__tests__/web3Service.ethers.test.js
+++ b/unlock-js/src/__tests__/web3Service.ethers.test.js
@@ -1461,6 +1461,288 @@ describe('Web3Service', () => {
     })
   })
 
+  describe.each([
+    ['v0', UnlockV0, v0, 0],
+    //['v01', UnlockV01, v01, 1],
+    //['v02', UnlockV02, v02, 2],
+  ])('%s', (version, UnlockVersion, LockVersion, actualVersion) => {
+    async function versionedNockBeforeEach(endpoint = readOnlyProvider) {
+      nock.cleanAll()
+      nock.netVersionAndYield(1)
+      web3Service = new Web3Service({
+        readOnlyProvider: endpoint,
+        unlockAddress,
+        blockTime,
+        requiredConfirmations,
+        useEthers: true,
+      })
+      web3Service._ethers_getPublicLockVersionFromContract = jest.fn(
+        () => actualVersion
+      )
+      web3Service._ethers_getVersionFromContract = jest.fn(() => actualVersion)
+      return nock.resolveWhenAllNocksUsed()
+    }
+
+    describe('_genKeyOwnersFromLockContractIterative', () => {
+      it('calls owners with the correct index', async () => {
+        expect.assertions(2)
+        await versionedNockBeforeEach()
+        const metadata = new ethers.utils.Interface(LockVersion.PublicLock.abi)
+        const encoder = ethers.utils.defaultAbiCoder
+
+        nock.ethGetCodeAndYield(
+          lockAddress,
+          LockVersion.PublicLock.deployedBytecode
+        )
+
+        nock.ethCallAndYield(
+          metadata.functions['owners(uint256)'].encode([2 * 2]),
+          ethers.utils.getAddress(lockAddress),
+          encoder.encode(['address'], [account])
+        )
+
+        nock.ethCallAndFail(
+          metadata.functions['owners(uint256)'].encode([2 * 2 + 1]),
+          ethers.utils.getAddress(lockAddress),
+          { code: 200, error: 'NO_OWNER' }
+        )
+
+        nock.ethCallAndYield(
+          metadata.functions['keyExpirationTimestampFor(address)'].encode([
+            account,
+          ]),
+          ethers.utils.getAddress(lockAddress),
+          encoder.encode(['uint256'], [ethers.utils.bigNumberify(12345)])
+        )
+
+        nock.ethCallAndFail(
+          metadata.functions['keyExpirationTimestampFor(address)'].encode([
+            ethers.constants.AddressZero,
+          ]),
+          ethers.utils.getAddress(lockAddress),
+          encoder.encode(
+            ['bytes'],
+            [ethers.utils.hexlify(ethers.utils.toUtf8Bytes('NO_SUCH_KEY'))]
+          )
+        )
+
+        const lockContract = await web3Service.getLockContract(lockAddress)
+
+        const keys = await web3Service._ethers_genKeyOwnersFromLockContractIterative(
+          lockAddress,
+          lockContract,
+          2 /* page */,
+          2 /* byPage */
+        )
+
+        expect(keys).toEqual([expect.any(Promise), expect.any(Promise)])
+        const resolved = await Promise.all(keys)
+        expect(resolved).toEqual([
+          {
+            expiration: 12345,
+            id: `${lockAddress}-${account}`,
+            lock: lockAddress,
+            owner: account,
+          },
+          null,
+        ])
+      })
+    })
+
+    describe('_genKeyOwnersFromLockContract', () => {
+      it('retrieves key owners via the API', async () => {
+        expect.assertions(2)
+        await versionedNockBeforeEach()
+        const metadata = new ethers.utils.Interface(LockVersion.PublicLock.abi)
+        const encoder = ethers.utils.defaultAbiCoder
+
+        nock.ethGetCodeAndYield(
+          lockAddress,
+          LockVersion.PublicLock.deployedBytecode
+        )
+
+        const lockContract = await web3Service.getLockContract(lockAddress)
+
+        nock.ethCallAndYield(
+          metadata.functions['getOwnersByPage(uint256,uint256)'].encode([2, 2]),
+          ethers.utils.getAddress(lockAddress),
+          encoder.encode(
+            [
+              metadata.functions['getOwnersByPage(uint256,uint256)'].outputs[0]
+                .type,
+            ],
+            [[account, unlockAddress]]
+          )
+        )
+
+        nock.ethCallAndYield(
+          metadata.functions['keyExpirationTimestampFor(address)'].encode([
+            account,
+          ]),
+          ethers.utils.getAddress(lockAddress),
+          encoder.encode(['uint256'], [ethers.utils.bigNumberify(12345)])
+        )
+
+        nock.ethCallAndFail(
+          metadata.functions['keyExpirationTimestampFor(address)'].encode([
+            unlockAddress,
+          ]),
+          ethers.utils.getAddress(lockAddress),
+          encoder.encode(
+            ['bytes'],
+            [ethers.utils.hexlify(ethers.utils.toUtf8Bytes('NO_SUCH_KEY'))]
+          )
+        )
+
+        const keys = await web3Service._ethers_genKeyOwnersFromLockContract(
+          lockAddress,
+          lockContract,
+          2 /* page */,
+          2 /* byPage */
+        )
+
+        expect(keys).toEqual([expect.any(Promise), expect.any(Promise)])
+        const resolved = await Promise.all(keys)
+        expect(resolved).toEqual([
+          {
+            expiration: 12345,
+            id: `${lockAddress}-${account}`,
+            lock: lockAddress,
+            owner: account,
+          },
+          {
+            expiration: 0,
+            id: `${lockAddress}-${unlockAddress}`,
+            lock: lockAddress,
+            owner: unlockAddress,
+          },
+        ])
+      })
+
+      it('throws on failure', async () => {
+        expect.assertions(1)
+        await versionedNockBeforeEach()
+        const metadata = new ethers.utils.Interface(LockVersion.PublicLock.abi)
+
+        nock.ethGetCodeAndYield(
+          lockAddress,
+          LockVersion.PublicLock.deployedBytecode
+        )
+
+        const lockContract = await web3Service.getLockContract(lockAddress)
+
+        nock.ethCallAndFail(
+          metadata.functions['getOwnersByPage(uint256,uint256)'].encode([2, 2]),
+          ethers.utils.getAddress(lockAddress),
+          { code: 200, message: 'NO_USER_KEYS' }
+        )
+
+        try {
+          await web3Service._ethers_genKeyOwnersFromLockContract(
+            lockAddress,
+            lockContract,
+            2 /* page */,
+            2 /* byPage */
+          )
+        } catch (e) {
+          expect(e).toBeInstanceOf(Error)
+        }
+      })
+    })
+
+    describe('getKeysForLockOnPage', () => {
+      let keyPromises
+      let iterativePromises
+
+      function testsSetup({ owners, iterative }) {
+        web3Service._ethers_genKeyOwnersFromLockContract = jest.fn(() => owners)
+        web3Service._ethers_genKeyOwnersFromLockContractIterative = jest.fn(
+          () => iterative
+        )
+      }
+
+      beforeEach(() => {
+        keyPromises = [Promise.resolve('normal'), Promise.resolve(null)]
+        iterativePromises = [
+          Promise.resolve('iterative'),
+          Promise.resolve(null),
+        ]
+      })
+
+      it('tries _genKeyOwnersFromLockContract first', async () => {
+        expect.assertions(3)
+
+        await versionedNockBeforeEach()
+        testsSetup({
+          owners: Promise.resolve(keyPromises),
+          iterative: Promise.resolve(iterativePromises),
+        })
+
+        web3Service.on('keys.page', (lock, page, keys) => {
+          expect(lock).toBe(lockAddress)
+          expect(page).toBe(3)
+          expect(keys).toEqual(['normal'])
+        })
+
+        await web3Service.ethers_getKeysForLockOnPage(lockAddress, 3, 2)
+      })
+
+      it('falls back to _genKeyOwnersFromLockContractIterative if keyPromises is empty', async () => {
+        expect.assertions(3)
+
+        await versionedNockBeforeEach()
+        testsSetup({
+          owners: Promise.resolve([]),
+          iterative: Promise.resolve(iterativePromises),
+        })
+
+        web3Service.on('keys.page', (lock, page, keys) => {
+          expect(lock).toBe(lockAddress)
+          expect(page).toBe(3)
+          expect(keys).toEqual(['iterative'])
+        })
+
+        await web3Service.ethers_getKeysForLockOnPage(lockAddress, 3, 2)
+      })
+
+      it('falls back to _genKeyOwnersFromLockContractIterative if _genKeyOwnersFromLockContract throws', async () => {
+        expect.assertions(3)
+
+        await versionedNockBeforeEach()
+        testsSetup({
+          owners: Promise.reject(new Error()),
+          iterative: Promise.resolve(iterativePromises),
+        })
+
+        web3Service.on('keys.page', (lock, page, keys) => {
+          expect(lock).toBe(lockAddress)
+          expect(page).toBe(3)
+          expect(keys).toEqual(['iterative'])
+        })
+
+        await web3Service.ethers_getKeysForLockOnPage(lockAddress, 3, 2)
+      })
+    })
+  })
+
+  describe('_emitKeyOwners', () => {
+    it('resolves the promises and emits keys.page', async done => {
+      expect.assertions(3)
+      await nockBeforeEach()
+
+      const keyPromises = [Promise.resolve(null), Promise.resolve('key')]
+
+      web3Service.on('keys.page', (lock, page, keys) => {
+        expect(lock).toBe(lockAddress)
+        expect(page).toBe(2)
+        expect(keys).toEqual(['key'])
+        done()
+      })
+
+      web3Service._emitKeyOwners(lockAddress, 2, keyPromises)
+    })
+  })
+
   describe('versions', () => {
     const versionSpecificLockMethods = ['getLock']
 

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -8,12 +8,7 @@ import Web3Utils from './utils'
 import ethers_utils from './utils.ethers'
 import TransactionTypes from './transactionTypes'
 import UnlockService from './unlockService'
-import {
-  MAX_UINT,
-  UNLIMITED_KEYS_COUNT,
-  KEY_ID,
-  ETHERS_MAX_UINT,
-} from './constants'
+import { MAX_UINT, UNLIMITED_KEYS_COUNT, KEY_ID } from './constants'
 
 /**
  * This service reads data from the RPC endpoint.
@@ -184,9 +179,7 @@ export default class Web3Service extends UnlockService {
           lock: newLockAddress,
         })
 
-        if (
-          ethers_utils.bigNumberify(params._maxNumberOfKeys).eq(ETHERS_MAX_UINT)
-        ) {
+        if (ethers_utils.isInfiniteKeys(params._maxNumberOfKeys)) {
           params._maxNumberOfKeys = UNLIMITED_KEYS_COUNT
         }
 


### PR DESCRIPTION
# Description

This is the last ethers migration PR, migrating the paging of keys on lock to ethers. Note that somehow none of these methods had tests, so I added new ones.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
