### PR TITLE
new cache abstraction layer for keys/locks/transactions

### DIFF
--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -1,0 +1,160 @@
+import {
+  setup,
+  addKey,
+  addLock,
+  addTransaction,
+  getKeys,
+  getLocks,
+  getTransactions,
+} from '../../data-iframe/cacheHandler'
+import { storageId } from '../../data-iframe/cache'
+
+describe('cacheHandler', () => {
+  let fakeWindow
+  const id = storageId('network', 'account')
+  const myKey = {
+    id: 'myKey',
+    owner: 'owner',
+    lock: 'lock',
+    expirationTimestamp: 0,
+  }
+  const myLock = {
+    address: 'myLock',
+    keyPrice: '1',
+  }
+  const myTransaction = {
+    hash: 'myTransaction',
+    lock: 'lock',
+  }
+
+  beforeEach(() => {
+    setup('network', 'account')
+    fakeWindow = {
+      storage: {},
+      localStorage: {
+        setItem(key, item) {
+          fakeWindow.storage[key] = item
+        },
+        getItem(key) {
+          return fakeWindow.storage[key]
+        },
+        removeItem(key) {
+          delete fakeWindow.storage[key]
+        },
+      },
+    }
+  })
+
+  describe('setting values', () => {
+    it('addKey', async () => {
+      expect.assertions(1)
+
+      await addKey(fakeWindow, myKey)
+
+      expect(fakeWindow.storage).toEqual({
+        [id]: JSON.stringify({
+          keys: {
+            myKey,
+          },
+        }),
+      })
+    })
+
+    it('addLock', async () => {
+      expect.assertions(1)
+
+      await addLock(fakeWindow, myLock)
+
+      expect(fakeWindow.storage).toEqual({
+        [id]: JSON.stringify({
+          locks: {
+            myLock,
+          },
+        }),
+      })
+    })
+
+    it('addTransaction', async () => {
+      expect.assertions(1)
+
+      await addTransaction(fakeWindow, myTransaction)
+
+      expect(fakeWindow.storage).toEqual({
+        [id]: JSON.stringify({
+          transactions: {
+            myTransaction,
+          },
+        }),
+      })
+    })
+
+    it('setting multiple cache values', async () => {
+      expect.assertions(1)
+
+      await addKey(fakeWindow, myKey)
+      await addLock(fakeWindow, myLock)
+      await addTransaction(fakeWindow, myTransaction)
+
+      expect(fakeWindow.storage).toEqual({
+        [id]: JSON.stringify({
+          keys: {
+            myKey,
+          },
+          locks: {
+            myLock,
+          },
+          transactions: {
+            myTransaction,
+          },
+        }),
+      })
+    })
+  })
+  describe('getting values', () => {
+    beforeEach(async () => {
+      setup('network', 'account')
+      fakeWindow = {
+        storage: {},
+        localStorage: {
+          setItem(key, item) {
+            fakeWindow.storage[key] = item
+          },
+          getItem(key) {
+            return fakeWindow.storage[key]
+          },
+          removeItem(key) {
+            delete fakeWindow.storage[key]
+          },
+        },
+      }
+
+      await addKey(fakeWindow, myKey)
+      await addLock(fakeWindow, myLock)
+      await addTransaction(fakeWindow, myTransaction)
+    })
+
+    it('getKeys', async () => {
+      expect.assertions(1)
+
+      const keys = await getKeys(fakeWindow)
+
+      expect(keys).toEqual({ myKey })
+    })
+
+    it('getLocks', async () => {
+      expect.assertions(1)
+
+      const locks = await getLocks(fakeWindow)
+
+      expect(locks).toEqual({ myLock })
+    })
+
+    it('getTransactions', async () => {
+      expect.assertions(1)
+
+      const transactions = await getTransactions(fakeWindow)
+
+      expect(transactions).toEqual({ myTransaction })
+    })
+  })
+})

--- a/paywall/src/data-iframe/cacheHandler.js
+++ b/paywall/src/data-iframe/cacheHandler.js
@@ -8,38 +8,38 @@ export function setup(networkId, account) {
   currentAccount = account
 }
 
+async function _get(window, key) {
+  return await cache.get(window, currentNetwork, currentAccount, key)
+}
+
 export async function getKeys(window) {
-  return await cache.get(window, currentNetwork, currentAccount, 'keys')
+  return await _get(window, 'keys')
 }
 
 export async function getLocks(window) {
-  return await cache.get(window, currentNetwork, currentAccount, 'locks')
+  return await _get(window, 'locks')
 }
 
 export async function getTransactions(window) {
-  return await cache.get(window, currentNetwork, currentAccount, 'transactions')
+  return await _get(window, 'transactions')
 }
 
 export async function addKey(window, key) {
-  const keys =
-    (await cache.get(window, currentNetwork, currentAccount, 'keys')) || {}
+  const keys = (await getKeys(window)) || {}
 
   keys[key.id] = key
   await cache.put(window, currentNetwork, currentAccount, 'keys', keys)
 }
 
 export async function addLock(window, lock) {
-  const locks =
-    (await cache.get(window, currentNetwork, currentAccount, 'locks')) || {}
+  const locks = (await getLocks(window)) || {}
 
   locks[lock.address] = lock
   await cache.put(window, currentNetwork, currentAccount, 'locks', locks)
 }
 
 export async function addTransaction(window, transaction) {
-  const transactions =
-    (await cache.get(window, currentNetwork, currentAccount, 'transactions')) ||
-    {}
+  const transactions = (await getTransactions(window)) || {}
 
   transactions[transaction.hash] = transaction
   await cache.put(

--- a/paywall/src/data-iframe/cacheHandler.js
+++ b/paywall/src/data-iframe/cacheHandler.js
@@ -1,0 +1,52 @@
+import * as cache from './cache'
+
+let currentNetwork
+let currentAccount
+
+export function setup(networkId, account) {
+  currentNetwork = networkId
+  currentAccount = account
+}
+
+export async function getKeys(window) {
+  return await cache.get(window, currentNetwork, currentAccount, 'keys')
+}
+
+export async function getLocks(window) {
+  return await cache.get(window, currentNetwork, currentAccount, 'locks')
+}
+
+export async function getTransactions(window) {
+  return await cache.get(window, currentNetwork, currentAccount, 'transactions')
+}
+
+export async function addKey(window, key) {
+  const keys =
+    (await cache.get(window, currentNetwork, currentAccount, 'keys')) || {}
+
+  keys[key.id] = key
+  await cache.put(window, currentNetwork, currentAccount, 'keys', keys)
+}
+
+export async function addLock(window, lock) {
+  const locks =
+    (await cache.get(window, currentNetwork, currentAccount, 'locks')) || {}
+
+  locks[lock.address] = lock
+  await cache.put(window, currentNetwork, currentAccount, 'locks', locks)
+}
+
+export async function addTransaction(window, transaction) {
+  const transactions =
+    (await cache.get(window, currentNetwork, currentAccount, 'transactions')) ||
+    {}
+
+  transactions[transaction.hash] = transaction
+  await cache.put(
+    window,
+    currentNetwork,
+    currentAccount,
+    'transactions',
+    transactions
+  )
+}


### PR DESCRIPTION
# Description

This adds some unlock-specific abstractions over the caching layer, to get and save `keys`, `locks`, and `transactions`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
