### PR TITLE
add support for requesting deploy by version name instead of just the contract

### DIFF
--- a/unlock-js/src/deploy.js
+++ b/unlock-js/src/deploy.js
@@ -1,4 +1,8 @@
 const ethers = require('ethers')
+const v0 = require('unlock-abi-0')
+const v01 = require('unlock-abi-0-1')
+const v02 = require('unlock-abi-0-2')
+
 const gas = require('./constants').GAS_AMOUNTS
 
 export default async function deploy(
@@ -7,14 +11,28 @@ export default async function deploy(
   Unlock,
   onNewContractInstance = () => {}
 ) {
+  let Contract
+  switch (Unlock) {
+    case 'v0':
+      Contract = v0.Unlock
+      break
+    case 'v01':
+      Contract = v01.Unlock
+      break
+    case 'v02':
+      Contract = v02.Unlock
+      break
+    default:
+      Contract = Unlock
+  }
   const provider = new ethers.providers.JsonRpcProvider(
     `http://${host}:${port}`
   )
   // Load the wallet to deploy the contract with
   const wallet = provider.getSigner(0)
   const factory = new ethers.ContractFactory(
-    Unlock.abi,
-    Unlock.bytecode,
+    Contract.abi,
+    Contract.bytecode,
     wallet
   )
   const accounts = await provider.listAccounts()


### PR DESCRIPTION
# Description

This will allow us to remove the `unlock-abi-0*` packages from all the apps that use ganache, speeding up build times, and also simplifying upgrades to new contract versions.

It preserves the ability to pass in a contract as well, so will provide for a smooth transition and also easy testing of new contracts prior to officially supporting them

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
