### PR TITLE
listen for messages from the main window, send data back

### DIFF
--- a/paywall/src/__tests__/data-iframe/postOfficeListener.test.js
+++ b/paywall/src/__tests__/data-iframe/postOfficeListener.test.js
@@ -1,0 +1,130 @@
+import { _clearHandlers, iframePostOffice } from '../../utils/postOffice'
+import setupPostOfficeListener from '../../data-iframe/postOfficeListener'
+import {
+  POST_MESSAGE_READY,
+  POST_MESSAGE_DATA_REQUEST,
+} from '../../paywall-builder/constants'
+
+describe('postOffice listener', () => {
+  let fakeWindow
+  let fakeTarget
+  let fakeUpdater
+
+  function callListener(type, payload) {
+    fakeWindow.handlers.message({
+      source: fakeTarget,
+      data: {
+        type,
+        payload,
+      },
+      origin: 'http://fun.times',
+    })
+  }
+
+  beforeEach(() => {
+    fakeTarget = {
+      postMessage: jest.fn(),
+    }
+    fakeUpdater = jest.fn()
+
+    fakeWindow = {
+      console: {
+        error: jest.fn(),
+      },
+      parent: fakeTarget,
+      location: {
+        href: 'http://example.com?origin=http%3A%2F%2Ffun.times',
+      },
+      handlers: {},
+      addEventListener(type, handler) {
+        fakeWindow.handlers[type] = handler
+      },
+    }
+    _clearHandlers()
+    iframePostOffice(fakeWindow)
+  })
+
+  it('responds to ready message by calling updater for all the data', () => {
+    expect.assertions(5)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_READY, undefined)
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(4)
+    expect(fakeUpdater).toHaveBeenNthCalledWith(1, 'network')
+    expect(fakeUpdater).toHaveBeenNthCalledWith(2, 'account')
+    expect(fakeUpdater).toHaveBeenNthCalledWith(3, 'balance')
+    expect(fakeUpdater).toHaveBeenNthCalledWith(4, 'locks')
+  })
+
+  it('responds to a data request message "locks" by calling updater with "locks"', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'locks')
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater).toHaveBeenCalledWith('locks')
+  })
+
+  it('responds to a data request message "account" by calling updater with "account"', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'account')
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater).toHaveBeenCalledWith('account')
+  })
+
+  it('responds to a data request message "balance" by calling updater with "balance"', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'balance')
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater).toHaveBeenCalledWith('balance')
+  })
+
+  it('responds to a data request message "network" by calling updater with "network"', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'network')
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater).toHaveBeenCalledWith('network')
+  })
+
+  it('responds to a malicious data request by logging and bailing', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, { try: 'to crash us and fail' })
+
+    expect(fakeWindow.console.error).toHaveBeenCalledWith(
+      'ignoring malformed data'
+    )
+    expect(fakeUpdater).not.toHaveBeenCalled()
+  })
+
+  it('responds to a misspelled data request by logging and bailing', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'nitwerk')
+
+    expect(fakeWindow.console.error).toHaveBeenCalledWith(
+      'Unknown data type "nitwerk" requested, ignoring'
+    )
+    expect(fakeUpdater).not.toHaveBeenCalled()
+  })
+})

--- a/paywall/src/data-iframe/postOfficeListener.js
+++ b/paywall/src/data-iframe/postOfficeListener.js
@@ -1,0 +1,50 @@
+import { setHandler } from '../utils/postOffice'
+import {
+  POST_MESSAGE_READY,
+  POST_MESSAGE_DATA_REQUEST,
+} from '../paywall-builder/constants'
+
+/**
+ * Create the listener to send all data when the main window is ready
+ * @param {Function} updater a callback returned from the postOffice used to trigger data sending
+ *                           to the main window
+ */
+export const makeReadyListener = updater =>
+  function readyPostOfficeListener() {
+    updater('network')
+    updater('account')
+    updater('balance')
+    updater('locks')
+  }
+
+/**
+ * Create the listener for data
+ * @param {Function} logger a logging function like console.log
+ * @param {Function} updater a callback returned from the postOffice used to trigger data sending
+ *                           to the main window
+ */
+export const makeRequestListener = (logger, updater) =>
+  function requestPostOfficeListener(type) {
+    if (typeof type !== 'string') {
+      logger('ignoring malformed data')
+      return
+    }
+    if (!['locks', 'account', 'balance', 'network'].includes(type)) {
+      logger(`Unknown data type "${type}" requested, ignoring`)
+      return
+    }
+    updater(type)
+  }
+
+/**
+ * Set up listening for POST_MESSAGE_READY and POST_MESSAGE_DATA_REQUEST from the main window
+ * @param {window} window the global context (window, self, global)
+ * @param {Function} updater a callback returned from the postOffice used to trigger data sending
+ *                           to the main window
+ */
+export default function setupPostOfficeListener(window, updater) {
+  const readyListener = makeReadyListener(updater)
+  const requestListener = makeRequestListener(window.console.error, updater)
+  setHandler(POST_MESSAGE_READY, readyListener)
+  setHandler(POST_MESSAGE_DATA_REQUEST, requestListener)
+}

--- a/paywall/src/paywall-builder/constants.js
+++ b/paywall/src/paywall-builder/constants.js
@@ -9,3 +9,5 @@ export const POST_MESSAGE_CONFIG = 'config'
 export const POST_MESSAGE_ACCOUNT = 'account'
 export const POST_MESSAGE_WEB3 = 'web3'
 export const POST_MESSAGE_WALLET_INFO = 'walletInfo'
+
+export const POST_MESSAGE_DATA_REQUEST = 'data/request'


### PR DESCRIPTION
# Description

Following up on #3354 this PR introduces the listening side of the passing of lock/account/balance/network data to the main window. It depends on the updater returned from `postOffice.js` in #3354 but is generic enough to work with any callback that matches this API.

Note that all of the annoying nitty-gritty of managing postMessage is abstracted away behind `iframePostOffice` which makes the source functions tiny.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
