### PR TITLE
fix potential race where data is sent before config is sent to checkout UI

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
@@ -13,6 +13,7 @@ import {
   POST_MESSAGE_ERROR,
   POST_MESSAGE_UPDATE_WALLET,
   POST_MESSAGE_READY_WEB3,
+  POST_MESSAGE_SEND_UPDATES,
 } from '../../paywall-builder/constants'
 
 describe('setupPostOffice', () => {
@@ -107,16 +108,25 @@ describe('setupPostOffice', () => {
   })
 
   it('responds to POST_MESSAGE_READY by sending the config to both iframes', () => {
-    expect.assertions(4)
+    expect.assertions(5)
 
     sendMessage(fakeDataIframe, POST_MESSAGE_READY)
     sendMessage(fakeUIIframe, POST_MESSAGE_READY)
 
-    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledTimes(1)
-    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledWith(
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledTimes(2)
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
+      1,
       {
         type: POST_MESSAGE_CONFIG,
         payload: fakeWindow.unlockProtocolConfig,
+      },
+      'http://paywall'
+    )
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
+      2,
+      {
+        type: POST_MESSAGE_SEND_UPDATES,
+        payload: undefined,
       },
       'http://paywall'
     )

--- a/paywall/src/unlock.js/setupPostOffices.js
+++ b/paywall/src/unlock.js/setupPostOffices.js
@@ -12,6 +12,7 @@ import {
   POST_MESSAGE_ERROR,
   POST_MESSAGE_UPDATE_WALLET,
   POST_MESSAGE_DISMISS_CHECKOUT,
+  POST_MESSAGE_SEND_UPDATES,
 } from '../paywall-builder/constants'
 import dispatchEvent from './dispatchEvent'
 import web3Proxy from '../paywall-builder/web3Proxy'
@@ -97,6 +98,8 @@ export default function setupPostOffices(window, dataIframe, CheckoutUIIframe) {
   addCheckoutMessageHandler(POST_MESSAGE_READY, (_, respond) => {
     if (window.unlockProtocolConfig) {
       respond(POST_MESSAGE_CONFIG, window.unlockProtocolConfig)
+      // trigger a send of the current state
+      dataPostOffice(POST_MESSAGE_SEND_UPDATES)
     }
   })
 


### PR DESCRIPTION
# Description

In testing with throttled CPU and/or network, it turned out it was possible that updates could be sent out-of-order, so that the locks where sent after the config. This is a problem for the Checkout UI, which needs the locks after the config, otherwise it can't validate that the locks sent match the configuration (in terms of which locks it should expect to receive).

This fixes it simply by requesting the current data be sent to the checkout UI as soon as configuration is sent.

# Issues

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
