### PR TITLE
new helper for the ad remover paywall to retrieve existing transactions from locksmith

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/locksmithTransactions.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/locksmithTransactions.test.js
@@ -11,6 +11,7 @@ describe('locksmithTransactions - retrieving existing transactions', () => {
   let fakeWindow
   let fakeWeb3Service
   let fetchedResult
+  const fakeWalletService = {}
 
   beforeEach(() => {
     setAccount('account')
@@ -29,15 +30,25 @@ describe('locksmithTransactions - retrieving existing transactions', () => {
   it('ensures wallet is ready', async () => {
     expect.assertions(1)
 
-    await locksmithTransactions(fakeWindow, 'host', fakeWeb3Service)
+    await locksmithTransactions(
+      fakeWindow,
+      'host',
+      fakeWeb3Service,
+      fakeWalletService
+    )
 
-    expect(ensureWalletReady).toHaveBeenCalled()
+    expect(ensureWalletReady).toHaveBeenCalledWith(fakeWalletService)
   })
 
   it('calls fetch with the correct url', async () => {
     expect.assertions(1)
 
-    await locksmithTransactions(fakeWindow, 'host', fakeWeb3Service)
+    await locksmithTransactions(
+      fakeWindow,
+      'host',
+      fakeWeb3Service,
+      fakeWalletService
+    )
 
     expect(fakeWindow.fetch).toHaveBeenCalledWith(
       'host/transactions?sender=account'
@@ -50,7 +61,8 @@ describe('locksmithTransactions - retrieving existing transactions', () => {
     const result = await locksmithTransactions(
       fakeWindow,
       'host',
-      fakeWeb3Service
+      fakeWeb3Service,
+      fakeWalletService
     )
 
     expect(result).toEqual({})
@@ -81,7 +93,8 @@ describe('locksmithTransactions - retrieving existing transactions', () => {
     const result = await locksmithTransactions(
       fakeWindow,
       'host',
-      fakeWeb3Service
+      fakeWeb3Service,
+      fakeWalletService
     )
 
     expect(result).toEqual({
@@ -119,7 +132,12 @@ describe('locksmithTransactions - retrieving existing transactions', () => {
       },
     }
 
-    await locksmithTransactions(fakeWindow, 'host', fakeWeb3Service)
+    await locksmithTransactions(
+      fakeWindow,
+      'host',
+      fakeWeb3Service,
+      fakeWalletService
+    )
 
     expect(fakeWeb3Service.getTransaction).toHaveBeenNthCalledWith(1, 'hash2')
     expect(fakeWeb3Service.getTransaction).toHaveBeenNthCalledWith(2, 'hash3')

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/locksmithTransactions.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/locksmithTransactions.test.js
@@ -1,0 +1,127 @@
+import ensureWalletReady from '../../../data-iframe/blockchainHandler/ensureWalletReady'
+import locksmithTransactions from '../../../data-iframe/blockchainHandler/locksmithTransactions'
+import { setAccount } from '../../../data-iframe/blockchainHandler/account'
+import { setNetwork } from '../../../data-iframe/blockchainHandler/network'
+
+jest.mock('../../../data-iframe/blockchainHandler/ensureWalletReady', () =>
+  jest.fn().mockResolvedValue()
+)
+
+describe('locksmithTransactions - retrieving existing transactions', () => {
+  let fakeWindow
+  let fakeWeb3Service
+  let fetchedResult
+
+  beforeEach(() => {
+    setAccount('account')
+    setNetwork(1)
+    fetchedResult = {}
+    fakeWindow = {
+      fetch: jest
+        .fn()
+        .mockResolvedValue({ json: () => Promise.resolve(fetchedResult) }),
+    }
+    fakeWeb3Service = {
+      getTransaction: jest.fn(hash => Promise.resolve({ hash })),
+    }
+  })
+
+  it('ensures wallet is ready', async () => {
+    expect.assertions(1)
+
+    await locksmithTransactions(fakeWindow, 'host', fakeWeb3Service)
+
+    expect(ensureWalletReady).toHaveBeenCalled()
+  })
+
+  it('calls fetch with the correct url', async () => {
+    expect.assertions(1)
+
+    await locksmithTransactions(fakeWindow, 'host', fakeWeb3Service)
+
+    expect(fakeWindow.fetch).toHaveBeenCalledWith(
+      'host/transactions?sender=account'
+    )
+  })
+
+  it('returns an empty {} if there are no transactions for that user', async () => {
+    expect.assertions(1)
+
+    const result = await locksmithTransactions(
+      fakeWindow,
+      'host',
+      fakeWeb3Service
+    )
+
+    expect(result).toEqual({})
+  })
+
+  it('returns the transactions for that user', async () => {
+    expect.assertions(1)
+
+    fetchedResult = {
+      data: {
+        transactions: [
+          {
+            transactionHash: 'hash1',
+            chain: 2,
+            to: 'lock 1',
+            from: 'account',
+          },
+          {
+            transactionHash: 'hash2',
+            chain: 1,
+            to: 'lock 2',
+            from: 'account',
+          },
+        ],
+      },
+    }
+
+    const result = await locksmithTransactions(
+      fakeWindow,
+      'host',
+      fakeWeb3Service
+    )
+
+    expect(result).toEqual({
+      hash2: {
+        hash: 'hash2',
+      },
+    })
+  })
+
+  it('calls web3Service.getTransaction for each transaction returned', async () => {
+    expect.assertions(2)
+
+    fetchedResult = {
+      data: {
+        transactions: [
+          {
+            transactionHash: 'hash1',
+            chain: 2,
+            to: 'lock 1',
+            from: 'account',
+          },
+          {
+            transactionHash: 'hash2',
+            chain: 1,
+            to: 'lock 2',
+            from: 'account',
+          },
+          {
+            transactionHash: 'hash3',
+            chain: 1,
+            to: 'lock 3',
+            from: 'account',
+          },
+        ],
+      },
+    }
+
+    await locksmithTransactions(fakeWindow, 'host', fakeWeb3Service)
+
+    expect(fakeWeb3Service.getTransaction).toHaveBeenNthCalledWith(1, 'hash2')
+    expect(fakeWeb3Service.getTransaction).toHaveBeenNthCalledWith(2, 'hash3')
+  })
+})

--- a/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
+++ b/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
@@ -1,0 +1,40 @@
+import ensureWalletReady from './ensureWalletReady'
+import { getAccount } from './account'
+import { getNetwork } from './network'
+
+export default async function locksmithTransactions(
+  window,
+  locksmithHost,
+  web3Service
+) {
+  await ensureWalletReady(window)
+  const account = getAccount()
+  const network = getNetwork()
+
+  const url = `${locksmithHost}/transactions?sender=${account}`
+
+  const response = await window.fetch(url)
+  const result = await response.json()
+  if (result.data && result.data.transactions) {
+    const newTransactions = result.data.transactions
+      .map(t => ({
+        hash: t.transactionHash,
+        network: t.chain,
+        to: t.recipient,
+        from: t.sender,
+      }))
+      .filter(transaction => transaction.network === network)
+      .map(transaction => {
+        return web3Service.getTransaction(transaction.hash)
+      })
+    const updatedTransactions = await Promise.all(newTransactions)
+    return updatedTransactions.reduce(
+      (collect, transaction) => ({
+        ...collect,
+        [transaction.hash]: transaction,
+      }),
+      {}
+    )
+  }
+  return {}
+}

--- a/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
+++ b/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
@@ -2,12 +2,19 @@ import ensureWalletReady from './ensureWalletReady'
 import { getAccount } from './account'
 import { getNetwork } from './network'
 
+/**
+ * @param {window} window the global window context, needed for both `fetch`
+ * @param {string} locksmithHost the full URI for locksmith
+ * @param {web3Service} web3Service the web3Service instance
+ * @param {walletService} walletService the walletService instance, needed to ensure account and network are accurate
+ */
 export default async function locksmithTransactions(
   window,
   locksmithHost,
-  web3Service
+  web3Service,
+  walletService
 ) {
-  await ensureWalletReady(window)
+  await ensureWalletReady(walletService)
   const account = getAccount()
   const network = getNetwork()
 

--- a/paywall/src/data-iframe/blockchainHandler/network.js
+++ b/paywall/src/data-iframe/blockchainHandler/network.js
@@ -1,0 +1,9 @@
+let network
+
+export function getNetwork() {
+  return network
+}
+
+export function setNetwork(id) {
+  network = id
+}


### PR DESCRIPTION
# Description

This portion of the blockchain handler retrieves existing transaction hashes from locksmith. It ignores any transactions that are not on the current network.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
