### PR TITLE
new waitFor promise

### DIFF
--- a/paywall/src/__tests__/utils/promises.test.js
+++ b/paywall/src/__tests__/utils/promises.test.js
@@ -1,0 +1,87 @@
+import { delayPromise, waitFor } from '../../utils/promises'
+
+describe('promises', () => {
+  describe('delayPromise', () => {
+    it('should delay for the number of milliseconds specified', async () => {
+      expect.assertions(3)
+
+      jest.useFakeTimers()
+
+      let delayed = 0
+      let time = delayPromise(100)
+
+      expect(delayed).toBe(0)
+      jest.advanceTimersByTime(99)
+      expect(delayed).toBe(0)
+      jest.advanceTimersByTime(101)
+      delayed = await time
+
+      expect(delayed).toBe(100)
+    })
+  })
+
+  describe('waitFor', () => {
+    it('should resolve when condition is truthy', async () => {
+      expect.assertions(9)
+
+      jest.useFakeTimers()
+
+      let condition = false
+      let resolved = false
+      let conditionFunc = jest.fn(() => condition)
+
+      waitFor(conditionFunc)
+        .then(() => (resolved = true))
+        .then(() => expect(condition).toBe(true))
+
+      expect(setInterval).toHaveBeenCalled()
+      // initial call
+      expect(conditionFunc).toHaveBeenCalledTimes(1)
+      expect(resolved).toBe(false)
+
+      jest.runOnlyPendingTimers()
+      // first call on the interval
+      expect(conditionFunc).toHaveBeenCalledTimes(2)
+
+      jest.runOnlyPendingTimers()
+      // second call on the interval
+      expect(conditionFunc).toHaveBeenCalledTimes(3)
+
+      condition = true
+      jest.runOnlyPendingTimers()
+      // third call on the interval
+      expect(conditionFunc).toHaveBeenCalledTimes(4)
+
+      jest.runOnlyPendingTimers()
+      // setInterval should be shut down, no additional calls
+      expect(conditionFunc).toHaveBeenCalledTimes(4)
+
+      await Promise.resolve()
+      expect(resolved).toBe(true)
+    })
+  })
+
+  it('should resolve immediately if condition is truthy on the start', async () => {
+    expect.assertions(5)
+
+    jest.useFakeTimers()
+
+    let condition = true
+    let resolved = false
+    let conditionFunc = jest.fn(() => condition)
+
+    waitFor(conditionFunc)
+      .then(() => (resolved = true))
+      .then(() => expect(condition).toBe(true))
+
+    expect(setInterval).not.toHaveBeenCalled()
+    // initial call
+    expect(conditionFunc).toHaveBeenCalledTimes(1)
+    await Promise.resolve()
+    expect(resolved).toBe(true)
+
+    jest.runOnlyPendingTimers()
+    // first call on the interval
+    expect(conditionFunc).toHaveBeenCalledTimes(1)
+  })
+})

--- a/paywall/src/utils/promises.js
+++ b/paywall/src/utils/promises.js
@@ -6,3 +6,15 @@
 export function delayPromise(ms) {
   return new Promise(resolve => setTimeout(resolve.bind(null, ms), ms))
 }
+
+export function waitFor(condition) {
+  return new Promise(resolve => {
+    if (condition()) return resolve()
+    const interval = setInterval(() => {
+      if (condition()) {
+        clearInterval(interval)
+        resolve()
+      }
+    })
+  })
+}


### PR DESCRIPTION
# Description

This adds a promise that we can use to wait for some state to shift. In the ad remover paywall, it will be used to wait for a key purchase callback to have been constructed, which only happens after the blockchain handler has lazy-loaded.

However, this can be used all over. For instance, many of the tests implement their own version of `waitFor`, and this appears to be the same logical basis behind react-testing-library's `waitForElement`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
