### PR TITLE
enable hooks linting rules for paywall

### DIFF
--- a/paywall/.eslintrc.js
+++ b/paywall/.eslintrc.js
@@ -32,5 +32,7 @@ module.exports = {
       },
     ],
     'react/jsx-filename-extension': [0, { extensions: ['.js', '.jsx'] }],
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
   },
 }


### PR DESCRIPTION
# Description

The hooks eslint rules were not actually enabled. This fixes that oversight. A follow-up PR will address the warnings from missing `useEffect` dependencies.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
