### PR TITLE
custom dispatcher for the "unlocked" and "locked" events in unlock.min.js

### DIFF
--- a/paywall/src/__tests__/unlock.js/dispatchEvent.test.js
+++ b/paywall/src/__tests__/unlock.js/dispatchEvent.test.js
@@ -1,0 +1,35 @@
+import dispatchEvent from '../../unlock.js/dispatchEvent'
+
+describe('dispatchEvent', () => {
+  it('creates a CustomEvent with the specified detail and dispatches it on window', () => {
+    expect.assertions(1)
+
+    const spy = jest.spyOn(window, 'dispatchEvent')
+    dispatchEvent(window, 'hi')
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: 'hi',
+        type: 'unlockProtocol',
+      })
+    )
+  })
+
+  it('creates a CustomEvent with the specified detail and dispatches it on window (old way)', () => {
+    expect.assertions(1)
+
+    window.CustomEvent = function() {
+      throw new Error('unsupported')
+    }
+    const spy = jest.spyOn(window, 'dispatchEvent')
+
+    dispatchEvent(window, 'hi')
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: 'hi',
+        type: 'unlockProtocol',
+      })
+    )
+  })
+})

--- a/paywall/src/unlock.js/dispatchEvent.js
+++ b/paywall/src/unlock.js/dispatchEvent.js
@@ -9,8 +9,15 @@ export default function dispatchEvent(window, detail) {
     event = new window.CustomEvent('unlockProtocol', { detail })
   } catch (e) {
     // older browsers do events this clunky way.
+    // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events#The_old-fashioned_way
+    // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent#Parameters
     event = window.document.createEvent('customevent')
-    event.initCustomEvent('unlockProtocol', true, true, detail)
+    event.initCustomEvent(
+      'unlockProtocol',
+      true /* canBubble */,
+      true /* cancelable */,
+      detail
+    )
   }
   window.dispatchEvent(event)
 }

--- a/paywall/src/unlock.js/dispatchEvent.js
+++ b/paywall/src/unlock.js/dispatchEvent.js
@@ -1,0 +1,16 @@
+/**
+ * create and dispatch an 'unlockProtocol' event with the given detail
+ * @param {window} window the current global context (window, self)
+ * @param {*} detail the custom data to pass along with the event
+ */
+export default function dispatchEvent(window, detail) {
+  let event
+  try {
+    event = new window.CustomEvent('unlockProtocol', { detail })
+  } catch (e) {
+    // older browsers do events this clunky way.
+    event = window.document.createEvent('customevent')
+    event.initCustomEvent('unlockProtocol', true, true, detail)
+  }
+  window.dispatchEvent(event)
+}


### PR DESCRIPTION
# Description

This is a helper function we will use to dispatch the `unlockProtocol` event on the main window, with `detail` set to `'unlocked'` or `'locked'`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3364 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
