### PR TITLE
submitted transaction listener

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
@@ -1,0 +1,307 @@
+import { setAccount } from '../../../../data-iframe/blockchainHandler/account'
+import { TRANSACTION_TYPES } from '../../../../constants'
+import submittedListener from '../../../../data-iframe/blockchainHandler/purchaseKey/submittedListener'
+import { setNetwork } from '../../../../data-iframe/blockchainHandler/network'
+
+describe('submittedListener', () => {
+  let fakeWalletService
+
+  beforeEach(() => {
+    fakeWalletService = {
+      handlers: {},
+      once: (type, cb) => (fakeWalletService.handlers[type] = cb),
+    }
+  })
+
+  it('returns immediately if the key is submitted', async () => {
+    expect.assertions(2)
+
+    setAccount('account')
+    const transactions = {
+      'submitted-lock-account': {
+        hash: null,
+        from: 'account',
+        to: 'lock',
+        key: 'lock-account',
+        lock: 'lock',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        confirmations: 2,
+        blockNumber: Number.MAX_SAFE_INTEGER,
+        status: 'submitted',
+      },
+    }
+    const keys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 10000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    const result = await submittedListener({
+      lockAddress: 'lock',
+      existingTransactions: transactions,
+      existingKeys: keys,
+      walletService: fakeWalletService,
+      requiredConfirmations: 3,
+    })
+
+    expect(result.transactions).toBe(transactions)
+    expect(result.keys).toBe(keys)
+  })
+
+  it('returns immediately if the key is pending', async () => {
+    expect.assertions(2)
+
+    setAccount('account')
+    const transactions = {
+      hash: {
+        hash: 'hash',
+        from: 'account',
+        to: 'lock',
+        key: 'lock-account',
+        lock: 'lock',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        confirmations: 2,
+        blockNumber: Number.MAX_SAFE_INTEGER,
+        status: 'pending',
+      },
+    }
+    const keys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 10000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    const result = await submittedListener({
+      lockAddress: 'lock',
+      existingTransactions: transactions,
+      existingKeys: keys,
+      walletService: fakeWalletService,
+      requiredConfirmations: 3,
+    })
+
+    expect(result.transactions).toBe(transactions)
+    expect(result.keys).toBe(keys)
+  })
+
+  it('returns immediately if the key is confirming', async () => {
+    expect.assertions(2)
+
+    setAccount('account')
+    const transactions = {
+      hash: {
+        hash: 'hash',
+        from: 'account',
+        to: 'lock',
+        key: 'lock-account',
+        lock: 'lock',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        confirmations: 2,
+        blockNumber: 123,
+        status: 'mined',
+      },
+    }
+    const keys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 10000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    const result = await submittedListener({
+      lockAddress: 'lock',
+      existingTransactions: transactions,
+      existingKeys: keys,
+      walletService: fakeWalletService,
+      requiredConfirmations: 3,
+    })
+
+    expect(result.transactions).toBe(transactions)
+    expect(result.keys).toBe(keys)
+  })
+
+  it('returns immediately if the key is valid', async () => {
+    expect.assertions(2)
+
+    setAccount('account')
+    const transactions = {
+      hash: {
+        hash: 'hash',
+        from: 'account',
+        to: 'lock',
+        key: 'lock-account',
+        lock: 'lock',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        confirmations: 5,
+        blockNumber: 123,
+        status: 'mined',
+      },
+    }
+    const keys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 10000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    const result = await submittedListener({
+      lockAddress: 'lock',
+      existingTransactions: transactions,
+      existingKeys: keys,
+      walletService: fakeWalletService,
+      requiredConfirmations: 3,
+    })
+
+    expect(result.transactions).toBe(transactions)
+    expect(result.keys).toBe(keys)
+  })
+
+  it('ignores transaction.pending for other transaction types', async done => {
+    expect.assertions(2)
+
+    setAccount('account')
+    setNetwork(1)
+    const existingTransactions = {}
+    const existingKeys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: 0,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    submittedListener({
+      lockAddress: 'lock',
+      existingTransactions,
+      existingKeys,
+      walletService: fakeWalletService,
+      requiredConfirmations: 3,
+    }).then(({ transactions, keys }) => {
+      const submitted = {
+        hash: null,
+        from: 'account',
+        to: 'lock',
+        status: 'submitted',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        key: 'lock-account',
+        lock: 'lock',
+        confirmations: 0,
+        network: 1,
+        blockNumber: Number.MAX_SAFE_INTEGER,
+      }
+      expect(transactions).toEqual({
+        'submitted-lock-account': submitted,
+      })
+
+      expect(keys).toEqual({
+        'lock-account': {
+          ...existingKeys['lock-account'],
+          status: 'submitted',
+          transactions: [submitted],
+        },
+      })
+      done()
+    })
+
+    fakeWalletService.handlers['transaction.pending']('not a key purchase')
+    fakeWalletService.handlers['transaction.pending'](
+      TRANSACTION_TYPES.KEY_PURCHASE
+    )
+  })
+
+  it('handles expired key new transactions', async done => {
+    expect.assertions(2)
+
+    setAccount('account')
+    setNetwork(1)
+    const old = {
+      hash: 'old',
+      from: 'account',
+      to: 'lock',
+      status: 'mined',
+      type: TRANSACTION_TYPES.KEY_PURCHASE,
+      key: 'lock-account',
+      lock: 'lock',
+      confirmations: 1345,
+      network: 1,
+      blockNumber: 123,
+    }
+    const existingTransactions = {
+      old,
+    }
+    const existingKeys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 - 1000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    submittedListener({
+      lockAddress: 'lock',
+      existingTransactions,
+      existingKeys,
+      walletService: fakeWalletService,
+      requiredConfirmations: 3,
+    }).then(({ transactions, keys }) => {
+      const submitted = {
+        hash: null,
+        from: 'account',
+        to: 'lock',
+        status: 'submitted',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        key: 'lock-account',
+        lock: 'lock',
+        confirmations: 0,
+        network: 1,
+        blockNumber: Number.MAX_SAFE_INTEGER,
+      }
+      expect(transactions).toEqual({
+        'submitted-lock-account': submitted,
+        old,
+      })
+
+      expect(keys).toEqual({
+        'lock-account': {
+          ...existingKeys['lock-account'],
+          status: 'submitted',
+          transactions: [submitted, old],
+        },
+      })
+      done()
+    })
+
+    fakeWalletService.handlers['transaction.pending'](
+      TRANSACTION_TYPES.KEY_PURCHASE
+    )
+  })
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
@@ -316,4 +316,81 @@ describe('pendingListener', () => {
       'submitted'
     )
   })
+
+  it('handles failed key new transactions', async done => {
+    expect.assertions(2)
+
+    setAccount('account')
+    setNetwork(1)
+    const old = {
+      hash: 'old',
+      from: 'account',
+      to: 'lock',
+      status: 'failed',
+      type: TRANSACTION_TYPES.KEY_PURCHASE,
+      key: 'lock-account',
+      lock: 'lock',
+      confirmations: 1345,
+      network: 1,
+      blockNumber: 123,
+    }
+    const existingTransactions = {
+      old,
+    }
+    const existingKeys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 - 1000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    pendingListener({
+      lockAddress: 'lock',
+      existingTransactions,
+      existingKeys,
+      walletService: fakeWalletService,
+      requiredConfirmations: 3,
+    }).then(({ transactions, keys }) => {
+      const hash = {
+        hash: 'hash',
+        from: 'account',
+        to: 'lock',
+        status: 'submitted',
+        input: 'input',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        key: 'lock-account',
+        lock: 'lock',
+        confirmations: 0,
+        network: 1,
+        blockNumber: Number.MAX_SAFE_INTEGER,
+      }
+      expect(transactions).toEqual({
+        hash,
+        old,
+      })
+
+      expect(keys).toEqual({
+        'lock-account': {
+          ...existingKeys['lock-account'],
+          status: 'submitted',
+          transactions: [hash, old],
+        },
+      })
+      done()
+    })
+
+    fakeWalletService.handlers['transaction.new'](
+      'hash' /* transaction hash */,
+      'account' /* from */,
+      'lock' /* to */,
+      'input' /* input */,
+      TRANSACTION_TYPES.KEY_PURCHASE /* type */,
+      'submitted'
+    )
+  })
 })

