### PR TITLE
Web3ProxyProvider for inter-window communication to a wallet

### DIFF
--- a/paywall/src/__tests__/providers/Web3ProxyProvider.test.js
+++ b/paywall/src/__tests__/providers/Web3ProxyProvider.test.js
@@ -1,0 +1,172 @@
+import { WalletService } from '@unlock-protocol/unlock-js'
+import Web3ProxyProvider from '../../providers/Web3ProxyProvider'
+import {
+  POST_MESSAGE_READY,
+  POST_MESSAGE_WALLET_INFO,
+  POST_MESSAGE_WEB3,
+} from '../../paywall-builder/constants'
+
+describe('Web3ProxyProvider', () => {
+  let fakeWindow
+  let fakeParent
+  const unlockAddress = '0x1234567890123456789012345678901234567890'
+
+  function fakeEvent(type, payload) {
+    fakeWindow.handlers.message({
+      source: fakeParent,
+      origin: 'origin',
+      data: {
+        type,
+        payload,
+      },
+    })
+  }
+  beforeEach(() => {
+    fakeParent = {
+      postMessage: jest.fn(),
+    }
+
+    fakeWindow = {
+      location: {
+        href: 'http://localhost?origin=origin',
+      },
+      parent: fakeParent,
+      handlers: {},
+      addEventListener: (type, handler) => {
+        fakeWindow.handlers[type] = handler
+      },
+    }
+  })
+
+  it('posts POST_MESSAGE_READY on init', () => {
+    expect.assertions(1)
+    new Web3ProxyProvider(fakeWindow)
+
+    expect(fakeParent.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: POST_MESSAGE_READY,
+        payload: undefined,
+      }),
+      'origin'
+    )
+  })
+
+  it('throws if the wallet info has not yet been received', async () => {
+    expect.assertions(2)
+    const provider = new Web3ProxyProvider(fakeWindow)
+    const walletService = new WalletService({ unlockAddress })
+
+    try {
+      await walletService.connect(provider)
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+      expect(e.message).toBe('no ethereum wallet is available')
+    }
+  })
+
+  it('throws if the wallet info says we have no wallet', async () => {
+    expect.assertions(2)
+    const provider = new Web3ProxyProvider(fakeWindow)
+    const walletService = new WalletService({ unlockAddress })
+
+    fakeEvent(POST_MESSAGE_WALLET_INFO, {
+      isMetamask: false,
+      noWallet: true,
+      notEnabled: false,
+    })
+    try {
+      await walletService.connect(provider)
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+      expect(e.message).toBe('no ethereum wallet is available')
+    }
+  })
+
+  it('throws if the wallet info says we rejected being enabled', async () => {
+    expect.assertions(2)
+    const provider = new Web3ProxyProvider(fakeWindow)
+    const walletService = new WalletService({ unlockAddress })
+
+    fakeEvent(POST_MESSAGE_WALLET_INFO, {
+      isMetamask: false,
+      noWallet: false,
+      notEnabled: true,
+    })
+    try {
+      await walletService.connect(provider)
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+      expect(e.message).toBe('user declined to enable the ethereum wallet')
+    }
+  })
+
+  it('posts the right message for net_version', async done => {
+    expect.assertions(2)
+    const provider = new Web3ProxyProvider(fakeWindow)
+    const walletService = new WalletService({ unlockAddress })
+
+    fakeEvent(POST_MESSAGE_WALLET_INFO, {
+      isMetamask: false,
+      noWallet: false,
+      notEnabled: false,
+    })
+
+    fakeParent.postMessage = (data, origin) => {
+      expect(data).toEqual({
+        type: POST_MESSAGE_WEB3,
+        payload: {
+          method: 'net_version',
+          params: [],
+          id: 1,
+        },
+      })
+      expect(origin).toBe('origin')
+      done()
+    }
+    await walletService.connect(provider)
+  })
+
+  it('returns the right values', async () => {
+    expect.assertions(4)
+    const provider = new Web3ProxyProvider(fakeWindow)
+    const spy = jest.spyOn(provider, 'sendAsync')
+    const walletService = new WalletService({ unlockAddress })
+
+    fakeEvent(POST_MESSAGE_WALLET_INFO, {
+      isMetamask: false,
+      noWallet: false,
+      notEnabled: false,
+    })
+
+    fakeParent.postMessage = (data, origin) => {
+      expect(data).toEqual({
+        type: POST_MESSAGE_WEB3,
+        payload: {
+          method: 'net_version',
+          params: [],
+          id: 1,
+        },
+      })
+      expect(origin).toBe('origin')
+      setTimeout(() => {
+        fakeEvent(POST_MESSAGE_WEB3, {
+          error: null,
+          result: {
+            id: 1,
+            jsonrpc: '2.0',
+            result: '1',
+          },
+        })
+      })
+    }
+    await walletService.connect(provider)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'net_version',
+        params: [],
+      }),
+      expect.any(Function)
+    )
+  })
+})

