### PR TITLE
add handler chaining to the postOffice util

### DIFF
--- a/paywall/src/__tests__/utils/postOffice.test.js
+++ b/paywall/src/__tests__/utils/postOffice.test.js
@@ -223,7 +223,7 @@ describe('postOffice', () => {
           )
         })
 
-        it('chains handlers', () => {
+        it('should call all handlers registered with setHandler for the message type', () => {
           expect.assertions(2)
 
           listener = jest.fn()

--- a/paywall/src/__tests__/utils/postOffice.test.js
+++ b/paywall/src/__tests__/utils/postOffice.test.js
@@ -195,6 +195,7 @@ describe('postOffice', () => {
       describe('message handler', () => {
         let listener
         beforeEach(() => {
+          _clearHandlers()
           listener = jest.fn()
           setHandler('hi', listener)
           setupPostOffice(fakeWindow, fakeTarget, 'origin')
@@ -219,6 +220,35 @@ describe('postOffice', () => {
           expect(fakeTarget.postMessage).toHaveBeenCalledWith(
             { type: 'type', payload: 'response' },
             'origin'
+          )
+        })
+
+        it('chains handlers', () => {
+          expect.assertions(2)
+
+          listener = jest.fn()
+          const listener2 = jest.fn()
+          _clearHandlers()
+
+          setHandler('hi', listener)
+          setHandler('hi', listener2)
+
+          fakeWindow.handlers.message({
+            source: fakeTarget,
+            origin: 'origin',
+            data: {
+              type: 'hi',
+              payload: 'it worked!',
+            },
+          })
+
+          expect(listener).toHaveBeenCalledWith(
+            'it worked!',
+            expect.any(Function)
+          )
+          expect(listener2).toHaveBeenCalledWith(
+            'it worked!',
+            expect.any(Function)
           )
         })
       })

--- a/paywall/src/utils/postOffice.js
+++ b/paywall/src/utils/postOffice.js
@@ -87,7 +87,10 @@ export function mainWindowPostOffice(window, iframe, iframeOrigin) {
  * @param {handlerCallback}}handler the callback. This should
  */
 export function setHandler(type, handler) {
-  handlers[type] = handler
+  const currentHandler = handlers[type] || (() => 1)
+  handlers[type] = (type, response) => (
+    currentHandler(type, response), handler(type, response)
+  )
 }
 
 // for unit testing, clearing state between tests

--- a/paywall/src/utils/postOffice.js
+++ b/paywall/src/utils/postOffice.js
@@ -83,11 +83,17 @@ export function mainWindowPostOffice(window, iframe, iframeOrigin) {
 /**
  * Set a handler for a posted message
  *
+ * This creates a linked list of handlers for a specific message type
+ *
  * @param {string} type the message type this handler is intended to respond to
  * @param {handlerCallback}}handler the callback. This should
  */
 export function setHandler(type, handler) {
-  const currentHandler = handlers[type] || (() => 1)
+  const currentHandler =
+    handlers[type] ||
+    (() => {
+      /* no-op */
+    })
   handlers[type] = (type, response) => (
     currentHandler(type, response), handler(type, response)
   )


### PR DESCRIPTION
# Description

The `unlock.min.js` post office handler for `POST_MESSAGE_READY` needs to do 2 unrelated actions, return the wallet info for the `Web3ProxyProvider` and also send the configuration. This requires the ability to chain 2 handlers. This simplistic approach is designed to allow chaining but not support removing handlers. All handlers are for-the-lifetime-of-the-script.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3364

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
