### PR TITLE
fix getLocks to include the lock address

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/getLocks.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/getLocks.test.js
@@ -8,7 +8,8 @@ describe('Locks retrieval', () => {
     let fakeWeb3Service
     beforeEach(() => {
       fakeWeb3Service = {
-        getLock: jest.fn(address => Promise.resolve({ address })),
+        // locks returned from getLock do not have "address" set for some reason
+        getLock: jest.fn(address => Promise.resolve({ thing: address })),
       }
     })
 
@@ -36,9 +37,9 @@ describe('Locks retrieval', () => {
       })
 
       expect(result).toEqual({
-        1: { address: 1 },
-        2: { address: 2 },
-        3: { address: 3 },
+        1: { address: 1, thing: 1 },
+        2: { address: 2, thing: 2 },
+        3: { address: 3, thing: 3 },
       })
     })
   })

--- a/paywall/src/data-iframe/blockchainHandler/getLocks.js
+++ b/paywall/src/data-iframe/blockchainHandler/getLocks.js
@@ -12,9 +12,12 @@ export default async function getLocks({ locksToRetrieve, web3Service }) {
   )
   // convert into a map indexed by lock address
   return newLocks.reduce(
-    (allLocks, lock) => ({
+    (allLocks, lock, index) => ({
       ...allLocks,
-      [lock.address]: lock,
+      [locksToRetrieve[index]]: {
+        address: locksToRetrieve[index],
+        ...lock,
+      },
     }),
     {}
   )


### PR DESCRIPTION
# Description

The result of `web3Service.getLock` does not include the lock address, this PR adds it in manually to the returned data.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
