### PR TITLE
pass transaction data as defaults for transactions pulled from locksmith

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/locksmithTransactions.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/locksmithTransactions.test.js
@@ -79,12 +79,14 @@ describe('locksmithTransactions - retrieving existing transactions', () => {
             chain: 2,
             to: 'lock 1',
             from: 'account',
+            data: undefined,
           },
           {
             transactionHash: 'hash2',
             chain: 1,
             to: 'lock 2',
             from: 'account',
+            data: 'data 2',
           },
         ],
       },
@@ -113,20 +115,23 @@ describe('locksmithTransactions - retrieving existing transactions', () => {
           {
             transactionHash: 'hash1',
             chain: 2,
-            to: 'lock 1',
-            from: 'account',
+            recipient: 'lock 1',
+            sender: 'account',
+            data: null,
           },
           {
             transactionHash: 'hash2',
             chain: 1,
-            to: 'lock 2',
-            from: 'account',
+            recipient: 'lock 2',
+            sender: 'account',
+            data: 'data 2',
           },
           {
             transactionHash: 'hash3',
             chain: 1,
-            to: 'lock 3',
-            from: 'account',
+            recipient: 'lock 3',
+            sender: 'account',
+            data: null,
           },
         ],
       },
@@ -139,7 +144,21 @@ describe('locksmithTransactions - retrieving existing transactions', () => {
       fakeWalletService
     )
 
-    expect(fakeWeb3Service.getTransaction).toHaveBeenNthCalledWith(1, 'hash2')
-    expect(fakeWeb3Service.getTransaction).toHaveBeenNthCalledWith(2, 'hash3')
+    expect(fakeWeb3Service.getTransaction).toHaveBeenNthCalledWith(
+      1,
+      'hash2',
+      expect.objectContaining({
+        to: 'lock 2',
+        from: 'account',
+        input: 'data 2',
+        network: 1,
+        hash: 'hash2',
+      })
+    )
+    expect(fakeWeb3Service.getTransaction).toHaveBeenNthCalledWith(
+      2,
+      'hash3',
+      undefined
+    )
   })
 })

--- a/paywall/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/paywall/src/__tests__/middlewares/storageMiddleware.test.js
@@ -69,6 +69,7 @@ describe('Storage middleware', () => {
         to: 'unlock',
         from: 'julien',
         network: 1984,
+        input: 'data',
       }
       const action = { type: NEW_TRANSACTION, transaction }
 
@@ -80,7 +81,8 @@ describe('Storage middleware', () => {
         transaction.hash,
         transaction.from,
         transaction.to,
-        transaction.network
+        transaction.network,
+        transaction.input
       )
       expect(next).toHaveBeenCalledTimes(1)
     })

--- a/paywall/src/__tests__/middlewares/web3Middleware.test.js
+++ b/paywall/src/__tests__/middlewares/web3Middleware.test.js
@@ -543,6 +543,26 @@ describe('Web3 middleware', () => {
     )
   })
 
