### PR TITLE
Add a full-screen modal template for password reset prompt

### DIFF
--- a/unlock-app/src/__tests__/components/interface/modal-templates/ResetPasswordPrompt.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/modal-templates/ResetPasswordPrompt.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { ResetPasswordPrompt } from '../../../../components/interface/modal-templates/ResetPasswordPrompt'
+import { dismissResetPasswordPrompt } from '../../../../actions/fullScreenModals'
+import { changePassword } from '../../../../actions/user'
+
+let dispatch: (_: any) => any
+const email = 'geoff@bitconnect.gov'
+
+describe('Reset Password Prompt', () => {
+  beforeEach(() => {
+    dispatch = jest.fn((_: any) => true) // eslint-disable-line no-unused-vars
+  })
+
+  it("should render a form including user's email address", () => {
+    // No assertions, getByDisplayValue will throw if this element is not present.
+    expect.assertions(0)
+
+    const { getByDisplayValue } = rtl.render(
+      <ResetPasswordPrompt email={email} dispatch={dispatch} />
+    )
+
+    getByDisplayValue(email)
+  })
+
+  it('should dispatch a password change action when submitted', () => {
+    expect.assertions(2)
+    const oldPassword = 'guest'
+    const newPassword = 'gU35tp@55word'
+
+    const { getByPlaceholderText, getByText } = rtl.render(
+      <ResetPasswordPrompt email={email} dispatch={dispatch} />
+    )
+
+    const passwordInput = getByPlaceholderText('Current Password')
+    const newInputs = [
+      getByPlaceholderText('New Password'),
+      getByPlaceholderText('Confirm New Password'),
+    ]
+
+    rtl.fireEvent.change(passwordInput, { target: { value: oldPassword } })
+
+    newInputs.forEach(input => {
+      rtl.fireEvent.change(input, { target: { value: newPassword } })
+    })
+
+    const submitButton = getByText('Submit')
+    rtl.fireEvent.click(submitButton)
+
+    expect(dispatch).toHaveBeenCalledWith(
+      changePassword(oldPassword, newPassword)
+    )
+    expect(dispatch).toHaveBeenCalledWith(dismissResetPasswordPrompt())
+  })
+
+  it('should do nothing if submit is clicked without valid input', () => {
+    expect.assertions(1)
+
+    const { getByText } = rtl.render(
+      <ResetPasswordPrompt email={email} dispatch={dispatch} />
+    )
+
+    const submitButton = getByText('Submit')
+
+    rtl.fireEvent.click(submitButton)
+
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('should dismiss the prompt if cancel button is clicked', () => {
+    expect.assertions(2)
+
+    const { getByText } = rtl.render(
+      <ResetPasswordPrompt email={email} dispatch={dispatch} />
+    )
+
+    const cancelButton = getByText('Cancel')
+
+    rtl.fireEvent.click(cancelButton)
+
+    expect(dispatch).toHaveBeenCalledWith(dismissResetPasswordPrompt())
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -34854,6 +34854,367 @@ Object {
 }
 `;
 
+exports[`Storyshots Full Screen Modals The Password Reset Prompt Overlay 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c3 {
+  height: 24px;
+  font-size: 20px;
+  font-family: Roboto,sans-serif;
+  text-align: center;
+  border: none;
+  background: none;
+  color: var(--grey);
+  color: var(--lightred);
+}
+
+.c3:hover {
+  color: var(--link);
+}
+
+.c3:hover {
+  color: var(--red);
+}
+
+.c4 {
+  height: 24px;
+  font-size: 20px;
+  font-family: Roboto,sans-serif;
+  text-align: center;
+  border: none;
+  background: none;
+  color: var(--grey);
+  color: var(--green);
+}
+
+.c4:hover {
+  color: var(--link);
+}
+
+.c4:hover {
+  color: var(--darkgreen);
+}
+
+.c1 {
+  background: var(--white);
+  min-width: 50%;
+  max-width: 98%;
+  border-radius: 4px;
+  padding: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: var(--darkgrey);
+  font-size: 20px;
+}
+
+.c0 {
+  background: rgba(0,0,0,0.5);
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  left: 0;
+  top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  z-index: var(--alwaysontop);
+}
+
+.c2 {
+  height: 50px;
+  width: 75%;
+  border: none;
+  background-color: var(--lightgrey);
+  border-radius: 4px;
+  padding: 10px;
+  font-size: 16px;
+  margin-bottom: 1em;
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <p>
+            To change your password, please enter your current password and the desired new password.
+          </p>
+          <input
+            class="c2"
+            disabled=""
+            placeholder="Password"
+            type="email"
+            value="geoff@bitconnect.gov"
+          />
+          <input
+            class="c2"
+            name="currentPassword"
+            placeholder="Current Password"
+            type="password"
+            value=""
+          />
+          <input
+            class="c2"
+            name="newPassword"
+            placeholder="New Password"
+            type="password"
+            value=""
+          />
+          <input
+            class="c2"
+            name="confirmNewPassword"
+            placeholder="Confirm New Password"
+            type="password"
+            value=""
+          />
+          <div>
+            <button
+              class="c3"
+            >
+              Cancel
+            </button>
+            <button
+              class="c4"
+              disabled=""
+            >
+              Submit
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-chPdSV jcGbFL"
+    >
+      <div
+        class="sc-kAzzGY gfmPHv"
+      >
+        <p>
+          To change your password, please enter your current password and the desired new password.
+        </p>
+        <input
+          class="sc-kgoBCf jHyeuu"
+          disabled=""
+          placeholder="Password"
+          type="email"
+          value="geoff@bitconnect.gov"
+        />
+        <input
+          class="sc-kgoBCf jHyeuu"
+          name="currentPassword"
+          placeholder="Current Password"
+          type="password"
+          value=""
+        />
+        <input
+          class="sc-kgoBCf jHyeuu"
+          name="newPassword"
+          placeholder="New Password"
+          type="password"
+          value=""
+        />
+        <input
+          class="sc-kgoBCf jHyeuu"
+          name="confirmNewPassword"
+          placeholder="Confirm New Password"
+          type="password"
+          value=""
+        />
+        <div>
+          <button
+            class="sc-fjdhpX sc-jzJRlG hxaimc"
+          >
+            Cancel
+          </button>
+          <button
+            class="sc-fjdhpX sc-cSHVUG liDWOB"
+            disabled=""
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Full Screen Modals The Password Reset Prompt Overlay, inactive 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots Full Screen Modals The Wallet Check Overlay 1`] = `
 Object {
   "asFragment": [Function],
@@ -35243,6 +35604,255 @@ Object {
         </button>
         <button
           class="sc-fjdhpX sc-cSHVUG liDWOB"
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Full Screen Modals/templates The Password Reset Prompt Overlay 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c2 {
+  height: 24px;
+  font-size: 20px;
+  font-family: Roboto,sans-serif;
+  text-align: center;
+  border: none;
+  background: none;
+  color: var(--grey);
+  color: var(--lightred);
+}
+
+.c2:hover {
+  color: var(--link);
+}
+
+.c2:hover {
+  color: var(--red);
+}
+
+.c3 {
+  height: 24px;
+  font-size: 20px;
+  font-family: Roboto,sans-serif;
+  text-align: center;
+  border: none;
+  background: none;
+  color: var(--grey);
+  color: var(--green);
+}
+
+.c3:hover {
+  color: var(--link);
+}
+
+.c3:hover {
+  color: var(--darkgreen);
+}
+
+.c0 {
+  background: var(--white);
+  min-width: 50%;
+  max-width: 98%;
+  border-radius: 4px;
+  padding: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: var(--darkgrey);
+  font-size: 20px;
+}
+
+.c1 {
+  height: 50px;
+  width: 75%;
+  border: none;
+  background-color: var(--lightgrey);
+  border-radius: 4px;
+  padding: 10px;
+  font-size: 16px;
+  margin-bottom: 1em;
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <p>
+          To change your password, please enter your current password and the desired new password.
+        </p>
+        <input
+          class="c1"
+          disabled=""
+          placeholder="Password"
+          type="email"
+          value="geoff@bitconnect.gov"
+        />
+        <input
+          class="c1"
+          name="currentPassword"
+          placeholder="Current Password"
+          type="password"
+          value=""
+        />
+        <input
+          class="c1"
+          name="newPassword"
+          placeholder="New Password"
+          type="password"
+          value=""
+        />
+        <input
+          class="c1"
+          name="confirmNewPassword"
+          placeholder="Confirm New Password"
+          type="password"
+          value=""
+        />
+        <div>
+          <button
+            class="c2"
+          >
+            Cancel
+          </button>
+          <button
+            class="c3"
+            disabled=""
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-kAzzGY gfmPHv"
+    >
+      <p>
+        To change your password, please enter your current password and the desired new password.
+      </p>
+      <input
+        class="sc-kgoBCf jHyeuu"
+        disabled=""
+        placeholder="Password"
+        type="email"
+        value="geoff@bitconnect.gov"
+      />
+      <input
+        class="sc-kgoBCf jHyeuu"
+        name="currentPassword"
+        placeholder="Current Password"
+        type="password"
+        value=""
+      />
+      <input
+        class="sc-kgoBCf jHyeuu"
+        name="newPassword"
+        placeholder="New Password"
+        type="password"
+        value=""
+      />
+      <input
+        class="sc-kgoBCf jHyeuu"
+        name="confirmNewPassword"
+        placeholder="Confirm New Password"
+        type="password"
+        value=""
+      />
+      <div>
+        <button
+          class="sc-fjdhpX sc-jzJRlG hxaimc"
+        >
+          Cancel
+        </button>
+        <button
+          class="sc-fjdhpX sc-cSHVUG liDWOB"
+          disabled=""
         >
           Submit
         </button>

--- a/unlock-app/src/components/interface/FullScreenModals.tsx
+++ b/unlock-app/src/components/interface/FullScreenModals.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { KindOfModal, Dispatch } from '../../unlockTypes' // eslint-disable-line
-import { WalletCheck, styles, PasswordPrompt } from './modal-templates'
+import {
+  WalletCheck,
+  styles,
+  PasswordPrompt,
+  ResetPasswordPrompt,
+} from './modal-templates'
 
 interface Props {
   active: boolean
@@ -17,6 +22,9 @@ export const FullScreenModal = ({ active, kindOfModal, dispatch }: Props) => {
       break
     case KindOfModal.PasswordPrompt:
       Template = PasswordPrompt
+      break
+    case KindOfModal.ResetPasswordPrompt:
+      Template = ResetPasswordPrompt
       break
     default:
       // We were given a KindOfModal that we don't have a template for. Do nothing.

--- a/unlock-app/src/components/interface/modal-templates/ResetPasswordPrompt.tsx
+++ b/unlock-app/src/components/interface/modal-templates/ResetPasswordPrompt.tsx
@@ -1,0 +1,131 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { Dispatch, EncryptedPrivateKey } from '../../../unlockTypes' // eslint-disable-line
+import { MessageBox, Cancel, Submit, Input } from './styles'
+import { dismissPasswordPrompt } from '../../../actions/fullScreenModals'
+import { changePassword } from '../../../actions/user'
+
+interface Props {
+  dispatch: Dispatch
+  email: string
+}
+
+interface State {
+  currentPassword: string
+  newPassword: string
+  confirmNewPassword: string
+}
+
+// TODO: Generalize this into a class that can be extended?
+export class ResetPasswordPrompt extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      currentPassword: '',
+      newPassword: '',
+      confirmNewPassword: '',
+    }
+  }
+
+  submit = () => {
+    const { dispatch } = this.props
+    const { currentPassword, newPassword } = this.state
+    dispatch(changePassword(currentPassword, newPassword))
+    this.dismiss()
+  }
+
+  dismiss = () => {
+    const { dispatch } = this.props
+    dispatch(dismissPasswordPrompt())
+  }
+
+  handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { value, name },
+    } = event
+    this.setState(prevState => ({
+      ...prevState,
+      [name]: value,
+    }))
+  }
+
+  handleKey = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const { key } = event
+    if (key === 'Enter') {
+      event.preventDefault()
+      event.stopPropagation()
+      this.submit()
+    }
+
+    if (key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      this.dismiss()
+    }
+  }
+
+  render() {
+    const { email } = this.props
+    const { currentPassword, newPassword, confirmNewPassword } = this.state
+    // TODO: Port validation from normal password selection and handle button styling.
+    const disabled = !(
+      newPassword === confirmNewPassword && newPassword.length >= 8
+    )
+    return (
+      <MessageBox>
+        <p>
+          To change your password, please enter your current password and the
+          desired new password.
+        </p>
+        <Input type="email" value={email} placeholder="Password" disabled />
+        <Input
+          type="password"
+          name="currentPassword"
+          value={currentPassword}
+          onChange={this.handleChange}
+          onKeyDown={this.handleKey}
+          placeholder="Current Password"
+          autoFocus
+        />
+        <Input
+          type="password"
+          name="newPassword"
+          value={newPassword}
+          onChange={this.handleChange}
+          onKeyDown={this.handleKey}
+          placeholder="New Password"
+        />
+        <Input
+          type="password"
+          name="confirmNewPassword"
+          value={confirmNewPassword}
+          onChange={this.handleChange}
+          onKeyDown={this.handleKey}
+          placeholder="Confirm New Password"
+        />
+        <div>
+          <Cancel onClick={this.dismiss}>Cancel</Cancel>
+          <Submit disabled={disabled} onClick={this.submit}>
+            Submit
+          </Submit>
+        </div>
+      </MessageBox>
+    )
+  }
+}
+
+interface ReduxState {
+  userDetails: {
+    key: EncryptedPrivateKey
+    email: string
+  }
+}
+
+export const mapStateToProps = (state: ReduxState) => {
+  const { email } = state.userDetails
+  return {
+    email,
+  }
+}
+
+export default connect(mapStateToProps)(ResetPasswordPrompt)

--- a/unlock-app/src/components/interface/modal-templates/ResetPasswordPrompt.tsx
+++ b/unlock-app/src/components/interface/modal-templates/ResetPasswordPrompt.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { Dispatch, EncryptedPrivateKey } from '../../../unlockTypes' // eslint-disable-line
 import { MessageBox, Cancel, Submit, Input } from './styles'
-import { dismissPasswordPrompt } from '../../../actions/fullScreenModals'
+import { dismissResetPasswordPrompt } from '../../../actions/fullScreenModals'
 import { changePassword } from '../../../actions/user'
 
 interface Props {
@@ -36,7 +36,7 @@ export class ResetPasswordPrompt extends React.Component<Props, State> {
 
   dismiss = () => {
     const { dispatch } = this.props
-    dispatch(dismissPasswordPrompt())
+    dispatch(dismissResetPasswordPrompt())
   }
 
   handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/unlock-app/src/components/interface/modal-templates/index.ts
+++ b/unlock-app/src/components/interface/modal-templates/index.ts
@@ -1,5 +1,6 @@
 import WalletCheck from './WalletCheck'
 import PasswordPrompt from './PasswordPrompt'
+import ResetPasswordPrompt from './ResetPasswordPrompt'
 import * as styles from './styles'
 
-export { WalletCheck, PasswordPrompt, styles }
+export { WalletCheck, PasswordPrompt, ResetPasswordPrompt, styles }

--- a/unlock-app/src/stories/interface/FullScreenModals.stories.js
+++ b/unlock-app/src/stories/interface/FullScreenModals.stories.js
@@ -1,12 +1,25 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { Provider } from 'react-redux'
 import { FullScreenModal } from '../../components/interface/FullScreenModals'
 import {
   WalletCheck,
   PasswordPrompt,
+  ResetPasswordPrompt,
 } from '../../components/interface/modal-templates'
 import { KindOfModal } from '../../unlockTypes'
 import doNothing from '../../utils/doNothing'
+
+const emailState = {
+  userDetails: {
+    email: 'geoff@bitconnect.gov',
+  },
+}
+
+const store = {
+  getState: () => emailState,
+  subscribe: () => doNothing,
+}
 
 storiesOf('Full Screen Modals', module)
   .add('The Wallet Check Overlay', () => {
@@ -47,6 +60,29 @@ storiesOf('Full Screen Modals', module)
       />
     )
   })
+  .add('The Password Reset Prompt Overlay', () => {
+    // This one needs a provider because ResetPasswordPrompt needs to read the
+    // user's email address from state.
+    return (
+      <Provider store={store}>
+        <FullScreenModal
+          active
+          kindOfModal={KindOfModal.ResetPasswordPrompt}
+          dispatch={doNothing}
+        />
+      </Provider>
+    )
+  })
+  .add('The Password Reset Prompt Overlay, inactive', () => {
+    // This is supposed to not render anything.
+    return (
+      <FullScreenModal
+        active={false}
+        kindOfModal={KindOfModal.ResetPasswordPrompt}
+        dispatch={doNothing}
+      />
+    )
+  })
 
 storiesOf('Full Screen Modals/templates', module)
   .add('The Wallet Check Overlay', () => {
@@ -54,4 +90,13 @@ storiesOf('Full Screen Modals/templates', module)
   })
   .add('The Password Prompt Overlay', () => {
     return <PasswordPrompt dispatch={doNothing} />
+  })
+  .add('The Password Reset Prompt Overlay', () => {
+    // This one needs a provider because ResetPasswordPrompt needs to read the
+    // user's email address from state.
+    return (
+      <Provider store={store}>
+        <ResetPasswordPrompt dispatch={doNothing} />
+      </Provider>
+    )
   })

--- a/unlock-app/src/stories/interface/FullScreenModals.stories.js
+++ b/unlock-app/src/stories/interface/FullScreenModals.stories.js
@@ -18,7 +18,8 @@ const emailState = {
 
 const store = {
   getState: () => emailState,
-  subscribe: () => doNothing,
+  subscribe: doNothing,
+  dispatch: doNothing,
 }
 
 storiesOf('Full Screen Modals', module)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Another chunk of #2166, this PR introduces the UI by which users can input the new password to re-encrypt their account. I'd like to think of this as just an initial iteration; in particular a next step would be to port over the (slightly) better password validation from account creation. (a next-next step would be to have a better standard password validation for all components to use.)

The component is hooked up to the `FullScreenModals` render path, but nothing yet dispatches an action that can trigger it.

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/9300702/58034661-15a19d00-7af5-11e9-8c55-d6c1123207af.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
