### PR TITLE
Adds pre-purchase approval to ERC20 Locks

### DIFF
--- a/unlock-js/src/__tests__/erc20.test.js
+++ b/unlock-js/src/__tests__/erc20.test.js
@@ -1,5 +1,9 @@
 import { ethers } from 'ethers'
-import { getErc20BalanceForAddress, getErc20Decimals } from '../erc20'
+import {
+  getErc20BalanceForAddress,
+  getErc20Decimals,
+  approveTransfer,
+} from '../erc20'
 import NockHelper from './helpers/nockHelper'
 import utils from '../utils'
 
@@ -8,6 +12,7 @@ const nock = new NockHelper(endpoint, false /** debug */, false /** record */)
 
 const erc20ContractAddress = '0x591AD9066603f5499d12fF4bC207e2f577448c46'
 const lockContractAddress = '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a'
+const callerAddress = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
 
 const provider = new ethers.providers.JsonRpcProvider(endpoint)
 
@@ -65,6 +70,66 @@ describe('erc20', () => {
         provider
       )
       expect(balance).toEqual('1337')
+    })
+  })
+
+  describe('approveTransfer', () => {
+    it('should dispatch the appropriate transaction', async () => {
+      expect.assertions(2)
+
+      let gas = '0x73b3'
+      let approvalAmount = 2
+      let transactionHash =
+        '0xbb1f660b4a40e1931b1206d15421f364487b494920b2e67152a9ff4c74dcb66d'
+      let transactionData =
+        '0x095ea7b3000000000000000000000000e29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a0000000000000000000000000000000000000000000000000000000000000002'
+
+      nock.accountsAndYield([callerAddress])
+      nock.netVersionAndYield(0)
+      nock.ethGetCodeAndYield(erc20ContractAddress, '0x0')
+      nock.ethEstimateGas(
+        '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+        erc20ContractAddress,
+        transactionData,
+        gas
+      )
+      nock.ethSendTransactionAndYield(
+        {
+          gas: gas,
+          to: erc20ContractAddress,
+          data: transactionData,
+          from: callerAddress,
+        },
+        null,
+        transactionHash
+      )
+
+      nock.ethGetTransactionByHash(transactionHash, {
+        hash: transactionHash,
+        nonce: '0x8',
+        blockHash: null,
+        blockNumber: null,
+        transactionIndex: null,
+        from: callerAddress,
+        to: erc20ContractAddress,
+        value: '0x0',
+        gas: gas,
+        gasPrice: '0x4a817c800',
+        input: transactionData,
+        v: '0x1c',
+        r: '0x4666676244df72f2a2527b30ef7316b7c21e4c70985f968dd6dfeff0f1d0c6b8',
+        s: '0x237f5b5bde381eedd1c016111ca9549beb7742abb7c9a7af25aad3c53f98f792',
+      })
+
+      let result = await approveTransfer(
+        erc20ContractAddress,
+        lockContractAddress,
+        approvalAmount,
+        provider
+      )
+
+      expect(result).toHaveProperty('hash', transactionHash)
+      expect(result).toHaveProperty('data', transactionData)
     })
   })
 })

--- a/unlock-js/src/__tests__/helpers/nockHelper.js
+++ b/unlock-js/src/__tests__/helpers/nockHelper.js
@@ -252,6 +252,20 @@ export class NockHelper {
     )
   }
 