+  it('should handle ADD_TRANSACTION with data input', () => {
+    expect.assertions(2)
+    const { next, invoke } = create()
+    const action = {
+      type: ADD_TRANSACTION,
+      transaction: {
+        ...transaction,
+        input: 'data',
+      },
+    }
+    mockWeb3Service.getTransaction = jest.fn()
+
+    invoke(action)
+    expect(next).toHaveBeenCalled()
+    expect(mockWeb3Service.getTransaction).toHaveBeenCalledWith(
+      transaction.hash,
+      action.transaction
+    )
+  })
+
   it('should handle NEW_TRANSACTION', () => {
     expect.assertions(3)
     const {

--- a/paywall/src/__tests__/middlewares/web3Middleware.test.js
+++ b/paywall/src/__tests__/middlewares/web3Middleware.test.js
@@ -530,7 +530,7 @@ describe('Web3 middleware', () => {
     })
   })
 
-  it('should handle ADD_TRANSACTION', () => {
+  it('should handle ADD_TRANSACTION with no data input', () => {
     expect.assertions(2)
     const { next, invoke } = create()
     const action = { type: ADD_TRANSACTION, transaction }

--- a/paywall/src/__tests__/services/storageService.test.js
+++ b/paywall/src/__tests__/services/storageService.test.js
@@ -24,6 +24,7 @@ describe('StorageService', () => {
               transactionHash: '0x456',
               sender: '0xabc',
               recipient: '0xfgh',
+              data: 'data',
               chain: 1984,
             },
           ],
@@ -32,7 +33,13 @@ describe('StorageService', () => {
       const hashes = await storageService.getTransactionsHashesSentBy(sender)
       expect(hashes).toEqual([
         { hash: '0x123', from: '0xabc', to: '0xcde', network: 1984 },
-        { hash: '0x456', from: '0xabc', to: '0xfgh', network: 1984 },
+        {
+          hash: '0x456',
+          from: '0xabc',
+          to: '0xfgh',
+          network: 1984,
+          input: 'data',
+        },
       ])
       expect(axios.get).toHaveBeenCalledWith(
         `${serviceHost}/transactions?sender=${sender}`
@@ -47,19 +54,22 @@ describe('StorageService', () => {
       const senderAddress = ' 0xsender'
       const recipientAddress = ' 0xrecipient'
       const chain = 1984
+      const data = 'data'
       axios.post.mockReturnValue({})
 
       await storageService.storeTransaction(
         transactionHash,
         senderAddress,
         recipientAddress,
-        chain
+        chain,
+        data
       )
       expect(axios.post).toHaveBeenCalledWith(`${serviceHost}/transaction`, {
         transactionHash,
         sender: senderAddress,
         recipient: recipientAddress,
         chain,
+        data,
       })
     })
   })

--- a/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
+++ b/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
@@ -28,11 +28,18 @@ export default async function locksmithTransactions(
         hash: t.transactionHash,
         network: t.chain,
         to: t.recipient,
+        input: t.data,
         from: t.sender,
       }))
       .filter(transaction => transaction.network === network)
       .map(transaction => {
-        return web3Service.getTransaction(transaction.hash)
+        // we pass the transaction as defaults if it has input set, so that we can
+        // parse out the transaction type and other details. If input is not set,
+        // we can't safely pass the transaction default
+        return web3Service.getTransaction(
+          transaction.hash,
+          transaction.input ? transaction : undefined
+        )
       })
     const updatedTransactions = await Promise.all(newTransactions)
     return updatedTransactions.reduce(

--- a/paywall/src/middlewares/storageMiddleware.js
+++ b/paywall/src/middlewares/storageMiddleware.js
@@ -38,7 +38,8 @@ const storageMiddleware = config => {
               action.transaction.hash,
               action.transaction.from,
               action.transaction.to,
-              getState().network.name
+              getState().network.name,
+              action.transaction.input
             )
             .catch(error => {
               dispatch(storageError(error))

--- a/paywall/src/middlewares/web3Middleware.js
+++ b/paywall/src/middlewares/web3Middleware.js
@@ -105,7 +105,16 @@ const web3Middleware = config => ({ getState, dispatch }) => {
   return function(next) {
     return function(action) {
       if (action.type === ADD_TRANSACTION) {
-        web3Service.getTransaction(action.transaction.hash)
+        if (action.transaction.input) {
+          // we only pass the transaction defaults if input is set, otherwise
+          // parsing of input will crash
+          web3Service.getTransaction(
+            action.transaction.hash,
+            action.transaction
+          )
+        } else {
+          web3Service.getTransaction(action.transaction.hash)
+        }
       }
 
       if (action.type === NEW_TRANSACTION) {

--- a/paywall/src/services/storageService.js
+++ b/paywall/src/services/storageService.js
@@ -11,11 +11,18 @@ export default class StorageService {
    * @param {*} senderAddress
    * @param {*} recipientAddress
    */
-  storeTransaction(transactionHash, senderAddress, recipientAddress, chain) {
+  storeTransaction(
+    transactionHash,
+    senderAddress,
+    recipientAddress,
+    chain,
+    data
+  ) {
     const payload = {
       transactionHash,
       sender: senderAddress,
       recipient: recipientAddress,
+      data,
       chain,
     }
     return axios.post(`${this.host}/transaction`, payload)
@@ -36,6 +43,7 @@ export default class StorageService {
         hash: t.transactionHash,
         network: t.chain,
         to: t.recipient,
+        input: t.data,
         from: t.sender,
       }))
     }


### PR DESCRIPTION
This fixes #3246.

Normal checklist got blown away, so basically I did a review, and here's a screencast showing it working on the draft PR:

![out](https://user-images.githubusercontent.com/98250/58105090-ebfb7b00-7bb3-11e9-84e7-94d1aa899379.gif)

adding @akeem to ensure I'm using locksmith the way he intended here.