### PR TITLE
Ensure container type exists before setting subtype

### DIFF
--- a/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
@@ -298,6 +298,30 @@ describe('localStorage cache', () => {
       )
     })
 
+    it('should save a new sub-value if the primary value does not exist', async () => {
+      expect.assertions(1)
+
+      const key3 = {
+        thing3: 'hi3',
+      }
+
+      await merge({
+        window: fakeWindow,
+        networkId: 123,
+        type: 'keys',
+        subType: 'key3',
+        value: key3,
+      })
+
+      expect(fakeWindow.storage[storageId(123, nullAccount)]).toEqual(
+        JSON.stringify({
+          keys: {
+            key3,
+          },
+        })
+      )
+    })
+
     it('saves a new sub-value, non-account-specific', async () => {
       expect.assertions(1)
 

--- a/paywall/src/data-iframe/cache/localStorage.js
+++ b/paywall/src/data-iframe/cache/localStorage.js
@@ -125,6 +125,7 @@ export async function merge({
   if (value === undefined) {
     delete container[type][subType]
   } else {
+    container[type] = container[type] || {}
     container[type][subType] = value
   }
 


### PR DESCRIPTION
# Description

Blown out of #3546. Fixes localstorage.merge to ensure that the container type exists before setting the subtype.

# Issues

Fixes #3547

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
