### PR TITLE
adding the ability to add the iframe back when it has been removed by the user

### DIFF
--- a/paywall/src/__tests__/paywall-builder/build.test.js
+++ b/paywall/src/__tests__/paywall-builder/build.test.js
@@ -163,6 +163,15 @@ describe('buildPaywall', () => {
       expect(mockAdd).toHaveBeenCalledWith(document, mockIframeImpl)
     })
 
+    it('adds the iframe to the page over and over again', () => {
+      expect.assertions(4) // 2 are in the addEventListener in the mock window (see beforeEach)
+      jest.useFakeTimers()
+      buildPaywall(window, document, fakeLockAddress)
+      expect(setInterval).toHaveBeenCalledTimes(1)
+      jest.advanceTimersByTime(500)
+      expect(mockAdd).toHaveBeenCalledTimes(2)
+    })
+
     it('passes the correct origin to scrollLoop', () => {
       expect.assertions(4) // 2 are in the addEventListener in the mock window (see beforeEach)
 

--- a/paywall/src/paywall-builder/build.js
+++ b/paywall/src/paywall-builder/build.js
@@ -37,6 +37,12 @@ export default function buildPaywall(window, document, lockAddress, blocker) {
     const iframe = getIframe(document, paywallUrlWithOrigin)
     const origin = new window.URL(paywallUrl).origin
 
+    // If the user removes the iframe, make sure we add it back!
+    // TODO: consider performance/battery impact
+    setInterval(() => {
+      add(document, iframe)
+    }, 500)
+
     add(document, iframe)
     setupReadyListener(window, iframe, origin)
 


### PR DESCRIPTION
# Description

One of our early adopters complained that it was too easy to remove the iframe and was fine with a simple measure to add the iframe back when/if the user removed it.
This PR does that!


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread