### PR TITLE
refactor cacheHandler tests to be non-localStorage-specific and more robust

### DIFF
--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -200,19 +200,19 @@ describe('cacheHandler', () => {
       await setAccount(fakeWindow, 'different')
     })
 
-    it('cached locks still return', async () => {
+    it('should still return cached locks', async () => {
       expect.assertions(1)
 
       expect(await getLocks(fakeWindow)).toEqual(myLocks)
     })
 
-    it('cached keys are not returned', async () => {
+    it('should not return cached keys', async () => {
       expect.assertions(1)
 
       expect(await getKeys(fakeWindow)).toEqual({})
     })
 
-    it('cached transactions are not returned', async () => {
+    it('should not return cached transactions', async () => {
       expect.assertions(1)
 
       expect(await getTransactions(fakeWindow)).toEqual({})
@@ -268,13 +268,13 @@ describe('cacheHandler', () => {
       expect(await getLocks(fakeWindow)).toEqual({})
     })
 
-    it('cached keys are not returned', async () => {
+    it('should not return cached keys', async () => {
       expect.assertions(1)
 
       expect(await getKeys(fakeWindow)).toEqual({})
     })
 
-    it('cached transactions are not returned', async () => {
+    it('should not return cached transactions', async () => {
       expect.assertions(1)
 
       expect(await getTransactions(fakeWindow)).toEqual({})

--- a/paywall/src/data-iframe/cacheHandler.js
+++ b/paywall/src/data-iframe/cacheHandler.js
@@ -32,7 +32,7 @@ async function _put(window, key, value) {
 }
 
 export async function getKeys(window) {
-  return _get(window, 'keys')
+  return (await _get(window, 'keys')) || {}
 }
 
 /**


### PR DESCRIPTION
# Description

This is an improvement of testing, and is also designed to make the follow-up PR that adds `setKey` and `setTransaction` be smaller and easier to review.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3138

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
