### PR TITLE
escaping in the pr template

### DIFF
--- a/scripts/production-pull-request-template.sh
+++ b/scripts/production-pull-request-template.sh
@@ -5,7 +5,7 @@ This deploys the code from master as of commit $COMMIT_TO_DEPLOY.
 
 Reviewing code for this Pull Request is not practical, however, you are asked to check wether the current staging environment is stable and could be released. For this, follow these steps:
 
-* [ ] This pull request has no conflicts with the `production` branch.
+* [ ] This pull request has no conflicts with the \`production\` branch.
 * [ ] Go to http://staging.unlock-protocol.com/ and ensure that the website loads fine.
 
 ## Creator Dashboard


### PR DESCRIPTION
# Description

Very small change to fix a lame warning on production pull rqeuest:
> ./scripts/production-pull-request-template.sh: line 30: production: command not found



# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread