### PR TITLE
cachehandler creates keys just-in-time when calling getKeys

### DIFF
--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -200,6 +200,28 @@ describe('cacheHandler', () => {
       expect(keys).toEqual(myKeys)
     })
 
+    it("getKeys, some locks don't have a key", async () => {
+      expect.assertions(1)
+
+      await setLocks(fakeWindow, {
+        ...myLocks,
+        another: {
+          address: 'another',
+        },
+      })
+      const keys = await getKeys(fakeWindow)
+
+      expect(keys).toEqual({
+        ...myKeys,
+        another: {
+          expiration: 0,
+          id: 'another-account',
+          lock: 'another',
+          owner: 'account',
+        },
+      })
+    })
+
     it('getLocks', async () => {
       expect.assertions(1)
 
@@ -284,10 +306,23 @@ describe('cacheHandler', () => {
       expect(await getLocks(fakeWindow)).toEqual(myLocks)
     })
 
-    it('should not return cached keys', async () => {
+    it('should return dummy keys', async () => {
       expect.assertions(1)
 
-      expect(await getKeys(fakeWindow)).toEqual({})
+      expect(await getKeys(fakeWindow)).toEqual({
+        lock: {
+          expiration: 0,
+          id: 'lock-different',
+          lock: 'lock',
+          owner: 'different',
+        },
+        lock2: {
+          expiration: 0,
+          id: 'lock2-different',
+          lock: 'lock2',
+          owner: 'different',
+        },
+      })
     })
 
     it('should not return cached transactions', async () => {
@@ -300,6 +335,13 @@ describe('cacheHandler', () => {
       expect.assertions(2)
 
       const differentKeys = {
+        // a dummy key created just-in-time
+        lock: {
+          expiration: 0,
+          id: 'lock-different',
+          lock: 'lock',
+          owner: 'different',
+        },
         lock2: {
           lock: 'lock2',
           owner: 'different',


### PR DESCRIPTION
# Description

Blown out of #3546. The cache handler now creates keys just in time as needed.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3548 
Refs #3546

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
