### PR TITLE
Move unlockProvider into unlock-js, with some changes

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 0.2.0
+Introducing unlock-provider to enable use of user accounts
+
 ## 0.1.5
 
 - Yielding the Lock version on getLock, as publicLockVersion

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/unlockProvider.test.js
+++ b/unlock-js/src/__tests__/unlockProvider.test.js
@@ -1,6 +1,29 @@
 import UnlockProvider from '../unlockProvider'
 
-const Wallet = require('ethers').Wallet
+const key = {
+  id: 'fb1280c0-d646-4e40-9550-7026b1be504a',
+  address: '88a5c2d9919e46f883eb62f7b8dd9d0cc45bc290',
+  Crypto: {
+    kdfparams: {
+      dklen: 32,
+      p: 1,
+      salt: 'bbfa53547e3e3bfcc9786a2cbef8504a5031d82734ecef02153e29daeed658fd',
+      r: 8,
+      n: 262144,
+    },
+    kdf: 'scrypt',
+    ciphertext:
+      '10adcc8bcaf49474c6710460e0dc974331f71ee4c7baa7314b4a23d25fd6c406',
+    mac: '1cf53b5ae8d75f8c037b453e7c3c61b010225d916768a6b145adf5cf9cb3a703',
+    cipher: 'aes-128-ctr',
+    cipherparams: {
+      iv: '1dcdf13e49cea706994ed38804f6d171',
+    },
+  },
+  version: 3,
+}
+
+const password = 'foo'
 
 const rpc = method => ({
   id: 1, // except for `method` these are just dummy values of no import
@@ -9,21 +32,21 @@ const rpc = method => ({
 })
 
 describe('Unlock Provider', () => {
-  let wallet
   let provider
-  beforeEach(() => {
+  beforeEach(async () => {
     const send = jest.fn((_, cb) => cb(null, 'a response'))
-    wallet = Wallet.createRandom()
     // TODO: Mock the fallback provider in a better way.
     provider = new UnlockProvider({ send, _ethersType: 'Provider' })
-    provider.connect(wallet)
+    await provider.connect({ key, password })
   })
 
   it('should respond to eth_account with an array containing only `this.wallet.address` after being initialized', done => {
     expect.assertions(2)
     provider.send(rpc('eth_accounts'), (_, data) => {
       expect(data.result).toHaveLength(1)
-      expect(data.result[0]).toBe(wallet.address)
+      expect(data.result[0]).toEqual(
+        '0x88a5C2d9919e46F883EB62F7b8Dd9d0CC45bc290'
+      )
       done()
     })
   })

--- a/unlock-js/src/__tests__/unlockProvider.test.js
+++ b/unlock-js/src/__tests__/unlockProvider.test.js
@@ -1,0 +1,38 @@
+import UnlockProvider from '../unlockProvider'
+
+const Wallet = require('ethers').Wallet
+
+const rpc = method => ({
+  id: 1, // except for `method` these are just dummy values of no import
+  jsonrpc: 3,
+  method,
+})
+
+describe('Unlock Provider', () => {
+  let wallet
+  let provider
+  beforeEach(() => {
+    const send = jest.fn((_, cb) => cb(null, 'a response'))
+    wallet = Wallet.createRandom()
+    // TODO: Mock the fallback provider in a better way.
+    provider = new UnlockProvider({ send, _ethersType: 'Provider' })
+    provider.connect(wallet)
+  })
+
+  it('should respond to eth_account with an array containing only `this.wallet.address` after being initialized', done => {
+    expect.assertions(2)
+    provider.send(rpc('eth_accounts'), (_, data) => {
+      expect(data.result).toHaveLength(1)
+      expect(data.result[0]).toBe(wallet.address)
+      done()
+    })
+  })
+
+  it('should call the fallback provider for any method it does not implement', done => {
+    expect.assertions(1)
+    provider.send(rpc('not_a_real_method'), () => {
+      expect(provider.fallbackProvider.send).toHaveBeenCalled()
+      done()
+    })
+  })
+})

--- a/unlock-js/src/index.js
+++ b/unlock-js/src/index.js
@@ -7,3 +7,4 @@ export {
 } from './accounts'
 export { getCurrentProvider, getWeb3Provider } from './providers'
 export { default as deploy } from './deploy'
+export { default as UnlockProvider } from './unlockProvider'

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -1,0 +1,50 @@
+// UnlockProvider implements a subset of Web3 provider functionality, sufficient
+// to allow us to use it as a stand-in for MetaMask or other Web3 integration in
+// the browser.
+export default class UnlockProvider {
+  constructor(fallbackProvider) {
+    this.fallbackProvider = fallbackProvider
+    this.ready = false
+    this.wallet = null
+  }
+
+  connect(wallet) {
+    this.wallet = wallet
+    wallet.connect(this.fallbackProvider)
+    this.ready = true
+  }
+
+  disconnect() {
+    return true
+  }
+
+  async eth_accounts(respond) {
+    // Must always return an array of addresses
+    if (this.wallet) {
+      respond([this.wallet.address])
+    } else {
+      respond([])
+    }
+  }
+
+  send(args, cb) {
+    const { id, jsonrpc, method } = args
+    // Calling respond with some argument will call the callback with
+    // a "fake" JSON-RPC response constructed by the provider.
+    const respond = result => {
+      cb(null, {
+        id,
+        jsonrpc,
+        result,
+      })
+    }
+
+    try {
+      return this[method](respond)
+    } catch (err) {
+      // We haven't implemented this method, defer to the fallback provider.
+      // TODO: Catch methods we don't want to dispatch and throw an error
+      return this.fallbackProvider.send(args, cb)
+    }
+  }
+}

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -1,3 +1,5 @@
+import { getAccountFromPrivateKey } from './accounts'
+
 // UnlockProvider implements a subset of Web3 provider functionality, sufficient
 // to allow us to use it as a stand-in for MetaMask or other Web3 integration in
 // the browser.
@@ -8,10 +10,20 @@ export default class UnlockProvider {
     this.wallet = null
   }
 
-  connect(wallet) {
-    this.wallet = wallet
-    wallet.connect(this.fallbackProvider)
-    this.ready = true
+  // You should be able to just pass the action for
+  // GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD into here
+  async connect({ key, password }) {
+    try {
+      this.wallet = await getAccountFromPrivateKey(key, password)
+      this.wallet.connect(this.fallbackProvider)
+      this.ready = true
+
+      return true
+    } catch (err) {
+      // decryption failed (bad password?)
+      // Possible also that wallet couldn't connect with provider?
+      throw err
+    }
   }
 
   disconnect() {


### PR DESCRIPTION
# Description
This is the basic unlock-provider that we had in `unlock-app`, now migrated to `unlock-js`. It is only barely more sophisticated than the one in the app. The major difference is that it has a connect method which sets the wallet (we would pass this in after decrypting a stored private key, thus activating the provider).

The connect method is designed such that it should be sufficient to just pass in the action from `GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD`

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
