### PR TITLE
refactor linkKeysToLocks to accept keys instead of retrieve them

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/getLocks.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/getLocks.test.js
@@ -47,24 +47,6 @@ describe('Locks retrieval', () => {
   })
 
   describe('linkKeysToLocks', () => {
-    let fakeWeb3Service
-    let fakeWalletService
-
-    beforeEach(() => {
-      fakeWalletService = {}
-      fakeWeb3Service = {
-        keyExpiry: {},
-        getKeyByLockForOwner(lock) {
-          return {
-            id: 'whatever' + lock,
-            lock,
-            owner: 'account',
-            expiration: fakeWeb3Service.keyExpiry[lock] || 0,
-          }
-        },
-      }
-    })
-
     it('links keys to the locks they unlock', async () => {
       expect.assertions(1)
 
@@ -83,9 +65,19 @@ describe('Locks retrieval', () => {
         },
       }
 
-      fakeWeb3Service.keyExpiry = {
-        '0x123': new Date().getTime() / 1000 + 123,
-        // no expiry for '0x456' means 0
+      const keys = {
+        '0x123': {
+          id: 'whatever0x123',
+          lock: '0x123',
+          owner: 'account',
+          expiration: new Date().getTime() / 1000 + 123,
+        },
+        '0x456': {
+          id: 'whatever0x456',
+          lock: '0x456',
+          owner: 'account',
+          expiration: 0,
+        },
       }
 
       const transactions = {
@@ -113,9 +105,8 @@ describe('Locks retrieval', () => {
 
       const newLocks = await linkKeysToLocks({
         locks,
-        walletService: fakeWalletService,
+        keys,
         transactions,
-        web3Service: fakeWeb3Service,
         requiredConfirmations: 3,
       })
 
@@ -124,7 +115,7 @@ describe('Locks retrieval', () => {
           ...locks['0x123'],
           key: {
             confirmations: 2,
-            expiration: fakeWeb3Service.keyExpiry['0x123'],
+            expiration: keys['0x123'].expiration,
             id: 'whatever0x123',
             lock: '0x123',
             owner: 'account',

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/getLocks.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/getLocks.test.js
@@ -1,7 +1,4 @@
-import {
-  getLocks,
-  linkKeysToLocks,
-} from '../../../data-iframe/blockchainHandler/getLocks'
+import getLocks from '../../../data-iframe/blockchainHandler/getLocks'
 import { setAccount } from '../../../data-iframe/blockchainHandler/account'
 
 jest.mock('../../../data-iframe/blockchainHandler/ensureWalletReady')
@@ -42,99 +39,6 @@ describe('Locks retrieval', () => {
         1: { address: 1 },
         2: { address: 2 },
         3: { address: 3 },
-      })
-    })
-  })
-
-  describe('linkKeysToLocks', () => {
-    it('links keys to the locks they unlock', async () => {
-      expect.assertions(1)
-
-      const locks = {
-        '0x123': {
-          address: '0x123',
-          keyPrice: '5',
-          expirationDuration: '6',
-          maxNumberOfKeys: 4,
-        },
-        '0x456': {
-          address: '0x456',
-          keyPrice: '55',
-          expirationDuration: '66',
-          maxNumberOfKeys: 44,
-        },
-      }
-
-      const keys = {
-        '0x123': {
-          id: 'whatever0x123',
-          lock: '0x123',
-          owner: 'account',
-          expiration: new Date().getTime() / 1000 + 123,
-        },
-        '0x456': {
-          id: 'whatever0x456',
-          lock: '0x456',
-          owner: 'account',
-          expiration: 0,
-        },
-      }
-
-      const transactions = {
-        hash: {
-          hash: 'hash',
-          from: 'account',
-          to: '0x123',
-          key: '0x123-account',
-          lock: '0x123',
-          status: 'mined',
-          confirmations: 2,
-          blockNumber: 5,
-        },
-        old: {
-          hash: 'old',
-          from: 'account',
-          to: '0x123',
-          key: '0x123-account',
-          lock: '0x123',
-          status: 'mined',
-          confirmations: 223,
-          blockNumber: 4,
-        },
-      }
-
-      const newLocks = await linkKeysToLocks({
-        locks,
-        keys,
-        transactions,
-        requiredConfirmations: 3,
-      })
-
-      expect(newLocks).toEqual({
-        '0x123': {
-          ...locks['0x123'],
-          key: {
-            confirmations: 2,
-            expiration: keys['0x123'].expiration,
-            id: 'whatever0x123',
-            lock: '0x123',
-            owner: 'account',
-            status: 'confirming',
-            transactions: [transactions.hash, transactions.old],
-          },
-        },
-        '0x456': {
-          ...locks['0x456'],
-          key: {
-            confirmations: 0,
-            expiration: 0,
-            id: 'whatever0x456',
-            lock: '0x456',
-            owner: 'account',
-            status: 'none',
-            transactions: [],
-          },
-        },
       })
     })
   })

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/linkKeysToLocks.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/linkKeysToLocks.test.js
@@ -1,0 +1,94 @@
+import linkKeysToLocks from '../../../data-iframe/blockchainHandler/linkKeysToLocks'
+
+describe('linkKeysToLocks', () => {
+  it('links keys to the locks they unlock', async () => {
+    expect.assertions(1)
+
+    const locks = {
+      '0x123': {
+        address: '0x123',
+        keyPrice: '5',
+        expirationDuration: '6',
+        maxNumberOfKeys: 4,
+      },
+      '0x456': {
+        address: '0x456',
+        keyPrice: '55',
+        expirationDuration: '66',
+        maxNumberOfKeys: 44,
+      },
+    }
+
+    const keys = {
+      '0x123': {
+        id: 'whatever0x123',
+        lock: '0x123',
+        owner: 'account',
+        expiration: new Date().getTime() / 1000 + 123,
+      },
+      '0x456': {
+        id: 'whatever0x456',
+        lock: '0x456',
+        owner: 'account',
+        expiration: 0,
+      },
+    }
+
+    const transactions = {
+      hash: {
+        hash: 'hash',
+        from: 'account',
+        to: '0x123',
+        key: '0x123-account',
+        lock: '0x123',
+        status: 'mined',
+        confirmations: 2,
+        blockNumber: 5,
+      },
+      old: {
+        hash: 'old',
+        from: 'account',
+        to: '0x123',
+        key: '0x123-account',
+        lock: '0x123',
+        status: 'mined',
+        confirmations: 223,
+        blockNumber: 4,
+      },
+    }
+
+    const newLocks = await linkKeysToLocks({
+      locks,
+      keys,
+      transactions,
+      requiredConfirmations: 3,
+    })
+
+    expect(newLocks).toEqual({
+      '0x123': {
+        ...locks['0x123'],
+        key: {
+          confirmations: 2,
+          expiration: keys['0x123'].expiration,
+          id: 'whatever0x123',
+          lock: '0x123',
+          owner: 'account',
+          status: 'confirming',
+          transactions: [transactions.hash, transactions.old],
+        },
+      },
+      '0x456': {
+        ...locks['0x456'],
+        key: {
+          confirmations: 0,
+          expiration: 0,
+          id: 'whatever0x456',
+          lock: '0x456',
+          owner: 'account',
+          status: 'none',
+          transactions: [],
+        },
+      },
+    })
+  })
+})

--- a/paywall/src/data-iframe/blockchainHandler/getLocks.js
+++ b/paywall/src/data-iframe/blockchainHandler/getLocks.js
@@ -1,4 +1,3 @@
-import getKeys from './getKeys'
 import { linkTransactionsToKey } from './keyStatus'
 
 /**
@@ -25,19 +24,11 @@ export async function getLocks({ locksToRetrieve, web3Service }) {
 
 export async function linkKeysToLocks({
   locks,
-  walletService,
+  keys,
   transactions,
-  web3Service,
   requiredConfirmations,
 }) {
   const lockArray = Object.values(locks)
-  const keys = await getKeys({
-    locks: lockArray.map(lock => lock.address),
-    walletService,
-    transactions,
-    web3Service,
-    requiredConfirmations,
-  })
 
   // convert into a map indexed by lock address
   // and link each key to its lock

--- a/paywall/src/data-iframe/blockchainHandler/getLocks.js
+++ b/paywall/src/data-iframe/blockchainHandler/getLocks.js
@@ -1,5 +1,3 @@
-import { linkTransactionsToKey } from './keyStatus'
-
 /**
  * Retrieve lock information and construct default keys for the locks
  *
@@ -8,7 +6,7 @@ import { linkTransactionsToKey } from './keyStatus'
  * @param {web3Service} web3Service the web3Service, needed for getLock
  * @returns {{ locks, keys }}
  */
-export async function getLocks({ locksToRetrieve, web3Service }) {
+export default async function getLocks({ locksToRetrieve, web3Service }) {
   const newLocks = await Promise.all(
     locksToRetrieve.map(lockAddress => web3Service.getLock(lockAddress))
   )
@@ -17,32 +15,6 @@ export async function getLocks({ locksToRetrieve, web3Service }) {
     (allLocks, lock) => ({
       ...allLocks,
       [lock.address]: lock,
-    }),
-    {}
-  )
-}
-
-export async function linkKeysToLocks({
-  locks,
-  keys,
-  transactions,
-  requiredConfirmations,
-}) {
-  const lockArray = Object.values(locks)
-
-  // convert into a map indexed by lock address
-  // and link each key to its lock
-  return lockArray.reduce(
-    (allLocks, lock) => ({
-      ...allLocks,
-      [lock.address]: {
-        ...lock,
-        key: linkTransactionsToKey({
-          key: keys[lock.address],
-          transactions,
-          requiredConfirmations,
-        }),
-      },
     }),
     {}
   )

--- a/paywall/src/data-iframe/blockchainHandler/linkKeysToLocks.js
+++ b/paywall/src/data-iframe/blockchainHandler/linkKeysToLocks.js
@@ -1,0 +1,27 @@
+import { linkTransactionsToKey } from './keyStatus'
+
+export default async function linkKeysToLocks({
+  locks,
+  keys,
+  transactions,
+  requiredConfirmations,
+}) {
+  const lockArray = Object.values(locks)
+
+  // convert into a map indexed by lock address
+  // and link each key to its lock
+  return lockArray.reduce(
+    (allLocks, lock) => ({
+      ...allLocks,
+      [lock.address]: {
+        ...lock,
+        key: linkTransactionsToKey({
+          key: keys[lock.address],
+          transactions,
+          requiredConfirmations,
+        }),
+      },
+    }),
+    {}
+  )
+}


### PR DESCRIPTION
# Description

This removes some internal complexity of `linkKeysToLocks` so that it instead accepts keys instead of retrieving them. Because it is no longer directly related to lock retrieval, it is now in its own file

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
