### PR TITLE
makeSetConfig for creating a setConfig handler

### DIFF
--- a/paywall/src/__tests__/data-iframe/start/makeSetConfig.test.js
+++ b/paywall/src/__tests__/data-iframe/start/makeSetConfig.test.js
@@ -1,0 +1,125 @@
+import makeSetConfig from '../../../data-iframe/start/makeSetConfig'
+import connectToBlockchain from '../../../data-iframe/start/connectToBlockchain'
+import { getLocks } from '../../../data-iframe/cacheHandler'
+
+jest.mock('../../../data-iframe/start/connectToBlockchain', () =>
+  jest.genMockFromModule('../../../data-iframe/start/connectToBlockchain')
+)
+
+describe('makeSetConfig', () => {
+  const window = 'window'
+  const constants = {
+    hi: 'there',
+    thing: 2,
+  }
+  let updater
+
+  it('should return a callback function which is used to receive paywall config', () => {
+    expect.assertions(1)
+
+    const setConfig = makeSetConfig(window, updater, constants)
+
+    expect(setConfig).toBeInstanceOf(Function)
+  })
+
+  describe('setConfig callback', () => {
+    let setConfig
+
+    beforeEach(() => {
+      updater = jest.fn()
+      setConfig = makeSetConfig(window, updater, constants)
+    })
+
+    it('should immediately trigger sends of cached blockchain data', async () => {
+      expect.assertions(4)
+
+      const config = {}
+      await setConfig(config)
+
+      expect(updater).toHaveBeenNthCalledWith(1, 'network')
+      expect(updater).toHaveBeenNthCalledWith(2, 'account')
+      expect(updater).toHaveBeenNthCalledWith(3, 'balance')
+      expect(updater).toHaveBeenNthCalledWith(4, 'locks')
+    })
+
+    it('should connect to the blockchain', async () => {
+      expect.assertions(1)
+
+      const config = {}
+      await setConfig(config)
+
+      expect(connectToBlockchain).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...constants,
+          config,
+          window,
+          onChange: expect.any(Function),
+        })
+      )
+    })
+
+    describe('onChange callback behavior', () => {
+      let onChange
+      let setConfig
+      let fakeWindow
+
+      beforeEach(async () => {
+        fakeWindow = {
+          storage: {},
+          localStorage: {
+            getItem: jest.fn(key => fakeWindow.storage[key]),
+            setItem: jest.fn((key, value) => {
+              if (typeof value !== 'string') {
+                throw new Error('localStorage only supports strings')
+              }
+              fakeWindow.storage[key] = value
+            }),
+            removeItem: jest.fn(key => {
+              delete fakeWindow.storage[key]
+            }),
+          },
+        }
+        connectToBlockchain.mockReset()
+
+        updater = jest.fn()
+        setConfig = makeSetConfig(fakeWindow, updater, constants)
+
+        const config = {}
+        await setConfig(config)
+
+        onChange = connectToBlockchain.mock.calls[0][0].onChange
+        updater.mockReset()
+      })
+
+      it('should pass errors directly to the updater', () => {
+        expect.assertions(1)
+
+        onChange({ error: 'fail' })
+
+        expect(updater).toHaveBeenCalledWith('error', 'fail')
+      })
+
+      it('should pass walletModal notifications directly to the updater', () => {
+        expect.assertions(1)
+
+        onChange({ walletModal: true })
+
+        expect(updater).toHaveBeenCalledWith('walletModal')
+      })
+
+      it('should sync the other values to cache', async () => {
+        expect.assertions(1)
+
+        const update = {
+          locks: {
+            lock: { address: 'lock' },
+          },
+        }
+
+        onChange(update)
+
+        expect(await getLocks(fakeWindow)).toEqual(update.locks)
+      })
+    })
+  })
+})

--- a/paywall/src/data-iframe/start/makeSetConfig.js
+++ b/paywall/src/data-iframe/start/makeSetConfig.js
@@ -1,0 +1,55 @@
+import connectToBlockchain from './connectToBlockchain'
+import syncToCache from './syncToCache'
+
+/**
+ * Create the callback that will be used when paywall configuration is received.
+ *
+ * The primary repsonsibility of this callback is to trigger sending the current cache
+ * values to the main window, followed by connecting to the blockchain handler and
+ * providing its onChange handler for passing updates to the cache, and
+ * error/walletModal updates directly to the main window.
+ *
+ * @param {window} window the current global context (window, self, global)
+ * @param {Function} updater the updater that will be used to trigger sending
+ *                           of data to the main window
+ * @param {object} constants the values required to start the blockchain. Specifically:
+ *                           - readOnlyProvider
+ *                           - unlockAddress
+ *                           - blockTime
+ *                           - requiredConfirmations
+ *                           - locksmithHost
+ */
+const makeSetConfig = (window, updater, constants) =>
+  async function setConfig(configValue) {
+    // now we can retrieve the cached data
+    updater('network')
+    updater('account')
+    updater('balance')
+    updater('locks')
+
+    // bridge from the blockchain to the cache
+    // and to the main window for errors/wallet modal
+    const onChange = updates => {
+      // pass errors on directly
+      if (updates.error) {
+        updater('error', updates.error)
+        return
+      }
+      // pass wallet feedback notifications on directly
+      if (updates.walletModal) {
+        updater('walletModal')
+        return
+      }
+      // for everything else, it stores it in the cache
+      // cache listeners will transmit it to the script
+      syncToCache(window, updates)
+    }
+    connectToBlockchain({
+      ...constants,
+      config: configValue,
+      window,
+      onChange,
+    })
+  }
+
+export default makeSetConfig


### PR DESCRIPTION
# Description

When configuration is received, we need to send cached data to the main window and start the blockchain handler. This PR does this.

Because `setConfig` is only called with the configuration, this closes over the variables needed to work.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3140

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
