### PR TITLE
Move KeyChainContent to use master LogInSignUp component

### DIFF
--- a/unlock-app/src/components/content/KeyChainContent.js
+++ b/unlock-app/src/components/content/KeyChainContent.js
@@ -8,65 +8,32 @@ import DeveloperOverlay from '../developer/DeveloperOverlay'
 import Layout from '../interface/Layout'
 import Account from '../interface/Account'
 import { pageTitle } from '../../constants'
-import LogIn from '../interface/LogIn'
-import SignUp from '../interface/SignUp'
-import FinishSignup from '../interface/FinishSignup'
+import LogInSignUp from '../interface/LogInSignUp'
 
-export class KeyChainContent extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      // TODO: Add method to toggle signup and pass it to subcomponents, so that
-      // we can switch back and forth between views for logging in and signing
-      // up.
-      signup: true,
-    }
-  }
+export const KeyChainContent = ({ account, network, router }) => {
+  const { hash } = router.location
+  const emailAddress = hash.slice(1) // trim off leading '#'
 
-  toggleSignup = () => {
-    this.setState(prevState => ({
-      ...prevState,
-      signup: !prevState.signup,
-    }))
-  }
-
-  render() {
-    const { account, network, router } = this.props
-    const { signup } = this.state
-    const { hash } = router.location
-    const emailAddress = hash.slice(1) // trim off leading '#'
-
-    return (
-      <GlobalErrorConsumer>
-        <Layout title="Key Chain">
-          <Head>
-            <title>{pageTitle('Key Chain')}</title>
-          </Head>
-          {account && (
-            <BrowserOnly>
-              <Account network={network} account={account} />
-              <DeveloperOverlay />
-            </BrowserOnly>
-          )}
-          {!account && !signup && (
-            <BrowserOnly>
-              <LogIn toggleSignup={this.toggleSignup} />
-            </BrowserOnly>
-          )}
-          {!account && signup && !emailAddress && (
-            <BrowserOnly>
-              <SignUp toggleSignup={this.toggleSignup} />
-            </BrowserOnly>
-          )}
-          {!account && signup && emailAddress && (
-            <BrowserOnly>
-              <FinishSignup emailAddress={emailAddress} />
-            </BrowserOnly>
-          )}
-        </Layout>
-      </GlobalErrorConsumer>
-    )
-  }
+  return (
+    <GlobalErrorConsumer>
+      <Layout title="Key Chain">
+        <Head>
+          <title>{pageTitle('Key Chain')}</title>
+        </Head>
+        {account && (
+          <BrowserOnly>
+            <Account network={network} account={account} />
+            <DeveloperOverlay />
+          </BrowserOnly>
+        )}
+        {!account && (
+          // Default to sign up form. User can toggle to login. If email
+          // address is truthy, do the signup flow.
+          <LogInSignUp signup emailAddress={emailAddress} />
+        )}
+      </Layout>
+    </GlobalErrorConsumer>
+  )
 }
 
 KeyChainContent.propTypes = {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR is a little bit of cleanup utilizing #3159. Now the `KeyChain` page makes use of a master component for the login/signup flow instead of having a bunch of little components and conditions.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
