### PR TITLE
retrieving the erc20 token balance for an erc20 locks

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changes
 
+## 0.2.1
+
+- getLock now returns the erc20 balance for erc20 locks
+
 ## 0.2.0
-Introducing unlock-provider to enable use of user accounts
+
+- Introducing unlock-provider to enable use of user accounts
 
 ## 0.1.5
 

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
# Description

This is the last change to unlock-js so we can display ERC20 locks on the dashbaord correctly!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread