### PR TITLE
update useLFPM to allow merging received value with defaults

### DIFF
--- a/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
@@ -11,6 +11,7 @@ describe('useListenForPostMessage hook', () => {
 
   let fakeWindow
   let config
+  let called = jest.fn()
 
   function Wrapper(props) {
     return (
@@ -36,25 +37,29 @@ describe('useListenForPostMessage hook', () => {
     config = { isServer: false, isInIframe: true }
   })
 
-  function MockListener({ type, defaultValue, validator }) {
+  function MockListener({ type, defaultValue, validator, getValue }) {
     const value = useListenForPostMessage({
       type,
       defaultValue,
       validator,
+      getValue,
     })
-    return <div title="value">{value}</div>
+    called()
+    return <div title="value">{JSON.stringify(value)}</div>
   }
 
   MockListener.propTypes = {
     type: PropTypes.string,
     defaultValue: PropTypes.string,
     validator: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+    getValue: PropTypes.func,
   }
 
   MockListener.defaultProps = {
     type: 'listenFor',
     defaultValue: 'hi',
     validator: false,
+    getValue: (value, defaults) => value || defaults,
   }
 
   function getListener() {
@@ -78,6 +83,7 @@ describe('useListenForPostMessage hook', () => {
       expect(fakeWindow.addEventListener).not.toHaveBeenCalled()
     })
   })
+
   describe('subscription', () => {
     it('subscribes on mount only', () => {
       expect.assertions(2)
@@ -96,6 +102,7 @@ describe('useListenForPostMessage hook', () => {
       expect(fakeWindow.addEventListener).toHaveBeenCalledTimes(1)
     })
   })
+
   it('unsubscribes on unmount', () => {
     expect.assertions(2)
 
@@ -112,6 +119,7 @@ describe('useListenForPostMessage hook', () => {
 
     expect(fakeWindow.addEventListener).toHaveBeenCalledTimes(1)
   })
+
   describe('postmessage event handling', () => {
     let event
     beforeEach(() => {
@@ -120,10 +128,11 @@ describe('useListenForPostMessage hook', () => {
         origin: 'origin',
         data: {
           type: 'listenFor',
-          payload: 'got it!',
+          payload: { thing: 'got it!' },
         },
       }
     })
+
     describe('invalid postmessage events', () => {
       it.each([
         [
@@ -163,6 +172,7 @@ describe('useListenForPostMessage hook', () => {
         expect(wrapper.getByTitle('value')).toHaveTextContent('hi')
       })
     })
+
     describe('valid postmessage events', () => {
       it('updates the value', () => {
         expect.assertions(1)
@@ -180,6 +190,78 @@ describe('useListenForPostMessage hook', () => {
         })
 
         expect(wrapper.getByTitle('value')).toHaveTextContent('got it!')
+      })
+
+      it('calls the getValue helper to merge the value with its defaults', () => {
+        expect.assertions(1)
+
+        let wrapper
+        rtl.act(() => {
+          wrapper = rtl.render(
+            <Wrapper
+              defaultValue="boo"
+              getValue={(v, d) => JSON.stringify(v) + d}
+            />
+          )
+        })
+
+        // this is the callback saveData, which was passed to addEventListener
+        const listener = getListener()
+
+        rtl.act(() => {
+          listener(event)
+        })
+
+        expect(wrapper.getByTitle('value')).toHaveTextContent(
+          '"{\\"thing\\":\\"got it!\\"}boo"'
+        )
+      })
+
+      it('updates the value only once if it does not change', () => {
+        expect.assertions(4)
+        called = jest.fn()
+        let listener
+
+        const listeners = {
+          message: new Map(),
+        }
+
+        fakeWindow.addEventListener = (event, cb) => {
+          listener = cb
+          listeners.message.set(cb, cb)
+        }
+        fakeWindow.removeEventListener = (event, cb) => {
+          listeners.message.delete(cb)
+        }
+
+        let wrapper
+        rtl.act(() => {
+          wrapper = rtl.render(<Wrapper defaultValue="hi" />)
+        })
+        expect(wrapper.getByTitle('value')).toHaveTextContent('hi')
+
+        rtl.act(() => {
+          listener(event)
+        })
+        expect(wrapper.getByTitle('value')).toHaveTextContent('got it!')
+        event.data.payload = { ...event.data.payload }
+
+        rtl.act(() => {
+          listener(event)
+        })
+        event.data.payload = { ...event.data.payload }
+
+        rtl.act(() => {
+          listener(event)
+        })
+        event.data.payload = { ...event.data.payload }
+
+        rtl.act(() => {
+          listener(event)
+        })
+
+        expect(wrapper.getByTitle('value')).toHaveTextContent('got it!')
+        expect(called).toHaveBeenCalledTimes(2)
       })
     })
   })

--- a/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
+++ b/paywall/src/__tests__/hooks/browser/useListenForPostMessage.test.js
@@ -235,6 +235,13 @@ describe('useListenForPostMessage hook', () => {
         }
 
         let wrapper
+
+        // the rtl.act calls are wrappers so that the async nature of re-rendering is
+        // made synchronous so we can test the effects of the hooks
+        // we wrap each call in a separate act so that we can test
+        // in between the calls, as if the browser had sent several
+        // postMessage events with the same object, but it looks
+        // different once it arrives
         rtl.act(() => {
           wrapper = rtl.render(<Wrapper defaultValue="hi" />)
         })

--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -68,6 +68,9 @@ export default function useListenForPostMessage({
       // optional validator
       if (!validator || (validator && validator(event.data.payload))) {
         const newValue = getValue(event.data.payload, defaultValue)
+        // this comparison is designed to avoid the need for deep equality check
+        // If the configuration grows considerably, using some kind of traversing equality check
+        // will make more sense
         if (JSON.stringify(newValue) === JSON.stringify(data)) return
         // this triggers a re-render if and only if the value is different
         setData(newValue)


### PR DESCRIPTION
# Description

This PR does 3 things:

1. fixes some issues found in linting with hooks rules enabled
2. enables a new ability to pass in a callback that can be used to merge the value returned from postMessage with defaults
3. ensures that re-renders don't happen if the message payload is unchanged

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
