### PR TITLE
ignore .tgz files generated by npm pack

### DIFF
--- a/unlock-js/.gitignore
+++ b/unlock-js/.gitignore
@@ -1,3 +1,4 @@
 # Builds are in:
 /lib
 coverage/
+*.tgz


### PR DESCRIPTION
# Description

while testing, occasionally one may want to `npm pack` to generate a .tgz to test installing from, this makes sure we don't accidentally commit these to git

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
