### PR TITLE
fix Web3ProxyProvider/web3Proxy startup flow

### DIFF
--- a/paywall/src/__tests__/paywall-builder/web3Proxy.test.js
+++ b/paywall/src/__tests__/paywall-builder/web3Proxy.test.js
@@ -2,7 +2,7 @@ import * as config from '../../paywall-builder/config'
 import web3Proxy from '../../paywall-builder/web3Proxy'
 import { _clearHandlers } from '../../utils/postOffice'
 import {
-  POST_MESSAGE_READY,
+  POST_MESSAGE_READY_WEB3,
   POST_MESSAGE_WALLET_INFO,
   POST_MESSAGE_WEB3,
 } from '../../paywall-builder/constants'
@@ -40,7 +40,7 @@ describe('web3Proxy', () => {
       _clearHandlers()
     })
 
-    it('listens for POST_MESSAGE_READY and dispatches the result', done => {
+    it('listens for POST_MESSAGE_READY_WEB3 and dispatches the result', done => {
       expect.assertions(2)
 
       web3Proxy(fakeWindow, fakeIframe, 'http://fun.times')
@@ -49,7 +49,7 @@ describe('web3Proxy', () => {
         source: fakeIframe.contentWindow,
         origin: 'http://fun.times',
         data: {
-          type: POST_MESSAGE_READY,
+          type: POST_MESSAGE_READY_WEB3,
           payload: 'it worked!',
         },
       })
@@ -79,7 +79,7 @@ describe('web3Proxy', () => {
         source: fakeIframe.contentWindow,
         origin: 'http://fun.times',
         data: {
-          type: POST_MESSAGE_READY,
+          type: POST_MESSAGE_READY_WEB3,
           payload: 'it worked!',
         },
       })
@@ -152,7 +152,7 @@ describe('web3Proxy', () => {
         source: fakeIframe.contentWindow,
         origin: 'http://fun.times',
         data: {
-          type: POST_MESSAGE_READY,
+          type: POST_MESSAGE_READY_WEB3,
           payload: 'it worked!',
         },
       })
@@ -183,7 +183,7 @@ describe('web3Proxy', () => {
         source: fakeIframe.contentWindow,
         origin: 'http://fun.times',
         data: {
-          type: POST_MESSAGE_READY,
+          type: POST_MESSAGE_READY_WEB3,
           payload: 'it worked!',
         },
       })
@@ -221,7 +221,7 @@ describe('web3Proxy', () => {
           source: fakeIframe.contentWindow,
           origin: 'http://fun.times',
           data: {
-            type: POST_MESSAGE_READY,
+            type: POST_MESSAGE_READY_WEB3,
             payload: 'it worked!',
           },
         })
@@ -289,7 +289,7 @@ describe('web3Proxy', () => {
             source: fakeIframe.contentWindow,
             origin: 'http://fun.times',
             data: {
-              type: POST_MESSAGE_READY,
+              type: POST_MESSAGE_READY_WEB3,
               payload: 'it worked!',
             },
           })
@@ -446,7 +446,7 @@ describe('web3Proxy', () => {
             source: fakeIframe.contentWindow,
             origin: 'http://fun.times',
             data: {
-              type: POST_MESSAGE_READY,
+              type: POST_MESSAGE_READY_WEB3,
               payload: 'it worked!',
             },
           })

--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
@@ -12,6 +12,7 @@ import {
   POST_MESSAGE_WALLET_INFO,
   POST_MESSAGE_ERROR,
   POST_MESSAGE_UPDATE_WALLET,
+  POST_MESSAGE_READY_WEB3,
 } from '../../paywall-builder/constants'
 
 describe('setupPostOffice', () => {
@@ -84,10 +85,10 @@ describe('setupPostOffice', () => {
     expect(fakeUIIframe.className).toBe('unlock start show')
   })
 
-  it('responds to POST_MESSAGE_READY by sending POST_MESSAGE_WALLET_INFO', () => {
+  it('responds to POST_MESSAGE_READY_WEB3 by sending POST_MESSAGE_WALLET_INFO', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_READY, {
+    sendMessage(fakeDataIframe, POST_MESSAGE_READY_WEB3, {
       lock: { address: 'lock' },
     })
 

--- a/paywall/src/paywall-builder/constants.js
+++ b/paywall/src/paywall-builder/constants.js
@@ -8,6 +8,7 @@ export const POST_MESSAGE_READY = 'ready'
 export const POST_MESSAGE_CONFIG = 'config'
 export const POST_MESSAGE_ACCOUNT = 'account'
 export const POST_MESSAGE_WEB3 = 'web3'
+export const POST_MESSAGE_READY_WEB3 = 'ready/web3'
 export const POST_MESSAGE_WALLET_INFO = 'walletInfo'
 
 export const POST_MESSAGE_UPDATE_LOCKS = 'update/locks'

--- a/paywall/src/paywall-builder/web3Proxy.js
+++ b/paywall/src/paywall-builder/web3Proxy.js
@@ -1,8 +1,8 @@
 import { enable } from './config'
 import { mainWindowPostOffice, setHandler } from '../utils/postOffice'
 import {
-  POST_MESSAGE_READY,
   POST_MESSAGE_WEB3,
+  POST_MESSAGE_READY_WEB3,
   POST_MESSAGE_WALLET_INFO,
 } from './constants'
 
@@ -59,7 +59,7 @@ export default function web3Proxy(window, iframe, origin) {
   // initialize, we do this once the iframe is ready to receive information on the wallet
   // we need to tell the iframe if the wallet is metamask
   // TODO: pass the name of the wallet if we know it? (secondary importance right now, so omitting)
-  setHandler(POST_MESSAGE_READY, async (_, respond) => {
+  setHandler(POST_MESSAGE_READY_WEB3, async (_, respond) => {
     const isMetamask = !!(
       window.web3 &&
       window.web3.currentProvider &&

--- a/paywall/src/providers/Web3ProxyProvider.js
+++ b/paywall/src/providers/Web3ProxyProvider.js
@@ -1,9 +1,10 @@
 import { iframePostOffice, setHandler } from '../utils/postOffice'
 import {
   POST_MESSAGE_WEB3,
-  POST_MESSAGE_READY,
+  POST_MESSAGE_READY_WEB3,
   POST_MESSAGE_WALLET_INFO,
 } from '../paywall-builder/constants'
+import { waitFor } from '../utils/promises'
 
 /**
  * an iframe->main window web3 wallet proxy provider
@@ -19,6 +20,7 @@ export default class Web3ProxyProvider {
   constructor(window) {
     // set up the post office inside the iframe
     this.postMessage = iframePostOffice(window)
+    this.waiting = true
 
     // this is the postMessage version of connecting to the wallet
     setHandler(POST_MESSAGE_WALLET_INFO, walletInfo => {
@@ -28,6 +30,8 @@ export default class Web3ProxyProvider {
       this.isMetamask = !!walletInfo.isMetamask
       this.noWallet = !!walletInfo.noWallet
       this.notEnabled = !!walletInfo.notEnabled
+      // now we are ready to do work
+      this.waiting = false
     })
 
     // this is the postMessage version of the callback for sendAsync
@@ -54,14 +58,16 @@ export default class Web3ProxyProvider {
     this.requests = {}
 
     this.noWallet = true // until we hear back from the main window
-    this.postMessage(POST_MESSAGE_READY)
+    this.postMessage(POST_MESSAGE_READY_WEB3)
   }
 
   /**
    * @param {object} methodCall this object contains the method and params for the json-rpc call
    * @param {function} callback this is a standard node callback
    */
-  sendAsync({ method, params }, callback) {
+  async sendAsync({ method, params }, callback) {
+    // don't do anything until we have heard back on the wallet status
+    await waitFor(() => !this.waiting)
     if (this.noWallet) {
       callback(new Error('no ethereum wallet is available'))
       return


### PR DESCRIPTION
# Description

This fixes a 2 vexing bugs that took hours to kill.

(1)
Basically, the `unlock.min.js` script uses `POST_MESSAGE_READY` as a signal to send the paywall config to both the data iframe and the checkout UI iframe. In the data iframe, this is used to start the blockchain handler and sends data to the cache when its ready.

By re-using `POST_MESSAGE_READY` as the signal that the `Web3ProxyProvider` is good to go, this meant that we created an infinite loop.

data iframe -> POST_MESSAGE_READY -> main window
main window -> POST_MESSAGE_CONFIG -> data iframe
* data iframe starts blockchain *
data iframe Web3ProxyProvider -> POST_MESSAGE_READY -> main window
main window -> POST_MESSAGE_WALLET_INFO -> data iframe
*and*
main window -> POST_MESSAGE_CONFIG -> data iframe

starting the merry-go-round again.

Changing the message type used by the `Web3ProxyProvider` fixes this little disaster

(2)
The `Web3ProxyProvider` was always failing immediately because no wallet is present. This adds a poll that waits for the receipt of `POST_MESSAGE_WALLET_INFO` before attempting any actions.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
