### PR TITLE
retrieve new keys and transactions when the user's account changes

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/index.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/index.test.js
@@ -314,14 +314,16 @@ describe('blockchain handler index', () => {
       })
     })
 
-    it('should retrieve new keys ands locks on getting account.changed event', async done => {
+    it('should retrieve new keys ands transactions on getting account.changed event', async done => {
       expect.assertions(2)
 
       const locksToRetrieve = ['locks']
       fakeWalletService.on = async (type, listener) => {
         if (type !== 'account.changed') return
         await listener('new account')
+        // this is called when we retrieve new keys
         expect(fakeWeb3Service.getKeyByLockForOwner).toHaveBeenCalled()
+        // this is called when we retrieve transactions from locksmith
         expect(fakeWindow.fetch).toHaveBeenCalled()
         done()
       }

--- a/paywall/src/__tests__/data-iframe/start/connectToBlockchain.test.js
+++ b/paywall/src/__tests__/data-iframe/start/connectToBlockchain.test.js
@@ -139,9 +139,12 @@ describe('connectToBlockchain', () => {
 
       expect(listenForAccountNetworkChanges).toHaveBeenCalledWith(
         expect.objectContaining({
+          window,
+          locksmithHost,
           walletService,
           web3Service,
           onChange,
+          locksToRetrieve: Object.keys(config.locks),
         })
       )
     })

--- a/paywall/src/data-iframe/start/connectToBlockchain.js
+++ b/paywall/src/data-iframe/start/connectToBlockchain.js
@@ -74,7 +74,14 @@ export default async function connectToBlockchain({
     })
   )
 
-  listenForAccountNetworkChanges({ walletService, web3Service, onChange })
+  listenForAccountNetworkChanges({
+    locksToRetrieve,
+    walletService,
+    web3Service,
+    locksmithHost,
+    onChange,
+    window,
+  })
   // at this point the blockchain handler is live!
   return retrieveChainData({
     locksToRetrieve,


### PR DESCRIPTION
# Description

When the account changes, we need to retrieve new keys and transactions for that user. This adds that missing functionality

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3639 
Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