+  ethEstimateGas(from, to, data, result) {
+    return this._jsonRpcRequest(
+      'eth_estimateGas',
+      [
+        {
+          from,
+          to,
+          data,
+        },
+      ],
+      result
+    )
+  }
+
   getTransactionCount(address, count) {
     return this._jsonRpcRequest(
       'eth_getTransactionCount',

--- a/unlock-js/src/__tests__/v10/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v10/purchaseKey.test.js
@@ -3,6 +3,7 @@ import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
+import erc20 from '../../erc20'
 
 const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
@@ -13,6 +14,10 @@ let transaction
 let transactionResult
 let setupSuccess
 let setupFail
+
+jest.mock('../../erc20.js', () => {
+  return { approveTransfer: jest.fn() }
+})
 
 describe('v10', () => {
   describe('purchaseKey', () => {
@@ -27,6 +32,11 @@ describe('v10', () => {
         endpoint,
         nock
       )
+
+      // Reset the mock
+      erc20.approveTransfer = jest.fn(() => {
+        Promise.resolve()
+      })
 
       const callMethodData = prepContract({
         contract: UnlockV10.PublicLock,
@@ -58,6 +68,7 @@ describe('v10', () => {
       walletService._handleMethodCall = jest.fn(() =>
         Promise.resolve(transaction.hash)
       )
+
       const mock = walletService._handleMethodCall
 
       await walletService.purchaseKey(lockAddress, owner, keyPrice)
@@ -72,6 +83,72 @@ describe('v10', () => {
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should call approveTransfer when the lock is an ERC20 lock', async () => {
+      expect.assertions(1)
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      const erc20Address = '0x6f7a54d6629b7416e17fc472b4003ae8ef18ef4c'
+
+      // This is very confusing!
+      // prepContract above will actually nock things that it does not need to nock
+      // The result is that we test the internals of _handleMethodCall in each and
+      // every function which uses it.
+      // We should have great coverage for `_handleMethodCall` and then confidently
+      // mock its behavior inside of each function which actually calls it
+      walletService._handleMethodCall = jest.fn(
+        async sendTransactionPromise => {
+          const result = await sendTransactionPromise
+          await result.wait()
+          return Promise.resolve(transaction.hash)
+        }
+      )
+
+      await walletService.purchaseKey(
+        lockAddress,
+        owner,
+        keyPrice,
+        null,
+        null,
+        erc20Address
+      )
+
+      expect(erc20.approveTransfer).toHaveBeenCalledWith(
+        erc20Address,
+        lockAddress,
+        keyPrice,
+        walletService.provider
+      )
+      await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should not call approveTransfer when the lock is not an ERC20 lock', async () => {
+      expect.assertions(1)
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      // This is very confusing!
+      // prepContract above will actually nock things that it does not need to nock
+      // The result is that we test the internals of _handleMethodCall in each and
+      // every function which uses it.
+      // We should have great coverage for `_handleMethodCall` and then confidently
+      // mock its behavior inside of each function which actually calls it
+      walletService._handleMethodCall = jest.fn(
+        async sendTransactionPromise => {
+          const result = await sendTransactionPromise
+          await result.wait()
+          return Promise.resolve(transaction.hash)
+        }
+      )
+
+      await walletService.purchaseKey(lockAddress, owner, keyPrice)
+
+      expect(erc20.approveTransfer).not.toHaveBeenCalled()
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/erc20.js
+++ b/unlock-js/src/erc20.js
@@ -31,7 +31,26 @@ export async function getErc20Decimals(erc20ContractAddress, provider) {
   return utils.toNumber(decimals)
 }
 
+export async function approveTransfer(
+  erc20ContractAddress,
+  lockContractAddress,
+  value,
+  provider
+) {
+  const contract = new ethers.Contract(
+    erc20ContractAddress,
+    ['function approve(address spender, uint256 value) returns (bool value)'],
+    provider.getSigner()
+  )
+  return contract.approve(lockContractAddress, approvalValue(value))
+}
+
+function approvalValue(value) {
+  return Math.ceil(value)
+}
+
 export default {
+  approveTransfer,
   getErc20BalanceForAddress,
   getErc20Decimals,
 }

--- a/unlock-js/src/v10/purchaseKey.js
+++ b/unlock-js/src/v10/purchaseKey.js
@@ -2,6 +2,7 @@ import Web3Utils from '../utils'
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
 import Errors from '../errors'
+import { approveTransfer } from '../erc20'
 
 /**
  * Purchase a key to a lock by account.
@@ -15,8 +16,19 @@ import Errors from '../errors'
  * @param {string} data
  * @param {string} account
  */
-export default async function(lockAddress, owner, keyPrice) {
+export default async function(
+  lockAddress,
+  owner,
+  keyPrice,
+  account,
+  data,
+  erc20Address
+) {
   const lockContract = await this.getLockContract(lockAddress)
+  if (erc20Address) {
+    await approveTransfer(erc20Address, lockAddress, keyPrice, this.provider)
+  }
+
   let transactionPromise
   try {
     transactionPromise = lockContract['purchaseFor(address)'](owner, {

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -142,10 +142,18 @@ export default class WalletService extends UnlockService {
    * @param {string} keyPrice
    * @param {string} data
    * @param {string} account
+   * @param {string} erc20Address
    */
-  async purchaseKey(lock, owner, keyPrice, account, data = '') {
+  async purchaseKey(lock, owner, keyPrice, account, data = '', erc20Address) {
     const version = await this.lockContractAbiVersion(lock)
-    return version.purchaseKey.bind(this)(lock, owner, keyPrice, account, data)
+    return version.purchaseKey.bind(this)(
+      lock,
+      owner,
+      keyPrice,
+      account,
+      data,
+      erc20Address
+    )
   }
 
   /**


### PR DESCRIPTION
# Description

* Moves getLock & getAddress up in the object hierarchy, supporting downstream usecases.
* Purchase key now requests approval prior to the purchase when an address has been provided

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
