### PR TITLE
Add reset password modal actions

### DIFF
--- a/unlock-app/src/__tests__/actions/fullScreenModals.test.ts
+++ b/unlock-app/src/__tests__/actions/fullScreenModals.test.ts
@@ -5,6 +5,8 @@ import {
   dismissWalletCheck,
   promptForPassword,
   dismissPasswordPrompt,
+  promptForResetPassword,
+  dismissResetPasswordPrompt,
 } from '../../actions/fullScreenModals'
 import { KindOfModal } from '../../unlockTypes'
 
@@ -47,5 +49,25 @@ describe('FullScreenModals actions', () => {
     }
 
     expect(dismissPasswordPrompt()).toEqual(expectedAction)
+  })
+
+  it('should create an action to prompt for password reset', () => {
+    expect.assertions(1)
+    const expectedAction = {
+      type: LAUNCH_MODAL,
+      kindOfModal: KindOfModal.ResetPasswordPrompt,
+    }
+
+    expect(promptForResetPassword()).toEqual(expectedAction)
+  })
+
+  it('should create an action to dismiss a password reset prompt', () => {
+    expect.assertions(1)
+    const expectedAction = {
+      type: DISMISS_MODAL,
+      kindOfModal: KindOfModal.ResetPasswordPrompt,
+    }
+
+    expect(dismissResetPasswordPrompt()).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/actions/fullScreenModals.ts
+++ b/unlock-app/src/actions/fullScreenModals.ts
@@ -29,3 +29,8 @@ export const dismissWalletCheck = () =>
 export const promptForPassword = () => launchModal(KindOfModal.PasswordPrompt)
 export const dismissPasswordPrompt = () =>
   dismissModal(KindOfModal.PasswordPrompt)
+
+export const promptForResetPassword = () =>
+  launchModal(KindOfModal.ResetPasswordPrompt)
+export const dismissResetPasswordPrompt = () =>
+  dismissModal(KindOfModal.ResetPasswordPrompt)

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -24,6 +24,7 @@ export enum TransactionStatus {
 export enum KindOfModal {
   WalletCheckOverlay,
   PasswordPrompt,
+  ResetPasswordPrompt,
 }
 /* eslint-enable no-unused-vars */
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Another bit of splitting #2166, this PR adds actions (and a type) used to launch a password reset modal.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
