### PR TITLE
refactor getLocks to separate lock retrieval from linking to keys

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/getLocks.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/getLocks.test.js
@@ -1,90 +1,150 @@
-import getLocksAndKeys from '../../../data-iframe/blockchainHandler/getLocks'
+import {
+  getLocks,
+  linkKeysToLocks,
+} from '../../../data-iframe/blockchainHandler/getLocks'
 import { setAccount } from '../../../data-iframe/blockchainHandler/account'
 
-describe('getLocks', () => {
-  let fakeWeb3Service
-  const fakeWalletService = {}
-  beforeEach(() => {
-    fakeWeb3Service = {
-      getLock: jest.fn(address => Promise.resolve({ address })),
-    }
-  })
+jest.mock('../../../data-iframe/blockchainHandler/ensureWalletReady')
 
-  it('calls web3Service.getLock for all the locks', async () => {
-    expect.assertions(4)
-
-    await getLocksAndKeys({
-      walletService: fakeWalletService,
-      locksToRetrieve: [1, 2, 3],
-      existingKeys: {},
-      web3Service: fakeWeb3Service,
+describe('Locks retrieval', () => {
+  describe('getLocks', () => {
+    let fakeWeb3Service
+    beforeEach(() => {
+      fakeWeb3Service = {
+        getLock: jest.fn(address => Promise.resolve({ address })),
+      }
     })
 
-    expect(fakeWeb3Service.getLock).toHaveBeenCalledTimes(3)
-    expect(fakeWeb3Service.getLock).toHaveBeenNthCalledWith(1, 1)
-    expect(fakeWeb3Service.getLock).toHaveBeenNthCalledWith(2, 2)
-    expect(fakeWeb3Service.getLock).toHaveBeenNthCalledWith(3, 3)
-  })
+    it('calls web3Service.getLock for all the locks', async () => {
+      expect.assertions(4)
 
-  it("creates default keys for locks that don't have one", async () => {
-    expect.assertions(1)
+      await getLocks({
+        locksToRetrieve: [1, 2, 3],
+        web3Service: fakeWeb3Service,
+      })
 
-    setAccount('account')
-    const result = await getLocksAndKeys({
-      walletService: fakeWalletService,
-      locksToRetrieve: [1, 2, 3],
-      existingKeys: { '2-account': 'hi' },
-      web3Service: fakeWeb3Service,
+      expect(fakeWeb3Service.getLock).toHaveBeenCalledTimes(3)
+      expect(fakeWeb3Service.getLock).toHaveBeenNthCalledWith(1, 1)
+      expect(fakeWeb3Service.getLock).toHaveBeenNthCalledWith(2, 2)
+      expect(fakeWeb3Service.getLock).toHaveBeenNthCalledWith(3, 3)
     })
 
-    expect(result).toEqual({
-      locks: {
+    it('returns the locks indexed by address', async () => {
+      expect.assertions(1)
+
+      setAccount('account')
+      const result = await getLocks({
+        locksToRetrieve: [1, 2, 3],
+        web3Service: fakeWeb3Service,
+      })
+
+      expect(result).toEqual({
         1: { address: 1 },
         2: { address: 2 },
         3: { address: 3 },
-      },
-      keys: {
-        '1-account': {
-          lock: 1,
-          owner: 'account',
-          expiration: 0,
-          confirmations: 0,
-          status: 'none',
-          transactions: [],
-        },
-        '2-account': 'hi',
-        '3-account': {
-          lock: 3,
-          owner: 'account',
-          expiration: 0,
-          confirmations: 0,
-          status: 'none',
-          transactions: [],
-        },
-      },
+      })
     })
   })
 
-  it('does not make keys if there is no account', async () => {
-    expect.assertions(1)
+  describe('linkKeysToLocks', () => {
+    let fakeWeb3Service
+    let fakeWalletService
 
-    setAccount(null)
-    const result = await getLocksAndKeys({
-      walletService: fakeWalletService,
-      locksToRetrieve: [1, 2, 3],
-      existingKeys: { '2-account': 'hi' },
-      web3Service: fakeWeb3Service,
+    beforeEach(() => {
+      fakeWalletService = {}
+      fakeWeb3Service = {
+        keyExpiry: {},
+        getKeyByLockForOwner(lock) {
+          return {
+            id: 'whatever' + lock,
+            lock,
+            owner: 'account',
+            expiration: fakeWeb3Service.keyExpiry[lock] || 0,
+          }
+        },
+      }
     })
 
-    expect(result).toEqual({
-      locks: {
-        1: { address: 1 },
-        2: { address: 2 },
-        3: { address: 3 },
-      },
-      keys: {
-        '2-account': 'hi',
-      },
+    it('links keys to the locks they unlock', async () => {
+      expect.assertions(1)
+
+      const locks = {
+        '0x123': {
+          address: '0x123',
+          keyPrice: '5',
+          expirationDuration: '6',
+          maxNumberOfKeys: 4,
+        },
+        '0x456': {
+          address: '0x456',
+          keyPrice: '55',
+          expirationDuration: '66',
+          maxNumberOfKeys: 44,
+        },
+      }
+
+      fakeWeb3Service.keyExpiry = {
+        '0x123': new Date().getTime() / 1000 + 123,
+        // no expiry for '0x456' means 0
+      }
+
+      const transactions = {
+        hash: {
+          hash: 'hash',
+          from: 'account',
+          to: '0x123',
+          key: '0x123-account',
+          lock: '0x123',
+          status: 'mined',
+          confirmations: 2,
+          blockNumber: 5,
+        },
+        old: {
+          hash: 'old',
+          from: 'account',
+          to: '0x123',
+          key: '0x123-account',
+          lock: '0x123',
+          status: 'mined',
+          confirmations: 223,
+          blockNumber: 4,
+        },
+      }
+
+      const newLocks = await linkKeysToLocks({
+        locks,
+        walletService: fakeWalletService,
+        transactions,
+        web3Service: fakeWeb3Service,
+        requiredConfirmations: 3,
+      })
+
+      expect(newLocks).toEqual({
+        '0x123': {
+          ...locks['0x123'],
+          key: {
+            confirmations: 2,
+            expiration: fakeWeb3Service.keyExpiry['0x123'],
+            id: 'whatever0x123',
+            lock: '0x123',
+            owner: 'account',
+            status: 'confirming',
+            transactions: [transactions.hash, transactions.old],
+          },
+        },
+        '0x456': {
+          ...locks['0x456'],
+          key: {
+            confirmations: 0,
+            expiration: 0,
+            id: 'whatever0x456',
+            lock: '0x456',
+            owner: 'account',
+            status: 'none',
+            transactions: [],
+          },
+        },
+      })
     })
   })
 })

--- a/paywall/src/data-iframe/blockchainHandler/getLocks.js
+++ b/paywall/src/data-iframe/blockchainHandler/getLocks.js
@@ -1,4 +1,5 @@
-import { getAccount } from './account'
+import getKeys from './getKeys'
+import { linkTransactionsToKey } from './keyStatus'
 
 /**
  * Retrieve lock information and construct default keys for the locks
@@ -8,37 +9,50 @@ import { getAccount } from './account'
  * @param {web3Service} web3Service the web3Service, needed for getLock
  * @returns {{ locks, keys }}
  */
-export default async function getLocksAndKeys({
-  locksToRetrieve,
-  existingKeys,
-  web3Service,
-}) {
+export async function getLocks({ locksToRetrieve, web3Service }) {
   const newLocks = await Promise.all(
     locksToRetrieve.map(lockAddress => web3Service.getLock(lockAddress))
   )
-  const account = getAccount()
-  const keys = { ...existingKeys }
   // convert into a map indexed by lock address
-  const locks = newLocks.reduce(
-    (allLocks, lock) => ({ ...allLocks, [lock.address]: lock }),
+  return newLocks.reduce(
+    (allLocks, lock) => ({
+      ...allLocks,
+      [lock.address]: lock,
+    }),
     {}
   )
-  newLocks.forEach(lock => {
-    const lockAddress = lock.address
-    if (account) {
-      const keyId = `${lockAddress}-${account}`
-      if (!keys[keyId]) {
-        // create a default key for every lock that doesn't already have one
-        keys[keyId] = {
-          lock: lockAddress,
-          owner: account,
-          expiration: 0,
-          status: 'none',
-          confirmations: 0,
-          transactions: [],
-        }
-      }
-    }
+}
+
+export async function linkKeysToLocks({
+  locks,
+  walletService,
+  transactions,
+  web3Service,
+  requiredConfirmations,
+}) {
+  const lockArray = Object.values(locks)
+  const keys = await getKeys({
+    locks: lockArray.map(lock => lock.address),
+    walletService,
+    transactions,
+    web3Service,
+    requiredConfirmations,
   })
-  return { locks, keys }
+
+  // convert into a map indexed by lock address
+  // and link each key to its lock
+  return lockArray.reduce(
+    (allLocks, lock) => ({
+      ...allLocks,
+      [lock.address]: {
+        ...lock,
+        key: linkTransactionsToKey({
+          key: keys[lock.address],
+          transactions,
+          requiredConfirmations,
+        }),
+      },
+    }),
+    {}
+  )
 }


### PR DESCRIPTION
# Description

This PR refactors `getLocks` to split it into 2 related functions, `getLocks` and `linkKeysToLocks`.

The basic idea is to simplify. `getLocks` only retrieves the locks data from the blockchain without augmenting it. `linkKeysToLocks` takes the list of keys generated by `getKeys` and the transactions returned from the chain, finds the lock that corresponds to the key, and sets the `key` property to the key, augmenting it with properties from `linkTransactionsToKey`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
