### PR TITLE
Store encrypted private key in Redux

### DIFF
--- a/unlock-app/src/__tests__/actions/user.test.ts
+++ b/unlock-app/src/__tests__/actions/user.test.ts
@@ -17,6 +17,8 @@ import {
   changePassword,
   GOT_PASSWORD,
   gotPassword,
+  SET_ENCRYPTED_PRIVATE_KEY,
+  setEncryptedPrivateKey,
 } from '../../actions/user'
 
 describe('user account actions', () => {
@@ -54,6 +56,39 @@ describe('user account actions', () => {
       }
 
       expect(loginFailed(reason)).toEqual(expectedAction)
+    })
+
+    it("should create an action to set the user's encrypted key in the state", () => {
+      expect.assertions(1)
+      const key = {
+        version: 3,
+        id: '04e9bcbb-96fa-497b-94d1-14df4cd20af6',
+        address: '2c7536e3605d9c16a7a3d7b1898e529396a65c23',
+        crypto: {
+          ciphertext:
+            'a1c25da3ecde4e6a24f3697251dd15d6208520efc84ad97397e906e6df24d251',
+          cipherparams: { iv: '2885df2b63f7ef247d753c82fa20038a' },
+          cipher: 'aes-128-ctr',
+          kdf: 'scrypt',
+          kdfparams: {
+            dklen: 32,
+            salt:
+              '4531b3c174cc3ff32a6a7a85d6761b410db674807b2d216d022318ceee50be10',
+            n: 262144,
+            r: 8,
+            p: 1,
+          },
+          mac:
+            'b8b010fff37f9ae5559a352a185e86f9b9c1d7f7a9f1bd4e82a5dd35468fc7f6',
+        },
+      }
+
+      const expectedAction = {
+        type: SET_ENCRYPTED_PRIVATE_KEY,
+        key,
+      }
+
+      expect(setEncryptedPrivateKey(key)).toEqual(expectedAction)
     })
   })
 

--- a/unlock-app/src/__tests__/reducers/privateKeyReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/privateKeyReducer.test.ts
@@ -1,0 +1,71 @@
+import reducer, { initialState } from '../../reducers/privateKeyReducer'
+
+import { SET_ENCRYPTED_PRIVATE_KEY } from '../../actions/user'
+
+import { SET_PROVIDER } from '../../actions/provider'
+import { SET_NETWORK } from '../../actions/network'
+import { SET_ACCOUNT } from '../../actions/accounts'
+
+const oldKeyState = {
+  version: 3,
+  id: '04e9bcbb-96fa-497b-94d1-14df4cd20af6',
+  address: '2c7536e3605d9c16a7a3d7b1898e529396a65c23',
+  crypto: {
+    ciphertext:
+      'a1c25da3ecde4e6a24f3697251dd15d6208520efc84ad97397e906e6df24d251',
+    cipherparams: { iv: '2885df2b63f7ef247d753c82fa20038a' },
+    cipher: 'aes-128-ctr',
+    kdf: 'scrypt',
+    kdfparams: {
+      dklen: 32,
+      salt: '4531b3c174cc3ff32a6a7a85d6761b410db674807b2d216d022318ceee50be10',
+      n: 262144,
+      r: 8,
+      p: 1,
+    },
+    mac: 'b8b010fff37f9ae5559a352a185e86f9b9c1d7f7a9f1bd4e82a5dd35468fc7f6',
+  },
+}
+
+const newKeyState = {
+  version: 3,
+  id: 'different than the other one',
+  address: '2c7536e3605d9c16a7a3d7b1898e529396a65c23',
+  crypto: {
+    ciphertext:
+      'a1c25da3ecde4e6a24f3697251dd15d6208520efc84ad97397e906e6df24d251',
+    cipherparams: { iv: '2885df2b63f7ef247d753c82fa20038a' },
+    cipher: 'ROT13',
+    kdf: 'scrypt',
+    kdfparams: {
+      dklen: 32,
+      salt: '4531b3c174cc3ff32a6a7a85d6761b410db674807b2d216d022318ceee50be10',
+      n: 262144,
+      r: 8,
+      p: 1,
+    },
+    mac: 'b8b010fff37f9ae5559a352a185e86f9b9c1d7f7a9f1bd4e82a5dd35468fc7f6',
+  },
+}
+
+describe('privateKeyReducer', () => {
+  it.each([SET_ACCOUNT, SET_PROVIDER, SET_NETWORK])(
+    'should return initialState when receiving %s',
+    actionType => {
+      expect.assertions(1)
+      const action = { type: actionType }
+      expect(reducer(oldKeyState, action)).toEqual(initialState)
+    }
+  )
+
+  it('should set the key when receiving SET_ENCRYPTED_PRIVATE_KEY', () => {
+    expect.assertions(2)
+    const action = {
+      type: SET_ENCRYPTED_PRIVATE_KEY,
+      key: newKeyState,
+    }
+
+    expect(reducer(initialState, action)).toEqual(newKeyState)
+    expect(reducer(oldKeyState, action)).toEqual(newKeyState)
+  })
+})

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -1,3 +1,5 @@
+import { EncryptedPrivateKey } from '../unlockTypes' // eslint-disable-line no-unused-vars
+
 export const LOGIN_CREDENTIALS = 'login/GOT_CREDENTIALS'
 export const LOGIN_SUCCEEDED = 'login/SUCCESS'
 export const LOGIN_FAILED = 'login/FAILED'
