### PR TITLE
refactor linking transactions to keys

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/keyStatus.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/keyStatus.test.js
@@ -2,6 +2,7 @@ import {
   isValidKey,
   getKeyStatus,
   linkTransactionsToKeys,
+  linkTransactionsToKey,
 } from '../../../data-iframe/blockchainHandler/keyStatus'
 import { setAccount } from '../../../data-iframe/blockchainHandler/account'
 import { MAX_UINT, TRANSACTION_TYPES } from '../../../constants'
@@ -126,6 +127,367 @@ describe('key status manipulation', () => {
     })
   })
 
+  describe('linkTransactionToKey', () => {
+    it('uses the newest transaction', () => {
+      expect.assertions(1)
+      setAccount('account')
+      const key = {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 1000,
+      }
+      const transactions = {
+        transaction3: {
+          hash: 'transaction3',
+          lock: 'lock',
+          from: 'account',
+          to: 'lock',
+          key: 'lock-account',
+          confirmations: 120,
+          status: 'mined',
+          blockNumber: 2,
+        },
+        transaction: {
+          hash: 'transaction',
+          lock: 'lock',
+          from: 'account',
+          to: 'lock',
+          key: 'lock-account',
+          confirmations: 123,
+          status: 'mined',
+          blockNumber: 1,
+        },
+        transaction2: {
+          hash: 'transaction2',
+          lock: 'lock',
+          from: 'account',
+          to: 'lock',
+          key: 'lock-account',
+          confirmations: 0,
+          status: 'mined',
+          blockNumber: 12,
+        },
+      }
+
+      expect(
+        linkTransactionsToKey({
+          key,
+          transactions,
+          requiredConfirmations: 1,
+        })
+      ).toEqual({
+        ...key,
+        confirmations: 0,
+        transactions: [
+          transactions.transaction2,
+          transactions.transaction3,
+          transactions.transaction,
+        ],
+        status: 'confirming',
+      })
+    })
+
+    it('none', () => {
+      expect.assertions(1)
+
+      const key = {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: 0,
+      }
+      const transactions = {
+        notme: {
+          hash: 'notme',
+          from: 'another account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 123,
+          confirmations: 12345,
+          status: 'mined',
+        },
+      }
+
+      expect(
+        linkTransactionsToKey({
+          key,
+          transactions,
+          requiredConfirmations: 1,
+        })
+      ).toEqual({
+        ...key,
+        confirmations: 0,
+        status: 'none',
+        transactions: [],
+      })
+    })
+
+    it('submitted', () => {
+      expect.assertions(1)
+
+      const key = {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 100,
+      }
+      const transactions = {
+        submitted: {
+          hash: null,
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: MAX_UINT,
+          confirmations: 0,
+          status: 'submitted',
+        },
+        old: {
+          hash: 'old',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 123,
+          confirmations: 12345,
+          status: 'mined',
+        },
+      }
+
+      expect(
+        linkTransactionsToKey({
+          key,
+          transactions,
+          requiredConfirmations: 1,
+        })
+      ).toEqual({
+        ...key,
+        transactions: [transactions.submitted, transactions.old],
+        status: 'submitted',
+        confirmations: 0,
+      })
+    })
+
+    it('pending', () => {
+      expect.assertions(1)
+
+      const key = {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 100,
+      }
+      const transactions = {
+        new: {
+          hash: 'new',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: MAX_UINT,
+          confirmations: 0,
+          status: 'pending',
+        },
+        old: {
+          hash: 'old',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 123,
+          confirmations: 12345,
+          status: 'mined',
+        },
+      }
+
+      expect(
+        linkTransactionsToKey({
+          key,
+          transactions,
+          requiredConfirmations: 1,
+        })
+      ).toEqual({
+        ...key,
+        transactions: [transactions.new, transactions.old],
+        status: 'pending',
+        confirmations: 0,
+      })
+    })
+
+    it('confirming', () => {
+      expect.assertions(1)
+
+      const key = {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 10000,
+      }
+      const transactions = {
+        confirming: {
+          hash: 'confirming',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 234,
+          confirmations: 2,
+          status: 'mined',
+        },
+        old: {
+          hash: 'old',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 123,
+          confirmations: 12345,
+          status: 'mined',
+        },
+      }
+
+      expect(
+        linkTransactionsToKey({
+          key,
+          transactions,
+          requiredConfirmations: 5,
+        })
+      ).toEqual({
+        ...key,
+        transactions: [transactions.confirming, transactions.old],
+        status: 'confirming',
+        confirmations: 2,
+      })
+    })
+
+    it('valid', () => {
+      expect.assertions(1)
+
+      const key = {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 10000,
+      }
+      const transactions = {
+        confirming: {
+          hash: 'confirming',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 234,
+          confirmations: 6,
+          status: 'mined',
+        },
+        old: {
+          hash: 'old',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 123,
+          confirmations: 12345,
+          status: 'mined',
+        },
+      }
+
+      expect(
+        linkTransactionsToKey({
+          key,
+          transactions,
+          requiredConfirmations: 5,
+        })
+      ).toEqual({
+        ...key,
+        transactions: [transactions.confirming, transactions.old],
+        status: 'valid',
+        confirmations: 6,
+      })
+    })
+
+    it('expired', () => {
+      expect.assertions(1)
+
+      const key = {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 - 10000,
+      }
+      const transactions = {
+        confirming: {
+          hash: 'confirming',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 234,
+          confirmations: 6,
+          status: 'mined',
+        },
+        old: {
+          hash: 'old',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 123,
+          confirmations: 12345,
+          status: 'mined',
+        },
+      }
+
+      expect(
+        linkTransactionsToKey({
+          key,
+          transactions,
+          requiredConfirmations: 5,
+        })
+      ).toEqual({
+        ...key,
+        transactions: [transactions.confirming, transactions.old],
+        status: 'expired',
+        confirmations: 6,
+      })
+    })
+
+    it('expired while confirming', () => {
+      expect.assertions(1)
+
+      const key = {
+        id: 'lock-account',
+        lock: 'lock',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 - 10000,
+      }
+      const transactions = {
+        confirming: {
+          hash: 'confirming',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 234,
+          confirmations: 4,
+          status: 'mined',
+        },
+        old: {
+          hash: 'old',
+          from: 'account',
+          to: 'lock',
+          type: TRANSACTION_TYPES.KEY_PURCHASE,
+          blockNumber: 123,
+          confirmations: 12345,
+          status: 'mined',
+        },
+      }
+
+      expect(
+        linkTransactionsToKey({
+          key,
+          transactions,
+          requiredConfirmations: 5,
+        })
+      ).toEqual({
+        ...key,
+        transactions: [transactions.confirming, transactions.old],
+        status: 'expired',
+        confirmations: 4,
+      })
+    })
+  })
+
   describe('linkTransactionsToKeys', () => {
     it('uses the newest transaction', () => {
       expect.assertions(1)
@@ -136,14 +498,12 @@ describe('key status manipulation', () => {
           lock: 'lock',
           owner: 'account',
           expiration: new Date().getTime() / 1000 + 1000,
-          transactions: {},
         },
         'lock 2-account': {
           id: 'lock 2-account',
           lock: 'lock 2',
           owner: 'account',
           expiration: new Date().getTime() / 1000 + 1000,
-          transactions: {},
         },
       }
       const transactions = {
@@ -192,6 +552,8 @@ describe('key status manipulation', () => {
         'lock 2-account': {
           ...keys['lock 2-account'],
           status: 'valid',
+          confirmations: 0,
+          transactions: [],
         },
         'lock-account': {
           ...keys['lock-account'],
@@ -215,7 +577,8 @@ describe('key status manipulation', () => {
           lock: 'lock',
           owner: 'account',
           expiration: 0,
-          transaction: [],
+          confirmations: 0,
+          transactions: [],
           status: 'none',
         },
       }


### PR DESCRIPTION
# Description

This is one of the first steps to making the data structures for the paywall simpler. We will put keys inside their locks, and since there is only ever 1 valid account at a time, the addition of `linkTransactionsToKey` will allow simple augmenting of that key with its relevant metadata. Then, in the UI side of things, we can access a lock's key like so:

```js
if (lock.key.status === 'valid') // we are unlocked
console.log(lock.key.confirmations) // contrived, but you get the idea
```

Note that `linkTransactionsToKeys` has been refactored to use this new function. In the process, found some inconsistencies, and those tests have been corrected.

A key without any history will have these values:

```js
{
  owner: 'account',
  lock: 'lock',
  expiration: 0,
  status: 'none',
  confirmations: 0,
  transactions: [],
}
```

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
