### PR TITLE
renaming hideModal into onClick so that we can re-use it in the checkout component

### DIFF
--- a/paywall/src/components/interface/buttons/overlay/ConfirmedKey.js
+++ b/paywall/src/components/interface/buttons/overlay/ConfirmedKey.js
@@ -4,11 +4,11 @@ import styled from 'styled-components'
 import Svg from '../../svg'
 import Button from '../Button'
 
-const ConfirmedKey = ({ hideModal, ...props }) => (
+const ConfirmedKey = ({ onClick, ...props }) => (
   <ConfirmedKeyButton
     {...props}
     backgroundHoverColor="var(--green)"
-    onClick={() => hideModal()}
+    onClick={onClick}
   >
     <Checkmark />
     <Arrow />
@@ -16,7 +16,7 @@ const ConfirmedKey = ({ hideModal, ...props }) => (
 )
 
 ConfirmedKey.propTypes = {
-  hideModal: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
 }
 
 export const Checkmark = styled(Svg.Checkmark)``

--- a/paywall/src/components/lock/ConfirmedFlag.js
+++ b/paywall/src/components/lock/ConfirmedFlag.js
@@ -24,7 +24,7 @@ export default function ConfirmedFlag({ dismiss }) {
       </OptimisticLogo>
       <p>Purchase Confirmed</p>
       <ConfirmedKeyWrapper>
-        <ConfirmedKey height="24px" width="24px" hideModal={dismiss} />
+        <ConfirmedKey height="24px" width="24px" onClick={dismiss} />
       </ConfirmedKeyWrapper>
       <PoweredByUnlock>
         <p>Powered by</p>

--- a/paywall/src/components/lock/ConfirmedKeyLock.js
+++ b/paywall/src/components/lock/ConfirmedKeyLock.js
@@ -17,10 +17,10 @@ import ConfirmedKey, {
 import { HoverFooter, NotHoverFooter } from './HoverFooters'
 import BalanceProvider from '../helpers/BalanceProvider'
 
-const ConfirmedKeyLock = ({ lock, hideModal }) => (
+const ConfirmedKeyLock = ({ lock, onClick }) => (
   <LockWrapper lock={lock}>
     <LockHeader>{lock.name}</LockHeader>
-    <Body onClick={() => hideModal()}>
+    <Body onClick={onClick}>
       <BalanceProvider
         amount={lock.keyPrice}
         render={(ethPrice, fiatPrice) => (
@@ -32,7 +32,7 @@ const ConfirmedKeyLock = ({ lock, hideModal }) => (
           </React.Fragment>
         )}
       />
-      <ConfirmedKey size="50px" hideModal={hideModal} />
+      <ConfirmedKey size="50px" onClick={onClick} />
       <NotHoverFooter backgroundColor="var(--green)">
         Payment Confirmed
       </NotHoverFooter>
@@ -42,7 +42,7 @@ const ConfirmedKeyLock = ({ lock, hideModal }) => (
 )
 
 ConfirmedKeyLock.propTypes = {
-  hideModal: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
   lock: UnlockPropTypes.lock.isRequired,
 }
 

--- a/paywall/src/components/lock/Lock.js
+++ b/paywall/src/components/lock/Lock.js
@@ -31,7 +31,7 @@ export const Lock = ({
       return <ConfirmingKeyLock lock={lock} transaction={transaction} />
     case 'confirmed':
     case 'valid':
-      return <ConfirmedKeyLock lock={lock} hideModal={hideModal} />
+      return <ConfirmedKeyLock lock={lock} onClick={hideModal} />
     case 'none':
     case 'expired':
     default:


### PR DESCRIPTION
# Description

The `hideModal` name is a bit too specific. After all, different components may do different things when the user clicks on them

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->