### PR TITLE
purchase callback creation for the data iframe

### DIFF
--- a/paywall/src/__tests__/data-iframe/start/makePurchaseCallback.test.js
+++ b/paywall/src/__tests__/data-iframe/start/makePurchaseCallback.test.js
@@ -1,0 +1,128 @@
+import makePurchaseCallback from '../../../data-iframe/start/makePurchaseCallback'
+import {
+  setLocks,
+  setKeys,
+  setAccount,
+  setNetwork,
+} from '../../../data-iframe/cacheHandler'
+import { setAccount as setBlockchainAccount } from '../../../data-iframe/blockchainHandler/account'
+
+describe('makePurchaseCallback', () => {
+  let walletService
+  let web3Service
+  const requiredConfirmations = 2
+  let update
+  let fakeWindow
+
+  it('should return a function that can be used to purchase a key', () => {
+    expect.assertions(1)
+
+    const purchase = makePurchaseCallback({
+      walletService,
+      web3Service,
+      requiredConfirmations,
+      update,
+      window: fakeWindow,
+    })
+
+    expect(purchase).toBeInstanceOf(Function)
+  })
+
+  describe('purchase callback', () => {
+    let purchase
+
+    beforeEach(async () => {
+      fakeWindow = {
+        storage: {},
+        localStorage: {
+          setItem(key, item) {
+            fakeWindow.storage[key] = item
+          },
+          getItem(key) {
+            return fakeWindow.storage[key]
+          },
+          removeItem(key) {
+            delete fakeWindow.storage[key]
+          },
+        },
+      }
+
+      web3Service = {}
+      walletService = {
+        ready: true,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        once: jest.fn(),
+        on: jest.fn(),
+        purchaseKey: jest.fn().mockResolvedValue(),
+      }
+      update = jest.fn()
+
+      purchase = makePurchaseCallback({
+        walletService,
+        web3Service,
+        requiredConfirmations,
+        update,
+        window: fakeWindow,
+      })
+
+      await setAccount(fakeWindow, 'account')
+      setBlockchainAccount('account') // this is handled in the "ensureWalletReady()" portion
+      await setNetwork(fakeWindow, 2)
+      await setLocks(fakeWindow, {
+        lock: {
+          address: 'lock',
+          keyPrice: '123',
+        },
+      })
+      await setKeys(fakeWindow, {
+        lock: {
+          lock: 'lock',
+          owner: 'account',
+        },
+      })
+    })
+
+    it('should initiate a key purchase', async () => {
+      expect.assertions(1)
+
+      await purchase('lock')
+
+      await new Promise(resolve => {
+        const interval = setInterval(() => {
+          if (walletService.purchaseKey.mock.calls.length) {
+            clearInterval(interval)
+            resolve()
+          }
+        })
+      })
+      expect(walletService.purchaseKey).toHaveBeenCalledWith(
+        'lock',
+        'account',
+        '123'
+      )
+    })
+
+    it('should initiate monitoring of key purchase transaction', async () => {
+      expect.assertions(1)
+
+      await purchase('lock')
+
+      await new Promise(resolve => {
+        const interval = setInterval(() => {
+          if (walletService.addListener.mock.calls.length) {
+            clearInterval(interval)
+            resolve()
+          }
+        })
+      })
+
+      // this is called by processKeyPurchaseTransactions, and is a quick way to verify that we
+      // called it
+      expect(walletService.addListener).toHaveBeenCalledWith(
+        'transaction.pending',
+        expect.any(Function)
+      )
+    })
+  })
+})

--- a/paywall/src/data-iframe/start/makePurchaseCallback.js
+++ b/paywall/src/data-iframe/start/makePurchaseCallback.js
@@ -1,6 +1,14 @@
 import { getLocks, getTransactions, getKeys } from '../cacheHandler'
 
 // extraTip is not implemented yet, we need to do bignumber math, so post-pone this until walletService adds support
