### PR TITLE
unlock-provider needs to take a URL to construct the provider from

### DIFF
--- a/unlock-js/src/__tests__/unlockProvider.test.js
+++ b/unlock-js/src/__tests__/unlockProvider.test.js
@@ -1,5 +1,16 @@
 import UnlockProvider from '../unlockProvider'
 
+const ethers = require.requireActual('ethers')
+
+function provider() {
+  return {
+    send: jest.fn((_, cb) => cb(null, 'a response')),
+    _ethersType: 'Provider',
+  }
+}
+
+ethers.providers.JsonRpcProvider = provider
+
 const key = {
   id: 'fb1280c0-d646-4e40-9550-7026b1be504a',
   address: '88a5c2d9919e46f883eb62f7b8dd9d0cc45bc290',
@@ -34,9 +45,8 @@ const rpc = method => ({
 describe('Unlock Provider', () => {
   let provider
   beforeEach(async () => {
-    const send = jest.fn((_, cb) => cb(null, 'a response'))
-    // TODO: Mock the fallback provider in a better way.
-    provider = new UnlockProvider({ send, _ethersType: 'Provider' })
+    const readOnlyProvider = 'http://localhost:8545'
+    provider = new UnlockProvider({ readOnlyProvider })
     await provider.connect({ key, password })
   })
 

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -5,9 +5,9 @@ import { getAccountFromPrivateKey } from './accounts'
 // to allow us to use it as a stand-in for MetaMask or other Web3 integration in
 // the browser.
 export default class UnlockProvider {
-  constructor(readOnlyProviderUrl) {
+  constructor({ readOnlyProvider }) {
     this.fallbackProvider = new ethers.providers.JsonRpcProvider(
-      readOnlyProviderUrl
+      readOnlyProvider
     )
     this.ready = false
     this.wallet = null

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -1,11 +1,14 @@
+import { ethers } from 'ethers'
 import { getAccountFromPrivateKey } from './accounts'
 
 // UnlockProvider implements a subset of Web3 provider functionality, sufficient
 // to allow us to use it as a stand-in for MetaMask or other Web3 integration in
 // the browser.
 export default class UnlockProvider {
-  constructor(fallbackProvider) {
-    this.fallbackProvider = fallbackProvider
+  constructor(readOnlyProviderUrl) {
+    this.fallbackProvider = new ethers.providers.JsonRpcProvider(
+      readOnlyProviderUrl
+    )
     this.ready = false
     this.wallet = null
   }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR sets up `unlock-provider` correctly, since it needs to construct a read-only provider itself using ethers.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #2414

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
