### PR TITLE
export enable, send a different error if we have no web3 at all

### DIFF
--- a/paywall/src/__tests__/paywall-builder/config.test.js
+++ b/paywall/src/__tests__/paywall-builder/config.test.js
@@ -1,4 +1,8 @@
-import { sendConfig, setupReadyListener } from '../../paywall-builder/config'
+import {
+  sendConfig,
+  setupReadyListener,
+  enable,
+} from '../../paywall-builder/config'
 import {
   POST_MESSAGE_CONFIG,
   POST_MESSAGE_READY,
@@ -260,6 +264,40 @@ describe('paywall configuration inter-window communication', () => {
 
         expect(iframe.contentWindow.postMessage).not.toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('enable', () => {
+    it('throws ReferenceError if web3 is not available', async () => {
+      expect.assertions(2)
+
+      try {
+        await enable({
+          Promise: Promise,
+        })
+      } catch (e) {
+        expect(e).toBeInstanceOf(ReferenceError)
+        expect(e.message).toBe('no web3 wallet exists')
+      }
+    })
+
+    it('throws if the provider enable throws', async () => {
+      expect.assertions(1)
+
+      try {
+        await enable({
+          Promise: Promise,
+          web3: {
+            currentProvider: {
+              enable: async () => {
+                throw new Error('oops')
+              },
+            },
+          },
+        })
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error)
+      }
     })
   })
 })

--- a/paywall/src/paywall-builder/config.js
+++ b/paywall/src/paywall-builder/config.js
@@ -16,11 +16,20 @@ export function sendConfig(config, iframe, origin) {
   )
 }
 
-function enable(window) {
+export function enable(window) {
   return new window.Promise((resolve, reject) => {
-    if (!window.web3 || !window.web3.currentProvider) return reject()
+    if (!window.web3 || !window.web3.currentProvider) {
+      return reject(new ReferenceError('no web3 wallet exists'))
+    }
     if (!window.web3.currentProvider.enable) return resolve()
-    window.web3.currentProvider.enable().then(resolve)
+    window.web3.currentProvider
+      .enable()
+      .then(() => {
+        return resolve()
+      })
+      .catch(e => {
+        reject(e)
+      })
   })
 }
 


### PR DESCRIPTION
# Description

In order to detect the difference between not having web3, and when the user declines to enable the wallet, `enable` now throws a `ReferenceError` for web3 not existing (which fits its purpose). In addition, in order to re-use this inside the `web3Proxy`, the function is publicly exported

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
