### PR TITLE
postOffice: postMessage handler for iframe/main window communication

### DIFF
--- a/paywall/src/__tests__/utils/postOffice.test.js
+++ b/paywall/src/__tests__/utils/postOffice.test.js
@@ -1,0 +1,311 @@
+import {
+  setupPostOffice,
+  _clearHandlers,
+  setHandler,
+  iframePostOffice,
+  mainWindowPostOffice,
+} from '../../utils/postOffice'
+
+describe('postOffice', () => {
+  describe('setupPostOffice', () => {
+    let fakeWindow
+    let fakeTarget
+
+    beforeEach(() => {
+      fakeWindow = {
+        handlers: {},
+        addEventListener(type, handler) {
+          fakeWindow.handlers[type] = handler
+        },
+      }
+      fakeTarget = {
+        postMessage: jest.fn(),
+      }
+    })
+
+    it('throws if targetOrigin is not specified', () => {
+      expect.assertions(1)
+
+      expect(() => {
+        setupPostOffice(fakeWindow, fakeTarget)
+      }).toThrow('cannot safely postMessage without knowing the target origin')
+    })
+
+    it('throws if target is not specified', () => {
+      expect.assertions(1)
+
+      expect(() => {
+        setupPostOffice(fakeWindow, undefined, 'hi')
+      }).toThrow('cannot safely postMessage without knowing the target origin')
+    })
+
+    it('adds a message event listener', () => {
+      expect.assertions(1)
+
+      setupPostOffice(fakeWindow, fakeTarget, 'hi')
+      expect(fakeWindow.handlers.message).toEqual(expect.any(Function))
+    })
+
+    describe('message listener', () => {
+      beforeEach(() => {
+        fakeWindow = {
+          handlers: {},
+          addEventListener(type, handler) {
+            fakeWindow.handlers[type] = handler
+          },
+        }
+        fakeTarget = {
+          postMessage: jest.fn(),
+        }
+        _clearHandlers()
+      })
+
+      it('bails if message is not from our target', () => {
+        expect.assertions(2)
+
+        const listener = jest.fn()
+        setHandler('hi', listener)
+        setupPostOffice(fakeWindow, fakeTarget, 'origin')
+
+        fakeWindow.handlers.message({
+          source: 'not from us',
+          origin: 'origin',
+          data: {
+            type: 'hi',
+            payload: 'hi again',
+          },
+        })
+
+        expect(listener).toHaveBeenCalledTimes(0)
+
+        fakeWindow.handlers.message({
+          source: fakeTarget,
+          origin: 'not our origin',
+          data: {
+            type: 'hi',
+            payload: 'hi again',
+          },
+        })
+
+        expect(listener).toHaveBeenCalledTimes(0)
+      })
+
+      it('bails if the message data is malformed', () => {
+        expect.assertions(4)
+
+        const listener = jest.fn()
+        setHandler('hi', listener)
+        setupPostOffice(fakeWindow, fakeTarget, 'origin')
+
+        fakeWindow.handlers.message({
+          source: fakeTarget,
+          origin: 'origin',
+        })
+
+        expect(listener).toHaveBeenCalledTimes(0)
+
+        fakeWindow.handlers.message({
+          source: fakeTarget,
+          origin: 'origin',
+          data: {},
+        })
+
+        expect(listener).toHaveBeenCalledTimes(0)
+
+        fakeWindow.handlers.message({
+          source: fakeTarget,
+          origin: 'origin',
+          data: {
+            type: 'oops',
+          },
+        })
+
+        expect(listener).toHaveBeenCalledTimes(0)
+
+        fakeWindow.handlers.message({
+          source: fakeTarget,
+          origin: 'origin',
+          data: {
+            type: 1,
+            payload: 'oops',
+          },
+        })
+
+        expect(listener).toHaveBeenCalledTimes(0)
+      })
+
+      it('calls the handler for the message type', () => {
+        expect.assertions(1)
+
+        const listener = jest.fn()
+        setHandler('hi', listener)
+        setupPostOffice(fakeWindow, fakeTarget, 'origin')
+
+        fakeWindow.handlers.message({
+          source: fakeTarget,
+          origin: 'origin',
+          data: {
+            type: 'hi',
+            payload: 'it worked!',
+          },
+        })
+
+        expect(listener).toHaveBeenCalledWith(
+          'it worked!',
+          expect.any(Function)
+        )
+      })
+
+      it('does nothing if there is no handler for the type', () => {
+        expect.assertions(1)
+
+        const listener = jest.fn()
+        setHandler('hi', listener)
+        setupPostOffice(fakeWindow, fakeTarget, 'origin')
+
+        fakeWindow.handlers.message({
+          source: fakeTarget,
+          origin: 'origin',
+          data: {
+            type: 'not hi',
+            payload: 'it worked!',
+          },
+        })
+
+        expect(listener).not.toHaveBeenCalled()
+      })
+
+      describe('message handler', () => {
+        let listener
+        beforeEach(() => {
+          listener = jest.fn()
+          setHandler('hi', listener)
+          setupPostOffice(fakeWindow, fakeTarget, 'origin')
+
+          fakeWindow.handlers.message({
+            source: fakeTarget,
+            origin: 'origin',
+            data: {
+              type: 'hi',
+              payload: 'it worked!',
+            },
+          })
+        })
+
+        it('calls the handler with a response callback', () => {
+          expect.assertions(1)
+
+          const response = listener.mock.calls[0][1]
+
+          response('type', 'response')
+
+          expect(fakeTarget.postMessage).toHaveBeenCalledWith(
+            { type: 'type', payload: 'response' },
+            'origin'
+          )
+        })
+      })
+    })
+  })
+
+  describe('iframePostOffice', () => {
+    let fakeWindow
+    let fakeTarget
+
+    beforeEach(() => {
+      fakeTarget = {
+        postMessage: jest.fn(),
+      }
+
+      fakeWindow = {
+        parent: fakeTarget,
+        location: {
+          href: 'http://example.com?origin=http%3A%2F%2Ffun.times',
+        },
+        handlers: {},
+        addEventListener(type, handler) {
+          fakeWindow.handlers[type] = handler
+        },
+      }
+      _clearHandlers()
+    })
+
+    it('calls setupPostOffice with the iframe params', () => {
+      expect.assertions(1)
+
+      const listener = jest.fn()
+      setHandler('hi', listener)
+
+      iframePostOffice(fakeWindow)
+
+      fakeWindow.handlers.message({
+        source: fakeTarget,
+        origin: 'http://fun.times',
+        data: {
+          type: 'hi',
+          payload: 'it worked!',
+        },
+      })
+
+      const response = listener.mock.calls[0][1]
+
+      response('type', 'response')
+
+      expect(fakeTarget.postMessage).toHaveBeenCalledWith(
+        { type: 'type', payload: 'response' },
+        'http://fun.times'
+      )
+    })
+  })
+
+  describe('mainWindowPostOffice', () => {
+    let fakeWindow
+    let iframe
+
+    beforeEach(() => {
+      iframe = {
+        contentWindow: {
+          postMessage: jest.fn(),
+        },
+      }
+
+      fakeWindow = {
+        location: {
+          href: 'http://example.com?origin=http%3A%2F%2Ffun.times',
+        },
+        handlers: {},
+        addEventListener(type, handler) {
+          fakeWindow.handlers[type] = handler
+        },
+      }
+      _clearHandlers()
+    })
+
+    it('calls setupPostOffice with the main window params', () => {
+      expect.assertions(1)
+
+      const listener = jest.fn()
+      setHandler('hi', listener)
+
+      mainWindowPostOffice(fakeWindow, iframe, 'http://fun.times')
+
+      fakeWindow.handlers.message({
+        source: iframe.contentWindow,
+        origin: 'http://fun.times',
+        data: {
+          type: 'hi',
+          payload: 'it worked!',
+        },
+      })
+
+      const response = listener.mock.calls[0][1]
+
+      response('type', 'response')
+
+      expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+        { type: 'type', payload: 'response' },
+        'http://fun.times'
+      )
+    })
+  })
+})

