### PR TITLE
when parsing a route, return the origin no matter what

### DIFF
--- a/paywall/src/__tests__/utils/routes.test.js
+++ b/paywall/src/__tests__/utils/routes.test.js
@@ -59,6 +59,7 @@ describe('route utilities', () => {
         origin: 'origin/',
       })
     })
+
     it('should return the correct redirect parameter when it matches', () => {
       expect.assertions(1)
       expect(
@@ -73,6 +74,7 @@ describe('route utilities', () => {
         origin: 'origin/',
       })
     })
+
     it('should return the correct account parameter when it matches', () => {
       expect.assertions(2)
       expect(
@@ -99,6 +101,7 @@ describe('route utilities', () => {
         origin: 'origin/',
       })
     })
+
     it('should return the correct transaction parameter when it matches', () => {
       expect.assertions(2)
       expect(
@@ -126,6 +129,7 @@ describe('route utilities', () => {
         origin: 'origin/',
       })
     })
+
     it('should ignore malformed account parameter', () => {
       expect.assertions(1)
       expect(
@@ -141,6 +145,7 @@ describe('route utilities', () => {
         origin: 'origin/',
       })
     })
+
     it('should ignore malformed transaction parameter', () => {
       expect.assertions(1)
       expect(
@@ -156,6 +161,7 @@ describe('route utilities', () => {
         origin: 'origin/',
       })
     })
+
     it('should return account parameter if redirect is not present', () => {
       expect.assertions(1)
 
@@ -171,7 +177,21 @@ describe('route utilities', () => {
         origin: 'origin/',
       })
     })
+
+    it('should return the origin no matter what', () => {
+      expect.assertions(1)
+
+      expect(
+        lockRoute(
+          '/?origin=origin%2F#0xaaa8825a3e7Fb15263D0DD455B8aAfc08503bb54'
+        )
+      ).toEqual({
+        ...baseRoute,
+        origin: 'origin/',
+      })
+    })
   })
+
   describe('getRouteFromWindow', () => {
     it('should parse route from window.location', () => {
       expect.assertions(1)

--- a/paywall/src/__tests__/utils/routes.test.js
+++ b/paywall/src/__tests__/utils/routes.test.js
@@ -1,4 +1,8 @@
-import { lockRoute, getRouteFromWindow } from '../../utils/routes'
+import {
+  lockRoute,
+  getRouteFromWindow,
+  polyfilledURL,
+} from '../../utils/routes'
 
 describe('route utilities', () => {
   const baseRoute = {
@@ -188,6 +192,15 @@ describe('route utilities', () => {
       ).toEqual({
         ...baseRoute,
         origin: 'origin/',
+      })
+    })
+
+    it('should not crash if there are no search params on polyfilled server URL', () => {
+      expect.assertions(1)
+
+      expect(lockRoute('/', polyfilledURL)).toEqual({
+        ...baseRoute,
+        origin: null,
       })
     })
   })

--- a/paywall/src/utils/routes.js
+++ b/paywall/src/utils/routes.js
@@ -4,20 +4,24 @@ import {
   TRANSACTION_REGEXP,
 } from '../constants'
 
+export const polyfilledURL = function() {
+  return {
+    pathname: '',
+    hash: false,
+    searchParams: {
+      has: () => false,
+    },
+  }
+}
 if (!global.URL) {
   // polyfill for server
-  global.URL = function() {
-    return {
-      pathname: '',
-      hash: false,
-    }
-  }
+  global.URL = polyfilledURL
 }
 /**
  * Returns a hash of lockAddress and prefix based on a path.
  * @param {*} path
  */
-export const lockRoute = path => {
+export const lockRoute = (path, URL = global.URL) => {
   // note: undocumented "feature" of the URL class is that it throws
   // if the URL is invalid. In our case, we are passing in a relative path,
   // and so it throws unless we pass in a base url. Since the base URL
@@ -25,6 +29,9 @@ export const lockRoute = path => {
   // https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
   const url = new URL(path, 'http://paywall.unlock-protocol.com')
   const match = url.pathname.match(LOCK_PATH_NAME_REGEXP)
+  const origin = url.searchParams.has('origin')
+    ? url.searchParams.get('origin')
+    : null
 
   if (!match) {
     return {
@@ -33,9 +40,7 @@ export const lockRoute = path => {
       redirect: null,
       account: null,
       transaction: null,
-      origin: url.searchParams.has('origin')
-        ? url.searchParams.get('origin')
-        : null,
+      origin,
     }
   }
 
@@ -52,9 +57,7 @@ export const lockRoute = path => {
     redirect: (match[3] && decodeURIComponent(match[3])) || null,
     account,
     transaction,
-    origin: url.searchParams.has('origin')
-      ? url.searchParams.get('origin')
-      : null,
+    origin,
   }
 }
 

--- a/paywall/src/utils/routes.js
+++ b/paywall/src/utils/routes.js
@@ -33,7 +33,9 @@ export const lockRoute = path => {
       redirect: null,
       account: null,
       transaction: null,
-      origin: null,
+      origin: url.searchParams.has('origin')
+        ? url.searchParams.get('origin')
+        : null,
     }
   }
 


### PR DESCRIPTION
# Description

For the checkout process, we don't pass a lock address in the URL at all, but do need to retrieve the origin from the URL. This PR adds that functionality

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3366

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
