### PR TITLE
fix incorrect usage of POST_MESSAGE_SEND_UPDATES

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
@@ -108,12 +108,12 @@ describe('setupPostOffice', () => {
   })
 
   it('responds to POST_MESSAGE_READY by sending the config to both iframes', () => {
-    expect.assertions(5)
+    expect.assertions(8)
 
     sendMessage(fakeDataIframe, POST_MESSAGE_READY)
     sendMessage(fakeUIIframe, POST_MESSAGE_READY)
 
-    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledTimes(2)
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledTimes(5)
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
       1,
       {
@@ -126,7 +126,31 @@ describe('setupPostOffice', () => {
       2,
       {
         type: POST_MESSAGE_SEND_UPDATES,
-        payload: undefined,
+        payload: 'network',
+      },
+      'http://paywall'
+    )
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
+      3,
+      {
+        type: POST_MESSAGE_SEND_UPDATES,
+        payload: 'account',
+      },
+      'http://paywall'
+    )
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
+      4,
+      {
+        type: POST_MESSAGE_SEND_UPDATES,
+        payload: 'balance',
+      },
+      'http://paywall'
+    )
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
+      5,
+      {
+        type: POST_MESSAGE_SEND_UPDATES,
+        payload: 'locks',
       },
       'http://paywall'
     )

--- a/paywall/src/unlock.js/setupPostOffices.js
+++ b/paywall/src/unlock.js/setupPostOffices.js
@@ -99,7 +99,10 @@ export default function setupPostOffices(window, dataIframe, CheckoutUIIframe) {
     if (window.unlockProtocolConfig) {
       respond(POST_MESSAGE_CONFIG, window.unlockProtocolConfig)
       // trigger a send of the current state
-      dataPostOffice(POST_MESSAGE_SEND_UPDATES)
+      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'network')
+      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'account')
+      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'balance')
+      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'locks')
     }
   })
 


### PR DESCRIPTION
# Description

The last fix sent worked by a fluke (config arrived before locks). This is the proper fix, which uses `POST_MESSAGE_SEND_UPDATES` to properly request the cached data

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
