### PR TITLE
Removing base64 encoding of signed event address

### DIFF
--- a/tickets/src/__tests__/components/content/EventVerify.test.js
+++ b/tickets/src/__tests__/components/content/EventVerify.test.js
@@ -34,6 +34,12 @@ const lock = {
   transaction: 'deployedid',
 }
 
+// Base64-encoded event signature
+const encodedSignature =
+  'MHgyNzJhNDU4MTFkMzdlM2VjNDFmMDRjMWZlZTRkNDYzZDE2Y2E1ZDExMmM0MThlZGNjNTA1NjcwZWJmZmE1MDE0MWU1OGU4MzBkMGUyMDNhMGY0Yzk0Yjc2MTYwZjI3NTlkMDkyOTZlYzA5OTZlYjVmNWI2NWM1NDNjMmY0NWEyMjAw'
+const decodedSignature =
+  '0x272a45811d37e3ec41f04c1fee4d463d16ca5d112c418edcc505670ebffa50141e58e830d0e203a0f4c94b76160f2759d09296ec0996eb5f5b65c543c2f45a2200'
+
 describe('EventVerify', () => {
   it('should display an event when given appropriate properties', () => {
     expect.assertions(1)
@@ -91,7 +97,7 @@ describe('mapStateToProps', () => {
           pathname:
             '/checkin/0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9/' +
             '0x49dbdc4CdBda8dc99c82D66d97B264386E41c0E9/' +
-            '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E943493903943',
+            encodedSignature,
         },
       },
     })
@@ -111,7 +117,7 @@ describe('mapStateToProps', () => {
         address: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
       },
       publicKey: '0x49dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
-      signature: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E943493903943',
+      signature: decodedSignature,
     }
 
     expect(props).toEqual(expectedProps)

--- a/tickets/src/__tests__/utils/routes.test.js
+++ b/tickets/src/__tests__/utils/routes.test.js
@@ -5,6 +5,12 @@ describe('route utilities', () => {
     lockAddress: null,
     prefix: null,
   }
+  const rsvpBaseRoute = {
+    signature: null,
+    publicKey: null,
+    lockAddress: null,
+    prefix: null,
+  }
   describe('lockRoute', () => {
     it('should return null value when it does not match', () => {
       expect.assertions(2)
@@ -26,8 +32,8 @@ describe('route utilities', () => {
   describe('rsvpRoute', () => {
     it('should return null value when it does not match', () => {
       expect.assertions(2)
-      expect(rsvpRoute('/dashboard')).toEqual(baseRoute)
-      expect(rsvpRoute('/lock')).toEqual(baseRoute)
+      expect(rsvpRoute('/dashboard')).toEqual(rsvpBaseRoute)
+      expect(rsvpRoute('/lock')).toEqual(rsvpBaseRoute)
     })
 
     it('should return the right prefix and lockAddress value when it matches', () => {

--- a/tickets/src/components/content/EventVerify.js
+++ b/tickets/src/components/content/EventVerify.js
@@ -72,8 +72,11 @@ export const mapStateToProps = ({ router, locks, account, event }) => {
     router.location.pathname
   )
 
-  signature = atob(signature) // Unlock.js encodes in base64 unnecessarily. Decoding for now
-  // TODO: remove base64 encoding from the signing method in unlock.js so we don't need this anymore
+  if (signature) {
+    const sigBuffer = Buffer.from(signature, 'base64')
+    signature = sigBuffer.toString('utf8') // Unlock.js encodes in base64 unnecessarily. Decoding for now
+    // TODO: remove base64 encoding from the signing method in unlock.js so we don't need this anymore
+  }
 
   const lock = Object.values(locks).find(
     thisLock => thisLock.address === lockAddress

--- a/tickets/src/components/content/EventVerify.js
+++ b/tickets/src/components/content/EventVerify.js
@@ -68,9 +68,12 @@ export const mapDispatchToProps = dispatch => ({
 })
 
 export const mapStateToProps = ({ router, locks, account, event }) => {
-  const { lockAddress, publicKey, signature } = rsvpRoute(
+  let { lockAddress, publicKey, signature } = rsvpRoute(
     router.location.pathname
   )
+
+  signature = atob(signature) // Unlock.js encodes in base64 unnecessarily. Decoding for now
+  // TODO: remove base64 encoding from the signing method in unlock.js so we don't need this anymore
 
   const lock = Object.values(locks).find(
     thisLock => thisLock.address === lockAddress

--- a/tickets/src/utils/routes.js
+++ b/tickets/src/utils/routes.js
@@ -41,6 +41,8 @@ export const rsvpRoute = path => {
 
   if (!match) {
     return {
+      signature: null,
+      publicKey: null,
       lockAddress: null,
       prefix: null,
     }


### PR DESCRIPTION
# Description

The signing method in unlock.js encodes in base64. I realized I wasn't removing this encoding before calling ecRecover. We shouldn't do the base64 encoding to begin with, but because we have it encoded in a bunch of QR codes already, let's do it this way for now.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
