### PR TITLE
transaction update listener

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/updateListener.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/updateListener.test.js
@@ -1,0 +1,283 @@
+import { setAccount } from '../../../../data-iframe/blockchainHandler/account'
+import { TRANSACTION_TYPES } from '../../../../constants'
+import updateListener from '../../../../data-iframe/blockchainHandler/purchaseKey/updateListener'
+
+describe('updateListener', () => {
+  let fakeWeb3Service
+
+  beforeEach(() => {
+    fakeWeb3Service = {
+      handlers: {},
+      once: (type, cb) => (fakeWeb3Service.handlers[type] = cb),
+    }
+  })
+  it('ignores transactions that are not in process', async () => {
+    expect.assertions(2)
+
+    setAccount('account')
+    const transactions = {
+      hash: {
+        hash: 'hash',
+        from: 'account',
+        to: 'lock',
+        key: 'lock-account',
+        lock: 'lock',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        confirmations: 5,
+        blockNumber: 123,
+        status: 'mined',
+      },
+    }
+    const keys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: 0,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    const result = await updateListener({
+      lockAddress: 'lock',
+      existingTransactions: transactions,
+      existingKeys: keys,
+      web3Service: fakeWeb3Service,
+      requiredConfirmations: 3,
+    })
+
+    expect(result.transactions).toBe(transactions)
+    expect(result.keys).toBe(keys)
+  })
+
+  it('ignores confirmed transactions', async () => {
+    expect.assertions(2)
+
+    setAccount('account')
+    const transactions = {
+      hash: {
+        hash: 'hash',
+        from: 'account',
+        to: 'lock',
+        key: 'lock-account',
+        lock: 'lock',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        confirmations: 5,
+        blockNumber: 123,
+        status: 'mined',
+      },
+    }
+    const keys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 1000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    const result = await updateListener({
+      lockAddress: 'lock',
+      existingTransactions: transactions,
+      existingKeys: keys,
+      web3Service: fakeWeb3Service,
+      requiredConfirmations: 3,
+    })
+
+    expect(result.transactions).toBe(transactions)
+    expect(result.keys).toBe(keys)
+  })
+
+  it('gets a transaction update for submitted transactions', async done => {
+    expect.assertions(2)
+
+    setAccount('account')
+    const hash = {
+      hash: 'hash',
+      from: 'account',
+      to: 'lock',
+      status: 'submitted',
+      type: TRANSACTION_TYPES.KEY_PURCHASE,
+      key: 'lock-account',
+      lock: 'lock',
+      confirmations: 0,
+      blockNumber: Number.MAX_SAFE_INTEGER,
+    }
+    const existingTransactions = {
+      hash,
+    }
+    const existingKeys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 1000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    updateListener({
+      lockAddress: 'lock',
+      existingTransactions,
+      existingKeys,
+      web3Service: fakeWeb3Service,
+      requiredConfirmations: 3,
+    }).then(({ transactions, keys }) => {
+      const newHash = {
+        ...hash,
+        status: 'pending',
+        thing: 'hi',
+      }
+      expect(transactions).toEqual({
+        hash: newHash,
+      })
+
+      expect(keys).toEqual({
+        'lock-account': {
+          ...existingKeys['lock-account'],
+          status: 'pending',
+          transactions: [newHash],
+        },
+      })
+      done()
+    })
+
+    fakeWeb3Service.handlers['transaction.updated'](
+      'hash' /* transaction hash */,
+      { thing: 'hi', status: 'pending' }
+    )
+  })
+
+  it('gets a transaction update for pending transactions', async done => {
+    expect.assertions(2)
+
+    setAccount('account')
+    const hash = {
+      hash: 'hash',
+      from: 'account',
+      to: 'lock',
+      status: 'pending',
+      type: TRANSACTION_TYPES.KEY_PURCHASE,
+      key: 'lock-account',
+      lock: 'lock',
+      confirmations: 0,
+      blockNumber: Number.MAX_SAFE_INTEGER,
+    }
+    const existingTransactions = {
+      hash,
+    }
+    const existingKeys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 1000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    updateListener({
+      lockAddress: 'lock',
+      existingTransactions,
+      existingKeys,
+      web3Service: fakeWeb3Service,
+      requiredConfirmations: 3,
+    }).then(({ transactions, keys }) => {
+      const newHash = {
+        ...hash,
+        status: 'mined',
+        thing: 'hi',
+        blockNumber: 1234,
+      }
+      expect(transactions).toEqual({
+        hash: newHash,
+      })
+
+      expect(keys).toEqual({
+        'lock-account': {
+          ...existingKeys['lock-account'],
+          status: 'confirming',
+          transactions: [newHash],
+        },
+      })
+      done()
+    })
+
+    fakeWeb3Service.handlers['transaction.updated'](
+      'hash' /* transaction hash */,
+      { thing: 'hi', status: 'mined', blockNumber: 1234 }
+    )
+  })
+
+  it('gets a transaction update for mined transactions', async done => {
+    expect.assertions(2)
+
+    setAccount('account')
+    const hash = {
+      hash: 'hash',
+      from: 'account',
+      to: 'lock',
+      status: 'mined',
+      type: TRANSACTION_TYPES.KEY_PURCHASE,
+      key: 'lock-account',
+      lock: 'lock',
+      confirmations: 0,
+      blockNumber: 1234,
+    }
+    const existingTransactions = {
+      hash,
+    }
+    const existingKeys = {
+      'lock-account': {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 1000,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+      },
+    }
+
+    updateListener({
+      lockAddress: 'lock',
+      existingTransactions,
+      existingKeys,
+      web3Service: fakeWeb3Service,
+      requiredConfirmations: 3,
+    }).then(({ transactions, keys }) => {
+      const newHash = {
+        ...hash,
+        confirmations: 1,
+        thing: 'hi',
+      }
+      expect(transactions).toEqual({
+        hash: newHash,
+      })
+
+      expect(keys).toEqual({
+        'lock-account': {
+          ...existingKeys['lock-account'],
+          status: 'confirming',
+          confirmations: 1,
+          transactions: [newHash],
+        },
+      })
+      done()
+    })
+
+    fakeWeb3Service.handlers['transaction.updated'](
+      'hash' /* transaction hash */,
+      { thing: 'hi', confirmations: 1 }
+    )
+  })
+})

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey/updateListener.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey/updateListener.js
@@ -1,0 +1,64 @@
+import { getAccount } from '../account'
+import { linkTransactionsToKeys } from '../keyStatus'
+
+export default async function updateListener({
+  lockAddress,
+  existingTransactions,
+  existingKeys,
+  web3Service,
+  requiredConfirmations,
+}) {
+  const account = getAccount()
+  const keyToPurchase = `${lockAddress}-${account}`
+  // expire any keys that are expired
+  const keys = linkTransactionsToKeys({
+    keys: existingKeys,
+    transactions: existingTransactions,
+    locks: [lockAddress],
+    requiredConfirmations,
+  })
+  const key = keys[keyToPurchase]
+  const transaction = key.transactions[0]
+  if (
+    !['submitted', 'pending', 'mined'].includes(transaction.status) ||
+    (transaction.status === 'mined' &&
+      transaction.confirmations > requiredConfirmations)
+  ) {
+    return {
+      transactions: existingTransactions,
+      keys: existingKeys,
+    }
+  }
+
+  // get one transaction update
+  let done
+  const transactionUpdateReceived = new Promise(resolve => (done = resolve))
+
+  function handleTransactionUpdate(hash, update) {
+    if (hash !== transaction.hash) {
+      // only respond to our transaction
+      return web3Service.once('transaction.updated', handleTransactionUpdate)
+    }
+    done(update)
+  }
+
+  web3Service.once('transaction.updated', handleTransactionUpdate)
+  const update = await transactionUpdateReceived
+  const newTransaction = {
+    ...transaction,
+    ...update,
+  }
+  const transactions = {
+    ...existingTransactions,
+    [newTransaction.hash]: newTransaction,
+  }
+  return {
+    transactions,
+    keys: linkTransactionsToKeys({
+      keys: existingKeys,
+      transactions,
+      locks: [lockAddress],
+      requiredConfirmations,
+    }),
+  }
+}


### PR DESCRIPTION
# Description

This introduces the equivalent of the `web3Middleware` side of transaction life cycle handling. The `updateListener` returns a `Promise` that resolves when it receives a transaction update. This allows some very simple code to poll for transaction updates:

```js
do {
  const { transactions, keys } = await updateListener({...})
  // send transactions/keys to the cache and to the UI for updating display here
  const key = keys[`${lockAddress}-${account}`]
} while (key.status !== 'valid' && key.status !== 'expired' && key.status !== 'failed')
```

When paired with the `pendingListener`, it represents the full life cycle of a key purchase transaction

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
