### PR TITLE
add missing lock field

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -1037,6 +1037,8 @@ describe('Form field validators', () => {
             outstandingKeys: 0,
             balance: '0',
             owner: '0x1234567890123456789012345678901234567890',
+            currencyContractAddress:
+              '0x9876543210987654321098765432109876543210',
           })
         ).toBe(true)
       })

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -198,7 +198,15 @@ export const isValidLock = lock => {
     !isValidObject(
       lock,
       ['address', 'keyPrice', 'expirationDuration', 'key'],
-      ['name', 'asOf', 'maxNumberOfKeys', 'outstandingKeys', 'balance', 'owner']
+      [
+        'name',
+        'asOf',
+        'maxNumberOfKeys',
+        'outstandingKeys',
+        'balance',
+        'owner',
+        'currencyContractAddress',
+      ]
     )
   ) {
     return false


### PR DESCRIPTION
# Description

v10 introduced a new field to the lock, `currencyContractAddress`. This adds it to the optional fields in lock validation.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3637 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
