### PR TITLE
fix dismissing of checkout

### DIFF
--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -49,6 +49,7 @@ export default function CheckoutContent() {
   const hideCheckout = () => {
     postMessage({
       type: POST_MESSAGE_DISMISS_CHECKOUT,
+      payload: undefined, // this must be set to trigger a response in unlock.min.js
     })
   }
 


### PR DESCRIPTION
# Description

The post office in `unlock.min.js` is very strict that the message sent must have a payload even when the payload is unused. This is to prevent accidental responding to other scripts in the same page. Thus, this PR is required to allow dismissing of the checkout iframe.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
