### PR TITLE
adding a script which starts ganache and transfers some of the accounts[0] eth to the ETHEREUM_ACCOUNT

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "link-parent-bin": "link-parent-bin -c . -s true",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start-ganache": "ganache-cli -i 1984 --mnemonic 'hello unlock save the web'",
+    "start-ganache": "./scripts/start-ganache.sh",
     "postinstall": "./scripts/postinstall.sh",
     "build": "cd smart-contracts && npm run build && cd ../unlock-app && npm run build && cd ../locksmith && npm run build",
     "start": "./scripts/start.sh",

--- a/scripts/start-ganache.sh
+++ b/scripts/start-ganache.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Fail if anything fails!
+set -e
+
+# This script starts ganache along with the extra params passed to it
+# Optionally, if an ETHEREUM_ACCOUNT env variable is set, the script
+# will transfer some of the eth of the first unlocked account on the ganache
+# node to it.
+
+NETWORK_ID=1984
+MNEMONIC="'hello unlock save the web'"
+EXTRA_PARAMS=$@
+PORT=8545
+HOST=localhost
+UNLOCK_ENV=dev # defaults to dev
+FROM="0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2" # First unlocked account on node
+AMOUNT=10000000000000000000 # 10 Eth (by default  unlocked account on the node have 100 Eth)
+DOT_ENV_FILE=".env.$UNLOCK_ENV.local"
+
+echo "> ganache-cli -i $NETWORK_ID -p $PORT -h $HOST --mnemonic $MNEMONIC $EXTRA_PARAMS"
+ganache-cli -i $NETWORK_ID -p $PORT -h $HOST --mnemonic $MNEMONIC $EXTRA_PARAMS &
+
+
+if [ -f $DOT_ENV_FILE ]
+then
+  source $DOT_ENV_FILE
+  if [ -n "$ETHEREUM_ADDRESS" ]
+  then
+    echo "> Sending $AMOUNT to $ETHEREUM_ADDRESS from $FROM"
+    sleep 5 # We need to wait 5 seconds for the ganache node to be ready... not great but
+    # should work for now
+    POST_PARAMS="{\"jsonrpc\":\"2.0\",\"method\":\"eth_sendTransaction\",\"params\":[{\"from\":\"$FROM\",\"to\":\"$ETHEREUM_ADDRESS\",\"value\":\"$AMOUNT\"}],\"id\":1}"
+    curl -X POST --data "$POST_PARAMS" http://$HOST:$PORT/
+  fi
+fi


### PR DESCRIPTION
# Description

This is a step into letting us use Metamask for local dev.
It adds ether to the users account (set as the env var ETHEREUM_ADDRESS) when starting.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread