### PR TITLE
generic pollForChanges helper to be used in account polling

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/pollForChanges.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/pollForChanges.test.js
@@ -1,0 +1,114 @@
+import pollForChanges from '../../../data-iframe/blockchainHandler/pollForChanges'
+
+// note: the "await Promise.resolve()" calls cause our test to "attach" to the await calls in the function.
+// without them, the function will run after the test has completed.
+describe('pollForChanges', () => {
+  async function runToInitValue() {
+    await Promise.resolve() // flushes the "await getFunc" line
+  }
+  // run the pollForChanges up to the next iteration
+  async function runToFirstDelay() {
+    await runToInitValue() // flushes the "await getFunc" line
+    jest.runOnlyPendingTimers() // flushes the delayPromise setTimeout
+    await Promise.resolve() // flushes the delayPromise promise
+  }
+
+  // this should be run after "runToInitValue" and then can be run repeatedly
+  async function runIteration() {
+    await Promise.resolve() // flushes the "await getFunc" line
+    await Promise.resolve() // flushes the "await hasValueChanged" line
+    await Promise.resolve() // flushes the delayPromise promise
+    jest.runOnlyPendingTimers() // flushes the delayPromise setTimeout
+    await Promise.resolve() // flushes the delayPromise promise
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetAllMocks()
+    jest.restoreAllMocks()
+    jest.useFakeTimers()
+  })
+
+  it('calls getFunc on start', () => {
+    expect.assertions(1)
+    const getFunc = jest.fn()
+
+    pollForChanges(getFunc, () => false, () => 1, 15)
+    expect(getFunc).toHaveBeenCalled()
+  })
+
+  it('delays for the delay milliseconds on start', async () => {
+    expect.assertions(1)
+
+    pollForChanges(() => 1, () => false, () => 1, 15)
+    // this quirk is needed to flush the Promise queue
+    await runToInitValue() // flushes the "await getFunc" line
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 15)
+  })
+
+  it('calls getFunc again after the first delay', async () => {
+    expect.assertions(1)
+    const getFunc = jest.fn()
+
+    pollForChanges(getFunc, () => false, () => 1, 15)
+    await runToFirstDelay()
+    expect(getFunc).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not call the change listener if hasValueChanged returns falsy', async () => {
+    expect.assertions(1)
+    const listener = jest.fn()
+
+    pollForChanges(() => 1, () => false, listener, 15)
+    await runToFirstDelay()
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('calls the change listener if hasValueChanged returns truthy', async done => {
+    expect.assertions(1)
+    let checkOnlyOnce = val => {
+      expect(val).toBe(1)
+      done()
+    }
+    const listener = val => {
+      checkOnlyOnce(val)
+      checkOnlyOnce = () => 1 // this continues to poll in the test, so stop asserting
+    }
+
+    pollForChanges(() => 1, () => true, listener, 15)
+    await runToFirstDelay()
+  })
+
+  it('polls repeatedly', async () => {
+    expect.assertions(2)
+    const getFunc = jest.fn()
+
+    pollForChanges(getFunc, () => false, () => 1, 15)
+    await runToFirstDelay()
+    expect(getFunc).toHaveBeenCalledTimes(2)
+
+    await runIteration()
+    expect(getFunc).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not call change listener if the value has changed but remains unchanged on the next poll', async () => {
+    expect.assertions(2)
+    const listener = jest.fn()
+
+    let callNumber = 0
+
+    const hasValueChanged = () => {
+      if (callNumber++) return false
+      return true // trigger a change notification on the first round only
+    }
+
+    pollForChanges(() => 1, hasValueChanged, listener, 15)
+    await runToFirstDelay()
+    await runIteration()
+
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    await runIteration()
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/paywall/src/data-iframe/blockchainHandler/pollForChanges.js
+++ b/paywall/src/data-iframe/blockchainHandler/pollForChanges.js
@@ -15,23 +15,31 @@ import { delayPromise } from '../../utils/promises'
  */
 
 /**
+ * @callback continuePolling
+ * @param {*} currentValue
+ * @returns {bool} true if the polling should continue
+ */
+
+/**
  * Poll for changes every 5 seconds in something, and call the changeListener when it changes
  *
- * @param {Function} getFunc should return the current value(s) we are polling for changes
+ * @param {Function} getCurrentValue should return the current value(s) we are polling for changes
  * @param {compareFunc} hasValueChanged
+ * @param {continuePolling} continuePolling
  * @param {changeListener} changeListener
  * @param {int} delay
  */
 export default async function pollForChanges(
-  getFunc,
+  getCurrentValue,
   hasValueChanged,
+  continuePolling,
   changeListener,
   delay
 ) {
-  let before = await getFunc()
-  while (true) {
+  let before = await getCurrentValue()
+  while (await continuePolling(before)) {
     await delayPromise(delay)
-    const after = await getFunc()
+    const after = await getCurrentValue()
     if (await hasValueChanged(before, after)) {
       changeListener(after)
       before = after

--- a/paywall/src/data-iframe/blockchainHandler/pollForChanges.js
+++ b/paywall/src/data-iframe/blockchainHandler/pollForChanges.js
@@ -1,0 +1,40 @@
+import { delayPromise } from '../../utils/promises'
+
+/**
+ * Compare 2 things and return truthy if they are different
+ *
+ * @callback compareFunc
+ * @param {*} oldValue
+ * @param {*} newValue
+ * @returns {bool} true if the values are different
+ */
+
+/**
+ * @callback changeListener
+ * @param {*} newValue
+ */
+
+/**
+ * Poll for changes every 5 seconds in something, and call the changeListener when it changes
+ *
+ * @param {Function} getFunc should return the current value(s) we are polling for changes
+ * @param {compareFunc} hasValueChanged
+ * @param {changeListener} changeListener
+ * @param {int} delay
+ */
+export default async function pollForChanges(
+  getFunc,
+  hasValueChanged,
+  changeListener,
+  delay
+) {
+  let before = await getFunc()
+  while (true) {
+    await delayPromise(delay)
+    const after = await getFunc()
+    if (await hasValueChanged(before, after)) {
+      changeListener(after)
+      before = after
+    }
+  }
+}


### PR DESCRIPTION
# Description

Initially, I coded all the account polling in this function, but it's very difficult to test an infinite loop that does something. This way, the infinite part can be safely mocked out in the account polling test, and the source for account polling becomes declarative as in:

```js

export async function pollForAccountChange(
  walletService,
  web3Service,
  onAccountChange = () => {}
) {
  await ensureWalletReady()

  pollForChanges(
    async () => await walletService.getAccount() /* getFunc */,
    (before, after) => before !== after /* hasValueChanged */,
    () => true /* continuePolling */,
    async newAccount => {
      // only called when account has changed
      /* changeListener */
      setAccount(newAccount)
      setAccountBalance(
        newAccount ? await web3Service.getAddressBalance(newAccount) : 0
      )
      onAccountChange(account, accountBalance)
    }
  )
}
```

Because there is a continuePolling option, we can also use it to poll for things that have a limit, like transaction confirmations.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
