### PR TITLE
refactor key purchase to return the raw key, linking will be downstream

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
@@ -2,8 +2,10 @@ import { TRANSACTION_TYPES } from '../../../../constants'
 import submittedListener from '../../../../data-iframe/blockchainHandler/purchaseKey/submittedListener'
 import { setNetwork } from '../../../../data-iframe/blockchainHandler/network'
 
-describe('pendingListener', () => {
+describe('submittedListener', () => {
   let fakeWalletService
+  let fakeWeb3Service
+  let newKey
 
   beforeEach(() => {
     fakeWalletService = {
@@ -11,6 +13,9 @@ describe('pendingListener', () => {
       on: (type, cb) => (fakeWalletService.handlers[type] = cb),
       once: (type, cb) => (fakeWalletService.handlers[type] = cb),
       off: type => delete fakeWalletService.handlers[type],
+    }
+    fakeWeb3Service = {
+      getKeyByLockForOwner: jest.fn(() => newKey),
     }
   })
 
@@ -35,9 +40,6 @@ describe('pendingListener', () => {
       lock: 'lock',
       owner: 'account',
       expiration: new Date().getTime() / 1000 + 10000,
-      transactions: [],
-      status: 'none',
-      confirmations: 0,
     }
 
     const result = await submittedListener({
@@ -45,6 +47,7 @@ describe('pendingListener', () => {
       existingTransactions: transactions,
       existingKey: key,
       walletService: fakeWalletService,
+      web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
     })
 
@@ -73,15 +76,13 @@ describe('pendingListener', () => {
       lock: 'lock',
       owner: 'account',
       expiration: new Date().getTime() / 1000 + 10000,
-      transactions: [],
-      status: 'none',
-      confirmations: 0,
     }
 
     const result = await submittedListener({
       lockAddress: 'lock',
       existingTransactions: transactions,
       existingKey: key,
+      web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     })
@@ -111,15 +112,14 @@ describe('pendingListener', () => {
       lock: 'lock',
       owner: 'account',
       expiration: new Date().getTime() / 1000 + 10000,
-      transactions: [],
-      status: 'none',
-      confirmations: 0,
     }
+    newKey = key
 
     const result = await submittedListener({
       lockAddress: 'lock',
       existingTransactions: transactions,
       existingKey: key,
+      web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     })
@@ -149,15 +149,14 @@ describe('pendingListener', () => {
       lock: 'lock',
       owner: 'account',
       expiration: new Date().getTime() / 1000 + 10000,
-      transactions: [],
-      status: 'none',
-      confirmations: 0,
     }
+    newKey = key
 
     const result = await submittedListener({
       lockAddress: 'lock',
       existingTransactions: transactions,
       existingKey: key,
+      web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     })
@@ -177,15 +176,14 @@ describe('pendingListener', () => {
       lock: 'lock',
       owner: 'account',
       expiration: new Date().getTime() / 1000 - 1000,
-      transactions: [],
-      status: 'none',
-      confirmations: 0,
     }
+    newKey = existingKey
 
     submittedListener({
       lockAddress: 'lock',
       existingTransactions,
       existingKey,
+      web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     }).then(({ transactions, key }) => {
@@ -206,11 +204,7 @@ describe('pendingListener', () => {
         hash,
       })
 
-      expect(key).toEqual({
-        ...existingKey,
-        status: 'submitted',
-        transactions: [hash],
-      })
+      expect(key).toEqual(existingKey)
       done()
     })
 
@@ -248,15 +242,14 @@ describe('pendingListener', () => {
       lock: 'lock',
       owner: 'account',
       expiration: new Date().getTime() / 1000 - 1000,
-      transactions: [],
-      status: 'none',
-      confirmations: 0,
     }
+    newKey = existingKey
 
     submittedListener({
       lockAddress: 'lock',
       existingTransactions,
       existingKey,
+      web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     }).then(({ transactions, key }) => {
@@ -278,11 +271,7 @@ describe('pendingListener', () => {
         old,
       })
 
-      expect(key).toEqual({
-        ...existingKey,
-        status: 'submitted',
-        transactions: [hash, old],
-      })
+      expect(key).toEqual(existingKey)
       done()
     })
 
@@ -320,15 +309,14 @@ describe('pendingListener', () => {
       lock: 'lock',
       owner: 'account',
       expiration: new Date().getTime() / 1000 - 1000,
-      transactions: [],
-      status: 'none',
-      confirmations: 0,
     }
+    newKey = existingKey
 
     submittedListener({
       lockAddress: 'lock',
       existingTransactions,
       existingKey,
+      web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     }).then(({ transactions, key }) => {
@@ -350,11 +338,7 @@ describe('pendingListener', () => {
         old,
       })
 
-      expect(key).toEqual({
-        ...existingKey,
-        status: 'submitted',
-        transactions: [hash, old],
-      })
+      expect(key).toEqual(existingKey)
       done()
     })
 
@@ -392,15 +376,14 @@ describe('pendingListener', () => {
       lock: 'lock',
       owner: 'account',
       expiration: new Date().getTime() / 1000 - 1000,
-      transactions: [],
-      status: 'none',
-      confirmations: 0,
     }
+    newKey = existingKey
 
     submittedListener({
       lockAddress: 'lock',
       existingTransactions,
       existingKey,
+      web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
     }).catch(e => {

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey/updateListener.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey/updateListener.js
@@ -6,14 +6,14 @@ export default async function updateListener({
   web3Service,
   requiredConfirmations,
 }) {
-  // expire any keys that are expired
-  const key = linkTransactionsToKey({
+  const linkedKey = linkTransactionsToKey({
     key: existingKey,
     transactions: existingTransactions,
     requiredConfirmations,
   })
-  const transaction = key.transactions[0]
+  const transaction = linkedKey.transactions[0]
   if (
+    !transaction ||
     !['submitted', 'pending', 'mined'].includes(transaction.status) ||
     (transaction.status === 'mined' &&
       transaction.confirmations > requiredConfirmations)
@@ -58,10 +58,10 @@ export default async function updateListener({
   }
   return {
     transactions,
-    key: linkTransactionsToKey({
-      key: existingKey,
-      transactions,
-      requiredConfirmations,
-    }),
+    // this ensures we always have the latest expiration info
+    key: await web3Service.getKeyByLockForOwner(
+      existingKey.lock,
+      existingKey.owner
+    ),
   }
 }


### PR DESCRIPTION
# Description

This PR addresses 3 issues. 2 are minor, the other is a design flaw.

1. on a brand new key purchase transaction, `updateListener` was crashing because the key's `transactions[0]` was undefined. This adds a simple `!transaction` as one of the bail-out conditions
2. in `updateListener`, we were asserting on the `status` of the raw key to determine whether to keep polling, but `status` only exists on a linked key. This now does just-in-time linking before the conditional of the do/while loop. Tests are updated to ensure we return properly
3. The key purchase transaction monitoring incorrectly added the custom fields of the key to the key.  This is a problem because the data actually sent to the user is from the cache. We need to cache the raw blockchain data, as returned from `web3Service`. The mixing of key/lock/transaction can happen right before it is sent to the UI.

To make point 2 possible, this PR does 2 things:

1. removes `linkTransactionsToKey` calls on the returned data, and just returns the key
2. since the only field that actually could change is the expiration timestamp of a key, we request the current value of the key from the blockchain via `web3Service.getKeyByLockForOwner`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3139 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
