### PR TITLE
Convert StorageService to be an EventEmitter

### DIFF
--- a/unlock-app/src/__tests__/actions/storage.test.js
+++ b/unlock-app/src/__tests__/actions/storage.test.js
@@ -1,9 +1,4 @@
-import {
-  storageError,
-  STORAGE_ERROR,
-  storeLockName,
-  STORE_LOCK_NAME,
-} from '../../actions/storage'
+import { storageError, STORAGE_ERROR } from '../../actions/storage'
 
 describe('Storage error', () => {
   it('should create an action emitting a storage error', () => {
@@ -16,23 +11,5 @@ describe('Storage error', () => {
     }
 
     expect(storageError(error)).toEqual(expectation)
-  })
-})
-
-describe('Store Lock Creation', () => {
-  it('should create an action indicating storage of a newly created lock', () => {
-    expect.assertions(1)
-    const owner = "An owner's address"
-    const lock = {}
-    const token = 'An authorization token'
-
-    const expectation = {
-      type: STORE_LOCK_NAME,
-      owner: owner,
-      lock: lock,
-      token: token,
-    }
-
-    expect(storeLockName(owner, lock, token)).toEqual(expectation)
   })
 })

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -432,13 +432,23 @@ describe('StorageService', () => {
 
   describe('Retrieve a user recovery phrase', () => {
     describe('When a recovery phrase can be retrieved', () => {
-      it('returns a successful promise', async () => {
-        expect.assertions(1)
-        axios.get.mockReturnValue({})
+      it('emits a success', done => {
+        expect.assertions(3)
+        axios.get.mockReturnValue({
+          data: {
+            recoveryPhrase: 'quick wafting zephyrs vex bold jim',
+          },
+        })
 
-        await storageService.getUserRecoveryPhrase(
-          'hello@unlock-protocol.com',
-          null
+        storageService.getUserRecoveryPhrase('hello@unlock-protocol.com', null)
+
+        storageService.on(
+          success.getUserRecoveryPhrase,
+          ({ emailAddress, recoveryPhrase }) => {
+            expect(emailAddress).toBe('hello@unlock-protocol.com')
+            expect(recoveryPhrase).toBe('quick wafting zephyrs vex bold jim')
+            done()
+          }
         )
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -452,18 +462,20 @@ describe('StorageService', () => {
     })
 
     describe('When a recovery phrase cannot be retrieved', () => {
-      it('returns a rejected promise', async () => {
-        expect.assertions(2)
+      it('emits a failure', done => {
+        expect.assertions(3)
         axios.get.mockRejectedValue('Zounds! An Error')
 
-        try {
-          await storageService.getUserRecoveryPhrase(
-            'hello@unlock-protocol.com',
-            null
-          )
-        } catch (error) {
-          expect(error).toEqual('Zounds! An Error')
-        }
+        storageService.getUserRecoveryPhrase('hello@unlock-protocol.com', null)
+
+        storageService.on(
+          failure.getUserRecoveryPhrase,
+          ({ emailAddress, error }) => {
+            expect(emailAddress).toBe('hello@unlock-protocol.com')
+            expect(error).toEqual('Zounds! An Error')
+            done()
+          }
+        )
 
         expect(axios.get).toHaveBeenCalledWith(
           `${serviceHost}/users/${encodeURIComponent(

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -130,7 +130,7 @@ describe('StorageService', () => {
     })
 
     describe('when a lock can not be updated', () => {
-      it('returns an rejected Promise', async () => {
+      it('returns an rejected Promise', done => {
         expect.assertions(3)
         axios.put.mockRejectedValue('An Error')
 
@@ -139,6 +139,7 @@ describe('StorageService', () => {
         storageService.on(failure.updateLockDetails, ({ address, error }) => {
           expect(address).toBe('lock_address')
           expect(error).toBe('An Error')
+          done()
         })
 
         expect(axios.put).toHaveBeenCalledWith(

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -105,13 +105,19 @@ describe('StorageService', () => {
 
   describe('updateLockDetails', () => {
     describe('when a lock can be updated', () => {
-      it('returns a successful promise', async () => {
-        expect.assertions(1)
+      it('returns a successful promise', done => {
+        expect.assertions(2)
         axios.put.mockReturnValue()
-        await storageService.updateLockDetails('lock_address', {
+        storageService.updateLockDetails('lock_address', {
           name: 'new_lock_name',
           address: 'lock_address',
         })
+
+        storageService.on(success.updateLockDetails, address => {
+          expect(address).toBe('lock_address')
+          done()
+        })
+
         expect(axios.put).toHaveBeenCalledWith(
           `${serviceHost}/lock/lock_address`,
           {
@@ -125,14 +131,15 @@ describe('StorageService', () => {
 
     describe('when a lock can not be updated', () => {
       it('returns an rejected Promise', async () => {
-        expect.assertions(2)
+        expect.assertions(3)
         axios.put.mockRejectedValue('An Error')
 
-        try {
-          await storageService.updateLockDetails('lock_address')
-        } catch (error) {
-          expect(error).toEqual('An Error')
-        }
+        storageService.updateLockDetails('lock_address')
+
+        storageService.on(failure.updateLockDetails, ({ address, error }) => {
+          expect(address).toBe('lock_address')
+          expect(error).toBe('An Error')
+        })
 
         expect(axios.put).toHaveBeenCalledWith(
           `${serviceHost}/lock/lock_address`,

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import StorageService from '../../services/storageService'
+import StorageService, { success, failure } from '../../services/storageService'
 
 jest.mock('axios')
 
@@ -171,14 +171,14 @@ describe('StorageService', () => {
   })
 
   describe('storeTransaction', () => {
-    it('returns a successful promise', async () => {
-      expect.assertions(1)
+    it('emits a success value', done => {
+      expect.assertions(2)
       const transactionHash = ' 0xhash'
       const senderAddress = ' 0xsender'
       const recipientAddress = ' 0xrecipient'
       axios.post.mockReturnValue({})
 
-      await storageService.storeTransaction(
+      storageService.storeTransaction(
         transactionHash,
         senderAddress,
         recipientAddress
@@ -187,6 +187,33 @@ describe('StorageService', () => {
         transactionHash,
         sender: senderAddress,
         recipient: recipientAddress,
+      })
+      storageService.on(success.storeTransaction, hash => {
+        expect(hash).toBe(transactionHash)
+        done()
+      })
+    })
+
+    it('emits a failure value', done => {
+      expect.assertions(2)
+      const transactionHash = ' 0xhash'
+      const senderAddress = ' 0xsender'
+      const recipientAddress = ' 0xrecipient'
+      axios.post.mockRejectedValue('I am error.')
+
+      storageService.storeTransaction(
+        transactionHash,
+        senderAddress,
+        recipientAddress
+      )
+      expect(axios.post).toHaveBeenCalledWith(`${serviceHost}/transaction`, {
+        transactionHash,
+        sender: senderAddress,
+        recipient: recipientAddress,
+      })
+      storageService.on(failure.storeTransaction, err => {
+        expect(err).toBe('I am error.')
+        done()
       })
     })
   })

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import StorageService, { success, failure } from '../../services/storageService'
+import { StorageService, success, failure } from '../../services/storageService'
 
 jest.mock('axios')
 

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -315,8 +315,8 @@ describe('StorageService', () => {
 
   describe('Update user', () => {
     describe('When a user can be updated', () => {
-      it('returns a successful promise', async () => {
-        expect.assertions(1)
+      it('emits a success', done => {
+        expect.assertions(2)
         axios.put.mockReturnValue()
         const user = {
           emailAddress: 'goodbye@unlock-protocol.com',
@@ -324,7 +324,12 @@ describe('StorageService', () => {
           privateKey: 'bar',
         }
 
-        await storageService.updateUser('hello@unlock-protocol.com', user, null)
+        storageService.updateUser('hello@unlock-protocol.com', user, null)
+
+        storageService.on(success.updateUser, lastEmail => {
+          expect(lastEmail).toBe('hello@unlock-protocol.com')
+          done()
+        })
 
         expect(axios.put).toHaveBeenCalledWith(
           `${serviceHost}/users/${encodeURIComponent(
@@ -337,8 +342,8 @@ describe('StorageService', () => {
     })
 
     describe('When a user cannot be updated', () => {
-      it('returns a rejected promise', async () => {
-        expect.assertions(2)
+      it('emits a failure', done => {
+        expect.assertions(3)
         axios.put.mockRejectedValue('Egads! An Error')
         const user = {
           emailAddress: 'goodbye@unlock-protocol.com',
@@ -346,15 +351,13 @@ describe('StorageService', () => {
           privateKey: 'bar',
         }
 
-        try {
-          await storageService.updateUser(
-            'hello@unlock-protocol.com',
-            user,
-            null
-          )
-        } catch (error) {
+        storageService.updateUser('hello@unlock-protocol.com', user, null)
+
+        storageService.on(failure.updateUser, ({ email, error }) => {
+          expect(email).toBe('hello@unlock-protocol.com')
           expect(error).toEqual('Egads! An Error')
-        }
+          done()
+        })
 
         expect(axios.put).toHaveBeenCalledWith(
           `${serviceHost}/users/${encodeURIComponent(

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -275,12 +275,12 @@ describe('StorageService', () => {
           privateKey: 'bar',
         }
         axios.post.mockReturnValue({})
-        storageService.createUser(user)
 
-        storageService.on(success.createUser, emailAddress => {
-          expect(emailAddress).toBe(user.emailAddress)
+        storageService.on(success.createUser, publicKey => {
+          expect(publicKey).toBe(user.publicKey)
           done()
         })
+        storageService.createUser(user)
 
         expect(axios.post).toHaveBeenCalledWith(
           `${serviceHost}/users/`,

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -51,13 +51,19 @@ describe('StorageService', () => {
 
   describe('storeLockDetails', () => {
     describe('when storing a new lock', () => {
-      it('returns a successful promise', async () => {
-        expect.assertions(1)
+      it('emits a success', done => {
+        expect.assertions(2)
         axios.post.mockReturnValue()
-        await storageService.storeLockDetails({
+        storageService.storeLockDetails({
           name: 'lock_name',
           address: 'lock_address',
         })
+
+        storageService.on(success.storeLockDetails, address => {
+          expect(address).toBe('lock_address')
+          done()
+        })
+
         expect(axios.post).toHaveBeenCalledWith(
           `${serviceHost}/lock`,
           {
@@ -70,17 +76,20 @@ describe('StorageService', () => {
     })
 
     describe('when attempting to store an existing lock', () => {
-      it('returns a failure promise', async () => {
-        expect.assertions(2)
+      it('emits a failure', done => {
+        expect.assertions(3)
         axios.post.mockRejectedValue('An Error')
-        try {
-          await storageService.storeLockDetails({
-            name: 'lock_name',
-            address: 'existing_address',
-          })
-        } catch (error) {
-          expect(error).toEqual('An Error')
-        }
+
+        storageService.storeLockDetails({
+          name: 'lock_name',
+          address: 'existing_address',
+        })
+
+        storageService.on(failure.storeLockDetails, ({ address, error }) => {
+          expect(address).toBe('existing_address')
+          expect(error).toBe('An Error')
+          done()
+        })
 
         expect(axios.post).toHaveBeenCalledWith(
           `${serviceHost}/lock`,

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -353,8 +353,8 @@ describe('StorageService', () => {
 
         storageService.updateUser('hello@unlock-protocol.com', user, null)
 
-        storageService.on(failure.updateUser, ({ email, error }) => {
-          expect(email).toBe('hello@unlock-protocol.com')
+        storageService.on(failure.updateUser, ({ emailAddress, error }) => {
+          expect(emailAddress).toBe('hello@unlock-protocol.com')
           expect(error).toEqual('Egads! An Error')
           done()
         })

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -5,10 +5,11 @@ jest.mock('axios')
 
 describe('StorageService', () => {
   const serviceHost = 'http://127.0.0.1:8080'
-  const storageService = new StorageService(serviceHost)
+  let storageService
 
   beforeEach(() => {
     jest.clearAllMocks()
+    storageService = new StorageService(serviceHost)
   })
 
   describe('lockLookUp', () => {
@@ -26,6 +27,24 @@ describe('StorageService', () => {
         storageService.on(success.lockLookUp, ({ address, name }) => {
           expect(address).toBe('0x42')
           expect(name).toBe('hello')
+          done()
+        })
+
+        expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x42`)
+      })
+    })
+
+    describe('when the requested lock exists but does not have a name', () => {
+      it('emits a failure', done => {
+        expect.assertions(2)
+        axios.get.mockReturnValue({
+          data: {},
+        })
+
+        storageService.lockLookUp('0x42')
+
+        storageService.on(failure.lockLookUp, error => {
+          expect(error).toBe('No name for this lock.')
           done()
         })
 

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -266,15 +266,20 @@ describe('StorageService', () => {
 
   describe('Create user', () => {
     describe('When a user can be created', () => {
-      it('returns a successful promise', async () => {
-        expect.assertions(1)
+      it('emits a success', done => {
+        expect.assertions(2)
         const user = {
           emailAddress: 'hello@unlock-protocol.com',
           publicKey: 'foo',
           privateKey: 'bar',
         }
         axios.post.mockReturnValue({})
-        await storageService.createUser(user)
+        storageService.createUser(user)
+
+        storageService.on(success.createUser, emailAddress => {
+          expect(emailAddress).toBe(user.emailAddress)
+          done()
+        })
 
         expect(axios.post).toHaveBeenCalledWith(
           `${serviceHost}/users/`,
@@ -285,7 +290,7 @@ describe('StorageService', () => {
     })
 
     describe('When a user cannot be created', () => {
-      it('returns a rejected promise', async () => {
+      it('emits a failure', done => {
         expect.assertions(2)
         const user = {
           emailAddress: 'hello@unlock-protocol.com',
@@ -293,11 +298,11 @@ describe('StorageService', () => {
           privateKey: 'bar',
         }
         axios.post.mockRejectedValue('Hark! An Error')
-        try {
-          await storageService.createUser(user)
-        } catch (error) {
+        storageService.createUser(user)
+        storageService.on(failure.createUser, error => {
           expect(error).toEqual('Hark! An Error')
-        }
+          done()
+        })
 
         expect(axios.post).toHaveBeenCalledWith(
           `${serviceHost}/users/`,

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -13,28 +13,37 @@ describe('StorageService', () => {
 
   describe('lockLookUp', () => {
     describe('when the requested lock exists', () => {
-      it('returns the details', async () => {
-        expect.assertions(2)
+      it('returns the details', done => {
+        expect.assertions(3)
         axios.get.mockReturnValue({
           data: {
             name: 'hello',
           },
         })
-        const result = await storageService.lockLookUp('0x42')
-        expect(result).toEqual('hello')
+
+        storageService.lockLookUp('0x42')
+
+        storageService.on(success.lockLookUp, ({ address, name }) => {
+          expect(address).toBe('0x42')
+          expect(name).toBe('hello')
+          done()
+        })
+
         expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x42`)
       })
     })
 
     describe('when the requested lock doesnt exist', () => {
-      it('raises an appropriate error', async () => {
+      it('raises an appropriate error', done => {
         expect.assertions(2)
         axios.get.mockRejectedValue('An Error')
-        try {
-          await storageService.lockLookUp('0x1234243')
-        } catch (error) {
+        storageService.lockLookUp('0x1234243')
+
+        storageService.on(failure.lockLookUp, error => {
           expect(error).toEqual('An Error')
-        }
+          done()
+        })
+
         expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x1234243`)
       })
     })

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -372,20 +372,26 @@ describe('StorageService', () => {
 
   describe('Retrieve a private key for a user', () => {
     describe('When a private key can be retrieved', () => {
-      it('returns a successful promise', async () => {
-        expect.assertions(2)
+      it('emits a success', done => {
+        expect.assertions(3)
         axios.get.mockReturnValue({
           data: {
             passwordEncryptedPrivateKey: 'Private Key  reporting for duty',
           },
         })
 
-        const key = await storageService.getUserPrivateKey(
-          'hello@unlock-protocol.com',
-          null
-        )
+        storageService.getUserPrivateKey('hello@unlock-protocol.com', null)
 
-        expect(key).toBe('Private Key  reporting for duty')
+        storageService.on(
+          success.getUserPrivateKey,
+          ({ emailAddress, passwordEncryptedPrivateKey }) => {
+            expect(emailAddress).toBe('hello@unlock-protocol.com')
+            expect(passwordEncryptedPrivateKey).toBe(
+              'Private Key  reporting for duty'
+            )
+            done()
+          }
+        )
 
         expect(axios.get).toHaveBeenCalledWith(
           `${serviceHost}/users/${encodeURIComponent(
@@ -398,18 +404,20 @@ describe('StorageService', () => {
     })
 
     describe('When a private key cannot be retrieved', () => {
-      it('returns a rejected promise', async () => {
-        expect.assertions(2)
+      it('emits a failure', done => {
+        expect.assertions(3)
         axios.get.mockRejectedValue('Great Snakes! An Error')
 
-        try {
-          await storageService.getUserPrivateKey(
-            'hello@unlock-protocol.com',
-            null
-          )
-        } catch (error) {
-          expect(error).toEqual('Great Snakes! An Error')
-        }
+        storageService.getUserPrivateKey('hello@unlock-protocol.com', null)
+
+        storageService.on(
+          failure.getUserPrivateKey,
+          ({ emailAddress, error }) => {
+            expect(emailAddress).toBe('hello@unlock-protocol.com')
+            expect(error).toEqual('Great Snakes! An Error')
+            done()
+          }
+        )
 
         expect(axios.get).toHaveBeenCalledWith(
           `${serviceHost}/users/${encodeURIComponent(

--- a/unlock-app/src/actions/storage.js
+++ b/unlock-app/src/actions/storage.js
@@ -1,18 +1,8 @@
 export const STORAGE_ERROR = 'storage/STORAGE_ERROR'
-export const STORE_LOCK_NAME = 'storage/STORE_LOCK_NAME'
 
 export function storageError(error) {
   return {
     type: STORAGE_ERROR,
     error: error,
-  }
-}
-
-export function storeLockName(owner, lock, token) {
-  return {
-    type: STORE_LOCK_NAME,
-    owner: owner,
-    lock: lock,
-    token: token,
   }
 }

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -169,7 +169,7 @@ export class StorageService extends EventEmitter {
     const opts = {}
     try {
       await axios.post(`${this.host}/users/`, user, opts)
-      this.emit(success.createUser, user.emailAddress)
+      this.emit(success.createUser, user.publicKey)
     } catch (error) {
       this.emit(failure.createUser, error)
     }
@@ -223,6 +223,9 @@ export class StorageService extends EventEmitter {
           passwordEncryptedPrivateKey:
             response.data.passwordEncryptedPrivateKey,
         })
+        // We also return from this one so that we can use the value directly to
+        // avoid passing the password around too much.
+        return response.data.passwordEncryptedPrivateKey
       }
     } catch (error) {
       this.emit(failure.getUserPrivateKey, { emailAddress, error })

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -14,6 +14,7 @@ export const success = {
   createUser: 'createUser.success',
   updateUser: 'updateUser.success',
   getUserPrivateKey: 'getUserPrivateKey.success',
+  getUserRecoveryPhrase: 'getUserRecoveryPhrase.success',
 }
 
 export const failure = {
@@ -25,6 +26,7 @@ export const failure = {
   createUser: 'createUser.failure',
   updateUser: 'updateUser.failure',
   getUserPrivateKey: 'getUserPrivateKey.failure',
+  getUserRecoveryPhrase: 'getUserRecoveryPhrase.failure',
 }
 
 export default class StorageService extends EventEmitter {
@@ -237,13 +239,20 @@ export default class StorageService extends EventEmitter {
   async getUserRecoveryPhrase(emailAddress) {
     const opts = {}
     try {
-      return await axios.get(
+      const response = await axios.get(
         `${this.host}/users/${encodeURIComponent(emailAddress)}/recoveryphrase`,
         null,
         opts
       )
+      if (response.data && response.data.recoveryPhrase) {
+        const recoveryPhrase = response.data.recoveryPhrase
+        this.emit(success.getUserRecoveryPhrase, {
+          emailAddress,
+          recoveryPhrase,
+        })
+      }
     } catch (error) {
-      return Promise.reject(error)
+      this.emit(failure.getUserRecoveryPhrase, { emailAddress, error })
     }
   }
 }

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -8,6 +8,7 @@ export const success = {
   storeLockDetails: 'storeLockDetails.success',
   updateLockDetails: 'updateLockDetails.success',
   createUser: 'createUser.success',
+  updateUser: 'updateUser.success',
 }
 
 export const failure = {
@@ -17,6 +18,7 @@ export const failure = {
   storeLockDetails: 'storeLockDetails.failure',
   updateLockDetails: 'updateLockDetails.failure',
   createUser: 'createUser.failure',
+  updateUser: 'updateUser.failure',
 }
 
 export default class StorageService extends EventEmitter {
@@ -181,13 +183,14 @@ export default class StorageService extends EventEmitter {
       opts.headers = this.genAuthorizationHeader(token)
     }
     try {
-      return await axios.put(
+      await axios.put(
         `${this.host}/users/${encodeURIComponent(email)}`,
         user,
         opts
       )
+      this.emit(success.updateUser, email)
     } catch (error) {
-      return Promise.reject(error)
+      this.emit(failure.updateUser, { email, error })
     }
   }
 

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -184,7 +184,7 @@ export default class StorageService extends EventEmitter {
    * @param {*} token
    * @returns {Promise<*>}
    */
-  async updateUser(email, user, token) {
+  async updateUser(emailAddress, user, token) {
     const opts = {}
     if (token) {
       // TODO: tokens aren't optional
@@ -192,13 +192,13 @@ export default class StorageService extends EventEmitter {
     }
     try {
       await axios.put(
-        `${this.host}/users/${encodeURIComponent(email)}`,
+        `${this.host}/users/${encodeURIComponent(emailAddress)}`,
         user,
         opts
       )
-      this.emit(success.updateUser, email)
+      this.emit(success.updateUser, emailAddress)
     } catch (error) {
-      this.emit(failure.updateUser, { email, error })
+      this.emit(failure.updateUser, { emailAddress, error })
     }
   }
 

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -1,6 +1,10 @@
 import axios from 'axios'
 import { EventEmitter } from 'events'
 
+// The goal of the success and failure objects is to act as a registry of events
+// that StorageService will emit. Nothing should be emitted that isn't in one of
+// these objects, and nothing that isn't emitted should be in one of these
+// objects.
 export const success = {
   storeTransaction: 'storeTransaction.success',
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.success',
@@ -9,6 +13,7 @@ export const success = {
   updateLockDetails: 'updateLockDetails.success',
   createUser: 'createUser.success',
   updateUser: 'updateUser.success',
+  getUserPrivateKey: 'getUserPrivateKey.success',
 }
 
 export const failure = {
@@ -19,6 +24,7 @@ export const failure = {
   updateLockDetails: 'updateLockDetails.failure',
   createUser: 'createUser.failure',
   updateUser: 'updateUser.failure',
+  getUserPrivateKey: 'getUserPrivateKey.failure',
 }
 
 export default class StorageService extends EventEmitter {
@@ -210,10 +216,14 @@ export default class StorageService extends EventEmitter {
         opts
       )
       if (response.data && response.data.passwordEncryptedPrivateKey) {
-        return response.data.passwordEncryptedPrivateKey
+        this.emit(success.getUserPrivateKey, {
+          emailAddress,
+          passwordEncryptedPrivateKey:
+            response.data.passwordEncryptedPrivateKey,
+        })
       }
     } catch (error) {
-      return Promise.reject(error)
+      this.emit(failure.getUserPrivateKey, { emailAddress, error })
     }
   }
 

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -7,6 +7,7 @@ export const success = {
   lockLookUp: 'lockLookUp.success',
   storeLockDetails: 'storeLockDetails.success',
   updateLockDetails: 'updateLockDetails.success',
+  createUser: 'createUser.success',
 }
 
 export const failure = {
@@ -15,6 +16,7 @@ export const failure = {
   lockLookUp: 'lockLookUp.failure',
   storeLockDetails: 'storeLockDetails.failure',
   updateLockDetails: 'updateLockDetails.failure',
+  createUser: 'createUser.failure',
 }
 
 export default class StorageService extends EventEmitter {
@@ -156,9 +158,10 @@ export default class StorageService extends EventEmitter {
   async createUser(user) {
     const opts = {}
     try {
-      return await axios.post(`${this.host}/users/`, user, opts)
+      await axios.post(`${this.host}/users/`, user, opts)
+      this.emit(success.createUser, user.emailAddress)
     } catch (error) {
-      return Promise.reject(error)
+      this.emit(failure.createUser, error)
     }
   }
 

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -5,12 +5,14 @@ export const success = {
   storeTransaction: 'storeTransaction.success',
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.success',
   lockLookUp: 'lockLookUp.success',
+  storeLockDetails: 'storeLockDetails.success',
 }
 
 export const failure = {
   storeTransaction: 'storeTransaction.failure',
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.failure',
   lockLookUp: 'lockLookUp.failure',
+  storeLockDetails: 'storeLockDetails.failure',
 }
 
 export default class StorageService extends EventEmitter {
@@ -111,9 +113,13 @@ export default class StorageService extends EventEmitter {
       opts.headers = this.genAuthorizationHeader(token)
     }
     try {
-      return await axios.post(`${this.host}/lock`, lockDetails, opts)
+      await axios.post(`${this.host}/lock`, lockDetails, opts)
+      this.emit(success.storeLockDetails, lockDetails.address)
     } catch (error) {
-      return Promise.reject(error)
+      this.emit(failure.storeLockDetails, {
+        address: lockDetails.address,
+        error,
+      })
     }
   }
 

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -6,6 +6,7 @@ export const success = {
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.success',
   lockLookUp: 'lockLookUp.success',
   storeLockDetails: 'storeLockDetails.success',
+  updateLockDetails: 'updateLockDetails.success',
 }
 
 export const failure = {
@@ -13,6 +14,7 @@ export const failure = {
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.failure',
   lockLookUp: 'lockLookUp.failure',
   storeLockDetails: 'storeLockDetails.failure',
+  updateLockDetails: 'updateLockDetails.failure',
 }
 
 export default class StorageService extends EventEmitter {
@@ -138,9 +140,10 @@ export default class StorageService extends EventEmitter {
       opts.headers = this.genAuthorizationHeader(token)
     }
     try {
-      return await axios.put(`${this.host}/lock/${address}`, update, opts)
+      await axios.put(`${this.host}/lock/${address}`, update, opts)
+      this.emit(success.updateLockDetails, address)
     } catch (error) {
-      return Promise.reject(error)
+      this.emit(failure.updateLockDetails, { address, error })
     }
   }
 

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -29,7 +29,7 @@ export const failure = {
   getUserRecoveryPhrase: 'getUserRecoveryPhrase.failure',
 }
 
-export default class StorageService extends EventEmitter {
+export class StorageService extends EventEmitter {
   constructor(host) {
     super()
     this.host = host

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -1,7 +1,18 @@
 import axios from 'axios'
+import { EventEmitter } from 'events'
 
-export default class StorageService {
+export const success = {
+  storeTransaction: 'storeTransaction.success',
+  getTransactionHashesSentBy: '',
+}
+
+export const failure = {
+  storeTransaction: 'storeTransaction.failure',
+}
+
+export default class StorageService extends EventEmitter {
   constructor(host) {
+    super()
     this.host = host
   }
 
@@ -12,14 +23,24 @@ export default class StorageService {
    * @param {*} recipientAddress
    * @param {*} chain
    */
-  storeTransaction(transactionHash, senderAddress, recipientAddress, chain) {
+  async storeTransaction(
+    transactionHash,
+    senderAddress,
+    recipientAddress,
+    chain
+  ) {
     const payload = {
       transactionHash,
       sender: senderAddress,
       recipient: recipientAddress,
       chain,
     }
-    return axios.post(`${this.host}/transaction`, payload)
+    try {
+      await axios.post(`${this.host}/transaction`, payload)
+      this.emit(success.storeTransaction, transactionHash)
+    } catch (error) {
+      this.emit(failure.storeTransaction, error)
+    }
   }
 
   /**

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -4,11 +4,13 @@ import { EventEmitter } from 'events'
 export const success = {
   storeTransaction: 'storeTransaction.success',
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.success',
+  lockLookUp: 'lockLookUp.success',
 }
 
 export const failure = {
   storeTransaction: 'storeTransaction.failure',
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.failure',
+  lockLookUp: 'lockLookUp.failure',
 }
 
 export default class StorageService extends EventEmitter {
@@ -85,11 +87,13 @@ export default class StorageService extends EventEmitter {
     try {
       const result = await axios.get(`${this.host}/lock/${address}`)
       if (result.data && result.data.name) {
-        return result.data.name
+        const name = result.data.name
+        this.emit(success.lockLookUp, { address, name })
+      } else {
+        this.emit(failure.lockLookUp, 'No name for this lock.')
       }
-      return Promise.reject(null)
     } catch (error) {
-      return Promise.reject(error)
+      this.emit(failure.lockLookUp, error)
     }
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR converts `StorageService` into an `EventEmitter` for ease of testing (coverage went up precipitously as part of this work) and to keep it more consistent with the other services.

The one thing that is not handled through events is logging in, to avoid having to pass the credentials around too much.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3077

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
