### PR TITLE
implement non-user-specific caching functionality

### DIFF
--- a/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
@@ -1,4 +1,14 @@
-import { get, put, clear } from '../../../data-iframe/cache'
+import {
+  get,
+  put,
+  clear,
+  getAccount,
+  setAccount,
+  getNetwork,
+  setNetwork,
+  getReadOnly,
+  putReadOnly,
+} from '../../../data-iframe/cache'
 
 jest.mock('../../../utils/localStorage', () => () => false)
 
@@ -14,11 +24,31 @@ describe('localStorage cache', () => {
       }
     })
 
+    it('getReadOnly', async () => {
+      expect.assertions(1)
+
+      try {
+        await getReadOnly()
+      } catch (e) {
+        expect(e.message).toBe('Cannot get value from localStorage')
+      }
+    })
+
     it('put', async () => {
       expect.assertions(1)
 
       try {
         await put()
+      } catch (e) {
+        expect(e.message).toBe('Cannot put value into localStorage')
+      }
+    })
+
+    it('putReadOnly', async () => {
+      expect.assertions(1)
+
+      try {
+        await putReadOnly()
       } catch (e) {
         expect(e.message).toBe('Cannot put value into localStorage')
       }
@@ -31,6 +61,46 @@ describe('localStorage cache', () => {
         await clear()
       } catch (e) {
         expect(e.message).toBe('Cannot clear localStorage cache')
+      }
+    })
+
+    it('getAccount', async () => {
+      expect.assertions(1)
+
+      try {
+        await getAccount()
+      } catch (e) {
+        expect(e.message).toBe('Cannot get value from localStorage')
+      }
+    })
+
+    it('getNetwork', async () => {
+      expect.assertions(1)
+
+      try {
+        await getNetwork()
+      } catch (e) {
+        expect(e.message).toBe('Cannot get value from localStorage')
+      }
+    })
+
+    it('setAccount', async () => {
+      expect.assertions(1)
+
+      try {
+        await setAccount()
+      } catch (e) {
+        expect(e.message).toBe('Cannot put value into localStorage')
+      }
+    })
+
+    it('setNetwork', async () => {
+      expect.assertions(1)
+
+      try {
+        await setNetwork()
+      } catch (e) {
+        expect(e.message).toBe('Cannot put value into localStorage')
       }
     })
   })

--- a/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
@@ -6,8 +6,6 @@ import {
   setAccount,
   getNetwork,
   setNetwork,
-  getReadOnly,
-  putReadOnly,
 } from '../../../data-iframe/cache'
 
 jest.mock('../../../utils/localStorage', () => () => false)
@@ -18,19 +16,11 @@ describe('localStorage cache', () => {
       expect.assertions(1)
 
       try {
-        await get()
+        await get({ type: 'thing' })
       } catch (e) {
-        expect(e.message).toBe('Cannot get value from localStorage')
-      }
-    })
-
-    it('getReadOnly', async () => {
-      expect.assertions(1)
-
-      try {
-        await getReadOnly()
-      } catch (e) {
-        expect(e.message).toBe('Cannot get value from localStorage')
+        expect(e.message).toBe(
+          'localStorage is unavailable, cannot get thing from cache'
+        )
       }
     })
 
@@ -38,19 +28,11 @@ describe('localStorage cache', () => {
       expect.assertions(1)
 
       try {
-        await put()
+        await put({ type: 'thing' })
       } catch (e) {
-        expect(e.message).toBe('Cannot put value into localStorage')
-      }
-    })
-
-    it('putReadOnly', async () => {
-      expect.assertions(1)
-
-      try {
-        await putReadOnly()
-      } catch (e) {
-        expect(e.message).toBe('Cannot put value into localStorage')
+        expect(e.message).toBe(
+          'localStorage is unavailable, cannot save thing in cache'
+        )
       }
     })
 
@@ -58,9 +40,11 @@ describe('localStorage cache', () => {
       expect.assertions(1)
 
       try {
-        await clear()
+        await clear({})
       } catch (e) {
-        expect(e.message).toBe('Cannot clear localStorage cache')
+        expect(e.message).toBe(
+          'localStorage is unavailable, cannot clear cache'
+        )
       }
     })
 
