### PR TITLE
Ben fix event validation regex

### DIFF
--- a/tickets/src/__tests__/utils/routes.test.js
+++ b/tickets/src/__tests__/utils/routes.test.js
@@ -34,13 +34,14 @@ describe('route utilities', () => {
       expect.assertions(1)
       expect(
         rsvpRoute(
-          '/checkin/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/0x80b8825a3e7Fb15263D0DD455B8aAfc08503bb54/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54d23493439'
+          '/checkin/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/0x80b8825a3e7Fb15263D0DD455B8aAfc08503bb54/MMdskljfsdIOJWERO79b8825a3e7Fb15263D0DD455B8aAfc08503bb54d23493439'
         )
       ).toEqual({
         ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         publicKey: '0x80b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
-        signature: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54d23493439',
+        signature:
+          'MMdskljfsdIOJWERO79b8825a3e7Fb15263D0DD455B8aAfc08503bb54d23493439',
         prefix: 'checkin',
       })
     })

--- a/tickets/src/constants.ts
+++ b/tickets/src/constants.ts
@@ -61,7 +61,7 @@ export const LOCK_PATH_NAME_REGEXP = new RegExp(
 
 // private helpers for the EVENT_PATH_NAME_REGEXP
 const userAddress = accountRegex
-const signature = '0x[a-fA-F0-9]+'
+const signature = '[a-zA-Z0-9]+'
 
 /**
  * This regexp matches several important parameters passed in the url for the demo and paywall pages.


### PR DESCRIPTION
# Description

Whoops! The previous version of this regex didn't quite reflect reality. I've fixed the expression and the test.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
