### PR TITLE
the easy part of making unlock-js es module-able

### DIFF
--- a/unlock-js/src/__tests__/helpers/walletServiceHelper.js
+++ b/unlock-js/src/__tests__/helpers/walletServiceHelper.js
@@ -3,7 +3,7 @@ import * as UnlockV01 from 'unlock-abi-0-1'
 import * as UnlockV02 from 'unlock-abi-0-2'
 import { ethers } from 'ethers'
 
-import * as utils from '../../utils'
+import utils from '../../utils'
 import { GAS_AMOUNTS } from '../../constants'
 
 import WalletService from '../../walletService'

--- a/unlock-js/src/__tests__/v0/createLock.test.js
+++ b/unlock-js/src/__tests__/v0/createLock.test.js
@@ -1,5 +1,5 @@
 import * as UnlockV0 from 'unlock-abi-0'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/__tests__/v0/getLock.test.js
+++ b/unlock-js/src/__tests__/v0/getLock.test.js
@@ -2,7 +2,7 @@ import * as UnlockV0 from 'unlock-abi-0'
 import { ethers } from 'ethers'
 import Web3Service from '../../web3Service'
 import NockHelper from '../helpers/nockHelper'
-import * as utils from '../../utils'
+import utils from '../../utils'
 
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)

--- a/unlock-js/src/__tests__/v0/partialWithdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v0/partialWithdrawFromLock.test.js
@@ -1,5 +1,5 @@
 import * as UnlockV0 from 'unlock-abi-0'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/__tests__/v0/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v0/purchaseKey.test.js
@@ -1,5 +1,5 @@
 import * as UnlockV0 from 'unlock-abi-0'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/__tests__/v0/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v0/updateKeyPrice.test.js
@@ -1,5 +1,5 @@
 import * as UnlockV0 from 'unlock-abi-0'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/__tests__/v01/createLock.ethers.js
+++ b/unlock-js/src/__tests__/v01/createLock.ethers.js
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import * as UnlockV01 from 'unlock-abi-0-1'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/__tests__/v01/getLock.test.js
+++ b/unlock-js/src/__tests__/v01/getLock.test.js
@@ -2,7 +2,7 @@ import * as UnlockV01 from 'unlock-abi-0-1'
 import { ethers } from 'ethers'
 import Web3Service from '../../web3Service'
 import NockHelper from '../helpers/nockHelper'
-import * as utils from '../../utils'
+import utils from '../../utils'
 
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)

--- a/unlock-js/src/__tests__/v01/partialWithdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v01/partialWithdrawFromLock.test.js
@@ -1,5 +1,5 @@
 import * as UnlockV01 from 'unlock-abi-0-1'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/__tests__/v01/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v01/updateKeyPrice.test.js
@@ -1,5 +1,5 @@
 import * as UnlockV01 from 'unlock-abi-0-1'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/__tests__/v02/createLock.test.js
+++ b/unlock-js/src/__tests__/v02/createLock.test.js
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import * as UnlockV02 from 'unlock-abi-0-2'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/__tests__/v02/getLock.test.js
+++ b/unlock-js/src/__tests__/v02/getLock.test.js
@@ -2,7 +2,7 @@ import * as UnlockV02 from 'unlock-abi-0-2'
 import { ethers } from 'ethers'
 import Web3Service from '../../web3Service'
 import NockHelper from '../helpers/nockHelper'
-import * as utils from '../../utils'
+import utils from '../../utils'
 
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */, true /** ethers */)

--- a/unlock-js/src/__tests__/v02/partialWithdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v02/partialWithdrawFromLock.test.js
@@ -1,5 +1,5 @@
 import * as UnlockV02 from 'unlock-abi-0-2'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/__tests__/v02/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v02/updateKeyPrice.test.js
@@ -1,5 +1,5 @@
 import * as UnlockV02 from 'unlock-abi-0-2'
-import * as utils from '../../utils'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'

