### PR TITLE
don't retrieve a web3 provider at all, just return the URL, and let walletService make its own

### DIFF
--- a/unlock-js/src/__tests__/providers.test.js
+++ b/unlock-js/src/__tests__/providers.test.js
@@ -1,12 +1,11 @@
 import { getWeb3Provider } from '../providers'
 
 describe('web3 provider creator', () => {
-  it('getWeb3Provider returns a valid web3 provider for a URL', () => {
-    expect.assertions(2)
+  it('getWeb3Provider returns the URL it is given', () => {
+    expect.assertions(1)
 
     // using ws so that the test will still pass when we move to WebSocketProvider
     const provider = getWeb3Provider('ws://1.2.3.4:1234')
-    expect(provider.send).toBeInstanceOf(Function)
-    expect(provider.disconnect).toBeInstanceOf(Function)
+    expect(provider).toBe('ws://1.2.3.4:1234')
   })
 })

--- a/unlock-js/src/providers.js
+++ b/unlock-js/src/providers.js
@@ -1,5 +1,3 @@
-import Web3 from 'web3'
-
 // There is no standard way to detect the provider name...
 // TODO: remove? this convenience function is unused
 export function getCurrentProvider(environment) {
@@ -39,5 +37,5 @@ export function getCurrentProvider(environment) {
 }
 
 export function getWeb3Provider(url) {
-  return new Web3.providers.HttpProvider(url)
+  return url // we will simply return the URL, walletService will construct its own ethers provider!
 }


### PR DESCRIPTION
# Description

So this is a short PR that requires a long explanation.

In our web3 version of `unlock-js`, we were instantiating providers in `config.js` and passing them down to set up the `walletService`. In the preparation to move away from `web3`, this code was extracted to `unlock-js` `providers.js`.  Originally, `walletService` simply accepted a provider as its argument to `connect`.

Now, the relevant code in `walletService.connect` is:

```js
    if (typeof provider === 'string') {
      this.provider = new ethersProviders.JsonRpcProvider(provider)
      this.web3Provider = false
    } else {
      this.provider = new ethersProviders.Web3Provider(provider)
      this.web3Provider = provider
    }
```

Thus, we can accept a string (the URL we will find our HTTP provider at), and create our own ethers `JsonRpcProvider`. On the other hand, if the provider passed in is (for instance) metamask, which is a `web3` provider, we will use it with an ethers `Web3Provider`.

The only instance in which we will use an HTTP provider is in local development (ganache), and so having `getWeb3Provider` return the URL it is passed means we can remove the only remaining dependency on `web3` in the `unlock-js` source.

At a future date, we may wish to change this behavior, so I think it's worth keeping this.

For instance, we might decide to create an ethers JsonRpcProvider or even a webservice provider from the URL passed in. So, instead of removing `getWeb3Provider`, this PR has it return its URL argument.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
