### PR TITLE
refactor purchase transaction handlers to work with only 1 key

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
@@ -1,6 +1,6 @@
 import { setAccount } from '../../../../data-iframe/blockchainHandler/account'
 import { TRANSACTION_TYPES } from '../../../../constants'
-import pendingListener from '../../../../data-iframe/blockchainHandler/purchaseKey/submittedListener'
+import submittedListener from '../../../../data-iframe/blockchainHandler/purchaseKey/submittedListener'
 import { setNetwork } from '../../../../data-iframe/blockchainHandler/network'
 
 describe('pendingListener', () => {
@@ -30,28 +30,26 @@ describe('pendingListener', () => {
         status: 'submitted',
       },
     }
-    const keys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 + 10000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const key = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 10000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
-    const result = await pendingListener({
+    const result = await submittedListener({
       lockAddress: 'lock',
       existingTransactions: transactions,
-      existingKeys: keys,
+      existingKey: key,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     })
 
     expect(result.transactions).toBe(transactions)
-    expect(result.keys).toBe(keys)
+    expect(result.key).toBe(key)
   })
 
   it('returns immediately if the key is pending', async () => {
@@ -71,28 +69,26 @@ describe('pendingListener', () => {
         status: 'pending',
       },
     }
-    const keys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 + 10000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const key = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 10000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
-    const result = await pendingListener({
+    const result = await submittedListener({
       lockAddress: 'lock',
       existingTransactions: transactions,
-      existingKeys: keys,
+      existingKey: key,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     })
 
     expect(result.transactions).toBe(transactions)
-    expect(result.keys).toBe(keys)
+    expect(result.key).toBe(key)
   })
 
   it('returns immediately if the key is confirming', async () => {
@@ -112,28 +108,26 @@ describe('pendingListener', () => {
         status: 'mined',
       },
     }
-    const keys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 + 10000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const key = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 10000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
-    const result = await pendingListener({
+    const result = await submittedListener({
       lockAddress: 'lock',
       existingTransactions: transactions,
-      existingKeys: keys,
+      existingKey: key,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     })
 
     expect(result.transactions).toBe(transactions)
-    expect(result.keys).toBe(keys)
+    expect(result.key).toBe(key)
   })
 
   it('returns immediately if the key is valid', async () => {
@@ -153,28 +147,26 @@ describe('pendingListener', () => {
         status: 'mined',
       },
     }
-    const keys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 + 10000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const key = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 10000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
-    const result = await pendingListener({
+    const result = await submittedListener({
       lockAddress: 'lock',
       existingTransactions: transactions,
-      existingKeys: keys,
+      existingKey: key,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     })
 
     expect(result.transactions).toBe(transactions)
-    expect(result.keys).toBe(keys)
+    expect(result.key).toBe(key)
   })
 
   it('handles key with no transactions', async done => {
@@ -184,25 +176,23 @@ describe('pendingListener', () => {
     setNetwork(1)
 
     const existingTransactions = {}
-    const existingKeys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 - 1000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const existingKey = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 - 1000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
-    pendingListener({
+    submittedListener({
       lockAddress: 'lock',
       existingTransactions,
-      existingKeys,
+      existingKey,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
-    }).then(({ transactions, keys }) => {
+    }).then(({ transactions, key }) => {
       const hash = {
         hash: 'hash',
         from: 'account',
@@ -220,12 +210,10 @@ describe('pendingListener', () => {
         hash,
       })
 
-      expect(keys).toEqual({
-        'lock-account': {
-          ...existingKeys['lock-account'],
-          status: 'submitted',
-          transactions: [hash],
-        },
+      expect(key).toEqual({
+        ...existingKey,
+        status: 'submitted',
+        transactions: [hash],
       })
       done()
     })
@@ -260,25 +248,23 @@ describe('pendingListener', () => {
     const existingTransactions = {
       old,
     }
-    const existingKeys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 - 1000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const existingKey = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 - 1000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
-    pendingListener({
+    submittedListener({
       lockAddress: 'lock',
       existingTransactions,
-      existingKeys,
+      existingKey,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
-    }).then(({ transactions, keys }) => {
+    }).then(({ transactions, key }) => {
       const hash = {
         hash: 'hash',
         from: 'account',
@@ -297,12 +283,10 @@ describe('pendingListener', () => {
         old,
       })
 
-      expect(keys).toEqual({
-        'lock-account': {
-          ...existingKeys['lock-account'],
-          status: 'submitted',
-          transactions: [hash, old],
-        },
+      expect(key).toEqual({
+        ...existingKey,
+        status: 'submitted',
+        transactions: [hash, old],
       })
       done()
     })
@@ -337,25 +321,23 @@ describe('pendingListener', () => {
     const existingTransactions = {
       old,
     }
-    const existingKeys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 - 1000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const existingKey = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 - 1000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
-    pendingListener({
+    submittedListener({
       lockAddress: 'lock',
       existingTransactions,
-      existingKeys,
+      existingKey,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
-    }).then(({ transactions, keys }) => {
+    }).then(({ transactions, key }) => {
       const hash = {
         hash: 'hash',
         from: 'account',
@@ -374,12 +356,10 @@ describe('pendingListener', () => {
         old,
       })
 
-      expect(keys).toEqual({
-        'lock-account': {
-          ...existingKeys['lock-account'],
-          status: 'submitted',
-          transactions: [hash, old],
-        },
+      expect(key).toEqual({
+        ...existingKey,
+        status: 'submitted',
+        transactions: [hash, old],
       })
       done()
     })

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
@@ -1,4 +1,3 @@
-import { setAccount } from '../../../../data-iframe/blockchainHandler/account'
 import { TRANSACTION_TYPES } from '../../../../constants'
 import submittedListener from '../../../../data-iframe/blockchainHandler/purchaseKey/submittedListener'
 import { setNetwork } from '../../../../data-iframe/blockchainHandler/network'
@@ -16,7 +15,6 @@ describe('pendingListener', () => {
   it('returns immediately if the key is submitted', async () => {
     expect.assertions(2)
 
-    setAccount('account')
     const transactions = {
       hash: {
         hash: 'hash',
@@ -55,7 +53,6 @@ describe('pendingListener', () => {
   it('returns immediately if the key is pending', async () => {
     expect.assertions(2)
 
-    setAccount('account')
     const transactions = {
       hash: {
         hash: 'hash',
@@ -94,7 +91,6 @@ describe('pendingListener', () => {
   it('returns immediately if the key is confirming', async () => {
     expect.assertions(2)
 
-    setAccount('account')
     const transactions = {
       hash: {
         hash: 'hash',
@@ -133,7 +129,6 @@ describe('pendingListener', () => {
   it('returns immediately if the key is valid', async () => {
     expect.assertions(2)
 
-    setAccount('account')
     const transactions = {
       hash: {
         hash: 'hash',
@@ -172,7 +167,6 @@ describe('pendingListener', () => {
   it('handles key with no transactions', async done => {
     expect.assertions(2)
 
-    setAccount('account')
     setNetwork(1)
 
     const existingTransactions = {}
@@ -231,7 +225,6 @@ describe('pendingListener', () => {
   it('handles expired key new transactions', async done => {
     expect.assertions(2)
 
-    setAccount('account')
     setNetwork(1)
     const old = {
       hash: 'old',
@@ -304,7 +297,6 @@ describe('pendingListener', () => {
   it('handles failed key new transactions', async done => {
     expect.assertions(2)
 
-    setAccount('account')
     setNetwork(1)
     const old = {
       hash: 'old',

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/updateListener.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/updateListener.test.js
@@ -28,28 +28,26 @@ describe('updateListener', () => {
         status: 'mined',
       },
     }
-    const keys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: 0,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const key = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: 0,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
     const result = await updateListener({
       lockAddress: 'lock',
       existingTransactions: transactions,
-      existingKeys: keys,
+      existingKey: key,
       web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
     })
 
     expect(result.transactions).toBe(transactions)
-    expect(result.keys).toBe(keys)
+    expect(result.key).toBe(key)
   })
 
   it('ignores confirmed transactions', async () => {
@@ -69,28 +67,26 @@ describe('updateListener', () => {
         status: 'mined',
       },
     }
-    const keys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 + 1000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const key = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 1000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
     const result = await updateListener({
       lockAddress: 'lock',
       existingTransactions: transactions,
-      existingKeys: keys,
+      existingKey: key,
       web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
     })
 
     expect(result.transactions).toBe(transactions)
-    expect(result.keys).toBe(keys)
+    expect(result.key).toBe(key)
   })
 
   it('gets a transaction update for submitted transactions', async done => {
@@ -111,25 +107,23 @@ describe('updateListener', () => {
     const existingTransactions = {
       hash,
     }
-    const existingKeys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 + 1000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const existingKey = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 1000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
     updateListener({
       lockAddress: 'lock',
       existingTransactions,
-      existingKeys,
+      existingKey,
       web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
-    }).then(({ transactions, keys }) => {
+    }).then(({ transactions, key }) => {
       const newHash = {
         ...hash,
         status: 'pending',
@@ -139,12 +133,10 @@ describe('updateListener', () => {
         hash: newHash,
       })
 
-      expect(keys).toEqual({
-        'lock-account': {
-          ...existingKeys['lock-account'],
-          status: 'pending',
-          transactions: [newHash],
-        },
+      expect(key).toEqual({
+        ...existingKey,
+        status: 'pending',
+        transactions: [newHash],
       })
       done()
     })
@@ -173,25 +165,23 @@ describe('updateListener', () => {
     const existingTransactions = {
       hash,
     }
-    const existingKeys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 + 1000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const existingKey = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 1000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
     updateListener({
       lockAddress: 'lock',
       existingTransactions,
-      existingKeys,
+      existingKey,
       web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
-    }).then(({ transactions, keys }) => {
+    }).then(({ transactions, key }) => {
       const newHash = {
         ...hash,
         status: 'mined',
@@ -202,12 +192,10 @@ describe('updateListener', () => {
         hash: newHash,
       })
 
-      expect(keys).toEqual({
-        'lock-account': {
-          ...existingKeys['lock-account'],
-          status: 'confirming',
-          transactions: [newHash],
-        },
+      expect(key).toEqual({
+        ...existingKey,
+        status: 'confirming',
+        transactions: [newHash],
       })
       done()
     })
@@ -236,25 +224,23 @@ describe('updateListener', () => {
     const existingTransactions = {
       hash,
     }
-    const existingKeys = {
-      'lock-account': {
-        id: 'lock-account',
-        lock: 'lock',
-        owner: 'account',
-        expiration: new Date().getTime() / 1000 + 1000,
-        transactions: [],
-        status: 'none',
-        confirmations: 0,
-      },
+    const existingKey = {
+      id: 'lock-account',
+      lock: 'lock',
+      owner: 'account',
+      expiration: new Date().getTime() / 1000 + 1000,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
     }
 
     updateListener({
       lockAddress: 'lock',
       existingTransactions,
-      existingKeys,
+      existingKey,
       web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
-    }).then(({ transactions, keys }) => {
+    }).then(({ transactions, key }) => {
       const newHash = {
         ...hash,
         confirmations: 1,
@@ -264,13 +250,11 @@ describe('updateListener', () => {
         hash: newHash,
       })
 
-      expect(keys).toEqual({
-        'lock-account': {
-          ...existingKeys['lock-account'],
-          status: 'confirming',
-          confirmations: 1,
-          transactions: [newHash],
-        },
+      expect(key).toEqual({
+        ...existingKey,
+        status: 'confirming',
+        confirmations: 1,
+        transactions: [newHash],
       })
       done()
     })

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
@@ -1,4 +1,3 @@
-import { getAccount } from '../account'
 import { linkTransactionsToKey } from '../keyStatus'
 import { getNetwork } from '../network'
 
@@ -24,7 +23,6 @@ export default async function submittedListener({
   walletService,
   requiredConfirmations,
 }) {
-  const account = getAccount()
   // update key status for expired keys
   const key = linkTransactionsToKey({
     key: existingKey,
@@ -61,7 +59,7 @@ export default async function submittedListener({
   const newTransaction = await pendingTransactionFinished
   const transaction = {
     ...newTransaction,
-    key: `${newTransaction.to}-${account}`,
+    key: `${newTransaction.to}-${newTransaction.from}`,
     lock: newTransaction.to,
     confirmations: 0,
     network,

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
@@ -1,5 +1,5 @@
 import { getAccount } from '../account'
-import { linkTransactionsToKeys } from '../keyStatus'
+import { linkTransactionsToKey } from '../keyStatus'
 import { getNetwork } from '../network'
 
 /**
@@ -19,23 +19,19 @@ import { getNetwork } from '../network'
  * @param {int} requiredConfirmations the number of required confirmations for a transaction to be considered permanent
  */
 export default async function submittedListener({
-  lockAddress,
   existingTransactions,
-  existingKeys,
+  existingKey,
   walletService,
   requiredConfirmations,
 }) {
+  const account = getAccount()
   // update key status for expired keys
-  const keys = linkTransactionsToKeys({
-    keys: existingKeys,
+  const key = linkTransactionsToKey({
+    key: existingKey,
     transactions: existingTransactions,
-    locks: [lockAddress],
     requiredConfirmations,
   })
-  const account = getAccount()
   const network = getNetwork()
-  const keyToPurchase = `${lockAddress}-${account}`
-  const key = keys[keyToPurchase]
   // key.status is one of:
   // none, submitted, pending, confirming, valid, expired, failed
   // we can only initiate a new purchase if the current key is not valid, and is
@@ -47,7 +43,7 @@ export default async function submittedListener({
   ) {
     return {
       transactions: existingTransactions,
-      keys: existingKeys,
+      key: existingKey,
     }
   }
 
@@ -65,7 +61,7 @@ export default async function submittedListener({
   const newTransaction = await pendingTransactionFinished
   const transaction = {
     ...newTransaction,
-    key: keyToPurchase,
+    key: `${newTransaction.to}-${account}`,
     lock: newTransaction.to,
     confirmations: 0,
     network,
@@ -78,10 +74,9 @@ export default async function submittedListener({
   }
   return {
     transactions,
-    keys: linkTransactionsToKeys({
-      keys: existingKeys,
+    key: linkTransactionsToKey({
+      key: existingKey,
       transactions,
-      locks: [lockAddress],
       requiredConfirmations,
     }),
   }

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey/updateListener.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey/updateListener.js
@@ -1,23 +1,17 @@
-import { getAccount } from '../account'
-import { linkTransactionsToKeys } from '../keyStatus'
+import { linkTransactionsToKey } from '../keyStatus'
 
 export default async function updateListener({
-  lockAddress,
   existingTransactions,
-  existingKeys,
+  existingKey,
   web3Service,
   requiredConfirmations,
 }) {
-  const account = getAccount()
-  const keyToPurchase = `${lockAddress}-${account}`
   // expire any keys that are expired
-  const keys = linkTransactionsToKeys({
-    keys: existingKeys,
+  const key = linkTransactionsToKey({
+    key: existingKey,
     transactions: existingTransactions,
-    locks: [lockAddress],
     requiredConfirmations,
   })
-  const key = keys[keyToPurchase]
   const transaction = key.transactions[0]
   if (
     !['submitted', 'pending', 'mined'].includes(transaction.status) ||
@@ -26,7 +20,7 @@ export default async function updateListener({
   ) {
     return {
       transactions: existingTransactions,
-      keys: existingKeys,
+      key: existingKey,
     }
   }
 
@@ -54,10 +48,9 @@ export default async function updateListener({
   }
   return {
     transactions,
-    keys: linkTransactionsToKeys({
-      keys: existingKeys,
+    key: linkTransactionsToKey({
+      key: existingKey,
       transactions,
-      locks: [lockAddress],
       requiredConfirmations,
     }),
   }


### PR DESCRIPTION
# Description

When purchasing a key, the transaction evolution can only refer to one key. This PR refactors the `purchaseKey/*Listener`s to use `linkTransactionToKey` and accept a key and return a key, instead of all the keys and return all of the keys.

*it also renames the function in the test for submittedListener, copy/paste errror was not caught in the past commits*

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
