### PR TITLE
Downgrades Ticket application to utilize personal sign for addresses

### DIFF
--- a/tickets/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/tickets/src/__tests__/middlewares/walletMiddleware.test.js
@@ -333,17 +333,20 @@ describe('Wallet middleware', () => {
       publicKey: account.address,
       eventAddress: address,
     })
-    mockWalletService.signData = jest.fn((_, address, cb) =>
+    mockWalletService.signDataPersonal = jest.fn((_, address, cb) =>
       cb(null, `ENCRYPTED: ${JSON.stringify(address)}`)
     )
     invoke(action)
-    expect(mockWalletService.signData).toHaveBeenCalledWith(
+    expect(mockWalletService.signDataPersonal).toHaveBeenCalledWith(
       getState().account.address,
-      data,
+      JSON.stringify(data),
       expect.any(Function)
     )
     expect(dispatch).toHaveBeenCalledWith(
-      gotSignedAddress(address, `ENCRYPTED: ${JSON.stringify(data)}`)
+      gotSignedAddress(
+        address,
+        `ENCRYPTED: ${JSON.stringify(JSON.stringify(data))}`
+      )
     )
     expect(next).toHaveBeenCalledWith(action)
   })

--- a/tickets/src/middlewares/walletMiddleware.js
+++ b/tickets/src/middlewares/walletMiddleware.js
@@ -160,9 +160,9 @@ const walletMiddleware = config => {
             eventAddress: address,
           })
 
-          walletService.signData(
+          walletService.signDataPersonal(
             account.address,
-            data,
+            JSON.stringify(data),
             (error, signedAddress) => {
               if (error) {
                 // TODO: Does this need to be handled in the error consumer?


### PR DESCRIPTION
# Description

Due to lack of availability to sign typed data by certain wallets this is being rolled back.

For most web3 providers, personal.sign will be used. In development & integration sign will be used as personal.sign is unavailable in the current configuration


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
