### PR TITLE
fix account polling in the data iframe

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/account.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/account.test.js
@@ -5,6 +5,7 @@ import {
   getAccount,
   getAccountBalance,
 } from '../../../data-iframe/blockchainHandler/account'
+import { POLLING_INTERVAL } from '../../../constants'
 
 let mockPoll
 jest.mock('../../../data-iframe/blockchainHandler/ensureWalletReady', () =>
@@ -54,7 +55,7 @@ describe('blockchainHandler account handling', () => {
         expect.any(Function) /* hasValueChanged */,
         expect.any(Function) /* continuePolling */,
         expect.any(Function) /*changeListener */,
-        5000 /* delay */
+        POLLING_INTERVAL /* delay */
       )
     })
 

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/account.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/account.test.js
@@ -38,7 +38,7 @@ describe('blockchainHandler account handling', () => {
         onAccountChange
       )
 
-      expect(ensureWalletReady).toBeCalled()
+      expect(ensureWalletReady).toBeCalledWith(fakeWalletService)
     })
 
     it('polls for account changes', async () => {
@@ -49,7 +49,13 @@ describe('blockchainHandler account handling', () => {
         onAccountChange
       )
 
-      expect(pollForChanges).toBeCalled()
+      expect(pollForChanges).toHaveBeenCalledWith(
+        expect.any(Function) /* getFunc */,
+        expect.any(Function) /* hasValueChanged */,
+        expect.any(Function) /* continuePolling */,
+        expect.any(Function) /*changeListener */,
+        5000 /* delay */
+      )
     })
 
     it('getFunc retrieves the current account', async () => {

--- a/paywall/src/data-iframe/blockchainHandler/account.js
+++ b/paywall/src/data-iframe/blockchainHandler/account.js
@@ -25,7 +25,7 @@ export async function pollForAccountChange(
   web3Service,
   onAccountChange = () => {}
 ) {
-  await ensureWalletReady()
+  await ensureWalletReady(walletService)
 
   pollForChanges(
     async () => await walletService.getAccount() /* getFunc */,
@@ -39,6 +39,7 @@ export async function pollForAccountChange(
         newAccount ? await web3Service.getAddressBalance(newAccount) : 0
       )
       onAccountChange(account, accountBalance)
-    }
+    } /*changeListener */,
+    5000 /* delay */
   )
 }

--- a/paywall/src/data-iframe/blockchainHandler/account.js
+++ b/paywall/src/data-iframe/blockchainHandler/account.js
@@ -1,5 +1,6 @@
 import ensureWalletReady from './ensureWalletReady'
 import pollForChanges from './pollForChanges'
+import { POLLING_INTERVAL } from '../../constants'
 
 let account
 let accountBalance = 0
@@ -40,6 +41,6 @@ export async function pollForAccountChange(
       )
       onAccountChange(account, accountBalance)
     } /*changeListener */,
-    5000 /* delay */
+    POLLING_INTERVAL /* delay */
   )
 }


### PR DESCRIPTION
# Description

This fixes account polling. There were 2 errors that became obvious in live testing. First, `ensureWalletReady` needs a `walletService` to do its magic. Next, we were polling for account changes every event loop instead of every 5 seconds, which literally crashed the browser.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
