### PR TITLE
check against the actual value used for unlockVersion (oops)

### DIFF
--- a/unlock-js/src/__tests__/helpers/walletServiceHelper.js
+++ b/unlock-js/src/__tests__/helpers/walletServiceHelper.js
@@ -62,10 +62,10 @@ export const prepWalletService = async (
     // this is "Contract.publicLockVersion()" with params [] (0xd1bbd49c)
 
     nock.ethCallAndYield('0xd1bbd49c', checksumContractAddress, unlockVersion)
-    if (unlockVersion === 1) {
-      nock.ethGetCodeAndYield(contractAddress, contract.deployedBytecode)
-    }
-    if (unlockVersion === 1) {
+    if (
+      unlockVersion ===
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    ) {
       nock.ethGetCodeAndYield(contractAddress, contract.deployedBytecode)
     }
     await walletService.getLockContract(contractAddress)


### PR DESCRIPTION
# Description

Sometimes, v02 tests were failing on setup, because of a missing nock call. This corrects the assertion in `walletService.helper.js` when checking for version 1, which triggers an additional `eth_getCode` to verify which contract we are using.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3112


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
