### PR TITLE
Add signed-in message to the LogIn component

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -48041,19 +48041,19 @@ Object {
     />
     <div>
       <h1
-        class="sc-eHgmQL ethFFU"
+        class="sc-jWBwVP jxrhEF"
       >
         Log In to Your Account
       </h1>
       <form>
         <label
-          class="sc-cMljjf eWiKRa"
+          class="sc-jDwBTQ ewBJjx"
           for="emailInput"
         >
           Email Address
         </label>
         <input
-          class="sc-jWBwVP bQrQve"
+          class="sc-cMljjf bnsXNv"
           id="emailInput"
           name="emailAddress"
           placeholder="Enter your email"
@@ -48061,13 +48061,13 @@ Object {
         />
         <br />
         <label
-          class="sc-cMljjf eWiKRa"
+          class="sc-jDwBTQ ewBJjx"
           for="passwordInput"
         >
           Password
         </label>
         <input
-          class="sc-jWBwVP bQrQve"
+          class="sc-cMljjf bnsXNv"
           id="passwordInput"
           name="password"
           placeholder="Enter your password"
@@ -48075,18 +48075,18 @@ Object {
         />
         <br />
         <input
-          class="sc-brqgnP kRdmxU"
+          class="sc-jAaTju Aanxf"
           type="submit"
           value="Submit"
         />
       </form>
       <p
-        class="sc-cvbbAY dbdRQm"
+        class="sc-brqgnP kLeLPN"
       >
         Don't have an account?
          
         <a
-          class="sc-jAaTju hdRCBs"
+          class="sc-gPEVay eKpZDv"
         >
           Sign up here.
         </a>
@@ -48712,12 +48712,12 @@ Object {
     />
     <div>
       <h1
-        class="sc-jDwBTQ fertdr"
+        class="sc-iRbamj dRHgwJ"
       >
         Sign Up
       </h1>
       <p
-        class="sc-gPEVay idhqHf"
+        class="sc-jlyJG haszTb"
       >
         The link you used is invalid. Please try again.
          
@@ -48912,19 +48912,19 @@ Object {
     />
     <div>
       <h1
-        class="sc-eHgmQL ethFFU"
+        class="sc-jWBwVP jxrhEF"
       >
         Log In to Your Account
       </h1>
       <form>
         <label
-          class="sc-cMljjf eWiKRa"
+          class="sc-jDwBTQ ewBJjx"
           for="emailInput"
         >
           Email Address
         </label>
         <input
-          class="sc-jWBwVP bQrQve"
+          class="sc-cMljjf bnsXNv"
           id="emailInput"
           name="emailAddress"
           placeholder="Enter your email"
@@ -48932,13 +48932,13 @@ Object {
         />
         <br />
         <label
-          class="sc-cMljjf eWiKRa"
+          class="sc-jDwBTQ ewBJjx"
           for="passwordInput"
         >
           Password
         </label>
         <input
-          class="sc-jWBwVP bQrQve"
+          class="sc-cMljjf bnsXNv"
           id="passwordInput"
           name="password"
           placeholder="Enter your password"
@@ -48946,18 +48946,18 @@ Object {
         />
         <br />
         <input
-          class="sc-brqgnP kRdmxU"
+          class="sc-jAaTju Aanxf"
           type="submit"
           value="Submit"
         />
       </form>
       <p
-        class="sc-cvbbAY dbdRQm"
+        class="sc-brqgnP kLeLPN"
       >
         Don't have an account?
          
         <a
-          class="sc-jAaTju hdRCBs"
+          class="sc-gPEVay eKpZDv"
         >
           Sign up here.
         </a>
@@ -49296,7 +49296,7 @@ Object {
         <p
           class="c1"
         >
-          You are now signed up! Go to
+          You are now signed in! Go to
            
           <a
             href="/keychain"
@@ -49315,14 +49315,14 @@ Object {
     />
     <div>
       <h1
-        class="sc-iRbamj dRHgwJ"
+        class="sc-eHgmQL ethFFU"
       >
         Sign Up
       </h1>
       <p
-        class="sc-jlyJG haszTb"
+        class="sc-cvbbAY dbdRQm"
       >
-        You are now signed up! Go to
+        You are now signed in! Go to
          
         <a
           href="/keychain"
@@ -53886,12 +53886,12 @@ Object {
     />
     <div>
       <h1
-        class="sc-jDwBTQ fertdr"
+        class="sc-iRbamj dRHgwJ"
       >
         Sign Up
       </h1>
       <p
-        class="sc-gPEVay idhqHf"
+        class="sc-jlyJG haszTb"
       >
         The link you used is invalid. Please try again.
          
@@ -54236,7 +54236,7 @@ Object {
         <p
           class="c1"
         >
-          You are now signed up! Go to
+          You are now signed in! Go to
            
           <a
             href="/keychain"
@@ -54255,14 +54255,14 @@ Object {
     />
     <div>
       <h1
-        class="sc-iRbamj dRHgwJ"
+        class="sc-eHgmQL ethFFU"
       >
         Sign Up
       </h1>
       <p
-        class="sc-jlyJG haszTb"
+        class="sc-cvbbAY dbdRQm"
       >
-        You are now signed up! Go to
+        You are now signed in! Go to
          
         <a
           href="/keychain"

--- a/unlock-app/src/components/interface/LogIn.tsx
+++ b/unlock-app/src/components/interface/LogIn.tsx
@@ -3,11 +3,15 @@ import React, { FormEvent } from 'react'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
 // eslint-disable-next-line no-unused-vars
+import { Account } from '../../unlockTypes'
+import SignupSuccess from './SignupSuccess'
+// eslint-disable-next-line no-unused-vars
 import { loginCredentials, Credentials } from '../../actions/user'
 
 interface Props {
   toggleSignup: () => void
   loginCredentials: (credentials: Credentials) => void
+  account?: Account
 }
 
 interface State {
@@ -58,6 +62,12 @@ export class LogIn extends React.Component<Props, State> {
   }
 
   render = () => {
+    const { account } = this.props
+
+    if (account && account.address) {
+      return <SignupSuccess />
+    }
+
     return (
       <div>
         <Heading>Log In to Your Account</Heading>

--- a/unlock-app/src/components/interface/SignupSuccess.tsx
+++ b/unlock-app/src/components/interface/SignupSuccess.tsx
@@ -8,7 +8,7 @@ export const SignupSuccess = () => (
   <div>
     <Heading>Sign Up</Heading>
     <Description>
-      You are now signed up! Go to{' '}
+      You are now signed in! Go to{' '}
       <Link href="/keychain">
         <a>your key chain</a>
       </Link>


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR simply makes `<LogIn>` consistent with `<SignUp>`. They both now show a generic message and a link to the `<Keychain>` when authentication is successful.

(this is a prerequisite to merging the UnlockProvider integration)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
