### PR TITLE
making sure wedlocks is also deployed on production builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,12 +337,15 @@ workflows:
       - deploy-locksmith-beanstalk:
           filters:
             branches:
-              only: master
+              only:
+                - master
           requires:
             - integration-tests
       - deploy-wedlocks-netlify:
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - production
           requires:
             - integration-tests


### PR DESCRIPTION
# Description

In an attempt at debugging why email creation accounts are not being sent, I found that wedlocks
is not deployed in production which is a bummer.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->