### PR TITLE
new caching library to ensure speedy return visits for paywall

### DIFF
--- a/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
@@ -1,0 +1,37 @@
+import { get, put, clear } from '../../../data-iframe/cache'
+
+jest.mock('../../../utils/localStorage', () => () => false)
+
+describe('localStorage cache', () => {
+  describe('localStorage unavailable', () => {
+    it('get', async () => {
+      expect.assertions(1)
+
+      try {
+        await get()
+      } catch (e) {
+        expect(e.message).toBe('Cannot get value from localStorage')
+      }
+    })
+
+    it('put', async () => {
+      expect.assertions(1)
+
+      try {
+        await put()
+      } catch (e) {
+        expect(e.message).toBe('Cannot put value into localStorage')
+      }
+    })
+
+    it('clear', async () => {
+      expect.assertions(1)
+
+      try {
+        await clear()
+      } catch (e) {
+        expect(e.message).toBe('Cannot clear localStorage cache')
+      }
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
@@ -1,0 +1,366 @@
+import {
+  get,
+  put,
+  clear,
+  storageId,
+  addListener,
+  removeListener,
+} from '../../../data-iframe/cache'
+
+jest.mock('../../../utils/localStorage', () => () => true)
+
+describe('localStorage cache', () => {
+  let fakeWindow
+  function makeWindow() {
+    fakeWindow = {
+      storage: {},
+      localStorage: {
+        getItem: jest.fn(key => fakeWindow.storage[key]),
+        setItem: jest.fn((key, value) => {
+          if (typeof value !== 'string') {
+            throw new Error('localStorage only supports strings')
+          }
+          fakeWindow.storage[key] = value
+        }),
+        removeItem: jest.fn(key => {
+          delete fakeWindow.storage[key]
+        }),
+      },
+    }
+  }
+  describe('get', () => {
+    beforeEach(() => {
+      makeWindow()
+    })
+
+    it('value is not yet set', async () => {
+      expect.assertions(1)
+
+      expect(await get(fakeWindow, 123, 'hi', 'there')).toBeNull()
+    })
+
+    it('value is set', async () => {
+      expect.assertions(1)
+      fakeWindow.storage[storageId(123, 'hi')] = JSON.stringify({
+        there: 'hello',
+      })
+
+      expect(await get(fakeWindow, 123, 'hi', 'there')).toEqual('hello')
+    })
+
+    it('value is set, but malformed', async () => {
+      expect.assertions(1)
+      fakeWindow.storage[storageId(123, 'hi')] = JSON.stringify({
+        there: 'hello',
+      }).substring(1, 4)
+
+      expect(await get(fakeWindow, 123, 'hi', 'there')).toBeNull()
+    })
+
+    it('value is set, different network', async () => {
+      expect.assertions(1)
+      fakeWindow.storage[storageId(456, 'hi')] = JSON.stringify({
+        there: 'hello',
+      })
+
+      expect(await get(fakeWindow, 123, 'hi', 'there')).toBeNull()
+    })
+
+    it('value is set, different account', async () => {
+      expect.assertions(1)
+      fakeWindow.storage[storageId(123, 'another')] = JSON.stringify({
+        there: 'hello',
+      })
+
+      expect(await get(fakeWindow, 123, 'hi', 'there')).toBeNull()
+    })
+
+    it('value is set, entire cache for user wanted', async () => {
+      expect.assertions(1)
+      fakeWindow.storage[storageId(123, 'hi')] = JSON.stringify({
+        there: 'hello',
+        it: 'is',
+      })
+
+      expect(await get(fakeWindow, 123, 'hi')).toEqual({
+        there: 'hello',
+        it: 'is',
+      })
+    })
+  })
+
+  describe('put', () => {
+    beforeEach(() => {
+      makeWindow()
+    })
+    it('saves the value', async () => {
+      expect.assertions(1)
+
+      await put(fakeWindow, 123, 'hi', 'there', 'hello')
+
+      expect(fakeWindow.storage[storageId(123, 'hi')]).toBe(
+        JSON.stringify({
+          there: 'hello',
+        })
+      )
+    })
+  })
+
+  describe('clear', () => {
+    beforeEach(async () => {
+      makeWindow()
+      await put(fakeWindow, 123, 'hi', 'foo', 'bar')
+      await put(fakeWindow, 456, 'hi', 'foo', 'bar')
+      await put(fakeWindow, 123, 'hi', 'bar', 'bar')
+      await put(fakeWindow, 123, 'bar', 'fooe', 'bare')
+      await put(fakeWindow, 456, 'bar', 'fooe', 'bare')
+      await put(fakeWindow, 123, 'bar', 'bare', 'bare')
+    })
+
+    it('initial value is correct', () => {
+      expect.assertions(1)
+
+      expect(fakeWindow.storage).toEqual({
+        'unlock-protocol/123/bar': '{"fooe":"bare","bare":"bare"}',
+        'unlock-protocol/123/hi': '{"foo":"bar","bar":"bar"}',
+        'unlock-protocol/456/bar': '{"fooe":"bare"}',
+        'unlock-protocol/456/hi': '{"foo":"bar"}',
+      })
+    })
+
+    it('clearing just one value of the cache', async () => {
+      expect.assertions(2)
+
+      await clear(fakeWindow, 123, 'hi', 'foo')
+      expect(fakeWindow.storage).toEqual({
+        'unlock-protocol/123/bar': '{"fooe":"bare","bare":"bare"}',
+        'unlock-protocol/123/hi': '{"bar":"bar"}',
+        'unlock-protocol/456/bar': '{"fooe":"bare"}',
+        'unlock-protocol/456/hi': '{"foo":"bar"}',
+      })
+
+      await clear(fakeWindow, 123, 'hi', 'bar')
+      expect(fakeWindow.storage).toEqual({
+        'unlock-protocol/123/bar': '{"fooe":"bare","bare":"bare"}',
+        'unlock-protocol/123/hi': '{}',
+        'unlock-protocol/456/bar': '{"fooe":"bare"}',
+        'unlock-protocol/456/hi': '{"foo":"bar"}',
+      })
+    })
+
+    it('clearing the whole cache for a user', async () => {
+      expect.assertions(1)
+
+      await clear(fakeWindow, 123, 'hi')
+      expect(fakeWindow.storage).toEqual({
+        'unlock-protocol/123/bar': '{"fooe":"bare","bare":"bare"}',
+        'unlock-protocol/456/bar': '{"fooe":"bare"}',
+        'unlock-protocol/456/hi': '{"foo":"bar"}',
+      })
+    })
+
+    it("does not clear other user's cache", async () => {
+      expect.assertions(1)
+
+      await clear(fakeWindow, 123, 'hi')
+      const bare = await get(fakeWindow, 123, 'bar')
+
+      expect(bare).toEqual({
+        fooe: 'bare',
+        bare: 'bare',
+      })
+    })
+
+    it("does not clear same user's cache on a different network", async () => {
+      expect.assertions(1)
+
+      await clear(fakeWindow, 123, 'hi')
+      const other = await get(fakeWindow, 456, 'hi')
+
+      expect(other).toEqual({
+        foo: 'bar',
+      })
+    })
+  })
+
+  describe('addListener', () => {
+    let fakeWindow
+    let listeners
+    beforeEach(() => {
+      listeners = {}
+      fakeWindow = {
+        addEventListener: (message, listener) => {
+          listeners[message] = listeners[message] || new Map()
+          listeners[message].set(listener, listener)
+        },
+        removeEventListener: (message, listener) => {
+          listeners[message] = listeners[message] || new Map()
+          listeners[message].delete(listener)
+        },
+      }
+    })
+
+    it('adds a listener for a user on a network', async () => {
+      expect.assertions(2)
+      const listen = jest.fn()
+
+      await addListener(fakeWindow, 123, 'hi', listen)
+
+      expect(listeners.storage.size).toBe(1)
+
+      for (let [listener] of listeners.storage) {
+        listener({
+          key: 'unlock-protocol/123/hi',
+          oldValue: 'bye',
+          newValue: 'hi',
+        })
+      }
+      expect(listen).toHaveBeenCalledWith('bye', 'hi')
+    })
+
+    it('clears prior listeners', async () => {
+      expect.assertions(1)
+      const listen = jest.fn()
+
+      await addListener(fakeWindow, 123, 'hi', listen)
+      await addListener(fakeWindow, 123, 'hi', listen)
+
+      expect(listeners.storage.size).toBe(1)
+    })
+
+    it('does not affect listeners on a different network, same user', async () => {
+      expect.assertions(3)
+      const listen = jest.fn()
+      const listen2 = jest.fn()
+
+      await addListener(fakeWindow, 123, 'hi', listen)
+      await addListener(fakeWindow, 456, 'hi', listen2)
+
+      expect(listeners.storage.size).toBe(2)
+
+      for (let [listener] of listeners.storage) {
+        listener({
+          key: 'unlock-protocol/123/hi',
+          oldValue: 'bye',
+          newValue: 'hi',
+        })
+      }
+
+      expect(listen).toHaveBeenCalled()
+      expect(listen2).not.toHaveBeenCalled()
+    })
+
+    it('does not affect listeners for a different user, same network', async () => {
+      expect.assertions(3)
+      const listen = jest.fn()
+      const listen2 = jest.fn()
+
+      await addListener(fakeWindow, 123, 'hi', listen)
+      await addListener(fakeWindow, 123, 'bye', listen2)
+
+      expect(listeners.storage.size).toBe(2)
+
+      for (let [listener] of listeners.storage) {
+        listener({
+          key: 'unlock-protocol/123/hi',
+          oldValue: 'bye',
+          newValue: 'hi',
+        })
+      }
+
+      expect(listen).toHaveBeenCalled()
+      expect(listen2).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('removeListener', () => {
+    let fakeWindow
+    let listeners
+    beforeEach(() => {
+      listeners = {}
+      fakeWindow = {
+        addEventListener: (message, listener) => {
+          listeners[message] = listeners[message] || new Map()
+          listeners[message].set(listener, listener)
+        },
+        removeEventListener: (message, listener) => {
+          listeners[message] = listeners[message] || new Map()
+          listeners[message].delete(listener)
+        },
+      }
+    })
+
+    it('removes a listener for a user on a network', async () => {
+      expect.assertions(2)
+      const listen = jest.fn()
+
+      await addListener(fakeWindow, 123, 'hi', listen)
+
+      expect(listeners.storage.size).toBe(1)
+
+      await removeListener(fakeWindow, 123, 'hi', listen)
+
+      expect(listeners.storage.size).toBe(0)
+    })
+
+    it('does not remove a listener for the same user on a different network', async () => {
+      expect.assertions(5)
+      const listen = jest.fn()
+      const listen2 = jest.fn()
+
+      await addListener(fakeWindow, 123, 'hi', listen)
+      await addListener(fakeWindow, 456, 'hi', listen2)
+
+      expect(listeners.storage.size).toBe(2)
+
+      await removeListener(fakeWindow, 123, 'hi', listen)
+
+      expect(listeners.storage.size).toBe(1)
+
+      for (let [listener] of listeners.storage) {
+        listener({
+          key: 'unlock-protocol/123/hi',
+          oldValue: 'bye',
+          newValue: 'hi',
+        })
+      }
+
+      expect(listen).not.toHaveBeenCalled()
+      expect(listen2).not.toHaveBeenCalled()
+
+      await removeListener(fakeWindow, 456, 'hi', listen2)
+
+      expect(listeners.storage.size).toBe(0)
+    })
+
+    it('does not remove a listener for the same network, different user', async () => {
+      expect.assertions(5)
+      const listen = jest.fn()
+      const listen2 = jest.fn()
+
+      await addListener(fakeWindow, 123, 'hi', listen)
+      await addListener(fakeWindow, 123, 'bye', listen2)
+
+      expect(listeners.storage.size).toBe(2)
+
+      await removeListener(fakeWindow, 123, 'hi', listen)
+
+      expect(listeners.storage.size).toBe(1)
+
+      for (let [listener] of listeners.storage) {
+        listener({
+          key: 'unlock-protocol/123/hi',
+          oldValue: 'bye',
+          newValue: 'hi',
+        })
+      }
+
+      expect(listen).not.toHaveBeenCalled()
+      expect(listen2).not.toHaveBeenCalled()
+
+      await removeListener(fakeWindow, 123, 'bye', listen2)
+
+      expect(listeners.storage.size).toBe(0)
+    })
+  })
+})

--- a/paywall/src/data-iframe/cache/index.js
+++ b/paywall/src/data-iframe/cache/index.js
@@ -1,5 +1,5 @@
 /**
- * All storrage drivers are async
+ * All storage drivers are async
  */
 export {
   get,

--- a/paywall/src/data-iframe/cache/index.js
+++ b/paywall/src/data-iframe/cache/index.js
@@ -1,0 +1,11 @@
+/**
+ * All storrage drivers are async
+ */
+export {
+  get,
+  put,
+  clear,
+  addListener,
+  removeListener,
+  storageId,
+} from './localStorage'

--- a/paywall/src/data-iframe/cache/localStorage.js
+++ b/paywall/src/data-iframe/cache/localStorage.js
@@ -1,0 +1,151 @@
+import localStorageAvailable from '../../utils/localStorage'
+
+export function storageId(networkId, accountAddress) {
+  return `unlock-protocol/${networkId}/${accountAddress}`
+}
+
+/**
+ * retrieve the container from localStorage, ensure the optional type
+ * exists as a key if requested
+ *
+ * @param {string} key the key for the item in localStorage
+ * @param {string} type the sub-key (if any) which must exist on return
+ */
+function getContainer(window, key, type = false) {
+  const value = window.localStorage.getItem(key)
+  if (!value) {
+    if (type) {
+      return { [type]: null }
+    }
+    return {}
+  }
+  let container
+  try {
+    container = JSON.parse(value)
+  } catch (e) {
+    // always work, cache is invalid, so we will overwrite on next write
+    return { [type]: null }
+  }
+
+  if (typeof container !== 'object') {
+    if (type) {
+      return { [type]: null }
+    }
+    return {}
+  }
+
+  if (!type) {
+    return container
+  }
+  if (!container[type]) {
+    container[type] = null
+  }
+  return container
+}
+
+/**
+ * Retrieve a cached value for a user on a specific network
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @param {int} networkId the ethereum network id
+ * @param {string} accountAddress the ethereum account address of the user whose data is cached
+ * @param {string} type the type of account data to retrieve
+ */
+export async function get(window, networkId, accountAddress, type) {
+  if (!localStorageAvailable(window)) {
+    throw new Error('Cannot get value from localStorage')
+  }
+  const key = storageId(networkId, accountAddress)
+
+  const container = getContainer(window, key, type)
+  if (!type) return container
+  return container[type]
+}
+
+/**
+ * Cache a value for a user on a network
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @param {int} networkId the ethereum network id
+ * @param {string} accountAddress the ethereum account address of the user whose data is cached
+ * @param {string} type the type of account data to set
+ * @param {*} value the value to store. This must be serializable as JSON
+ */
+export async function put(window, networkId, accountAddress, type, value) {
+  if (!localStorageAvailable(window)) {
+    throw new Error('Cannot put value into localStorage')
+  }
+  const key = storageId(networkId, accountAddress)
+  const container = getContainer(window, key, type)
+  if (value === undefined) {
+    delete container[type]
+  } else {
+    container[type] = value
+  }
+
+  window.localStorage.setItem(key, JSON.stringify(container))
+}
+
+/**
+ * clear the cache, either for the user or for a specific value
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @param {int} networkId the ethereum network id
+ * @param {string} accountAddress the ethereum account address of the user whose data is cached
+ * @param {string} type the type of account data to set
+ */
+export async function clear(window, networkId, accountAddress, type) {
+  if (!localStorageAvailable(window)) {
+    throw new Error('Cannot clear localStorage cache')
+  }
+  const key = storageId(networkId, accountAddress)
+  if (!type) {
+    window.localStorage.removeItem(key)
+    return
+  }
+
+  await put(window, networkId, accountAddress, type, undefined)
+}
+
+const listeners = {}
+
+/**
+ * Listen for changes to cached values in other tabs
+ *
+ * @param {object} window this is the global context, either global, window or self
+ * @param {int} networkId the ethereum network id
+ * @param {string} accountAddress the ethereum account address of the user whose data is cached
+ */
+export async function addListener(
+  window,
+  networkId,
+  accountAddress,
+  changeCallback = () => {}
+) {
+  const key = storageId(networkId, accountAddress)
+  if (listeners[key]) {
+    removeListener(window, networkId, accountAddress)
+  }
+  listeners[key] = evt => {
+    if (evt.storageArea !== window.localStorage) return // ignore sessionStorage
+    const changedKey = evt.key
+    if (changedKey === key) {
+      changeCallback(evt.oldValue, evt.newValue)
+    }
+  }
+  window.addEventListener('storage', listeners[key])
+}
+
+/**
+ * Stop listening for changes to cached values in other tabs
+ *
+ * @param {object} window this is the global context, either global, window or self
+ * @param {int} networkId the ethereum network id
+ * @param {string} accountAddress the ethereum account address of the user whose data is cached
+ */
+export async function removeListener(window, networkId, accountAddress) {
+  const key = storageId(networkId, accountAddress)
+  if (!listeners[key]) return
+  window.removeEventListener('storage', listeners[key])
+  delete listeners[key]
+}


### PR DESCRIPTION
# Description

As a part of the Forbes ad remover paywall, caching will be important. This implements a caching library. There is a non-trivial chance that we may need to move to a different kind of backend, and all of the other possibilities (`Cache`, `indexeddb`) are async, so this makes the `localStorage` driver async.

Otherwise it's pretty standard cache stuff, with `get`, `put` and `clear` which can be done by user, or by sub-key (like keys, for instance)

Because localStorage can be changed in any open tab, this also provides a facility to listen for changes to the localStorage key for a specific user on a specific network.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
