### PR TITLE
add logging of postMessage messages if DEBUG=1 in checkout UI

### DIFF
--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -43,9 +43,11 @@ export default function useListenForPostMessage({
   validator = false,
   defaultValue,
   getValue = (value, defaults) => value || defaults,
+  local = 'iframe',
+  remote = 'main window', // this is configurable because of web3ProxyProvider
 }) {
   const window = useWindow()
-  const { isInIframe, isServer } = useConfig()
+  const { isInIframe, isServer, debugMode } = useConfig()
   const parent = window && window.parent
   const [data, setData] = useState(defaultValue)
 
@@ -68,6 +70,15 @@ export default function useListenForPostMessage({
       // optional validator
       if (!validator || (validator && validator(event.data.payload))) {
         const newValue = getValue(event.data.payload, defaultValue)
+        if (debugMode) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `[uLFPM] ${local} <-- ${remote}`,
+            type,
+            event.data.payload,
+            origin
+          )
+        }
         // this comparison is designed to avoid the need for deep equality check
         // If the configuration grows considerably, using some kind of traversing equality check
         // will make more sense
@@ -91,6 +102,9 @@ export default function useListenForPostMessage({
     type,
     validator,
     window,
+    local,
+    debugMode,
+    remote,
   ])
 
   return data

--- a/paywall/src/hooks/browser/usePostMessage.js
+++ b/paywall/src/hooks/browser/usePostMessage.js
@@ -3,9 +3,9 @@ import useConfig from '../utils/useConfig'
 import { getRouteFromWindow } from '../../utils/routes'
 import useWindow from './useWindow'
 
-export default function usePostMessage() {
+export default function usePostMessage(local = 'iframe') {
   const window = useWindow()
-  const { isInIframe, isServer } = useConfig()
+  const { isInIframe, isServer, debugMode } = useConfig()
   // track the last message sent. useRef is the equivalent to using this.lastMessage in a class-based component
   const lastMessage = useRef()
   const postMessage = useCallback(
@@ -20,9 +20,13 @@ export default function usePostMessage() {
       )
         return
       lastMessage.current = message
+      if (debugMode) {
+        // eslint-disable-next-line no-console
+        console.log(`[uPM] ${local} --> main window`, message, origin)
+      }
       window.parent.postMessage(message, origin)
     },
-    [isServer, isInIframe, window]
+    [window, isServer, isInIframe, debugMode, local]
   )
   return { postMessage }
 }


### PR DESCRIPTION
# Description

This adds auto-logging of postMessage to the console if `DEBUG=1 npm run dev`. It also fixes some linting errors with the hooks.

I did not include tests since this does not affect production at all, and is super-straightforward, but would be happy to add them if you feel it is necessary.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
