### PR TITLE
Make signup form password-manager-compatible

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -34229,11 +34229,24 @@ Object {
         <p
           class="c1"
         >
-          Create a password for your account: 
-          geoff@bitconnect.gov
-          .
+          Create a password for your account.
         </p>
         <form>
+          <label
+            class="c2"
+            for="emailPlaceholder"
+          >
+            Email
+          </label>
+          <input
+            class="c3"
+            disabled=""
+            id="emailPlaceholder"
+            name="emailPlaceholder"
+            type="email"
+            value="geoff@bitconnect.gov"
+          />
+          <br />
           <label
             class="c2"
             for="passwordInput"
@@ -34290,11 +34303,24 @@ Object {
       <p
         class="sc-kpOJdX wegZY"
       >
-        Create a password for your account: 
-        geoff@bitconnect.gov
-        .
+        Create a password for your account.
       </p>
       <form>
+        <label
+          class="sc-dxgOiQ kuSlwR"
+          for="emailPlaceholder"
+        >
+          Email
+        </label>
+        <input
+          class="sc-ckVGcZ kVQLNc"
+          disabled=""
+          id="emailPlaceholder"
+          name="emailPlaceholder"
+          type="email"
+          value="geoff@bitconnect.gov"
+        />
+        <br />
         <label
           class="sc-dxgOiQ kuSlwR"
           for="passwordInput"

--- a/unlock-app/src/components/interface/FinishSignup.tsx
+++ b/unlock-app/src/components/interface/FinishSignup.tsx
@@ -101,10 +101,17 @@ export class FinishSignup extends React.Component<Props, State> {
     return (
       <div>
         <Heading>Create Your Unlock Wallet</Heading>
-        <Instructions>
-          Create a password for your account: {emailAddress}.
-        </Instructions>
+        <Instructions>Create a password for your account.</Instructions>
         <form onSubmit={this.handleSubmit}>
+          <Label htmlFor="emailPlaceholder">Email</Label>
+          <Input
+            name="emailPlaceholder"
+            type="email"
+            id="emailPlaceholder"
+            value={emailAddress}
+            disabled
+          />
+          <br />
           <Label htmlFor="passwordInput">Password</Label>
           <Input
             name="password"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR adds a disabled field containing the confirmed email address to the password form. This enables browser password managers to associate the email and password used for an Unlock account so they'll be able to offer to save it.

<img width="1299" alt="Screen Shot 2019-05-07 at 10 49 58 AM" src="https://user-images.githubusercontent.com/9300702/57309901-db78da00-70b6-11e9-86d4-1288cb87960d.png">

<img width="1299" alt="Screen Shot 2019-05-07 at 10 50 39 AM" src="https://user-images.githubusercontent.com/9300702/57309907-de73ca80-70b6-11e9-9483-444688c2bd0d.png">


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2722 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
