### PR TITLE
GlobalErrorConsumer back at the app level

### DIFF
--- a/unlock-app/src/components/content/DashboardContent.js
+++ b/unlock-app/src/components/content/DashboardContent.js
@@ -8,7 +8,6 @@ import Account from '../interface/Account'
 import CreatorLocks from '../creator/CreatorLocks'
 import DeveloperOverlay from '../developer/DeveloperOverlay'
 import BrowserOnly from '../helpers/BrowserOnly'
-import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import { pageTitle } from '../../constants'
 import {
   CreateLockButton,
@@ -27,25 +26,23 @@ export const DashboardContent = ({
     formIsVisible ? hideForm() : showForm()
   }
   return (
-    <GlobalErrorConsumer>
-      <Layout title="Creator Dashboard">
-        <Head>
-          <title>{pageTitle('Dashboard')}</title>
-        </Head>
-        {account && (
-          <BrowserOnly>
-            <AccountWrapper>
-              <Account network={network} account={account} />
-              <CreateLockButton id="CreateLockButton" onClick={toggleForm}>
-                Create Lock
-              </CreateLockButton>
-            </AccountWrapper>
-            <CreatorLocks />
-            <DeveloperOverlay />
-          </BrowserOnly>
-        )}
-      </Layout>
-    </GlobalErrorConsumer>
+    <Layout title="Creator Dashboard">
+      <Head>
+        <title>{pageTitle('Dashboard')}</title>
+      </Head>
+      {account && (
+        <BrowserOnly>
+          <AccountWrapper>
+            <Account network={network} account={account} />
+            <CreateLockButton id="CreateLockButton" onClick={toggleForm}>
+              Create Lock
+            </CreateLockButton>
+          </AccountWrapper>
+          <CreatorLocks />
+          <DeveloperOverlay />
+        </BrowserOnly>
+      )}
+    </Layout>
   )
 }
 

--- a/unlock-app/src/components/content/KeyChainContent.js
+++ b/unlock-app/src/components/content/KeyChainContent.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux'
 import Head from 'next/head'
 import BrowserOnly from '../helpers/BrowserOnly'
 import UnlockPropTypes from '../../propTypes'
-import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import DeveloperOverlay from '../developer/DeveloperOverlay'
 import Layout from '../interface/Layout'
 import Account from '../interface/Account'
@@ -15,24 +14,22 @@ export const KeyChainContent = ({ account, network, router }) => {
   const emailAddress = hash.slice(1) // trim off leading '#'
 
   return (
-    <GlobalErrorConsumer>
-      <Layout title="Key Chain">
-        <Head>
-          <title>{pageTitle('Key Chain')}</title>
-        </Head>
-        {account && (
-          <BrowserOnly>
-            <Account network={network} account={account} />
-            <DeveloperOverlay />
-          </BrowserOnly>
-        )}
-        {!account && (
-          // Default to sign up form. User can toggle to login. If email
-          // address is truthy, do the signup flow.
-          <LogInSignUp signup emailAddress={emailAddress} />
-        )}
-      </Layout>
-    </GlobalErrorConsumer>
+    <Layout title="Key Chain">
+      <Head>
+        <title>{pageTitle('Key Chain')}</title>
+      </Head>
+      {account && (
+        <BrowserOnly>
+          <Account network={network} account={account} />
+          <DeveloperOverlay />
+        </BrowserOnly>
+      )}
+      {!account && (
+        // Default to sign up form. User can toggle to login. If email
+        // address is truthy, do the signup flow.
+        <LogInSignUp signup emailAddress={emailAddress} />
+      )}
+    </Layout>
   )
 }
 

--- a/unlock-app/src/components/content/LogContent.tsx
+++ b/unlock-app/src/components/content/LogContent.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link'
 import Layout from '../interface/Layout'
 import Account from '../interface/Account'
 import BrowserOnly from '../helpers/BrowserOnly'
-import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import CreatorLog from '../creator/CreatorLog'
 import { pageTitle } from '../../constants'
 import withConfig from '../../utils/withConfig'
@@ -35,29 +34,27 @@ export const LogContent = ({
   showForm,
 }: Props) => {
   return (
-    <GlobalErrorConsumer>
-      <Layout title="Creator Log">
-        <Head>
-          <title>{pageTitle('Log')}</title>
-        </Head>
-        {account && (
-          <BrowserOnly>
-            <AccountWrapper>
-              <Account network={network} account={account} />
-              <Link href="/dashboard">
-                <CreateLockButton onClick={showForm} id="CreateLockButton">
-                  Create Lock
-                </CreateLockButton>
-              </Link>
-            </AccountWrapper>
-            <CreatorLog
-              transactionFeed={transactionFeed}
-              explorerLinks={explorerLinks}
-            />
-          </BrowserOnly>
-        )}
-      </Layout>
-    </GlobalErrorConsumer>
+    <Layout title="Creator Log">
+      <Head>
+        <title>{pageTitle('Log')}</title>
+      </Head>
+      {account && (
+        <BrowserOnly>
+          <AccountWrapper>
+            <Account network={network} account={account} />
+            <Link href="/dashboard">
+              <CreateLockButton onClick={showForm} id="CreateLockButton">
+                Create Lock
+              </CreateLockButton>
+            </Link>
+          </AccountWrapper>
+          <CreatorLog
+            transactionFeed={transactionFeed}
+            explorerLinks={explorerLinks}
+          />
+        </BrowserOnly>
+      )}
+    </Layout>
   )
 }
 

--- a/unlock-app/src/components/content/LoginContent.tsx
+++ b/unlock-app/src/components/content/LoginContent.tsx
@@ -1,20 +1,17 @@
 import React from 'react'
 import Head from 'next/head'
 import Layout from '../interface/Layout'
-import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import { pageTitle } from '../../constants'
 import LogInSignUp from '../interface/LogInSignUp'
 
 export const LoginContent = () => {
   return (
-    <GlobalErrorConsumer>
-      <Layout title="Login">
-        <Head>
-          <title>{pageTitle('Login')}</title>
-        </Head>
-        <LogInSignUp login />
-      </Layout>
-    </GlobalErrorConsumer>
+    <Layout title="Login">
+      <Head>
+        <title>{pageTitle('Login')}</title>
+      </Head>
+      <LogInSignUp login />
+    </Layout>
   )
 }
 

--- a/unlock-app/src/components/content/SignupContent.tsx
+++ b/unlock-app/src/components/content/SignupContent.tsx
@@ -1,20 +1,17 @@
 import React from 'react'
 import Head from 'next/head'
 import Layout from '../interface/Layout'
-import GlobalErrorConsumer from '../interface/GlobalErrorConsumer'
 import { pageTitle } from '../../constants'
 import LogInSignUp from '../interface/LogInSignUp'
 
 export const SignupContent = () => {
   return (
-    <GlobalErrorConsumer>
-      <Layout title="Signup">
-        <Head>
-          <title>{pageTitle('Signup')}</title>
-        </Head>
-        <LogInSignUp signup />
-      </Layout>
-    </GlobalErrorConsumer>
+    <Layout title="Signup">
+      <Head>
+        <title>{pageTitle('Signup')}</title>
+      </Head>
+      <LogInSignUp signup />
+    </Layout>
   )
 }
 

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -9,6 +9,7 @@ import GlobalStyle from '../theme/globalStyle'
 import { ConfigContext } from '../utils/withConfig'
 
 import FullScreenModal from '../components/interface/FullScreenModals'
+import GlobalErrorConsumer from '../components/interface/GlobalErrorConsumer'
 
 // Middlewares
 import web3Middleware from '../middlewares/web3Middleware'
@@ -110,7 +111,9 @@ The Unlock team
           <FullScreenModal />
           <ConnectedRouter>
             <ConfigProvider value={config}>
-              <Component {...pageProps} />
+              <GlobalErrorConsumer>
+                <Component {...pageProps} />
+              </GlobalErrorConsumer>
             </ConfigProvider>
           </ConnectedRouter>
         </Provider>


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR helps out with the overall error refactor. We're moving GlobalErrorConsumer back to a more global app-level instead of happening at the page level.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
