### PR TITLE
reset the form when we change the selected lock

### DIFF
--- a/tickets/src/__tests__/components/content/CreateContent.test.js
+++ b/tickets/src/__tests__/components/content/CreateContent.test.js
@@ -169,6 +169,52 @@ describe('CreateContent', () => {
     expect(loadEvent).toHaveBeenCalledWith('abc123')
   })
 
+  it('should reset the fields when a different lock is selected', () => {
+    expect.assertions(2)
+
+    let date = new Date('2020-11-23T00:00:00.000')
+    const store = createUnlockStore({
+      account: { address: 'ben' },
+      locks: inputLocks,
+    })
+
+    const event = {
+      lockAddress: 'abc123',
+      name: 'Test Event',
+      description: 'This is my test event',
+      location: 'Testville',
+      owner: 'ben',
+      logo: '',
+      date,
+    }
+    const addEvent = jest.fn()
+    const loadEvent = jest.fn()
+    const now = new Date('2022-03-02T00:00:00.000') // March 2nd, 2022
+
+    const form = rtl.render(
+      <Provider store={store}>
+        <CreateContent
+          config={config}
+          account={{ address: 'ben' }}
+          locks={['abc123', 'def456']}
+          addEvent={addEvent}
+          loadEvent={loadEvent}
+          now={now}
+          event={event}
+        />
+      </Provider>
+    )
+
+    expect(form.getByDisplayValue('Test Event')).not.toBeNull()
+
+    // Now select a different lock!
+    rtl.fireEvent.change(form.getByTestId('Choose a lock'), {
+      target: { value: 'def456' }, // Selected abc123 lock
+    })
+
+    expect(form.queryByDisplayValue('Test Event')).toBeNull()
+  })
+
   it('should load an event from props', () => {
     expect.assertions(3)
 

--- a/tickets/src/components/content/CreateContent.js
+++ b/tickets/src/components/content/CreateContent.js
@@ -32,18 +32,28 @@ export class CreateContent extends Component {
     super(props)
     const { now, locks, submitted, event } = props
 
+    this.defaultState = {
+      lockAddress: '',
+      name: '',
+      description: '',
+      location: '',
+      date: now,
+      submitted: false,
+    }
+
     this.state = {
-      lockAddress: locks[0] || event.lockAddress || '',
-      name: event.name || '',
-      description: event.description || '',
-      location: event.location || '',
-      date: event.date || now,
-      submitted,
+      lockAddress:
+        locks[0] || event.lockAddress || this.defaultState.lockAddress,
+      name: event.name || this.defaultState.name,
+      description: event.description || this.defaultState.description,
+      location: event.location || this.defaultState.location,
+      date: event.date || this.defaultState.date,
+      submitted: submitted || this.defaultState.submitted,
     }
 
     this.onChange = this.onChange.bind(this)
     this.dateChanged = this.dateChanged.bind(this)
-    this.addressChanged = this.addressChanged.bind(this)
+    this.lockChanged = this.lockChanged.bind(this)
     this.onSubmit = this.onSubmit.bind(this)
     this.updateStateFromEvent = this.updateStateFromEvent.bind(this)
   }
@@ -86,9 +96,15 @@ export class CreateContent extends Component {
     })
   }
 
-  addressChanged(address) {
+  lockChanged(address) {
     const { loadEvent } = this.props
-    this.changeField('lockAddress', address)
+    this.setState(state => {
+      return {
+        ...state,
+        ...this.defaultState,
+        lockAddress: address,
+      }
+    })
     loadEvent(address)
   }
 
@@ -147,7 +163,7 @@ export class CreateContent extends Component {
                       }))}
                       onChange={selectedOption => {
                         if (selectedOption.value)
-                          this.addressChanged(selectedOption.value)
+                          this.lockChanged(selectedOption.value)
                       }}
                     />
                     <Text>


### PR DESCRIPTION
# Description

When selecting another lock, the form resets.

# Issues

Fixes #3097

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread