### PR TITLE
convert ethers's representation of infinite keys to UNLIMITED_KEYS_COUNT

### DIFF
--- a/unlock-js/index.js
+++ b/unlock-js/index.js
@@ -6,12 +6,10 @@ const {
 } = require('./lib/accounts')
 const { getCurrentProvider, getWeb3Provider } = require('./lib/providers')
 const deploy = require('./lib/deploy').default
-const { ETHERS_MAX_UINT } = require('./lib/constants')
 
 module.exports = {
   Web3Service: Web3Service.default,
   WalletService: WalletService.default,
-  INFINITE_KEYS: ETHERS_MAX_UINT,
   createAccountAndPasswordEncryptKey,
   getAccountFromPrivateKey,
   getCurrentProvider,

--- a/unlock-js/index.js
+++ b/unlock-js/index.js
@@ -6,10 +6,12 @@ const {
 } = require('./lib/accounts')
 const { getCurrentProvider, getWeb3Provider } = require('./lib/providers')
 const deploy = require('./lib/deploy').default
+const { ETHERS_MAX_UINT } = require('./lib/constants')
 
 module.exports = {
   Web3Service: Web3Service.default,
   WalletService: WalletService.default,
+  INFINITE_KEYS: ETHERS_MAX_UINT,
   createAccountAndPasswordEncryptKey,
   getAccountFromPrivateKey,
   getCurrentProvider,

--- a/unlock-js/src/__tests__/v0/getLock.test.js
+++ b/unlock-js/src/__tests__/v0/getLock.test.js
@@ -117,7 +117,7 @@ describe('v0', () => {
     })
 
     it('should successfully yield a lock with an unlimited number of keys', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
       await nockBeforeEach()
       callReadOnlyFunction({
         maxKeys:
@@ -131,7 +131,16 @@ describe('v0', () => {
         })
       })
 
-      return web3Service.getLock(lockAddress)
+      const lock = await web3Service.getLock(lockAddress)
+      expect(lock).toEqual({
+        asOf: 1337,
+        balance: '0.000000003735944941',
+        expirationDuration: 2592000,
+        keyPrice: '0.01',
+        maxNumberOfKeys: -1,
+        outstandingKeys: 17,
+        owner: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
+      })
     })
   })
 })