--- a/unlock-js/src/constants.js
+++ b/unlock-js/src/constants.js
@@ -1,4 +1,4 @@
-import { constants } from 'ethers'
+import { ethers } from 'ethers'
 
 export const GAS_AMOUNTS = {
   createLock: 3500000,
@@ -11,7 +11,7 @@ export const GAS_AMOUNTS = {
 
 export const MAX_UINT =
   '115792089237316195423570985008687907853269984665640564039457584007913129639935'
-export const ETHERS_MAX_UINT = constants.MaxUint256
+export const ETHERS_MAX_UINT = ethers.constants.MaxUint256
 
 export const UNLIMITED_KEYS_COUNT = -1
 
@@ -24,4 +24,4 @@ export default {
   KEY_ID,
 }
 
-export const ZERO = constants.AddressZero
+export const ZERO = ethers.constants.AddressZero

--- a/unlock-js/src/v0/index.js
+++ b/unlock-js/src/v0/index.js
@@ -6,6 +6,9 @@ import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 
+const version = 'v0'
+const Unlock = abis.v0.Unlock
+const PublicLock = abis.v0.PublicLock
 export default {
   createLock,
   getLock,
@@ -13,7 +16,7 @@ export default {
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
-  version: 'v0',
-  Unlock: abis.v0.Unlock,
-  PublicLock: abis.v0.PublicLock,
+  version,
+  Unlock,
+  PublicLock,
 }

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -1,8 +1,8 @@
-import { providers as ethersProviders } from 'ethers'
+import { ethers } from 'ethers'
 import UnlockService from './unlockService'
 import FetchJsonProvider from './FetchJsonProvider'
 import { GAS_AMOUNTS } from './constants'
-import * as utils from './utils'
+import utils from './utils'
 
 /**
  * This service interacts with the user's wallet.
@@ -40,7 +40,7 @@ export default class WalletService extends UnlockService {
       this.provider = new FetchJsonProvider(provider)
       this.web3Provider = false
     } else {
-      this.provider = new ethersProviders.Web3Provider(provider)
+      this.provider = new ethers.providers.Web3Provider(provider)
       this.web3Provider = provider
     }
     const { chainId: networkId } = await this.provider.getNetwork()

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -1,7 +1,4 @@
-import {
-  providers as ethersProviders,
-  utils as ethersMetadataHandling,
-} from 'ethers'
+import { ethers } from 'ethers'
 import utils from './utils'
 import TransactionTypes from './transactionTypes'
 import UnlockService from './unlockService'
@@ -121,7 +118,7 @@ export default class Web3Service extends UnlockService {
     if (typeof readOnlyProvider === 'string') {
       this.provider = new FetchJsonProvider(readOnlyProvider)
     } else if (readOnlyProvider.send) {
-      this.provider = new ethersProviders.Web3Provider(readOnlyProvider)
+      this.provider = new ethers.providers.Web3Provider(readOnlyProvider)
     }
   }
 
@@ -133,7 +130,7 @@ export default class Web3Service extends UnlockService {
       this.unlockContractAddress
     )
 
-    return ethersMetadataHandling.getContractAddress({
+    return ethers.utils.getContractAddress({
       from: this.unlockContractAddress,
       nonce: transactionCount,
     })
@@ -164,7 +161,7 @@ export default class Web3Service extends UnlockService {
       return null
     }
 
-    const metadata = new ethersMetadataHandling.Interface(contract.abi)
+    const metadata = new ethers.utils.Interface(contract.abi)
     const transactionInfo = metadata.parseTransaction({ data })
 
     // If there is no matching method, return null
@@ -280,7 +277,7 @@ export default class Web3Service extends UnlockService {
     contract,
     transactionReceipt
   ) {
-    const metadata = new ethersMetadataHandling.Interface(contract.abi)
+    const metadata = new ethers.utils.Interface(contract.abi)
 
     transactionReceipt.logs.forEach(log => {
       // For each log, let's find which event it is
@@ -320,7 +317,7 @@ export default class Web3Service extends UnlockService {
       blockNumber: Number.MAX_SAFE_INTEGER, // Asign the largest block number for sorting purposes
     })
 
-    const metadata = new ethersMetadataHandling.Interface(contract.abi)
+    const metadata = new ethers.utils.Interface(contract.abi)
 
     const transactionInfo = metadata.parseTransaction({ data })
 


### PR DESCRIPTION
# Description

Moving all the utils imports to be `import utils from './utils'` and moving all references to subsets of `ethers` to just be from `{ ethers }` is an important step in the es modulization of unlock-js

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
