### PR TITLE
Add an account utility to re-encrypt a private key with new password

### DIFF
--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -1,6 +1,7 @@
 import {
   createAccountAndPasswordEncryptKey,
   getAccountFromPrivateKey,
+  reEncryptPrivateKey,
 } from '../accounts'
 
 jest.setTimeout(15000)
@@ -60,6 +61,34 @@ describe('account helpers', () => {
         expect(e).toBeInstanceOf(Error)
         expect(e.message).toBe('invalid password')
       }
+    })
+  })
+
+  describe('re-encrypting a private key with a new password', () => {
+    it('should return a new wallet that can be decrypted with the new password', async () => {
+      expect.assertions(1)
+      const oldPassword = 'p@55ω0rd'
+      const newPassword = 'γΘτΕ'
+      const {
+        address,
+        passwordEncryptedPrivateKey,
+      } = await createAccountAndPasswordEncryptKey(oldPassword)
+
+      const newEncryptedKey = await reEncryptPrivateKey(
+        passwordEncryptedPrivateKey,
+        oldPassword,
+        newPassword
+      )
+
+      const wallet = await getAccountFromPrivateKey(
+        newEncryptedKey,
+        newPassword
+      )
+
+      const newKeyAddress = wallet.signingKey.address
+      // This means we successfully decrypted the new payload with the new
+      // password, and we got the same account back out of it.
+      expect(newKeyAddress).toEqual(address)
     })
   })
 })

--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -37,11 +37,13 @@ describe('account helpers', () => {
 
       expect(decryptedAddress).toEqual(
         expect.objectContaining({
-          address: address,
-          privateKey: expect.any(String),
-          publicKey: expect.any(String),
-          signDigest: expect.any(Function),
-          computeSharedSecret: expect.any(Function),
+          signingKey: expect.objectContaining({
+            address: address,
+            privateKey: expect.any(String),
+            publicKey: expect.any(String),
+            signDigest: expect.any(Function),
+            computeSharedSecret: expect.any(Function),
+          }),
         })
       )
     })

--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -91,4 +91,19 @@ describe('account helpers', () => {
       expect(newKeyAddress).toEqual(address)
     })
   })
+
+  it('should throw when an incorrect password is given for an account', async () => {
+    expect.assertions(2)
+    const {
+      passwordEncryptedPrivateKey,
+    } = await createAccountAndPasswordEncryptKey('ghost')
+
+    try {
+      // Note that password order has been swapped
+      await reEncryptPrivateKey(passwordEncryptedPrivateKey, 'geist', 'ghost')
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+      expect(e.message).toBe('invalid password')
+    }
+  })
 })

--- a/unlock-js/src/accounts.js
+++ b/unlock-js/src/accounts.js
@@ -25,5 +25,5 @@ export async function getAccountFromPrivateKey(encryptedPrivateKey, password) {
     JSON.stringify(encryptedPrivateKey),
     password
   )
-  return wallet.signingKey
+  return wallet
 }

--- a/unlock-js/src/accounts.js
+++ b/unlock-js/src/accounts.js
@@ -27,3 +27,21 @@ export async function getAccountFromPrivateKey(encryptedPrivateKey, password) {
   )
   return wallet
 }
+
+/**
+ * Given an encrypted private key, the password, and a new password,
+ * decrypts the private key and re-encrypts it with the new password.
+ * @param {*} encryptedPrivateKey
+ * @param {string} password
+ * @param {string} newPassword
+ * @throws Throws an error if the password does not decrypt private key.
+ */
+export async function reEncryptPrivateKey(
+  encryptedPrivateKey,
+  password,
+  newPassword
+) {
+  const wallet = await getAccountFromPrivateKey(encryptedPrivateKey, password)
+  const newWallet = await wallet.encrypt(newPassword)
+  return JSON.parse(newWallet)
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Fixes #3170. This PR introduces a function that allows us to re-encrypt a user's private key with a new password. This will be used to implement password reset functionality. If this is all good, a future PR will bump the `unlock-js` version, and a further PR will try to upgrade `unlock-js` in `unlock-app` so that we can take advantage of this functionality.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