--- a/unlock-js/src/__tests__/v01/createLock.ethers.js
+++ b/unlock-js/src/__tests__/v01/createLock.ethers.js
@@ -5,6 +5,7 @@ import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
+import { UNLIMITED_KEYS_COUNT, ETHERS_MAX_UINT } from '../../../lib/constants'
 
 const { FAILED_TO_CREATE_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
@@ -25,7 +26,7 @@ const owner = '0xdeadfeed'
 
 describe('v01', () => {
   describe('createLock', () => {
-    async function nockBeforeEach() {
+    async function nockBeforeEach(maxNumberOfKeys = lock.maxNumberOfKeys) {
       nock.cleanAll()
       walletService = await prepWalletService(
         UnlockV01.Unlock,
@@ -50,7 +51,7 @@ describe('v01', () => {
         lock.expirationDuration,
         ethers.constants.AddressZero,
         utils.toWei(lock.keyPrice, 'ether'),
-        lock.maxNumberOfKeys
+        maxNumberOfKeys
       )
 
       transaction = testTransaction
@@ -104,6 +105,38 @@ describe('v01', () => {
       })
 
       await walletService.createLock(lock, owner)
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should convert unlimited keys from UNLIMITED_KEYS_COUNT to ETHERS_MAX_UINT for the function call', async () => {
+      expect.assertions(2)
+
+      // this param tells the call to createLock to pass in this value instead of the lock's value
+      // for maxNumberOfKeys. The test will fail if the function call does not convert
+      await nockBeforeEach(ETHERS_MAX_UINT)
+      setupSuccess()
+
+      walletService.on('lock.updated', (lockAddress, update) => {
+        expect(lockAddress).toBe(lock.address)
+        expect(update).toEqual({
+          transaction: transaction.hash,
+          balance: '0',
+          expirationDuration: lock.expirationDuration,
+          keyPrice: lock.keyPrice,
+          maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+          outstandingKeys: 0,
+          owner,
+        })
+      })
+
+      await walletService.createLock(
+        {
+          ...lock,
+          maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+        },
+        owner
+      )
+
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v01/getLock.test.js
+++ b/unlock-js/src/__tests__/v01/getLock.test.js
@@ -128,7 +128,7 @@ describe('v01', () => {
     })
 
     it('should successfully yield a lock with an unlimited number of keys', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
       await nockBeforeEach()
       callReadOnlyFunction({
         maxKeys:
@@ -142,7 +142,16 @@ describe('v01', () => {
         })
       })
 
-      return web3Service.getLock(lockAddress)
+      const lock = await web3Service.getLock(lockAddress)
+      expect(lock).toEqual({
+        asOf: 1337,
+        balance: '0.000000003735944941',
+        expirationDuration: 2592000,
+        keyPrice: '0.01',
+        maxNumberOfKeys: -1,
+        outstandingKeys: 17,
+        owner: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
+      })
     })
   })
 })

--- a/unlock-js/src/__tests__/v02/createLock.test.js
+++ b/unlock-js/src/__tests__/v02/createLock.test.js
@@ -5,6 +5,7 @@ import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
+import { UNLIMITED_KEYS_COUNT, ETHERS_MAX_UINT } from '../../../lib/constants'
 
 const { FAILED_TO_CREATE_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
@@ -25,7 +26,7 @@ const owner = '0xdeadfeed'
 
 describe('v02', () => {
   describe('createLock', () => {
-    async function nockBeforeEach() {
+    async function nockBeforeEach(maxNumberOfKeys = lock.maxNumberOfKeys) {
       nock.cleanAll()
       walletService = await prepWalletService(
         UnlockV02.Unlock,
@@ -50,7 +51,7 @@ describe('v02', () => {
         lock.expirationDuration,
         ethers.constants.AddressZero,
         utils.toWei(lock.keyPrice, 'ether'),
-        lock.maxNumberOfKeys
+        maxNumberOfKeys
       )
 
       transaction = testTransaction
@@ -104,6 +105,38 @@ describe('v02', () => {
       })
 
       await walletService.createLock(lock, owner)
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should convert unlimited keys from UNLIMITED_KEYS_COUNT to ETHERS_MAX_UINT for the function call', async () => {
+      expect.assertions(2)
+
+      // this param tells the call to createLock to pass in this value instead of the lock's value
+      // for maxNumberOfKeys. The test will fail if the function call does not convert
+      await nockBeforeEach(ETHERS_MAX_UINT)
+      setupSuccess()
+
+      walletService.on('lock.updated', (lockAddress, update) => {
+        expect(lockAddress).toBe(lock.address)
+        expect(update).toEqual({
+          transaction: transaction.hash,
+          balance: '0',
+          expirationDuration: lock.expirationDuration,
+          keyPrice: lock.keyPrice,
+          maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+          outstandingKeys: 0,
+          owner,
+        })
+      })
+
+      await walletService.createLock(
+        {
+          ...lock,
+          maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
+        },
+        owner
+      )
+
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v02/getLock.test.js
+++ b/unlock-js/src/__tests__/v02/getLock.test.js
@@ -128,7 +128,7 @@ describe('v02', () => {
     })
 
     it('should successfully yield a lock with an unlimited number of keys', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
       await nockBeforeEach()
       callReadOnlyFunction({
         maxKeys:
@@ -142,7 +142,16 @@ describe('v02', () => {
         })
       })
 
-      return web3Service.getLock(lockAddress)
+      const lock = await web3Service.getLock(lockAddress)
+      expect(lock).toEqual({
+        asOf: 1337,
+        balance: '0.000000003735944941',
+        expirationDuration: 2592000,
+        keyPrice: '0.01',
+        maxNumberOfKeys: -1,
+        outstandingKeys: 17,
+        owner: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
+      })
     })
   })
 })

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -447,6 +447,7 @@ describe('WalletService (ethers)', () => {
     it.each(versionSpecificUnlockMethods)(
       'should invoke the implementation of the corresponding version of %s',
       async method => {
+        await resetTestsAndConnect()
         const args = []
         const result = {}
         const version = {

--- a/unlock-js/src/v0/createLock.js
+++ b/unlock-js/src/v0/createLock.js
@@ -1,4 +1,4 @@
-import ethersUtils from '../utils.ethers'
+import ethersUtils from '../utils'
 import { GAS_AMOUNTS, ETHERS_MAX_UINT } from '../constants'
 import TransactionTypes from '../transactionTypes'
 import { UNLIMITED_KEYS_COUNT } from '../../lib/constants'

--- a/unlock-js/src/v0/createLock.js
+++ b/unlock-js/src/v0/createLock.js
@@ -1,6 +1,7 @@
-import ethersUtils from '../utils'
-import { GAS_AMOUNTS } from '../constants'
+import ethersUtils from '../utils.ethers'
+import { GAS_AMOUNTS, ETHERS_MAX_UINT } from '../constants'
 import TransactionTypes from '../transactionTypes'
+import { UNLIMITED_KEYS_COUNT } from '../../lib/constants'
 
 /**
  * Creates a lock on behalf of the user, using version v0
@@ -9,6 +10,10 @@ import TransactionTypes from '../transactionTypes'
  */
 export default async function(lock, owner) {
   const unlockContract = await this.getUnlockContract()
+  let maxNumberOfKeys = lock.maxNumberOfKeys
+  if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
+    maxNumberOfKeys = ETHERS_MAX_UINT
+  }
   let transactionPromise
   try {
     transactionPromise = unlockContract.functions[
@@ -16,7 +21,7 @@ export default async function(lock, owner) {
     ](
       lock.expirationDuration,
       ethersUtils.toWei(lock.keyPrice, 'ether'),
-      lock.maxNumberOfKeys,
+      maxNumberOfKeys,
       {
         gasLimit: GAS_AMOUNTS.createLock, // overrides default value for transaction gas price
       }

--- a/unlock-js/src/v01/createLock.js
+++ b/unlock-js/src/v01/createLock.js
@@ -1,6 +1,7 @@
 import ethersUtils from '../utils'
-import { GAS_AMOUNTS, ZERO } from '../constants'
+import { GAS_AMOUNTS, ZERO, ETHERS_MAX_UINT } from '../constants'
 import TransactionTypes from '../transactionTypes'
+import { UNLIMITED_KEYS_COUNT } from '../../lib/constants'
 
 /**
  * Creates a lock on behalf of the user, using version v0
@@ -9,6 +10,10 @@ import TransactionTypes from '../transactionTypes'
  */
 export default async function(lock, owner) {
   const unlockContract = await this.getUnlockContract()
+  let maxNumberOfKeys = lock.maxNumberOfKeys
+  if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
+    maxNumberOfKeys = ETHERS_MAX_UINT
+  }
   let transactionPromise
   try {
     transactionPromise = unlockContract.functions[
@@ -17,7 +22,7 @@ export default async function(lock, owner) {
       lock.expirationDuration,
       ZERO, // ERC20 address, 0 is for eth
       ethersUtils.toWei(lock.keyPrice, 'ether'),
-      lock.maxNumberOfKeys,
+      maxNumberOfKeys,
       {
         gasLimit: GAS_AMOUNTS.createLock, // overrides default value for transaction gas price
       }

--- a/unlock-js/src/v01/getLock.js
+++ b/unlock-js/src/v01/getLock.js
@@ -45,6 +45,7 @@ export default async function(address) {
   // totalSupply was previously called outstandingKeys. In order to keep compatibility
   // we also assign it. This behavior will eventually be deprecated
   update.outstandingKeys = update.totalSupply
+  delete update.totalSupply
 
   // Once all lock attributes have been fetched
   this.emit('lock.updated', address, update)

--- a/unlock-js/src/v02/createLock.js
+++ b/unlock-js/src/v02/createLock.js
@@ -1,6 +1,7 @@
 import ethersUtils from '../utils'
-import { GAS_AMOUNTS, ZERO } from '../constants'
+import { GAS_AMOUNTS, ZERO, ETHERS_MAX_UINT } from '../constants'
 import TransactionTypes from '../transactionTypes'
+import { UNLIMITED_KEYS_COUNT } from '../../lib/constants'
 
 /**
  * Creates a lock on behalf of the user, using version v0
@@ -9,6 +10,10 @@ import TransactionTypes from '../transactionTypes'
  */
 export default async function(lock, owner) {
   const unlockContract = await this.getUnlockContract()
+  let maxNumberOfKeys = lock.maxNumberOfKeys
+  if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
+    maxNumberOfKeys = ETHERS_MAX_UINT
+  }
   let transactionPromise
   try {
     transactionPromise = unlockContract.functions[
@@ -17,7 +22,7 @@ export default async function(lock, owner) {
       lock.expirationDuration,
       ZERO, // ERC20 address, 0 is for eth
       ethersUtils.toWei(lock.keyPrice, 'ether'),
-      lock.maxNumberOfKeys,
+      maxNumberOfKeys,
       {
         gasLimit: GAS_AMOUNTS.createLock, // overrides default value for transaction gas price
       }

--- a/unlock-js/src/v02/getLock.js
+++ b/unlock-js/src/v02/getLock.js
@@ -45,6 +45,7 @@ export default async function(address) {
   // totalSupply was previously called outstandingKeys. In order to keep compatibility
   // we also assign it. This behavior will eventually be deprecated
   update.outstandingKeys = update.totalSupply
+  delete update.totalSupply
 
   // Once all lock attributes have been fetched
   this.emit('lock.updated', address, update)


### PR DESCRIPTION
# Description

One of the details of Unlock that will cause issues when upgrading to use ethers is that infinite keys is represented internally slightly differently.

This PR provides a thin layer of abstraction that will allow us to clearly communicate to ethers the value of infinity without hard-coding it in the apps.

When installing the ethers version of the app, we will need to update walletMiddleware listening to `CREATE_LOCK` and then convert our app representation of infinity (`-1`) to `unlock-js`'s representation (`INFINITE_KEYS`). Note that web3 used a totally different system to represent the uint256 value we use for infinity, so this breaks creation of infinite keys

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