--- a/paywall/src/providers/Web3ProxyProvider.js
+++ b/paywall/src/providers/Web3ProxyProvider.js
@@ -1,0 +1,78 @@
+import { iframePostOffice, setHandler } from '../utils/postOffice'
+import {
+  POST_MESSAGE_WEB3,
+  POST_MESSAGE_READY,
+  POST_MESSAGE_WALLET_INFO,
+} from '../paywall-builder/constants'
+
+/**
+ * an iframe->main window web3 wallet proxy provider
+ *
+ * This provider allows WalletService to interface with a wallet it
+ * does not directly have access to
+ *
+ * It is used to proxy all net calls to the main window, including transactions
+ * It also returns results from the main window, which must be running
+ * `web3Proxy` as a listener for the postMessage calls
+ */
+export default class Web3ProxyProvider {
+  constructor(window) {
+    // set up the post office inside the iframe
+    this.postMessage = iframePostOffice(window)
+
+    // this is the postMessage version of connecting to the wallet
+    setHandler(POST_MESSAGE_WALLET_INFO, walletInfo => {
+      if (!walletInfo || typeof walletInfo !== 'object') {
+        return
+      }
+      this.isMetamask = !!walletInfo.isMetamask
+      this.noWallet = !!walletInfo.noWallet
+      this.notEnabled = !!walletInfo.notEnabled
+    })
+
+    // this is the postMessage version of the callback for sendAsync
+    setHandler(POST_MESSAGE_WEB3, web3Result => {
+      if (
+        !web3Result.hasOwnProperty('error') ||
+        !web3Result.hasOwnProperty('result')
+      ) {
+        return
+      }
+      const { result, error } = web3Result
+      const id = result.id
+      if (!this.requests[id]) {
+        // no pending request with that id
+        return
+      }
+      const callback = this.requests[id]
+      delete this.requests[id]
+      result.id = 42 // ethers needs to not do this...
+      callback(error, result)
+    })
+
+    this.id = 0
+    this.requests = {}
+
+    this.noWallet = true // until we hear back from the main window
+    this.postMessage(POST_MESSAGE_READY)
+  }
+
+  /**
+   * @param {object} methodCall this object contains the method and params for the json-rpc call
+   * @param {function} callback this is a standard node callback
+   */
+  sendAsync({ method, params }, callback) {
+    if (this.noWallet) {
+      callback(new Error('no ethereum wallet is available'))
+      return
+    }
+    if (this.notEnabled) {
+      callback(new Error('user declined to enable the ethereum wallet'))
+      return
+    }
+    const id = ++this.id // ethers always uses 42, so we will use our own id
+    this.requests[id] = callback
+    const payload = { method, params, id }
+    this.postMessage(POST_MESSAGE_WEB3, payload)
+  }
+}


### PR DESCRIPTION
# Description

This is the iframe side of the `Web3ProxyProvider`, which implements `sendAsync`, the only actual requirement for a web3 provider in ethers. It uses the `iframePostOffice` to handle the actual postMessaging back and forth. The basic flow on construction is:

iframe asks main window: what kind of wallet are you? --->
<--- main window `enable()`s the wallet (if needed), and returns basic metadata about the wallet

iframe can then send web3 requests

iframe sends a web3 request to the main window --->
<--- main window passes it to `web3.currentProvider.send` and returns the result

The test verifies this behavior simply by running `walletService.connect` with our new provider. As part of this connection process, `ethers` asks the provider what chainId (network id) it is on by sending a `'eth_version'` request. The test verifies that not only do we get asked to send it, but that when we receive a reply, it propagates back to `ethers` properly.

This kind of birds-eye-view testing will allow us to drastically change the underlying implementation and still have the test pass.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3139 
Refs #3140 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
