### PR TITLE
introducing web3ServiceHub

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/web3ServiceHub.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/web3ServiceHub.test.js
@@ -1,0 +1,228 @@
+import web3ServiceHub from '../../../data-iframe/blockchainHandler/web3ServiceHub'
+import { setTransaction, setAccount } from '../../../data-iframe/cacheHandler'
+import { TRANSACTION_TYPES } from '../../../constants'
+
+describe('web3ServiceHub', () => {
+  let fakeWindow
+  function makeFakeWindow() {
+    fakeWindow = {
+      storage: {},
+      localStorage: {
+        getItem: jest.fn(key => fakeWindow.storage[key]),
+        setItem: jest.fn((key, value) => {
+          if (typeof value !== 'string') {
+            throw new Error('localStorage only supports strings')
+          }
+          fakeWindow.storage[key] = value
+        }),
+        removeItem: jest.fn(key => {
+          delete fakeWindow.storage[key]
+        }),
+      },
+    }
+  }
+
+  beforeEach(() => {
+    makeFakeWindow()
+  })
+
+  it("should set up a listener for 'transaction.updated'", async () => {
+    expect.assertions(1)
+
+    const onChange = () => {}
+    const web3Service = {
+      on: jest.fn(),
+    }
+
+    await web3ServiceHub({
+      web3Service,
+      onChange,
+      window: fakeWindow,
+    })
+
+    expect(web3Service.on).toHaveBeenNthCalledWith(
+      1,
+      'transaction.updated',
+      expect.any(Function)
+    )
+  })
+
+  it("should set up a listener for 'error'", async () => {
+    expect.assertions(1)
+
+    const onChange = () => {}
+    const web3Service = {
+      on: jest.fn(),
+    }
+
+    await web3ServiceHub({
+      web3Service,
+      onChange,
+      window: fakeWindow,
+    })
+
+    expect(web3Service.on).toHaveBeenNthCalledWith(
+      2,
+      'error',
+      expect.any(Function)
+    )
+  })
+
+  describe('transaction.updated listener', () => {
+    let onChange
+    let web3Service
+
+    function getTransactionListener() {
+      return web3Service.on.mock.calls[0][1]
+    }
+    beforeEach(async () => {
+      makeFakeWindow()
+      onChange = jest.fn()
+      web3Service = {
+        on: jest.fn(),
+        getKeyByLockForOwner: (lock, owner) => ({
+          expiration: 123,
+          lock,
+          owner,
+        }),
+      }
+      await setAccount(fakeWindow, 'account')
+    })
+
+    it('should use the cached transaction as a base', async () => {
+      expect.assertions(1)
+
+      await web3ServiceHub({
+        web3Service,
+        onChange,
+        window: fakeWindow,
+      })
+
+      const listener = getTransactionListener()
+
+      await setTransaction(fakeWindow, {
+        hash: 'hi',
+        thing: 'value',
+      })
+
+      await listener('hi', { another: 'thing' })
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transaction: {
+            hash: 'hi',
+            thing: 'value',
+            another: 'thing',
+          },
+        })
+      )
+    })
+
+    it('should use an empty transaction as a base if it is not cached', async () => {
+      expect.assertions(1)
+
+      await web3ServiceHub({
+        web3Service,
+        onChange,
+        window: fakeWindow,
+      })
+
+      const listener = getTransactionListener()
+
+      await listener('hi', { another: 'thing' })
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transaction: {
+            hash: 'hi',
+            another: 'thing',
+            blockNumber: Number.MAX_SAFE_INTEGER,
+          },
+        })
+      )
+    })
+
+    it('should not call onChange for non-key purchase transactions', async () => {
+      expect.assertions(1)
+
+      await web3ServiceHub({
+        web3Service,
+        onChange,
+        window: fakeWindow,
+      })
+
+      const listener = getTransactionListener()
+
+      await listener('hi', {
+        another: 'thing',
+        type: TRANSACTION_TYPES.LOCK_CREATION,
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call onChange with the new key for key purchases', async () => {
+      expect.assertions(2)
+
+      await web3ServiceHub({
+        web3Service,
+        onChange,
+        window: fakeWindow,
+      })
+
+      const listener = getTransactionListener()
+
+      await listener('hi', {
+        another: 'thing',
+        type: TRANSACTION_TYPES.KEY_PURCHASE,
+        lock: 'lock',
+        key: 'lock-account',
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(2)
+      expect(onChange).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          key: {
+            expiration: 123,
+            lock: 'lock',
+            owner: 'account', // this verifies we pulled it from the cache
+          },
+        })
+      )
+    })
+  })
+
+  describe('error listener', () => {
+    let onChange
+    let web3Service
+
+    function getErrorListener() {
+      return web3Service.on.mock.calls[1][1]
+    }
+    beforeEach(async () => {
+      makeFakeWindow()
+      onChange = jest.fn()
+      web3Service = {
+        on: jest.fn(),
+      }
+      await setAccount(fakeWindow, 'account')
+    })
+
+    it('should call onChange with the error', async () => {
+      expect.assertions(1)
+
+      await web3ServiceHub({
+        web3Service,
+        onChange,
+        window: fakeWindow,
+      })
+
+      const listener = getErrorListener()
+
+      await listener('error')
+
+      expect(onChange).toHaveBeenCalledWith({ error: 'error' })
+    })
+  })
+})

--- a/paywall/src/data-iframe/blockchainHandler/web3ServiceHub.js
+++ b/paywall/src/data-iframe/blockchainHandler/web3ServiceHub.js
@@ -1,0 +1,50 @@
+import { getTransactions, getAccount } from '../cacheHandler'
+
+/**
+ * Listen for transaction updates, update the transaction and key that it affects
+ * if the transaction is for a key purchase.
+ *
+ * Also listen for errors, and feed all changes back to the cache via onChange
+ *
+ * @param {web3Service} web3Service the web3Service object we will listen for events on
+ * @param {Function} onChange the blockchain onChange callback
+ * @param {window} window the current global context
+ */
+export default async function web3ServiceHub({
+  web3Service,
+  onChange,
+  window,
+}) {
+  web3Service.on('transaction.updated', async (hash, update) => {
+    const account = await getAccount(window)
+    const transactions = await getTransactions(window)
+    // we need to build on the previous transaction because 'transaction.updated'
+    // never returns the full transaction, we will rely upon the cache
+    const oldTransaction = transactions[hash] || {
+      hash,
+      blockNumber: Number.MAX_SAFE_INTEGER,
+    }
+    const transaction = {
+      ...oldTransaction,
+      ...update,
+    }
+    // report the changed transaction to syncToCache
+    onChange({
+      transaction,
+    })
+    if (transaction.key) {
+      // ensure that if the key expiration has changed, that we report it to syncToCache
+      const key = await web3Service.getKeyByLockForOwner(
+        transaction.lock,
+        account
+      )
+      onChange({
+        key,
+      })
+    }
+  })
+  web3Service.on('error', error => {
+    // report all errors to the main window
+    onChange({ error })
+  })
+}


### PR DESCRIPTION
# Description

This is the core of the fix for #3535. It simply listens for transaction updates and errors, and reports them directly to the `onChange` which is used to sync to cache and also to pass errors to the checkout UI.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3550 #3535 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
