### PR TITLE
Add and use a constant for scrypt/N in account creation

### DIFF
--- a/unlock-js/src/__tests__/accounts.test.js
+++ b/unlock-js/src/__tests__/accounts.test.js
@@ -4,12 +4,14 @@ import {
   reEncryptPrivateKey,
 } from '../accounts'
 
+import { walletEncryptionOptions } from '../constants'
+
 jest.setTimeout(15000)
 
 describe('account helpers', () => {
   describe('web3 accounts creation', () => {
     it('should call ethers.createRandom', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       const {
         address,
@@ -19,6 +21,9 @@ describe('account helpers', () => {
       expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/)
       expect(passwordEncryptedPrivateKey.address).toBe(
         address.substring(2).toLowerCase()
+      )
+      expect(passwordEncryptedPrivateKey.Crypto.kdfparams.n).toBe(
+        walletEncryptionOptions.scrypt.N
       )
     })
   })

--- a/unlock-js/src/accounts.js
+++ b/unlock-js/src/accounts.js
@@ -1,10 +1,12 @@
+import { walletEncryptionOptions } from './constants'
+
 const Wallet = require('ethers').Wallet
 
 export async function createAccountAndPasswordEncryptKey(password) {
   const newWallet = Wallet.createRandom()
   const address = await newWallet.getAddress()
   const passwordEncryptedPrivateKey = JSON.parse(
-    await newWallet.encrypt(password)
+    await newWallet.encrypt(password, walletEncryptionOptions)
   )
 
   return {

--- a/unlock-js/src/constants.js
+++ b/unlock-js/src/constants.js
@@ -24,4 +24,14 @@ export default {
   KEY_ID,
 }
 
+// See
+// https://docs.ethers.io/ethers.js/html/api-wallet.html#encrypted-json-wallets
+// for available params; right now a custom value of scrypt/N covers our needs.
+export const walletEncryptionOptions = {
+  scrypt: {
+    // web3 used 1 << 13, ethers default is 1 << 18 so this is a nice middle ground
+    N: 1 << 16,
+  },
+}
+
 export const ZERO = ethers.constants.AddressZero


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR comes as a result of the discussion in #3297. It makes our user accounts a bit faster to encrypt and decrypt, though there is a tradeoff in terms of resistance to brute force attacks (which can be mitigated by enforcing a strong password policy). Overall, we are comfortable with this tradeoff because the accounts we host never actually hold any currency.

A follow-up PR will bump the version of `unlock-js` and update the CHANGELOG.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3297 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
