### PR TITLE
fix the iframe adding/polling code

### DIFF
--- a/paywall/src/__tests__/unlock.js/iframeManager.test.js
+++ b/paywall/src/__tests__/unlock.js/iframeManager.test.js
@@ -18,12 +18,17 @@ describe('iframeManager', () => {
     expect(iframe.className).toBe('unlock start')
   })
 
-  it('adds the iframe to the document every 500 ms', () => {
-    expect.assertions(3)
+  it('should try to add the iframe to the document every 500 ms', () => {
+    expect.assertions(4)
+
     // unfortunately, this function does not exist in js-dom
     window.document.body.insertAdjacentElement = jest.fn()
 
     const iframe = makeIframe(window, 'http://example.com')
+
+    let doesItExist = false
+
+    window.document.querySelector = () => (doesItExist ? iframe : null)
 
     addIframeToDocument(window, iframe)
 
@@ -32,6 +37,10 @@ describe('iframeManager', () => {
       iframe
     )
     expect(window.document.body.insertAdjacentElement).toHaveBeenCalledTimes(1)
+    doesItExist = false // someone removed it from the DOM, so we should re-add it
+    jest.runOnlyPendingTimers()
+    expect(window.document.body.insertAdjacentElement).toHaveBeenCalledTimes(2)
+    doesItExist = true // no one removed it
     jest.runOnlyPendingTimers()
     expect(window.document.body.insertAdjacentElement).toHaveBeenCalledTimes(2)
   })

--- a/paywall/src/unlock.js/iframeManager.js
+++ b/paywall/src/unlock.js/iframeManager.js
@@ -7,11 +7,11 @@ export function makeIframe(window, src) {
 }
 
 export function addIframeToDocument(window, iframe) {
+  if (window.document.querySelector(`iframe[src="${iframe.src}"]`)) return
   window.document.body.insertAdjacentElement('afterbegin', iframe)
-  window.setInterval(
-    () => window.document.body.insertAdjacentElement('afterbegin', iframe),
-    500
-  )
+  window.setInterval(() => {
+    addIframeToDocument(window, iframe)
+  }, 500)
 }
 
 export function showIframe(window, iframe) {


### PR DESCRIPTION
# Description

The existing code simply re-added the iframe into the DOM every half second. This fixes that so it only attempts to re-add if the element does not already exist in the DOM

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
