### PR TITLE
attempt at fixing the wedlocks logger based on netlify support responses

### DIFF
--- a/wedlocks/logger.js
+++ b/wedlocks/logger.js
@@ -1,15 +1,36 @@
+/* eslint no-console: 0 */
+
 import winston from 'winston'
 import config from './config'
 
+// TODO: remove me. this is suggestion by the netlify support to debug logging...
+console.log('Logger imported')
 /**
  * The logger. Logging to stdout
  */
 
+// log function overwritten based on comments at https://github.com/winstonjs/winston/issues/1594#issuecomment-492420971
+const LEVEL = Symbol.for('level')
+const MESSAGE = Symbol.for('message')
+
 const consoleTransport = new winston.transports.Console({
   silent: config.unlockEnv === 'test',
+  log: function(info, callback) {
+    setImmediate(() => this.emit('logged', info))
+
+    if (this.stderrLevels[info[LEVEL]]) {
+      console.error(info[MESSAGE])
+      if (callback) callback()
+      return
+    }
+
+    console.log(info[MESSAGE])
+    if (callback) callback()
+  },
 })
 
 export default winston.createLogger({
+  format: winston.format.json(),
   transports: [consoleTransport],
   level: config.unlockEnv === 'dev' ? 'debug' : 'info',
 })


### PR DESCRIPTION
# Description

Apparently logging on netlify functions is hard. Their support team asked me to
try the following

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread