### PR TITLE
Fixes to ensure event verification validates with signature & key to lock

### DIFF
--- a/tickets/src/__tests__/components/content/ValidationIcon.test.js
+++ b/tickets/src/__tests__/components/content/ValidationIcon.test.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
-import { ValidationIcon } from '../../../components/content/validate/ValidationIcon'
+import {
+  ValidationIcon,
+  mapStateToProps,
+} from '../../../components/content/validate/ValidationIcon'
 
 describe('ValidationIcon', () => {
   it('should display a valid notice when the valid property is set to true', () => {
@@ -29,5 +32,92 @@ describe('ValidationIcon', () => {
     )
 
     expect(wrapper.getByText('Ticket Validating')).not.toBeNull()
+  })
+})
+
+describe('mapStateToProps', () => {
+  it('should return valid is true if there is a key and the signature is marked as valid', () => {
+    expect.assertions(1)
+
+    const publicKey = '0x123'
+    const eventAddress = '0x321'
+
+    const { valid } = mapStateToProps(
+      {
+        tickets: {
+          valid: {
+            signature: publicKey,
+          },
+        },
+        keys: {
+          mykey: {
+            lock: eventAddress,
+            owner: publicKey,
+          },
+        },
+      },
+      {
+        signature: 'signature',
+        publicKey,
+        eventAddress,
+      }
+    )
+
+    expect(valid).toBe(true)
+  })
+
+  it('should return null if there is no key yet but the signature is marked as valid', () => {
+    expect.assertions(1)
+
+    const publicKey = '0x123'
+    const eventAddress = '0x321'
+
+    const { valid } = mapStateToProps(
+      {
+        tickets: {
+          valid: {
+            signature: publicKey,
+          },
+        },
+        keys: {},
+      },
+      {
+        signature: 'signature',
+        publicKey,
+        eventAddress,
+      }
+    )
+
+    expect(valid).toBe(null)
+  })
+
+  it('should return invalid if there is a key but the signature is marked as invalid', () => {
+    expect.assertions(1)
+
+    const publicKey = '0x123'
+    const eventAddress = '0x321'
+
+    const { valid } = mapStateToProps(
+      {
+        tickets: {
+          invalid: {
+            signature: publicKey,
+          },
+        },
+        keys: {
+          mykey: {
+            lock: eventAddress,
+            owner: publicKey,
+          },
+        },
+      },
+      {
+        signature: 'signature',
+        publicKey,
+        eventAddress,
+      }
+    )
+
+    expect(valid).toBe(false)
   })
 })

--- a/tickets/src/__tests__/components/content/ValidationIcon.test.js
+++ b/tickets/src/__tests__/components/content/ValidationIcon.test.js
@@ -53,6 +53,7 @@ describe('mapStateToProps', () => {
           mykey: {
             lock: eventAddress,
             owner: publicKey,
+            expiration: new Date().getTime() / 1000 + 86400,
           },
         },
       },
@@ -64,6 +65,37 @@ describe('mapStateToProps', () => {
     )
 
     expect(valid).toBe(true)
+  })
+
+  it('should return invalid if there is an expired key and the signature is marked as valid', () => {
+    expect.assertions(1)
+
+    const publicKey = '0x123'
+    const eventAddress = '0x321'
+
+    const { valid } = mapStateToProps(
+      {
+        tickets: {
+          valid: {
+            signature: publicKey,
+          },
+        },
+        keys: {
+          mykey: {
+            lock: eventAddress,
+            owner: publicKey,
+            expiration: 1,
+          },
+        },
+      },
+      {
+        signature: 'signature',
+        publicKey,
+        eventAddress,
+      }
+    )
+
+    expect(valid).toBe(false)
   })
 
   it('should return null if there is no key yet but the signature is marked as valid', () => {
@@ -108,6 +140,7 @@ describe('mapStateToProps', () => {
           mykey: {
             lock: eventAddress,
             owner: publicKey,
+            expiration: new Date().getTime() / 1000 + 86400,
           },
         },
       },

--- a/tickets/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/tickets/src/__tests__/middlewares/walletMiddleware.test.js
@@ -384,14 +384,14 @@ describe('Wallet middleware', () => {
       signedAddress: 'encrypted sig',
     }
 
-    mockWalletService.recoverAccountFromSignedData = jest.fn((data, sa, cb) =>
-      cb(null, data.message.address.publicKey)
-    )
+    mockWalletService.recoverAccountFromSignedData = jest.fn((data, sa, cb) => {
+      cb(null, JSON.parse(data).message.address.publicKey)
+    })
 
     invoke(action)
 
     expect(mockWalletService.recoverAccountFromSignedData).toHaveBeenCalledWith(
-      data,
+      JSON.stringify(data),
       signedAddress,
       expect.any(Function)
     )
@@ -433,7 +433,7 @@ describe('Wallet middleware', () => {
     invoke(action)
 
     expect(mockWalletService.recoverAccountFromSignedData).toHaveBeenCalledWith(
-      data,
+      JSON.stringify(data),
       signedAddress,
       expect.any(Function)
     )

--- a/tickets/src/components/content/validate/ValidationIcon.js
+++ b/tickets/src/components/content/validate/ValidationIcon.js
@@ -66,7 +66,11 @@ ValidationIcon.defaultProps = {
 
 const mapStateToProps = ({ tickets }, { signature, publicKey }) => {
   let valid
-  if (tickets.valid && tickets.valid[signature] === publicKey) {
+  if (
+    tickets.valid &&
+    tickets.valid[signature].toString().toLowerCase() ===
+      publicKey.toString().toLowerCase()
+  ) {
     valid = true
   } else if (tickets.invalid && tickets.invalid[signature]) {
     valid = false

--- a/tickets/src/components/content/validate/ValidationIcon.js
+++ b/tickets/src/components/content/validate/ValidationIcon.js
@@ -70,14 +70,26 @@ export const mapStateToProps = (
 ) => {
   let valid = null
   let normalizedPublicKey
+  let potentialKeys = false
 
   if (publicKey) {
     normalizedPublicKey = publicKey.toString().toLowerCase()
 
+    const now = new Date().getTime() / 1000
+
     const keysForEvent = Object.values(keys).filter(key => {
-      return (
+      // We need to remember if there were some suitable keys so we know whether or not to return invalid
+      // or if we're in a state where the keys could potentially still be loading
+      if (
         key.lock === eventAddress &&
         key.owner.toString().toLowerCase() === normalizedPublicKey
+      )
+        potentialKeys = true
+
+      return (
+        key.lock === eventAddress &&
+        key.owner.toString().toLowerCase() === normalizedPublicKey &&
+        key.expiration > now
       )
     })
 
@@ -88,7 +100,10 @@ export const mapStateToProps = (
       keysForEvent.length
     ) {
       valid = true
-    } else if (tickets.invalid && tickets.invalid[signature]) {
+    } else if (
+      (tickets.invalid && tickets.invalid[signature]) ||
+      potentialKeys
+    ) {
       valid = false
     }
   }

--- a/tickets/src/components/content/validate/ValidationIcon.js
+++ b/tickets/src/components/content/validate/ValidationIcon.js
@@ -64,16 +64,33 @@ ValidationIcon.defaultProps = {
   valid: null,
 }
 
-const mapStateToProps = ({ tickets }, { signature, publicKey }) => {
-  let valid
-  if (
-    tickets.valid &&
-    tickets.valid[signature].toString().toLowerCase() ===
-      publicKey.toString().toLowerCase()
-  ) {
-    valid = true
-  } else if (tickets.invalid && tickets.invalid[signature]) {
-    valid = false
+export const mapStateToProps = (
+  { tickets, keys },
+  { signature, publicKey, eventAddress }
+) => {
+  let valid = null
+  let normalizedPublicKey
+
+  if (publicKey) {
+    normalizedPublicKey = publicKey.toString().toLowerCase()
+
+    const keysForEvent = Object.values(keys).filter(key => {
+      return (
+        key.lock === eventAddress &&
+        key.owner.toString().toLowerCase() === normalizedPublicKey
+      )
+    })
+
+    if (
+      tickets.valid &&
+      tickets.valid[signature].toString().toLowerCase() ===
+        normalizedPublicKey &&
+      keysForEvent.length
+    ) {
+      valid = true
+    } else if (tickets.invalid && tickets.invalid[signature]) {
+      valid = false
+    }
   }
 
   return {

--- a/tickets/src/middlewares/walletMiddleware.js
+++ b/tickets/src/middlewares/walletMiddleware.js
@@ -194,14 +194,22 @@ const walletMiddleware = config => {
           })
 
           walletService.recoverAccountFromSignedData(
-            data,
+            JSON.stringify(data),
             signedAddress,
             (error, account) => {
-              if (error || account !== publicKey) {
-                dispatch(signedAddressMismatch(publicKey, signedAddress))
-              } else if (account === publicKey) {
+              const normalizedAccount = account.toString().toLowerCase()
+              const normalizedPublicKey = publicKey.toString().toLowerCase()
+              if (error || normalizedAccount !== normalizedPublicKey) {
                 dispatch(
-                  signedAddressVerified(publicKey, signedAddress, eventAddress)
+                  signedAddressMismatch(normalizedPublicKey, signedAddress)
+                )
+              } else if (normalizedAccount === normalizedPublicKey) {
+                dispatch(
+                  signedAddressVerified(
+                    normalizedPublicKey,
+                    signedAddress,
+                    eventAddress
+                  )
                 )
               }
             }

--- a/tickets/src/middlewares/web3Middleware.js
+++ b/tickets/src/middlewares/web3Middleware.js
@@ -16,7 +16,7 @@ import { setError } from '../actions/error'
 import { transactionTypeMapping } from '../utils/types'
 import { lockRoute } from '../utils/routes'
 import { addKey, updateKey } from '../actions/key'
-//import { SIGNED_ADDRESS_VERIFIED } from '../actions/ticket'
+import { SIGNED_ADDRESS_VERIFIED } from '../actions/ticket'
 
 const { Web3Service } = UnlockJs
 
@@ -184,18 +184,13 @@ const web3Middleware = config => {
           }
         }
 
-        /*        if (
+        if (
           action.type === SIGNED_ADDRESS_VERIFIED &&
           action.eventAddress &&
           action.address
         ) {
-          dispatch(
-            web3Service.getKeyByLockForOwner(
-              action.eventAddress,
-              action.address
-            )
-          )
-        }*/
+          web3Service.getKeyByLockForOwner(action.eventAddress, action.address)
+        }
       }
     }
   }

--- a/tickets/src/middlewares/web3Middleware.js
+++ b/tickets/src/middlewares/web3Middleware.js
@@ -16,7 +16,7 @@ import { setError } from '../actions/error'
 import { transactionTypeMapping } from '../utils/types'
 import { lockRoute } from '../utils/routes'
 import { addKey, updateKey } from '../actions/key'
-import { SIGNED_ADDRESS_VERIFIED } from '../actions/ticket'
+//import { SIGNED_ADDRESS_VERIFIED } from '../actions/ticket'
 
 const { Web3Service } = UnlockJs
 
@@ -184,7 +184,7 @@ const web3Middleware = config => {
           }
         }
 
-        if (
+        /*        if (
           action.type === SIGNED_ADDRESS_VERIFIED &&
           action.eventAddress &&
           action.address
@@ -195,7 +195,7 @@ const web3Middleware = config => {
               action.address
             )
           )
-        }
+        }*/
       }
     }
   }


### PR DESCRIPTION
# Description

Makes fixes to signature validation that ensures a ticket is validated when a signature is valid and the signature signer owns a key to the lock.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
