### PR TITLE
configuration to allow building with postMessage debugging

### DIFF
--- a/paywall/data-iframe.1.0.webpack.config.js
+++ b/paywall/data-iframe.1.0.webpack.config.js
@@ -4,6 +4,7 @@ const webpack = require('webpack')
 const dotenv = require('dotenv')
 
 const unlockEnv = process.env.UNLOCK_ENV || 'dev'
+const debug = process.env.DEBUG ? 1 : 0
 
 dotenv.config({
   path: path.resolve(__dirname, '..', `.env.${unlockEnv}.local`),
@@ -43,6 +44,7 @@ module.exports = () => {
     plugins: [
       new webpack.DefinePlugin({
         'process.env.UNLOCK_ENV': "'" + unlockEnv + "'",
+        'process.env.DEBUG': debug,
         'process.env.PAYWALL_URL':
           "'" + requiredConfigVariables.paywallUrl + "'",
         'process.env.LOCKSMITH_URI':

--- a/paywall/next.config.js
+++ b/paywall/next.config.js
@@ -23,6 +23,7 @@ const requiredConfigVariables = {
 
 const optionalConfigVariables = {
   httpProvider: process.env.HTTP_PROVIDER,
+  debugMode: process.env.DEBUG,
 }
 
 Object.keys(requiredConfigVariables).forEach(configVariableName => {

--- a/paywall/package.json
+++ b/paywall/package.json
@@ -15,8 +15,8 @@
     "svg-2-components": "./node_modules/@svgr/cli/bin/svgr --title-prop --no-dimensions --template src/components/interface/svg/template.js --no-dimensions -d src/components/interface/svg/ src/static/images/svg/",
     "build-paywall": "cross-env NODE_ENV=production rollup -c rollup.paywall.config.js",
     "build-checkout": "npm run build-unlock.1.0.js && npm run build-data-iframe.1.0.js",
-    "build-unlock.1.0.js": "webpack --config unlock.1.0.js.webpack.config.js --env.UNLOCK_ENV=$UNLOCK_ENV --env.PAYWALL_URL=$PAYWALL_URL",
-    "build-data-iframe.1.0.js": "webpack --config data-iframe.1.0.webpack.config.js --env.UNLOCK_ENV=$UNLOCK_ENV --env.PAYWALL_URL=$PAYWALL_URL --env.LOCKSMITH_URI=$LOCKSMITH_URI --env.READ_ONLY_PROVIDER=$READ_ONLY_PROVIDER",
+    "build-unlock.1.0.js": "webpack --config unlock.1.0.js.webpack.config.js",
+    "build-data-iframe.1.0.js": "webpack --config data-iframe.1.0.webpack.config.js",
     "storybook": "start-storybook -p 9002 -c .storybook -s .",
     "ci": "npm run lint && npm test"
   },

--- a/paywall/src/config.js
+++ b/paywall/src/config.js
@@ -29,6 +29,7 @@ export default function configure(
 ) {
   const isServer = typeof window === 'undefined'
   const isInIframe = inIframe(useWindow)
+  const debugMode = runtimeConfig.debugMode
 
   const env = runtimeConfig.unlockEnv
   const locksmithUri = runtimeConfig.locksmithUri || 'http://0.0.0.0:8080'
@@ -131,5 +132,6 @@ export default function configure(
     unlockAddress,
     services,
     supportedProviders,
+    debugMode,
   }
 }

--- a/paywall/unlock.1.0.js.webpack.config.js
+++ b/paywall/unlock.1.0.js.webpack.config.js
@@ -4,6 +4,7 @@ var path = require('path')
 const webpack = require('webpack')
 
 const unlockEnv = process.env.UNLOCK_ENV || 'dev'
+const debug = process.env.DEBUG ? 1 : 0
 
 dotenv.config({
   path: path.resolve(__dirname, '..', `.env.${unlockEnv}.local`),
@@ -48,6 +49,7 @@ module.exports = () => {
     plugins: [
       new webpack.DefinePlugin({
         'process.env.UNLOCK_ENV': "'" + unlockEnv + "'",
+        'process.env.DEBUG': debug,
         'process.env.PAYWALL_URL':
           "'" + requiredConfigVariables.paywallUrl + "'",
       }),


### PR DESCRIPTION
# Description

In order to make debugging the new architecture for the paywall stuff possible, this adds configuration that will enable debugging. Inside the `.min.js` scripts, code such as the following:

```js
if (process.env.DEBUG) {
 ...
}
```

will actually be stripped by webpack's dead code removal if `DEBUG` is not truthy. Thus, this will allow simply turning on debugging without affecting any runtime performance with:

```
DEBUG=1 npm run dev
```

In my testing, for instance, `unlock.min.js` with debugging (PR forthcoming) is 11.8k. When compiled without debugging, it is 11.3k

*Note: also contained in this PR is the removal of the superfluous `--env.BLAH=$BLAH` stuff because we don't use that any longer to build the environment*

# Issues

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
