### PR TITLE
balance is in eth, and can be a decimal number

### DIFF
--- a/paywall/src/__tests__/hooks/useBlockchainData.test.js
+++ b/paywall/src/__tests__/hooks/useBlockchainData.test.js
@@ -145,7 +145,7 @@ describe('useBlockchainData hook', () => {
     const component = rtl.render(<Wrapper />)
     const account = {
       address: '0x1234567890123456789012345678901234567890',
-      balance: '5',
+      balance: '5.3',
     }
 
     const accountUpdater = getAddressListener()

--- a/paywall/src/hooks/useBlockchainData.js
+++ b/paywall/src/hooks/useBlockchainData.js
@@ -32,6 +32,7 @@ export default function useBlockchainData(window, paywallConfig) {
     validator: val => isPositiveInteger(val) && typeof val === 'number',
   })
   // our default account balance is '0' until we hear from the blockchain handler
+  // balance is in eth, we must use isPositiveNumber to validate
   const balance = useListenForPostMessage({
     type: POST_MESSAGE_UPDATE_ACCOUNT_BALANCE,
     defaultValue: '0',

--- a/paywall/src/hooks/useBlockchainData.js
+++ b/paywall/src/hooks/useBlockchainData.js
@@ -5,7 +5,12 @@ import {
   POST_MESSAGE_UPDATE_LOCKS,
   POST_MESSAGE_UPDATE_NETWORK,
 } from '../paywall-builder/constants'
-import { isAccount, isPositiveInteger, isValidLocks } from '../utils/validators'
+import {
+  isAccount,
+  isPositiveInteger,
+  isValidLocks,
+  isPositiveNumber,
+} from '../utils/validators'
 import useConfig from './utils/useConfig'
 
 /**
@@ -30,7 +35,7 @@ export default function useBlockchainData(window, paywallConfig) {
   const balance = useListenForPostMessage({
     type: POST_MESSAGE_UPDATE_ACCOUNT_BALANCE,
     defaultValue: '0',
-    validator: val => isPositiveInteger(val) && typeof val === 'string',
+    validator: val => isPositiveNumber(val) && typeof val === 'string',
   })
   // retrieve the locks from the data iframe
   const blockChainLocks = useListenForPostMessage({


### PR DESCRIPTION
# Description

When designing `useBlockchainData`, I assumed the account balance was in wei, but it is in fact in eth, thus we need to support decimal numbers as well. This PR fixes that.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
