### PR TITLE
making sure we only return the current users' owned locks

### DIFF
--- a/tickets/src/__tests__/components/content/CreateContent.test.js
+++ b/tickets/src/__tests__/components/content/CreateContent.test.js
@@ -13,9 +13,15 @@ import createUnlockStore from '../../../createUnlockStore'
 const config = {
   unlockAppUrl: 'https://unlock-protocol.com',
 }
+
+const account = {
+  address: '0x123',
+}
+
 const inputLocks = {
-  abc123: { address: 'abc123' },
-  def459: { address: 'def456' },
+  abc123: { address: 'abc123', owner: '0x123' },
+  def459: { address: 'def456', owner: '0x123' },
+  ghi789: { address: 'ghi789', owner: '0x567' },
 }
 
 // Fake select to mock react-select
@@ -206,9 +212,9 @@ describe('CreateContent', () => {
 })
 
 describe('mapStateToProps', () => {
-  it('should return an array of locks when given a redux lock object', () => {
+  it('should return an array of locks owned by the current user when given a redux locks object', () => {
     expect.assertions(4)
-    const props = mapStateToProps({ locks: inputLocks }, { now: null })
+    const props = mapStateToProps({ locks: inputLocks, account }, { now: null })
 
     expect(props.locks.length).toEqual(2)
     expect(props.locks[0]).toEqual('abc123')
@@ -219,7 +225,7 @@ describe('mapStateToProps', () => {
   it('should pass through an event to props when given one in state', () => {
     expect.assertions(1)
     const props = mapStateToProps(
-      { locks: inputLocks, event: 'foo' },
+      { locks: inputLocks, event: 'foo', account },
       { now: null }
     )
 

--- a/tickets/src/components/content/CreateContent.js
+++ b/tickets/src/components/content/CreateContent.js
@@ -229,8 +229,10 @@ CreateContent.defaultProps = {
 }
 
 export const mapStateToProps = ({ locks, account, event }, { now }) => {
-  let selectLocks = []
-  Object.values(locks).map(lock => selectLocks.push(lock.address))
+  let selectLocks = Object.values(locks)
+    .filter(lock => lock.owner === account.address)
+    .map(lock => lock.address)
+
   return {
     locks: selectLocks,
     account,

--- a/tickets/src/stories/content/CreateContent.stories.js
+++ b/tickets/src/stories/content/CreateContent.stories.js
@@ -14,8 +14,11 @@ const config = configure({
 
 const store = createUnlockStore({
   locks: {
-    abc123: { address: 'abc123' },
-    def459: { address: 'def456' },
+    abc123: { address: 'abc123', owner: '0xuser' },
+    def459: { address: 'def456', owner: '0xuser' },
+  },
+  account: {
+    address: '0xuser',
   },
 })
 


### PR DESCRIPTION
# Description

Up until now the select would show all locks in store, including locks from other users for which
the current user owns a key.

# Issues

Fixes #3099

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread