### PR TITLE
rename the config variable to match the forbes proposal

### DIFF
--- a/paywall/src/__tests__/paywall-builder/config.test.js
+++ b/paywall/src/__tests__/paywall-builder/config.test.js
@@ -65,7 +65,7 @@ describe('paywall configuration inter-window communication', () => {
     it('should post a message when ready', () => {
       expect.assertions(1)
 
-      window.unlockConfig = 'hi'
+      window.unlockProtocolConfig = 'hi'
       const event = {
         origin: 'origin',
         source: iframe.contentWindow,
@@ -210,7 +210,7 @@ describe('paywall configuration inter-window communication', () => {
       it('should not post if origin does not match', () => {
         expect.assertions(1)
 
-        window.unlockConfig = 'hi'
+        window.unlockProtocolConfig = 'hi'
         const event = {
           origin: 'origin',
           source: iframe.contentWindow,
@@ -228,7 +228,7 @@ describe('paywall configuration inter-window communication', () => {
       it('should not post if source does not match', () => {
         expect.assertions(1)
 
-        window.unlockConfig = 'hi'
+        window.unlockProtocolConfig = 'hi'
         const event = {
           origin: 'origin',
           source: window,
@@ -246,7 +246,7 @@ describe('paywall configuration inter-window communication', () => {
       it('should not post if message is not POST_MESSAGE_READY', () => {
         expect.assertions(1)
 
-        window.unlockConfig = 'hi'
+        window.unlockProtocolConfig = 'hi'
         const event = {
           origin: 'origin',
           source: iframe.contentWindow,

--- a/paywall/src/paywall-builder/config.js
+++ b/paywall/src/paywall-builder/config.js
@@ -53,9 +53,9 @@ export function setupReadyListener(window, iframe, origin) {
     if (event.data === POST_MESSAGE_READY) {
       // we were ready first, send the paywall configuration now
       // this script assumes that the metadata is set in a script tag like:
-      // <script type="text/javascript">window.unlockConfig = {...}</script>
+      // <script type="text/javascript">window.unlockProtocolConfig = {...}</script>
       // immediately before paywall.min.js is loaded
-      sendConfig(window.unlockConfig, iframe, origin)
+      sendConfig(window.unlockProtocolConfig, iframe, origin)
       enable(window)
         .then(() => getAccount(window, iframe, origin))
         .catch(() => {}) // no web3, don't retrieve account


### PR DESCRIPTION
# Description

This renames the configuration variable used to set global config for the paywall to `unlockProtocolConfig` to match the proposal sent to Forbes.com

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