@@ -70,7 +54,9 @@ describe('localStorage cache', () => {
       try {
         await getAccount()
       } catch (e) {
-        expect(e.message).toBe('Cannot get value from localStorage')
+        expect(e.message).toBe(
+          'localStorage is unavailable, cannot get account from cache'
+        )
       }
     })
 
@@ -80,7 +66,9 @@ describe('localStorage cache', () => {
       try {
         await getNetwork()
       } catch (e) {
-        expect(e.message).toBe('Cannot get value from localStorage')
+        expect(e.message).toBe(
+          'localStorage is unavailable, cannot get network from cache'
+        )
       }
     })
 
@@ -90,7 +78,9 @@ describe('localStorage cache', () => {
       try {
         await setAccount()
       } catch (e) {
-        expect(e.message).toBe('Cannot put value into localStorage')
+        expect(e.message).toBe(
+          'localStorage is unavailable, cannot save account in cache'
+        )
       }
     })
 
@@ -100,7 +90,9 @@ describe('localStorage cache', () => {
       try {
         await setNetwork()
       } catch (e) {
-        expect(e.message).toBe('Cannot put value into localStorage')
+        expect(e.message).toBe(
+          'localStorage is unavailable, cannot save network in cache'
+        )
       }
     })
   })

--- a/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
@@ -9,8 +9,6 @@ import {
   setAccount,
   setNetwork,
   getNetwork,
-  putReadOnly,
-  getReadOnly,
 } from '../../../data-iframe/cache'
 
 jest.mock('../../../utils/localStorage', () => () => true)
