### PR TITLE
refactor data iframe cache to be race condition-resistant

### DIFF
--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -10,19 +10,21 @@ import {
   setNetwork,
   getFormattedCacheValues,
   setAccountBalance,
+  setKey,
+  getKey,
 } from '../../data-iframe/cacheHandler'
-import { storageId } from '../../data-iframe/cache'
 import { TRANSACTION_TYPES } from '../../constants'
 
 describe('cacheHandler', () => {
   let fakeWindow
-  const id = storageId('network', 'account')
-  const nonAccountSpecificId = storageId(
-    'network',
-    '0x0000000000000000000000000000000000000000'
-  )
   const myKeys = {
     lock: {
+      id: 'myKey',
+      owner: 'owner',
+      lock: 'lock',
+      expirationTimestamp: 0,
+    },
+    lock2: {
       id: 'myKey',
       owner: 'owner',
       lock: 'lock',
@@ -60,17 +62,23 @@ describe('cacheHandler', () => {
     }
   })
 
-  describe('setting values', () => {
+  fdescribe('setting values', () => {
+    fit('setKey', async () => {
+      expect.assertions(1)
+
+      await setKey(fakeWindow, {
+        key: 'my key',
+      })
+
+      expect(await getKey(fakeWindow, ''))
+    })
+
     it('setKeys', async () => {
       expect.assertions(1)
 
       await setKeys(fakeWindow, myKeys)
 
-      expect(fakeWindow.storage).toEqual({
-        [id]: JSON.stringify({
-          keys: myKeys,
-        }),
-      })
+      expect(await getKeys(fakeWindow)).toEqual(myKeys)
     })
 
     it('setLocks', async () => {
@@ -78,11 +86,7 @@ describe('cacheHandler', () => {
 
       await setLocks(fakeWindow, myLocks)
 
-      expect(fakeWindow.storage).toEqual({
-        [nonAccountSpecificId]: JSON.stringify({
-          locks: myLocks,
-        }),
-      })
+      expect(await getLocks(fakeWindow)).toEqual(myLocks)
     })
 
     it('setTransactions', async () => {
@@ -90,11 +94,7 @@ describe('cacheHandler', () => {
 
       await setTransactions(fakeWindow, myTransactions)
 
-      expect(fakeWindow.storage).toEqual({
-        [id]: JSON.stringify({
-          transactions: myTransactions,
-        }),
-      })
+      expect(await getTransactions(fakeWindow)).toEqual(myTransactions)
     })
 
     it('setting multiple cache values', async () => {
@@ -104,15 +104,9 @@ describe('cacheHandler', () => {
       await setLocks(fakeWindow, myLocks)
       await setTransactions(fakeWindow, myTransactions)
 
-      expect(fakeWindow.storage).toEqual({
-        [nonAccountSpecificId]: JSON.stringify({
-          locks: myLocks,
-        }),
-        [id]: JSON.stringify({
-          keys: myKeys,
-          transactions: myTransactions,
-        }),
-      })
+      expect(await getKeys(fakeWindow)).toEqual(myKeys)
+      expect(await getLocks(fakeWindow)).toEqual(myLocks)
+      expect(await getTransactions(fakeWindow)).toEqual(myTransactions)
     })
   })
 

--- a/paywall/src/data-iframe/cache/localStorage.js
+++ b/paywall/src/data-iframe/cache/localStorage.js
@@ -1,7 +1,9 @@
 import localStorageAvailable from '../../utils/localStorage'
 
-export function storageId(networkId, accountAddress) {
-  return `unlock-protocol/${networkId}/${accountAddress}`
+export function storageId(networkId, accountAddress, type) {
+  return `unlock-protocol/${networkId}/${accountAddress}${
+    type ? `#${type}` : ''
+  }`
 }
 
 const nullAccount = '0x0000000000000000000000000000000000000000'
@@ -11,37 +13,20 @@ const nullAccount = '0x0000000000000000000000000000000000000000'
  * exists as a key if requested
  *
  * @param {string} key the key for the item in localStorage
- * @param {string} type the sub-key (if any) which must exist on return
  */
-function getContainer(window, key, type = false) {
+function getContainer(window, key) {
   const value = window.localStorage.getItem(key)
   if (!value) {
-    if (type) {
-      return { [type]: null }
-    }
-    return {}
+    return null
   }
   let container
   try {
     container = JSON.parse(value)
   } catch (e) {
     // always work, cache is invalid, so we will overwrite on next write
-    return { [type]: null }
+    return null
   }
 
-  if (typeof container !== 'object') {
-    if (type) {
-      return { [type]: null }
-    }
-    return {}
-  }
-
-  if (!type) {
-    return container
-  }
-  if (!container[type]) {
-    container[type] = null
-  }
   return container
 }
 
@@ -72,11 +57,9 @@ export async function get({
   accountAddress = nullAccount,
 }) {
   ensureLocalStorageAvailable(window, `get ${type} from cache`)
-  const key = storageId(networkId, accountAddress)
+  const key = storageId(networkId, accountAddress, type)
 
-  const container = getContainer(window, key, type)
-  if (!type) return container
-  return container[type]
+  return getContainer(window, key)
 }
 
 /**
@@ -97,15 +80,12 @@ export async function put({
   accountAddress = nullAccount,
 }) {
   ensureLocalStorageAvailable(window, `save ${type} in cache`)
-  const key = storageId(networkId, accountAddress)
-  const container = getContainer(window, key, type)
+  const key = storageId(networkId, accountAddress, type)
   if (value === undefined) {
-    delete container[type]
+    return clear({ window, networkId, accountAddress, type })
   } else {
-    container[type] = value
+    window.localStorage.setItem(key, JSON.stringify(value))
   }
-
-  window.localStorage.setItem(key, JSON.stringify(container))
 }
 
 /**
@@ -162,13 +142,8 @@ export async function setNetwork(window, network) {
  */
 export async function clear({ window, networkId, accountAddress, type }) {
   ensureLocalStorageAvailable(window, 'clear cache')
-  const key = storageId(networkId, accountAddress)
-  if (!type) {
-    window.localStorage.removeItem(key)
-    return
-  }
-
-  await put({ window, networkId, accountAddress, type, value: undefined })
+  const key = storageId(networkId, accountAddress, type)
+  window.localStorage.removeItem(key)
 }
 
 const listeners = {}
@@ -187,13 +162,14 @@ export async function addListener({
   accountAddress = nullAccount,
 }) {
   const key = storageId(networkId, accountAddress)
+  const keyMatcher = new RegExp('^' + key)
   if (listeners[key]) {
     removeListener({ window, networkId, accountAddress })
   }
   listeners[key] = evt => {
     if (evt.storageArea !== window.localStorage) return // ignore sessionStorage
     const changedKey = evt.key
-    if (changedKey === key) {
+    if (changedKey.match(keyMatcher)) {
       changeCallback(evt.oldValue, evt.newValue)
     }
   }


### PR DESCRIPTION
# Description

The current design of the data iframe cache stores a user's data under a single localStorage key. This has a dangerous side effect: if 2 async processes attempt to update the store at the same time, stale data might overwrite more current data.

The solution is to store the sensitive data (keys, transactions) in separate localStorage entries. To do this, the PR adds getters and setters for `key` and `transaction`, and refactors the plural setters and getters to use these single setters for keys/transactions. In addition, the localStorage cache driver is refactored to be a bit simpler. This change means we now use a regex to match storage keys that change in different tabs in order to sync across open tabs in the browser.

In addition, `cacheHandler.js` is re-organized to group related functionality, and adds comments to capture necessary context that is not obvious. For example, with this change, we need to use something to figure out which cache entries to pull for keys. By indexing keys via the lock they correspond with, we only need the list of locks. Fortunately, this list is sent in the paywall config at startup, and so will be the very first thing cached.

The last change is that the cacheHandler test is refactored to remove implementation details, and to test important behavior, such as how the cache should react if the current user account or current user network changes.

With these changes, the cache will be more resistant to subtle bugs as well as easier to refactor internally (including swapping out for a different storage driver underneath)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3138

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
