### PR TITLE
changed the createLock to remain consistent

### DIFF
--- a/docker/development/deploy-locks.js
+++ b/docker/development/deploy-locks.js
@@ -62,9 +62,9 @@ async function deployERC20Lock(wallet, account, contractAddress) {
       expirationDuration: 60 * 5, // 1 minute!
       keyPrice: '0.02', // 0.01 Eth
       maxNumberOfKeys: -1, // Unlimited
+      currencyContractAddress: contractAddress,
     },
-    account,
-    contractAddress
+    account
   )
 }
 

--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.1.3
+
+- Changing the createLock API to remain consistent
+
 ## 0.1.2
 
 - Updated gas amounts to fix deploying new locks

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/v02/createLock.test.js
+++ b/unlock-js/src/__tests__/v02/createLock.test.js
@@ -96,15 +96,23 @@ describe('v02', () => {
 
         await nockBeforeEach()
 
+        const Erc20Lock = {
+          address: '0x0987654321098765432109876543210987654321',
+          expirationDuration: 86400, // 1 day
+          keyPrice: '0.1', // 0.1 Eth
+          maxNumberOfKeys: 100,
+          currencyContractAddress: testERC20ContractAddress,
+        }
+
         let {
           testTransaction,
           testTransactionResult,
           success,
         } = callMethodData(
-          lock.expirationDuration,
+          Erc20Lock.expirationDuration,
           testERC20ContractAddress,
-          utils.toWei(lock.keyPrice, 'ether'),
-          lock.maxNumberOfKeys
+          utils.toWei(Erc20Lock.keyPrice, 'ether'),
+          Erc20Lock.maxNumberOfKeys
         )
 
         transaction = testTransaction
@@ -113,7 +121,7 @@ describe('v02', () => {
 
         setupSuccess()
 
-        await walletService.createLock(lock, owner, testERC20ContractAddress)
+        await walletService.createLock(Erc20Lock, owner)
         await nock.resolveWhenAllNocksUsed()
       })
     })

--- a/unlock-js/src/__tests__/v10/createLock.test.js
+++ b/unlock-js/src/__tests__/v10/createLock.test.js
@@ -98,16 +98,25 @@ describe('v10', () => {
 
         await nockBeforeEach()
 
+        const Erc20Lock = {
+          name: 'ERC20 Lock',
+          address: '0x0987654321098765432109876543210987654321',
+          expirationDuration: 86400, // 1 day
+          keyPrice: '0.1', // 0.1 Eth
+          maxNumberOfKeys: 100,
+          currencyContractAddress: testERC20ContractAddress,
+        }
+
         let {
           testTransaction,
           testTransactionResult,
           success,
         } = callMethodData(
-          lock.expirationDuration,
+          Erc20Lock.expirationDuration,
           testERC20ContractAddress,
-          utils.toWei(lock.keyPrice, 'ether'),
-          lock.maxNumberOfKeys,
-          lock.name
+          utils.toWei(Erc20Lock.keyPrice, 'ether'),
+          Erc20Lock.maxNumberOfKeys,
+          Erc20Lock.name
         )
 
         transaction = testTransaction
@@ -116,7 +125,7 @@ describe('v10', () => {
 
         setupSuccess()
 
-        await walletService.createLock(lock, owner, testERC20ContractAddress)
+        await walletService.createLock(Erc20Lock, owner)
         await nock.resolveWhenAllNocksUsed()
       })
     })

--- a/unlock-js/src/v02/createLock.js
+++ b/unlock-js/src/v02/createLock.js
@@ -1,19 +1,21 @@
 import ethersUtils from '../utils'
 import { GAS_AMOUNTS, ETHERS_MAX_UINT } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import { UNLIMITED_KEYS_COUNT } from '../../lib/constants'
+import { UNLIMITED_KEYS_COUNT, ZERO } from '../../lib/constants'
 
 /**
  * Creates a lock on behalf of the user, using version v0
  * @param {PropTypes.lock} lock
  * @param {PropTypes.address} owner
  */
-export default async function(lock, owner, currencyContractAddress) {
+export default async function(lock, owner) {
   const unlockContract = await this.getUnlockContract()
   let maxNumberOfKeys = lock.maxNumberOfKeys
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
     maxNumberOfKeys = ETHERS_MAX_UINT
   }
+  let currencyContractAddress = lock.currencyContractAddress || ZERO
+
   let transactionPromise
   try {
     transactionPromise = unlockContract.functions[

--- a/unlock-js/src/v10/createLock.js
+++ b/unlock-js/src/v10/createLock.js
@@ -1,19 +1,21 @@
 import ethersUtils from '../utils'
 import { GAS_AMOUNTS, ETHERS_MAX_UINT } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import { UNLIMITED_KEYS_COUNT } from '../../lib/constants'
+import { UNLIMITED_KEYS_COUNT, ZERO } from '../../lib/constants'
 
 /**
  * Creates a lock on behalf of the user, using version v10
  * @param {PropTypes.lock} lock
  * @param {PropTypes.address} owner
  */
-export default async function(lock, owner, currencyContractAddress) {
+export default async function(lock, owner) {
   const unlockContract = await this.getUnlockContract()
   let maxNumberOfKeys = lock.maxNumberOfKeys
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
     maxNumberOfKeys = ETHERS_MAX_UINT
   }
+  let currencyContractAddress = lock.currencyContractAddress || ZERO
+
   let transactionPromise
   try {
     const lockName = lock.name || 'New Lock'

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers'
 import UnlockService from './unlockService'
 import FetchJsonProvider from './FetchJsonProvider'
-import { GAS_AMOUNTS, ZERO } from './constants'
+import { GAS_AMOUNTS } from './constants'
 import utils from './utils'
 
 /**
@@ -125,11 +125,10 @@ export default class WalletService extends UnlockService {
    * Creates a lock on behalf of the user.
    * @param {PropTypes.lock} lock
    * @param {PropTypes.address} owner
-   * @param {PropTypes.address} currencyContract : The address of the denominating contract
    */
-  async createLock(lock, owner, currencyContract = ZERO) {
+  async createLock(lock, owner) {
     const version = await this.unlockContractAbiVersion()
-    return version.createLock.bind(this)(lock, owner, currencyContract)
+    return version.createLock.bind(this)(lock, owner)
   }
 
   /**


### PR DESCRIPTION
# Description

This will make integration slightly easier on the creator dashboard and also allows us to not "break" the API (even though we had defaults in place)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread