### PR TITLE
Store the encrypted private key in Redux

### DIFF
--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -20,6 +20,7 @@ import {
   SIGNUP_CREDENTIALS,
   loginFailed,
   loginSucceeded,
+  setEncryptedPrivateKey,
 } from '../actions/user'
 import UnlockUser from '../structured_data/unlockUser'
 
@@ -146,7 +147,9 @@ const storageMiddleware = config => {
               const account = getAccountFromPrivateKey(key, password)
               if (account && account.address) {
                 dispatch(loginSucceeded())
-                dispatch(setAccount(account))
+                // setAccount call must come before setEncryptedPrivateKey
+                dispatch(setAccount({ address: account.address }))
+                dispatch(setEncryptedPrivateKey(key, emailAddress))
               }
             } catch (err) {
               dispatch(loginFailed(err))


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR follows on #3143 and #3163 and actually dispatches the action that sets the user details (including encrypted private key) in Redux.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
