### PR TITLE
Fix issue with ticket verification icons not showing in Chrome

### DIFF
--- a/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -9667,6 +9667,11 @@ Object {
   margin: auto;
 }
 
+.c2 {
+  width: 450px;
+  max-width: 100%;
+}
+
 @media only screen and (min-width:736px) {
   .c0 {
     padding-left: 20px;
@@ -9687,6 +9692,7 @@ Object {
         class="c1"
       >
         <svg
+          class="c2"
           fill="none"
           viewBox="0 0 92 92"
         >
@@ -9715,6 +9721,7 @@ Object {
       class="r7g3m7-0 fSVEBA"
     >
       <svg
+        class="r7g3m7-3 cupMqN"
         fill="none"
         viewBox="0 0 92 92"
       >
@@ -9809,6 +9816,11 @@ Object {
   color: var(--link);
 }
 
+.c2 {
+  width: 450px;
+  max-width: 100%;
+}
+
 @media only screen and (min-width:736px) {
   .c0 {
     padding-left: 20px;
@@ -9829,6 +9841,7 @@ Object {
         class="c1"
       >
         <svg
+          class="c2"
           fill="none"
           viewBox="0 0 92 92"
         >
@@ -9863,6 +9876,7 @@ Object {
       class="r7g3m7-0 fSVEBA"
     >
       <svg
+        class="r7g3m7-2 dFyPjO"
         fill="none"
         viewBox="0 0 92 92"
       >
@@ -9962,6 +9976,11 @@ Object {
   margin: auto;
 }
 
+.c2 {
+  width: 450px;
+  max-width: 100%;
+}
+
 @media only screen and (min-width:736px) {
   .c0 {
     padding-left: 20px;
@@ -9982,6 +10001,7 @@ Object {
         class="c1"
       >
         <svg
+          class="c2"
           fill="none"
           viewBox="0 0 92 92"
         >
@@ -10010,6 +10030,7 @@ Object {
       class="r7g3m7-0 fSVEBA"
     >
       <svg
+        class="r7g3m7-3 cupMqN"
         fill="none"
         viewBox="0 0 92 92"
       >
@@ -10089,14 +10110,14 @@ exports[`Storyshots Event verification page Event verification page with verific
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c9 {
+    .c10 {
   background-color: var(--brand);
   height: 28px;
   width: 28px;
   border-radius: 50%;
 }
 
-.c9 > svg {
+.c10 > svg {
   fill: white;
 }
 
@@ -10115,7 +10136,7 @@ Object {
   height: 24px;
 }
 
-.c8 {
+.c9 {
   position: relative;
   bottom: 0;
   display: grid;
@@ -10162,6 +10183,11 @@ Object {
 }
 
 .c7 {
+  width: 450px;
+  max-width: 100%;
+}
+
+.c8 {
   font-family: 'IBM Plex Sans',sans serif;
   font-weight: bold;
   font-size: 16px;
@@ -10169,7 +10195,7 @@ Object {
 }
 
 @media only screen and (min-width:135px) and (max-width:736px) {
-  .c9 {
+  .c10 {
     height: 16px;
     width: 16px;
   }
@@ -10193,13 +10219,13 @@ Object {
 }
 
 @media only screen and (min-width:135px) and (max-width:736px) {
-  .c10 {
+  .c11 {
     display: none;
   }
 }
 
 @media only screen and (min-width:135px) and (max-width:736px) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
@@ -10217,7 +10243,7 @@ Object {
 }
 
 @media only screen and (min-width:736px) {
-  .c7 {
+  .c8 {
     padding-left: 20px;
   }
 }
@@ -10255,6 +10281,7 @@ Object {
             class="c6"
           >
             <svg
+              class="c7"
               fill="none"
               viewBox="0 0 92 92"
             >
@@ -10268,15 +10295,15 @@ Object {
             </svg>
           </div>
           <h2
-            class="c7"
+            class="c8"
           >
             My Doctor Who party
           </h2>
           <div
-            class="c8"
+            class="c9"
           >
             <div
-              class="c9"
+              class="c10"
             >
               <svg
                 viewBox="0 0 56 56"
@@ -10293,7 +10320,7 @@ Object {
           </div>
         </div>
         <div
-          class="c10"
+          class="c11"
         />
       </div>
     </div>
@@ -10331,6 +10358,7 @@ Object {
           class="r7g3m7-0 fSVEBA"
         >
           <svg
+            class="r7g3m7-3 cupMqN"
             fill="none"
             viewBox="0 0 92 92"
           >

--- a/tickets/src/components/content/validate/ValidationIcon.js
+++ b/tickets/src/components/content/validate/ValidationIcon.js
@@ -24,7 +24,7 @@ export const ValidationIcon = ({
       <Fragment>
         <ValidTitle>Ticket Valid</ValidTitle>
         <IconHolder>
-          <SvgIconCheckmark />
+          <Checkmark />
         </IconHolder>
       </Fragment>
     )
@@ -33,7 +33,7 @@ export const ValidationIcon = ({
       <Fragment>
         <Title>Ticket Not Valid</Title>
         <IconHolder>
-          <SvgIconBg />
+          <NoCheckmark />
         </IconHolder>
       </Fragment>
     )
@@ -42,7 +42,7 @@ export const ValidationIcon = ({
       <Fragment>
         <Title>Ticket Validating</Title>
         <IconHolder>
-          <SvgIconBg />
+          <NoCheckmark />
         </IconHolder>
       </Fragment>
     )
@@ -130,4 +130,14 @@ const IconHolder = styled.div`
 
 const ValidTitle = styled(Title)`
   color: var(--link);
+`
+
+const Checkmark = styled(SvgIconCheckmark)`
+  width: 450px;
+  max-width: 100%;
+`
+
+const NoCheckmark = styled(SvgIconBg)`
+  width: 450px;
+  max-width: 100%;
 `


### PR DESCRIPTION
# Description

The icons weren't displaying in Chrome, but looked fine in Firefox. It turns out Chrome needed the width to be explicitly set.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<img width="389" alt="Screen Shot 2019-05-21 at 12 58 56 PM" src="https://user-images.githubusercontent.com/624104/58126833-c7f66480-7bc8-11e9-9a33-a2de3d68934a.png">
<img width="389" alt="Screen Shot 2019-05-21 at 12 57 34 PM" src="https://user-images.githubusercontent.com/624104/58126834-c88efb00-7bc8-11e9-81fc-a0697b72f636.png">

