### PR TITLE
Access the correct property in privateKeyReducer

### DIFF
--- a/unlock-app/src/__tests__/reducers/privateKeyReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/privateKeyReducer.test.ts
@@ -71,7 +71,7 @@ describe('privateKeyReducer', () => {
     const action = {
       type: SET_ENCRYPTED_PRIVATE_KEY,
       key: newKeyState.key,
-      email: 'angrybees@BZZZZZZZZZZZZZ.STING',
+      emailAddress: 'angrybees@BZZZZZZZZZZZZZ.STING',
     }
     expect(reducer(initialState, action)).toEqual(newKeyState)
     expect(reducer(oldKeyState, action)).toEqual(newKeyState)

--- a/unlock-app/src/reducers/privateKeyReducer.ts
+++ b/unlock-app/src/reducers/privateKeyReducer.ts
@@ -18,7 +18,7 @@ const privateKeyReducer = (
   if (action.type === SET_ENCRYPTED_PRIVATE_KEY) {
     return {
       key: action.key,
-      email: action.email,
+      email: action.emailAddress,
     }
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
In the last stage of testing `changePassword`, I noticed that the user's email wasn't set in the state. This is because the wrong property name was used in the reducer. This PR fixes that.

This would have been caught with a more concrete action type, and it wouldn't hurt to normalize the use of `email`/`emailAddress` as well.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #2166 
Prerequisite for #3609 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
