### PR TITLE
Add a method that handles eth_signTypedData

### DIFF
--- a/unlock-js/src/__tests__/unlockProvider.test.js
+++ b/unlock-js/src/__tests__/unlockProvider.test.js
@@ -4,7 +4,7 @@ const ethers = require.requireActual('ethers')
 
 function provider() {
   return {
-    send: jest.fn((_, cb) => cb(null, 'a response')),
+    send: jest.fn(() => 'a response'),
     _ethersType: 'Provider',
   }
 }
@@ -36,12 +36,6 @@ const key = {
 
 const password = 'foo'
 
-const rpc = method => ({
-  id: 1, // except for `method` these are just dummy values of no import
-  jsonrpc: 3,
-  method,
-})
-
 describe('Unlock Provider', () => {
   let provider
   beforeEach(async () => {
@@ -50,22 +44,16 @@ describe('Unlock Provider', () => {
     await provider.connect({ key, password })
   })
 
-  it('should respond to eth_account with an array containing only `this.wallet.address` after being initialized', done => {
+  it('should respond to eth_account with an array containing only `this.wallet.address` after being initialized', async () => {
     expect.assertions(2)
-    provider.send(rpc('eth_accounts'), (_, data) => {
-      expect(data.result).toHaveLength(1)
-      expect(data.result[0]).toEqual(
-        '0x88a5C2d9919e46F883EB62F7b8Dd9d0CC45bc290'
-      )
-      done()
-    })
+    const accounts = await provider.send('eth_accounts')
+    expect(accounts).toHaveLength(1)
+    expect(accounts[0]).toEqual('0x88a5C2d9919e46F883EB62F7b8Dd9d0CC45bc290')
   })
 
-  it('should call the fallback provider for any method it does not implement', done => {
+  it('should call the fallback provider for any method it does not implement', async () => {
     expect.assertions(1)
-    provider.send(rpc('not_a_real_method'), () => {
-      expect(provider.fallbackProvider.send).toHaveBeenCalled()
-      done()
-    })
+    await provider.send('not_a_real_method')
+    expect(provider.fallbackProvider.send).toHaveBeenCalled()
   })
 })

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -33,33 +33,22 @@ export default class UnlockProvider {
     return true
   }
 
-  async eth_accounts(respond) {
+  async eth_accounts() {
     // Must always return an array of addresses
     if (this.wallet) {
-      respond([this.wallet.address])
+      return [this.wallet.address]
     } else {
-      respond([])
+      return []
     }
   }
 
-  send(args, cb) {
-    const { id, jsonrpc, method } = args
-    // Calling respond with some argument will call the callback with
-    // a "fake" JSON-RPC response constructed by the provider.
-    const respond = result => {
-      cb(null, {
-        id,
-        jsonrpc,
-        result,
-      })
-    }
-
+  async send(method, params) {
     try {
-      return this[method](respond)
+      return this[method](method, params)
     } catch (err) {
       // We haven't implemented this method, defer to the fallback provider.
       // TODO: Catch methods we don't want to dispatch and throw an error
-      return this.fallbackProvider.send(args, cb)
+      return this.fallbackProvider.send(method, params)
     }
   }
 }

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -42,6 +42,13 @@ export default class UnlockProvider {
     }
   }
 
+  async eth_signTypedData(params) {
+    // params is [ account, data ]
+    // we don't need account
+    const data = params[1]
+    return this.wallet.signMessage(data)
+  }
+
   async send(method, params) {
     try {
       return this[method](method, params)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a method to respond to the `eth_signTypedData` JSON-RPC call. In the process of doing this, I noticed that the way `unlock-provider` was structured no longer meshes well with `walletService`, so this PR also makes `unlock-provider` consistent with the new way of working.

@akeem I would appreciate a sanity check that I am doing the correct kind of signature here.

Relevant docs:
https://docs.ethers.io/ethers.js/html/api-wallet.html#signing
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#eth_signtypeddata

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #2414

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
