### PR TITLE
remove brief flash of ads in ad remover paywall

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
@@ -108,12 +108,12 @@ describe('setupPostOffice', () => {
   })
 
   it('responds to POST_MESSAGE_READY by sending the config to both iframes', () => {
-    expect.assertions(5)
+    expect.assertions(8)
 
     sendMessage(fakeDataIframe, POST_MESSAGE_READY)
     sendMessage(fakeUIIframe, POST_MESSAGE_READY)
 
-    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledTimes(2)
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledTimes(5)
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
       1,
       {
@@ -126,7 +126,31 @@ describe('setupPostOffice', () => {
       2,
       {
         type: POST_MESSAGE_SEND_UPDATES,
-        payload: undefined,
+        payload: 'network',
+      },
+      'http://paywall'
+    )
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
+      3,
+      {
+        type: POST_MESSAGE_SEND_UPDATES,
+        payload: 'account',
+      },
+      'http://paywall'
+    )
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
+      4,
+      {
+        type: POST_MESSAGE_SEND_UPDATES,
+        payload: 'balance',
+      },
+      'http://paywall'
+    )
+    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
+      5,
+      {
+        type: POST_MESSAGE_SEND_UPDATES,
+        payload: 'locks',
       },
       'http://paywall'
     )

--- a/paywall/src/__tests__/unlock.js/startup.test.js
+++ b/paywall/src/__tests__/unlock.js/startup.test.js
@@ -1,0 +1,152 @@
+import startup from '../../unlock.js/startup'
+
+describe('unlock.js startup', () => {
+  let fakeWindow
+  let call
+  let fakeDataIframe
+  let fakeCheckoutIframe
+
+  beforeEach(() => {
+    call = 0
+    fakeDataIframe = {
+      name: 'data iframe',
+      origin: 'http://paywall',
+      setAttribute: jest.fn(),
+      contentWindow: {
+        postMessage: jest.fn(),
+      },
+    }
+    fakeCheckoutIframe = {
+      name: 'checkout iframe',
+      origin: 'http://paywall',
+      setAttribute: jest.fn(),
+      contentWindow: {
+        postMessage: jest.fn(),
+      },
+    }
+    process.env.PAYWALL_URL = 'http://paywall'
+    fakeWindow = {
+      setInterval: jest.fn(),
+      document: {
+        querySelector: jest.fn(),
+        body: {
+          style: {},
+          insertAdjacentElement: jest.fn(),
+        },
+        createElement: jest.fn(() => {
+          if (call++) {
+            return fakeCheckoutIframe
+          }
+          return fakeDataIframe
+        }),
+      },
+      origin: 'http://fun.times',
+      web3: {
+        currentProvider: {
+          send: jest.fn(),
+        },
+      },
+      CustomEvent: window.CustomEvent,
+      dispatchEvent: jest.fn(),
+      unlockProtocolConfig: {
+        config: 'thing',
+      },
+      handlers: {},
+      addEventListener: jest.fn((type, handler) => {
+        fakeWindow.handlers[type] = fakeWindow.handlers[type] || []
+        fakeWindow.handlers[type].push(handler)
+      }),
+      storage: {},
+      localStorage: {
+        getItem: jest.fn(key => fakeWindow.storage[key]),
+        setItem: jest.fn((key, value) => {
+          if (typeof value !== 'string') {
+            throw new Error('localStorage only supports strings')
+          }
+          fakeWindow.storage[key] = value
+        }),
+        removeItem: jest.fn(key => {
+          delete fakeWindow.storage[key]
+        }),
+      },
+    }
+  })
+
+  describe('look for immediate cache of locked state', () => {
+    it('should dispatch locked if the cache is locked', () => {
+      expect.assertions(2)
+
+      fakeWindow.storage['__unlockProtocol.locked'] = 'true'
+
+      startup(fakeWindow)
+
+      const event = fakeWindow.dispatchEvent.mock.calls[0][0]
+      expect(event.type).toBe('unlockProtocol')
+      expect(event.detail).toBe('locked')
+    })
+
+    it('should dispatch unlocked if the cache is unlocked', () => {
+      expect.assertions(2)
+
+      fakeWindow.storage['__unlockProtocol.locked'] = 'false'
+
+      startup(fakeWindow)
+
+      const event = fakeWindow.dispatchEvent.mock.calls[0][0]
+      expect(event.type).toBe('unlockProtocol')
+      expect(event.detail).toBe('unlocked')
+    })
+
+    it('should not dispatch unlocked if the cache is empty', () => {
+      expect.assertions(1)
+
+      startup(fakeWindow)
+
+      expect(fakeWindow.dispatchEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('iframe creation', () => {
+    it('should create a data iframe with the correct URL', () => {
+      expect.assertions(2)
+
+      startup(fakeWindow)
+
+      expect(fakeDataIframe.setAttribute).toHaveBeenCalledWith(
+        'src',
+        'http://paywall/static/dataIframe.html?origin=http%3A%2F%2Ffun.times'
+      )
+      expect(
+        fakeWindow.document.body.insertAdjacentElement
+      ).toHaveBeenNthCalledWith(1, 'afterbegin', fakeDataIframe)
+    })
+
+    it('should create a Checkout UI iframe with the correct URL', () => {
+      expect.assertions(2)
+
+      startup(fakeWindow)
+
+      expect(fakeCheckoutIframe.setAttribute).toHaveBeenCalledWith(
+        'src',
+        'http://paywall/checkout?origin=http%3A%2F%2Ffun.times'
+      )
+      expect(
+        fakeWindow.document.body.insertAdjacentElement
+      ).toHaveBeenNthCalledWith(2, 'afterbegin', fakeCheckoutIframe)
+    })
+  })
+
+  it('should set up the post offices', () => {
+    expect.assertions(1)
+
+    startup(fakeWindow)
+
+    // this is a simple way to test whether setupPostOffices was called
+    // by checking to see if event listeners for postMessage were set up
+    // The 3 are:
+    // - the data iframe post office
+    // - the checkout UI post office
+    // - the Web3ProxyProvider post office
+    expect(fakeWindow.addEventListener).toHaveBeenCalledTimes(3)
+  })
+})

--- a/paywall/src/unlock.js/index.js
+++ b/paywall/src/unlock.js/index.js
@@ -1,20 +1,12 @@
-import { makeIframe, addIframeToDocument } from './iframeManager'
-import setupPostOffices from './setupPostOffices'
+import startup from './startup'
 import '../paywall-builder/iframe.css'
 
-window.onload = () => {
-  const origin = '?origin=' + encodeURIComponent(window.origin)
-
-  const dataIframe = makeIframe(
-    window,
-    process.env.PAYWALL_URL + '/static/dataIframe.html' + origin
-  )
-  addIframeToDocument(window, dataIframe)
-  const checkoutIframe = makeIframe(
-    window,
-    process.env.PAYWALL_URL + '/checkout' + origin
-  )
-  addIframeToDocument(window, checkoutIframe)
-
-  setupPostOffices(window, dataIframe, checkoutIframe)
+if (document.readyState !== 'loading') {
+  // in most cases, we will start up after the document is interactive
+  // so listening for the DOMContentLoaded or load events is superfluous
+  startup(window)
+} else {
+  // if we reach here, the page is sitll loading
+  window.addEventListener('DOMContentLoaded', () => startup(window))
+  window.addEventListener('load', () => startup(window))
 }

--- a/paywall/src/unlock.js/setupPostOffices.js
+++ b/paywall/src/unlock.js/setupPostOffices.js
@@ -99,7 +99,10 @@ export default function setupPostOffices(window, dataIframe, CheckoutUIIframe) {
     if (window.unlockProtocolConfig) {
       respond(POST_MESSAGE_CONFIG, window.unlockProtocolConfig)
       // trigger a send of the current state
-      dataPostOffice(POST_MESSAGE_SEND_UPDATES)
+      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'network')
+      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'account')
+      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'balance')
+      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'locks')
     }
   })
 

--- a/paywall/src/unlock.js/setupPostOffices.js
+++ b/paywall/src/unlock.js/setupPostOffices.js
@@ -113,6 +113,20 @@ export default function setupPostOffices(window, dataIframe, CheckoutUIIframe) {
   // relay the unlocked event both to the main window
   // and to the checkout UI
   addDataMessageHandler(POST_MESSAGE_UNLOCKED, locks => {
+    dispatchEvent(window, 'unlocked')
+    try {
+      // this is a fast cache. The value will only be used
+      // to prevent a flash of ads on startup. If a cheeky
+      // user attempts to prevent display of ads by setting
+      // the localStorage cache, it will only work for a
+      // few milliseconds
+      window.localStorage.setItem(
+        '__unlockProtocol.locked',
+        JSON.stringify(false)
+      )
+    } catch (e) {
+      // ignore
+    }
     CheckoutUIPostOffice(POST_MESSAGE_UNLOCKED, locks)
     if (
       locks.filter(address => {
@@ -125,7 +139,6 @@ export default function setupPostOffices(window, dataIframe, CheckoutUIIframe) {
     ) {
       hideCheckoutModal()
     }
-    dispatchEvent(window, 'unlocked')
   })
 
   // if the user chooses to close the checkout modal, we hide the iframe
@@ -136,8 +149,17 @@ export default function setupPostOffices(window, dataIframe, CheckoutUIIframe) {
   // relay the locked event both to the main window
   // and to the checkout UI
   addDataMessageHandler(POST_MESSAGE_LOCKED, () => {
-    CheckoutUIPostOffice(POST_MESSAGE_LOCKED)
     dispatchEvent(window, 'locked')
+    try {
+      // reset the cache to locked for the next page view
+      window.localStorage.setItem(
+        '__unlockProtocol.locked',
+        JSON.stringify(true)
+      )
+    } catch (e) {
+      // ignore
+    }
+    CheckoutUIPostOffice(POST_MESSAGE_LOCKED)
   })
 
   // relay error messages to the checkout UI

--- a/paywall/src/unlock.js/startup.js
+++ b/paywall/src/unlock.js/startup.js
@@ -1,0 +1,38 @@
+import { makeIframe, addIframeToDocument } from './iframeManager'
+import setupPostOffices from './setupPostOffices'
+import dispatchEvent from './dispatchEvent'
+
+export default function startup(window) {
+  try {
+    // this is a cache for the time between script startup and the full load
+    // of the data iframe. The data iframe will then send down the current
+    // value, overriding this. A bit later, the blockchain handler will update
+    // with the actual value, so this is only used for a few milliseconds
+    const locked = JSON.parse(
+      window.localStorage.getItem('__unlockProtocol.locked')
+    )
+    if (locked === true) {
+      dispatchEvent(window, 'locked')
+    }
+    if (locked === false) {
+      dispatchEvent(window, 'unlocked')
+    }
+  } catch (e) {
+    // ignore
+  }
+
+  const origin = '?origin=' + encodeURIComponent(window.origin)
+
+  const dataIframe = makeIframe(
+    window,
+    process.env.PAYWALL_URL + '/static/dataIframe.html' + origin
+  )
+  addIframeToDocument(window, dataIframe)
+  const checkoutIframe = makeIframe(
+    window,
+    process.env.PAYWALL_URL + '/checkout' + origin
+  )
+  addIframeToDocument(window, checkoutIframe)
+
+  setupPostOffices(window, dataIframe, checkoutIframe)
+}


### PR DESCRIPTION
# Description

This PR removes a brief flash of ads at the start of the ad remover paywall if the user has purchased a key in the past in this browser.

I also took this opportunity to refactor `unlock.js/index.js` to extract the functionality into `unlock.js/start.js` so that it can be easily tested.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
