### PR TITLE
make sure errors surface from dispatches

### DIFF
--- a/paywall/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/storageMiddleware.test.js
@@ -2,6 +2,7 @@ import storageMiddleware from '../../middlewares/storageMiddleware'
 import { addTransaction, NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ACCOUNT } from '../../actions/accounts'
 import configure from '../../config'
+import { delayPromise } from '../../utils/promises'
 
 /**
  * This is a "fake" middleware caller
@@ -111,6 +112,7 @@ describe('Storage middleware', () => {
         ])
       })
       await invoke(action)
+      await delayPromise(1)
 
       expect(
         mockStorageService.getTransactionsHashesSentBy

--- a/paywall/src/middlewares/storageMiddleware.js
+++ b/paywall/src/middlewares/storageMiddleware.js
@@ -1,5 +1,4 @@
 /* eslint promise/prefer-await-to-then: 0 */
-import { batch } from 'react-redux'
 
 import StorageService from '../services/storageService'
 import { storageError } from '../actions/storage'
@@ -20,14 +19,12 @@ const storageMiddleware = config => {
           storageService
             .getTransactionsHashesSentBy(action.account.address)
             .then(transactions => {
-              // Dispatch each transaction, but only trigger 1 re-render
-              batch(() =>
-                transactions.forEach(transaction => {
-                  if (transaction.network === getState().network.name) {
-                    dispatch(addTransaction(transaction))
-                  }
+              transactions.forEach(transaction => {
+                if (transaction.network !== getState().network.name) return
+                setTimeout(() => {
+                  dispatch(addTransaction(transaction))
                 })
-              )
+              })
             })
             .catch(error => {
               dispatch(storageError(error))


### PR DESCRIPTION
# Description

While tracking down #3246, it turned out that dispatching synchronously in the `storageMiddleware` swallowed up all the errors downstream in `web3Middleware`. This change makes it possible to debug when things go south.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3246

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