+
+/**
+ * @param {walletService} walletService the walletService instance that will be used to purchase a key
+ * @param {web3Service} web3Service the web3Service instance that will be used to monitor the transaction
+ * @param {number} requiredConfirmations the minimum confirmations needed to consider the purchase final
+ * @param {Function} update a callback that accepts a keyed object with updates to blockchain data
+ * @param {window} window the current global context (window, global, self)
+ */
 const makePurchaseCallback = ({
   walletService,
   web3Service,
@@ -11,19 +19,26 @@ const makePurchaseCallback = ({
   async function purchase(lockAddress /*, extraTip */) {
     // note that the dynamic import is what makes code splitting
     // happen, and cannot be changed to a static import
+    // https://webpack.js.org/guides/code-splitting/#dynamic-imports
     const [
-      { purchaseKey, processKeyPurchaseTransactions },
-      locks,
-      startingTransactions,
-      keys,
+      {
+        purchaseKey,
+        processKeyPurchaseTransactions,
+      } /* import('../blockchainHandler/purchaseKey') */,
+      locks /* getLocks(window) */,
+      startingTransactions /* getTransactions(window) */,
+      keys /* getKeys(window) */,
     ] = await Promise.all([
-      import('../blockchainHandler/purchaseKey'),
+      import('../blockchainHandler/purchaseKey'), // code-splitting import
       getLocks(window),
       getTransactions(window),
       getKeys(window),
     ])
     const startingKey = keys[lockAddress]
 
+    // if purchaseKey errors out, it will emit an error, which
+    // is listened for by processKeyPurchaseTransactions, aborting both
+    // promises
     return Promise.all([
       purchaseKey({
         walletService,

--- a/paywall/src/data-iframe/start/makePurchaseCallback.js
+++ b/paywall/src/data-iframe/start/makePurchaseCallback.js
@@ -1,0 +1,44 @@
+import { getLocks, getTransactions, getKeys } from '../cacheHandler'
+
+// extraTip is not implemented yet, we need to do bignumber math, so post-pone this until walletService adds support
+const makePurchaseCallback = ({
+  walletService,
+  web3Service,
+  requiredConfirmations,
+  update,
+  window,
+}) =>
+  async function purchase(lockAddress /*, extraTip */) {
+    const [
+      { purchaseKey, processKeyPurchaseTransactions },
+      locks,
+      startingTransactions,
+      keys,
+    ] = await Promise.all([
+      import('../blockchainHandler/purchaseKey'),
+      getLocks(window),
+      getTransactions(window),
+      getKeys(window),
+    ])
+    const startingKey = keys[lockAddress]
+
+    Promise.all([
+      purchaseKey({
+        walletService,
+        lockAddress,
+        amountToSend: locks[lockAddress].keyPrice,
+      }),
+      processKeyPurchaseTransactions({
+        walletService,
+        web3Service,
+        startingTransactions,
+        startingKey,
+        lockAddress,
+        requiredConfirmations,
+        update,
+        walletAction: () => update({ walletAction: true }),
+      }),
+    ])
+  }
+
+export default makePurchaseCallback

--- a/paywall/src/data-iframe/start/makePurchaseCallback.js
+++ b/paywall/src/data-iframe/start/makePurchaseCallback.js
@@ -9,6 +9,8 @@ const makePurchaseCallback = ({
   window,
 }) =>
   async function purchase(lockAddress /*, extraTip */) {
+    // note that the dynamic import is what makes code splitting
+    // happen, and cannot be changed to a static import
     const [
       { purchaseKey, processKeyPurchaseTransactions },
       locks,
@@ -22,7 +24,7 @@ const makePurchaseCallback = ({
     ])
     const startingKey = keys[lockAddress]
 
-    Promise.all([
+    return Promise.all([
       purchaseKey({
         walletService,
         lockAddress,


### PR DESCRIPTION
# Description

Because purchaseKey can only be called with the information passed to it (lock address and any extra tip to add on), we need to close around the things needed to handle the purchase.

Note that the tests only ensure we are calling the purchaseKey functions with the expected parameters, and that the transaction monitoring begins. I considered doing a more complex test with a fake provider so we are not testing implementation details at all, but in the end we can't do this effectively because the implementation details of the smart contract would break the test every time we upgrade.

Integration tests will have to be used to verify the end-to-end flow.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
