### PR TITLE
 Events URL now uses base domain from configuration 

### DIFF
--- a/tickets/src/__tests__/components/content/CreateContent.test.js
+++ b/tickets/src/__tests__/components/content/CreateContent.test.js
@@ -9,10 +9,14 @@ import {
   mapStateToProps,
 } from '../../../components/content/CreateContent'
 import createUnlockStore from '../../../createUnlockStore'
+import { ConfigContext } from '../../../utils/withConfig'
 
 const config = {
   unlockAppUrl: 'https://unlock-protocol.com',
+  unlockTicketsUrl: 'https://tickets.unlock-protocol.com',
 }
+
+const ConfigProvider = ConfigContext.Provider
 
 const account = {
   address: '0x123',
@@ -96,14 +100,16 @@ describe('CreateContent', () => {
 
     const form = rtl.render(
       <Provider store={store}>
-        <CreateContent
-          config={config}
-          account={{ address: 'ben' }}
-          locks={['abc123', 'def456']}
-          addEvent={addEvent}
-          now={now}
-          loadEvent={jest.fn()}
-        />
+        <ConfigProvider value={config}>
+          <CreateContent
+            config={config}
+            account={{ address: 'ben' }}
+            locks={['abc123', 'def456']}
+            addEvent={addEvent}
+            now={now}
+            loadEvent={jest.fn()}
+          />
+        </ConfigProvider>
       </Provider>
     )
 
@@ -151,14 +157,16 @@ describe('CreateContent', () => {
 
     const form = rtl.render(
       <Provider store={store}>
-        <CreateContent
-          config={config}
-          account={{ address: 'ben' }}
-          locks={['abc123', 'def456']}
-          addEvent={addEvent}
-          loadEvent={loadEvent}
-          now={now}
-        />
+        <ConfigProvider value={config}>
+          <CreateContent
+            config={config}
+            account={{ address: 'ben' }}
+            locks={['abc123', 'def456']}
+            addEvent={addEvent}
+            loadEvent={loadEvent}
+            now={now}
+          />
+        </ConfigProvider>
       </Provider>
     )
 

--- a/tickets/src/__tests__/components/helpers/EventUrl.test.js
+++ b/tickets/src/__tests__/components/helpers/EventUrl.test.js
@@ -2,10 +2,14 @@ import React from 'react'
 import * as rtl from 'react-testing-library'
 import { EventUrl } from '../../../components/helpers/EventUrl'
 
+const config = {
+  unlockTicketsUrl: 'https://tickets.unlock-protocol.com',
+}
+
 describe('EventUrl helper component', () => {
   it('shows an event URL when an address is supplied', () => {
     expect.assertions(1)
-    const wrapper = rtl.render(<EventUrl address="0x123" />)
+    const wrapper = rtl.render(<EventUrl address="0x123" config={config} />)
     expect(
       wrapper.queryByText('https://tickets.unlock-protocol.com/event/0x123')
     ).not.toBeNull()

--- a/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -3487,7 +3487,7 @@ Object {
                       href="/event/abc123"
                       target="_blank"
                     >
-                      https://tickets.unlock-protocol.com/event/abc123
+                      http://0.0.0.0:3003/event/abc123
                     </a>
                   </label>
                 </div>
@@ -3936,7 +3936,7 @@ Object {
                     href="/event/abc123"
                     target="_blank"
                   >
-                    https://tickets.unlock-protocol.com/event/abc123
+                    http://0.0.0.0:3003/event/abc123
                   </a>
                 </label>
               </div>

--- a/tickets/src/components/helpers/EventUrl.js
+++ b/tickets/src/components/helpers/EventUrl.js
@@ -1,14 +1,16 @@
 import styled from 'styled-components'
 import React from 'react'
 import PropTypes from 'prop-types'
+import withConfig from '../../utils/withConfig'
+import UnlockPropTypes from '../../propTypes'
 
-export const EventUrl = ({ address }) => {
+export const EventUrl = ({ address, config }) => {
   if (!address) {
     return <span />
   }
 
   const path = `/event/${address}`
-  const url = `https://tickets.unlock-protocol.com${path}`
+  const url = config.unlockTicketsUrl + path
 
   return (
     <Text>
@@ -22,13 +24,14 @@ export const EventUrl = ({ address }) => {
 
 EventUrl.propTypes = {
   address: PropTypes.string,
+  config: UnlockPropTypes.configuration.isRequired,
 }
 
 EventUrl.defaultProps = {
   address: null,
 }
 
-export default EventUrl
+export default withConfig(EventUrl)
 
 const Text = styled.label`
   font-size: 13px;

--- a/tickets/src/stories/content/CreateContent.stories.js
+++ b/tickets/src/stories/content/CreateContent.stories.js
@@ -10,6 +10,7 @@ import createUnlockStore from '../../createUnlockStore'
 const ConfigProvider = ConfigContext.Provider
 const config = configure({
   unlockAppUrl: 'https://unlock-protocol.com',
+  unlockTicketsUrl: 'https://tickets.unlock-protocol.com',
 })
 
 const store = createUnlockStore({

--- a/tickets/src/stories/helpers/EventUrl.stories.js
+++ b/tickets/src/stories/helpers/EventUrl.stories.js
@@ -2,10 +2,14 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { EventUrl } from '../../components/helpers/EventUrl'
 
+const config = {
+  unlockTicketsUrl: 'https://tickets.unlock-protocol.com',
+}
+
 storiesOf('Event URL helper', module)
   .add('Event URL with address', () => {
-    return <EventUrl address="0x123" />
+    return <EventUrl address="0x123" config={config} />
   })
   .add('Event URL with no address', () => {
-    return <EventUrl address={null} />
+    return <EventUrl address={null} config={config} />
   })


### PR DESCRIPTION
# Description

I got tired of copying and pasting a partial path during debugging. You can now click on the event URL on the form screen no matter which domain the app is configured to use.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<img width="1244" alt="Screen Shot 2019-05-22 at 12 41 17 PM" src="https://user-images.githubusercontent.com/624104/58204287-e162e380-7c90-11e9-986b-c3cfb2919899.png">
