### PR TITLE
add ready listening, don't post network if there is none cached

### DIFF
--- a/paywall/src/__tests__/data-iframe/postOffice.test.js
+++ b/paywall/src/__tests__/data-iframe/postOffice.test.js
@@ -8,6 +8,7 @@ import {
   POST_MESSAGE_LOCKED,
   POST_MESSAGE_UNLOCKED,
   POST_MESSAGE_ERROR,
+  POST_MESSAGE_READY,
 } from '../../paywall-builder/constants'
 import {
   setAccount,
@@ -71,6 +72,22 @@ describe('data iframe postOffice', () => {
         makeWindow()
 
         updater = postOffice(fakeWindow, 12)
+      })
+
+      it('should send POST_MESSAGE_READY on ready', done => {
+        expect.assertions(1)
+
+        fakeTarget.postMessage = (...args) => {
+          expect(args).toEqual([
+            {
+              type: POST_MESSAGE_READY,
+              payload: undefined,
+            },
+            'http://fun.times',
+          ])
+          done()
+        }
+        updater('ready')
       })
 
       it('walletModal notifies the main window that a wallet popup is active', done => {
@@ -415,6 +432,23 @@ describe('data iframe postOffice', () => {
           }
 
           updater('locks')
+        })
+      })
+
+      describe('no cache present', () => {
+        beforeEach(() => {
+          makeWindow()
+
+          updater = postOffice(fakeWindow, 12)
+          fakeTarget.postMessage = jest.fn()
+        })
+
+        it('should not post a network change if there is no cache', async () => {
+          expect.assertions(1)
+
+          await updater('network')
+
+          expect(fakeTarget.postMessage).not.toHaveBeenCalled()
         })
       })
     })

--- a/paywall/src/data-iframe/postOffice.js
+++ b/paywall/src/data-iframe/postOffice.js
@@ -8,6 +8,7 @@ import {
   POST_MESSAGE_UPDATE_NETWORK,
   POST_MESSAGE_UPDATE_WALLET,
   POST_MESSAGE_ERROR,
+  POST_MESSAGE_READY,
 } from '../paywall-builder/constants'
 import { getFormattedCacheValues } from './cacheHandler'
 
@@ -57,6 +58,9 @@ export default function postOffice(window, requiredConfirmations) {
     walletModal() {
       postMessage(POST_MESSAGE_UPDATE_WALLET)
     },
+    ready() {
+      postMessage(POST_MESSAGE_READY)
+    },
     error(error) {
       postMessage(POST_MESSAGE_ERROR, error)
     },
@@ -68,6 +72,9 @@ export default function postOffice(window, requiredConfirmations) {
       requiredConfirmations
     )
     switch (update) {
+      case 'ready':
+        actions.ready()
+        break
       case 'locks':
         {
           actions.locks(cachedData.locks)
@@ -91,6 +98,7 @@ export default function postOffice(window, requiredConfirmations) {
         actions[update](cachedData[update])
         break
       case 'network':
+        if (cachedData.networkId === null) return
         actions.network(cachedData.networkId)
         break
       case 'walletModal':


### PR DESCRIPTION
# Description

This PR enables the `'ready'` update, which instructs the main window to send the paywall config, without which we can do nothing. In addition, it prevents sending an invalid network value

# Issues

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
