### PR TITLE
new validator for unlockProtocolConfig used by Forbes paywall

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -57,4 +57,356 @@ describe('Form field validators', () => {
       validators.isAccount('0X12345678901234567890abcdef0123ABCDEF0123')
     ).toBeFalsy()
   })
+
+  describe('isValidPaywallConfig', () => {
+    const lock = '0x1234567890123456789012345678901234567890'
+    const validConfig = {
+      callToAction: {
+        default: 'hi',
+      },
+      locks: {
+        [lock]: {
+          name: 'hi',
+        },
+      },
+      icon: 'hi',
+    }
+
+    describe('failures', () => {
+      it('config is falsy', () => {
+        expect.assertions(4)
+
+        expect(validators.isValidPaywallConfig(false)).toBe(false)
+        expect(validators.isValidPaywallConfig(null)).toBe(false)
+        expect(validators.isValidPaywallConfig(0)).toBe(false)
+        expect(validators.isValidPaywallConfig('')).toBe(false)
+      })
+
+      it('config is not an object', () => {
+        expect.assertions(3)
+
+        expect(validators.isValidPaywallConfig('hi')).toBe(false)
+        expect(validators.isValidPaywallConfig(1)).toBe(false)
+        expect(validators.isValidPaywallConfig([])).toBe(false)
+      })
+
+      it('config has wrong number of properties', () => {
+        expect.assertions(2)
+
+        expect(
+          validators.isValidPaywallConfig({
+            hi: 1,
+            there: 2,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            hi: 1,
+            there: 2,
+            I: 3,
+            suck: 4,
+          })
+        ).toBe(false)
+      })
+
+      it('config keys are unrecognized', () => {
+        expect.assertions(3)
+
+        expect(
+          validators.isValidPaywallConfig({
+            locks: 1,
+            icon: 2,
+            callToLaziness: 3,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            locks: 1,
+            iconic: 2,
+            callToAction: 3,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            goldilocks: 1,
+            icon: 2,
+            callToAction: 3,
+          })
+        ).toBe(false)
+      })
+
+      it('callToAction.default is malformed', () => {
+        expect.assertions(5)
+
+        expect(
+          validators.isValidPaywallConfig({
+            callToAction: false,
+            locks: {
+              '0x1234567890123456789012345678901234567890': {
+                name: 'hi',
+              },
+            },
+            icon: 'hi',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: false,
+            },
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: 1,
+            },
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: {},
+            },
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: [],
+            },
+          })
+        ).toBe(false)
+      })
+
+      it('locks is falsy', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: false,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: 0,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: '',
+          })
+        ).toBe(false)
+      })
+
+      it('locks is not an object', () => {
+        expect.assertions(3)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: 'null',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: [],
+          })
+        ).toBe(false)
+      })
+
+      it('locks has no locks', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: {},
+          })
+        ).toBe(false)
+      })
+
+      describe('locks', () => {
+        it('lock address is malformed', () => {
+          expect.assertions(3)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                notalock: {
+                  name: 'hahaha',
+                },
+              },
+            })
+          ).toBe(false)
+
+          const endsWithZ = lock.substring(0, lock.length - 1) + 'Z'
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [endsWithZ]: {
+                  name: 'hahaha I end in Z',
+                },
+              },
+            })
+          ).toBe(false)
+
+          const tooLong = lock + 'a'
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [tooLong]: {
+                  name: 'hahaha I am too long',
+                },
+              },
+            })
+          ).toBe(false)
+        })
+
+        it('lock is not an object', () => {
+          expect.assertions(4)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: false,
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: null,
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: 0,
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: '',
+              },
+            })
+          ).toBe(false)
+        })
+
+        it('lock has wrong number of properties', () => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: 'hi',
+                  whatthe: 'hey?',
+                },
+              },
+            })
+          ).toBe(false)
+        })
+
+        it('lock has no name', () => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  whatthe: 'hey?',
+                },
+              },
+            })
+          ).toBe(false)
+        })
+
+        it('lock name is not a string', () => {
+          expect.assertions(4)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: {},
+                },
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: [],
+                },
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: null,
+                },
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: 0,
+                },
+              },
+            })
+          ).toBe(false)
+        })
+      })
+    })
+
+    describe('valid cases', () => {
+      it('is valid config', () => {
+        expect.assertions(1)
+
+        expect(validators.isValidPaywallConfig(validConfig)).toBe(true)
+      })
+    })
+  })
 })

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -26,15 +26,15 @@ export const isAccount = val => {
  *
  * var unlockProtocolConfig = {
  * locks: {
- *	  '0xabc...': {
- *  		name: 'One Week',
- *	  },
- *	  '0xdef...': {
- *  		name: 'One Month',
- *  	},
- *  	'0xghi...': {
- *  		name: 'One Year',
- *   	},
+ *   '0xabc...': {
+ *  	  name: 'One Week',
+ *    },
+ *    '0xdef...': {
+ *      name: 'One Month',
+ *    },
+ *    '0xghi...': {
+ *      name: 'One Year',
+ *    },
  *  },
  *  icon: 'https://...',
  *  callToAction: {

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -18,3 +18,58 @@ export const isPositiveNumber = val => {
 export const isAccount = val => {
   return val.match(ACCOUNT_REGEXP)
 }
+
+// TODO: use npm package "validator" to validate the icon URL
+// https://www.npmjs.com/package/validator
+/**
+ * For now, this assumes this structure:
+ *
+ * var unlockProtocolConfig = {
+ * locks: {
+ *	  '0xabc...': {
+ *  		name: 'One Week',
+ *	  },
+ *	  '0xdef...': {
+ *  		name: 'One Month',
+ *  	},
+ *  	'0xghi...': {
+ *  		name: 'One Year',
+ *   	},
+ *  },
+ *  icon: 'https://...',
+ *  callToAction: {
+ *	default:
+ *  	'Enjoy Forbes Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.',
+ *  },
+ *}
+ *
+ */
+export const isValidPaywallConfig = config => {
+  if (!config) return false
+  if (typeof config !== 'object') return false
+  const keys = Object.keys(config)
+  if (keys.length !== 3) return false
+  keys.sort()
+  const testKeys = ['callToAction', 'icon', 'locks']
+  if (keys.filter((key, index) => testKeys[index] !== key).length) return false
+  if (typeof config.icon !== 'string') return false
+  if (!config.callToAction || !config.callToAction.default) return false
+  if (typeof config.callToAction.default !== 'string') return false
+  if (!config.locks) return false
+  if (typeof config.locks !== 'object') return false
+  const locks = Object.keys(config.locks)
+  if (!locks.length) return false
+  if (
+    locks.filter(lock => {
+      if (!isAccount(lock)) return false
+      const thisLock = config.locks[lock]
+      if (!thisLock || typeof thisLock !== 'object') return false
+      if (Object.keys(thisLock).length !== 1) return false
+      if (!thisLock.name || typeof thisLock.name !== 'string') return false
+      return true
+    }).length !== locks.length
+  ) {
+    return false
+  }
+  return true
+}


### PR DESCRIPTION
# Description

This adds a validator for the unlockProtocolConfig which will be passed by future paywall consumers such as Forbes to the paywall.

A subsequent PR will add the `validator` package in order to also validate the icon URL so that we don't allow weird URLs to be put in the img tag.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
