### PR TITLE
Also store user email along with encrypted private key

### DIFF
--- a/unlock-app/src/__tests__/actions/user.test.ts
+++ b/unlock-app/src/__tests__/actions/user.test.ts
@@ -82,13 +82,15 @@ describe('user account actions', () => {
             'b8b010fff37f9ae5559a352a185e86f9b9c1d7f7a9f1bd4e82a5dd35468fc7f6',
         },
       }
+      const email = 'ray@smuckles.escalade'
 
       const expectedAction = {
         type: SET_ENCRYPTED_PRIVATE_KEY,
         key,
+        email,
       }
 
-      expect(setEncryptedPrivateKey(key)).toEqual(expectedAction)
+      expect(setEncryptedPrivateKey(key, email)).toEqual(expectedAction)
     })
   })
 

--- a/unlock-app/src/__tests__/reducers/privateKeyReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/privateKeyReducer.test.ts
@@ -7,45 +7,53 @@ import { SET_NETWORK } from '../../actions/network'
 import { SET_ACCOUNT } from '../../actions/accounts'
 
 const oldKeyState = {
-  version: 3,
-  id: '04e9bcbb-96fa-497b-94d1-14df4cd20af6',
-  address: '2c7536e3605d9c16a7a3d7b1898e529396a65c23',
-  crypto: {
-    ciphertext:
-      'a1c25da3ecde4e6a24f3697251dd15d6208520efc84ad97397e906e6df24d251',
-    cipherparams: { iv: '2885df2b63f7ef247d753c82fa20038a' },
-    cipher: 'aes-128-ctr',
-    kdf: 'scrypt',
-    kdfparams: {
-      dklen: 32,
-      salt: '4531b3c174cc3ff32a6a7a85d6761b410db674807b2d216d022318ceee50be10',
-      n: 262144,
-      r: 8,
-      p: 1,
+  key: {
+    version: 3,
+    id: '04e9bcbb-96fa-497b-94d1-14df4cd20af6',
+    address: '2c7536e3605d9c16a7a3d7b1898e529396a65c23',
+    crypto: {
+      ciphertext:
+        'a1c25da3ecde4e6a24f3697251dd15d6208520efc84ad97397e906e6df24d251',
+      cipherparams: { iv: '2885df2b63f7ef247d753c82fa20038a' },
+      cipher: 'aes-128-ctr',
+      kdf: 'scrypt',
+      kdfparams: {
+        dklen: 32,
+        salt:
+          '4531b3c174cc3ff32a6a7a85d6761b410db674807b2d216d022318ceee50be10',
+        n: 262144,
+        r: 8,
+        p: 1,
+      },
+      mac: 'b8b010fff37f9ae5559a352a185e86f9b9c1d7f7a9f1bd4e82a5dd35468fc7f6',
     },
-    mac: 'b8b010fff37f9ae5559a352a185e86f9b9c1d7f7a9f1bd4e82a5dd35468fc7f6',
   },
+  email: 'bees@bzzzzzzzzzz.sting',
 }
 
 const newKeyState = {
-  version: 3,
-  id: 'different than the other one',
-  address: '2c7536e3605d9c16a7a3d7b1898e529396a65c23',
-  crypto: {
-    ciphertext:
-      'a1c25da3ecde4e6a24f3697251dd15d6208520efc84ad97397e906e6df24d251',
-    cipherparams: { iv: '2885df2b63f7ef247d753c82fa20038a' },
-    cipher: 'ROT13',
-    kdf: 'scrypt',
-    kdfparams: {
-      dklen: 32,
-      salt: '4531b3c174cc3ff32a6a7a85d6761b410db674807b2d216d022318ceee50be10',
-      n: 262144,
-      r: 8,
-      p: 1,
+  key: {
+    version: 3,
+    id: 'different than the other one',
+    address: '2c7536e3605d9c16a7a3d7b1898e529396a65c23',
+    crypto: {
+      ciphertext:
+        'a1c25da3ecde4e6a24f3697251dd15d6208520efc84ad97397e906e6df24d251',
+      cipherparams: { iv: '2885df2b63f7ef247d753c82fa20038a' },
+      cipher: 'ROT13',
+      kdf: 'scrypt',
+      kdfparams: {
+        dklen: 32,
+        salt:
+          '4531b3c174cc3ff32a6a7a85d6761b410db674807b2d216d022318ceee50be10',
+        n: 262144,
+        r: 8,
+        p: 1,
+      },
+      mac: 'b8b010fff37f9ae5559a352a185e86f9b9c1d7f7a9f1bd4e82a5dd35468fc7f6',
     },
-    mac: 'b8b010fff37f9ae5559a352a185e86f9b9c1d7f7a9f1bd4e82a5dd35468fc7f6',
   },
+  email: 'angrybees@BZZZZZZZZZZZZZ.STING',
 }
 
 describe('privateKeyReducer', () => {
@@ -62,9 +70,9 @@ describe('privateKeyReducer', () => {
     expect.assertions(2)
     const action = {
       type: SET_ENCRYPTED_PRIVATE_KEY,
-      key: newKeyState,
+      key: newKeyState.key,
+      email: 'angrybees@BZZZZZZZZZZZZZ.STING',
     }
-
     expect(reducer(initialState, action)).toEqual(newKeyState)
     expect(reducer(oldKeyState, action)).toEqual(newKeyState)
   })

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -71,7 +71,11 @@ export const gotPassword = (password: string) => ({
 // when a user logs in. This provides a bit of a timing concern, since
 // SET_ACCOUNT usually wipes out all the state. So SET_ACCOUNT must be sent
 // first.
-export const setEncryptedPrivateKey = (key: EncryptedPrivateKey) => ({
+export const setEncryptedPrivateKey = (
+  key: EncryptedPrivateKey,
+  email: string
+) => ({
   type: SET_ENCRYPTED_PRIVATE_KEY,
   key,
+  email,
 })

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -70,7 +70,7 @@ export const createUnlockStore = (
     errors: errorsReducer,
     lockFormStatus: lockFormVisibilityReducer,
     fullScreenModalStatus: fullScreenModalsReducer,
-    encryptedPrivateKey: privateKeyReducer,
+    userDetails: privateKeyReducer,
   }
 
   // Cleanup the defaultState to remove all null values so that we do not overwrite existing
@@ -96,7 +96,7 @@ export const createUnlockStore = (
       errors: defaultError,
       lockFormStatus: defaultLockFormVisibility,
       fullScreenModalStatus: defaultFullScreenModalsStatus,
-      encryptedPrivateKey: defaultPrivateKeyState,
+      userDetails: defaultPrivateKeyState,
     },
     {
       provider: Object.keys(config.providers)[0],

--- a/unlock-app/src/reducers/privateKeyReducer.ts
+++ b/unlock-app/src/reducers/privateKeyReducer.ts
@@ -4,16 +4,22 @@ import { SET_NETWORK } from '../actions/network'
 import { SET_ACCOUNT } from '../actions/accounts'
 import { Action, EncryptedPrivateKey } from '../unlockTypes' // eslint-disable-line no-unused-vars
 
-type State = EncryptedPrivateKey | null
+type State = { key: EncryptedPrivateKey; email: string } | null
 export const initialState: State = null
 
-const privateKeyReducer = (state: State = initialState, action: Action) => {
+const privateKeyReducer = (
+  state: State = initialState,
+  action: Action
+): State => {
   if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
     return initialState
   }
 
   if (action.type === SET_ENCRYPTED_PRIVATE_KEY) {
-    return action.key
+    return {
+      key: action.key,
+      email: action.email,
+    }
   }
 
   return state


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR follows on #3143 to correct a small oversight. Just having the user's encrypted key isn't enough, because we also need their email address to construct a `locksmith` call. This PR stores the email along with the key in the Redux state.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
