### PR TITLE
changePassword needs to know about both old and new

### DIFF
--- a/unlock-app/src/__tests__/actions/user.test.ts
+++ b/unlock-app/src/__tests__/actions/user.test.ts
@@ -157,14 +157,16 @@ describe('user account actions', () => {
   describe('user account maintenance actions', () => {
     it('should create an action indicating a password change', () => {
       expect.assertions(1)
+      const oldPassword = 'guest'
       // Much more secure now
       const newPassword = 'gUeSt1337'
       const expectedAction = {
         type: CHANGE_PASSWORD,
+        oldPassword,
         newPassword,
       }
 
-      expect(changePassword(newPassword)).toEqual(expectedAction)
+      expect(changePassword(oldPassword, newPassword)).toEqual(expectedAction)
     })
   })
 

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -59,8 +59,9 @@ export const signupSucceeded = () => ({
   type: SIGNUP_SUCCEEDED,
 })
 
-export const changePassword = (newPassword: string) => ({
+export const changePassword = (oldPassword: string, newPassword: string) => ({
   type: CHANGE_PASSWORD,
+  oldPassword,
   newPassword,
 })
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Part of splitting up my work on #2166, this PR updates the existing `changePassword` action to take both the old and new passwords, since we'll need both in the handler that responds to this action.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