--- a/paywall/src/data-iframe/blockchainHandler/keyStatus.js
+++ b/paywall/src/data-iframe/blockchainHandler/keyStatus.js
@@ -42,8 +42,7 @@ export function getKeyStatus(key, requiredConfirmations) {
 /**
  * Construct the transactions field for each key
  * @param {object} keys keys, indexed by their lock/owner ID (not the same as smart contract ID)
- * @param {object} transactions transactions, indexed by hash (submitted transaction is always
- *                              indexed under "submitted-${lock address}-${user account}")
+ * @param {object} transactions transactions, indexed by hash
  * @param {array} locks an array of lock addresses
  * @param {int} requiredConfirmations the number of confirmations needed to ensure a transaction went through
  */

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
@@ -36,9 +36,14 @@ export default async function submittedListener({
   const network = getNetwork()
   const keyToPurchase = `${lockAddress}-${account}`
   const key = keys[keyToPurchase]
+  // key.status is one of:
+  // none, submitted, pending, confirming, valid, expired, failed
+  // we can only initiate a new purchase if the current key is not valid, and is
+  // not being purchased. These 3 statuses are the
   if (
-    (key.status !== 'none' && key.status !== 'expired') ||
-    key.status === 'failed'
+    key.status !== 'none' &&
+    key.status !== 'expired' &&
+    key.status !== 'failed'
   ) {
     return {
       transactions: existingTransactions,

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
@@ -1,0 +1,93 @@
+import { linkTransactionsToKeys } from '../keyStatus'
+import { TRANSACTION_TYPES } from '../../../constants'
+import { getAccount } from '../account'
+import { getNetwork } from '../network'
+
+/**
+ * Listen for a submitted key purchase transaction
+ *
+ * If the latest transaction for a key is already pending or newer, we immediately return
+ * in order to allow declarative chaining of transaction listeners.
+ *
+ * This allows us to call the transaction listener chain for all transactions, including when
+ * the user refreshes the page in the middle of a transaction chain. In this case, the
+ * submitted listener will skip its work and pass to the next one in the chain
+ *
+ * @param {string} lockAddress the address of the lock we are listening for a submitted key purchase transaction
+ * @param {object} existingTransactions transactions, indexed by hash
+ * @param {object} existingKeys keys, indexed by "lock address-owner address"
+ * @param {walletService} walletService the walletService that initiated the key transaction
+ * @param {int} requiredConfirmations the number of required confirmations for a transaction to be considered permanent
+ */
+export default async function submittedListener({
+  lockAddress,
+  existingTransactions,
+  existingKeys,
+  walletService,
+  requiredConfirmations,
+}) {
+  // update key status for expired keys
+  const keys = linkTransactionsToKeys({
+    keys: existingKeys,
+    transactions: existingTransactions,
+    locks: [lockAddress],
+    requiredConfirmations,
+  })
+  const account = getAccount()
+  const network = getNetwork()
+  const keyToPurchase = `${lockAddress}-${account}`
+  const key = keys[keyToPurchase]
+  if (
+    (key.status !== 'expired' && key.status !== 'none') ||
+    key.status === 'failed'
+  ) {
+    return {
+      transactions: existingTransactions,
+      keys: existingKeys,
+    }
+  }
+
+  // we are initiating a key purchase
+  let done
+  const pendingTransactionFinished = new Promise(resolve => (done = resolve))
+
+  function waitForKeyPurchase(type) {
+    // ensure we don't match an errant transaction (this is highly unlikely and is just a sanity check)
+    if (type !== TRANSACTION_TYPES.KEY_PURCHASE) {
+      return walletService.once('transaction.pending', waitForKeyPurchase)
+    }
+    done(type)
+  }
+  walletService.once('transaction.pending', waitForKeyPurchase)
+  const transactionType = await pendingTransactionFinished // wait for walletService to emit transaction.pending
+
+  // default values
+  const submittedTransaction = {
+    hash: null,
+    from: account,
+    to: lockAddress,
+    status: 'submitted',
+    type: transactionType,
+    key: keyToPurchase,
+    lock: lockAddress,
+    confirmations: 0,
+    network,
+    blockNumber: Number.MAX_SAFE_INTEGER,
+  }
+  const transactions = {
+    ...existingTransactions,
+    // we have no transaction hash yet, so we will use "submitted" with the lock and owner to namespace this transaction
+    [`submitted-${lockAddress}-${account}`]: submittedTransaction,
+  }
+
+  return {
+    transactions,
+    // update the keys to include the new submitted transaction
+    keys: linkTransactionsToKeys({
+      keys: existingKeys,
+      transactions,
+      locks: [lockAddress],
+      requiredConfirmations,
+    }),
+  }
+}


### PR DESCRIPTION
# Description

This is the first of 2 steps in the transaction handling flow. It is designed to be called declaratively for all transactions, regardless of prior state. If the newest transaction for the current key is in a later state (confirming, valid, etc.) then this will return immediately.

Otherwise, it waits for the `'transaction.new'` event from walletService and responds by updating the transaction and key state

Probably the final code will look something like:

```js
const submittedTransaction = Promise.all([
  purchaseKey({
    walletService,
    window,
    lockAddress,
    amountToSend
  }),
  submittedListener({
    lockAddress,
    existingTransactions,
    existingKeys,
    walletService,
    requiredConfirmations,
  })
])
// cache the submitted transaction
// use it as defaults for web3Service.getTransaction
```

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
