### PR TITLE
fix startup for unlock.min.js

### DIFF
--- a/paywall/src/unlock.js/iframeManager.js
+++ b/paywall/src/unlock.js/iframeManager.js
@@ -8,10 +8,10 @@ export function makeIframe(window, src) {
 
 export function addIframeToDocument(window, iframe) {
   window.document.body.insertAdjacentElement('afterbegin', iframe)
-  window.setInterval(
-    () => window.document.body.insertAdjacentElement('afterbegin', iframe),
-    500
-  )
+  window.setInterval(() => {
+    if (document.querySelector(`iframe[src="${iframe.src}"]`)) return
+    window.document.body.insertAdjacentElement('afterbegin', iframe)
+  }, 500)
 }
 
 export function showIframe(window, iframe) {

--- a/paywall/src/unlock.js/index.js
+++ b/paywall/src/unlock.js/index.js
@@ -1,7 +1,20 @@
-import { makeIframe } from './iframeManager'
+import { makeIframe, addIframeToDocument } from './iframeManager'
 import setupPostOffices from './setupPostOffices'
+import '../paywall-builder/iframe.css'
 
-const dataIframe = makeIframe(window, '/static/dataIframe.html')
-const checkoutIframe = makeIframe(window, '/checkout')
+window.onload = () => {
+  const origin = '?origin=' + encodeURIComponent(window.origin)
 
-setupPostOffices(window, dataIframe, checkoutIframe)
+  const dataIframe = makeIframe(
+    window,
+    process.env.PAYWALL_URL + '/static/dataIframe.html' + origin
+  )
+  addIframeToDocument(window, dataIframe)
+  const checkoutIframe = makeIframe(
+    window,
+    process.env.PAYWALL_URL + '/checkout' + origin
+  )
+  addIframeToDocument(window, checkoutIframe)
+
+  setupPostOffices(window, dataIframe, checkoutIframe)
+}


### PR DESCRIPTION
# Description

this adds an exist case for iframeManager polling to re-add the iframe if it gets removed, and also fixes a logic flaw in the index.js where the iframe setup was assuming that it was in the unlock-protocol domain. Now, it passes the correct full URL with the `PAYWALL_URL` and the window.origin added.

It also adds the iframes to the document (whoops)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
