### PR TITLE
Sets up a fall through for signing of ticket information

### DIFF
--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -365,15 +365,12 @@ describe('WalletService', () => {
         let data = 'data to be signed'
         let account = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
 
-        walletService.web3.eth.personal.sign = jest
+        walletService.web3.eth.sign = jest
           .fn()
           .mockReturnValueOnce('a signature')
 
         walletService.signDataPersonal(account, data, () => {
-          expect(walletService.web3.eth.personal.sign).toBeCalledWith(
-            '0xdc8727bb847aebb19e4b2efa955b9b2c59192fd4656b6fe64bd61c09d8edb6d1',
-            account
-          )
+          expect(walletService.web3.eth.sign).toBeCalledWith(data, account)
           done()
         })
       })

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -412,8 +412,13 @@ export default class WalletService extends UnlockService {
 
   async signDataPersonal(account, data, callback) {
     try {
-      let dataHash = this.web3.utils.sha3(data)
-      let signature = await this.web3.eth.personal.sign(dataHash, account)
+      let signature
+
+      if (this.web3.currentProvider.constructor.name == 'HttpProvider') {
+        signature = await this.web3.eth.sign(data, account)
+      } else {
+        signature = await this.web3.eth.personal.sign(data, account)
+      }
 
       callback(null, Buffer.from(signature).toString('base64'))
     } catch (error) {


### PR DESCRIPTION
# Description

Our use of HTTPProvider has presented us with a scenario that does quite reflect what will be deployed and user will encounter.

This gives us a few options to be used when preparing QR codes.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
