### PR TITLE
refactor purchaseKey processing to emit only the changed transaction

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/index.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/index.test.js
@@ -440,21 +440,18 @@ describe('blockchain handler index', () => {
 
       onChange = info => {
         expect(info).toEqual({
-          transactions: {
-            ...fakeTransactionResults,
-            hash2: {
-              hash: 'hash2',
-              blockNumber: Number.MAX_SAFE_INTEGER,
-              confirmations: 0,
-              from: 'account',
-              to: 'lock',
-              input: 'input',
-              key: 'lock-account',
-              lock: 'lock',
-              network: 2,
-              status: 'submitted',
-              type: TRANSACTION_TYPES.KEY_PURCHASE,
-            },
+          transaction: {
+            hash: 'hash2',
+            blockNumber: Number.MAX_SAFE_INTEGER,
+            confirmations: 0,
+            from: 'account',
+            to: 'lock',
+            input: 'input',
+            key: 'lock-account',
+            lock: 'lock',
+            network: 2,
+            status: 'submitted',
+            type: TRANSACTION_TYPES.KEY_PURCHASE,
           },
           key: {
             id: '0x123-account',

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
@@ -58,12 +58,10 @@ describe('blockchainHandler purchaseKey', () => {
 
     function assertOnUpdates(expected, done) {
       let expectedIndex = 0
-      return (newTransactions, newKey) => {
-        const [expectedTransactions, expectedKey, desc] = expected[
-          expectedIndex
-        ]
+      return (newTransaction, newKey) => {
+        const [expectedTransaction, expectedKey, desc] = expected[expectedIndex]
         try {
-          expect(newTransactions).toEqual(expectedTransactions)
+          expect(newTransaction).toEqual(expectedTransaction)
           expect(newKey).toEqual(expectedKey)
         } catch (e) {
           // eslint-disable-next-line
@@ -128,9 +126,7 @@ describe('blockchainHandler purchaseKey', () => {
       }
       const expected = [
         [
-          {
-            hash: submittedTransaction,
-          },
+          submittedTransaction,
           {
             expiration: 0,
             id: 'lock-account',
@@ -253,17 +249,13 @@ describe('blockchainHandler purchaseKey', () => {
       const expected = [
         [
           // submitted transaction
-          {
-            hash: submittedTransaction,
-          },
+          submittedTransaction,
           newKeys.lock,
           'submitted transaction',
         ],
         [
           // update
-          {
-            hash: pendingTransaction,
-          },
+          pendingTransaction,
           newKeys.lock,
           'pending transaction',
         ],
@@ -354,9 +346,7 @@ describe('blockchainHandler purchaseKey', () => {
       const expected = [
         [
           // update
-          {
-            hash: pendingTransaction,
-          },
+          pendingTransaction,
           newKeys.lock,
           'pending transaction',
         ],
@@ -427,9 +417,7 @@ describe('blockchainHandler purchaseKey', () => {
       const expected = [
         [
           // update
-          {
-            hash: confirmingTransaction,
-          },
+          confirmingTransaction,
           key,
           'confirming transaction',
         ],
@@ -617,9 +605,7 @@ describe('blockchainHandler purchaseKey', () => {
       }
       const expected = [
         [
-          {
-            hash: submittedTransaction,
-          },
+          submittedTransaction,
           newKeys.lock,
           'submitted transaction after expire',
         ],

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/submittedListener.test.js
@@ -20,7 +20,7 @@ describe('submittedListener', () => {
   })
 
   it('returns immediately if the key is submitted', async () => {
-    expect.assertions(2)
+    expect.assertions(1)
 
     const transactions = {
       hash: {
@@ -51,12 +51,11 @@ describe('submittedListener', () => {
       requiredConfirmations: 3,
     })
 
-    expect(result.transactions).toBe(transactions)
-    expect(result.key).toBe(key)
+    expect(result).toBe(false)
   })
 
   it('returns immediately if the key is pending', async () => {
-    expect.assertions(2)
+    expect.assertions(1)
 
     const transactions = {
       hash: {
@@ -87,12 +86,11 @@ describe('submittedListener', () => {
       requiredConfirmations: 3,
     })
 
-    expect(result.transactions).toBe(transactions)
-    expect(result.key).toBe(key)
+    expect(result).toBe(false)
   })
 
   it('returns immediately if the key is confirming', async () => {
-    expect.assertions(2)
+    expect.assertions(1)
 
     const transactions = {
       hash: {
@@ -124,12 +122,11 @@ describe('submittedListener', () => {
       requiredConfirmations: 3,
     })
 
-    expect(result.transactions).toBe(transactions)
-    expect(result.key).toBe(key)
+    expect(result).toBe(false)
   })
 
   it('returns immediately if the key is valid', async () => {
-    expect.assertions(2)
+    expect.assertions(1)
 
     const transactions = {
       hash: {
@@ -161,8 +158,7 @@ describe('submittedListener', () => {
       requiredConfirmations: 3,
     })
 
-    expect(result.transactions).toBe(transactions)
-    expect(result.key).toBe(key)
+    expect(result).toBe(false)
   })
 
   it('handles key with no transactions', async done => {
@@ -186,7 +182,7 @@ describe('submittedListener', () => {
       web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
-    }).then(({ transactions, key }) => {
+    }).then(({ transaction, key }) => {
       const hash = {
         hash: 'hash',
         from: 'account',
@@ -200,9 +196,7 @@ describe('submittedListener', () => {
         network: 1,
         blockNumber: Number.MAX_SAFE_INTEGER,
       }
-      expect(transactions).toEqual({
-        hash,
-      })
+      expect(transaction).toEqual(hash)
 
       expect(key).toEqual(existingKey)
       done()
@@ -252,7 +246,7 @@ describe('submittedListener', () => {
       web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
-    }).then(({ transactions, key }) => {
+    }).then(({ transaction, key }) => {
       const hash = {
         hash: 'hash',
         from: 'account',
@@ -266,10 +260,7 @@ describe('submittedListener', () => {
         network: 1,
         blockNumber: Number.MAX_SAFE_INTEGER,
       }
-      expect(transactions).toEqual({
-        hash,
-        old,
-      })
+      expect(transaction).toEqual(hash)
 
       expect(key).toEqual(existingKey)
       done()
@@ -319,7 +310,7 @@ describe('submittedListener', () => {
       web3Service: fakeWeb3Service,
       walletService: fakeWalletService,
       requiredConfirmations: 3,
-    }).then(({ transactions, key }) => {
+    }).then(({ transaction, key }) => {
       const hash = {
         hash: 'hash',
         from: 'account',
@@ -333,10 +324,7 @@ describe('submittedListener', () => {
         network: 1,
         blockNumber: Number.MAX_SAFE_INTEGER,
       }
-      expect(transactions).toEqual({
-        hash,
-        old,
-      })
+      expect(transaction).toEqual(hash)
 
       expect(key).toEqual(existingKey)
       done()

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/updateListener.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey/updateListener.test.js
@@ -16,7 +16,7 @@ describe('updateListener', () => {
   })
 
   it('ignores keys with no transactions', async () => {
-    expect.assertions(2)
+    expect.assertions(1)
 
     const transactions = {}
     const key = {
@@ -34,12 +34,11 @@ describe('updateListener', () => {
       requiredConfirmations: 3,
     })
 
-    expect(result.transactions).toBe(transactions)
-    expect(result.key).toBe(key)
+    expect(result).toBe(false)
   })
 
   it('ignores transactions that are not in process', async () => {
-    expect.assertions(2)
+    expect.assertions(1)
 
     const transactions = {
       hash: {
@@ -70,12 +69,11 @@ describe('updateListener', () => {
       requiredConfirmations: 3,
     })
 
-    expect(result.transactions).toBe(transactions)
-    expect(result.key).toBe(key)
+    expect(result).toBe(false)
   })
 
   it('ignores confirmed transactions', async () => {
-    expect.assertions(2)
+    expect.assertions(1)
 
     const transactions = {
       hash: {
@@ -106,8 +104,7 @@ describe('updateListener', () => {
       requiredConfirmations: 3,
     })
 
-    expect(result.transactions).toBe(transactions)
-    expect(result.key).toBe(key)
+    expect(result).toBe(false)
   })
 
   it('gets a transaction update for submitted transactions', async done => {
@@ -141,15 +138,13 @@ describe('updateListener', () => {
       existingKey,
       web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
-    }).then(({ transactions, key }) => {
+    }).then(({ transaction, key }) => {
       const newHash = {
         ...hash,
         status: 'pending',
         thing: 'hi',
       }
-      expect(transactions).toEqual({
-        hash: newHash,
-      })
+      expect(transaction).toEqual(newHash)
 
       expect(key).toEqual(existingKey)
       done()
@@ -192,15 +187,13 @@ describe('updateListener', () => {
       existingKey,
       web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
-    }).then(({ transactions, key }) => {
+    }).then(({ transaction, key }) => {
       const newHash = {
         ...hash,
         status: 'pending',
         thing: 'hi',
       }
-      expect(transactions).toEqual({
-        hash: newHash,
-      })
+      expect(transaction).toEqual(newHash)
 
       expect(key).toEqual(existingKey)
       done()
@@ -248,16 +241,14 @@ describe('updateListener', () => {
       existingKey,
       web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
-    }).then(({ transactions, key }) => {
+    }).then(({ transaction, key }) => {
       const newHash = {
         ...hash,
         status: 'mined',
         thing: 'hi',
         blockNumber: 1234,
       }
-      expect(transactions).toEqual({
-        hash: newHash,
-      })
+      expect(transaction).toEqual(newHash)
 
       expect(key).toEqual(existingKey)
       done()
@@ -303,15 +294,13 @@ describe('updateListener', () => {
       existingKey,
       web3Service: fakeWeb3Service,
       requiredConfirmations: 3,
-    }).then(({ transactions, key }) => {
+    }).then(({ transaction, key }) => {
       const newHash = {
         ...hash,
         confirmations: 1,
         thing: 'hi',
       }
-      expect(transactions).toEqual({
-        hash: newHash,
-      })
+      expect(transaction).toEqual(newHash)
 
       expect(key).toEqual(newKey)
       done()

--- a/paywall/src/data-iframe/blockchainHandler/index.js
+++ b/paywall/src/data-iframe/blockchainHandler/index.js
@@ -97,8 +97,8 @@ export async function retrieveChainData({
     getKeys({ walletService, locks: locksToRetrieve, web3Service }),
     locksmithTransactions(window, locksmithHost, web3Service, walletService),
   ])
-  const update = async (transactions, key) => {
-    onChange({ transactions, key })
+  const update = async (transaction, key) => {
+    onChange({ transaction, key })
   }
   Object.values(transactions).forEach(transaction => {
     if (transaction.type === TRANSACTION_TYPES.KEY_PURCHASE) {

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey.js
@@ -55,10 +55,14 @@ export async function processKeyPurchaseTransactions({
   walletService.addListener('transaction.pending', walletAction)
   try {
     const afterEventProcessed = () => {
-      if (transactions !== result.transactions) {
-        transactions = result.transactions
+      if (result) {
+        const transaction = result.transaction
+        transactions = {
+          ...transactions,
+          [transaction.hash]: transaction,
+        }
         key = result.key
-        update(transactions, key)
+        update(transaction, key)
       }
     }
 

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey/submittedListener.js
@@ -41,10 +41,7 @@ export default async function submittedListener({
     linkedKey.status !== 'expired' &&
     linkedKey.status !== 'failed'
   ) {
-    return {
-      transactions: existingTransactions,
-      key: existingKey,
-    }
+    return false
   }
 
   // wait for the submitted transaction to become pending
@@ -78,12 +75,8 @@ export default async function submittedListener({
     blockNumber: Number.MAX_SAFE_INTEGER, // ensure this is always the current transaction until it is mined
   }
 
-  const transactions = {
-    ...existingTransactions,
-    [transaction.hash]: transaction,
-  }
   return {
-    transactions,
+    transaction,
     key: await web3Service.getKeyByLockForOwner(
       existingKey.lock,
       existingKey.owner

--- a/paywall/src/data-iframe/blockchainHandler/purchaseKey/updateListener.js
+++ b/paywall/src/data-iframe/blockchainHandler/purchaseKey/updateListener.js
@@ -18,10 +18,7 @@ export default async function updateListener({
     (transaction.status === 'mined' &&
       transaction.confirmations > requiredConfirmations)
   ) {
-    return {
-      transactions: existingTransactions,
-      key: existingKey,
-    }
+    return false
   }
 
   // get one transaction update
@@ -52,12 +49,8 @@ export default async function updateListener({
     ...transaction,
     ...update,
   }
-  const transactions = {
-    ...existingTransactions,
-    [newTransaction.hash]: newTransaction,
-  }
   return {
-    transactions,
+    transaction: newTransaction,
     // this ensures we always have the latest expiration info
     key: await web3Service.getKeyByLockForOwner(
       existingKey.lock,


### PR DESCRIPTION
# Description

This continues the refactoring to handle race conditions. When a key purchase transaction life cycle is being monitored, if we return all of the transactions, and 2 key purchases are happening simultaneously, this introduces a potential race condition where stale data will overwrite new data. By returning only the relevant transaction from the key purchase transaction monitor, and `false` if no change is needed, this is both easier to reason about and safer.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
