### PR TITLE
implement retrieval of paywall configuration, with default value and full input validation

### DIFF
--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -48,6 +48,7 @@ export default function useListenForPostMessage({
   const { isInIframe, isServer } = useConfig()
   const parent = window && window.parent
   const [data, setData] = useState(defaultValue)
+  // rebase comment
 
   // this hook subscribes to messages on mount, and unsubscribes on unmount
   // it does not do it on update (component re-render)

--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -48,7 +48,6 @@ export default function useListenForPostMessage({
   const { isInIframe, isServer } = useConfig()
   const parent = window && window.parent
   const [data, setData] = useState(defaultValue)
-  // rebase comment
 
   // this hook subscribes to messages on mount, and unsubscribes on unmount
   // it does not do it on update (component re-render)

--- a/paywall/src/hooks/usePaywallConfig.js
+++ b/paywall/src/hooks/usePaywallConfig.js
@@ -6,14 +6,42 @@ import {
 } from '../paywall-builder/constants'
 import useListenForPostMessage from './browser/useListenForPostMessage'
 import usePostMessage from './browser/usePostMessage'
+import { isValidPaywallConfig } from '../utils/validators'
+
+export function getValue(value, defaults) {
+  if (Object.keys(value.callToAction).length === 4) return value
+  return {
+    ...value,
+    callToAction: {
+      ...defaults.callToAction,
+      ...value.callToAction,
+    },
+  }
+}
+
+export const defaultValue = {
+  locks: {},
+  icon: false,
+  callToAction: {
+    default:
+      'You have reached your limit of free articles. Please purchase access',
+    expired:
+      'Your subscription has expired, please purchase a new key to continue',
+    pending: 'Purchase pending...',
+    confirmed: 'Purchase confirmed, content unlocked!',
+  },
+}
 
 export default function usePaywallConfig() {
   const { postMessage } = usePostMessage()
   const paywallConfig = useListenForPostMessage({
     type: POST_MESSAGE_CONFIG,
+    validator: isValidPaywallConfig,
+    defaultValue,
+    getValue,
   })
   useEffect(() => {
     postMessage(POST_MESSAGE_READY)
-  }, []) // only send this once, on startup
+  }, [postMessage]) // only send this once, on startup
   return paywallConfig
 }

--- a/paywall/src/hooks/usePaywallConfig.js
+++ b/paywall/src/hooks/usePaywallConfig.js
@@ -8,6 +8,13 @@ import useListenForPostMessage from './browser/useListenForPostMessage'
 import usePostMessage from './browser/usePostMessage'
 import { isValidPaywallConfig } from '../utils/validators'
 
+/**
+ * Merge in the call to action sentences from defaults for any that the
+ * paywall configruation did not define
+ *
+ * @param {object} value paywall configuration passed in from main window
+ * @param {object} defaults default value (defined below)
+ */
 export function getValue(value, defaults) {
   if (Object.keys(value.callToAction).length === 4) return value
   return {
@@ -41,6 +48,7 @@ export default function usePaywallConfig() {
     getValue,
   })
   useEffect(() => {
+    // this triggers the send of configuration from main window to the paywall
     postMessage(POST_MESSAGE_READY)
   }, [postMessage]) // only send this once, on startup
   return paywallConfig


### PR DESCRIPTION
# Description

This implements the expected format for the initial version of paywall configuration we will expect to be sent by the client. The initial use case is the ad remover paywall.

Note that the `isValidPaywallConfig` validator will not allow configurations through that do not define at least 1 lock, but will allow through configurations that don't define all of the `callToAction` sentences.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
