### PR TITLE
Setting and showing balances and key prices based on the number of decimals

### DIFF
--- a/unlock-js/src/__tests__/utils.test.js
+++ b/unlock-js/src/__tests__/utils.test.js
@@ -14,6 +14,32 @@ describe('ethers utils', () => {
     )
   })
 
+  describe('toDecimal', () => {
+    it('supports 18 decimals - which is the most frequent erc20', () => {
+      expect.assertions(2)
+
+      expect(ethersUtils.toDecimal('1', 18)).toEqual(
+        utils.bigNumberify('1000000000000000000')
+      )
+
+      expect(ethersUtils.toDecimal('100', 18)).toEqual(
+        utils.bigNumberify('100000000000000000000')
+      )
+    })
+
+    it('supports 0 decimal', () => {
+      expect.assertions(2)
+
+      expect(ethersUtils.toDecimal('1000', 0)).toEqual(
+        utils.bigNumberify('1000')
+      )
+
+      expect(ethersUtils.toDecimal('1000000000000', 0)).toEqual(
+        utils.bigNumberify('1000000000000')
+      )
+    })
+  })
+
   it('hexToNumberString', () => {
     expect.assertions(2)
 
@@ -37,6 +63,26 @@ describe('ethers utils', () => {
     )
 
     expect(ethersUtils.fromWei('100000000', 'ether')).toEqual('0.0000000001')
+  })
+
+  describe('fromDecimal', () => {
+    it('should support 18 decimals', () => {
+      expect.assertions(2)
+
+      expect(ethersUtils.fromDecimal('1000000000000000000000', 18)).toEqual(
+        '1000'
+      )
+
+      expect(ethersUtils.fromDecimal('100000000', 18)).toEqual('0.0000000001')
+    })
+
+    it('should support 0 decimals', () => {
+      expect.assertions(2)
+
+      expect(ethersUtils.fromDecimal('1000', 0)).toEqual('1000')
+
+      expect(ethersUtils.fromDecimal('100000000', 0)).toEqual('100000000')
+    })
   })
 
   it('isInfiniteKeys', () => {

--- a/unlock-js/src/__tests__/utils.test.js
+++ b/unlock-js/src/__tests__/utils.test.js
@@ -14,32 +14,6 @@ describe('ethers utils', () => {
     )
   })
 
-  describe('toDecimal', () => {
-    it('supports 18 decimals - which is the most frequent erc20', () => {
-      expect.assertions(2)
-
-      expect(ethersUtils.toDecimal('1', 18)).toEqual(
-        utils.bigNumberify('1000000000000000000')
-      )
-
-      expect(ethersUtils.toDecimal('100', 18)).toEqual(
-        utils.bigNumberify('100000000000000000000')
-      )
-    })
-
-    it('supports 0 decimal', () => {
-      expect.assertions(2)
-
-      expect(ethersUtils.toDecimal('1000', 0)).toEqual(
-        utils.bigNumberify('1000')
-      )
-
-      expect(ethersUtils.toDecimal('1000000000000', 0)).toEqual(
-        utils.bigNumberify('1000000000000')
-      )
-    })
-  })
-
   it('hexToNumberString', () => {
     expect.assertions(2)
 
@@ -63,26 +37,6 @@ describe('ethers utils', () => {
     )
 
     expect(ethersUtils.fromWei('100000000', 'ether')).toEqual('0.0000000001')
-  })
-
-  describe('fromDecimal', () => {
-    it('should support 18 decimals', () => {
-      expect.assertions(2)
-
-      expect(ethersUtils.fromDecimal('1000000000000000000000', 18)).toEqual(
-        '1000'
-      )
-
-      expect(ethersUtils.fromDecimal('100000000', 18)).toEqual('0.0000000001')
-    })
-
-    it('should support 0 decimals', () => {
-      expect.assertions(2)
-
-      expect(ethersUtils.fromDecimal('1000', 0)).toEqual('1000')
-
-      expect(ethersUtils.fromDecimal('100000000', 0)).toEqual('100000000')
-    })
   })
 
   it('isInfiniteKeys', () => {

--- a/unlock-js/src/__tests__/v10/getLock.test.js
+++ b/unlock-js/src/__tests__/v10/getLock.test.js
@@ -22,6 +22,7 @@ const erc20ContractAddress = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359'
 jest.mock('../../erc20.js', () => {
   return {
     getErc20BalanceForAddress: jest.fn(() => Promise.resolve(0)),
+    getErc20Decimals: jest.fn(() => Promise.resolve(18)), // 18 is the most frequent default for ERC20
   }
 })
 
@@ -169,11 +170,16 @@ describe('v10', () => {
       erc20.getErc20BalanceForAddress = jest.fn(() => {
         return Promise.resolve(balance)
       })
+      const decimals = 3
+      erc20.getErc20Decimals = jest.fn(() => {
+        return Promise.resolve(decimals)
+      })
+
       web3Service.on('lock.updated', (address, update) => {
         expect(address).toBe(lockAddress)
         expect(update).toEqual({
-          balance,
-          keyPrice: utils.fromWei('10000000000000000', 'ether'),
+          balance: '1.929',
+          keyPrice: utils.fromDecimal('10000000000000000', decimals),
           expirationDuration: 2592000,
           maxNumberOfKeys: 10,
           owner,

--- a/unlock-js/src/utils.js
+++ b/unlock-js/src/utils.js
@@ -4,6 +4,7 @@ import { ethers } from 'ethers'
 // or to migrate to a totally different library and have a single point of modification
 export default {
   toWei: (value, units) => ethers.utils.parseUnits(value, units),
+  toDecimal: (value, decimals) => ethers.utils.parseUnits(value, decimals),
   hexlify: ethers.utils.hexlify,
   hexStripZeros: ethers.utils.hexStripZeros,
   bigNumberify: ethers.utils.bigNumberify,
@@ -15,6 +16,11 @@ export default {
   fromWei: (num, units) => {
     return ethers.utils
       .formatUnits(ethers.utils.bigNumberify(num), units)
+      .replace(/\.0$/, '')
+  },
+  fromDecimal: (num, decimals) => {
+    return ethers.utils
+      .formatUnits(ethers.utils.bigNumberify(num), decimals)
       .replace(/\.0$/, '')
   },
   isInfiniteKeys: value => {

--- a/unlock-js/src/utils.js
+++ b/unlock-js/src/utils.js
@@ -4,7 +4,6 @@ import { ethers } from 'ethers'
 // or to migrate to a totally different library and have a single point of modification
 export default {
   toWei: (value, units) => ethers.utils.parseUnits(value, units),
-  toDecimal: (value, decimals) => ethers.utils.parseUnits(value, decimals),
   hexlify: ethers.utils.hexlify,
   hexStripZeros: ethers.utils.hexStripZeros,
   bigNumberify: ethers.utils.bigNumberify,
@@ -16,11 +15,6 @@ export default {
   fromWei: (num, units) => {
     return ethers.utils
       .formatUnits(ethers.utils.bigNumberify(num), units)
-      .replace(/\.0$/, '')
-  },
-  fromDecimal: (num, decimals) => {
-    return ethers.utils
-      .formatUnits(ethers.utils.bigNumberify(num), decimals)
       .replace(/\.0$/, '')
   },
   isInfiniteKeys: value => {

--- a/unlock-js/src/utils.js
+++ b/unlock-js/src/utils.js
@@ -4,6 +4,8 @@ import { ethers } from 'ethers'
 // or to migrate to a totally different library and have a single point of modification
 export default {
   toWei: (value, units) => ethers.utils.parseUnits(value, units),
+  // This converts a string representation from a value to a number of units, based on the number of decimals passed in
+  toDecimal: (value, decimals) => ethers.utils.parseUnits(value, decimals),
   hexlify: ethers.utils.hexlify,
   hexStripZeros: ethers.utils.hexStripZeros,
   bigNumberify: ethers.utils.bigNumberify,
@@ -15,6 +17,12 @@ export default {
   fromWei: (num, units) => {
     return ethers.utils
       .formatUnits(ethers.utils.bigNumberify(num), units)
+      .replace(/\.0$/, '')
+  },
+  // This converts a string representation from a unit value to a higher base
+  fromDecimal: (num, decimals) => {
+    return ethers.utils
+      .formatUnits(ethers.utils.bigNumberify(num), decimals)
       .replace(/\.0$/, '')
   },
   isInfiniteKeys: value => {

--- a/unlock-js/src/v10/createLock.js
+++ b/unlock-js/src/v10/createLock.js
@@ -2,6 +2,28 @@ import ethersUtils from '../utils'
 import { GAS_AMOUNTS, ETHERS_MAX_UINT } from '../constants'
 import TransactionTypes from '../transactionTypes'
 import { UNLIMITED_KEYS_COUNT, ZERO } from '../../lib/constants'
+import { getErc20Decimals } from '../erc20'
+
+/**
+ * Returns the key price in its currency, rather than its decimal representation (Ether vs. Wei for example)
+ * @param {*} currencyContractAddress
+ * @param {*} lock
+ * @param {*} provider
+ */
+async function _getKeyPrice(lock, provider) {
+  let currencyContractAddress = lock.currencyContractAddress || ZERO
+
+  if (currencyContractAddress !== ZERO) {
+    // We need to get the decimal value
+    const erc20Decimals = await getErc20Decimals(
+      currencyContractAddress,
+      provider
+    )
+    return ethersUtils.toDecimal(lock.keyPrice, erc20Decimals)
+  } else {
+    return ethersUtils.toWei(lock.keyPrice, 'ether')
+  }
+}
 
 /**
  * Creates a lock on behalf of the user, using version v10
@@ -14,6 +36,9 @@ export default async function(lock, owner) {
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
     maxNumberOfKeys = ETHERS_MAX_UINT
   }
+
+  const decimalKeyPrice = _getKeyPrice(lock, this.provider)
+
   let currencyContractAddress = lock.currencyContractAddress || ZERO
 
   let transactionPromise
@@ -24,7 +49,7 @@ export default async function(lock, owner) {
     ](
       lock.expirationDuration,
       currencyContractAddress, // ERC20 address, 0 is for eth
-      ethersUtils.toWei(lock.keyPrice, 'ether'),
+      decimalKeyPrice, // FIX ME!
       maxNumberOfKeys,
       lockName,
       {


### PR DESCRIPTION
# Description

We were assuming ether to be the currency for our ERC20 contracts. This fixes that bug.
Note: this requires #3557 and #3555 to be merged first.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread