### PR TITLE
new getKeys handler for the paywall blockchain handler

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/getKeys.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/getKeys.test.js
@@ -1,0 +1,103 @@
+import getKeys from '../../../data-iframe/blockchainHandler/getKeys'
+import ensureWalletReady from '../../../data-iframe/blockchainHandler/ensureWalletReady'
+import { setAccount } from '../../../data-iframe/blockchainHandler/account'
+
+jest.mock('../../../data-iframe/blockchainHandler/ensureWalletReady', () =>
+  jest.fn().mockResolvedValue()
+)
+
+describe('getKeys', () => {
+  let fakeWalletService
+  let fakeWeb3Service
+
+  beforeEach(() => {
+    fakeWalletService = {}
+    fakeWeb3Service = {
+      getKeyByLockForOwner: jest.fn((lock, owner) =>
+        Promise.resolve({ id: `${lock}-${owner}`, lock, owner, expiration: 0 })
+      ),
+    }
+  })
+
+  it('ensure the wallet is ready first', async () => {
+    expect.assertions(1)
+
+    await getKeys({
+      walletService: fakeWalletService,
+      locks: [1, 2],
+      web3Service: fakeWeb3Service,
+      requiredConfirmations: 12,
+    })
+
+    expect(ensureWalletReady).toHaveBeenCalledWith(fakeWalletService)
+  })
+
+  it('web3Service.getKeyByLockForOwner is called', async () => {
+    expect.assertions(3)
+
+    setAccount('account')
+    await getKeys({
+      walletService: fakeWalletService,
+      locks: [1, 2],
+      web3Service: fakeWeb3Service,
+      requiredConfirmations: 12,
+    })
+
+    expect(fakeWeb3Service.getKeyByLockForOwner).toHaveBeenCalledTimes(2)
+    expect(fakeWeb3Service.getKeyByLockForOwner).toHaveBeenNthCalledWith(
+      1,
+      1,
+      'account'
+    )
+    expect(fakeWeb3Service.getKeyByLockForOwner).toHaveBeenNthCalledWith(
+      2,
+      2,
+      'account'
+    )
+  })
+
+  it('returns the new keys', async () => {
+    expect.assertions(1)
+
+    setAccount('account')
+    let counter = 0
+    const expiration = new Date().getTime() + 10000
+    fakeWeb3Service.getKeyByLockForOwner = jest.fn((lock, owner) => {
+      if (!counter++) {
+        return Promise.resolve({
+          id: `${lock}-${owner}`,
+          lock,
+          owner,
+          expiration: 0,
+        })
+      }
+      return Promise.resolve({
+        id: `${lock}-${owner}`,
+        lock,
+        owner,
+        expiration,
+      })
+    })
+    const keys = await getKeys({
+      walletService: fakeWalletService,
+      locks: [1, 2],
+      web3Service: fakeWeb3Service,
+      requiredConfirmations: 12,
+    })
+
+    expect(keys).toEqual({
+      1: {
+        id: '1-account',
+        lock: 1,
+        owner: 'account',
+        expiration: 0,
+      },
+      2: {
+        id: '2-account',
+        lock: 2,
+        owner: 'account',
+        expiration,
+      },
+    })
+  })
+})

--- a/paywall/src/data-iframe/blockchainHandler/getKeys.js
+++ b/paywall/src/data-iframe/blockchainHandler/getKeys.js
@@ -1,0 +1,20 @@
+import ensureWalletReady from './ensureWalletReady'
+import { getAccount } from './account'
+
+export default async function getKeys({ walletService, locks, web3Service }) {
+  await ensureWalletReady(walletService)
+
+  const account = getAccount()
+
+  const keys = await Promise.all(
+    locks.map(async lock => web3Service.getKeyByLockForOwner(lock, account))
+  )
+
+  return keys.reduce(
+    (keysByLock, key) => ({
+      ...keysByLock,
+      [key.lock]: key,
+    }),
+    {}
+  )
+}


### PR DESCRIPTION
# Description

This implements simple key retrieval from the chain. Because this is on the paywall, the only valid keys are those of the current account holder. Thus, keys are indexed by the lock they open instead of the way they are on the dashboard.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
