### PR TITLE
new purchaseKeySetup utility for the data iframe

### DIFF
--- a/paywall/src/__tests__/data-iframe/start/purchaseKeySetup.test.js
+++ b/paywall/src/__tests__/data-iframe/start/purchaseKeySetup.test.js
@@ -1,0 +1,40 @@
+import {
+  setPurchaseKeyCallback,
+  purchaseKey,
+} from '../../../data-iframe/start/purchaseKeySetup'
+
+jest.useFakeTimers()
+
+describe('purchaseKeySetup', () => {
+  it('waits for purchase to be set', async () => {
+    expect.assertions(4)
+    const purchase = jest.fn()
+    let resolved = false
+
+    purchaseKey('lock', 'tip')
+      .then(() => (resolved = true))
+      .then(() => expect(purchase).toHaveBeenCalledWith('lock', 'tip'))
+
+    jest.runOnlyPendingTimers()
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    setPurchaseKeyCallback(purchase)
+    jest.runOnlyPendingTimers()
+    await Promise.resolve()
+
+    expect(resolved).toBe(false)
+    await Promise.resolve()
+    expect(resolved).toBe(true)
+  })
+
+  it('calls purchase with lock address and any extra tip to be added on to key price', async () => {
+    expect.assertions(1)
+    const purchase = jest.fn()
+
+    setPurchaseKeyCallback(purchase)
+
+    await purchaseKey('lock', 'tip')
+    expect(purchase).toHaveBeenCalledWith('lock', 'tip')
+  })
+})

--- a/paywall/src/data-iframe/start/purchaseKeySetup.js
+++ b/paywall/src/data-iframe/start/purchaseKeySetup.js
@@ -1,0 +1,13 @@
+import { waitFor } from '../../utils/promises'
+
+let purchase
+
+export function setPurchaseKeyCallback(purchaseKeyCallback) {
+  purchase = purchaseKeyCallback
+}
+
+export async function purchaseKey(lockAddress, extraTip) {
+  // resolve when purchasing is ready
+  await waitFor(() => purchase)
+  return purchase(lockAddress, extraTip)
+}


### PR DESCRIPTION
# Description

This simple file hides a deceptively complex situation.

When the data iframe loads, it loads in 2 stages. First, the cache portion loads and very quickly distributes the cache contents (if any) to the checkout UI iframe. While this is going on, it loads the heavy blockchain portion of the data iframe.

If the user happens to click on the "purchase this key" portion of the checkout UI while the blockchain portion is loading, it will not be able to respond.

This file enables waiting for the moment when the blockchain is ready and available to perform a key purchase finally.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
