### PR TITLE
using the right variable name for ticketLink

### DIFF
--- a/tickets/src/__tests__/actions/email.test.js
+++ b/tickets/src/__tests__/actions/email.test.js
@@ -7,7 +7,7 @@ describe('email actions', () => {
     const ticket = 'data-uri'
     const eventName = 'The party'
     const eventDate = 'June 26th 2019'
-    const confirmLink = 'https://tickets....'
+    const ticketLink = 'https://tickets....'
 
     const expectedAction = {
       type: SEND_CONFIRMATION,
@@ -15,10 +15,10 @@ describe('email actions', () => {
       ticket,
       eventName,
       eventDate,
-      confirmLink,
+      ticketLink,
     }
     expect(
-      sendConfirmation(recipient, ticket, eventName, eventDate, confirmLink)
+      sendConfirmation(recipient, ticket, eventName, eventDate, ticketLink)
     ).toEqual(expectedAction)
   })
 })

--- a/tickets/src/__tests__/middlewares/wedlockMiddleware.test.js
+++ b/tickets/src/__tests__/middlewares/wedlockMiddleware.test.js
@@ -49,7 +49,7 @@ describe('Wedlock middleware', () => {
       const ticket = 'data-uri'
       const eventName = 'The launch party!'
       const eventDate = 'Monday June 3rd, 2019'
-      const confirmLink = 'http://tickets.unlock-protocol.com/0x123'
+      const ticketLink = 'http://tickets.unlock-protocol.com/0x123'
 
       const action = {
         type: SEND_CONFIRMATION,
@@ -57,7 +57,7 @@ describe('Wedlock middleware', () => {
         ticket,
         eventName,
         eventDate,
-        confirmLink,
+        ticketLink,
       }
       mockWedlockService.confirmEvent = jest.fn(() => {
         return Promise.resolve()
@@ -69,7 +69,7 @@ describe('Wedlock middleware', () => {
         ticket,
         eventName,
         eventDate,
-        confirmLink
+        ticketLink
       )
       expect(next).toHaveBeenCalledTimes(1)
     })

--- a/tickets/src/__tests__/services/wedlockService.test.js
+++ b/tickets/src/__tests__/services/wedlockService.test.js
@@ -16,7 +16,7 @@ describe('Wedlocks Service', () => {
       const ticket = 'ticket-as-data-uri'
       const eventName = 'My party'
       const eventDate = 'December 26th 2019'
-      const confirmLink = 'http://tickets.unlock-protocol.com/0x...'
+      const ticketLink = 'http://tickets.unlock-protocol.com/0x...'
 
       const expectedPayload = {
         template: emailTemplate.confirmEvent,
@@ -29,11 +29,11 @@ describe('Wedlocks Service', () => {
         params: {
           eventName,
           eventDate,
-          confirmLink,
+          ticketLink,
         },
       }
       axios.post.mockReturnValue()
-      await w.confirmEvent(recipient, ticket, eventName, eventDate, confirmLink)
+      await w.confirmEvent(recipient, ticket, eventName, eventDate, ticketLink)
 
       expect(axios.post).toHaveBeenCalledWith(
         'http://notareal.host',

--- a/tickets/src/actions/email.js
+++ b/tickets/src/actions/email.js
@@ -5,12 +5,12 @@ export const sendConfirmation = (
   ticket,
   eventName,
   eventDate,
-  confirmLink
+  ticketLink
 ) => ({
   type: SEND_CONFIRMATION,
   recipient,
   ticket,
   eventName,
   eventDate,
-  confirmLink,
+  ticketLink,
 })

--- a/tickets/src/components/content/purchase/Ticket.js
+++ b/tickets/src/components/content/purchase/Ticket.js
@@ -119,9 +119,9 @@ export const mapDispatchToProps = dispatch => ({
   signAddress: address => {
     dispatch(signAddress(address))
   },
-  sendConfirmation: (recipient, ticket, eventName, eventDate, confirmLink) => {
+  sendConfirmation: (recipient, ticket, eventName, eventDate, ticketLink) => {
     dispatch(
-      sendConfirmation(recipient, ticket, eventName, eventDate, confirmLink)
+      sendConfirmation(recipient, ticket, eventName, eventDate, ticketLink)
     )
   },
 })

--- a/tickets/src/middlewares/wedlockMiddleware.js
+++ b/tickets/src/middlewares/wedlockMiddleware.js
@@ -11,20 +11,14 @@ const wedlockMiddleware = config => {
     return next => {
       return action => {
         if (action.type === SEND_CONFIRMATION) {
-          const {
-            recipient,
-            ticket,
-            eventName,
-            eventDate,
-            confirmLink,
-          } = action
+          const { recipient, ticket, eventName, eventDate, ticketLink } = action
 
           wedlockService.confirmEvent(
             recipient,
             ticket,
             eventName,
             eventDate,
-            confirmLink
+            ticketLink
           )
         }
 

--- a/tickets/src/services/wedlockService.ts
+++ b/tickets/src/services/wedlockService.ts
@@ -47,7 +47,7 @@ export default class WedlockService {
     ticket: string,
     eventName: string,
     eventDate: string,
-    confirmLink: string
+    ticketLink: string
   ) => {
     return this.sendEmail(
       emailTemplate.confirmEvent,
@@ -55,7 +55,7 @@ export default class WedlockService {
       {
         eventName,
         eventDate,
-        confirmLink,
+        ticketLink,
       },
       [{ path: ticket }]
     )


### PR DESCRIPTION
This was causing a `undefined` instead of the actual link in the emails...


- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread