### PR TITLE
don't crash if the user refreshes while the transaction is pending

### DIFF
--- a/unlock-js/src/__tests__/web3Service.test.js
+++ b/unlock-js/src/__tests__/web3Service.test.js
@@ -1129,6 +1129,29 @@ describe('Web3Service', () => {
         })
       })
 
+      describe('when the transaction is submitted and the user has refreshed the page', () => {
+        function testsSetup() {
+          // nock calls cannot be in beforeEach
+          nock.ethBlockNumber(`0x${(29).toString('16')}`)
+          nock.ethGetTransactionByHash(transaction.hash, null)
+          nock.ethGetCodeAndYield(unlockAddress, bytecode[version].Unlock)
+          // this is the call to unlockVersion() with params []
+          nock.ethCallAndYield('0x4220bd46', unlockAddress, actualVersion)
+        }
+
+        it('should not crash (#3246)', async () => {
+          expect.assertions(1)
+          await versionedNockBeforeEach()
+          testsSetup()
+
+          const result = await web3Service.getTransaction(
+            transaction.hash // no defaults, because we refreshed
+          )
+
+          expect(result).toBeNull()
+        })
+      })
+
       describe('when the transaction is pending/waiting to be mined', () => {
         const input =
           '0x2bc888bf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000278d00000000000000000000000000000000000000000000000000002386f26fc10000000000000000000000000000000000000000000000000000000000000000000a'

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -420,6 +420,10 @@ export default class Web3Service extends UnlockService {
       this.provider.getBlockNumber(),
       this.provider.getTransaction(transactionHash),
     ]).then(async ([blockNumber, blockTransaction]) => {
+      if (!blockTransaction && !defaults) {
+        // transaction is pending, but we have refreshed the page
+        return null
+      }
       // Let's find the type of contract before we can get its version
       const to = blockTransaction ? blockTransaction.to : defaults.to
       let version


### PR DESCRIPTION
# Description

Step 1 in solving #3246 is to ensure that `web3Service.getTransaction` works when the user refreshes and there is neither a transaction nor defaults available

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3246 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
