### PR TITLE
fix signing of the QR code for tickets app

### DIFF
--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -6,6 +6,7 @@ import v0 from '../v0'
 import v01 from '../v01'
 import v02 from '../v02'
 
+import utils from '../utils'
 import WalletService from '../walletService'
 import { GAS_AMOUNTS } from '../constants'
 
@@ -333,8 +334,7 @@ describe('WalletService (ethers)', () => {
         await resetTestsAndConnect()
         const data = 'data to be signed'
         const account = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
-        const hash =
-          '0xdc8727bb847aebb19e4b2efa955b9b2c59192fd4656b6fe64bd61c09d8edb6d1'
+        const hash = utils.utf8ToHex('data to be signed')
         const returned = Buffer.from('stuff').toString('base64')
         walletService.web3Provider = true // trigger the call to personalSign
 
@@ -353,8 +353,7 @@ describe('WalletService (ethers)', () => {
         await resetTestsAndConnect()
         const data = 'data to be signed'
         const account = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
-        const hash =
-          '0xdc8727bb847aebb19e4b2efa955b9b2c59192fd4656b6fe64bd61c09d8edb6d1'
+        const hash = utils.utf8ToHex('data to be signed')
         const returned = Buffer.from('stuff').toString('base64')
 
         nock.accountsAndYield([account])
@@ -373,8 +372,7 @@ describe('WalletService (ethers)', () => {
 
         const data = 'data to be signed'
         const account = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
-        const hash =
-          '0xdc8727bb847aebb19e4b2efa955b9b2c59192fd4656b6fe64bd61c09d8edb6d1'
+        const hash = utils.utf8ToHex('data to be signed')
         const error = { code: 404, message: 'oops' }
 
         nock.accountsAndYield([account])

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -200,7 +200,7 @@ export default class WalletService extends UnlockService {
   }
 
   async signMessage(data, method) {
-    const dataHash = utils.hexlify(utils.sha3(utils.utf8ToHex(data)))
+    const dataHash = utils.utf8ToHex(data)
     const signer = this.provider.getSigner()
     const addr = await signer.getAddress()
     let firstParam = dataHash


### PR DESCRIPTION
# Description

The implementation of `personal_sign` in `walletService` was doing to much to the data being sent to be signed. Now it properly simply encodes the string sent into a hex format, so that metamask (and others) will display the text being signed.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3106 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
