### PR TITLE
make sure owner is set in getKeys

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/getKeys.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/getKeys.test.js
@@ -67,14 +67,12 @@ describe('getKeys', () => {
         return Promise.resolve({
           id: `${lock}-${owner}`,
           lock,
-          owner,
           expiration: 0,
         })
       }
       return Promise.resolve({
         id: `${lock}-${owner}`,
         lock,
-        owner,
         expiration,
       })
     })

--- a/paywall/src/data-iframe/blockchainHandler/getKeys.js
+++ b/paywall/src/data-iframe/blockchainHandler/getKeys.js
@@ -13,7 +13,10 @@ export default async function getKeys({ walletService, locks, web3Service }) {
   return keys.reduce(
     (keysByLock, key) => ({
       ...keysByLock,
-      [key.lock]: key,
+      [key.lock]: {
+        ...key,
+        owner: account,
+      },
     }),
     {}
   )


### PR DESCRIPTION
# Description

It turns out that the key returned from `web3Service.getKeysByLockForOwner` does not set the owner field, so we have to do it manually.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
