### PR TITLE
add showing and hiding of the checkout modal UI iframe

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
@@ -33,6 +33,11 @@ describe('setupPostOffice', () => {
   beforeEach(() => {
     process.env.PAYWALL_URL = 'http://paywall'
     fakeWindow = {
+      document: {
+        body: {
+          style: {},
+        },
+      },
       origin: 'http://fun.times',
       web3: {
         currentProvider: {
@@ -63,8 +68,20 @@ describe('setupPostOffice', () => {
         origin: 'http://paywall',
         postMessage: jest.fn(),
       },
+      className: 'unlock start',
     }
     setupPostOffices(fakeWindow, fakeDataIframe, fakeUIIframe)
+  })
+
+  it('should create the unlockProtocol object with "loadCheckoutModal" that shows the iframe', () => {
+    expect.assertions(3)
+
+    expect(fakeWindow.unlockProtocol).not.toBeNull()
+    expect(fakeUIIframe.className).toBe('unlock start')
+
+    fakeWindow.unlockProtocol.loadCheckoutModal()
+
+    expect(fakeUIIframe.className).toBe('unlock start show')
   })
 
   it('responds to POST_MESSAGE_READY by sending POST_MESSAGE_WALLET_INFO', () => {
@@ -137,6 +154,16 @@ describe('setupPostOffice', () => {
         detail: 'unlocked',
       })
     )
+  })
+
+  it('responds to POST_MESSAGE_UNLOCKED by hiding the checkout UI', () => {
+    expect.assertions(1)
+
+    fakeUIIframe.className = 'unlock start show'
+
+    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED)
+
+    expect(fakeUIIframe.className).toBe('unlock start')
   })
 
   it('responds to POST_MESSAGE_LOCKED by sending locked to the UI iframe', () => {

--- a/paywall/src/paywall-builder/constants.js
+++ b/paywall/src/paywall-builder/constants.js
@@ -17,6 +17,7 @@ export const POST_MESSAGE_UPDATE_NETWORK = 'update/network'
 export const POST_MESSAGE_UPDATE_WALLET = 'update/walletmodal'
 
 export const POST_MESSAGE_ERROR = 'error'
-export const POST_MESSAGE_SEND_UPDATES = 'semd/updates'
+export const POST_MESSAGE_SEND_UPDATES = 'send/updates'
 
 export const POST_MESSAGE_PURCHASE_KEY = 'purchaseKey'
+export const POST_MESSAGE_DISMISS_CHECKOUT = 'dismiss/checkout'


### PR DESCRIPTION
# Description

This adds the showing and hiding for the checkout UI. To enable this, our spec states that the variable `window.unlockProtocol` will exist, as will `window.unlockProtocol.loadCheckoutModal`.

This PR creates a read-only, unfindable and unchangeable property so that it can't be hijacked.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3432 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
