### PR TITLE
fix key purchase on the data iframe

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/purchaseKey.test.js
@@ -58,7 +58,7 @@ describe('blockchainHandler purchaseKey', () => {
 
     function assertOnUpdates(expected, done) {
       let expectedIndex = 0
-      return (newTransaction, newKey) => {
+      return ({ transaction: newTransaction, key: newKey }) => {
         const [expectedTransaction, expectedKey, desc] = expected[expectedIndex]
         try {
           expect(newTransaction).toEqual(expectedTransaction)
@@ -92,6 +92,7 @@ describe('blockchainHandler purchaseKey', () => {
         removeListener: type => {
           delete fakeWeb3Service.handlers[type]
         },
+        getTransaction: jest.fn(),
         once: (type, cb) => (fakeWeb3Service.handlers[type] = cb),
         getKeyByLockForOwner: jest.fn(lock => newKeys[lock]),
       }
@@ -375,6 +376,7 @@ describe('blockchainHandler purchaseKey', () => {
 
       fakeWeb3Service.handlers['transaction.updated']('hash', {
         status: 'pending',
+        hash: 'hash',
         blockNumber: 123,
       })
     })

--- a/paywall/src/data-iframe/blockchainHandler/index.js
+++ b/paywall/src/data-iframe/blockchainHandler/index.js
@@ -97,9 +97,6 @@ export async function retrieveChainData({
     getKeys({ walletService, locks: locksToRetrieve, web3Service }),
     locksmithTransactions(window, locksmithHost, web3Service, walletService),
   ])
-  const update = async (transaction, key) => {
-    onChange({ transaction, key })
-  }
   Object.values(transactions).forEach(transaction => {
     if (transaction.type === TRANSACTION_TYPES.KEY_PURCHASE) {
       processKeyPurchaseTransactions({
@@ -110,7 +107,7 @@ export async function retrieveChainData({
         lockAddress: transaction.lock,
         requiredConfirmations,
         walletAction: () => onChange({ walletModal: true }),
-        update,
+        update: onChange,
       }).catch(error => {
         onChange({ error })
       })


### PR DESCRIPTION
# Description

This fixes a couple of key issues that were killing off key purchase in the data iframe.

1. the result sent to update needed to be an indexed object (`{ key, transaction }` instead of parameters `key`, `transaction`)
2. we were never actually calling `web3Service.getTransaction` to start the transaction update polling
3. the boundary condition for the update polling loop was incorrect, and should have been checking for 2 conditions (no changes to transaction or key, and key status was not valid or failed)

# Issues

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
