### PR TITLE
Adding verifyMessage to unlock.js so we can retrieve an address

### DIFF
--- a/unlock-js/src/__tests__/utils.test.js
+++ b/unlock-js/src/__tests__/utils.test.js
@@ -86,4 +86,17 @@ describe('ethers utils', () => {
       '0x49206c696b6520747572746c6573'
     )
   })
+
+  it('verifyMessage', () => {
+    expect.assertions(1)
+
+    const signature =
+      '0xddd0a7290af9526056b4e35a077b9a11b513aa0028ec6c9880948544508f3c63' +
+      '265e99e47ad31bb2cab9646c504576b3abc6939a1710afc08cbf3034d73214b8' +
+      '1c'
+
+    expect(ethersUtils.verifyMessage('hello world', signature)).toBe(
+      '0x14791697260E4c9A71f18484C9f997B308e59325'
+    )
+  })
 })

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -387,6 +387,30 @@ describe('WalletService (ethers)', () => {
     })
   })
 
+  describe('recoverAccountFromSignedData', () => {
+    it('returns the signing address', () => {
+      expect.hasAssertions()
+
+      const data = 'data to be signed'
+      const account = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
+      const hash = utils.utf8ToHex('data to be signed')
+
+      walletService.web3Provider = true
+
+      const signed = Buffer.from('stuff').toString('base64')
+
+      nock.accountsAndYield([account])
+      nock.ethSignAndYield(hash, account, 'stuff')
+
+      const returnedAddress = walletService.recoverAccountFromSignedData(
+        data,
+        signed
+      )
+
+      expect(returnedAddress).toBe(account)
+    })
+  })
+
   describe('versions', () => {
     const versionSpecificUnlockMethods = ['createLock']
 

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -391,20 +391,16 @@ describe('WalletService (ethers)', () => {
     it('returns the signing address', async () => {
       expect.hasAssertions()
 
-      const data = 'data to be signed'
-      const account = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
-      const hash = utils.utf8ToHex('data to be signed')
-
-      walletService.web3Provider = true
-
-      const signed = Buffer.from('stuff').toString('base64')
-
-      nock.accountsAndYield([account])
-      nock.ethSignAndYield(hash, account, 'stuff')
+      const data = 'hello world'
+      const account = '0x14791697260E4c9A71f18484C9f997B308e59325'
+      const signature =
+        '0xddd0a7290af9526056b4e35a077b9a11b513aa0028ec6c9880948544508f3c63' +
+        '265e99e47ad31bb2cab9646c504576b3abc6939a1710afc08cbf3034d73214b8' +
+        '1c'
 
       const returnedAddress = await walletService.recoverAccountFromSignedData(
         data,
-        signed
+        signature
       )
 
       expect(returnedAddress).toBe(account)

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -388,7 +388,7 @@ describe('WalletService (ethers)', () => {
   })
 
   describe('recoverAccountFromSignedData', () => {
-    it('returns the signing address', () => {
+    it('returns the signing address', async () => {
       expect.hasAssertions()
 
       const data = 'data to be signed'
@@ -402,7 +402,7 @@ describe('WalletService (ethers)', () => {
       nock.accountsAndYield([account])
       nock.ethSignAndYield(hash, account, 'stuff')
 
-      const returnedAddress = walletService.recoverAccountFromSignedData(
+      const returnedAddress = await walletService.recoverAccountFromSignedData(
         data,
         signed
       )

--- a/unlock-js/src/utils.js
+++ b/unlock-js/src/utils.js
@@ -25,7 +25,5 @@ module.exports = {
   },
   utf8ToHex: str => utils.hexlify(str.length ? utils.toUtf8Bytes(str) : 0),
   sha3: utils.keccak256,
-  verifyMessage: (messageStringOrArrayish, signature) => {
-    return utils.verifyMessage(messageStringOrArrayish, signature)
-  },
+  verifyMessage: utils.verifyMessage,
 }

--- a/unlock-js/src/utils.js
+++ b/unlock-js/src/utils.js
@@ -25,4 +25,7 @@ module.exports = {
   },
   utf8ToHex: str => utils.hexlify(str.length ? utils.toUtf8Bytes(str) : 0),
   sha3: utils.keccak256,
+  verifyMessage: (messageStringOrArrayish, signature) => {
+    return utils.verifyMessage(messageStringOrArrayish, signature)
+  },
 }

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -228,8 +228,6 @@ export default class WalletService extends UnlockService {
    * @returns {Promise<*>}
    */
   async recoverAccountFromSignedData(data, signedData) {
-    const dataHash = utils.utf8ToHex(data)
-    console.log(dataHash) // Test
-    return utils.verifyMessage(dataHash, signedData)
+    return utils.verifyMessage(data, signedData)
   }
 }

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -220,4 +220,15 @@ export default class WalletService extends UnlockService {
       return callback(error, null)
     }
   }
+
+  /**
+   * Given some data and a signed version of the same, returns the address of the account that signed it
+   * @param data
+   * @param signedData
+   * @returns {Promise<*>}
+   */
+  async recoverAccountFromSignedData(data, signedData) {
+    const dataHash = utils.utf8ToHex(data)
+    return utils.verifyMessage(dataHash, signedData)
+  }
 }

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -229,6 +229,7 @@ export default class WalletService extends UnlockService {
    */
   async recoverAccountFromSignedData(data, signedData) {
     const dataHash = utils.utf8ToHex(data)
+    console.log(dataHash) // Test
     return utils.verifyMessage(dataHash, signedData)
   }
 }


### PR DESCRIPTION
# Description

This will allow us to get the address back for event verification.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
