### PR TITLE
provide simple compatibility with old API for deploy

### DIFF
--- a/unlock-js/src/__tests__/deploy.test.js
+++ b/unlock-js/src/__tests__/deploy.test.js
@@ -210,12 +210,14 @@ describe('contract deployer', () => {
     })
 
     it('passes the new contract instance to onNewContractInstance', async () => {
-      expect.assertions(1)
+      expect.assertions(2)
 
       // const contractAddress = deployed.mock.calls[0][0].options.address // web3
       const sentAddress = deployed.mock.calls[0][0].address // ethers.js
+      const compatibilityAddress = deployed.mock.calls[0][0].options.address // ethers.js
 
       expect(sentAddress).toBe(contractAddress)
+      expect(compatibilityAddress).toBe(contractAddress)
     })
   })
 

--- a/unlock-js/src/deploy.js
+++ b/unlock-js/src/deploy.js
@@ -27,6 +27,7 @@ export default async function deploy(
   const result = await writableUnlockContract.initialize(accounts[0], {
     gasLimit: 1000000,
   })
+  unlockContract.options = { address: unlockContract.address } // compatibility with the web3 way
   onNewContractInstance(unlockContract)
   return result
 }


### PR DESCRIPTION
# Description

This PR resolves one minor API incompatibility between the web3 way and the ethers way. Ethers contract does not have an `options` member, and so accessing `contract.options.address` in `deploy-unlock.js` fails. This PR simply restores `options.address` so the script won't need to be changed, making upgrading even more seamless.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
