### PR TITLE
postOffice listener for config (locks to monitor), and sending junk back when requested

### DIFF
--- a/paywall/src/__tests__/data-iframe/postOfficeListener.test.js
+++ b/paywall/src/__tests__/data-iframe/postOfficeListener.test.js
@@ -1,0 +1,130 @@
+import { _clearHandlers, iframePostOffice } from '../../utils/postOffice'
+import setupPostOfficeListener from '../../data-iframe/postOfficeListener'
+import {
+  POST_MESSAGE_READY,
+  POST_MESSAGE_DATA_REQUEST,
+} from '../../paywall-builder/constants'
+
+describe('postOffice listener', () => {
+  let fakeWindow
+  let fakeTarget
+  let fakeUpdater
+
+  function callListener(type, payload) {
+    fakeWindow.handlers.message({
+      source: fakeTarget,
+      data: {
+        type,
+        payload,
+      },
+      origin: 'http://fun.times',
+    })
+  }
+
+  beforeEach(() => {
+    fakeTarget = {
+      postMessage: jest.fn(),
+    }
+    fakeUpdater = jest.fn()
+
+    fakeWindow = {
+      console: {
+        error: jest.fn(),
+      },
+      parent: fakeTarget,
+      location: {
+        href: 'http://example.com?origin=http%3A%2F%2Ffun.times',
+      },
+      handlers: {},
+      addEventListener(type, handler) {
+        fakeWindow.handlers[type] = handler
+      },
+    }
+    _clearHandlers()
+    iframePostOffice(fakeWindow)
+  })
+
+  it('responds to ready message by calling updater for all the data', () => {
+    expect.assertions(5)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_READY, undefined)
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(4)
+    expect(fakeUpdater).toHaveBeenNthCalledWith(1, 'network')
+    expect(fakeUpdater).toHaveBeenNthCalledWith(2, 'account')
+    expect(fakeUpdater).toHaveBeenNthCalledWith(3, 'balance')
+    expect(fakeUpdater).toHaveBeenNthCalledWith(4, 'locks')
+  })
+
+  it('responds to a data request message "locks" by calling updater with "locks"', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'locks')
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater).toHaveBeenCalledWith('locks')
+  })
+
+  it('responds to a data request message "account" by calling updater with "account"', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'account')
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater).toHaveBeenCalledWith('account')
+  })
+
+  it('responds to a data request message "balance" by calling updater with "balance"', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'balance')
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater).toHaveBeenCalledWith('balance')
+  })
+
+  it('responds to a data request message "network" by calling updater with "network"', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'network')
+
+    expect(fakeUpdater).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater).toHaveBeenCalledWith('network')
+  })
+
+  it('responds to a malicious data request by logging and bailing', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, { try: 'to crash us and fail' })
+
+    expect(fakeWindow.console.error).toHaveBeenCalledWith(
+      'ignoring malformed data'
+    )
+    expect(fakeUpdater).not.toHaveBeenCalled()
+  })
+
+  it('responds to a misspelled data request by logging and bailing', () => {
+    expect.assertions(2)
+
+    setupPostOfficeListener(fakeWindow, fakeUpdater)
+
+    callListener(POST_MESSAGE_DATA_REQUEST, 'nitwerk')
+
+    expect(fakeWindow.console.error).toHaveBeenCalledWith(
+      'Unknown data type "nitwerk" requested, ignoring'
+    )
+    expect(fakeUpdater).not.toHaveBeenCalled()
+  })
+})

--- a/paywall/src/__tests__/data-iframe/postOfficeListener.test.js
+++ b/paywall/src/__tests__/data-iframe/postOfficeListener.test.js
@@ -1,7 +1,7 @@
 import { _clearHandlers, iframePostOffice } from '../../utils/postOffice'
 import setupPostOfficeListener from '../../data-iframe/postOfficeListener'
 import {
-  POST_MESSAGE_DATA_REQUEST,
+  POST_MESSAGE_SEND_UPDATES,
   POST_MESSAGE_CONFIG,
   POST_MESSAGE_PURCHASE_KEY,
 } from '../../paywall-builder/constants'
