### PR TITLE
Adding paywall component to blog

### DIFF
--- a/unlock-protocol.com/src/__tests__/components/page/PaywallTags.test.js
+++ b/unlock-protocol.com/src/__tests__/components/page/PaywallTags.test.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import PaywallTags from '../../../components/page/PaywallTags'
+
+const lock = '0x123'
+
+describe('PaywallTags', () => {
+  it('should render paywall tags if a lock is supplied', () => {
+    expect.assertions(2)
+
+    const tags = rtl.render(<PaywallTags lock={lock} />)
+
+    expect(
+      tags.container.querySelector(`meta[content="${lock}"`)
+    ).not.toBeNull()
+    expect(
+      tags.container.querySelector(
+        'script[src="https://paywall.unlock-protocol.com/static/paywall.min.js"]'
+      )
+    ).not.toBeNull()
+  })
+
+  it('should render paywall tags if a lock is notsupplied', () => {
+    expect.assertions(1)
+
+    const tags = rtl.render(<PaywallTags lock={null} />)
+
+    expect(tags.container.querySelector(`meta[content="${lock}"`)).toBeNull()
+  })
+})

--- a/unlock-protocol.com/src/__tests__/components/page/PaywallTags.test.js
+++ b/unlock-protocol.com/src/__tests__/components/page/PaywallTags.test.js
@@ -20,7 +20,7 @@ describe('PaywallTags', () => {
     ).not.toBeNull()
   })
 
-  it('should render paywall tags if a lock is notsupplied', () => {
+  it('should render paywall tags if a lock is not supplied', () => {
     expect.assertions(1)
 
     const tags = rtl.render(<PaywallTags lock={null} />)

--- a/unlock-protocol.com/src/components/page/PaywallTags.js
+++ b/unlock-protocol.com/src/components/page/PaywallTags.js
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export const PaywallTags = ({ lock }) => {
+  if (lock) {
+    return (
+      <React.Fragment>
+        <script
+          src="https://paywall.unlock-protocol.com/static/paywall.min.js"
+          data-unlock-url="https://paywall.unlock-protocol.com"
+        />
+        <meta name="lock" content={lock} />
+      </React.Fragment>
+    )
+  } else {
+    return <React.Fragment />
+  }
+}
+
+PaywallTags.propTypes = {
+  lock: PropTypes.string,
+}
+
+PaywallTags.defaultProps = {
+  lock: null,
+}
+
+export default PaywallTags

--- a/unlock-protocol.com/src/pages/post.js
+++ b/unlock-protocol.com/src/pages/post.js
@@ -8,6 +8,7 @@ import { pageTitle } from '../constants'
 import { TwitterTags } from '../components/page/TwitterTags'
 import OpenGraphTags from '../components/page/OpenGraphTags'
 import { preparePostProps } from '../utils/blogLoader'
+import PaywallTags from '../components/page/PaywallTags'
 
 // TODO: move to PostContent
 const Post = ({ slug, post }) => {
@@ -16,6 +17,7 @@ const Post = ({ slug, post }) => {
   let description = post.description || ''
   let authorName = post.authorName || 'Unlock team'
   let publishDate = post.publishDate || ''
+  let paywallLock = post.paywallLock || ''
   let body = post.__content || ''
   let permalink = '/blog/' + slug
 
@@ -34,6 +36,7 @@ const Post = ({ slug, post }) => {
           type="application/rss+xml"
           href="/static/blog.rss"
         />
+        <PaywallTags lock={paywallLock} />
       </Head>
       <BlogPost
         body={body}


### PR DESCRIPTION
# Description

Blog posts with a `paywallLock` metadata entry set will now have a paywall applied. The entry needs to be a mainnet lock address.

cc @smombartz 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
