### PR TITLE
new FetchJsonProvider to make JsonRpcProvider serviceWorker-compatible

### DIFF
--- a/unlock-js/src/FetchJsonProvider.js
+++ b/unlock-js/src/FetchJsonProvider.js
@@ -1,0 +1,54 @@
+import { providers } from 'ethers'
+
+const whoAmI = global || self
+
+function getResult(payload) {
+  if (payload.error) {
+    const error = new Error(payload.error.message)
+    error.code = payload.error.code
+    error.data = payload.error.data
+    throw error
+  }
+
+  return payload.result
+}
+
+export default class FetchJsonProvider extends providers.JsonRpcProvider {
+  async send(method, params) {
+    if (!whoAmI.fetch) {
+      return providers.JsonRpcProvider.prototype.send.call(this, method, params)
+    }
+    const request = {
+      method: method,
+      params: params,
+      id: 42,
+      jsonrpc: '2.0',
+    }
+
+    const toFetch =
+      this.connection.url.indexOf('http') !== -1
+        ? this.connection.url
+        : whoAmI.location.protocol + '//' + this.connection.url
+    const response = await fetch(toFetch, {
+      body: JSON.stringify(request),
+      mode: 'cors',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // "Content-Type": "application/x-www-form-urlencoded",
+      },
+    })
+    if (!response.ok) {
+      throw new Error(`Fetch failed: ${response.status} ${response.statusText}`)
+    }
+    const processed = await response.json()
+    const result = getResult(processed)
+    this.emit('debug', {
+      action: 'send',
+      request: request,
+      response: result,
+      provider: this,
+    })
+    return result
+  }
+}

--- a/unlock-js/src/__tests__/FetchJsonProvider.test.js
+++ b/unlock-js/src/__tests__/FetchJsonProvider.test.js
@@ -1,0 +1,148 @@
+import NockHelper from './helpers/nockHelper'
+import FetchJsonProvider from '../FetchJsonProvider'
+
+const endpoint = 'http://127.0.0.1:8545'
+const nock = new NockHelper(endpoint, false /** debug */)
+
+describe('FetchJsonProvider', () => {
+  const originalFetch = global.fetch
+  describe('verify parameters passed in', () => {
+    let fetch
+
+    function fakeFetchSuccess(returnValue) {
+      fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              error: null,
+              result: returnValue,
+            }),
+        })
+      )
+      global.fetch = fetch
+    }
+
+    afterEach(() => {
+      global.fetch = originalFetch
+    })
+
+    it('should set cors mode, POST, and content-type', async () => {
+      expect.assertions(1)
+      const result = { id: 42, jsonrpc: '2.0', result: 123, error: null }
+
+      fakeFetchSuccess(result)
+
+      const provider = new FetchJsonProvider(endpoint)
+
+      await provider.send('net_version', [])
+
+      expect(fetch).toHaveBeenCalledWith(
+        endpoint,
+        expect.objectContaining({
+          body: JSON.stringify({
+            method: 'net_version',
+            params: [],
+            id: 42,
+            jsonrpc: '2.0',
+          }),
+          mode: 'cors',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            // "Content-Type": "application/x-www-form-urlencoded",
+          },
+        })
+      )
+      await new Promise(resolve => setTimeout(resolve, 1)) // this ensures our test finishes after the provider requests net_version
+    })
+  })
+
+  describe('failures', () => {
+    beforeEach(() => {
+      global.fetch = originalFetch
+      nock.cleanAll()
+    })
+
+    afterEach(() => {
+      nock.cleanAll()
+    })
+
+    it('if request fails, should throw', async () => {
+      expect.assertions(2)
+
+      nock.do404('net_version', [])
+      nock.do404('net_version', [])
+
+      try {
+        const provider = new FetchJsonProvider(endpoint)
+        await provider.send('net_version', [])
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error)
+        expect(e.message).toBe('invalid response - 404')
+      }
+      await new Promise(resolve => setTimeout(resolve, 1)) // this ensures our test finishes after the provider requests net_version
+    })
+
+    it('if json-rpc fails, should throw', async () => {
+      expect.assertions(2)
+
+      nock.ethCallAndFail('data', 'to', { code: 404, message: 'nope' })
+      nock.netVersionAndYield(1984)
+
+      try {
+        const provider = new FetchJsonProvider(endpoint)
+        await provider.send('eth_call', [{ data: 'data', to: 'to' }, 'latest'])
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error)
+        expect(e.message).toBe('nope')
+      }
+      await new Promise(resolve => setTimeout(resolve, 1)) // this ensures our test finishes after the provider requests net_version
+    })
+  })
+
+  describe('success', () => {
+    afterEach(() => {
+      nock.cleanAll()
+    })
+
+    it('should return the JSON value', async () => {
+      expect.assertions(1)
+
+      nock.netVersionAndYield(1984)
+      nock.netVersionAndYield(1984)
+
+      const provider = new FetchJsonProvider(endpoint)
+      const value = await provider.send('net_version', [])
+
+      expect(value).toBe(1984)
+      await new Promise(resolve => setTimeout(resolve, 1)) // this ensures our test finishes after the provider requests net_version
+    })
+
+    it('should emit a debug event', async () => {
+      expect.assertions(1)
+
+      nock.netVersionAndYield(1984)
+      nock.netVersionAndYield(1984)
+
+      const provider = new FetchJsonProvider(endpoint)
+      provider.emit = jest.fn()
+      await provider.send('net_version', [])
+      await new Promise(resolve => setTimeout(resolve, 1)) // this ensures our test finishes after the provider requests net_version
+      expect(provider.emit).toHaveBeenCalledWith(
+        'debug',
+        expect.objectContaining({
+          action: 'send',
+          request: {
+            method: 'net_version',
+            params: [],
+            id: 42,
+            jsonrpc: '2.0',
+          },
+          response: 1984,
+          provider,
+        })
+      )
+    })
+  })
+})

--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -124,6 +124,15 @@ export class NockHelper {
       .log(cb)
   }
 
+  do404(method, params) {
+    this.anyRequestSetUp = true // detect http calls made before any mocks setup
+    const cb = (...args) => this.logNock(args)
+    return this.nockScope
+      .post('/', { jsonrpc: '2.0', id: this._rpcRequestId, method, params })
+      .reply(404, '404 Not Found')
+      .log(cb)
+  }
+
   // net_version
   netVersionAndYield(netVersion) {
     return this._jsonRpcRequest('net_version', [], netVersion)


### PR DESCRIPTION
# Description

This introduces a sub-class of `ethers.JsonRpcProvider` that uses `fetch` instead of `XMLHttpRequest`, as `XMLHttpRequest` does not exist in a service worker context. It is also nextjs-serverside-compatible, in that it uses either `global` or `self` (`global` exists on node and in window context (alias of `window`), `self` in a service worker). If `fetch` does not exist, it falls back to the `JsonRpcProvider` `send`, so it works in all contexts.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3008 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
