### PR TITLE
New error constructors

### DIFF
--- a/unlock-app/src/__tests__/utils/Error.test.ts
+++ b/unlock-app/src/__tests__/utils/Error.test.ts
@@ -1,19 +1,23 @@
 import {
-  StorageError,
-  SignatureError,
+  ApplicationError,
   FormValidationError,
   LogInError,
   SignUpError,
+  SignatureError,
+  StorageError,
+  TransactionError,
 } from '../../utils/Error'
 
 describe('Error constructors', () => {
   it.each([
-    StorageError,
-    SignatureError,
+    ApplicationError,
     FormValidationError,
     LogInError,
     SignUpError,
-  ])('%s carries the message passed to it', constructors => {
+    SignatureError,
+    StorageError,
+    TransactionError,
+  ])('each of these carries the message passed to it', constructors => {
     expect.assertions(2)
     const fatalMessage = 'Not enough teapots, dumping core'
     const warning = 'Passwords must contain at least 43 different characters'

--- a/unlock-app/src/__tests__/utils/Error.test.ts
+++ b/unlock-app/src/__tests__/utils/Error.test.ts
@@ -1,0 +1,23 @@
+import {
+  StorageError,
+  SignatureError,
+  FormValidationError,
+  LogInError,
+  SignUpError,
+} from '../../utils/Error'
+
+describe('Error constructors', () => {
+  it.each([
+    StorageError,
+    SignatureError,
+    FormValidationError,
+    LogInError,
+    SignUpError,
+  ])('%s carries the message passed to it', constructors => {
+    expect.assertions(2)
+    const fatalMessage = 'Not enough teapots, dumping core'
+    const warning = 'Passwords must contain at least 43 different characters'
+    expect(constructors.Fatal(fatalMessage).message).toBe(fatalMessage)
+    expect(constructors.Warn(warning).message).toBe(warning)
+  })
+})

--- a/unlock-app/src/utils/Error.ts
+++ b/unlock-app/src/utils/Error.ts
@@ -1,0 +1,64 @@
+/**
+ * This module provides types and constructors for error values.
+ * Example usage:
+ *
+ * import { StorageError } from '/path/to/Error.ts'
+ * // oh no, an unrecoverable error has occurred!
+ * dispatch(StorageError.Fatal('we ran out of magnetic tape.'))
+ */
+
+/* eslint-disable */
+export enum ErrorLevel {
+  Fatal,
+  Warn,
+}
+
+export enum ErrorKind {
+  StorageError,
+  SignatureError,
+  FormValidationError,
+  LogInError,
+  SignUpError,
+}
+/* eslint-enable */
+
+export interface UnlockError {
+  level: ErrorLevel
+  kind: ErrorKind
+  message: string
+}
+
+// We very purposely do not export this: error messaging should be centralized
+// here. We want to avoid ad-hoc creation of unhandled error types.
+const errorMaker = (kind: ErrorKind, level: ErrorLevel) => (
+  message: string
+): UnlockError => ({
+  level,
+  kind,
+  message,
+})
+
+export const StorageError = {
+  Fatal: errorMaker(ErrorKind.StorageError, ErrorLevel.Fatal),
+  Warn: errorMaker(ErrorKind.StorageError, ErrorLevel.Warn),
+}
+
+export const SignatureError = {
+  Fatal: errorMaker(ErrorKind.SignatureError, ErrorLevel.Fatal),
+  Warn: errorMaker(ErrorKind.SignatureError, ErrorLevel.Warn),
+}
+
+export const FormValidationError = {
+  Fatal: errorMaker(ErrorKind.FormValidationError, ErrorLevel.Fatal),
+  Warn: errorMaker(ErrorKind.FormValidationError, ErrorLevel.Warn),
+}
+
+export const LogInError = {
+  Fatal: errorMaker(ErrorKind.LogInError, ErrorLevel.Fatal),
+  Warn: errorMaker(ErrorKind.LogInError, ErrorLevel.Warn),
+}
+
+export const SignUpError = {
+  Fatal: errorMaker(ErrorKind.SignUpError, ErrorLevel.Fatal),
+  Warn: errorMaker(ErrorKind.SignUpError, ErrorLevel.Warn),
+}

--- a/unlock-app/src/utils/Error.ts
+++ b/unlock-app/src/utils/Error.ts
@@ -4,17 +4,20 @@
  *
  * import { StorageError } from '/path/to/Error.ts'
  * // oh no, an unrecoverable error has occurred!
- * dispatch(StorageError.Fatal('we ran out of magnetic tape.'))
+ * const err = StorageError.Fatal('we ran out of magnetic tape.')
+ * dispatch(setError(err))
  */
 
 type ErrorLevel = 'Fatal' | 'Warning'
 
 type ErrorKind =
-  | 'StorageError'
-  | 'SignatureError'
+  | 'ApplicationError'
   | 'FormValidationError'
   | 'LogInError'
   | 'SignUpError'
+  | 'SignatureError'
+  | 'StorageError'
+  | 'TransactionError'
 
 interface UnlockError<L extends ErrorLevel, K extends ErrorKind> {
   level: L
@@ -47,27 +50,45 @@ interface ErrorMakers<K extends ErrorKind> {
   Warn: (message: string) => UnlockError<'Warning', K>
 }
 
+// Used for application level failures -- most of these will be fatal (wrong
+// network, no provider...)
+export const ApplicationError: ErrorMakers<'ApplicationError'> = {
+  Fatal: fatalMaker('ApplicationError'),
+  Warn: warningMaker('ApplicationError'),
+}
+
+// Used for errors in communicating with locksmith
 export const StorageError: ErrorMakers<'StorageError'> = {
   Fatal: fatalMaker('StorageError'),
   Warn: warningMaker('StorageError'),
 }
 
+// Used for errors in signing data
 export const SignatureError: ErrorMakers<'SignatureError'> = {
   Fatal: fatalMaker('SignatureError'),
   Warn: warningMaker('SignatureError'),
 }
 
+// Used for errors encountered while validating a form (invalid duration...)
 export const FormValidationError: ErrorMakers<'FormValidationError'> = {
   Fatal: fatalMaker('FormValidationError'),
   Warn: warningMaker('FormValidationError'),
 }
 
+// errors that occur while logging in (wrong password...)
 export const LogInError: ErrorMakers<'LogInError'> = {
   Fatal: fatalMaker('LogInError'),
   Warn: warningMaker('LogInError'),
 }
 
+// errors that occur while signing up/creating accounts
 export const SignUpError: ErrorMakers<'SignUpError'> = {
   Fatal: fatalMaker('SignUpError'),
   Warn: warningMaker('SignUpError'),
+}
+
+// Transaction errors (failed to create lock, etc.)
+export const TransactionError: ErrorMakers<'TransactionError'> = {
+  Fatal: fatalMaker('TransactionError'),
+  Warn: warningMaker('TransactionError'),
 }

--- a/unlock-app/src/utils/Error.ts
+++ b/unlock-app/src/utils/Error.ts
@@ -7,58 +7,67 @@
  * dispatch(StorageError.Fatal('we ran out of magnetic tape.'))
  */
 
-/* eslint-disable */
-export enum ErrorLevel {
-  Fatal,
-  Warn,
-}
+type ErrorLevel = 'Fatal' | 'Warning'
 
-export enum ErrorKind {
-  StorageError,
-  SignatureError,
-  FormValidationError,
-  LogInError,
-  SignUpError,
-}
-/* eslint-enable */
+type ErrorKind =
+  | 'StorageError'
+  | 'SignatureError'
+  | 'FormValidationError'
+  | 'LogInError'
+  | 'SignUpError'
 
-export interface UnlockError {
-  level: ErrorLevel
-  kind: ErrorKind
+interface UnlockError<L extends ErrorLevel, K extends ErrorKind> {
+  level: L
+  kind: K
   message: string
 }
 
-// We very purposely do not export this: error messaging should be centralized
+// We very purposely do not export these: error messaging should be centralized
 // here. We want to avoid ad-hoc creation of unhandled error types.
-const errorMaker = (kind: ErrorKind, level: ErrorLevel) => (
-  message: string
-): UnlockError => ({
-  level,
-  kind,
-  message,
-})
-
-export const StorageError = {
-  Fatal: errorMaker(ErrorKind.StorageError, ErrorLevel.Fatal),
-  Warn: errorMaker(ErrorKind.StorageError, ErrorLevel.Warn),
+function fatalMaker<K extends ErrorKind>(kind: K) {
+  return (message: string): UnlockError<'Fatal', K> => ({
+    level: 'Fatal',
+    kind,
+    message,
+  })
 }
 
-export const SignatureError = {
-  Fatal: errorMaker(ErrorKind.SignatureError, ErrorLevel.Fatal),
-  Warn: errorMaker(ErrorKind.SignatureError, ErrorLevel.Warn),
+function warningMaker<K extends ErrorKind>(kind: K) {
+  return (message: string): UnlockError<'Warning', K> => ({
+    level: 'Warning',
+    kind,
+    message,
+  })
 }
 
-export const FormValidationError = {
-  Fatal: errorMaker(ErrorKind.FormValidationError, ErrorLevel.Fatal),
-  Warn: errorMaker(ErrorKind.FormValidationError, ErrorLevel.Warn),
+// This is here to enforce that the Fatal property of a group of error
+// constructors will actually be fatal -- no accidentally ignored errors.
+interface ErrorMakers<K extends ErrorKind> {
+  Fatal: (message: string) => UnlockError<'Fatal', K>
+  Warn: (message: string) => UnlockError<'Warning', K>
 }
 
-export const LogInError = {
-  Fatal: errorMaker(ErrorKind.LogInError, ErrorLevel.Fatal),
-  Warn: errorMaker(ErrorKind.LogInError, ErrorLevel.Warn),
+export const StorageError: ErrorMakers<'StorageError'> = {
+  Fatal: fatalMaker('StorageError'),
+  Warn: warningMaker('StorageError'),
 }
 
-export const SignUpError = {
-  Fatal: errorMaker(ErrorKind.SignUpError, ErrorLevel.Fatal),
-  Warn: errorMaker(ErrorKind.SignUpError, ErrorLevel.Warn),
+export const SignatureError: ErrorMakers<'SignatureError'> = {
+  Fatal: fatalMaker('SignatureError'),
+  Warn: warningMaker('SignatureError'),
+}
+
+export const FormValidationError: ErrorMakers<'FormValidationError'> = {
+  Fatal: fatalMaker('FormValidationError'),
+  Warn: warningMaker('FormValidationError'),
+}
+
+export const LogInError: ErrorMakers<'LogInError'> = {
+  Fatal: fatalMaker('LogInError'),
+  Warn: warningMaker('LogInError'),
+}
+
+export const SignUpError: ErrorMakers<'SignUpError'> = {
+  Fatal: fatalMaker('SignUpError'),
+  Warn: warningMaker('SignUpError'),
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Another piece from #3332. This PR introduces new error types and constructors, which have some pretty nifty features, I think. This PR does not _use_ these errors yet, it just puts them in place.

For starters, the errors are now very strongly typed. The kind of error (which feature of the application it is associated with) and the level (fatal or warning) are enforced by the type system. Each error additionally carries a message payload. The previous iteration included a data payload which could be an arbitrary object, but much of the purpose of this infrastructure is to allow us to notify users, and for that reason a text description of the failure is absolutely necessary.

Here's some example usage:

```javascript
// file storageMiddleware.js
import { StorageError } from '/path/to/Error'

thisPromiseAlwaysFails()
  .catch(_ => {
    const err = StorageError.Warn('The code that always fails failed.')
    dispatch(setError(err))
  })
```

To handle these errors, we can filter them by level (fatal errors all handled in one place) or kind (signup page only shows signup errors, no matter what might be happening in the background) or we can use this information to display different kinds of errors differently.

I've given a constructor for every distinct kind of error we currently send out, and there's just a little bit of boilerplate involved in defining new ones.
# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
