### PR TITLE
fix validator for isValidLock to include unused fields

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -1007,6 +1007,21 @@ describe('Form field validators', () => {
         expect(validators.isValidLock(validLock)).toBe(true)
       })
 
+      it('should accept a valid lock with optional fields', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            asOf: 1,
+            maxNumberOfKeys: -1,
+            outstandingKeys: 0,
+            balance: '0',
+            owner: '0x1234567890123456789012345678901234567890',
+          })
+        ).toBe(true)
+      })
+
       it('should accept valid key price', () => {
         expect.assertions(4)
 

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -194,7 +194,7 @@ export const isValidLock = lock => {
     !isValidObject(
       lock,
       ['address', 'keyPrice', 'expirationDuration', 'key'],
-      ['name']
+      ['name', 'asOf', 'maxNumberOfKeys', 'outstandingKeys', 'balance', 'owner']
     )
   ) {
     return false


### PR DESCRIPTION
# Description

This adds permissiveness so that `isValidLock` returns true for locks that include fields not used on the paywall.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
