### PR TITLE
update the paywall unlockProtocolConfig for new values

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -63,6 +63,9 @@ describe('Form field validators', () => {
     const validConfig = {
       callToAction: {
         default: 'hi',
+        expired: 'there',
+        pending: 'pending',
+        confirmed: 'confirmed',
       },
       locks: {
         [lock]: {
@@ -135,52 +138,130 @@ describe('Form field validators', () => {
         ).toBe(false)
       })
 
-      it('callToAction.default is malformed', () => {
-        expect.assertions(5)
+      it('icon', () => {
+        expect.assertions(3)
 
         expect(
           validators.isValidPaywallConfig({
-            callToAction: false,
-            locks: {
-              '0x1234567890123456789012345678901234567890': {
-                name: 'hi',
+            ...validConfig,
+            icon: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: {},
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: 1,
+          })
+        ).toBe(false)
+      })
+
+      describe('callToAction', () => {
+        const noConfirmed = {
+          default: 'default',
+          expired: 'expired',
+          pending: 'pending',
+        }
+        const noPending = {
+          default: 'default',
+          expired: 'expired',
+          confirmed: 'confirmed',
+        }
+        const noExpired = {
+          default: 'default',
+          pending: 'pending',
+          confirmed: 'confirmed',
+        }
+        const noDefault = {
+          expired: 'expired',
+          pending: 'pending',
+          confirmed: 'confirmed',
+        }
+
+        it('callToAction has too many keys', () => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              callToAction: {
+                oops: 1,
+                I: 2,
+                did: 3,
+                it: 4,
+                again: 5,
               },
-            },
-            icon: 'hi',
-          })
-        ).toBe(false)
-        expect(
-          validators.isValidPaywallConfig({
-            ...validConfig,
-            callToAction: {
-              default: false,
-            },
-          })
-        ).toBe(false)
-        expect(
-          validators.isValidPaywallConfig({
-            ...validConfig,
-            callToAction: {
-              default: 1,
-            },
-          })
-        ).toBe(false)
-        expect(
-          validators.isValidPaywallConfig({
-            ...validConfig,
-            callToAction: {
-              default: {},
-            },
-          })
-        ).toBe(false)
-        expect(
-          validators.isValidPaywallConfig({
-            ...validConfig,
-            callToAction: {
-              default: [],
-            },
-          })
-        ).toBe(false)
+            })
+          ).toBe(false)
+        })
+
+        it.each([noConfirmed, noPending, noExpired, noDefault])(
+          'callToAction has unrecognized keys',
+          defaults => {
+            expect.assertions(1)
+
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  ...defaults,
+                  nubbin: 'oops',
+                },
+              })
+            ).toBe(false)
+          }
+        )
+
+        it.each(['default', 'expired', 'pending', 'confirmed'])(
+          'callToAction.%s is malformed',
+          key => {
+            expect.assertions(5)
+
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: false,
+              })
+            ).toBe(false)
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  [key]: false,
+                },
+              })
+            ).toBe(false)
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  [key]: 1,
+                },
+              })
+            ).toBe(false)
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  [key]: {},
+                },
+              })
+            ).toBe(false)
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  [key]: [],
+                },
+              })
+            ).toBe(false)
+          }
+        )
       })
 
       it('locks is falsy', () => {
@@ -403,9 +484,42 @@ describe('Form field validators', () => {
 
     describe('valid cases', () => {
       it('is valid config', () => {
-        expect.assertions(1)
+        expect.assertions(5)
 
         expect(validators.isValidPaywallConfig(validConfig)).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: false,
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: 'hi',
+            },
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: 'hi',
+              expired: 'hi',
+            },
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: 'hi',
+              expired: 'hi',
+              pending: 'hi',
+            },
+          })
+        ).toBe(true)
       })
     })
   })

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -25,24 +25,29 @@ export const isAccount = val => {
  * For now, this assumes this structure:
  *
  * var unlockProtocolConfig = {
- * locks: {
- *   '0xabc...': {
- *  	  name: 'One Week',
+ *   locks: {
+ *     '0xabc...': {
+ *   	   name: 'One Week',
+ *      },
+ *      '0xdef...': {
+ *        name: 'One Month',
+ *      },
+ *      '0xghi...': {
+ *        name: 'One Year',
+ *      },
  *    },
- *    '0xdef...': {
- *      name: 'One Month',
- *    },
- *    '0xghi...': {
- *      name: 'One Year',
- *    },
- *  },
- *  icon: 'https://...',
- *  callToAction: {
- *	default:
- *  	'Enjoy Forbes Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.',
- *  },
- *}
+ *    icon: 'https://...',
+ *    callToAction: {
+ *	    default:
+ *        'Enjoy Forbes Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.',
+ *      expired:
+ *        'your key has expired, please purchase a new one',
+ *      pending: 'Purchase pending...',
+ *      confirmed: 'Your content is unlocked!',
+ *   },
+ * }
  *
+ * The fields in callToAction are all optional, and icon can be false for none
  */
 export const isValidPaywallConfig = config => {
   if (!config) return false
@@ -52,9 +57,19 @@ export const isValidPaywallConfig = config => {
   keys.sort()
   const testKeys = ['callToAction', 'icon', 'locks']
   if (keys.filter((key, index) => testKeys[index] !== key).length) return false
-  if (typeof config.icon !== 'string') return false
-  if (!config.callToAction || !config.callToAction.default) return false
-  if (typeof config.callToAction.default !== 'string') return false
+  // allow false for icon
+  if (config.icon && typeof config.icon !== 'string') return false
+  if (!config.callToAction || typeof config.callToAction !== 'object')
+    return false
+  const callsToAction = ['default', 'expired', 'pending', 'confirmed']
+  const ctaKeys = Object.keys(config.callToAction)
+  if (ctaKeys.length > callsToAction.length) return false
+  if (ctaKeys.filter(key => !callsToAction.includes(key)).length) return false
+  if (
+    ctaKeys.filter(key => typeof config.callToAction[key] !== 'string').length
+  ) {
+    return false
+  }
   if (!config.locks) return false
   if (typeof config.locks !== 'object') return false
   const locks = Object.keys(config.locks)


### PR DESCRIPTION
# Description

This PR extends and relaxes the validation for `callToAction` and `icon`. `icon` can now be false for none, and `callToAction` can define up to 4 messages, `default`, `expired`, `pending` and `confirmed`.

These messages correspond to the defaults in `Overlay.js`:

```js
  switch (keyStatus) {
    case 'confirming':
    case 'submitted':
    case 'pending':
      message = 'Purchase pending...'
      break
    case 'valid':
    case 'confirmed':
      message = 'Purchase confirmed, content unlocked!'
      break
    case 'expired':
      message =
        'Your subscription has expired, please purchase a new key to continue'
      break
    default:
      message =
        'You have reached your limit of free articles. Please purchase access'
  }
```

Overlay will use these values to customize the messages.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
