### PR TITLE
Integrate UnlockProvider with app

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -1,5 +1,4 @@
 import EventEmitter from 'events'
-import { createAccountAndPasswordEncryptKey } from '@unlock-protocol/unlock-js'
 import walletMiddleware from '../../middlewares/walletMiddleware'
 import {
   CREATE_LOCK,
@@ -11,7 +10,7 @@ import {
 } from '../../actions/lock'
 import { LAUNCH_MODAL, DISMISS_MODAL } from '../../actions/fullScreenModals'
 import { PURCHASE_KEY } from '../../actions/key'
-import { SET_ACCOUNT, setAccount } from '../../actions/accounts'
+import { SET_ACCOUNT } from '../../actions/accounts'
 import { SET_NETWORK } from '../../actions/network'
 import { PROVIDER_READY } from '../../actions/provider'
 import { NEW_TRANSACTION } from '../../actions/transaction'
@@ -29,10 +28,6 @@ import {
   SIGNATURE_ERROR,
 } from '../../actions/signature'
 import { HIDE_FORM } from '../../actions/lockFormVisibility'
-import {
-  GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD,
-  setEncryptedPrivateKey,
-} from '../../actions/user'
 
 let mockConfig
 
@@ -685,80 +680,6 @@ describe('Wallet middleware', () => {
         type: SIGNATURE_ERROR,
         error,
       })
-    })
-  })
-
-  describe('GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD', () => {
-    const emailAddress = 'test@us.er'
-    const password = 'guest'
-    let key
-    let address
-    beforeEach(async () => {
-      const info = await createAccountAndPasswordEncryptKey(password)
-      key = info.passwordEncryptedPrivateKey
-      address = info.address
-    })
-    it('should set the account and encrypted key in state', done => {
-      expect.assertions(3)
-      // This is a bit annoying, but it lets us more easily test the async stuff
-      const timesToCallDispatch = 2
-      let timesDispatchHasBeenCalled = 0
-      const dispatchImplementation = () => {
-        timesDispatchHasBeenCalled++
-        if (timesDispatchHasBeenCalled === timesToCallDispatch) {
-          expect(store.dispatch).toHaveBeenNthCalledWith(
-            1,
-            setAccount({ address })
-          )
-          expect(store.dispatch).toHaveBeenNthCalledWith(
-            2,
-            setEncryptedPrivateKey(key, emailAddress)
-          )
-          done()
-        }
-      }
-      const { next, invoke, store } = create(dispatchImplementation)
-
-      const action = {
-        type: GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD,
-        key,
-        emailAddress,
-        password,
-      }
-
-      invoke(action)
-
-      expect(next).toHaveBeenCalled()
-    })
-
-    it('should dispatch an error if it cannot decrypt', done => {
-      expect.assertions(2)
-      const dispatchImplementation = () => {
-        expect(store.dispatch).toHaveBeenCalledWith(
-          expect.objectContaining({
-            type: SET_ERROR,
-            error: {
-              level: 'Warning',
-              kind: 'LogIn',
-              message:
-                'Failed to decrypt private key. Check your password and try again.',
-            },
-          })
-        )
-        done()
-      }
-      const { next, invoke, store } = create(dispatchImplementation)
-
-      const action = {
-        type: GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD,
-        key,
-        emailAddress,
-        password: 'not the correct password, I assure you',
-      }
-
-      invoke(action)
-
-      expect(next).toHaveBeenCalled()
     })
   })
 })

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -55,7 +55,9 @@ export async function initializeUnlockProvider(
     dispatch(setAccount({ address }))
     dispatch(setEncryptedPrivateKey(key, emailAddress))
     dispatch(providerReady())
-  } catch (_) {
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e)
     // TODO: password isn't the only thing that can go wrong here...
     dispatch(
       setError(

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -56,6 +56,7 @@ export async function initializeUnlockProvider(
     dispatch(setEncryptedPrivateKey(key, emailAddress))
     dispatch(providerReady())
   } catch (_) {
+    // TODO: password isn't the only thing that can go wrong here...
     dispatch(
       setError(
         LogIn.Warning(
@@ -83,7 +84,8 @@ export const providerMiddleware = (config: any) => {
             initializeProvider(provider, dispatch)
           }
         } else if (action.type === GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD) {
-          initializeUnlockProvider(action, getState().provider, dispatch)
+          const provider = config.providers[getState().provider]
+          initializeUnlockProvider(action, provider, dispatch)
         }
 
         next(action)

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -17,7 +17,8 @@ interface Provider {
   isUnlock?: boolean
 }
 
-function initializeProvider(provider: Provider, dispatch: any) {
+export function initializeProvider(provider: Provider, dispatch: any) {
+  // TODO: when UnlockProvider is enabled, this error should never happen.
   if (!provider) {
     dispatch(setError(Application.Fatal(FATAL_MISSING_PROVIDER)))
     return
@@ -41,7 +42,7 @@ function initializeProvider(provider: Provider, dispatch: any) {
   }
 }
 
-async function initializeUnlockProvider(
+export async function initializeUnlockProvider(
   action: Action,
   unlockProvider: any,
   dispatch: any
@@ -65,7 +66,7 @@ async function initializeUnlockProvider(
   }
 }
 
-const providerMiddleware = (config: any) => {
+export const providerMiddleware = (config: any) => {
   return ({ getState, dispatch }: { [key: string]: any }) => {
     return function(next: any) {
       // Initialize provider based on the one grabbed in the state. Fragile?

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -1,8 +1,5 @@
 /* eslint promise/prefer-await-to-then: 0 */
-import {
-  getAccountFromPrivateKey,
-  WalletService,
-} from '@unlock-protocol/unlock-js'
+import { WalletService } from '@unlock-protocol/unlock-js'
 
 import {
   CREATE_LOCK,
@@ -21,7 +18,7 @@ import { newTransaction } from '../actions/transaction'
 import { waitForWallet, dismissWalletCheck } from '../actions/fullScreenModals'
 import { POLLING_INTERVAL, ETHEREUM_NETWORKS_NAMES } from '../constants'
 
-import { Application, Transaction, LogIn } from '../utils/Error'
+import { Application, Transaction } from '../utils/Error'
 
 import {
   FATAL_NO_USER_ACCOUNT,
@@ -32,10 +29,6 @@ import { SIGN_DATA, signedData, signatureError } from '../actions/signature'
 import { TransactionType } from '../unlockTypes'
 import { hideForm } from '../actions/lockFormVisibility'
 import { transactionTypeMapping } from '../utils/types' // TODO change POLLING_INTERVAL into ACCOUNT_POLLING_INTERVAL
-import {
-  GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD,
-  setEncryptedPrivateKey,
-} from '../actions/user'
 
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
@@ -224,25 +217,6 @@ const walletMiddleware = config => {
               dispatch(signedData(action.data, signature))
             }
           )
-        } else if (action.type === GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD) {
-          const { key, emailAddress, password } = action
-          // TODO: How will this interact with unlock-provider?
-          getAccountFromPrivateKey(key, password)
-            .then(wallet => {
-              const address = wallet.signingKey.address
-              dispatch(setAccount({ address }))
-              dispatch(setEncryptedPrivateKey(key, emailAddress))
-            })
-            .catch(() => {
-              // handle error here
-              dispatch(
-                setError(
-                  LogIn.Warning(
-                    'Failed to decrypt private key. Check your password and try again.'
-                  )
-                )
-              )
-            })
         }
 
         next(action)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR moves handling of user account log in to `providerMiddleware`, which instantiates `UnlockProvider` with the user's decrypted wallet, then sets the account address in state and dispatches `providerReady`.

This PR does _not_ add `UnlockProvider` to the config, since I think we don't want it to be used yet (once we add `UnlockProvider` to config, it will always be present and there will not be an error message for people without MetaMask; we don't want that to happen until `UnlockProvider` is more capable)

To do a live test of `UnlockProvider` in this branch, or after it is merged, you have to import `UnlockProvider` in the config, disable the `Web3` and `HTTP` providers, and after the `readOnlyProvider` is set, do `providers['Unlock'] = new UnlockProvider({ readOnlyProvider })`.

Then you can go to the signup or login page and try it out.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #2414
# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
