### PR TITLE
Pass account state to LogIn component

### DIFF
--- a/unlock-app/src/__tests__/components/interface/LogIn.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/LogIn.test.tsx
@@ -50,4 +50,25 @@ describe('LogIn', () => {
       })
     )
   })
+
+  it('should show SignupSuccess when there is an account in state', () => {
+    expect.assertions(0)
+
+    const toggleSignup = jest.fn()
+    const loginCredentials = jest.fn()
+    const account = {
+      address: '0x123abc',
+      balance: '0',
+    }
+
+    const { getByText } = rtl.render(
+      <LogIn
+        toggleSignup={toggleSignup}
+        loginCredentials={loginCredentials}
+        account={account}
+      />
+    )
+
+    getByText('Sign Up')
+  })
 })

--- a/unlock-app/src/components/interface/LogIn.tsx
+++ b/unlock-app/src/components/interface/LogIn.tsx
@@ -106,8 +106,16 @@ const mapDispatchToProps = (dispatch: any) => ({
     dispatch(loginCredentials({ emailAddress, password })),
 })
 
+interface ReduxState {
+  account?: Account
+}
+
+const mapStateToProps = ({ account }: ReduxState) => ({
+  account,
+})
+
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(LogIn)
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
The `LogIn` component has an optional property for account info, but we never connected the component to the state, so it never got it. This PR connects the component, which allows it to show the success case for logging in.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
