### PR TITLE
implement merging a value into an existing cache to remove possibility of stale data

### DIFF
--- a/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
@@ -7,6 +7,7 @@ import {
   getNetwork,
   setNetwork,
 } from '../../../data-iframe/cache'
+import { merge } from '../../../data-iframe/cache/localStorage'
 
 jest.mock('../../../utils/localStorage', () => () => false)
 
@@ -32,6 +33,18 @@ describe('localStorage cache', () => {
       } catch (e) {
         expect(e.message).toBe(
           'localStorage is unavailable, cannot save thing in cache'
+        )
+      }
+    })
+
+    it('merge', async () => {
+      expect.assertions(1)
+
+      try {
+        await merge({ type: 'thing', subType: 'another' })
+      } catch (e) {
+        expect(e.message).toBe(
+          'localStorage is unavailable, cannot save thing/another in cache'
         )
       }
     })

--- a/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage-no-localStorage.test.js
@@ -13,7 +13,7 @@ jest.mock('../../../utils/localStorage', () => () => false)
 
 describe('localStorage cache', () => {
   describe('localStorage unavailable', () => {
-    it('get', async () => {
+    it('should throw when get is called', async () => {
       expect.assertions(1)
 
       try {
@@ -25,7 +25,7 @@ describe('localStorage cache', () => {
       }
     })
 
-    it('put', async () => {
+    it('should throw when put is called', async () => {
       expect.assertions(1)
 
       try {
@@ -37,7 +37,7 @@ describe('localStorage cache', () => {
       }
     })
 
-    it('merge', async () => {
+    it('should throw when merge is called', async () => {
       expect.assertions(1)
 
       try {
@@ -49,7 +49,7 @@ describe('localStorage cache', () => {
       }
     })
 
-    it('clear', async () => {
+    it('should throw when clear is called', async () => {
       expect.assertions(1)
 
       try {
@@ -61,7 +61,7 @@ describe('localStorage cache', () => {
       }
     })
 
-    it('getAccount', async () => {
+    it('should throw when getAccount is called', async () => {
       expect.assertions(1)
 
       try {
@@ -73,7 +73,7 @@ describe('localStorage cache', () => {
       }
     })
 
-    it('getNetwork', async () => {
+    it('should throw when getNetwork is called', async () => {
       expect.assertions(1)
 
       try {
@@ -85,7 +85,7 @@ describe('localStorage cache', () => {
       }
     })
 
-    it('setAccount', async () => {
+    it('should throw when setAccount is called', async () => {
       expect.assertions(1)
 
       try {
@@ -97,7 +97,7 @@ describe('localStorage cache', () => {
       }
     })
 
-    it('setNetwork', async () => {
+    it('should throw when setNetwork is called', async () => {
       expect.assertions(1)
 
       try {

--- a/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
@@ -10,6 +10,7 @@ import {
   setNetwork,
   getNetwork,
 } from '../../../data-iframe/cache'
+import { merge } from '../../../data-iframe/cache/localStorage'
 
 jest.mock('../../../utils/localStorage', () => () => true)
 
@@ -183,6 +184,206 @@ describe('localStorage cache', () => {
       expect(fakeWindow.storage[storageId(123, nullAccount)]).toBe(
         JSON.stringify({
           there: 'hello',
+        })
+      )
+    })
+  })
+
+  describe('merge', () => {
+    const keys = {
+      key1: {
+        thing: 'hi',
+      },
+      key2: {
+        thing2: 'hi2',
+      },
+    }
+    beforeEach(async () => {
+      makeWindow()
+    })
+
+    it('saves a new sub-value', async () => {
+      expect.assertions(1)
+
+      const key3 = {
+        thing3: 'hi3',
+      }
+
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'keys',
+        value: keys,
+      })
+
+      await merge({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'keys',
+        subType: 'key3',
+        value: key3,
+      })
+
+      expect(fakeWindow.storage[storageId(123, 'hi')]).toEqual(
+        JSON.stringify({
+          keys: {
+            ...keys,
+            key3,
+          },
+        })
+      )
+    })
+
+    it('removes an existing sub-value', async () => {
+      expect.assertions(1)
+
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'keys',
+        value: keys,
+      })
+
+      await merge({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'keys',
+        subType: 'key2',
+      })
+
+      expect(fakeWindow.storage[storageId(123, 'hi')]).toEqual(
+        JSON.stringify({
+          keys: {
+            key1: keys.key1,
+          },
+        })
+      )
+    })
+
+    it('replaces an existing sub-value', async () => {
+      expect.assertions(1)
+
+      const key2 = {
+        thing3: 'hi3',
+      }
+
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'keys',
+        value: keys,
+      })
+
+      await merge({
+        window: fakeWindow,
+        networkId: 123,
+        accountAddress: 'hi',
+        type: 'keys',
+        subType: 'key2',
+        value: key2,
+      })
+
+      expect(fakeWindow.storage[storageId(123, 'hi')]).toEqual(
+        JSON.stringify({
+          keys: {
+            key1: keys.key1,
+            key2,
+          },
+        })
+      )
+    })
+
+    it('saves a new sub-value, non-account-specific', async () => {
+      expect.assertions(1)
+
+      const key3 = {
+        thing3: 'hi3',
+      }
+
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        type: 'keys',
+        value: keys,
+      })
+
+      await merge({
+        window: fakeWindow,
+        networkId: 123,
+        type: 'keys',
+        subType: 'key3',
+        value: key3,
+      })
+
+      expect(fakeWindow.storage[storageId(123, nullAccount)]).toEqual(
+        JSON.stringify({
+          keys: {
+            ...keys,
+            key3,
+          },
+        })
+      )
+    })
+
+    it('removes a sub-value, non-account-specific', async () => {
+      expect.assertions(1)
+
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        type: 'keys',
+        value: keys,
+      })
+
+      await merge({
+        window: fakeWindow,
+        networkId: 123,
+        type: 'keys',
+        subType: 'key2',
+      })
+
+      expect(fakeWindow.storage[storageId(123, nullAccount)]).toEqual(
+        JSON.stringify({
+          keys: {
+            key1: keys.key1,
+          },
+        })
+      )
+    })
+
+    it('replaces an existing sub-value, non-account-specific', async () => {
+      expect.assertions(1)
+
+      const key2 = {
+        thing3: 'hi3',
+      }
+
+      await put({
+        window: fakeWindow,
+        networkId: 123,
+        type: 'keys',
+        value: keys,
+      })
+
+      await merge({
+        window: fakeWindow,
+        networkId: 123,
+        type: 'keys',
+        subType: 'key2',
+        value: key2,
+      })
+
+      expect(fakeWindow.storage[storageId(123, nullAccount)]).toEqual(
+        JSON.stringify({
+          keys: {
+            key1: keys.key1,
+            key2,
+          },
         })
       )
     })

--- a/paywall/src/data-iframe/cache/index.js
+++ b/paywall/src/data-iframe/cache/index.js
@@ -4,6 +4,7 @@
 export {
   get,
   put,
+  merge,
   clear,
   addListener,
   removeListener,

--- a/paywall/src/data-iframe/cache/localStorage.js
+++ b/paywall/src/data-iframe/cache/localStorage.js
@@ -29,13 +29,6 @@ function getContainer(window, key, type = false) {
     return { [type]: null }
   }
 
-  if (typeof container !== 'object') {
-    if (type) {
-      return { [type]: null }
-    }
-    return {}
-  }
-
   if (!type) {
     return container
   }
@@ -103,6 +96,36 @@ export async function put({
     delete container[type]
   } else {
     container[type] = value
+  }
+
+  window.localStorage.setItem(key, JSON.stringify(container))
+}
+
+/**
+ * Merge a sub-value into a larger value store in the cache
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @param {int} networkId the ethereum network id
+ * @param {string} type the type of account data to set
+ * @param {*} value the value to store. This must be serializable as JSON
+ * @param {string} accountAddress the ethereum account address of the user whose data is cached. For general
+ *                                values like locks, use null account to make them available to anyone
+ */
+export async function merge({
+  window,
+  networkId,
+  type,
+  subType,
+  value,
+  accountAddress = nullAccount,
+}) {
+  ensureLocalStorageAvailable(window, `save ${type}/${subType} in cache`)
+  const key = storageId(networkId, accountAddress)
+  const container = getContainer(window, key, type)
+  if (value === undefined) {
+    delete container[type][subType]
+  } else {
+    container[type][subType] = value
   }
 
   window.localStorage.setItem(key, JSON.stringify(container))


### PR DESCRIPTION
# Description

This adds `merge`, which is an atomic way to write to the cache for a sub-value (like a key within keys, or transaction within transactions)

A follow-up PR will implement `setKey` and `setTransaction` based on `merge`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3206

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
