### PR TITLE
Removing dash in email signoff

### DIFF
--- a/wedlocks/src/__tests__/templates/confirmEmail.test.js
+++ b/wedlocks/src/__tests__/templates/confirmEmail.test.js
@@ -25,7 +25,7 @@ If you have any questions, you can always email us at hello@unlock-protocol.com.
 
 And again, welcome!
 
-- The Unlock team
+The Unlock team
 `
     )
   })

--- a/wedlocks/src/__tests__/templates/confirmEvent.test.js
+++ b/wedlocks/src/__tests__/templates/confirmEvent.test.js
@@ -28,7 +28,7 @@ You can also show the QR code attached to this email.
 
 Enjoy!
 
-- The Unlock team
+The Unlock team
 `
     )
   })

--- a/wedlocks/src/__tests__/templates/ejectedEmail.test.js
+++ b/wedlocks/src/__tests__/templates/ejectedEmail.test.js
@@ -21,7 +21,7 @@ Your funds are yours and you can still transfer them via a third-party tool. How
 
 If you have any questions, you can always email us at hello@unlock-protocol.com.
 
-- The Unlock team
+The Unlock team
 `
     )
   })

--- a/wedlocks/src/__tests__/templates/ejectionWarningEmail.test.js
+++ b/wedlocks/src/__tests__/templates/ejectionWarningEmail.test.js
@@ -24,7 +24,7 @@ Your funds are yours and you will be able to transfer them via a third-party too
 
 If you have any questions, you can always email us at hello@unlock-protocol.com.
 
-- The Unlock team
+The Unlock team
 `
     )
   })

--- a/wedlocks/src/__tests__/templates/recoveryKeyConfirmEmail.test.js
+++ b/wedlocks/src/__tests__/templates/recoveryKeyConfirmEmail.test.js
@@ -23,7 +23,7 @@ If you did not make this request, please disregard this email. Otherwise, please
 
 If you have any questions, you can always email us at hello@unlock-protocol.com.
 
-- The Unlock team
+The Unlock team
 `
     )
   })

--- a/wedlocks/src/__tests__/templates/recoveryKeyEmail.test.js
+++ b/wedlocks/src/__tests__/templates/recoveryKeyEmail.test.js
@@ -23,7 +23,7 @@ We recommend that you make sure you've saved this key somewhere safe where you'l
 
 If you have any questions, you can always email us at hello@unlock-protocol.com.
 
-- The Unlock team
+The Unlock team
 `
     )
   })

--- a/wedlocks/src/templates/confirmEmail.js
+++ b/wedlocks/src/templates/confirmEmail.js
@@ -13,6 +13,6 @@ If you have any questions, you can always email us at hello@unlock-protocol.com.
 
 And again, welcome!
 
-- The Unlock team
+The Unlock team
 `,
 }

--- a/wedlocks/src/templates/confirmEvent.js
+++ b/wedlocks/src/templates/confirmEvent.js
@@ -15,6 +15,6 @@ You can also show the QR code attached to this email.
 
 Enjoy!
 
-- The Unlock team
+The Unlock team
 `,
 }

--- a/wedlocks/src/templates/ejectedEmail.js
+++ b/wedlocks/src/templates/ejectedEmail.js
@@ -11,6 +11,6 @@ Your funds are yours and you can still transfer them via a third-party tool. How
 
 If you have any questions, you can always email us at hello@unlock-protocol.com.
 
-- The Unlock team
+The Unlock team
 `,
 }

--- a/wedlocks/src/templates/ejectionWarningEmail.js
+++ b/wedlocks/src/templates/ejectionWarningEmail.js
@@ -15,6 +15,6 @@ Your funds are yours and you will be able to transfer them via a third-party too
 
 If you have any questions, you can always email us at hello@unlock-protocol.com.
 
-- The Unlock team
+The Unlock team
 `,
 }

--- a/wedlocks/src/templates/recoveryKeyConfirmEmail.js
+++ b/wedlocks/src/templates/recoveryKeyConfirmEmail.js
@@ -9,6 +9,6 @@ If you did not make this request, please disregard this email. Otherwise, please
 
 If you have any questions, you can always email us at hello@unlock-protocol.com.
 
-- The Unlock team
+The Unlock team
 `,
 }

--- a/wedlocks/src/templates/recoveryKeyEmail.js
+++ b/wedlocks/src/templates/recoveryKeyEmail.js
@@ -11,6 +11,6 @@ We recommend that you make sure you've saved this key somewhere safe where you'l
 
 If you have any questions, you can always email us at hello@unlock-protocol.com.
 
-- The Unlock team
+The Unlock team
 `,
 }


### PR DESCRIPTION
# Description

Something in the email stack is turning our messages into markdown-generated HTML. We need to track it down, but in the meantime this PR removes the dash in signoff to avoid this situation:

<img width="357" alt="Screen Shot 2019-05-05 at 7 09 25 PM" src="https://user-images.githubusercontent.com/624104/57204011-66e45500-6f69-11e9-8cca-9e1126cf3bb2.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
