### PR TITLE
use the compressed bytecode and abi for contract deploy

### DIFF
--- a/unlock-js/src/__tests__/deploy.test.js
+++ b/unlock-js/src/__tests__/deploy.test.js
@@ -169,6 +169,34 @@ describe('contract deployer', () => {
         }
       })
 
+      it('throws if contract is unknown', async () => {
+        expect.assertions(2)
+        nock.accountsAndYield(unlockAccountsOnNode)
+        nock.ethGasPriceAndYield(gasPrice)
+
+        // contract deploy call
+        nock.ethSendTransactionAndYield(
+          {
+            from: unlockAccountsOnNode[0],
+            data: UnlockContract.bytecode,
+            gas: '0x' + GAS_AMOUNTS.deployContract.toString(16),
+          },
+          gasPrice,
+          transaction.hash,
+          new Error('ran out of gas, you miser')
+        )
+
+        try {
+          await deploy(host, port, 'oops')
+        } catch (e) {
+          // this is intentionally vague, since the actual error content will change with other frameworks
+          expect(e).toBeInstanceOf(Error)
+          expect(e.message).toBe(
+            'Contract version "oops" does not seem to exist'
+          )
+        }
+      })
+
       it('throws on yield of 0x in transactionReceipt', async () => {
         expect.assertions(1)
         nock.accountsAndYield(unlockAccountsOnNode)

--- a/unlock-js/src/deploy.js
+++ b/unlock-js/src/deploy.js
@@ -1,7 +1,6 @@
 const ethers = require('ethers')
-const v0 = require('unlock-abi-0')
-const v01 = require('unlock-abi-0-1')
-const v02 = require('unlock-abi-0-2')
+const bytecode = require('./bytecode').default
+const abis = require('./abis').default
 
 const gas = require('./constants').GAS_AMOUNTS
 
@@ -12,19 +11,19 @@ export default async function deploy(
   onNewContractInstance = () => {}
 ) {
   let Contract
-  switch (Unlock) {
-    case 'v0':
-      Contract = v0.Unlock
-      break
-    case 'v01':
-      Contract = v01.Unlock
-      break
-    case 'v02':
-      Contract = v02.Unlock
-      break
-    default:
-      Contract = Unlock
+  if (typeof Unlock === 'string') {
+    const version = Unlock
+    if (!abis[version]) {
+      throw new Error(`Contract version "${Unlock}" does not seem to exist`)
+    }
+    Contract = {
+      abi: abis[version].Unlock.abi,
+      bytecode: bytecode[version].Unlock,
+    }
+  } else {
+    Contract = Unlock
   }
+
   const provider = new ethers.providers.JsonRpcProvider(
     `http://${host}:${port}`
   )


### PR DESCRIPTION
# Description

This migrates the deploy script to use the new compressed bytecode and abi. This will allow us to move the (extremely heavy) `unlock-abi-0*` packages to devDependencies, saving about 1MB on standard install of `unlock-js`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3090 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