--- a/paywall/src/utils/postOffice.js
+++ b/paywall/src/utils/postOffice.js
@@ -9,7 +9,7 @@ let handlers = {}
  *
  * A message is of format: { type: 'type', payload: <any> }
  *
- * Handlers are passed teh payload and a callback that can be used to send
+ * Handlers are passed the payload and a callback that can be used to send
  * a response to the iframe that sent the query. It accepts the type and
  * the response payload
  *

--- a/paywall/src/utils/postOffice.js
+++ b/paywall/src/utils/postOffice.js
@@ -1,0 +1,93 @@
+let handlers = {}
+
+/**
+ * postMessage manager
+ *
+ * This abstracts the setting up of listeners and senders for postMessage
+ * It handles all security-related aspects and allows setting handlers that
+ * respond to specific message types.
+ *
+ * A message is of format: { type: 'type', payload: <any> }
+ *
+ * Handlers are passed teh payload and a callback that can be used to send
+ * a response to the iframe that sent the query. It accepts the type and
+ * the response payload
+ *
+ * @param {window} window the current window context
+ * @param {window} target the target window object
+ * @param {string} targetOrigin the origin of the target (in CORS settings
+ *                              this cannot be retrieved from the target)
+ */
+export function setupPostOffice(window, target, targetOrigin) {
+  if (!targetOrigin || !target) {
+    throw new Error(
+      'cannot safely postMessage without knowing the target origin'
+    )
+  }
+  window.addEventListener('message', event => {
+    // **SECURITY CHECKS**
+    // ignore messages that do not come from our target window
+    if (event.source !== target || event.origin !== targetOrigin) return
+    // data must be of shape { type: 'type', payload: <value> }
+    if (!event.data || !event.data.type) return
+    if (!event.data.hasOwnProperty('payload')) return
+    if (typeof event.data.type !== 'string') return
+    if (handlers[event.data.type]) {
+      const handler = handlers[event.data.type]
+      handler(event.data.payload, (type, response) => {
+        if (typeof type !== 'string') {
+          throw new Error('internal error: type must be a string')
+        }
+        target.postMessage({ type, payload: response }, targetOrigin)
+      })
+    }
+  })
+}
+
+/**
+ * set up a post office inside an iframe
+ *
+ * Note: the iframe *must* have a search parameter containing the parent window's origin
+ *
+ * https://iframe.url.com/?origin=<url-encoded parent window origin>
+ *
+ * @param {window} the iframe's window object
+ */
+export function iframePostOffice(window) {
+  const url = new URL(window.location.href)
+  const origin = url.searchParams.get('origin')
+  setupPostOffice(window, window.parent, origin)
+}
+
+/**
+ * set up a post office inside the primary application window
+ *
+ * @param {window} window the main window's window object
+ * @param {iframe} iframe the iframe tag (created with document.createElement())
+ * @param {string} iframeOrigin the origin of the created iframe
+ */
+export function mainWindowPostOffice(window, iframe, iframeOrigin) {
+  setupPostOffice(window, iframe.contentWindow, iframeOrigin)
+}
+
+/**
+ * @callback handlerCallback
+ * @param {string} type the message type to send
+ * @param {*} response the response to the original message.
+ *                     This is the payload of the response message
+ */
+
+/**
+ * Set a handler for a posted message
+ *
+ * @param {string} type the message type this handler is intended to respond to
+ * @param {handlerCallback}}handler the callback. This should
+ */
+export function setHandler(type, handler) {
+  handlers[type] = handler
+}
+
+// for unit testing, clearing state between tests
+export function _clearHandlers() {
+  handlers = {}
+}


### PR DESCRIPTION
# Description

`postOffice` is a one-stop shop for abstracting the vagaries of `postMessage` away, and making it easy to securely and accurately communicate, both 1 and 2-way messaging.

For example, on the iframe side:

```js
// 1-way binding
import { iframePostOffice, setHandler } from './postOffice'

setHandler('account', (address) => {
  locksmith.getPastTransactions(address)
})

iframePostOffice(window)
```

and in the main window (a 2-way binding example):

```js
import { mainWindowPostOffice, setHandler } from './postOffice'

setHandler('getAccount', (_, respond) => {
  window.web3.currentProvider.getAccounts().then(accounts => respond('account', accounts[0]))
})

mainWindowPostOffice(window, iframe, iframeOrigin)
```

For a (contrived) example of posting a message from a context outside of responding to another message:

```js
import { iframePostOffice, setHandler } from './postOffice'

const postMessage = iframePostOffice(window)
walletService.on('lock.updated', (hash, lock) => {
  postMessage('lock.updated', { hash, ...lock}
})
```

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
