### PR TITLE
fix data iframe startup

### DIFF
--- a/paywall/src/__tests__/data-iframe/start/index.test.js
+++ b/paywall/src/__tests__/data-iframe/start/index.test.js
@@ -26,6 +26,11 @@ describe('data iframe startup index', () => {
   it('should set up the post office', async () => {
     expect.assertions(1)
 
+    const updater = jest.fn()
+    const setConfig = jest.fn()
+    postOffice.mockImplementationOnce(() => updater)
+    makeSetConfig.mockImplementationOnce(() => setConfig)
+
     await start(window, constants)
 
     expect(postOffice).toHaveBeenCalledWith(
@@ -60,5 +65,18 @@ describe('data iframe startup index', () => {
       setConfig,
       purchaseKey
     )
+  })
+
+  it('should send "ready" to the updater to start the entire process', async () => {
+    expect.assertions(1)
+
+    const updater = jest.fn()
+    const setConfig = jest.fn()
+    postOffice.mockImplementationOnce(() => updater)
+    makeSetConfig.mockImplementationOnce(() => setConfig)
+
+    await start(window, constants)
+
+    expect(updater).toHaveBeenCalledWith('ready')
   })
 })

--- a/paywall/src/__tests__/data-iframe/start/makePurchaseCallback.test.js
+++ b/paywall/src/__tests__/data-iframe/start/makePurchaseCallback.test.js
@@ -109,11 +109,8 @@ describe('makePurchaseCallback', () => {
 
       walletService.purchaseKey = jest.fn().mockRejectedValue(new Error('fail'))
 
-      try {
-        await purchase('lock')
-      } catch (e) {
-        expect(e.message).toBe('fail')
-      }
+      await purchase('lock')
+      expect(update).toHaveBeenCalledWith({ error: 'fail' })
     })
 
     it('should initiate monitoring of key purchase transaction', async () => {
@@ -147,11 +144,8 @@ describe('makePurchaseCallback', () => {
           cb(new Error('fail'))
         }
       }
-      try {
-        await purchase('lock')
-      } catch (e) {
-        expect(e.message).toBe('fail')
-      }
+      await purchase('lock')
+      expect(update).toHaveBeenCalledWith({ error: 'fail' })
     })
   })
 })

--- a/paywall/src/data-iframe/start/index.js
+++ b/paywall/src/data-iframe/start/index.js
@@ -30,4 +30,6 @@ export default async function start(window, constants) {
     makeSetConfig(window, updater, constants),
     purchaseKey
   )
+  // start the ball rolling
+  updater('ready')
 }

--- a/paywall/src/data-iframe/start/makePurchaseCallback.js
+++ b/paywall/src/data-iframe/start/makePurchaseCallback.js
@@ -36,26 +36,27 @@ const makePurchaseCallback = ({
     ])
     const startingKey = keys[lockAddress]
 
-    // if purchaseKey errors out, it will emit an error, which
-    // is listened for by processKeyPurchaseTransactions, aborting both
-    // promises
-    return Promise.all([
-      purchaseKey({
-        walletService,
-        lockAddress,
-        amountToSend: locks[lockAddress].keyPrice,
-      }),
-      processKeyPurchaseTransactions({
-        walletService,
-        web3Service,
-        startingTransactions,
-        startingKey,
-        lockAddress,
-        requiredConfirmations,
-        update,
-        walletAction: () => update({ walletAction: true }),
-      }),
-    ])
+    try {
+      await Promise.all([
+        purchaseKey({
+          walletService,
+          lockAddress,
+          amountToSend: locks[lockAddress].keyPrice,
+        }),
+        processKeyPurchaseTransactions({
+          walletService,
+          web3Service,
+          startingTransactions,
+          startingKey,
+          lockAddress,
+          requiredConfirmations,
+          update,
+          walletAction: () => update({ walletModal: true }),
+        }),
+      ])
+    } catch (error) {
+      update({ error: error.message })
+    }
   }
 
 export default makePurchaseCallback

--- a/paywall/src/data-iframe/start/makeSetConfig.js
+++ b/paywall/src/data-iframe/start/makeSetConfig.js
@@ -44,12 +44,14 @@ const makeSetConfig = (window, updater, constants) =>
       // cache listeners will transmit it to the script
       syncToCache(window, updates)
     }
-    connectToBlockchain({
-      ...constants,
-      config: configValue,
-      window,
-      onChange,
-    })
+    onChange(
+      await connectToBlockchain({
+        ...constants,
+        config: configValue,
+        window,
+        onChange,
+      })
+    )
   }
 
 export default makeSetConfig


### PR DESCRIPTION
# Description

This fixes the data iframe's startup code. These are the issues:

1. we were never actually triggering the start of everything with the `'ready'` event!
2. key purchase error catching was not properly passing errors to the post office
3. after receiving the paywall config and using it to retrieve blockchain data, that data was not being passed to the cache via `onChange`, and so never being sent to the main window.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
