### PR TITLE
new validators for locks, lock, and key

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -588,4 +588,452 @@ describe('Form field validators', () => {
       })
     })
   })
+
+  describe('isValidKey', () => {
+    const validKey = {
+      expiration: 1,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
+      owner: '0x1234567890123456789012345678901234567890',
+    }
+
+    describe('failures', () => {
+      it('should fail with invalid objects', () => {
+        expect.assertions(5)
+
+        expect(validators.isValidKey(false)).toBe(false)
+        expect(validators.isValidKey('hi')).toBe(false)
+        expect(validators.isValidKey(0)).toBe(false)
+        expect(validators.isValidKey([])).toBe(false)
+        expect(
+          validators.isValidKey({
+            expiration: 1,
+            transactions: [],
+            status: 'hi',
+            confirmations: 2,
+            notakey: 4,
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if expiration is invalid', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            expiration: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            expiration: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            expiration: '1',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            expiration: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if transactions is not an array', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            transactions: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            transactions: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            transactions: 'hi',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            transactions: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if status is not a string', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if status is not a known value', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: 'notvalid',
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if confirmations is invalid', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            confirmations: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            confirmations: '1',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            confirmations: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            confirmations: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if owner is not a valid ethereum address', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            owner: '0xIamnot a valid ethereum address',
+          })
+        ).toBe(false)
+      })
+    })
+
+    describe('valid keys', () => {
+      it('should accept a basic valid key', () => {
+        expect.assertions(1)
+
+        expect(validators.isValidKey(validKey)).toBe(true)
+      })
+
+      it('should accept a basic valid key with optional id', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            id: 'id',
+          })
+        ).toBe(true)
+      })
+
+      describe('status', () => {
+        it.each([
+          'none',
+          'confirming',
+          'confirmed',
+          'expired',
+          'valid',
+          'submitted',
+          'pending',
+          'failed',
+        ])('should accept "%s" as a valid status', status => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidKey({
+              ...validKey,
+              status,
+            })
+          ).toBe(true)
+        })
+      })
+    })
+  })
+
+  describe('isValidLock', () => {
+    const validLock = {
+      address: '0x1234567890123456789009876543210987654321',
+      keyPrice: '123',
+      expirationDuration: 123,
+      key: {
+        expiration: 1,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+        owner: '0x1234567890123456789012345678901234567890',
+      },
+    }
+    describe('failures', () => {
+      it('should fail with invalid objects', () => {
+        expect.assertions(6)
+
+        expect(validators.isValidLock(false)).toBe(false)
+        expect(validators.isValidLock('hi')).toBe(false)
+        expect(validators.isValidLock(0)).toBe(false)
+        expect(validators.isValidLock([])).toBe(false)
+        expect(
+          validators.isValidLock({
+            address: 1,
+            keyPrice: [],
+            expirationDuration: 'hi',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            address: 1,
+            keyPrice: [],
+            expirationDuration: 'hi',
+            kery: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid name', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            name: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            name: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            name: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            name: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid lock address', () => {
+        expect.assertions(5)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: {},
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: 'not a valid lock address',
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid lock keyPrice', () => {
+        expect.assertions(5)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: {},
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: 'not a valid key price',
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid lock expirationDuration', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            expirationDuration: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            expirationDuration: '1',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            expirationDuration: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            expirationDuration: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid lock key', () => {
+        expect.assertions(1)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            key: null,
+          })
+        ).toBe(false)
+      })
+    })
+
+    describe('valid locks', () => {
+      it('should accept a basic valid lock', () => {
+        expect.assertions(1)
+
+        expect(validators.isValidLock(validLock)).toBe(true)
+      })
+    })
+  })
+
+  describe('isValidLocks', () => {
+    const validLock = {
+      address: '0x1234567890123456789009876543210987654321',
+      keyPrice: '123',
+      expirationDuration: 123,
+      key: {
+        expiration: 1,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+        owner: '0x1234567890123456789012345678901234567890',
+      },
+    }
+    const invalidLock = {
+      ...validLock,
+      address: 'not a valid lock',
+    }
+
+    it('should fail on invalid locks', () => {
+      expect.assertions(3)
+
+      expect(validators.isValidLocks(null)).toBe(false)
+      expect(validators.isValidLocks('hi')).toBe(false)
+      expect(validators.isValidLocks([])).toBe(false)
+    })
+
+    it('should fail on any invalid locks', () => {
+      expect.assertions(1)
+
+      expect(
+        validators.isValidLocks({
+          [validLock.address]: validLock,
+          invalidLock,
+        })
+      ).toBe(false)
+    })
+
+    it('should succeed if all locks are valid', () => {
+      expect.assertions(1)
+      const address = '0x0987654321098765432109876543210987654321'
+
+      expect(
+        validators.isValidLocks({
+          [validLock.address]: validLock,
+          [address]: {
+            ...validLock,
+            address,
+          },
+        })
+      ).toBe(true)
+    })
+  })
 })

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -21,8 +21,6 @@ export const isAccount = val => {
   return val.match(ACCOUNT_REGEXP)
 }
 
