### PR TITLE
fail if UNLOCK_ENV is not explicitly set

### DIFF
--- a/paywall/data-iframe.1.0.webpack.config.js
+++ b/paywall/data-iframe.1.0.webpack.config.js
@@ -3,15 +3,15 @@ var path = require('path')
 const webpack = require('webpack')
 const dotenv = require('dotenv')
 
-const unlockEnv = process.env.UNLOCK_ENV || 'dev'
+const unlockEnv = process.env.UNLOCK_ENV
 const debug = process.env.DEBUG ? 1 : 0
 
 dotenv.config({
-  path: path.resolve(__dirname, '..', `.env.${unlockEnv}.local`),
+  path: path.resolve(__dirname, '..', `.env.${unlockEnv || 'dev'}.local`),
 })
 
 const requiredConfigVariables = {
-  unlockEnv,
+  unlockEnv: process.env.UNLOCK_ENV,
   readOnlyProvider: process.env.READ_ONLY_PROVIDER,
   locksmithUri: process.env.LOCKSMITH_URI,
   paywallUrl: process.env.PAYWALL_URL,

--- a/paywall/unlock.1.0.js.webpack.config.js
+++ b/paywall/unlock.1.0.js.webpack.config.js
@@ -3,15 +3,15 @@ const dotenv = require('dotenv')
 var path = require('path')
 const webpack = require('webpack')
 
-const unlockEnv = process.env.UNLOCK_ENV || 'dev'
+const unlockEnv = process.env.UNLOCK_ENV
 const debug = process.env.DEBUG ? 1 : 0
 
 dotenv.config({
-  path: path.resolve(__dirname, '..', `.env.${unlockEnv}.local`),
+  path: path.resolve(__dirname, '..', `.env.${unlockEnv || 'dev'}.local`),
 })
 
 const requiredConfigVariables = {
-  unlockEnv,
+  unlockEnv: process.env.UNLOCK_ENV,
   paywallUrl: process.env.PAYWALL_URL,
 }
 


### PR DESCRIPTION
# Description

This re-vamps the generation scripts for `unlock.1.0.min.js` and `data-iframe.1.0.min.js` to be stricter. You must declare `UNLOCK_ENV`. It will still load `.env` files, and use the contents to set variables, but will fail on Circle if the env variables are not set.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
