### PR TITLE
Tighten types, rename a callback

### DIFF
--- a/paywall/src/components/checkout/Checkout.tsx
+++ b/paywall/src/components/checkout/Checkout.tsx
@@ -8,9 +8,9 @@ import CheckoutLock from './CheckoutLock'
 interface Props {
   locks: Locks
   config: PaywallConfig
-  account: Account
+  account: Account | null
   purchase: (...args: any[]) => any
-  clickOnConfirmedLock: (...args: any[]) => any
+  hideCheckout: (...args: any[]) => any
 }
 
 export const Checkout = ({
@@ -18,7 +18,7 @@ export const Checkout = ({
   config,
   account,
   purchase,
-  clickOnConfirmedLock,
+  hideCheckout,
 }: Props) => {
   const hasValidKey = Object.keys(locks).reduce(
     (isValid, address) => isValid || locks[address].key.status === 'valid',
@@ -41,7 +41,7 @@ export const Checkout = ({
                 account={account}
                 disabled={hasValidKey}
                 purchase={purchase}
-                clickOnConfirmedLock={clickOnConfirmedLock}
+                hideCheckout={hideCheckout}
               />
             )
           }

--- a/paywall/src/components/checkout/CheckoutLock.tsx
+++ b/paywall/src/components/checkout/CheckoutLock.tsx
@@ -5,14 +5,14 @@ import ConfirmingKeyLock from '../lock/ConfirmingKeyLock'
 import ConfirmedKeyLock from '../lock/ConfirmedKeyLock'
 import NoKeyLock from '../lock/NoKeyLock'
 
-import { Lock, Account, KeyStatus } from '../../unlockTypes'
+import { Lock, Account, KeyStatus, Key } from '../../unlockTypes'
 
 interface Props {
   lock: Lock
   disabled: boolean
-  account: Account
-  purchase: (...args: any[]) => any
-  clickOnConfirmedLock: (...args: any[]) => any
+  account: Account | null
+  purchase: (key: Key) => void
+  hideCheckout: (...args: any[]) => any
 }
 
 /**
@@ -27,7 +27,7 @@ export const CheckoutLock = ({
   account,
   disabled,
   purchase,
-  clickOnConfirmedLock,
+  hideCheckout,
 }: Props) => {
   const { key } = lock
 
@@ -45,7 +45,7 @@ export const CheckoutLock = ({
   }
 
   if (key.status === KeyStatus.VALID) {
-    return <ConfirmedKeyLock lock={lock} onClick={clickOnConfirmedLock} />
+    return <ConfirmedKeyLock lock={lock} onClick={hideCheckout} />
   }
 
   return (

--- a/paywall/src/components/checkout/CheckoutLock.tsx
+++ b/paywall/src/components/checkout/CheckoutLock.tsx
@@ -12,7 +12,7 @@ interface Props {
   disabled: boolean
   account: Account | null
   purchase: (key: Key) => void
-  hideCheckout: (...args: any[]) => any
+  hideCheckout: (...args: any[]) => void
 }
 
 /**

--- a/paywall/src/stories/checkout/Checkout.stories.js
+++ b/paywall/src/stories/checkout/Checkout.stories.js
@@ -7,7 +7,7 @@ import { ConfigContext } from '../../utils/withConfig'
 import configure from '../../config'
 
 const purchaseKey = () => {}
-const clickOnConfirmedLock = () => {}
+const hideCheckout = () => {}
 
 const ConfigProvider = ConfigContext.Provider
 
@@ -92,7 +92,7 @@ storiesOf('Checkout', module)
         config={paywallConfig}
         account={account}
         purchase={purchaseKey}
-        clickOnConfirmedLock={clickOnConfirmedLock}
+        hideCheckout={hideCheckout}
       />
     )
   })
@@ -117,7 +117,7 @@ storiesOf('Checkout', module)
         config={paywallConfig}
         account={account}
         purchase={purchaseKey}
-        clickOnConfirmedLock={clickOnConfirmedLock}
+        hideCheckout={hideCheckout}
       />
     )
   })
@@ -164,7 +164,7 @@ storiesOf('Checkout', module)
         config={paywallConfig}
         account={account}
         purchase={purchaseKey}
-        clickOnConfirmedLock={clickOnConfirmedLock}
+        hideCheckout={hideCheckout}
       />
     )
   })
@@ -211,7 +211,7 @@ storiesOf('Checkout', module)
         config={paywallConfig}
         account={account}
         purchase={purchaseKey}
-        clickOnConfirmedLock={clickOnConfirmedLock}
+        hideCheckout={hideCheckout}
       />
     )
   })
@@ -262,7 +262,7 @@ storiesOf('Checkout', module)
         config={paywallConfig}
         account={account}
         purchase={purchaseKey}
-        clickOnConfirmedLock={clickOnConfirmedLock}
+        hideCheckout={hideCheckout}
       />
     )
   })
@@ -309,7 +309,7 @@ storiesOf('Checkout', module)
         config={paywallConfig}
         account={account}
         purchase={purchaseKey}
-        clickOnConfirmedLock={clickOnConfirmedLock}
+        hideCheckout={hideCheckout}
       />
     )
   })


### PR DESCRIPTION
# Description

This primarily cosmetic change tightens the `Account` type and the types for some callbacks, and renames `clickOnConfirmedLock` to `hideCheckout` since it will also be used when the user clicks the little `X` to close in the upper right corner

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3366

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