@@ -44,7 +42,14 @@ describe('localStorage cache', () => {
     it('value is not yet set', async () => {
       expect.assertions(1)
 
-      expect(await get(fakeWindow, 123, 'hi', 'there')).toBeNull()
+      expect(
+        await get({
+          window: fakeWindow,
+          networkId: 123,
+          type: 'there',
+          accountAddress: 'hi',
+        })
+      ).toBeNull()
     })
 
     it('value is set', async () => {
@@ -53,7 +58,29 @@ describe('localStorage cache', () => {
         there: 'hello',
       })
 
-      expect(await get(fakeWindow, 123, 'hi', 'there')).toEqual('hello')
+      expect(
+        await get({
+          window: fakeWindow,
+          networkId: 123,
+          type: 'there',
+          accountAddress: 'hi',
+        })
+      ).toEqual('hello')
+    })
+
+    it('no account retrieves generic value', async () => {
+      expect.assertions(1)
+      fakeWindow.storage[storageId(123, nullAccount)] = JSON.stringify({
+        there: 'hello',
+      })
+
+      expect(
+        await get({
+          window: fakeWindow,
+          networkId: 123,
+          type: 'there',
+        })
+      ).toEqual('hello')
     })
 
     it('value is set, but malformed', async () => {
@@ -62,7 +89,14 @@ describe('localStorage cache', () => {
         there: 'hello',
       }).substring(1, 4)
 
-      expect(await get(fakeWindow, 123, 'hi', 'there')).toBeNull()
+      expect(
+        await get({
+          window: fakeWindow,
+          networkId: 123,
+          type: 'there',
+          accountAddress: 'hi',
+        })
+      ).toBeNull()
     })
 
     it('value is set, different network', async () => {
@@ -71,7 +105,14 @@ describe('localStorage cache', () => {
         there: 'hello',
       })
 
-      expect(await get(fakeWindow, 123, 'hi', 'there')).toBeNull()
+      expect(
+        await get({
+          window: fakeWindow,
+          networkId: 123,
+          type: 'there',
+          accountAddress: 'hi',
+        })
+      ).toBeNull()
     })
 
     it('value is set, different account', async () => {
@@ -80,7 +121,14 @@ describe('localStorage cache', () => {
         there: 'hello',
       })
 
-      expect(await get(fakeWindow, 123, 'hi', 'there')).toBeNull()
+      expect(
+        await get({
+          window: fakeWindow,
+          networkId: 123,
+          type: 'there',
+          accountAddress: 'hi',
+        })
+      ).toBeNull()
     })
 
     it('value is set, entire cache for user wanted', async () => {
@@ -90,59 +138,9 @@ describe('localStorage cache', () => {
         it: 'is',
       })
 
-      expect(await get(fakeWindow, 123, 'hi')).toEqual({
-        there: 'hello',
-        it: 'is',
-      })
-    })
-  })
-
-  describe('getReadOnly', () => {
-    beforeEach(() => {
-      makeWindow()
-    })
-
-    it('value is not yet set', async () => {
-      expect.assertions(1)
-
-      expect(await getReadOnly(fakeWindow, 123, 'there')).toBeNull()
-    })
-
-    it('value is set', async () => {
-      expect.assertions(1)
-      fakeWindow.storage[storageId(123, nullAccount)] = JSON.stringify({
-        there: 'hello',
-      })
-
-      expect(await getReadOnly(fakeWindow, 123, 'there')).toEqual('hello')
-    })
-
-    it('value is set, but malformed', async () => {
-      expect.assertions(1)
-      fakeWindow.storage[storageId(123, nullAccount)] = JSON.stringify({
-        there: 'hello',
-      }).substring(1, 4)
-
-      expect(await getReadOnly(fakeWindow, 123, 'there')).toBeNull()
-    })
-
-    it('value is set, different network', async () => {
-      expect.assertions(1)
-      fakeWindow.storage[storageId(456, 'hi')] = JSON.stringify({
-        there: 'hello',
-      })
-
-      expect(await getReadOnly(fakeWindow, 123, 'hi', 'there')).toBeNull()
-    })
-
-    it('value is set, entire cache for user wanted', async () => {
-      expect.assertions(1)
-      fakeWindow.storage[storageId(123, nullAccount)] = JSON.stringify({
-        there: 'hello',
-        it: 'is',
-      })
-
-      expect(await getReadOnly(fakeWindow, 123)).toEqual({
+      expect(
+        await get({ window: fakeWindow, networkId: 123, accountAddress: 'hi' })
+      ).toEqual({
         there: 'hello',
         it: 'is',
       })
@@ -153,10 +151,17 @@ describe('localStorage cache', () => {
     beforeEach(() => {
       makeWindow()
     })
+
     it('saves the value', async () => {
       expect.assertions(1)
 
-      await put(fakeWindow, 123, 'hi', 'there', 'hello')
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'there',
+        value: 'hello',
+      })
 
       expect(fakeWindow.storage[storageId(123, 'hi')]).toBe(
         JSON.stringify({
@@ -164,16 +169,16 @@ describe('localStorage cache', () => {
         })
       )
     })
-  })
 
-  describe('putReadOnly', () => {
-    beforeEach(() => {
-      makeWindow()
-    })
-    it('saves the value', async () => {
+    it('saves the value in generic storage if no account is specified', async () => {
       expect.assertions(1)
 
-      await putReadOnly(fakeWindow, 123, 'there', 'hello')
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        type: 'there',
+        value: 'hello',
+      })
 
       expect(fakeWindow.storage[storageId(123, nullAccount)]).toBe(
         JSON.stringify({
@@ -186,12 +191,48 @@ describe('localStorage cache', () => {
   describe('clear', () => {
     beforeEach(async () => {
       makeWindow()
-      await put(fakeWindow, 123, 'hi', 'foo', 'bar')
-      await put(fakeWindow, 456, 'hi', 'foo', 'bar')
-      await put(fakeWindow, 123, 'hi', 'bar', 'bar')
-      await put(fakeWindow, 123, 'bar', 'fooe', 'bare')
-      await put(fakeWindow, 456, 'bar', 'fooe', 'bare')
-      await put(fakeWindow, 123, 'bar', 'bare', 'bare')
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'foo',
+        value: 'bar',
+      })
+      await put({
+        window: fakeWindow,
+        networkId: 456,
+        accountAddress: 'hi',
+        type: 'foo',
+        value: 'bar',
+      })
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'bar',
+        value: 'bar',
+      })
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'bar',
+        type: 'fooe',
+        value: 'bare',
+      })
+      await put({
+        window: fakeWindow,
+        networkId: 456,
+        accountAddress: 'bar',
+        type: 'fooe',
+        value: 'bare',
+      })
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'bar',
+        type: 'bare',
+        value: 'bare',
+      })
     })
 
     it('initial value is correct', () => {
@@ -208,7 +249,12 @@ describe('localStorage cache', () => {
     it('clearing just one value of the cache', async () => {
       expect.assertions(2)
 
-      await clear(fakeWindow, 123, 'hi', 'foo')
+      await clear({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'foo',
+      })
       expect(fakeWindow.storage).toEqual({
         'unlock-protocol/123/bar': '{"fooe":"bare","bare":"bare"}',
         'unlock-protocol/123/hi': '{"bar":"bar"}',
@@ -216,7 +262,12 @@ describe('localStorage cache', () => {
         'unlock-protocol/456/hi': '{"foo":"bar"}',
       })
 
-      await clear(fakeWindow, 123, 'hi', 'bar')
+      await clear({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'bar',
+      })
       expect(fakeWindow.storage).toEqual({
         'unlock-protocol/123/bar': '{"fooe":"bare","bare":"bare"}',
         'unlock-protocol/123/hi': '{}',
@@ -228,7 +279,11 @@ describe('localStorage cache', () => {
     it('clearing the whole cache for a user', async () => {
       expect.assertions(1)
 
-      await clear(fakeWindow, 123, 'hi')
+      await clear({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+      })
       expect(fakeWindow.storage).toEqual({
         'unlock-protocol/123/bar': '{"fooe":"bare","bare":"bare"}',
         'unlock-protocol/456/bar': '{"fooe":"bare"}',
@@ -239,8 +294,16 @@ describe('localStorage cache', () => {
     it("does not clear other user's cache", async () => {
       expect.assertions(1)
 
-      await clear(fakeWindow, 123, 'hi')
-      const bare = await get(fakeWindow, 123, 'bar')
+      await clear({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+      })
+      const bare = await get({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'bar',
+      })
 
       expect(bare).toEqual({
         fooe: 'bare',
@@ -251,8 +314,16 @@ describe('localStorage cache', () => {
     it("does not clear same user's cache on a different network", async () => {
       expect.assertions(1)
 
-      await clear(fakeWindow, 123, 'hi')
-      const other = await get(fakeWindow, 456, 'hi')
+      await clear({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+      })
+      const other = await get({
+        window: fakeWindow,
+        networkId: 456,
+        accountAddress: 'hi',
+      })
 
       expect(other).toEqual({
         foo: 'bar',
@@ -326,7 +397,12 @@ describe('localStorage cache', () => {
       expect.assertions(2)
       const listen = jest.fn()
 
-      await addListener(fakeWindow, 123, 'hi', listen)
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
 
       expect(listeners.storage.size).toBe(1)
 
@@ -344,8 +420,19 @@ describe('localStorage cache', () => {
       expect.assertions(1)
       const listen = jest.fn()
 
-      await addListener(fakeWindow, 123, 'hi', listen)
-      await addListener(fakeWindow, 123, 'hi', listen)
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
+
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
 
       expect(listeners.storage.size).toBe(1)
     })
@@ -355,8 +442,19 @@ describe('localStorage cache', () => {
       const listen = jest.fn()
       const listen2 = jest.fn()
 
-      await addListener(fakeWindow, 123, 'hi', listen)
-      await addListener(fakeWindow, 456, 'hi', listen2)
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
+
+      await addListener({
+        window: fakeWindow,
+        networkId: 456,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
 
       expect(listeners.storage.size).toBe(2)
 
@@ -377,8 +475,19 @@ describe('localStorage cache', () => {
       const listen = jest.fn()
       const listen2 = jest.fn()
 
-      await addListener(fakeWindow, 123, 'hi', listen)
-      await addListener(fakeWindow, 123, 'bye', listen2)
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
+
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'bye',
+        changeCallback: listen2,
+      })
 
       expect(listeners.storage.size).toBe(2)
 
@@ -416,11 +525,21 @@ describe('localStorage cache', () => {
       expect.assertions(2)
       const listen = jest.fn()
 
-      await addListener(fakeWindow, 123, 'hi', listen)
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
 
       expect(listeners.storage.size).toBe(1)
 
-      await removeListener(fakeWindow, 123, 'hi', listen)
+      await removeListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
 
       expect(listeners.storage.size).toBe(0)
     })
@@ -430,12 +549,28 @@ describe('localStorage cache', () => {
       const listen = jest.fn()
       const listen2 = jest.fn()
 
-      await addListener(fakeWindow, 123, 'hi', listen)
-      await addListener(fakeWindow, 456, 'hi', listen2)
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
+
+      await addListener({
+        window: fakeWindow,
+        networkId: 456,
+        accountAddress: 'hi',
+        changeCallback: listen2,
+      })
 
       expect(listeners.storage.size).toBe(2)
 
-      await removeListener(fakeWindow, 123, 'hi', listen)
+      await removeListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
 
       expect(listeners.storage.size).toBe(1)
 
@@ -450,7 +585,12 @@ describe('localStorage cache', () => {
       expect(listen).not.toHaveBeenCalled()
       expect(listen2).not.toHaveBeenCalled()
 
-      await removeListener(fakeWindow, 456, 'hi', listen2)
+      await removeListener({
+        window: fakeWindow,
+        networkId: 456,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
 
       expect(listeners.storage.size).toBe(0)
     })
@@ -460,12 +600,28 @@ describe('localStorage cache', () => {
       const listen = jest.fn()
       const listen2 = jest.fn()
 
-      await addListener(fakeWindow, 123, 'hi', listen)
-      await addListener(fakeWindow, 123, 'bye', listen2)
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
+
+      await addListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'bye',
+        changeCallback: listen2,
+      })
 
       expect(listeners.storage.size).toBe(2)
 
-      await removeListener(fakeWindow, 123, 'hi', listen)
+      await removeListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        changeCallback: listen,
+      })
 
       expect(listeners.storage.size).toBe(1)
 
@@ -480,7 +636,12 @@ describe('localStorage cache', () => {
       expect(listen).not.toHaveBeenCalled()
       expect(listen2).not.toHaveBeenCalled()
 
-      await removeListener(fakeWindow, 123, 'bye', listen2)
+      await removeListener({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'bye',
+        changeCallback: listen,
+      })
 
       expect(listeners.storage.size).toBe(0)
     })

--- a/paywall/src/data-iframe/cache/index.js
+++ b/paywall/src/data-iframe/cache/index.js
@@ -4,8 +4,14 @@
 export {
   get,
   put,
+  getReadOnly,
+  putReadOnly,
   clear,
   addListener,
   removeListener,
   storageId,
+  getAccount,
+  getNetwork,
+  setAccount,
+  setNetwork,
 } from './localStorage'

--- a/paywall/src/data-iframe/cache/index.js
+++ b/paywall/src/data-iframe/cache/index.js
@@ -4,8 +4,6 @@
 export {
   get,
   put,
-  getReadOnly,
-  putReadOnly,
   clear,
   addListener,
   removeListener,

--- a/paywall/src/data-iframe/cache/localStorage.js
+++ b/paywall/src/data-iframe/cache/localStorage.js
@@ -4,6 +4,8 @@ export function storageId(networkId, accountAddress) {
   return `unlock-protocol/${networkId}/${accountAddress}`
 }
 
+const nullAccount = '0x0000000000000000000000000000000000000000'
+
 /**
  * retrieve the container from localStorage, ensure the optional type
  * exists as a key if requested
@@ -54,7 +56,8 @@ export async function getReadOnly(window, networkId, type) {
   return get(
     window,
     networkId,
-    '0x0000000000000000000000000000000000000000',
+    // using null account guarantees no collisions with real ethereum users
+    nullAccount,
     type
   )
 }
@@ -71,7 +74,8 @@ export async function putReadOnly(window, networkId, type, value) {
   return put(
     window,
     networkId,
-    '0x0000000000000000000000000000000000000000',
+    // using null account guarantees no collisions with real ethereum users
+    nullAccount,
     type,
     value
   )

--- a/paywall/src/data-iframe/cache/localStorage.js
+++ b/paywall/src/data-iframe/cache/localStorage.js
@@ -44,6 +44,40 @@ function getContainer(window, key, type = false) {
 }
 
 /**
+ * Retrieve a cached value for a non-user-specific type on a specific network
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @param {int} networkId the ethereum network id
+ * @param {string} type the type of account data to retrieve
+ */
+export async function getReadOnly(window, networkId, type) {
+  return get(
+    window,
+    networkId,
+    '0x0000000000000000000000000000000000000000',
+    type
+  )
+}
+
+/**
+ * Cache a value for a non-user-specific type on a network
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @param {int} networkId the ethereum network id
+ * @param {string} type the type of account data to set
+ * @param {*} value the value to store. This must be serializable as JSON
+ */
+export async function putReadOnly(window, networkId, type, value) {
+  return put(
+    window,
+    networkId,
+    '0x0000000000000000000000000000000000000000',
+    type,
+    value
+  )
+}
+
+/**
  * Retrieve a cached value for a user on a specific network
  *
  * @param {object} window this is the global context, either global, window, or self
@@ -84,6 +118,58 @@ export async function put(window, networkId, accountAddress, type, value) {
   }
 
   window.localStorage.setItem(key, JSON.stringify(container))
+}
+
+/**
+ * Retrieve the current cached account
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @returns {string}
+ */
+export async function getAccount(window) {
+  if (!localStorageAvailable(window)) {
+    throw new Error('Cannot get value from localStorage')
+  }
+  return window.localStorage.getItem('__unlockProtocol.account') || null
+}
+
+/**
+ * Set the current cached account
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @param {string} account the ethereum account address of the current user
+ */
+export async function setAccount(window, account) {
+  if (!localStorageAvailable(window)) {
+    throw new Error('Cannot put value into localStorage')
+  }
+  window.localStorage.setItem('__unlockProtocol.account', account)
+}
+
+/**
+ * Retrieve the current cached ethereum network
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @returns {number}
+ */
+export async function getNetwork(window) {
+  if (!localStorageAvailable(window)) {
+    throw new Error('Cannot get value from localStorage')
+  }
+  return +window.localStorage.getItem('__unlockProtocol.network') || null
+}
+
+/**
+ * Set the current cached network
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @param {number} network the id of the current ethereum network
+ */
+export async function setNetwork(window, network) {
+  if (!localStorageAvailable(window)) {
+    throw new Error('Cannot put value into localStorage')
+  }
+  window.localStorage.setItem('__unlockProtocol.network', String(network))
 }
 
 /**

--- a/paywall/src/data-iframe/cacheHandler.js
+++ b/paywall/src/data-iframe/cacheHandler.js
@@ -9,7 +9,12 @@ export function setup(networkId, account) {
 }
 
 async function _get(window, key) {
-  return await cache.get(window, currentNetwork, currentAccount, key)
+  return await cache.get({
+    window,
+    networkId: currentNetwork,
+    accountAddress: currentAccount,
+    type: key,
+  })
 }
 
 export async function getKeys(window) {
@@ -28,25 +33,37 @@ export async function addKey(window, key) {
   const keys = (await getKeys(window)) || {}
 
   keys[key.id] = key
-  await cache.put(window, currentNetwork, currentAccount, 'keys', keys)
+  await cache.put({
+    window,
+    networkId: currentNetwork,
+    accountAddress: currentAccount,
+    type: 'keys',
+    value: keys,
+  })
 }
 
 export async function addLock(window, lock) {
   const locks = (await getLocks(window)) || {}
 
   locks[lock.address] = lock
-  await cache.put(window, currentNetwork, currentAccount, 'locks', locks)
+  await cache.put({
+    window,
+    networkId: currentNetwork,
+    accountAddress: currentAccount,
+    type: 'locks',
+    value: locks,
+  })
 }
 
 export async function addTransaction(window, transaction) {
   const transactions = (await getTransactions(window)) || {}
 
   transactions[transaction.hash] = transaction
-  await cache.put(
+  await cache.put({
     window,
-    currentNetwork,
-    currentAccount,
-    'transactions',
-    transactions
-  )
+    networkId: currentNetwork,
+    accountAddress: currentAccount,
+    type: 'transactions',
+    value: transactions,
+  })
 }


### PR DESCRIPTION
# Description

In order to cache locks, which are not specific to any user, but are specific to networks, this PR introduces `getReadOnly` and `putReadOnly`.

In order to cache account/network, both of which are used as keys for everything else, this PR also introduces specific caching methods `getAccount` `getNetwork` and their setters.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3138 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
