### PR TITLE
add error handling to the data iframe's post office

### DIFF
--- a/paywall/src/__tests__/data-iframe/postOffice.test.js
+++ b/paywall/src/__tests__/data-iframe/postOffice.test.js
@@ -7,6 +7,7 @@ import {
   POST_MESSAGE_UPDATE_LOCKS,
   POST_MESSAGE_LOCKED,
   POST_MESSAGE_UNLOCKED,
+  POST_MESSAGE_ERROR,
 } from '../../paywall-builder/constants'
 import {
   setAccount,
@@ -86,6 +87,38 @@ describe('data iframe postOffice', () => {
           done()
         }
         updater('walletModal')
+      })
+
+      it('error passes on the error message of an Error to the main window', done => {
+        expect.assertions(1)
+
+        fakeTarget.postMessage = (...args) => {
+          expect(args).toEqual([
+            {
+              type: POST_MESSAGE_ERROR,
+              payload: 'fail',
+            },
+            'http://fun.times',
+          ])
+          done()
+        }
+        updater('error', new Error('fail'))
+      })
+
+      it('error passes on the error message to the main window', done => {
+        expect.assertions(1)
+
+        fakeTarget.postMessage = (...args) => {
+          expect(args).toEqual([
+            {
+              type: POST_MESSAGE_ERROR,
+              payload: 'fail',
+            },
+            'http://fun.times',
+          ])
+          done()
+        }
+        updater('error', 'fail')
       })
 
       it('account passes account address to the main window', async done => {

--- a/paywall/src/data-iframe/postOffice.js
+++ b/paywall/src/data-iframe/postOffice.js
@@ -7,6 +7,7 @@ import {
   POST_MESSAGE_UPDATE_ACCOUNT_BALANCE,
   POST_MESSAGE_UPDATE_NETWORK,
   POST_MESSAGE_UPDATE_WALLET,
+  POST_MESSAGE_ERROR,
 } from '../paywall-builder/constants'
 import { getFormattedCacheValues } from './cacheHandler'
 
@@ -56,9 +57,12 @@ export default function postOffice(window, requiredConfirmations) {
     walletModal() {
       postMessage(POST_MESSAGE_UPDATE_WALLET)
     },
+    error(error) {
+      postMessage(POST_MESSAGE_ERROR, error)
+    },
   }
 
-  return async update => {
+  return async (update, content) => {
     const cachedData = await getFormattedCacheValues(
       window,
       requiredConfirmations
@@ -91,6 +95,9 @@ export default function postOffice(window, requiredConfirmations) {
         break
       case 'walletModal':
         actions.walletModal()
+        break
+      case 'error':
+        actions.error(content.message ? content.message : content)
         break
     }
   }

--- a/paywall/src/paywall-builder/constants.js
+++ b/paywall/src/paywall-builder/constants.js
@@ -15,3 +15,5 @@ export const POST_MESSAGE_UPDATE_ACCOUNT = 'update/account'
 export const POST_MESSAGE_UPDATE_ACCOUNT_BALANCE = 'update/accountBalance'
 export const POST_MESSAGE_UPDATE_NETWORK = 'update/network'
 export const POST_MESSAGE_UPDATE_WALLET = 'update/walletmodal'
+
+export const POST_MESSAGE_ERROR = 'error'


### PR DESCRIPTION
# Description

This adds listening for errors. Any errors generated by the blockchain handler will then be passed on to the unlock.min.js script to send to the checkout UI.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