-// TODO: use npm package "validator" to validate the icon URL
-// https://www.npmjs.com/package/validator
 /**
  * For now, this assumes this structure:
  *
@@ -100,5 +98,119 @@ export const isValidPaywallConfig = config => {
   ) {
     return false
   }
+  return true
+}
+
+/**
+ * helper function to assert on a thing being an
+ * object with required and optional keys
+ *
+ * No assertion on the types of the values is done here
+ */
+function isValidObject(obj, validKeys, optionalKeys = []) {
+  if (!obj || typeof obj !== 'object') return false
+  const keys = Object.keys(obj)
+
+  if (keys.length > validKeys.length + optionalKeys.length) return false
+  if (keys.filter(key => !validKeys.includes(key)).length) {
+    if (optionalKeys.filter(key => !key.includes(key)).length) return false
+  }
+  return true
+}
+
+/**
+ * validate a single key. This should match the type in unlockTypes.ts
+ */
+export const isValidKey = key => {
+  if (
+    !isValidObject(
+      key,
+      ['expiration', 'transactions', 'status', 'confirmations', 'owner'],
+      ['id']
+    )
+  ) {
+    return false
+  }
+
+  if (
+    typeof key.expiration !== 'number' ||
+    !isPositiveInteger(key.expiration)
+  ) {
+    return false
+  }
+  if (!Array.isArray(key.transactions)) return false
+  if (typeof key.status !== 'string') return false
+  if (
+    ![
+      'none',
+      'confirming',
+      'confirmed',
+      'expired',
+      'valid',
+      'submitted',
+      'pending',
+      'failed',
+    ].includes(key.status)
+  ) {
+    return false
+  }
+  if (
+    typeof key.confirmations !== 'number' ||
+    !isPositiveInteger(key.confirmations)
+  ) {
+    return false
+  }
+  if (typeof key.owner !== 'string' || !isAccount(key.owner)) return false
+  // NOTE: transactions are not used in the UI, and may be removed, so
+  // for now we do not validate them. If this ever changes, they must
+  // be validated
+  /*
+  if (
+    key.transactions.filter(transaction => !isValidTransaction(transaction))
+      .length
+  ) {
+    return false
+  }
+  */
+  return true
+}
+
+/**
+ * validate a single lock. This should match the type in unlockTypes.ts
+ */
+export const isValidLock = lock => {
+  if (
+    !isValidObject(
+      lock,
+      ['address', 'keyPrice', 'expirationDuration', 'key'],
+      ['name']
+    )
+  ) {
+    return false
+  }
+
+  if (lock.hasOwnProperty('name') && typeof lock.name !== 'string') return false
+  if (typeof lock.address !== 'string' || !isAccount(lock.address)) return false
+  if (typeof lock.keyPrice !== 'string' || !lock.keyPrice.match(/[0-9]+/)) {
+    return false
+  }
+  if (
+    typeof lock.expirationDuration !== 'number' ||
+    !isPositiveInteger(lock.expirationDuration)
+  )
+    return false
+  if (!isValidKey(lock.key)) return false
+  return true
+}
+
+/**
+ * validate the list of locks returned from the data iframe
+ */
+export const isValidLocks = locks => {
+  if (!locks || typeof locks !== 'object' || Array.isArray(locks)) return false
+  const keys = Object.keys(locks)
+  if (keys.filter(key => !isAccount(key)).length) return false
+  const lockValues = Object.values(locks)
+  if (lockValues.filter(lock => !isValidLock(lock)).length) return false
   return true
 }


### PR DESCRIPTION
# Description

These new validators will be used to validate the locks sent by the data iframe to the checkout UI. This is to prevent any possible malicious attack vector by passing a random post message to our paywall.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3366

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
