### PR TITLE
implement instant return from sendTransaction

### DIFF
--- a/unlock-js/src/FastJsonRpcSigner.js
+++ b/unlock-js/src/FastJsonRpcSigner.js
@@ -1,0 +1,75 @@
+import { ethers } from 'ethers'
+import utils from './utils'
+
+/**
+ * This file is only needed with ethers v4. v5 will come with an UncheckedJsonSigner
+ * that we can use.
+ *
+ * See https://github.com/ethers-io/ethers.js/issues/511
+ */
+export default class FastJsonRpcSigner extends ethers.Signer {
+  constructor(signer) {
+    super()
+    ethers.utils.defineReadOnly(this, 'signer', signer)
+    ethers.utils.defineReadOnly(this, 'provider', signer.provider)
+  }
+
+  getAddress() {
+    return this.signer.getAddress()
+  }
+
+  async sendTransaction(transaction) {
+    const hash = await this.signer.sendUncheckedTransaction(transaction)
+    const ret = {
+      ...transaction,
+      hash: hash,
+      blockHash: null,
+      blockNumber: null,
+      creates: null,
+      gasLimit: utils.bigNumberify(
+        utils.hexStripZeros(utils.hexlify(transaction.gasLimit))
+      ),
+      gasPrice: utils.bigNumberify(
+        utils.hexStripZeros(utils.hexlify(transaction.gasLimit))
+      ),
+      value: utils.bigNumberify(transaction.value || 0),
+      networkId: 0,
+      nonce: 0,
+      transactionIndex: 0,
+      confirmations: 0,
+      to: await transaction.to,
+      from: await this.signer.getAddress(),
+      wait: async (confirmations = 0) => {
+        const tx = await this.provider.getTransaction(hash)
+        return {
+          hash,
+          logs: [],
+          wait: async () => {
+            const receipt = await this.provider.waitForTransaction(hash)
+            if (receipt == null && confirmations === 0) {
+              return null
+            }
+
+            if (receipt.status === 0) {
+              ethers.errors.throwError(
+                'transaction failed',
+                ethers.errors.CALL_EXCEPTION,
+                {
+                  transactionHash: tx.hash,
+                  transaction: tx,
+                }
+              )
+            }
+            return receipt
+          },
+        }
+      },
+    }
+    return ret
+  }
+
+  // unused in project atm, but here for completeness
+  signMessage(message) {
+    return this.signer.signMessage(message)
+  }
+}