@@ -7,6 +9,8 @@ export const SIGNUP_FAILED = 'signup/FAILED'
 export const SIGNUP_SUCCEEDED = 'signup/SUCCESS'
 export const CHANGE_PASSWORD = 'password/CHANGE'
 export const GOT_PASSWORD = 'userCredentials/PASSWORD'
+export const SET_ENCRYPTED_PRIVATE_KEY =
+  'userCredentials/SET_ENCRYPTED_PRIVATE_KEY'
 
 export interface Credentials {
   emailAddress: string
@@ -61,4 +65,11 @@ export const changePassword = (newPassword: string) => ({
 export const gotPassword = (password: string) => ({
   type: GOT_PASSWORD,
   password,
+})
+
+// This should be dispatched along with setAccount in the storage middleware
+// when a user logs in.
+export const setEncryptedPrivateKey = (key: EncryptedPrivateKey) => ({
+  type: SET_ENCRYPTED_PRIVATE_KEY,
+  key,
 })

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -68,7 +68,9 @@ export const gotPassword = (password: string) => ({
 })
 
 // This should be dispatched along with setAccount in the storage middleware
-// when a user logs in.
+// when a user logs in. This provides a bit of a timing concern, since
+// SET_ACCOUNT usually wipes out all the state. So SET_ACCOUNT must be sent
+// first.
 export const setEncryptedPrivateKey = (key: EncryptedPrivateKey) => ({
   type: SET_ENCRYPTED_PRIVATE_KEY,
   key,

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -45,6 +45,9 @@ import lockFormVisibilityReducer, {
 import fullScreenModalsReducer, {
   initialState as defaultFullScreenModalsStatus,
 } from './reducers/fullScreenModalsReducer'
+import privateKeyReducer, {
+  initialState as defaultPrivateKeyState,
+} from './reducers/privateKeyReducer'
 
 const config = configure()
 
@@ -67,6 +70,7 @@ export const createUnlockStore = (
     errors: errorsReducer,
     lockFormStatus: lockFormVisibilityReducer,
     fullScreenModalStatus: fullScreenModalsReducer,
+    encryptedPrivateKey: privateKeyReducer,
   }
 
   // Cleanup the defaultState to remove all null values so that we do not overwrite existing
@@ -92,6 +96,7 @@ export const createUnlockStore = (
       errors: defaultError,
       lockFormStatus: defaultLockFormVisibility,
       fullScreenModalStatus: defaultFullScreenModalsStatus,
+      encryptedPrivateKey: defaultPrivateKeyState,
     },
     {
       provider: Object.keys(config.providers)[0],

--- a/unlock-app/src/reducers/privateKeyReducer.ts
+++ b/unlock-app/src/reducers/privateKeyReducer.ts
@@ -1,0 +1,21 @@
+import { SET_ENCRYPTED_PRIVATE_KEY } from '../actions/user'
+import { SET_PROVIDER } from '../actions/provider'
+import { SET_NETWORK } from '../actions/network'
+import { SET_ACCOUNT } from '../actions/accounts'
+import { Action } from '../unlockTypes' // eslint-disable-line no-unused-vars
+
+export const initialState = null
+
+const privateKeyReducer = (state = initialState, action: Action) => {
+  if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
+    return initialState
+  }
+
+  if (action.type === SET_ENCRYPTED_PRIVATE_KEY) {
+    return action.key
+  }
+
+  return state
+}
+
+export default privateKeyReducer

--- a/unlock-app/src/reducers/privateKeyReducer.ts
+++ b/unlock-app/src/reducers/privateKeyReducer.ts
@@ -2,11 +2,12 @@ import { SET_ENCRYPTED_PRIVATE_KEY } from '../actions/user'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 import { SET_ACCOUNT } from '../actions/accounts'
-import { Action } from '../unlockTypes' // eslint-disable-line no-unused-vars
+import { Action, EncryptedPrivateKey } from '../unlockTypes' // eslint-disable-line no-unused-vars
 
-export const initialState = null
+type State = EncryptedPrivateKey | null
+export const initialState: State = null
 
-const privateKeyReducer = (state = initialState, action: Action) => {
+const privateKeyReducer = (state: State = initialState, action: Action) => {
   if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
     return initialState
   }

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -69,3 +69,11 @@ export interface Action {
 
 // TODO: Use this where we have TS files
 export type Dispatch = (action: Action) => any
+
+// This is currrently the way ethers checks the keystore format. TODO:
+// tighten this up? At the moment it just serves to make it difficult
+// to put a decrypted key into the state.
+export interface EncryptedPrivateKey {
+  version: number
+  [param: string]: any
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
A piece of #2111. Once we've gotten the user's encrypted private key, it makes sense to cache it in Redux instead of making repeated network calls for it.

Copying lots of people on this, I'd definitely like any thoughts that occur based on my comments below.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
