### PR TITLE
fix signing in walletService

### DIFF
--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -214,6 +214,10 @@ export class NockHelper {
     return this._jsonRpcRequest('personal_sign', [hash, account], result, error)
   }
 
+  ethSignAndYield(hash, account, result, error) {
+    return this._jsonRpcRequest('eth_sign', [account, hash], result, error)
+  }
+
   getTransactionCount(address, count) {
     return this._jsonRpcRequest(
       'eth_getTransactionCount',

--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -221,7 +221,7 @@ export class NockHelper {
   ethSignTypedDataAndYield(account, data, result, error) {
     return this._jsonRpcRequest(
       'eth_signTypedData',
-      [account, JSON.stringify(data)],
+      [account, data],
       result,
       error
     )
@@ -230,7 +230,7 @@ export class NockHelper {
   ethSignTypedDatav3AndYield(account, data, result, error) {
     return this._jsonRpcRequest(
       'eth_signTypedData_v3',
-      [account, JSON.stringify(data)],
+      [account, data],
       result,
       error
     )

--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -218,6 +218,24 @@ export class NockHelper {
     return this._jsonRpcRequest('eth_sign', [account, hash], result, error)
   }
 
+  ethSignTypedDataAndYield(account, data, result, error) {
+    return this._jsonRpcRequest(
+      'eth_signTypedData',
+      [account, JSON.stringify(data)],
+      result,
+      error
+    )
+  }
+
+  ethSignTypedDatav3AndYield(account, data, result, error) {
+    return this._jsonRpcRequest(
+      'eth_signTypedData_v3',
+      [account, JSON.stringify(data)],
+      result,
+      error
+    )
+  }
+
   getTransactionCount(address, count) {
     return this._jsonRpcRequest(
       'eth_getTransactionCount',

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -400,7 +400,7 @@ describe('WalletService (ethers)', () => {
     })
 
     describe('signDataPersonal', () => {
-      it('dispatches the request to personally sign the data to the corresponding web3 method', async done => {
+      it('dispatches the request to personally sign the data for non-http providers', async done => {
         expect.assertions(2)
         await resetTestsAndConnect()
         const data = 'data to be signed'
@@ -408,13 +408,33 @@ describe('WalletService (ethers)', () => {
         const hash =
           '0xdc8727bb847aebb19e4b2efa955b9b2c59192fd4656b6fe64bd61c09d8edb6d1'
         const returned = Buffer.from('stuff').toString('base64')
+        walletService.web3Provider = true // trigger the call to personalSign
 
         nock.accountsAndYield([account])
         nock.personalSignAndYield(hash, account, 'stuff')
 
         walletService.signDataPersonal(account, data, (error, result) => {
+          expect(error).toBeNull()
           expect(result).toBe(returned)
-          expect(error).toBe(null)
+          done()
+        })
+      })
+
+      it('calls eth_sign for http providers', async done => {
+        expect.assertions(2)
+        await resetTestsAndConnect()
+        const data = 'data to be signed'
+        const account = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
+        const hash =
+          '0x307864633837323762623834376165626231396534623265666139353562396232633539313932666434363536623666653634626436316330396438656462366431'
+        const returned = Buffer.from('stuff').toString('base64')
+
+        nock.accountsAndYield([account])
+        nock.ethSignAndYield(hash, account, 'stuff')
+
+        walletService.signDataPersonal(account, data, (error, result) => {
+          expect(error).toBeNull()
+          expect(result).toBe(returned)
           done()
         })
       })

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -279,7 +279,12 @@ describe('WalletService (ethers)', () => {
         await metamaskBeforeEach()
         await resetTestsAndConnect(metamask)
         data = []
-        nock.ethSignTypedDatav3AndYield(unlockAddress, data, hash)
+        // eth_signTypedData_v3 expects the data to be a JSON string
+        nock.ethSignTypedDatav3AndYield(
+          unlockAddress,
+          JSON.stringify(data),
+          hash
+        )
 
         await walletService.signData(unlockAddress, data, (error, result) => {
           expect(error).toBeNull()

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -426,7 +426,7 @@ describe('WalletService (ethers)', () => {
         const data = 'data to be signed'
         const account = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
         const hash =
-          '0x307864633837323762623834376165626231396534623265666139353562396232633539313932666434363536623666653634626436316330396438656462366431'
+          '0xdc8727bb847aebb19e4b2efa955b9b2c59192fd4656b6fe64bd61c09d8edb6d1'
         const returned = Buffer.from('stuff').toString('base64')
 
         nock.accountsAndYield([account])

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -185,24 +185,14 @@ export default class WalletService extends UnlockService {
    * @param {*} callback
    */
   async signData(account, data, callback) {
-    let method
-
-    if (this.web3Provider && this.web3Provider.isMetaMask) {
-      method = 'eth_signTypedData_v3'
-      data = JSON.stringify(data)
-    } else {
-      method = 'eth_signTypedData'
-    }
+    const isMetaMask = this.web3Provider && this.web3Provider.isMetaMask
+    const method = isMetaMask ? 'eth_signTypedData_v3' : 'eth_signTypedData'
+    const sendData = JSON.stringify(data)
 
     try {
-      const result = await this.provider.send(method, [account, data])
+      const result = await this.provider.send(method, [account, sendData])
 
-      // signature failure on the node
-      if (result.error) {
-        return callback(result.error, null)
-      }
-
-      callback(null, Buffer.from(result.result).toString('base64'))
+      callback(null, Buffer.from(result).toString('base64'))
     } catch (err) {
       return callback(err, null)
     }

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -187,10 +187,9 @@ export default class WalletService extends UnlockService {
   async signData(account, data, callback) {
     const isMetaMask = this.web3Provider && this.web3Provider.isMetaMask
     const method = isMetaMask ? 'eth_signTypedData_v3' : 'eth_signTypedData'
-    const sendData = JSON.stringify(data)
 
     try {
-      const result = await this.provider.send(method, [account, sendData])
+      const result = await this.provider.send(method, [account, data])
 
       callback(null, Buffer.from(result).toString('base64'))
     } catch (err) {

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -187,9 +187,11 @@ export default class WalletService extends UnlockService {
   async signData(account, data, callback) {
     const isMetaMask = this.web3Provider && this.web3Provider.isMetaMask
     const method = isMetaMask ? 'eth_signTypedData_v3' : 'eth_signTypedData'
+    // see https://github.com/MetaMask/metamask-extension/blob/c4caba131776ff7397d3a4071d7cc84907ac9a43/app/scripts/metamask-controller.js#L997
+    const sendData = isMetaMask ? JSON.stringify(data) : data
 
     try {
-      const result = await this.provider.send(method, [account, data])
+      const result = await this.provider.send(method, [account, sendData])
 
       callback(null, Buffer.from(result).toString('base64'))
     } catch (err) {


### PR DESCRIPTION
# Description

While testing `unlock-js` with the tickets app, several problems with the ethers migration of signatures surfaced that were not being caught by the tests. This PR fixes the problems and updates the tests so that they verify correct interaction with the underlying JSON-RPC library.

The calls to `eth_signTypedData` were totally wrong (passing string in the case of non-metamask providers), and the calls to personal_sign and eth_sign were all mixed up as well.

The tests now verify that the expected JSON-RPC calls are sent instead of mocking out the provider. This is a crucial step in verifying correctness, while still hiding implementation details.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2782 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
