### PR TITLE
show the checkout UI iframe while we are confirming

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
@@ -133,12 +133,12 @@ describe('setupPostOffice', () => {
   it('responds to POST_MESSAGE_UNLOCKED by sending unlocked to the UI iframe', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED)
+    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
 
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
         type: POST_MESSAGE_UNLOCKED,
-        payload: undefined,
+        payload: ['lock'],
       },
       'http://paywall'
     )
@@ -147,7 +147,7 @@ describe('setupPostOffice', () => {
   it('responds to POST_MESSAGE_UNLOCKED by dispatching unlockProtocol event', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED)
+    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
 
     expect(fakeWindow.dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -157,12 +157,29 @@ describe('setupPostOffice', () => {
     )
   })
 
-  it('responds to POST_MESSAGE_UNLOCKED by hiding the checkout UI', () => {
+  it('responds to POST_MESSAGE_UNLOCKED by not hiding the checkout UI if the key is not confirmed', () => {
     expect.assertions(1)
 
     fakeUIIframe.className = 'unlock start show'
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED)
+    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
+
+    expect(fakeUIIframe.className).toBe('unlock start show')
+  })
+
+  it('responds to POST_MESSAGE_UNLOCKED by hiding the checkout UI if the key is confirmed', () => {
+    expect.assertions(1)
+
+    fakeUIIframe.className = 'unlock start show'
+
+    sendMessage(fakeDataIframe, POST_MESSAGE_UPDATE_LOCKS, {
+      lock: {
+        key: {
+          status: 'valid',
+        },
+      },
+    })
+    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
 
     expect(fakeUIIframe.className).toBe('unlock start')
   })


### PR DESCRIPTION
# Description

This ensures the checkout iframe is visible while we are confirming, and hidden afterwards. We may elect to change this behavior in order to show the optimistic unlocking flag and time left as per Sascha's design.

This also moves to using `mainWindowPostOffice` since this is the exact case it was designed for.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
