### PR TITLE
Checkout lock spacing now cross-browser

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2189,14 +2189,13 @@ Object {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  grid-gap: 48px;
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   grid-template-columns: repeat(auto-fit,186px);
 }
 
@@ -2361,7 +2360,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-bZQynM jcYzPV"
+        class="sc-bZQynM droRCb"
       >
         <li
           class="sc-1549ebs-0 sc-5sgq84-0 lock bvdsPH"
@@ -2697,14 +2696,13 @@ Object {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  grid-gap: 48px;
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   grid-template-columns: repeat(auto-fit,186px);
 }
 
@@ -2963,7 +2961,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-bZQynM jcYzPV"
+        class="sc-bZQynM droRCb"
       >
         <li
           class="sc-1549ebs-0 sc-5sgq84-0 lock bvdsPH"
@@ -3514,14 +3512,13 @@ Object {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  grid-gap: 48px;
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   grid-template-columns: repeat(auto-fit,186px);
 }
 
@@ -3777,7 +3774,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-bZQynM jcYzPV"
+        class="sc-bZQynM droRCb"
       >
         <li
           class="sc-1549ebs-0 lock NDRQz"
@@ -4325,14 +4322,13 @@ Object {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  grid-gap: 48px;
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   grid-template-columns: repeat(auto-fit,186px);
 }
 
@@ -4584,7 +4580,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-bZQynM jcYzPV"
+        class="sc-bZQynM droRCb"
       >
         <li
           class="sc-1549ebs-0 lock NDRQz"
@@ -5128,14 +5124,13 @@ Object {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  grid-gap: 48px;
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   grid-template-columns: repeat(auto-fit,186px);
 }
 
@@ -5387,7 +5382,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-bZQynM jcYzPV"
+        class="sc-bZQynM droRCb"
       >
         <li
           class="sc-1549ebs-0 sc-5sgq84-0 lock bvdsPH"
@@ -6014,14 +6009,13 @@ Object {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  grid-gap: 48px;
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   grid-template-columns: repeat(auto-fit,186px);
 }
 
@@ -6304,7 +6298,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-bZQynM jcYzPV"
+        class="sc-bZQynM droRCb"
       >
         <li
           class="sc-1549ebs-0 lock NDRQz"
@@ -6650,14 +6644,13 @@ Object {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  grid-gap: 48px;
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   grid-template-columns: repeat(auto-fit,186px);
 }
 
@@ -6811,7 +6804,7 @@ Object {
           </p>
         </header>
         <ul
-          class="sc-bZQynM jcYzPV"
+          class="sc-bZQynM droRCb"
         />
         <footer
           class="sc-EHOje dRuRrt"
@@ -6992,14 +6985,13 @@ Object {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  grid-gap: 48px;
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   grid-template-columns: repeat(auto-fit,186px);
 }
 
@@ -7153,7 +7145,7 @@ Object {
           </p>
         </header>
         <ul
-          class="sc-bZQynM jcYzPV"
+          class="sc-bZQynM droRCb"
         />
         <footer
           class="sc-EHOje dRuRrt"

--- a/paywall/src/components/checkout/Checkout.tsx
+++ b/paywall/src/components/checkout/Checkout.tsx
@@ -114,10 +114,9 @@ const Footer = styled.footer`
 const CheckoutLocks = styled.ul`
   display: flex;
   flex-wrap: wrap;
-  grid-gap: 48px;
   list-style: none;
   margin: 0px;
   padding: 0px;
-  justify-content: center;
+  justify-content: space-around;
   grid-template-columns: repeat(auto-fit, 186px);
 `


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR changes the way locks are spaced on the `<Checkout>` page. The previous iteration worked on Firefox, but not Chrome (grid-gap not supported in a flex container on Chrome). I tried a few different ways to keep the exact spacing, but in the end the simplest and most robust solution was to use `space-around` to have a variable gap between locks that still looks good on both desktop and mobile.

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/9300702/58658477-8f543a80-82ee-11e9-8eba-e171b6c69515.png">

<img width="481" alt="image" src="https://user-images.githubusercontent.com/9300702/58658517-a1ce7400-82ee-11e9-8e6b-5578e61f9db2.png">


# Issues


<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3455 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
