### PR TITLE
Add structured_data to unlock-js

### DIFF
--- a/unlock-js/src/structured_data/unlockLock.js
+++ b/unlock-js/src/structured_data/unlockLock.js
@@ -1,0 +1,40 @@
+export default class UnlockLock {
+  static build(input) {
+    let domain = [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+    ]
+
+    let lock = [
+      { name: 'name', type: 'string' },
+      { name: 'owner', type: 'address' },
+      { name: 'address', type: 'address' },
+    ]
+
+    let domainData = {
+      name: 'Unlock Dashboard',
+      version: '1',
+    }
+
+    let message = {
+      lock: {
+        name: input.name,
+        owner: input.owner,
+        address: input.address,
+      },
+    }
+
+    return {
+      types: {
+        EIP712Domain: domain,
+        Lock: lock,
+      },
+      domain: domainData,
+      primaryType: 'Lock',
+      message: message,
+    }
+  }
+}

--- a/unlock-js/src/structured_data/unlockPurchaseRequest.js
+++ b/unlock-js/src/structured_data/unlockPurchaseRequest.js
@@ -1,0 +1,40 @@
+export default class UnlockPurchaseRequest {
+  static build(input) {
+    let domain = [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+    ]
+
+    let purchaseRequest = [
+      { name: 'recipient', type: 'address' },
+      { name: 'lock', type: 'address' },
+      { name: 'expiry', type: 'uint64' },
+    ]
+
+    let domainData = {
+      name: 'Unlock',
+      version: '1',
+    }
+
+    let message = {
+      purchaseRequest: {
+        recipient: input.recipient,
+        lock: input.lock,
+        expiry: input.expiry,
+      },
+    }
+
+    return {
+      types: {
+        EIP712Domain: domain,
+        PurchaseRequest: purchaseRequest,
+      },
+      domain: domainData,
+      primaryType: 'PurchaseRequest',
+      message: message,
+    }
+  }
+}

--- a/unlock-js/src/structured_data/unlockUser.js
+++ b/unlock-js/src/structured_data/unlockUser.js
@@ -1,0 +1,40 @@
+export default class UnlockUser {
+  static build(input) {
+    let domain = [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+    ]
+
+    let user = [
+      { name: 'emailAddress', type: 'string' },
+      { name: 'publicKey', type: 'address' },
+      { name: 'passwordEncryptedPrivateKey', type: 'string' },
+    ]
+
+    let domainData = {
+      name: 'Unlock',
+      version: '1',
+    }
+
+    let message = {
+      user: {
+        emailAddress: input.emailAddress,
+        publicKey: input.publicKey,
+        passwordEncryptedPrivateKey: input.passwordEncryptedPrivateKey,
+      },
+    }
+
+    return {
+      types: {
+        EIP712Domain: domain,
+        User: user,
+      },
+      domain: domainData,
+      primaryType: 'User',
+      message: message,
+    }
+  }
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
We have some structured data constructors in `unlock-app` that are only used to interact with managed accounts (or will only be used in that way in the near future[1]). This PR copies those constructors over to `unlock-js`, where they will be used in `UnlockProvider`.

Future PRs will import these to `UnlockProvider` and define methods that allow us to use them.


[1] We currently still have the `UPDATE_LOCK_NAME` action type, which requests a signature so that a lock name can be stored on `locksmith`. It is my understanding that this code will be removed because the name is now a part of the contract.
# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
