### PR TITLE
purchaseKey handler for the ad remover paywall

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
@@ -1,15 +1,19 @@
 import ensureWalletReady from '../../../data-iframe/blockchainHandler/ensureWalletReady'
 import { setAccount } from '../../../data-iframe/blockchainHandler/account'
-import { setNetwork } from '../../../data-iframe/blockchainHandler/network'
 import {
-  processKeyPurchaseTransaction,
   purchaseKey,
-  handleTransactionUpdate,
+  processKeyPurchaseTransaction,
+  pollForKeyPurchaseTransaction,
 } from '../../../data-iframe/blockchainHandler/purchaseKey'
+import { setNetwork } from '../../../data-iframe/blockchainHandler/network'
+import { TRANSACTION_TYPES } from '../../../constants'
+import pollForChanges from '../../../data-iframe/blockchainHandler/pollForChanges'
 
 jest.mock('../../../data-iframe/blockchainHandler/ensureWalletReady', () =>
   jest.fn().mockResolvedValue()
 )
+jest.mock('../../../data-iframe/blockchainHandler/pollForChanges')
+
 describe('blockchainHandler purchaseKey', () => {
   let fakeWalletService
   describe('purchaseKey', () => {
@@ -37,174 +41,407 @@ describe('blockchainHandler purchaseKey', () => {
   })
 
   describe('processKeyPurchaseTransaction', () => {
-    it('returns correct values, ready for getKeyPurchaseTransactionMonitor', async () => {
-      expect.assertions(1)
-
-      setAccount('account')
-      setNetwork('network')
-      const network = 'network'
-      const web3Service = 'hi'
-      const walletService = 'hi'
-      const lock = 'lock'
-      const requiredConfirmations = 15
-      const existingTransactions = {
-        transaction: 'hi',
-      }
-      const existingKeys = {
-        key: 'hi',
-      }
-
-      const values = await processKeyPurchaseTransaction({
-        web3Service,
-        walletService,
-        lock,
-        requiredConfirmations,
-        existingTransactions,
-        existingKeys,
-      })
-
-      expect(values).toEqual({
-        walletService,
-        network,
-        lock,
-        keyToPurchase: 'lock-account',
-        transactions: existingTransactions,
-        keys: existingKeys,
-        requiredConfirmations,
-        web3Service,
-      })
-    })
-  })
-
-  describe('getKeyPurchaseTransactionMonitor', () => {
-    it.todo('rejects on error')
-    it.todo('resolves on receiving "transaction.pending" to a new promise')
-    it.todo('post-pending promise rejects on error')
-    it.todo('post-pending promise resolves on "transaction.new"')
-    it.todo(
-      'post-pending promise result includes listener for next confirmation'
-    )
-  })
-  describe('handleTransactionUpdate', () => {
-    const keyToPurchase = 'myKey'
-    const requiredConfirmations = 12
-    const hash = 'hash'
-    const transaction = {
-      hash: 'hash',
-    }
     const transactions = {
-      hash: transaction,
+      hash: 'hi',
     }
     const keys = {
-      myKey: {
-        id: 'myKey',
-      },
+      key: 'hi',
     }
-
-    it('if fully confirmed resolves with boundary condition', async () => {
-      expect.assertions(1)
-
-      const update = {
-        thing: 1,
-        confirmations: 12,
+    let fakeWalletService
+    beforeEach(() => {
+      fakeWalletService = {
+        handlers: {},
+        once: (type, cb) => (fakeWalletService.handlers[type] = cb),
       }
-      const web3Service = {}
+      setAccount('account')
+      setNetwork(1)
+    })
 
-      const value = await handleTransactionUpdate({
-        transaction,
-        hash,
-        update,
-        transactions,
-        keyToPurchase,
-        requiredConfirmations,
-        web3Service,
-        keys,
+    it('sends update on transaction.pending', async done => {
+      expect.assertions(3)
+      const onTransactionUpdate = (t, k, status) => {
+        expect(t).toEqual(transactions)
+        expect(k).toEqual({
+          ...keys,
+          'lock-account': {
+            id: 'lock-account',
+            lock: 'lock',
+            owner: 'account',
+            expiration: 0,
+          },
+        })
+        expect(status).toBe('pending')
+        done()
+      }
+      processKeyPurchaseTransaction({
+        walletService: fakeWalletService,
+        lock: 'lock',
+        existingTransactions: transactions,
+        existingKeys: keys,
+        onTransactionUpdate,
       })
 
-      expect(value).toEqual({
-        nextConfirmation: false,
-        transactions: {
-          hash: {
-            ...transaction,
-            ...update,
+      fakeWalletService.handlers['transaction.pending'](
+        'new',
+        TRANSACTION_TYPES.KEY_PURCHASE
+      )
+    })
+
+    it('ignores pending transactions for other transaction types', async done => {
+      expect.assertions(3)
+      const onTransactionUpdate = (t, k, status) => {
+        expect(t).toEqual(transactions)
+        expect(k).toEqual({
+          ...keys,
+          'lock-account': {
+            id: 'lock-account',
+            lock: 'lock',
+            owner: 'account',
+            expiration: 0,
+          },
+        })
+        expect(status).toBe('pending')
+        done()
+      }
+      processKeyPurchaseTransaction({
+        walletService: fakeWalletService,
+        lock: 'lock',
+        existingTransactions: transactions,
+        existingKeys: keys,
+        onTransactionUpdate,
+      })
+
+      fakeWalletService.handlers['transaction.pending'](
+        'new',
+        TRANSACTION_TYPES.WITHDRAWAL
+      )
+      await Promise.resolve()
+
+      fakeWalletService.handlers['transaction.pending'](
+        'new',
+        TRANSACTION_TYPES.KEY_PURCHASE
+      )
+    })
+
+    it('sends update on transaction.new', async () => {
+      expect.assertions(4)
+      const onTransactionUpdate = jest.fn()
+
+      processKeyPurchaseTransaction({
+        walletService: fakeWalletService,
+        lock: 'lock',
+        existingTransactions: transactions,
+        existingKeys: keys,
+        onTransactionUpdate,
+      })
+
+      fakeWalletService.handlers['transaction.pending'](
+        'new',
+        TRANSACTION_TYPES.KEY_PURCHASE
+      )
+
+      await Promise.resolve()
+      fakeWalletService.handlers['transaction.new'](
+        'hash',
+        'from',
+        'to',
+        'input',
+        'type',
+        'submitted'
+      )
+      await Promise.resolve()
+
+      expect(onTransactionUpdate).toHaveBeenCalledTimes(2)
+      const call2 = onTransactionUpdate.mock.calls[1]
+      const [newTransactions, newKeys, newStatus] = call2
+      expect(newTransactions).toEqual({
+        ...transactions,
+        hash: {
+          hash: 'hash',
+          lock: 'lock',
+          key: 'lock-account',
+          confirmations: 0,
+          from: 'from',
+          to: 'to',
+          input: 'input',
+          type: 'type',
+          status: 'submitted',
+          network: 1,
+        },
+      })
+      expect(newKeys).toEqual({
+        ...keys,
+        'lock-account': {
+          id: 'lock-account',
+          lock: 'lock',
+          owner: 'account',
+          expiration: 0,
+          transactions: {
+            hash: newTransactions.hash,
           },
         },
-        keys: {
-          myKey: {
-            id: 'myKey',
+      })
+      expect(newStatus).toBe('submitted')
+    })
+
+    it('returns the transactions and keys with the new transaction', async done => {
+      expect.assertions(3)
+      const onTransactionUpdate = jest.fn()
+      const newTransaction = {
+        hash: 'hash',
+        lock: 'lock',
+        key: 'lock-account',
+        confirmations: 0,
+        from: 'from',
+        to: 'to',
+        input: 'input',
+        type: 'type',
+        status: 'submitted',
+        network: 1,
+      }
+
+      processKeyPurchaseTransaction({
+        walletService: fakeWalletService,
+        lock: 'lock',
+        existingTransactions: transactions,
+        existingKeys: keys,
+        onTransactionUpdate,
+      }).then(info => {
+        expect(info.transactions).toEqual({
+          ...transactions,
+          hash: newTransaction,
+        })
+        expect(info.keys).toEqual({
+          ...keys,
+          'lock-account': {
+            id: 'lock-account',
+            lock: 'lock',
+            owner: 'account',
+            expiration: 0,
             transactions: {
-              hash: {
-                ...transaction,
-                ...update,
-              },
+              hash: newTransaction,
             },
           },
-        },
-      })
-    })
-
-    it('resolves to a listener for the next confirmation', async done => {
-      expect.assertions(1)
-
-      const update = {
-        thing: 1,
-        confirmations: 11,
-      }
-      const web3Service = {
-        listeners: {},
-        once(type, cb) {
-          web3Service.listeners[type] = cb
-        },
-      }
-
-      handleTransactionUpdate({
-        transaction,
-        hash,
-        update,
-        transactions,
-        keyToPurchase,
-        requiredConfirmations,
-        web3Service,
-        keys,
-      }).then(value => {
-        expect(value).toEqual({
-          nextConfirmation: expect.any(Function),
-          transactions,
-          keys,
         })
+        expect(info.status).toBe('submitted')
         done()
       })
-      web3Service.listeners['transaction.updated'](hash, update)
+
+      fakeWalletService.handlers['transaction.pending'](
+        'new',
+        TRANSACTION_TYPES.KEY_PURCHASE
+      )
+
+      await Promise.resolve()
+      fakeWalletService.handlers['transaction.new'](
+        'hash',
+        'from',
+        'to',
+        'input',
+        'type',
+        'submitted'
+      )
+      await Promise.resolve()
+    })
+  })
+
+  describe('pollForKeyPurchaseTransaction', () => {
+    const hash = 'hash'
+    const startingTransaction = {
+      hash: 'hash',
+      lock: 'lock',
+      key: 'lock-account',
+      confirmations: 0,
+      from: 'from',
+      to: 'to',
+      input: 'input',
+      type: 'type',
+      status: 'submitted',
+      network: 1,
+    }
+    const existingTransactions = {
+      hash: startingTransaction,
+    }
+    const existingKeys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: 0,
+        transactions: {
+          hash: startingTransaction,
+        },
+      },
+    }
+    const requiredConfirmations = 3
+    const lock = 'lock'
+    const onTransactionUpdate = () => {}
+    beforeEach(() => {
+      pollForChanges.mockReset()
     })
 
-    it('rejects on error', async done => {
+    it('calls getTransaction to start the polling', async () => {
       expect.assertions(1)
-
-      const update = {
-        thing: 1,
-        confirmations: 11,
-      }
       const web3Service = {
-        listeners: {},
-        once(type, cb) {
-          web3Service.listeners[type] = cb
-        },
+        handlers: {},
+        getTransaction: jest.fn(),
+        once: (type, cb) => (web3Service.handlers[type] = cb),
       }
 
-      handleTransactionUpdate({
-        transaction,
-        hash,
-        update,
-        transactions,
-        keyToPurchase,
-        requiredConfirmations,
+      await pollForKeyPurchaseTransaction({
         web3Service,
-        keys,
-      }).catch(e => {
-        expect(e.message).toBe('oops')
+        hash,
+        existingTransactions,
+        existingKeys,
+        requiredConfirmations,
+        lock,
+        onTransactionUpdate,
+      })
+      expect(web3Service.getTransaction).toHaveBeenCalledWith('hash')
+    })
+
+    it('getCurrentValue resolves on transaction.updated', async done => {
+      expect.assertions(1)
+      const web3Service = {
+        handlers: {},
+        getTransaction: jest.fn(),
+        once: (type, cb) => (web3Service.handlers[type] = cb),
+      }
+
+      await pollForKeyPurchaseTransaction({
+        web3Service,
+        hash,
+        existingTransactions,
+        existingKeys,
+        requiredConfirmations,
+        lock,
+        onTransactionUpdate,
+      })
+
+      const getCurrentValue = pollForChanges.mock.calls[0][0]
+
+      getCurrentValue().then(values => {
+        expect(values).toEqual(existingTransactions.hash)
         done()
       })
-      web3Service.listeners.error(new Error('oops'))
+
+      web3Service.handlers['transaction.updated']('hi', {})
+    })
+
+    it('hasValueChanged checks for transaction value changes', async () => {
+      expect.assertions(3)
+      const web3Service = {
+        handlers: {},
+        getTransaction: jest.fn(),
+        once: (type, cb) => (web3Service.handlers[type] = cb),
+      }
+
+      await pollForKeyPurchaseTransaction({
+        web3Service,
+        hash,
+        existingTransactions,
+        existingKeys,
+        requiredConfirmations,
+        lock,
+        onTransactionUpdate,
+      })
+
+      const hasValueChanged = pollForChanges.mock.calls[0][1]
+
+      expect(hasValueChanged({ one: 'two' }, { one: 'two' })).toBeFalsy()
+      expect(hasValueChanged({ one: 'two' }, { one: 'three' })).toBeTruthy()
+      expect(
+        hasValueChanged({ one: 'two' }, { one: 'two', two: 'three' })
+      ).toBeTruthy()
+    })
+
+    it('continuePolling responds to confirmations', async () => {
+      expect.assertions(3)
+      const web3Service = {
+        handlers: {},
+        getTransaction: jest.fn(),
+        once: (type, cb) => (web3Service.handlers[type] = cb),
+      }
+
+      await pollForKeyPurchaseTransaction({
+        web3Service,
+        hash,
+        existingTransactions,
+        existingKeys,
+        requiredConfirmations,
+        lock,
+        onTransactionUpdate,
+      })
+
+      const continuePolling = pollForChanges.mock.calls[0][2]
+
+      expect(continuePolling({ confirmations: 1 })).toBeTruthy()
+      expect(continuePolling({ confirmations: 2 })).toBeTruthy()
+      expect(continuePolling({ confirmations: 3 })).toBeFalsy()
+    })
+
+    it('changeListener updates the transactions, keys and returns status', async done => {
+      expect.assertions(3)
+      const web3Service = {
+        handlers: {},
+        getTransaction: jest.fn(),
+        once: (type, cb) => (web3Service.handlers[type] = cb),
+      }
+      const onTransactionUpdate = (t, k, s) => {
+        expect(t).toEqual({
+          ...existingTransactions,
+          hash: {
+            hi: 'there',
+            status: 'confirmed',
+          },
+        })
+        expect(k).toEqual({
+          ...existingKeys,
+          'lock-account': {
+            ...existingKeys['lock-account'],
+            transactions: {
+              hash: { hi: 'there', status: 'confirmed' },
+            },
+          },
+        })
+        expect(s).toBe('confirmed')
+        done()
+      }
+
+      await pollForKeyPurchaseTransaction({
+        web3Service,
+        hash,
+        existingTransactions,
+        existingKeys,
+        requiredConfirmations,
+        lock,
+        onTransactionUpdate,
+      })
+
+      const changeListener = pollForChanges.mock.calls[0][3]
+
+      changeListener({ hi: 'there', status: 'confirmed' })
+    })
+
+    it('returns the transactions and keys with the new transaction', async () => {
+      expect.assertions(2)
+      const web3Service = {
+        handlers: {},
+        getTransaction: jest.fn(),
+        once: (type, cb) => (web3Service.handlers[type] = cb),
+      }
+
+      const ret = await pollForKeyPurchaseTransaction({
+        web3Service,
+        hash,
+        existingTransactions,
+        existingKeys,
+        requiredConfirmations,
+        lock,
+        onTransactionUpdate,
+      })
+      expect(ret.transactions).toEqual(existingTransactions)
+      expect(ret.keys).toEqual(existingKeys)
     })
   })
 })

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
@@ -1,0 +1,210 @@
+import ensureWalletReady from '../../../data-iframe/blockchainHandler/ensureWalletReady'
+import { setAccount } from '../../../data-iframe/blockchainHandler/account'
+import { setNetwork } from '../../../data-iframe/blockchainHandler/network'
+import {
+  processKeyPurchaseTransaction,
+  purchaseKey,
+  handleTransactionUpdate,
+} from '../../../data-iframe/blockchainHandler/purchaseKey'
+
+jest.mock('../../../data-iframe/blockchainHandler/ensureWalletReady', () =>
+  jest.fn().mockResolvedValue()
+)
+describe('blockchainHandler purchaseKey', () => {
+  let fakeWalletService
+  describe('purchaseKey', () => {
+    beforeEach(() => {
+      fakeWalletService = {
+        purchaseKey: jest.fn(),
+      }
+    })
+
+    it('ensures wallet is ready first', async () => {
+      expect.assertions(1)
+
+      setAccount('account')
+      await purchaseKey(fakeWalletService, window, 'lock')
+      expect(ensureWalletReady).toHaveBeenCalled()
+    })
+
+    it('calls purchaseKey with the key id to purchase', async () => {
+      expect.assertions(1)
+
+      setAccount('account')
+      await purchaseKey(fakeWalletService, window, 'lock')
+      expect(fakeWalletService.purchaseKey).toHaveBeenCalledWith('lock-account')
+    })
+  })
+
+  describe('processKeyPurchaseTransaction', () => {
+    it('returns correct values, ready for getKeyPurchaseTransactionMonitor', async () => {
+      expect.assertions(1)
+
+      setAccount('account')
+      setNetwork('network')
+      const network = 'network'
+      const web3Service = 'hi'
+      const walletService = 'hi'
+      const lock = 'lock'
+      const requiredConfirmations = 15
+      const existingTransactions = {
+        transaction: 'hi',
+      }
+      const existingKeys = {
+        key: 'hi',
+      }
+
+      const values = await processKeyPurchaseTransaction({
+        web3Service,
+        walletService,
+        lock,
+        requiredConfirmations,
+        existingTransactions,
+        existingKeys,
+      })
+
+      expect(values).toEqual({
+        walletService,
+        network,
+        lock,
+        keyToPurchase: 'lock-account',
+        transactions: existingTransactions,
+        keys: existingKeys,
+        requiredConfirmations,
+        web3Service,
+      })
+    })
+  })
+
+  describe('getKeyPurchaseTransactionMonitor', () => {
+    it.todo('rejects on error')
+    it.todo('resolves on receiving "transaction.pending" to a new promise')
+    it.todo('post-pending promise rejects on error')
+    it.todo('post-pending promise resolves on "transaction.new"')
+    it.todo(
+      'post-pending promise result includes listener for next confirmation'
+    )
+  })
+  describe('handleTransactionUpdate', () => {
+    const keyToPurchase = 'myKey'
+    const requiredConfirmations = 12
+    const hash = 'hash'
+    const transaction = {
+      hash: 'hash',
+    }
+    const transactions = {
+      hash: transaction,
+    }
+    const keys = {
+      myKey: {
+        id: 'myKey',
+      },
+    }
+
+    it('if fully confirmed resolves with boundary condition', async () => {
+      expect.assertions(1)
+
+      const update = {
+        thing: 1,
+        confirmations: 12,
+      }
+      const web3Service = {}
+
+      const value = await handleTransactionUpdate({
+        transaction,
+        hash,
+        update,
+        transactions,
+        keyToPurchase,
+        requiredConfirmations,
+        web3Service,
+        keys,
+      })
+
+      expect(value).toEqual({
+        nextConfirmation: false,
+        transactions: {
+          hash: {
+            ...transaction,
+            ...update,
+          },
+        },
+        keys: {
+          myKey: {
+            id: 'myKey',
+            transactions: {
+              hash: {
+                ...transaction,
+                ...update,
+              },
+            },
+          },
+        },
+      })
+    })
+
+    it('resolves to a listener for the next confirmation', async done => {
+      expect.assertions(1)
+
+      const update = {
+        thing: 1,
+        confirmations: 11,
+      }
+      const web3Service = {
+        listeners: {},
+        once(type, cb) {
+          web3Service.listeners[type] = cb
+        },
+      }
+
+      handleTransactionUpdate({
+        transaction,
+        hash,
+        update,
+        transactions,
+        keyToPurchase,
+        requiredConfirmations,
+        web3Service,
+        keys,
+      }).then(value => {
+        expect(value).toEqual({
+          nextConfirmation: expect.any(Function),
+          transactions,
+          keys,
+        })
+        done()
+      })
+      web3Service.listeners['transaction.updated'](hash, update)
+    })
+
+    it('rejects on error', async done => {
+      expect.assertions(1)
+
+      const update = {
+        thing: 1,
+        confirmations: 11,
+      }
+      const web3Service = {
+        listeners: {},
+        once(type, cb) {
+          web3Service.listeners[type] = cb
+        },
+      }
+
+      handleTransactionUpdate({
+        transaction,
+        hash,
+        update,
+        transactions,
+        keyToPurchase,
+        requiredConfirmations,
+        web3Service,
+        keys,
+      }).catch(e => {
+        expect(e.message).toBe('oops')
+        done()
+      })
+      web3Service.listeners.error(new Error('oops'))
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
@@ -72,6 +72,16 @@ describe('blockchainHandler purchaseKey', () => {
             lock: 'lock',
             owner: 'account',
             expiration: 0,
+            status: 'pending',
+            transactions: {
+              pending: {
+                status: 'pending',
+                type: TRANSACTION_TYPES.KEY_PURCHASE,
+                lock: 'lock',
+                key: 'lock-account',
+                confirmations: 0,
+              },
+            },
           },
         })
         expect(status).toBe('pending')
@@ -102,6 +112,16 @@ describe('blockchainHandler purchaseKey', () => {
             lock: 'lock',
             owner: 'account',
             expiration: 0,
+            status: 'pending',
+            transactions: {
+              pending: {
+                status: 'pending',
+                type: TRANSACTION_TYPES.KEY_PURCHASE,
+                lock: 'lock',
+                key: 'lock-account',
+                confirmations: 0,
+              },
+            },
           },
         })
         expect(status).toBe('pending')
@@ -180,6 +200,7 @@ describe('blockchainHandler purchaseKey', () => {
           lock: 'lock',
           owner: 'account',
           expiration: 0,
+          status: 'submitted',
           transactions: {
             hash: newTransactions.hash,
           },
@@ -222,6 +243,7 @@ describe('blockchainHandler purchaseKey', () => {
             lock: 'lock',
             owner: 'account',
             expiration: 0,
+            status: 'submitted',
             transactions: {
               hash: newTransaction,
             },
@@ -272,6 +294,7 @@ describe('blockchainHandler purchaseKey', () => {
         lock: 'lock',
         owner: 'account',
         expiration: 0,
+        status: 'submitted',
         transactions: {
           hash: startingTransaction,
         },
@@ -403,6 +426,7 @@ describe('blockchainHandler purchaseKey', () => {
           ...existingKeys,
           'lock-account': {
             ...existingKeys['lock-account'],
+            status: 'confirmed',
             transactions: {
               hash: { hi: 'there', status: 'confirmed' },
             },

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
@@ -31,12 +31,16 @@ describe('blockchainHandler purchaseKey', () => {
       expect(ensureWalletReady).toHaveBeenCalled()
     })
 
-    it('calls purchaseKey with the key id to purchase', async () => {
+    it('calls purchaseKey with the lock, account, and the amount of eth to send', async () => {
       expect.assertions(1)
 
       setAccount('account')
-      await purchaseKey(fakeWalletService, window, 'lock')
-      expect(fakeWalletService.purchaseKey).toHaveBeenCalledWith('lock-account')
+      await purchaseKey(fakeWalletService, window, 'lock', '1000')
+      expect(fakeWalletService.purchaseKey).toHaveBeenCalledWith(
+        'lock',
+        'account',
+        '1000'
+      )
     })
   })
 

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
@@ -11,6 +11,12 @@ export async function purchaseKey(walletService, window, lock, amountToSend) {
   return walletService.purchaseKey(lock, account, amountToSend)
 }
 
+/**
+ * Listens for the next time an event occurs, and resolves. If an error occurs first, it rejects
+ *
+ * @param {*} service either web3Service or walletService
+ * @param {string} event event to listen for
+ */
 function resolveOnEvent(service, event) {
   let resolved = false
   return new Promise((resolve, reject) => {
@@ -22,6 +28,12 @@ function resolveOnEvent(service, event) {
   })
 }
 
+/**
+ * Does a basic shallow equal for transaction objects to see if any changes have occurred
+ * This is used to decide whether to trigger an update to the data
+ * @param {*} a old transaction object
+ * @param {*} b new transaction object
+ */
 function sortOfEqual(a, b) {
   const aKeys = Object.keys(a).sort()
   const bKeys = Object.keys(b).sort()
@@ -31,6 +43,13 @@ function sortOfEqual(a, b) {
   return true
 }
 
+/**
+ * Listen for the transaction.pending and transaction.new events
+ *
+ * It calls `onTransactionUpdate` whenever one of these events is emitted
+ *
+ * It returns the updated list of all transactions, keys, and the current transaction status
+ */
 export async function processKeyPurchaseTransaction({
   walletService,
   lock,
@@ -92,6 +111,13 @@ export async function processKeyPurchaseTransaction({
   return { transactions, keys, status }
 }
 
+/**
+ * At this point, the transaction has been mined at least once.
+ *
+ * This function polls for transaction updates (transaction.updated event) and emits
+ * changes in `onTransactionUpdate`. When the required minimum number of confirmations are met
+ * it stops polling and returns the current transactions and keys
+ */
 export async function pollForKeyPurchaseTransaction({
   web3Service,
   hash,

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
@@ -4,13 +4,11 @@ import ensureWalletReady from './ensureWalletReady'
 import { TRANSACTION_TYPES } from '../../constants'
 import pollForChanges from './pollForChanges'
 
-export async function purchaseKey(walletService, window, lock) {
+export async function purchaseKey(walletService, window, lock, amountToSend) {
   await ensureWalletReady(window)
   const account = getAccount()
 
-  const keyToPurchase = `${lock}-${account}`
-
-  await walletService.purchaseKey(keyToPurchase)
+  return walletService.purchaseKey(lock, account, amountToSend)
 }
 
 function resolveOnEvent(service, event) {

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
@@ -55,6 +55,8 @@ export async function processKeyPurchaseTransaction({
       lock,
       owner: account,
       expiration: 0,
+      transactions: {},
+      status: 'pending',
     },
   }
   const network = getNetwork()
@@ -74,6 +76,7 @@ export async function processKeyPurchaseTransaction({
     key: keyToPurchase,
     confirmations: 0,
   }
+  keys[keyToPurchase].transactions.pending = transaction
   onTransactionUpdate(transactions, keys, 'pending')
   const [hash, from, to, input, type, status] = await resolveOnEvent(
     walletService,
@@ -91,6 +94,8 @@ export async function processKeyPurchaseTransaction({
     network,
   }
   transactions[hash] = transaction
+  delete keys[keyToPurchase].transactions.pending
+  keys[keyToPurchase].status = status
   keys[keyToPurchase].transactions = keys[keyToPurchase].transactions || {}
   keys[keyToPurchase].transactions[hash] = transaction
   onTransactionUpdate(transactions, keys, status)
@@ -146,6 +151,7 @@ export async function pollForKeyPurchaseTransaction({
     newTransaction => {
       transactions[hash] = newTransaction
       keys[keyToPurchase].transactions[hash] = newTransaction
+      keys[keyToPurchase].status = newTransaction.status
       onTransactionUpdate(transactions, keys, newTransaction.status)
     } /* changeListener */,
     0 /* delay */

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
@@ -146,12 +146,16 @@ export async function pollForKeyPurchaseTransaction({
       return !shallowEqual(oldTransaction, newTransaction)
     } /* hasValueChanged */,
     newTransaction => {
-      if (newTransaction.confirmations < requiredConfirmations) return true
+      if (newTransaction.confirmations <= requiredConfirmations) return true
     } /* continuePolling */,
     newTransaction => {
       transactions[hash] = newTransaction
       keys[keyToPurchase].transactions[hash] = newTransaction
-      keys[keyToPurchase].status = newTransaction.status
+      const status =
+        newTransaction.confirmations < requiredConfirmations
+          ? 'confirming'
+          : 'valid'
+      keys[keyToPurchase].status = status
       onTransactionUpdate(transactions, keys, newTransaction.status)
     } /* changeListener */,
     0 /* delay */

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
@@ -1,3 +1,4 @@
+import shallowEqual from 'shallow-equal/objects'
 import { getNetwork } from './network'
 import { getAccount } from './account'
 import ensureWalletReady from './ensureWalletReady'
@@ -26,21 +27,6 @@ function resolveOnEvent(service, event) {
     })
     service.once(event, (...args) => resolve(args))
   })
-}
-
-/**
- * Does a basic shallow equal for transaction objects to see if any changes have occurred
- * This is used to decide whether to trigger an update to the data
- * @param {*} a old transaction object
- * @param {*} b new transaction object
- */
-function sortOfEqual(a, b) {
-  const aKeys = Object.keys(a).sort()
-  const bKeys = Object.keys(b).sort()
-  if (aKeys.length !== bKeys.length) return false
-  if (aKeys.filter((key, index) => bKeys[index] !== key).length) return false
-  if (aKeys.filter(key => a[key] !== b[key]).length) return false
-  return true
 }
 
 /**
@@ -152,7 +138,7 @@ export async function pollForKeyPurchaseTransaction({
       }
     } /* getCurrentValue */,
     (oldTransaction, newTransaction) => {
-      return !sortOfEqual(oldTransaction, newTransaction)
+      return !shallowEqual(oldTransaction, newTransaction)
     } /* hasValueChanged */,
     newTransaction => {
       if (newTransaction.confirmations < requiredConfirmations) return true

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
@@ -1,0 +1,137 @@
+import { getNetwork } from './network'
+import { getAccount } from './account'
+import ensureWalletReady from './ensureWalletReady'
+
+export async function purchaseKey(walletService, window, lock) {
+  await ensureWalletReady(window)
+  const account = getAccount()
+
+  const keyToPurchase = `${lock}-${account}`
+
+  await walletService.purchaseKey(keyToPurchase)
+}
+
+export async function processKeyPurchaseTransaction({
+  web3Service,
+  walletService,
+  lock,
+  requiredConfirmations,
+  existingTransactions,
+  existingKeys,
+}) {
+  const account = getAccount()
+  const transactions = {
+    ...existingTransactions,
+  }
+  const keys = {
+    ...existingKeys,
+  }
+  const keyToPurchase = `${lock}-${account}`
+  const network = getNetwork()
+
+  return {
+    walletService,
+    network,
+    lock,
+    keyToPurchase,
+    transactions,
+    keys,
+    requiredConfirmations,
+    web3Service,
+  }
+}
+
+export function getKeyPurchaseTransactionMonitor({
+  walletService,
+  network,
+  lock,
+  keyToPurchase,
+  transactions,
+  keys,
+  requiredConfirmations,
+  web3Service,
+}) {
+  return new Promise((resolve, reject) => {
+    walletService.once('error', e => reject(e))
+    walletService.once('transaction.pending', () => {
+      resolve(
+        new Promise((resolve, reject) => {
+          walletService.once('error', e => reject(e))
+          walletService.once(
+            'transaction.new',
+            (hash, from, to, input, type, status) => {
+              const transaction = {
+                hash,
+                from,
+                to,
+                input,
+                type,
+                status,
+                network,
+                lock,
+                key: keyToPurchase,
+              }
+              transactions[hash] = transaction
+              keys[keyToPurchase].transactions[hash] = transaction
+
+              const nextConfirmation = handleTransactionUpdate({
+                hash,
+                update: { confirmations: 0 },
+                transactions,
+                keyToPurchase,
+                requiredConfirmations,
+                web3Service,
+                keys,
+              })
+              resolve({
+                transaction,
+                nextConfirmation,
+              })
+            }
+          )
+        })
+      )
+    })
+  })
+}
+
+export function handleTransactionUpdate({
+  hash,
+  update,
+  transactions,
+  keyToPurchase,
+  requiredConfirmations,
+  web3Service,
+  keys,
+}) {
+  transactions[hash] = {
+    ...transactions[hash],
+    ...update,
+  }
+  keys[keyToPurchase].transactions = keys[keyToPurchase].transactions || {}
+  keys[keyToPurchase].transactions[hash] = transactions[hash]
+  if (update.confirmations < requiredConfirmations) {
+    return new Promise((resolve, reject) => {
+      web3Service.once('error', e => reject(e))
+      web3Service.once('transaction.updated', (hash, newUpdate) => {
+        resolve({
+          nextConfirmation: () => {
+            return handleTransactionUpdate({
+              transaction: transactions[hash],
+              hash,
+              update: newUpdate,
+              transactions,
+              keyToPurchase,
+              requiredConfirmations,
+              web3Service,
+              keys,
+            })
+          },
+          transactions,
+          keys,
+        })
+      })
+    })
+  }
+  return Promise.resolve({ nextConfirmation: false, transactions, keys })
+}


### PR DESCRIPTION
# Description

This adds support for key purchase in the new ad remover paywall. It does it by adding 3 functions.

1. `purchaseKey` simply starts the purchase process
2. `processKeyPurchaseTransaction` listens for the `walletService`-side of things (pending and new transaction events) and prepares for the web3Service side of transaction polling
3. `pollForKeyPurchaseTransaction` listens for `transaction.updated` and handles confirmations and other changes.

This is basically a mashup of `walletMiddleware` and `web3Middleware` for doing a key purchase and monitoring the transaction it creates.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
