### PR TITLE
Ticket validation no longer requires a wallet

### DIFF
--- a/tickets/src/middlewares/web3Middleware.js
+++ b/tickets/src/middlewares/web3Middleware.js
@@ -163,13 +163,13 @@ const web3Middleware = config => {
             eventAddress: eventAddress,
           })
 
-          web3Service.recoverAccountFromSignedData(
-            JSON.stringify(data),
-            signedAddress,
-            (error, account) => {
+          web3Service
+            .recoverAccountFromSignedData(JSON.stringify(data), signedAddress)
+            .then(account => {
               const normalizedAccount = account.toString().toLowerCase()
               const normalizedPublicKey = publicKey.toString().toLowerCase()
-              if (error || normalizedAccount !== normalizedPublicKey) {
+
+              if (normalizedAccount !== normalizedPublicKey) {
                 dispatch(
                   signedAddressMismatch(normalizedPublicKey, signedAddress)
                 )
@@ -182,8 +182,7 @@ const web3Middleware = config => {
                   )
                 )
               }
-            }
-          )
+            })
         }
 
         const keyId = `${lockAddress}-${accountAddress}`


### PR DESCRIPTION
# Description

This is a pretty small change, following up on previous ones - we're now using an account verification method in ethers that doesn't require a wallet.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
