### PR TITLE
fix the POST_MESSAGE_READY message sent to the main window

### DIFF
--- a/paywall/src/__tests__/hooks/usePaywallConfig.test.js
+++ b/paywall/src/__tests__/hooks/usePaywallConfig.test.js
@@ -60,7 +60,7 @@ describe('usePaywallConfig hook', () => {
     rtl.render(<Wrapper />)
 
     expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith(
-      POST_MESSAGE_READY,
+      expect.objectContaining({ type: POST_MESSAGE_READY, payload: undefined }),
       'origin'
     )
   })

--- a/paywall/src/hooks/usePaywallConfig.js
+++ b/paywall/src/hooks/usePaywallConfig.js
@@ -49,7 +49,8 @@ export default function usePaywallConfig() {
   })
   useEffect(() => {
     // this triggers the send of configuration from main window to the paywall
-    postMessage(POST_MESSAGE_READY)
+    // payload must be defined for the post office in unlock.min.js to recognize it as valid and from us
+    postMessage({ type: POST_MESSAGE_READY, payload: undefined })
   }, [postMessage]) // only send this once, on startup
   return paywallConfig
 }


### PR DESCRIPTION
# Description

This small PR fixes the format of the `POST_MESSAGE_READY` message sent to the main window to match what `utils/postOffice` is expecting it to be.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
