### PR TITLE
update locks/account when state changes

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/account.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/account.test.js
@@ -88,22 +88,55 @@ describe('blockchainHandler account handling', () => {
       ).toBeTruthy()
     })
 
-    it('changeListener retrieves account balance and sends account and balance to the callback', async done => {
-      expect.assertions(4)
-      onAccountChange = (account, balance) => {
-        expect(account).toBe('new account')
-        expect(balance).toBe('123')
-        expect(getAccount()).toBe('new account')
-        expect(getAccountBalance()).toBe('123')
-        done()
-      }
-      await pollForAccountChange(
-        fakeWalletService,
-        fakeWeb3Service,
-        onAccountChange
-      )
+    describe('changeListener', () => {
+      beforeEach(() => {
+        pollForChanges.mockReset()
+        fakeWalletService = {
+          getAccount: jest.fn(() => 'account'),
+        }
+        fakeWeb3Service = {
+          getAddressBalance: jest.fn(() => '123'),
+        }
+      })
 
-      await pollForChanges.mock.calls[0][3]('new account')
+      it('should retrieve account balance and send account and balance to the callback', async done => {
+        expect.assertions(4)
+        onAccountChange = (account, balance) => {
+          expect(account).toBe('new account')
+          expect(balance).toBe('123')
+          expect(getAccount()).toBe('new account')
+          expect(getAccountBalance()).toBe('123')
+          done()
+        }
+        await pollForAccountChange(
+          fakeWalletService,
+          fakeWeb3Service,
+          onAccountChange
+        )
+
+        await pollForChanges.mock.calls[0][3]('new account')
+      })
+
+      it('should handle no account correctly', async done => {
+        expect.assertions(4)
+        fakeWeb3Service = {
+          getAddressBalance: jest.fn(() => null),
+        }
+        onAccountChange = (account, balance) => {
+          expect(account).toBe(null)
+          expect(balance).toBe('0')
+          expect(getAccount()).toBe(null)
+          expect(getAccountBalance()).toBe('0')
+          done()
+        }
+        await pollForAccountChange(
+          fakeWalletService,
+          fakeWeb3Service,
+          onAccountChange
+        )
+
+        await pollForChanges.mock.calls[0][3](false)
+      })
     })
   })
 })

--- a/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
@@ -562,12 +562,17 @@ describe('localStorage cache', () => {
     })
 
     it('getAccount', async () => {
-      expect.assertions(1)
+      expect.assertions(2)
 
       await setAccount(fakeWindow, 'hi')
 
       const account = await getAccount(fakeWindow)
       expect(account).toBe('hi')
+
+      await setAccount(fakeWindow, null)
+
+      const account2 = await getAccount(fakeWindow)
+      expect(account2).toBe(null)
     })
 
     it('getNetwork', async () => {
@@ -596,7 +601,7 @@ describe('localStorage cache', () => {
       await setAccount(fakeWindow, 'hi')
 
       expect(fakeWindow.storage).toEqual({
-        '__unlockProtocol.account': 'hi',
+        '__unlockProtocol.account': JSON.stringify('hi'),
       })
     })
   })

--- a/paywall/src/data-iframe/blockchainHandler/account.js
+++ b/paywall/src/data-iframe/blockchainHandler/account.js
@@ -35,11 +35,13 @@ export async function pollForAccountChange(
     async newAccount => {
       // only called when account has changed
       /* changeListener */
-      setAccount(newAccount)
-      setAccountBalance(
-        newAccount ? await web3Service.getAddressBalance(newAccount) : 0
-      )
-      onAccountChange(account, accountBalance)
+      const account = newAccount ? newAccount : null
+      const balance = newAccount
+        ? await web3Service.getAddressBalance(newAccount)
+        : '0'
+      setAccount(account)
+      setAccountBalance(balance)
+      onAccountChange(account, balance)
     } /*changeListener */,
     POLLING_INTERVAL /* delay */
   )

--- a/paywall/src/data-iframe/cache/localStorage.js
+++ b/paywall/src/data-iframe/cache/localStorage.js
@@ -140,7 +140,11 @@ export async function merge({
  */
 export async function getAccount(window) {
   ensureLocalStorageAvailable(window, 'get account from cache')
-  return window.localStorage.getItem('__unlockProtocol.account') || null
+  try {
+    return JSON.parse(window.localStorage.getItem('__unlockProtocol.account'))
+  } catch (e) {
+    return null
+  }
 }
 
 /**
@@ -151,7 +155,10 @@ export async function getAccount(window) {
  */
 export async function setAccount(window, account) {
   ensureLocalStorageAvailable(window, 'save account in cache')
-  window.localStorage.setItem('__unlockProtocol.account', account)
+  window.localStorage.setItem(
+    '__unlockProtocol.account',
+    JSON.stringify(account)
+  )
 }
 
 /**


### PR DESCRIPTION
# Description

This fixes several account-related bugs in the ad remover paywall.

- account was being stored as-is in localStorage, so `null` got coerced to `"null"` which was an invalid account name (can only be `null` or a valid ethereum address)
- when account changed, locks/keys/transactions were not re-propagated to the main window. keys/transactions change, and since keys are stored in the lock, all 3 need to be re-sent
- the code incorrectly assumed `walletService.getAccount()` returns `null` on no account, but it returns `false`. In addition, `web3Service.getAccountBalance` returns `null` instead of `0` if the address is unknown.

The confluence of these bugs prevented switching the view.

![out](https://user-images.githubusercontent.com/98250/59129428-cd7adb00-893a-11e9-8ec3-6f6f862ac224.gif)


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3626 
Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
