### PR TITLE
add lock to Key type/validation, allow decimals in keyPrice, allow data URIs in icon

### DIFF
--- a/paywall/src/__tests__/hooks/useBlockchainData.test.js
+++ b/paywall/src/__tests__/hooks/useBlockchainData.test.js
@@ -186,6 +186,7 @@ describe('useBlockchainData hook', () => {
           status: 'none',
           confirmations: 0,
           owner: address,
+          lock: address,
         },
       },
     }

--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -3056,40 +3056,14 @@ exports[`Storyshots Checkout Checkout with 3 locks and one confirming key purcha
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c30 {
+    .c22 {
   background-color: var(--brand);
   height: 28px;
   width: 28px;
   border-radius: 50%;
 }
 
-.c30 > svg {
-  fill: white;
-}
-
-.c13 {
-  background-color: var(--lightgrey);
-  cursor: pointer;
-  border-radius: 50%;
-  height: 50px;
-  width: 50px;
-  display: inline-block;
-  padding: 0;
-  border: 0;
-  line-height: 50px;
-}
-
-.c13 > svg {
-  fill: var(--grey);
-  height: 50px;
-  width: 50px;
-}
-
-.c13:hover {
-  background-color: var(--green);
-}
-
-.c13:hover > svg {
+.c22 > svg {
   fill: white;
 }
 
@@ -3154,6 +3128,22 @@ Object {
   align-self: center;
 }
 
+.c11 {
+  display: grid;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  text-align: center;
+  color: var(--dimgrey);
+  font-size: 15px;
+  font-weight: 300;
+  padding: 0px;
+}
+
 .c8 {
   display: grid;
   font-size: 15px;
@@ -3169,71 +3159,6 @@ Object {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
-}
-
-.c16 {
-  display: none;
-}
-
-.c12 {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c12:hover .c15 {
-  display: block;
-}
-
-.c12:hover .c14 {
-  display: none;
-}
-
-.c20 {
-  display: grid;
-  font-weight: 300;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
-  font-size: 20px;
-  line-height: 20px;
-  height: 40px;
-  border-radius: 0px 0px 4px 4px;
-  padding: 0px;
-  width: 200px;
-  background-color: var(--green);
-  color: var(--white);
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
-  display: none;
-}
-
-.c18 {
-  display: grid;
-  font-weight: 300;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
-  font-size: 20px;
-  line-height: 20px;
-  height: 40px;
-  border-radius: 0px 0px 4px 4px;
-  padding: 0px;
-  width: 200px;
-  background-color: var(--green);
-  color: var(--white);
-  -webkit-align-self: end;
-  -ms-flex-item-align: end;
-  align-self: end;
 }
 
 .c7 {
@@ -3257,43 +3182,31 @@ Object {
   border: 1px solid transparent;
   border-radius: 4px;
   background-color: var(--white);
-  border: 1px solid var(--green);
-  cursor: pointer;
+  border: 1px solid var(--yellow);
 }
 
-.c7 .c19 {
-  display: none;
-}
-
-.c7 .c17 {
+.c12 {
   display: grid;
+  font-weight: 300;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-size: 20px;
+  line-height: 20px;
+  height: 40px;
+  border-radius: 0px 0px 4px 4px;
+  padding: 0px;
+  width: 200px;
+  background-color: var(--yellow);
+  color: var(--white);
+  margin-top: 13px;
 }
 
-.c7:hover .c11 {
-  background-color: var(--green);
-}
-
-.c7:hover .c11 svg {
-  fill: var(--white);
-}
-
-.c7:hover .c15 {
-  display: block;
-}
-
-.c7:hover .c14 {
-  display: none;
-}
-
-.c7:hover .c19 {
-  display: grid;
-}
-
-.c7:hover .c17 {
-  display: none;
-}
-
-.c21 {
+.c13 {
   display: grid;
   justify-items: stretch;
   margin: 0px;
@@ -3304,11 +3217,11 @@ Object {
   grid-gap: 0px;
   background-clip: padding-box;
   grid-template-rows: 40px 140px;
-  opacity: 0.5;
-  cursor: not-allowed;
+  opacity: 1;
+  cursor: pointer;
 }
 
-.c28 {
+.c20 {
   display: grid;
   font-weight: 300;
   -webkit-box-pack: center;
@@ -3328,11 +3241,7 @@ Object {
   color: var(--white);
 }
 
-.c31:hover .c27 {
-  background-color: var(--activegreen);
-}
-
-.c22 {
+.c14 {
   display: grid;
   height: 140px;
   width: 200px;
@@ -3356,26 +3265,34 @@ Object {
   padding-top: 13px;
 }
 
-.c23 {
+.c14:hover {
+  border: 1px solid var(--activegreen);
+}
+
+.c14:hover .c19 {
+  background-color: var(--activegreen);
+}
+
+.c15 {
   font-size: 30px;
   text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
 
-.c24 {
+.c16 {
   font-size: 20px;
   font-weight: 300;
   color: var(--grey);
 }
 
-.c26 {
+.c18 {
   font-size: 20px;
   font-weight: 300;
   color: var(--grey);
 }
 
-.c25 {
+.c17 {
   color: var(--lightgrey);
 }
 
@@ -3405,13 +3322,13 @@ Object {
   height: 30px;
 }
 
-.c29 {
+.c21 {
   margin-top: 50px;
   font-size: 12px;
   text-align: center;
 }
 
-.c29 div {
+.c21 div {
   margin: 8px;
   vertical-align: middle;
   display: inline-block;
@@ -3439,7 +3356,7 @@ Object {
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
-  .c30 {
+  .c22 {
     height: 16px;
     width: 16px;
   }
@@ -3500,49 +3417,25 @@ Object {
                   ---
                 </div>
               </div>
-              <a
-                class="c11 c12 c13"
+              <div
+                class="c11"
               >
-                <svg
-                  class="c14 "
-                  viewBox="0 0 24 24"
-                >
-                  <title />
-                  <path
-                    clip-rule="evenodd"
-                    d="M16.857 7.6a.5.5 0 0 1 .099.7l-5.32 7.07a.5.5 0 0 1-.704.096l-3.236-2.482a.5.5 0 1 1 .608-.794l2.836 2.175L16.157 7.7a.5.5 0 0 1 .7-.098z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-                <svg
-                  class="c15 c16"
-                  viewBox="0 0 24 24"
-                >
-                  <title />
-                  <path
-                    clip-rule="evenodd"
-                    d="M17.5 12a.5.5 0 0 1-.175.38l-3.5 3a.5.5 0 1 1-.65-.76l2.473-2.12H7a.5.5 0 0 1 0-1h8.648l-2.473-2.12a.5.5 0 1 1 .65-.76l3.5 3a.5.5 0 0 1 .175.38z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-                
-              </a>
+                Waiting for confirmations
+                <br />
+                3
+                /
+                12
+              </div>
               <footer
-                class="c17 c18"
+                class="c12"
               >
-                Payment Confirmed
-              </footer>
-              <footer
-                class="c19 c20"
-              >
-                Go to Content
+                Payment Pending
               </footer>
             </div>
           </li>
           <li
-            class="lock c21"
+            class="lock c13"
             data-address="0x456"
-            disabled=""
           >
             <header
               class="c6"
@@ -3551,29 +3444,28 @@ Object {
             </header>
             <div>
               <div
-                class="c22"
-                disabled=""
+                class="c14"
               >
                 <div
-                  class="price c23"
+                  class="price c15"
                 >
                   0.3
                    Eth
                 </div>
                 <div>
                   <span
-                    class="c24"
+                    class="c16"
                   >
                     $
                     ---
                   </span>
                   <span
-                    class="c25"
+                    class="c17"
                   >
                      | 
                   </span>
                   <span
-                    class="c26"
+                    class="c18"
                   >
                     <span>
                       30 days
@@ -3581,7 +3473,7 @@ Object {
                   </span>
                 </div>
                 <footer
-                  class="c27 c28"
+                  class="c19 c20"
                 >
                   Purchase
                 </footer>
@@ -3589,9 +3481,8 @@ Object {
             </div>
           </li>
           <li
-            class="lock c21"
+            class="lock c13"
             data-address="0x789"
-            disabled=""
           >
             <header
               class="c6"
@@ -3600,29 +3491,28 @@ Object {
             </header>
             <div>
               <div
-                class="c22"
-                disabled=""
+                class="c14"
               >
                 <div
-                  class="price c23"
+                  class="price c15"
                 >
                   3.00
                    Eth
                 </div>
                 <div>
                   <span
-                    class="c24"
+                    class="c16"
                   >
                     $
                     ---
                   </span>
                   <span
-                    class="c25"
+                    class="c17"
                   >
                      | 
                   </span>
                   <span
-                    class="c26"
+                    class="c18"
                   >
                     <span>
                       365 days
@@ -3630,7 +3520,7 @@ Object {
                   </span>
                 </div>
                 <footer
-                  class="c27 c28"
+                  class="c19 c20"
                 >
                   Purchase
                 </footer>
@@ -3639,10 +3529,10 @@ Object {
           </li>
         </ul>
         <footer
-          class="c29"
+          class="c21"
         >
           <div
-            class="c30"
+            class="c22"
           >
             <svg
               viewBox="0 0 56 56"
@@ -3695,7 +3585,7 @@ Object {
             Weekly
           </header>
           <div
-            class="sc-1549ebs-3 ynhyps-0 dMttvX"
+            class="sc-1549ebs-3 bn9s5o-0 kTTKZX"
           >
             <div
               class="sc-1549ebs-6 hGyOOg"
@@ -3713,49 +3603,25 @@ Object {
                 ---
               </div>
             </div>
-            <a
-              class="sc-1hzn3pu-2 jZYYLs is925m-0 kmZaWo"
+            <div
+              class="sc-1549ebs-5 eUmWhY"
             >
-              <svg
-                class="sc-1hzn3pu-0 dozNUb"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  clip-rule="evenodd"
-                  d="M16.857 7.6a.5.5 0 0 1 .099.7l-5.32 7.07a.5.5 0 0 1-.704.096l-3.236-2.482a.5.5 0 1 1 .608-.794l2.836 2.175L16.157 7.7a.5.5 0 0 1 .7-.098z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <svg
-                class="sc-1hzn3pu-1 gckVYZ"
-                viewBox="0 0 24 24"
-              >
-                <title />
-                <path
-                  clip-rule="evenodd"
-                  d="M17.5 12a.5.5 0 0 1-.175.38l-3.5 3a.5.5 0 1 1-.65-.76l2.473-2.12H7a.5.5 0 0 1 0-1h8.648l-2.473-2.12a.5.5 0 1 1 .65-.76l3.5 3a.5.5 0 0 1 .175.38z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              
-            </a>
+              Waiting for confirmations
+              <br />
+              3
+              /
+              12
+            </div>
             <footer
-              class="sc-1549ebs-2 ik5149-0 ik5149-2 epNQgy"
+              class="sc-1549ebs-2 bn9s5o-1 eKTLUD"
             >
-              Payment Confirmed
-            </footer>
-            <footer
-              class="sc-1549ebs-2 ik5149-0 ik5149-1 ocNib"
-            >
-              Go to Content
+              Payment Pending
             </footer>
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 lock erANTa"
+          class="sc-1549ebs-0 sc-5sgq84-0 lock bvdsPH"
           data-address="0x456"
-          disabled=""
         >
           <header
             class="sc-1549ebs-1 cWinrG"
@@ -3764,8 +3630,7 @@ Object {
           </header>
           <div>
             <div
-              class="sc-1549ebs-3 sc-5sgq84-2 ddHjJt"
-              disabled=""
+              class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
             >
               <div
                 class="sc-5sgq84-3 price bIZSQm"
@@ -3802,9 +3667,8 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 lock erANTa"
+          class="sc-1549ebs-0 sc-5sgq84-0 lock bvdsPH"
           data-address="0x789"
-          disabled=""
         >
           <header
             class="sc-1549ebs-1 cWinrG"
@@ -3813,8 +3677,7 @@ Object {
           </header>
           <div>
             <div
-              class="sc-1549ebs-3 sc-5sgq84-2 ddHjJt"
-              disabled=""
+              class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
             >
               <div
                 class="sc-5sgq84-3 price bIZSQm"
@@ -5285,6 +5148,886 @@ Object {
           <div>
             <div
               class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
+            >
+              <div
+                class="sc-5sgq84-3 price bIZSQm"
+              >
+                3.00
+                 Eth
+              </div>
+              <div>
+                <span
+                  class="sc-5sgq84-4 gAXKCT"
+                >
+                  $
+                  ---
+                </span>
+                <span
+                  class="sc-5sgq84-6 evsHkc"
+                >
+                   | 
+                </span>
+                <span
+                  class="sc-5sgq84-4 sc-5sgq84-5 BEVkH"
+                >
+                  <span>
+                    365 days
+                  </span>
+                </span>
+              </div>
+              <footer
+                class="sc-1549ebs-2 sc-5sgq84-1 frvQEr"
+              >
+                Purchase
+              </footer>
+            </div>
+          </div>
+        </li>
+      </ul>
+      <footer
+        class="sc-ifAKCX dEukKU"
+      >
+        <div
+          class="sth0f3-0 khsUlM"
+        >
+          <svg
+            viewBox="0 0 56 56"
+          >
+            <title />
+            <path
+              d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+            />
+          </svg>
+        </div>
+        Powered by Unlock
+      </footer>
+    </section>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Checkout Checkout with 3 locks and one valid key purchase 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c30 {
+  background-color: var(--brand);
+  height: 28px;
+  width: 28px;
+  border-radius: 50%;
+}
+
+.c30 > svg {
+  fill: white;
+}
+
+.c13 {
+  background-color: var(--lightgrey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 50px;
+  width: 50px;
+  display: inline-block;
+  padding: 0;
+  border: 0;
+  line-height: 50px;
+}
+
+.c13 > svg {
+  fill: var(--grey);
+  height: 50px;
+  width: 50px;
+}
+
+.c13:hover {
+  background-color: var(--green);
+}
+
+.c13:hover > svg {
+  fill: white;
+}
+
+.c5 {
+  display: grid;
+  justify-items: stretch;
+  margin: 0px;
+  padding: 0px;
+  font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
+  width: 200px;
+  height: 180px;
+  grid-gap: 0px;
+  background-clip: padding-box;
+  grid-template-rows: 40px 140px;
+  opacity: 1;
+}
+
+.c6 {
+  display: grid;
+  font-weight: 300;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-size: 20px;
+  line-height: 20px;
+  height: 40px;
+  border-radius: 4px 4px 0px 0px;
+  padding: 0px;
+  color: var(--grey);
+}
+
+.c9 {
+  white-space: nowrap;
+  font-weight: bold;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c10 {
+  white-space: nowrap;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8 {
+  display: grid;
+  font-size: 15px;
+  grid-auto-columns: min-content;
+  grid-auto-flow: column;
+  color: var(--grey);
+  font-weight: 300;
+  grid-gap: 4px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  justify-items: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+}
+
+.c16 {
+  display: none;
+}
+
+.c12 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c12:hover .c15 {
+  display: block;
+}
+
+.c12:hover .c14 {
+  display: none;
+}
+
+.c20 {
+  display: grid;
+  font-weight: 300;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-size: 20px;
+  line-height: 20px;
+  height: 40px;
+  border-radius: 0px 0px 4px 4px;
+  padding: 0px;
+  width: 200px;
+  background-color: var(--green);
+  color: var(--white);
+  -webkit-align-self: end;
+  -ms-flex-item-align: end;
+  align-self: end;
+  display: none;
+}
+
+.c18 {
+  display: grid;
+  font-weight: 300;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-size: 20px;
+  line-height: 20px;
+  height: 40px;
+  border-radius: 0px 0px 4px 4px;
+  padding: 0px;
+  width: 200px;
+  background-color: var(--green);
+  color: var(--white);
+  -webkit-align-self: end;
+  -ms-flex-item-align: end;
+  align-self: end;
+}
+
+.c7 {
+  display: grid;
+  height: 140px;
+  width: 200px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
+  text-align: center;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  padding: 0px;
+  grid-template-rows: 40px 30px;
+  grid-gap: 8px;
+  padding-top: 0px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background-color: var(--white);
+  border: 1px solid var(--green);
+  cursor: pointer;
+}
+
+.c7 .c19 {
+  display: none;
+}
+
+.c7 .c17 {
+  display: grid;
+}
+
+.c7:hover .c11 {
+  background-color: var(--green);
+}
+
+.c7:hover .c11 svg {
+  fill: var(--white);
+}
+
+.c7:hover .c15 {
+  display: block;
+}
+
+.c7:hover .c14 {
+  display: none;
+}
+
+.c7:hover .c19 {
+  display: grid;
+}
+
+.c7:hover .c17 {
+  display: none;
+}
+
+.c21 {
+  display: grid;
+  justify-items: stretch;
+  margin: 0px;
+  padding: 0px;
+  font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
+  width: 200px;
+  height: 180px;
+  grid-gap: 0px;
+  background-clip: padding-box;
+  grid-template-rows: 40px 140px;
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.c28 {
+  display: grid;
+  font-weight: 300;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  font-size: 20px;
+  line-height: 20px;
+  height: 40px;
+  border-radius: 0px 0px 4px 4px;
+  padding: 0px;
+  width: 200px;
+  background-color: var(--green);
+  color: var(--white);
+}
+
+.c31:hover .c27 {
+  background-color: var(--activegreen);
+}
+
+.c22 {
+  display: grid;
+  height: 140px;
+  width: 200px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
+  text-align: center;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  padding: 0px;
+  grid-template-rows: 40px 30px;
+  grid-gap: 8px;
+  padding-top: 0px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background-color: var(--white);
+  padding-top: 13px;
+}
+
+.c23 {
+  font-size: 30px;
+  text-transform: uppercase;
+  color: var(--slate);
+  font-weight: bold;
+}
+
+.c24 {
+  font-size: 20px;
+  font-weight: 300;
+  color: var(--grey);
+}
+
+.c26 {
+  font-size: 20px;
+  font-weight: 300;
+  color: var(--grey);
+}
+
+.c25 {
+  color: var(--lightgrey);
+}
+
+.c0 {
+  max-width: 1000px;
+  padding: 10px 40px;
+  display: grid;
+  background-color: var(--offwhite);
+  color: var(--darkgrey);
+}
+
+.c1 {
+  display: grid;
+}
+
+.c1 p {
+  font-size: 20px;
+}
+
+.c2 {
+  font-size: 40px;
+  font-weight: 200;
+  vertical-align: middle;
+}
+
+.c3 {
+  height: 30px;
+}
+
+.c29 {
+  margin-top: 50px;
+  font-size: 12px;
+  text-align: center;
+}
+
+.c29 div {
+  margin: 8px;
+  vertical-align: middle;
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  grid-gap: 48px;
+  list-style: none;
+  margin: 0px;
+  padding: 0px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  grid-template-columns: repeat(auto-fit,186px);
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c30 {
+    height: 16px;
+    width: 16px;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <section
+        class="c0"
+      >
+        <header
+          class="c1"
+        >
+          <h1
+            class="c2"
+          >
+            <img
+              class="c3"
+              src="data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMDAgNTQiPg0KICA8cGF0aCBkPSJNMTEzLjMgMTguMmMwLTUuOC4xLTExLjIuNC0xNi4yTDk4LjQgNC45djEuNGwxLjUuMmMxLjEuMSAxLjguNSAyLjIgMS4xLjQuNy43IDEuNy45IDMuMi4yIDIuOS40IDkuNS4zIDE5LjkgMCAxMC4zLS4xIDE2LjgtLjMgMTkuMyA1LjUgMS4yIDkuOCAxLjcgMTMgMS43IDYgMCAxMC43LTEuNyAxNC4xLTUuMiAzLjQtMy40IDUuMi04LjIgNS4yLTE0LjEgMC00LjctMS4zLTguNi0zLjktMTEuNy0yLjYtMy4xLTUuOS00LjYtOS44LTQuNi0yLjYgMC01LjMuNy04LjMgMi4xem0uMyAzMC44Yy0uMi0zLjItLjQtMTIuOC0uNC0yOC41LjktLjMgMi4xLS41IDMuNi0uNSAyLjQgMCA0LjMgMS4yIDUuNyAzLjcgMS40IDIuNSAyLjEgNS41IDIuMSA5LjMgMCA0LjctLjggOC41LTIuNCAxMS43LTEuNiAzLjEtMy42IDQuNy02LjEgNC43LS44LS4yLTEuNi0uMy0yLjUtLjR6TTQxIDNIMXYybDIuMS4yYzEuNi4zIDIuNy45IDMuNCAxLjguNyAxIDEuMSAyLjYgMS4yIDQuOC44IDEwLjguOCAyMC45IDAgMzAuMi0uMiAyLjItLjYgMy44LTEuMiA0LjgtLjcgMS0xLjggMS42LTMuNCAxLjhsLTIuMS4zdjJoMjUuOHYtMmwtMi43LS4yYy0xLjYtLjItMi43LS45LTMuNC0xLjgtLjctMS0xLjEtMi42LTEuMi00LjgtLjMtNC0uNS04LjYtLjUtMTMuN2w1LjQuMWMyLjkuMSA0LjkgMi4zIDUuOSA2LjdoMlYxOC45aC0yYy0xIDQuMy0yLjkgNi41LTUuOSA2LjZsLTUuNC4xYzAtOSAuMi0xNS40LjUtMTkuM2g3LjljNS42IDAgOS40IDMuNiAxMS42IDEwLjhsMi40LS43TDQxIDN6bS00LjcgMzAuOGMwIDUuMiAxLjUgOS41IDQuNCAxMi45IDIuOSAzLjQgNy4yIDUgMTIuNiA1czkuOC0xLjcgMTMtNS4yYzMuMi0zLjQgNC43LTcuNyA0LjctMTIuOXMtMS41LTkuNS00LjQtMTIuOWMtMi45LTMuNC03LjItNS0xMi42LTVzLTkuOCAxLjctMTMgNS4yYy0zLjIgMy40LTQuNyA3LjctNC43IDEyLjl6bTIyLjMtMTEuNGMxLjIgMi45IDEuNyA2LjcgMS43IDExLjMgMCAxMC42LTIuMiAxNS44LTYuNSAxNS44LTIuMiAwLTMuOS0xLjUtNS4xLTQuNS0xLjItMy0xLjctNi44LTEuNy0xMS4zQzQ3IDIzLjIgNDkuMiAxOCA1My41IDE4YzIuMi0uMSAzLjkgMS40IDUuMSA0LjR6bTg0LjUgMjQuM2MzLjMgMy4zIDcuNSA1IDEyLjUgNSAzLjEgMCA1LjgtLjYgOC4yLTEuOSAyLjQtMS4yIDQuMy0yLjcgNS42LTQuNWwtMS0xLjJjLTIuMiAxLjctNC43IDIuNS03LjYgMi41LTQgMC03LjEtMS4zLTkuMi00LTIuMi0yLjctMy4yLTYuMS0zLTEwLjVIMTcwYzAtNC44LTEuMi04LjctMy43LTExLjgtMi41LTMtNi00LjUtMTAuNS00LjUtNS42IDAtOS45IDEuOC0xMyA1LjMtMy4xIDMuNS00LjYgNy44LTQuNiAxMi45IDAgNS4yIDEuNiA5LjQgNC45IDEyLjd6bTcuNC0yNS4xYzEuMS0yLjQgMi41LTMuNiA0LjQtMy42IDMgMCA0LjUgMy44IDQuNSAxMS41bC0xMC42LjJjLjEtMyAuNi01LjcgMS43LTguMXptNDYuNC00Yy0yLjctMS4yLTYuMS0xLjktMTAuMi0xLjktNC4yIDAtNy41IDEuMS0xMCAzLjJzLTMuOCA0LjctMy44IDcuOGMwIDIuNy44IDQuOCAyLjMgNi4zIDEuNSAxLjUgMy45IDIuOCA3IDMuOSAyLjggMSA0LjggMiA1LjggMi45IDEgMSAxLjYgMi4xIDEuNiAzLjYgMCAxLjQtLjUgMi43LTEuNiAzLjctMSAxLjEtMi40IDEuNi00LjIgMS42LTQuNCAwLTcuNy0zLjItMTAtOS42bC0xLjcuNS40IDEwYzMuNiAxLjQgNy42IDIuMSAxMiAyLjEgNC42IDAgOC4xLTEgMTAuNy0zLjEgMi42LTIgMy45LTQuOSAzLjktOC41IDAtMi40LS42LTQuNC0xLjktNS45LTEuMy0xLjUtMy40LTIuOC02LjQtNC0zLjMtMS4yLTUuNi0yLjMtNi44LTMuMy0xLjItMS0xLjgtMi4yLTEuOC0zLjdzLjQtMi43IDEuMy0zLjcgMi0xLjQgMy40LTEuNGM0IDAgNi45IDIuOSA4LjcgOC42bDEuNy0uNS0uNC04LjZ6bS05Ni4yLS45Yy0xLjQtLjctMi45LTEtNC42LTEtMS43IDAtMy40LjctNS4zIDIuMS0xLjkgMS40LTMuMyAzLjMtNC40IDUuOWwuMS04LTE1LjIgM3YxLjRsMS41LjFjMS45LjIgMyAxLjcgMy4yIDQuNC42IDYuMi42IDEyLjggMCAxOS44LS4yIDIuNy0xLjMgNC4xLTMuMiA0LjRsLTEuNS4ydjEuOWgyMS4yVjQ5bC0yLjctLjJjLTEuOS0uMi0zLTEuNy0zLjItNC40LS42LTUuOC0uNy0xMi0uMi0xOC40LjYtMSAxLjktMS42IDMuOS0xLjggMi0uMiA0LjMuNCA2LjcgMS44bDMuNy05LjN6Ij48L3BhdGg+DQo8L3N2Zz4="
+            />
+             Unlocked
+          </h1>
+          <p>
+            Enjoy Forbes Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.
+          </p>
+        </header>
+        <ul
+          class="c4"
+        >
+          <li
+            class="lock c5"
+            data-address="0x123"
+          >
+            <header
+              class="c6"
+            >
+              Weekly
+            </header>
+            <div
+              class="c7"
+            >
+              <div
+                class="c8"
+              >
+                <div
+                  class="c9"
+                >
+                  0.1
+                   ETH
+                </div>
+                <div
+                  class="c10"
+                >
+                  $
+                  ---
+                </div>
+              </div>
+              <a
+                class="c11 c12 c13"
+              >
+                <svg
+                  class="c14 "
+                  viewBox="0 0 24 24"
+                >
+                  <title />
+                  <path
+                    clip-rule="evenodd"
+                    d="M16.857 7.6a.5.5 0 0 1 .099.7l-5.32 7.07a.5.5 0 0 1-.704.096l-3.236-2.482a.5.5 0 1 1 .608-.794l2.836 2.175L16.157 7.7a.5.5 0 0 1 .7-.098z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+                <svg
+                  class="c15 c16"
+                  viewBox="0 0 24 24"
+                >
+                  <title />
+                  <path
+                    clip-rule="evenodd"
+                    d="M17.5 12a.5.5 0 0 1-.175.38l-3.5 3a.5.5 0 1 1-.65-.76l2.473-2.12H7a.5.5 0 0 1 0-1h8.648l-2.473-2.12a.5.5 0 1 1 .65-.76l3.5 3a.5.5 0 0 1 .175.38z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+                
+              </a>
+              <footer
+                class="c17 c18"
+              >
+                Payment Confirmed
+              </footer>
+              <footer
+                class="c19 c20"
+              >
+                Go to Content
+              </footer>
+            </div>
+          </li>
+          <li
+            class="lock c21"
+            data-address="0x456"
+            disabled=""
+          >
+            <header
+              class="c6"
+            >
+              Monthly
+            </header>
+            <div>
+              <div
+                class="c22"
+                disabled=""
+              >
+                <div
+                  class="price c23"
+                >
+                  0.3
+                   Eth
+                </div>
+                <div>
+                  <span
+                    class="c24"
+                  >
+                    $
+                    ---
+                  </span>
+                  <span
+                    class="c25"
+                  >
+                     | 
+                  </span>
+                  <span
+                    class="c26"
+                  >
+                    <span>
+                      30 days
+                    </span>
+                  </span>
+                </div>
+                <footer
+                  class="c27 c28"
+                >
+                  Purchase
+                </footer>
+              </div>
+            </div>
+          </li>
+          <li
+            class="lock c21"
+            data-address="0x789"
+            disabled=""
+          >
+            <header
+              class="c6"
+            >
+              Yearly
+            </header>
+            <div>
+              <div
+                class="c22"
+                disabled=""
+              >
+                <div
+                  class="price c23"
+                >
+                  3.00
+                   Eth
+                </div>
+                <div>
+                  <span
+                    class="c24"
+                  >
+                    $
+                    ---
+                  </span>
+                  <span
+                    class="c25"
+                  >
+                     | 
+                  </span>
+                  <span
+                    class="c26"
+                  >
+                    <span>
+                      365 days
+                    </span>
+                  </span>
+                </div>
+                <footer
+                  class="c27 c28"
+                >
+                  Purchase
+                </footer>
+              </div>
+            </div>
+          </li>
+        </ul>
+        <footer
+          class="c29"
+        >
+          <div
+            class="c30"
+          >
+            <svg
+              viewBox="0 0 56 56"
+            >
+              <title />
+              <path
+                d="M42.315 22.461h-1.862v-6.92h-6.919v6.92H22.48v-6.92h-6.918v6.92h-1.877v3.288h1.877v5.18c0 6.481 5.606 11.77 12.485 11.77 6.84 0 12.406-5.289 12.406-11.77v-5.18h1.862zm-8.78 8.468a5.515 5.515 0 0 1-5.488 5.567 5.583 5.583 0 0 1-5.567-5.567v-5.18h11.054z"
+              />
+            </svg>
+          </div>
+          Powered by Unlock
+        </footer>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <section
+      class="sc-bdVaJa eeigbB"
+    >
+      <header
+        class="sc-bwzfXH cZSkgv"
+      >
+        <h1
+          class="sc-htpNat dMiWqt"
+        >
+          <img
+            class="sc-bxivhb ZFyFM"
+            src="data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMDAgNTQiPg0KICA8cGF0aCBkPSJNMTEzLjMgMTguMmMwLTUuOC4xLTExLjIuNC0xNi4yTDk4LjQgNC45djEuNGwxLjUuMmMxLjEuMSAxLjguNSAyLjIgMS4xLjQuNy43IDEuNy45IDMuMi4yIDIuOS40IDkuNS4zIDE5LjkgMCAxMC4zLS4xIDE2LjgtLjMgMTkuMyA1LjUgMS4yIDkuOCAxLjcgMTMgMS43IDYgMCAxMC43LTEuNyAxNC4xLTUuMiAzLjQtMy40IDUuMi04LjIgNS4yLTE0LjEgMC00LjctMS4zLTguNi0zLjktMTEuNy0yLjYtMy4xLTUuOS00LjYtOS44LTQuNi0yLjYgMC01LjMuNy04LjMgMi4xem0uMyAzMC44Yy0uMi0zLjItLjQtMTIuOC0uNC0yOC41LjktLjMgMi4xLS41IDMuNi0uNSAyLjQgMCA0LjMgMS4yIDUuNyAzLjcgMS40IDIuNSAyLjEgNS41IDIuMSA5LjMgMCA0LjctLjggOC41LTIuNCAxMS43LTEuNiAzLjEtMy42IDQuNy02LjEgNC43LS44LS4yLTEuNi0uMy0yLjUtLjR6TTQxIDNIMXYybDIuMS4yYzEuNi4zIDIuNy45IDMuNCAxLjguNyAxIDEuMSAyLjYgMS4yIDQuOC44IDEwLjguOCAyMC45IDAgMzAuMi0uMiAyLjItLjYgMy44LTEuMiA0LjgtLjcgMS0xLjggMS42LTMuNCAxLjhsLTIuMS4zdjJoMjUuOHYtMmwtMi43LS4yYy0xLjYtLjItMi43LS45LTMuNC0xLjgtLjctMS0xLjEtMi42LTEuMi00LjgtLjMtNC0uNS04LjYtLjUtMTMuN2w1LjQuMWMyLjkuMSA0LjkgMi4zIDUuOSA2LjdoMlYxOC45aC0yYy0xIDQuMy0yLjkgNi41LTUuOSA2LjZsLTUuNC4xYzAtOSAuMi0xNS40LjUtMTkuM2g3LjljNS42IDAgOS40IDMuNiAxMS42IDEwLjhsMi40LS43TDQxIDN6bS00LjcgMzAuOGMwIDUuMiAxLjUgOS41IDQuNCAxMi45IDIuOSAzLjQgNy4yIDUgMTIuNiA1czkuOC0xLjcgMTMtNS4yYzMuMi0zLjQgNC43LTcuNyA0LjctMTIuOXMtMS41LTkuNS00LjQtMTIuOWMtMi45LTMuNC03LjItNS0xMi42LTVzLTkuOCAxLjctMTMgNS4yYy0zLjIgMy40LTQuNyA3LjctNC43IDEyLjl6bTIyLjMtMTEuNGMxLjIgMi45IDEuNyA2LjcgMS43IDExLjMgMCAxMC42LTIuMiAxNS44LTYuNSAxNS44LTIuMiAwLTMuOS0xLjUtNS4xLTQuNS0xLjItMy0xLjctNi44LTEuNy0xMS4zQzQ3IDIzLjIgNDkuMiAxOCA1My41IDE4YzIuMi0uMSAzLjkgMS40IDUuMSA0LjR6bTg0LjUgMjQuM2MzLjMgMy4zIDcuNSA1IDEyLjUgNSAzLjEgMCA1LjgtLjYgOC4yLTEuOSAyLjQtMS4yIDQuMy0yLjcgNS42LTQuNWwtMS0xLjJjLTIuMiAxLjctNC43IDIuNS03LjYgMi41LTQgMC03LjEtMS4zLTkuMi00LTIuMi0yLjctMy4yLTYuMS0zLTEwLjVIMTcwYzAtNC44LTEuMi04LjctMy43LTExLjgtMi41LTMtNi00LjUtMTAuNS00LjUtNS42IDAtOS45IDEuOC0xMyA1LjMtMy4xIDMuNS00LjYgNy44LTQuNiAxMi45IDAgNS4yIDEuNiA5LjQgNC45IDEyLjd6bTcuNC0yNS4xYzEuMS0yLjQgMi41LTMuNiA0LjQtMy42IDMgMCA0LjUgMy44IDQuNSAxMS41bC0xMC42LjJjLjEtMyAuNi01LjcgMS43LTguMXptNDYuNC00Yy0yLjctMS4yLTYuMS0xLjktMTAuMi0xLjktNC4yIDAtNy41IDEuMS0xMCAzLjJzLTMuOCA0LjctMy44IDcuOGMwIDIuNy44IDQuOCAyLjMgNi4zIDEuNSAxLjUgMy45IDIuOCA3IDMuOSAyLjggMSA0LjggMiA1LjggMi45IDEgMSAxLjYgMi4xIDEuNiAzLjYgMCAxLjQtLjUgMi43LTEuNiAzLjctMSAxLjEtMi40IDEuNi00LjIgMS42LTQuNCAwLTcuNy0zLjItMTAtOS42bC0xLjcuNS40IDEwYzMuNiAxLjQgNy42IDIuMSAxMiAyLjEgNC42IDAgOC4xLTEgMTAuNy0zLjEgMi42LTIgMy45LTQuOSAzLjktOC41IDAtMi40LS42LTQuNC0xLjktNS45LTEuMy0xLjUtMy40LTIuOC02LjQtNC0zLjMtMS4yLTUuNi0yLjMtNi44LTMuMy0xLjItMS0xLjgtMi4yLTEuOC0zLjdzLjQtMi43IDEuMy0zLjcgMi0xLjQgMy40LTEuNGM0IDAgNi45IDIuOSA4LjcgOC42bDEuNy0uNS0uNC04LjZ6bS05Ni4yLS45Yy0xLjQtLjctMi45LTEtNC42LTEtMS43IDAtMy40LjctNS4zIDIuMS0xLjkgMS40LTMuMyAzLjMtNC40IDUuOWwuMS04LTE1LjIgM3YxLjRsMS41LjFjMS45LjIgMyAxLjcgMy4yIDQuNC42IDYuMi42IDEyLjggMCAxOS44LS4yIDIuNy0xLjMgNC4xLTMuMiA0LjRsLTEuNS4ydjEuOWgyMS4yVjQ5bC0yLjctLjJjLTEuOS0uMi0zLTEuNy0zLjItNC40LS42LTUuOC0uNy0xMi0uMi0xOC40LjYtMSAxLjktMS42IDMuOS0xLjggMi0uMiA0LjMuNCA2LjcgMS44bDMuNy05LjN6Ij48L3BhdGg+DQo8L3N2Zz4="
+          />
+           Unlocked
+        </h1>
+        <p>
+          Enjoy Forbes Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.
+        </p>
+      </header>
+      <ul
+        class="sc-EHOje ilBouS"
+      >
+        <li
+          class="sc-1549ebs-0 lock NDRQz"
+          data-address="0x123"
+        >
+          <header
+            class="sc-1549ebs-1 cWinrG"
+          >
+            Weekly
+          </header>
+          <div
+            class="sc-1549ebs-3 ynhyps-0 dMttvX"
+          >
+            <div
+              class="sc-1549ebs-6 hGyOOg"
+            >
+              <div
+                class="sc-1549ebs-4 cXGnbO"
+              >
+                0.1
+                 ETH
+              </div>
+              <div
+                class="sc-1549ebs-4 kUlrFA"
+              >
+                $
+                ---
+              </div>
+            </div>
+            <a
+              class="sc-1hzn3pu-2 jZYYLs is925m-0 kmZaWo"
+            >
+              <svg
+                class="sc-1hzn3pu-0 dozNUb"
+                viewBox="0 0 24 24"
+              >
+                <title />
+                <path
+                  clip-rule="evenodd"
+                  d="M16.857 7.6a.5.5 0 0 1 .099.7l-5.32 7.07a.5.5 0 0 1-.704.096l-3.236-2.482a.5.5 0 1 1 .608-.794l2.836 2.175L16.157 7.7a.5.5 0 0 1 .7-.098z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              <svg
+                class="sc-1hzn3pu-1 gckVYZ"
+                viewBox="0 0 24 24"
+              >
+                <title />
+                <path
+                  clip-rule="evenodd"
+                  d="M17.5 12a.5.5 0 0 1-.175.38l-3.5 3a.5.5 0 1 1-.65-.76l2.473-2.12H7a.5.5 0 0 1 0-1h8.648l-2.473-2.12a.5.5 0 1 1 .65-.76l3.5 3a.5.5 0 0 1 .175.38z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              
+            </a>
+            <footer
+              class="sc-1549ebs-2 ik5149-0 ik5149-2 epNQgy"
+            >
+              Payment Confirmed
+            </footer>
+            <footer
+              class="sc-1549ebs-2 ik5149-0 ik5149-1 ocNib"
+            >
+              Go to Content
+            </footer>
+          </div>
+        </li>
+        <li
+          class="sc-1549ebs-0 sc-5sgq84-0 lock erANTa"
+          data-address="0x456"
+          disabled=""
+        >
+          <header
+            class="sc-1549ebs-1 cWinrG"
+          >
+            Monthly
+          </header>
+          <div>
+            <div
+              class="sc-1549ebs-3 sc-5sgq84-2 ddHjJt"
+              disabled=""
+            >
+              <div
+                class="sc-5sgq84-3 price bIZSQm"
+              >
+                0.3
+                 Eth
+              </div>
+              <div>
+                <span
+                  class="sc-5sgq84-4 gAXKCT"
+                >
+                  $
+                  ---
+                </span>
+                <span
+                  class="sc-5sgq84-6 evsHkc"
+                >
+                   | 
+                </span>
+                <span
+                  class="sc-5sgq84-4 sc-5sgq84-5 BEVkH"
+                >
+                  <span>
+                    30 days
+                  </span>
+                </span>
+              </div>
+              <footer
+                class="sc-1549ebs-2 sc-5sgq84-1 frvQEr"
+              >
+                Purchase
+              </footer>
+            </div>
+          </div>
+        </li>
+        <li
+          class="sc-1549ebs-0 sc-5sgq84-0 lock erANTa"
+          data-address="0x789"
+          disabled=""
+        >
+          <header
+            class="sc-1549ebs-1 cWinrG"
+          >
+            Yearly
+          </header>
+          <div>
+            <div
+              class="sc-1549ebs-3 sc-5sgq84-2 ddHjJt"
+              disabled=""
             >
               <div
                 class="sc-5sgq84-3 price bIZSQm"

--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -161,6 +161,18 @@ describe('Form field validators', () => {
         ).toBe(false)
       })
 
+      it('icon is data URI', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon:
+              'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMDAgNTQiPg0KICA8cGF0aCBkPSJNMTEzLjMgMTguMmMwLTUuOC4xLTExLjIuNC0xNi4yTDk4LjQgNC45djEuNGwxLjUuMmMxLjEuMSAxLjguNSAyLjIgMS4xLjQuNy43IDEuNy45IDMuMi4yIDIuOS40IDkuNS4zIDE5LjkgMCAxMC4zLS4xIDE2LjgtLjMgMTkuMyA1LjUgMS4yIDkuOCAxLjcgMTMgMS43IDYgMCAxMC43LTEuNyAxNC4xLTUuMiAzLjQtMy40IDUuMi04LjIgNS4yLTE0LjEgMC00LjctMS4zLTguNi0zLjktMTEuNy0yLjYtMy4xLTUuOS00LjYtOS44LTQuNi0yLjYgMC01LjMuNy04LjMgMi4xem0uMyAzMC44Yy0uMi0zLjItLjQtMTIuOC0uNC0yOC41LjktLjMgMi4xLS41IDMuNi0uNSAyLjQgMCA0LjMgMS4yIDUuNyAzLjcgMS40IDIuNSAyLjEgNS41IDIuMSA5LjMgMCA0LjctLjggOC41LTIuNCAxMS43LTEuNiAzLjEtMy42IDQuNy02LjEgNC43LS44LS4yLTEuNi0uMy0yLjUtLjR6TTQxIDNIMXYybDIuMS4yYzEuNi4zIDIuNy45IDMuNCAxLjguNyAxIDEuMSAyLjYgMS4yIDQuOC44IDEwLjguOCAyMC45IDAgMzAuMi0uMiAyLjItLjYgMy44LTEuMiA0LjgtLjcgMS0xLjggMS42LTMuNCAxLjhsLTIuMS4zdjJoMjUuOHYtMmwtMi43LS4yYy0xLjYtLjItMi43LS45LTMuNC0xLjgtLjctMS0xLjEtMi42LTEuMi00LjgtLjMtNC0uNS04LjYtLjUtMTMuN2w1LjQuMWMyLjkuMSA0LjkgMi4zIDUuOSA2LjdoMlYxOC45aC0yYy0xIDQuMy0yLjkgNi41LTUuOSA2LjZsLTUuNC4xYzAtOSAuMi0xNS40LjUtMTkuM2g3LjljNS42IDAgOS40IDMuNiAxMS42IDEwLjhsMi40LS43TDQxIDN6bS00LjcgMzAuOGMwIDUuMiAxLjUgOS41IDQuNCAxMi45IDIuOSAzLjQgNy4yIDUgMTIuNiA1czkuOC0xLjcgMTMtNS4yYzMuMi0zLjQgNC43LTcuNyA0LjctMTIuOXMtMS41LTkuNS00LjQtMTIuOWMtMi45LTMuNC03LjItNS0xMi42LTVzLTkuOCAxLjctMTMgNS4yYy0zLjIgMy40LTQuNyA3LjctNC43IDEyLjl6bTIyLjMtMTEuNGMxLjIgMi45IDEuNyA2LjcgMS43IDExLjMgMCAxMC42LTIuMiAxNS44LTYuNSAxNS44LTIuMiAwLTMuOS0xLjUtNS4xLTQuNS0xLjItMy0xLjctNi44LTEuNy0xMS4zQzQ3IDIzLjIgNDkuMiAxOCA1My41IDE4YzIuMi0uMSAzLjkgMS40IDUuMSA0LjR6bTg0LjUgMjQuM2MzLjMgMy4zIDcuNSA1IDEyLjUgNSAzLjEgMCA1LjgtLjYgOC4yLTEuOSAyLjQtMS4yIDQuMy0yLjcgNS42LTQuNWwtMS0xLjJjLTIuMiAxLjctNC43IDIuNS03LjYgMi41LTQgMC03LjEtMS4zLTkuMi00LTIuMi0yLjctMy4yLTYuMS0zLTEwLjVIMTcwYzAtNC44LTEuMi04LjctMy43LTExLjgtMi41LTMtNi00LjUtMTAuNS00LjUtNS42IDAtOS45IDEuOC0xMyA1LjMtMy4xIDMuNS00LjYgNy44LTQuNiAxMi45IDAgNS4yIDEuNiA5LjQgNC45IDEyLjd6bTcuNC0yNS4xYzEuMS0yLjQgMi41LTMuNiA0LjQtMy42IDMgMCA0LjUgMy44IDQuNSAxMS41bC0xMC42LjJjLjEtMyAuNi01LjcgMS43LTguMXptNDYuNC00Yy0yLjctMS4yLTYuMS0xLjktMTAuMi0xLjktNC4yIDAtNy41IDEuMS0xMCAzLjJzLTMuOCA0LjctMy44IDcuOGMwIDIuNy44IDQuOCAyLjMgNi4zIDEuNSAxLjUgMy45IDIuOCA3IDMuOSAyLjggMSA0LjggMiA1LjggMi45IDEgMSAxLjYgMi4xIDEuNiAzLjYgMCAxLjQtLjUgMi43LTEuNiAzLjctMSAxLjEtMi40IDEuNi00LjIgMS42LTQuNCAwLTcuNy0zLjItMTAtOS42bC0xLjcuNS40IDEwYzMuNiAxLjQgNy42IDIuMSAxMiAyLjEgNC42IDAgOC4xLTEgMTAuNy0zLjEgMi42LTIgMy45LTQuOSAzLjktOC41IDAtMi40LS42LTQuNC0xLjktNS45LTEuMy0xLjUtMy40LTIuOC02LjQtNC0zLjMtMS4yLTUuNi0yLjMtNi44LTMuMy0xLjItMS0xLjgtMi4yLTEuOC0zLjdzLjQtMi43IDEuMy0zLjcgMi0xLjQgMy40LTEuNGM0IDAgNi45IDIuOSA4LjcgOC42bDEuNy0uNS0uNC04LjZ6bS05Ni4yLS45Yy0xLjQtLjctMi45LTEtNC42LTEtMS43IDAtMy40LjctNS4zIDIuMS0xLjkgMS40LTMuMyAzLjMtNC40IDUuOWwuMS04LTE1LjIgM3YxLjRsMS41LjFjMS45LjIgMyAxLjcgMy4yIDQuNC42IDYuMi42IDEyLjggMCAxOS44LS4yIDIuNy0xLjMgNC4xLTMuMiA0LjRsLTEuNS4ydjEuOWgyMS4yVjQ5bC0yLjctLjJjLTEuOS0uMi0zLTEuNy0zLjItNC40LS42LTUuOC0uNy0xMi0uMi0xOC40LjYtMSAxLjktMS42IDMuOS0xLjggMi0uMiA0LjMuNCA2LjcgMS44bDMuNy05LjN6Ij48L3BhdGg+DQo8L3N2Zz4=',
+          })
+        ).toBe(true)
+      })
+
       describe('callToAction', () => {
         const noConfirmed = {
           default: 'default',
@@ -596,6 +608,7 @@ describe('Form field validators', () => {
       status: 'none',
       confirmations: 0,
       owner: '0x1234567890123456789012345678901234567890',
+      lock: '0x0987654321098765432109876543210987654321',
     }
 
     describe('failures', () => {
@@ -754,6 +767,17 @@ describe('Form field validators', () => {
           })
         ).toBe(false)
       })
+
+      it('should fail if lock is not a valid ethereum address', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            lock: '0xIamnot a valid ethereum address',
+          })
+        ).toBe(false)
+      })
     })
 
     describe('valid keys', () => {
@@ -809,6 +833,7 @@ describe('Form field validators', () => {
         status: 'none',
         confirmations: 0,
         owner: '0x1234567890123456789012345678901234567890',
+        lock: '0x0987654321098765432109876543210987654321',
       },
     }
     describe('failures', () => {
@@ -930,7 +955,7 @@ describe('Form field validators', () => {
         expect(
           validators.isValidLock({
             ...validLock,
-            keyPrice: 'not a valid key price',
+            keyPrice: '0.023.0',
           })
         ).toBe(false)
       })
@@ -981,6 +1006,35 @@ describe('Form field validators', () => {
 
         expect(validators.isValidLock(validLock)).toBe(true)
       })
+
+      it('should accept valid key price', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: '0.1',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: '.1',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: '1',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: '21.000',
+          })
+        ).toBe(true)
+      })
     })
   })
 
@@ -995,6 +1049,7 @@ describe('Form field validators', () => {
         status: 'none',
         confirmations: 0,
         owner: '0x1234567890123456789012345678901234567890',
+        lock: '0x0987654321098765432109876543210987654321',
       },
     }
     const invalidLock = {
@@ -1030,6 +1085,7 @@ describe('Form field validators', () => {
           [validLock.address]: validLock,
           [address]: {
             ...validLock,
+            lock: '0x098765432109876543210987654321098765432a',
             address,
           },
         })

--- a/paywall/src/stories/checkout/Checkout.stories.js
+++ b/paywall/src/stories/checkout/Checkout.stories.js
@@ -35,6 +35,7 @@ const paywallConfig = {
 
 const account = {
   address: '0x123',
+  balance: '789',
 }
 
 const store = createUnlockStore()
@@ -56,6 +57,7 @@ storiesOf('Checkout', module)
           status: 'none',
           transactions: [],
           expiration: 0,
+          lock: '0x123',
         },
       },
       '0x456': {
@@ -67,6 +69,7 @@ storiesOf('Checkout', module)
           status: 'none',
           transactions: [],
           expiration: 0,
+          lock: '0x456',
         },
       },
       '0x789': {
@@ -78,6 +81,7 @@ storiesOf('Checkout', module)
           status: 'none',
           transactions: [],
           expiration: 0,
+          lock: '0x789',
         },
       },
     }
@@ -262,7 +266,7 @@ storiesOf('Checkout', module)
       />
     )
   })
-  .add('Checkout with 3 locks and one confirming key purchase', () => {
+  .add('Checkout with 3 locks and one valid key purchase', () => {
     const locks = {
       '0x123': {
         name: 'Weekly',

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -103,4 +103,5 @@ export interface Key {
   status: string
   confirmations: number
   owner: string
+  lock: string
 }


### PR DESCRIPTION
# Description

This fixes a number of issues discovered in the infrastructure around the paywall config and locks passed from the data iframe.

- paywall config did not allow an icon to be a data URI
- `Key` type did not have a `lock` field, which is needed to successfully purchase a key (and is definitely passed in by the data iframe)
- key validation was based on the `Key` type and needed to have lock validation added.
- lock `keyPrice` did not allow decimals.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3366 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
