### PR TITLE
Adding svg files for ticket verification

### DIFF
--- a/tickets/src/components/interface/svg/Box.js
+++ b/tickets/src/components/interface/svg/Box.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const SvgBox = ({ title, ...props }) => (
-  <svg fill="none" {...props}>
+  <svg viewBox="0 0 14 16" fill="none" {...props}>
     <title>{title}</title>
     <path
       d="M13 4.216v7.566L6.999 15 1 11.778l.004-7.562L7.002 1 13 4.216z"

--- a/tickets/src/components/interface/svg/Home.js
+++ b/tickets/src/components/interface/svg/Home.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const SvgHome = ({ title, ...props }) => (
-  <svg {...props}>
+  <svg viewBox="0 0 24 24" {...props}>
     <title>{title}</title>
     <path d="M12.5 5.5c-.195-.192-.805-.192-1 0l-6.351 6.567a.5.5 0 0 0 .351.856h1.214V17.5a.5.5 0 0 0 .5.5h2.572a.5.5 0 0 0 .5-.5v-2.885h3.428V17.5a.5.5 0 0 0 .5.5h2.572a.5.5 0 0 0 .5-.5v-4.577H18.5a.5.5 0 0 0 .351-.856L12.5 5.5z" />
   </svg>

--- a/tickets/src/components/interface/svg/IconBg.js
+++ b/tickets/src/components/interface/svg/IconBg.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const SvgIconBg = ({ title, ...props }) => (
+  <svg viewBox="0 0 92 92" fill="none" {...props}>
+    <title>{title}</title>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M46 92c25.405 0 46-20.595 46-46S71.405 0 46 0 0 20.595 0 46s20.595 46 46 46z"
+      fill="#EEE"
+    />
+  </svg>
+)
+
+SvgIconBg.propTypes = {
+  title: PropTypes.string,
+}
+SvgIconBg.defaultProps = {
+  title: '',
+}
+export default SvgIconBg

--- a/tickets/src/components/interface/svg/IconCheckmark.js
+++ b/tickets/src/components/interface/svg/IconCheckmark.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const SvgIconCheckmark = ({ title, ...props }) => (
+  <svg viewBox="0 0 92 92" fill="none" {...props}>
+    <title>{title}</title>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M46 92c25.405 0 46-20.595 46-46S71.405 0 46 0 0 20.595 0 46s20.595 46 46 46z"
+      fill="#EEE"
+    />
+    <path
+      d="M30.667 48.25l12.404 9.515 20.395-27.098"
+      stroke="#A6A6A6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+SvgIconCheckmark.propTypes = {
+  title: PropTypes.string,
+}
+SvgIconCheckmark.defaultProps = {
+  title: '',
+}
+export default SvgIconCheckmark

--- a/tickets/src/components/interface/svg/KeyText.js
+++ b/tickets/src/components/interface/svg/KeyText.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const SvgKeyText = ({ title, ...props }) => (
-  <svg fill="none" {...props}>
+  <svg viewBox="0 0 201 245" fill="none" {...props}>
     <title>{title}</title>
     <path
       fillRule="evenodd"

--- a/tickets/src/static/images/svg/icon-bg.svg
+++ b/tickets/src/static/images/svg/icon-bg.svg
@@ -1,0 +1,3 @@
+<svg width="92" height="92" viewBox="0 0 92 92" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M46 92C71.4051 92 92 71.4051 92 46C92 20.5949 71.4051 0 46 0C20.5949 0 0 20.5949 0 46C0 71.4051 20.5949 92 46 92Z" fill="#EEEEEE"/>
+</svg>

--- a/tickets/src/static/images/svg/icon-checkmark.svg
+++ b/tickets/src/static/images/svg/icon-checkmark.svg
@@ -1,0 +1,4 @@
+<svg width="92" height="92" viewBox="0 0 92 92" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M46 92C71.4051 92 92 71.4051 92 46C92 20.5949 71.4051 0 46 0C20.5949 0 0 20.5949 0 46C0 71.4051 20.5949 92 46 92Z" fill="#EEEEEE"/>
+    <path d="M30.6667 48.2497L43.0714 57.7649L63.466 30.6667" stroke="#A6A6A6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
# Description

Adding SVG files used in event verification. A few collateral SVG files were updated in this change.

This is a portion of #3073.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
