### PR TITLE
increase coverage, fix bug in refreshAccountBalance

### DIFF
--- a/unlock-js/src/__tests__/v0/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v0/purchaseKey.test.js
@@ -23,7 +23,7 @@ describe('v0', () => {
     const account = '0xdeadbeef'
     const data = 'key data'
 
-    async function nockBeforeEach() {
+    async function nockBeforeEach(sendData = true) {
       nock.cleanAll()
       walletService = await prepWalletService(
         UnlockV0.PublicLock,
@@ -39,12 +39,13 @@ describe('v0', () => {
         value: keyPrice,
       })
 
-      const {
-        testTransaction,
-        testTransactionResult,
-        success,
-        fail,
-      } = callMethodData(owner, utils.utf8ToHex(data))
+      let result
+      if (sendData) {
+        result = callMethodData(owner, utils.utf8ToHex(data))
+      } else {
+        result = callMethodData(owner, utils.utf8ToHex(''))
+      }
+      const { testTransaction, testTransactionResult, success, fail } = result
 
       transaction = testTransaction
       transactionResult = testTransactionResult
@@ -102,6 +103,22 @@ describe('v0', () => {
         data
       )
       await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should work even with empty data', async () => {
+      expect.assertions(1)
+
+      await nockBeforeEach(false)
+      setupSuccess()
+
+      const result = await walletService.purchaseKey(
+        lockAddress,
+        owner,
+        keyPrice,
+        account
+      )
+      await nock.resolveWhenAllNocksUsed()
+      expect(result).toBe(transaction.hash)
     })
   })
 })

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -7,6 +7,7 @@ import v01 from '../v01'
 import v02 from '../v02'
 
 import WalletService from '../walletService'
+import { GAS_AMOUNTS } from '../constants'
 
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)
@@ -32,6 +33,14 @@ describe('WalletService (ethers)', () => {
     await walletService.connect(provider)
     await nock.resolveWhenAllNocksUsed()
   }
+
+  describe('gasAmountConstants', () => {
+    it('returns GAS_AMOUNTS', () => {
+      expect.assertions(1)
+
+      expect(WalletService.gasAmountConstants()).toBe(GAS_AMOUNTS)
+    })
+  })
 
   describe('connect', () => {
     beforeEach(() => {
@@ -406,6 +415,26 @@ describe('WalletService (ethers)', () => {
         walletService.signDataPersonal(account, data, (error, result) => {
           expect(result).toBe(returned)
           expect(error).toBe(null)
+          done()
+        })
+      })
+
+      it('calls the callback with any error', async done => {
+        expect.assertions(2)
+        await resetTestsAndConnect()
+
+        const data = 'data to be signed'
+        const account = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
+        const hash =
+          '0xdc8727bb847aebb19e4b2efa955b9b2c59192fd4656b6fe64bd61c09d8edb6d1'
+        const error = { code: 404, message: 'oops' }
+
+        nock.accountsAndYield([account])
+        nock.personalSignAndYield(hash, account, 'stuff', error)
+
+        walletService.signDataPersonal(account, data, (error, result) => {
+          expect(result).toBeNull()
+          expect(error).toBeInstanceOf(Error)
           done()
         })
       })

--- a/unlock-js/src/v0/purchaseKey.js
+++ b/unlock-js/src/v0/purchaseKey.js
@@ -15,13 +15,7 @@ import Errors from '../errors'
  * @param {string} data
  * @param {string} account
  */
-export default async function(
-  lockAddress,
-  owner,
-  keyPrice,
-  account,
-  data = ''
-) {
+export default async function(lockAddress, owner, keyPrice, account, data) {
   const lockContract = await this.getLockContract(lockAddress)
   let transactionPromise
   try {

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -147,6 +147,7 @@ export default class Web3Service extends UnlockService {
       this.emit('account.updated', account, {
         balance,
       })
+      return balance
     })
   }
 
@@ -591,24 +592,16 @@ export default class Web3Service extends UnlockService {
 
   _genKeyOwnersFromLockContract(lock, lockContract, page, byPage) {
     return new Promise((resolve, reject) => {
-      try {
-        lockContract.functions
-          .getOwnersByPage(page, byPage)
-          .then(ownerAddresses => {
-            const keyPromises = ownerAddresses.map(ownerAddress => {
-              return this._packageKeyholderInfo(
-                lock,
-                lockContract,
-                ownerAddress
-              )
-            })
-
-            resolve(keyPromises)
+      lockContract.functions
+        .getOwnersByPage(page, byPage)
+        .then(ownerAddresses => {
+          const keyPromises = ownerAddresses.map(ownerAddress => {
+            return this._packageKeyholderInfo(lock, lockContract, ownerAddress)
           })
-          .catch(error => reject(error))
-      } catch (e) {
-        reject(e)
-      }
+
+          resolve(keyPromises)
+        })
+        .catch(error => reject(error))
     })
   }
 


### PR DESCRIPTION
# Description

This increases coverage by removing dead code (and verifying it was dead prior to removing) in `_genKeyOwnersFromLockContract`, and fixes a bug in `refreshAccountBalance` because it was untested! There was no return value in the `then` clause and so it returned undefined instead of account balance.

It also removes the default value from purchaseKey because it is unnecessary. Later in the code, we set data to `''` if it is falsy, and that suffices.

Now, the only missing piece is testing `providers.js`, which needs a larger conversation.
<img width="663" alt="Screen Shot 2019-05-04 at 9 55 27 AM" src="https://user-images.githubusercontent.com/98250/57180099-46c27200-6e53-11e9-9f4b-cc8a5ba2a32f.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