@@ -96,7 +96,7 @@ describe('postOffice listener', () => {
 
     makePostOffice()
 
-    callListener(POST_MESSAGE_DATA_REQUEST, 'locks')
+    callListener(POST_MESSAGE_SEND_UPDATES, 'locks')
 
     expect(fakeUpdater).toHaveBeenCalledTimes(1)
     expect(fakeUpdater).toHaveBeenCalledWith('locks')
@@ -107,7 +107,7 @@ describe('postOffice listener', () => {
 
     makePostOffice()
 
-    callListener(POST_MESSAGE_DATA_REQUEST, 'account')
+    callListener(POST_MESSAGE_SEND_UPDATES, 'account')
 
     expect(fakeUpdater).toHaveBeenCalledTimes(1)
     expect(fakeUpdater).toHaveBeenCalledWith('account')
@@ -118,7 +118,7 @@ describe('postOffice listener', () => {
 
     makePostOffice()
 
-    callListener(POST_MESSAGE_DATA_REQUEST, 'balance')
+    callListener(POST_MESSAGE_SEND_UPDATES, 'balance')
 
     expect(fakeUpdater).toHaveBeenCalledTimes(1)
     expect(fakeUpdater).toHaveBeenCalledWith('balance')
@@ -129,7 +129,7 @@ describe('postOffice listener', () => {
 
     makePostOffice()
 
-    callListener(POST_MESSAGE_DATA_REQUEST, 'network')
+    callListener(POST_MESSAGE_SEND_UPDATES, 'network')
 
     expect(fakeUpdater).toHaveBeenCalledTimes(1)
     expect(fakeUpdater).toHaveBeenCalledWith('network')
@@ -140,7 +140,7 @@ describe('postOffice listener', () => {
 
     makePostOffice()
 
-    callListener(POST_MESSAGE_DATA_REQUEST, { try: 'to crash us and fail' })
+    callListener(POST_MESSAGE_SEND_UPDATES, { try: 'to crash us and fail' })
 
     expect(fakeWindow.console.error).toHaveBeenCalledWith(
       'ignoring malformed data'
@@ -153,7 +153,7 @@ describe('postOffice listener', () => {
 
     makePostOffice()
 
-    callListener(POST_MESSAGE_DATA_REQUEST, 'nitwerk')
+    callListener(POST_MESSAGE_SEND_UPDATES, 'nitwerk')
 
     expect(fakeWindow.console.error).toHaveBeenCalledWith(
       'Unknown data type "nitwerk" requested, ignoring'

--- a/paywall/src/data-iframe/postOfficeListener.js
+++ b/paywall/src/data-iframe/postOfficeListener.js
@@ -1,6 +1,6 @@
 import { setHandler } from '../utils/postOffice'
 import {
-  POST_MESSAGE_DATA_REQUEST,
+  POST_MESSAGE_SEND_UPDATES,
   POST_MESSAGE_CONFIG,
   POST_MESSAGE_PURCHASE_KEY,
 } from '../paywall-builder/constants'
@@ -84,6 +84,6 @@ export default function setupPostOfficeListener(
     purchase
   )
   setHandler(POST_MESSAGE_CONFIG, configListener)
-  setHandler(POST_MESSAGE_DATA_REQUEST, requestListener)
+  setHandler(POST_MESSAGE_SEND_UPDATES, requestListener)
   setHandler(POST_MESSAGE_PURCHASE_KEY, purchaseListener)
 }

--- a/paywall/src/data-iframe/postOfficeListener.js
+++ b/paywall/src/data-iframe/postOfficeListener.js
@@ -2,8 +2,10 @@ import { setHandler } from '../utils/postOffice'
 import {
   POST_MESSAGE_DATA_REQUEST,
   POST_MESSAGE_CONFIG,
+  POST_MESSAGE_PURCHASE_KEY,
 } from '../paywall-builder/constants'
 import { isValidPaywallConfig } from '../utils/validators'
+import { ACCOUNT_REGEXP } from '../constants'
 
 /**
  * Create the listener to respond to the configuration, which lists all locks on the page
@@ -38,15 +40,50 @@ export const makeRequestListener = (logger, updater) =>
     updater(type)
   }
 
+export const makePurchaseKeyListener = (logger, purchase) =>
+  function purchaseKeyPostOfficeListener(purchaseInfo) {
+    if (!purchaseInfo || typeof purchaseInfo !== 'object') {
+      logger('ignoring malformed purchase request')
+      return
+    }
+    if (typeof purchaseInfo.lock !== 'string') {
+      logger('ignoring malformed purchase request')
+      return
+    }
+    if (purchaseInfo.extraTip && typeof purchaseInfo.extraTip !== 'string') {
+      logger('ignoring malformed purchase request')
+      return
+    }
+    const { lock, extraTip } = purchaseInfo
+    if (
+      !lock.match(ACCOUNT_REGEXP) ||
+      (extraTip && !extraTip.match(/^[0-9]+$/))
+    ) {
+      logger('ignoring malformed purchase request')
+      return
+    }
+    purchase(lock, extraTip)
+  }
+
 /**
  * Set up listening for POST_MESSAGE_READY and POST_MESSAGE_DATA_REQUEST from the main window
  * @param {window} window the global context (window, self, global)
  * @param {Function} updater a callback returned from the postOffice used to trigger data sending
  *                           to the main window
  */
-export default function setupPostOfficeListener(window, updater, setConfig) {
+export default function setupPostOfficeListener(
+  window,
+  updater,
+  setConfig,
+  purchase
+) {
   const configListener = makeConfigListener(window.console.error, setConfig)
   const requestListener = makeRequestListener(window.console.error, updater)
+  const purchaseListener = makePurchaseKeyListener(
+    window.console.error,
+    purchase
+  )
   setHandler(POST_MESSAGE_CONFIG, configListener)
   setHandler(POST_MESSAGE_DATA_REQUEST, requestListener)
+  setHandler(POST_MESSAGE_PURCHASE_KEY, purchaseListener)
 }

--- a/paywall/src/data-iframe/postOfficeListener.js
+++ b/paywall/src/data-iframe/postOfficeListener.js
@@ -1,0 +1,50 @@
+import { setHandler } from '../utils/postOffice'
+import {
+  POST_MESSAGE_READY,
+  POST_MESSAGE_DATA_REQUEST,
+} from '../paywall-builder/constants'
+
+/**
+ * Create the listener to send all data when the main window is ready
+ * @param {Function} updater a callback returned from the postOffice used to trigger data sending
+ *                           to the main window
+ */
+export const makeReadyListener = updater =>
+  function readyPostOfficeListener() {
+    updater('network')
+    updater('account')
+    updater('balance')
+    updater('locks')
+  }
+
+/**
+ * Create the listener for data
+ * @param {Function} logger a logging function like console.log
+ * @param {Function} updater a callback returned from the postOffice used to trigger data sending
+ *                           to the main window
+ */
+export const makeRequestListener = (logger, updater) =>
+  function requestPostOfficeListener(type) {
+    if (typeof type !== 'string') {
+      logger('ignoring malformed data')
+      return
+    }
+    if (!['locks', 'account', 'balance', 'network'].includes(type)) {
+      logger(`Unknown data type "${type}" requested, ignoring`)
+      return
+    }
+    updater(type)
+  }
+
+/**
+ * Set up listening for POST_MESSAGE_READY and POST_MESSAGE_DATA_REQUEST from the main window
+ * @param {window} window the global context (window, self, global)
+ * @param {Function} updater a callback returned from the postOffice used to trigger data sending
+ *                           to the main window
+ */
+export default function setupPostOfficeListener(window, updater) {
+  const readyListener = makeReadyListener(updater)
+  const requestListener = makeRequestListener(window.console.error, updater)
+  setHandler(POST_MESSAGE_READY, readyListener)
+  setHandler(POST_MESSAGE_DATA_REQUEST, requestListener)
+}

--- a/paywall/src/paywall-builder/constants.js
+++ b/paywall/src/paywall-builder/constants.js
@@ -17,3 +17,4 @@ export const POST_MESSAGE_UPDATE_NETWORK = 'update/network'
 export const POST_MESSAGE_UPDATE_WALLET = 'update/walletmodal'
 
 export const POST_MESSAGE_ERROR = 'error'
+export const POST_MESSAGE_DATA_REQUEST = 'data/request'

--- a/paywall/src/paywall-builder/constants.js
+++ b/paywall/src/paywall-builder/constants.js
@@ -17,6 +17,6 @@ export const POST_MESSAGE_UPDATE_NETWORK = 'update/network'
 export const POST_MESSAGE_UPDATE_WALLET = 'update/walletmodal'
 
 export const POST_MESSAGE_ERROR = 'error'
-export const POST_MESSAGE_DATA_REQUEST = 'data/request'
+export const POST_MESSAGE_SEND_UPDATES = 'semd/updates'
 
 export const POST_MESSAGE_PURCHASE_KEY = 'purchaseKey'

--- a/paywall/src/paywall-builder/constants.js
+++ b/paywall/src/paywall-builder/constants.js
@@ -18,3 +18,5 @@ export const POST_MESSAGE_UPDATE_WALLET = 'update/walletmodal'
 
 export const POST_MESSAGE_ERROR = 'error'
 export const POST_MESSAGE_DATA_REQUEST = 'data/request'
+
+export const POST_MESSAGE_PURCHASE_KEY = 'purchaseKey'


### PR DESCRIPTION
# Description

This sets up the listener side of the data iframe post office. It responds to direct requests for data as well as listening for the `POST_MESSAGE_CONFIG` message which will contain the locks we need to monitor. It also listens for a `POST_MESSAGE_PURCHASE_KEY` message, which contains a lock to purchase a key on, and any extra tip (`purchaseFor` allows tipping) to add on to the key price.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
