### PR TITLE
fix flaky test

### DIFF
--- a/paywall/src/__tests__/providers/Web3ProxyProvider.test.js
+++ b/paywall/src/__tests__/providers/Web3ProxyProvider.test.js
@@ -159,7 +159,18 @@ describe('Web3ProxyProvider', () => {
         })
       })
     }
-    await walletService.connect(provider)
+    walletService.connect(provider)
+
+    // resolve when the spy has been called
+    // if we await on the connect call, it may hang
+    await new Promise(resolve => {
+      const interval = setInterval(() => {
+        if (spy.mock.calls.length) {
+          clearInterval(interval)
+          resolve()
+        }
+      })
+    })
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/paywall/src/__tests__/providers/Web3ProxyProvider.test.js
+++ b/paywall/src/__tests__/providers/Web3ProxyProvider.test.js
@@ -132,6 +132,7 @@ describe('Web3ProxyProvider', () => {
     const spy = jest.spyOn(provider, 'sendAsync')
     const walletService = new WalletService({ unlockAddress })
 
+    let called = false
     fakeEvent(POST_MESSAGE_WALLET_INFO, {
       isMetamask: false,
       noWallet: false,
@@ -157,6 +158,7 @@ describe('Web3ProxyProvider', () => {
             result: '1',
           },
         })
+        setTimeout(() => (called = true))
       })
     }
     walletService.connect(provider)
@@ -165,7 +167,7 @@ describe('Web3ProxyProvider', () => {
     // if we await on the connect call, it may hang
     await new Promise(resolve => {
       const interval = setInterval(() => {
-        if (spy.mock.calls.length) {
+        if (called) {
           clearInterval(interval)
           resolve()
         }


### PR DESCRIPTION
# Description

While developing, this test suddenly started failing, and it turns out it was because of a potential race. This makes the test robust by waiting for the message event to have been posted that allows us to assert on the behavior of the provider

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