--- a/unlock-js/src/__tests__/v0/createLock.test.js
+++ b/unlock-js/src/__tests__/v0/createLock.test.js
@@ -79,6 +79,7 @@ describe('v0', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v0/partialWithdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v0/partialWithdrawFromLock.test.js
@@ -76,6 +76,7 @@ describe('v0', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })
@@ -112,12 +113,16 @@ describe('v0', () => {
         Promise.resolve(transaction.hash)
       )
 
+      const mock = walletService._handleMethodCall
+
       await walletService.partialWithdrawFromLock(
         lock,
         account,
         amount,
         callback
       )
+      const result = await mock.mock.calls[0][0]
+      await result.wait()
 
       await nock.resolveWhenAllNocksUsed()
       expect(callback).toHaveBeenCalled()

--- a/unlock-js/src/__tests__/v0/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v0/purchaseKey.test.js
@@ -80,6 +80,7 @@ describe('v0', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v0/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v0/updateKeyPrice.test.js
@@ -70,6 +70,7 @@ describe('v0', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v0/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v0/withdrawFromLock.test.js
@@ -68,6 +68,7 @@ describe('v0', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v01/createLock.ethers.js
+++ b/unlock-js/src/__tests__/v01/createLock.ethers.js
@@ -81,6 +81,7 @@ describe('v01', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v01/partialWithdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v01/partialWithdrawFromLock.test.js
@@ -76,6 +76,7 @@ describe('v01', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })
@@ -112,12 +113,16 @@ describe('v01', () => {
         Promise.resolve(transaction.hash)
       )
 
+      const mock = walletService._handleMethodCall
+
       await walletService.partialWithdrawFromLock(
         lock,
         account,
         amount,
         callback
       )
+      const result = await mock.mock.calls[0][0]
+      await result.wait()
 
       await nock.resolveWhenAllNocksUsed()
       expect(callback).toHaveBeenCalled()

--- a/unlock-js/src/__tests__/v01/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v01/purchaseKey.test.js
@@ -70,6 +70,7 @@ describe('v01', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v01/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v01/updateKeyPrice.test.js
@@ -70,6 +70,7 @@ describe('v01', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v01/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v01/withdrawFromLock.test.js
@@ -68,6 +68,7 @@ describe('v01', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v02/createLock.test.js
+++ b/unlock-js/src/__tests__/v02/createLock.test.js
@@ -81,6 +81,7 @@ describe('v02', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v02/partialWithdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v02/partialWithdrawFromLock.test.js
@@ -76,6 +76,7 @@ describe('v02', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })
@@ -112,12 +113,16 @@ describe('v02', () => {
         Promise.resolve(transaction.hash)
       )
 
+      const mock = walletService._handleMethodCall
+
       await walletService.partialWithdrawFromLock(
         lock,
         account,
         amount,
         callback
       )
+      const result = await mock.mock.calls[0][0]
+      await result.wait()
 
       await nock.resolveWhenAllNocksUsed()
       expect(callback).toHaveBeenCalled()

--- a/unlock-js/src/__tests__/v02/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v02/purchaseKey.test.js
@@ -70,6 +70,7 @@ describe('v02', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v02/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v02/updateKeyPrice.test.js
@@ -70,6 +70,7 @@ describe('v02', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/v02/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v02/withdrawFromLock.test.js
@@ -68,6 +68,7 @@ describe('v02', () => {
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
+      await result.wait()
       expect(result).toEqual(transactionResult)
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -183,6 +183,13 @@ describe('WalletService (ethers)', () => {
         to: 'to',
         data: 'data',
       }
+      const inBetweenTransaction = {
+        hash: 'hash',
+        from: 'from',
+        to: 'to',
+        data: 'data',
+        wait: () => Promise.resolve(transaction),
+      }
 
       it('emits transaction.pending with transaction type', async () => {
         expect.assertions(1)
@@ -193,7 +200,7 @@ describe('WalletService (ethers)', () => {
         })
 
         await walletService._handleMethodCall(
-          Promise.resolve(transaction),
+          Promise.resolve(inBetweenTransaction),
           'transactionType'
         )
       })
@@ -205,7 +212,7 @@ describe('WalletService (ethers)', () => {
         let myResolve
         const myPromise = new Promise(resolve => {
           myResolve = jest.fn(resolve)
-          myResolve(transaction)
+          myResolve(inBetweenTransaction)
         })
 
         await walletService._handleMethodCall(myPromise, 'transactionType')
@@ -230,7 +237,7 @@ describe('WalletService (ethers)', () => {
         )
 
         await walletService._handleMethodCall(
-          Promise.resolve(transaction),
+          Promise.resolve(inBetweenTransaction),
           'transactionType'
         )
       })

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -5,6 +5,8 @@ import v0 from './v0'
 import v01 from './v01'
 import v02 from './v02'
 
+import FastJsonRpcSigner from './FastJsonRpcSigner'
+
 // mute warnings from overloaded smart contract methods (https://github.com/ethers-io/ethers.js/issues/499)
 ethers.errors.setLogLevel('error')
 
@@ -135,7 +137,9 @@ export default class UnlockService extends EventEmitter {
   }
 
   async getWritableContract(address, contract) {
-    const signer = this.provider.getSigner()
+    // TODO: replace this when v5 of ethers is out
+    // see https://github.com/ethers-io/ethers.js/issues/511
+    const signer = new FastJsonRpcSigner(this.provider.getSigner())
     return new ethers.Contract(address, contract.abi, signer)
   }
 

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -105,7 +105,8 @@ export default class WalletService extends UnlockService {
       transactionType,
       'submitted'
     )
-    return transaction.hash
+    const finalTransaction = await transaction.wait()
+    return finalTransaction.hash
     // errors fall through
   }
 


### PR DESCRIPTION
# Description

In preparation for upgrading to 0.0.25, it turned out that the default behavior of ethers contract transaction-based method calls does not return the hash until the first mined block. This is between 5-20 seconds on mainnet. Based on discussions with the maintainer of ethers, found in https://github.com/ethers-io/ethers.js/issues/511, this PR implements a new `Signer` that wraps the built-in one, but extends the behavior of `sendTransaction` to return right away.

In testing, it solves the delay.

As version 5 of ethers is due out soon and includes a first-class citizen `UncheckedJsonRpcSigner` that does this same thing, this is a temporary fix.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
