### PR TITLE
Make UnlockProvider inherit from ethers

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.2.6
+- `UnlockProvider` now inherits from `ethers.providers.JsonRpcProvider` instead
+  of storing one as a property.
+
 ## 0.2.5
 - Allow `walletService` to properly connect to `UnlockProvider`
 

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/unlockProvider.test.js
+++ b/unlock-js/src/__tests__/unlockProvider.test.js
@@ -1,17 +1,6 @@
 import sigUtil from 'eth-sig-util'
 import UnlockProvider from '../unlockProvider'
 
-const ethers = require.requireActual('ethers')
-
-function provider() {
-  return {
-    send: jest.fn(),
-    _ethersType: 'Provider',
-  }
-}
-
-ethers.providers.JsonRpcProvider = provider
-
 const key = {
   id: 'fb1280c0-d646-4e40-9550-7026b1be504a',
   address: '88a5c2d9919e46f883eb62f7b8dd9d0cc45bc290',
@@ -100,11 +89,5 @@ describe('Unlock Provider', () => {
         publicKey.toLowerCase()
       )
     })
-  })
-
-  it('should call the fallback provider for any method it does not implement', async () => {
-    expect.assertions(1)
-    await provider.send('not_a_real_method')
-    expect(provider.fallbackProvider.send).toHaveBeenCalled()
   })
 })

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers'
+import { providers } from 'ethers'
 import sigUtil from 'eth-sig-util'
 import { toBuffer } from 'ethereumjs-utils'
 import { getAccountFromPrivateKey } from './accounts'
@@ -6,12 +6,9 @@ import { getAccountFromPrivateKey } from './accounts'
 // UnlockProvider implements a subset of Web3 provider functionality, sufficient
 // to allow us to use it as a stand-in for MetaMask or other Web3 integration in
 // the browser.
-export default class UnlockProvider {
+export default class UnlockProvider extends providers.JsonRpcProvider {
   constructor({ readOnlyProvider }) {
-    this.fallbackProvider = new ethers.providers.JsonRpcProvider(
-      readOnlyProvider
-    )
-    this.ready = false
+    super(readOnlyProvider)
     this.wallet = null
     this.isUnlock = true
   }
@@ -21,8 +18,7 @@ export default class UnlockProvider {
   async connect({ key, password }) {
     try {
       this.wallet = await getAccountFromPrivateKey(key, password)
-      this.wallet.connect(this.fallbackProvider)
-      this.ready = true
+      this.wallet.connect(this)
 
       return true
     } catch (err) {
@@ -30,14 +26,6 @@ export default class UnlockProvider {
       // Possible also that wallet couldn't connect with provider?
       throw err
     }
-  }
-
-  disconnect() {
-    return true
-  }
-
-  async getNetwork() {
-    return await this.fallbackProvider.getNetwork()
   }
 
   async eth_accounts() {
@@ -60,7 +48,7 @@ export default class UnlockProvider {
     if (typeof this[method] === 'undefined') {
       // We haven't implemented this method, defer to the fallback provider.
       // TODO: Catch methods we don't want to dispatch and throw an error
-      return this.fallbackProvider.send(method, params)
+      return await super.send(method, params)
     }
 
     return this[method](params)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
I realized that the `UnlockProvider` code can be a bit simpler if instead of holding an `ethers` provider as a property on the object, we just make `UnlockProvider` inherit from an ethers provider. Essentially the same result, but with less boilerplate to write.

Incidentally, doing this allows us to have access to an inherited `getCode`, the lack of which caused a fatal error on logging in.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
