### PR TITLE
remove UPDATE_LOCK_NAME

### DIFF
--- a/unlock-app/src/__tests__/actions/lock.test.js
+++ b/unlock-app/src/__tests__/actions/lock.test.js
@@ -11,8 +11,6 @@ import {
   UPDATE_LOCK,
   WITHDRAW_FROM_LOCK,
   UPDATE_LOCK_KEY_PRICE,
-  updateLockName,
-  UPDATE_LOCK_NAME,
 } from '../../actions/lock'
 
 describe('lock actions', () => {
@@ -81,18 +79,5 @@ describe('lock actions', () => {
     }
 
     expect(updateKeyPrice(address, price)).toEqual(expectedAction)
-  })
-
-  it('should create an action to update the lock name', () => {
-    expect.assertions(1)
-    const address = '0x123'
-    const name = 'The Lock'
-    const expectedAction = {
-      type: UPDATE_LOCK_NAME,
-      address,
-      name,
-    }
-
-    expect(updateLockName(address, name)).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
+++ b/unlock-app/src/__tests__/components/creator/CreatorLock.test.js
@@ -10,11 +10,7 @@ import configure from '../../../config'
 import createUnlockStore from '../../../createUnlockStore'
 import { UNLIMITED_KEYS_COUNT } from '../../../constants'
 import { ConfigContext } from '../../../utils/withConfig'
-import {
-  UPDATE_LOCK_KEY_PRICE,
-  UPDATE_LOCK,
-  UPDATE_LOCK_NAME,
-} from '../../../actions/lock'
+import { UPDATE_LOCK_KEY_PRICE, UPDATE_LOCK } from '../../../actions/lock'
 
 jest.mock('next/link', () => {
   return ({ children }) => children
@@ -179,21 +175,6 @@ describe('CreatorLock', () => {
         address: lock.address,
         price: '6.66',
         type: UPDATE_LOCK_KEY_PRICE,
-      })
-    })
-
-    it('should dispatch updateLockName if the lock name has been changed', () => {
-      expect.assertions(1)
-      const newLock = Object.assign({}, unlimitedlock)
-      newLock.name = 'A New name'
-      const dispatch = jest.fn()
-      const { updateLock } = mapDispatchToProps(dispatch, { lock })
-      updateLock(newLock)
-
-      expect(dispatch).toHaveBeenCalledWith({
-        address: lock.address,
-        name: newLock.name,
-        type: UPDATE_LOCK_NAME,
       })
     })
 

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -3,11 +3,10 @@ import { createAccountAndPasswordEncryptKey } from '@unlock-protocol/unlock-js'
 import storageMiddleware, {
   changePassword,
 } from '../../middlewares/storageMiddleware'
-import { UPDATE_LOCK, updateLock, UPDATE_LOCK_NAME } from '../../actions/lock'
+import { UPDATE_LOCK, updateLock } from '../../actions/lock'
 import { addTransaction, NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ACCOUNT, setAccount } from '../../actions/accounts'
 import { SIGNED_DATA, SIGN_DATA } from '../../actions/signature'
-import UnlockLock from '../../structured_data/unlockLock'
 import { startLoading, doneLoading } from '../../actions/loading'
 import configure from '../../config'
 import {
@@ -294,44 +293,6 @@ describe('Storage middleware', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         setError(Storage.Warning('Could not store some lock metadata.'))
       )
-    })
-  })
-
-  describe('UPDATE_LOCK_NAME', () => {
-    it('should dispatch an action to sign message to update the name of a lock', () => {
-      expect.assertions(3)
-      const lock = {
-        address: '0x123',
-        name: 'my lock',
-        owner: '0xabc',
-      }
-      const data = {
-        message: {
-          lock: {},
-        },
-      }
-      const newName = 'a new name'
-      const { next, invoke, store } = create()
-      state.locks[lock.address] = lock
-
-      const action = {
-        type: UPDATE_LOCK_NAME,
-        address: lock.address,
-        name: newName,
-      }
-      UnlockLock.build = jest.fn(() => data)
-      invoke(action)
-      expect(UnlockLock.build).toHaveBeenCalledWith({
-        name: action.name,
-        owner: lock.owner,
-        address: lock.address,
-      })
-
-      expect(next).toHaveBeenCalledTimes(1)
-      expect(store.dispatch).toHaveBeenCalledWith({
-        data,
-        type: 'signature/SIGN_DATA',
-      })
     })
   })
 

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -232,7 +232,7 @@ describe('Wallet middleware', () => {
   })
 
   it('it should handle lock.updated events triggered by the walletService', () => {
-    expect.assertions(3)
+    expect.assertions(2)
     const { store } = create()
     const update = {
       transaction: '0x123',

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -6,7 +6,6 @@ import {
   WITHDRAW_FROM_LOCK,
   UPDATE_LOCK_KEY_PRICE,
   UPDATE_LOCK,
-  UPDATE_LOCK_NAME,
 } from '../../actions/lock'
 import { LAUNCH_MODAL, DISMISS_MODAL } from '../../actions/fullScreenModals'
 import { PURCHASE_KEY } from '../../actions/key'
@@ -240,14 +239,6 @@ describe('Wallet middleware', () => {
     }
 
     mockWalletService.emit('lock.updated', lock.address, update)
-
-    expect(store.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: UPDATE_LOCK_NAME,
-        address: lock.address,
-        name: lock.name,
-      })
-    )
 
     expect(store.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -13919,6 +13919,7 @@ Object {
         >
           <input
             data-valid="true"
+            disabled=""
             name="name"
             type="text"
             value="Existing Lock"
@@ -14072,6 +14073,7 @@ Object {
       >
         <input
           data-valid="true"
+          disabled=""
           name="name"
           type="text"
           value="Existing Lock"

--- a/unlock-app/src/actions/lock.js
+++ b/unlock-app/src/actions/lock.js
@@ -3,7 +3,6 @@ export const CREATE_LOCK = 'lock/CREATE_LOCK'
 export const DELETE_LOCK = 'lock/DELETE_LOCK'
 export const UPDATE_LOCK = 'lock/UPDATE_LOCK'
 export const UPDATE_LOCK_KEY_PRICE = 'lock/UPDATE_LOCK_KEY_PRICE'
-export const UPDATE_LOCK_NAME = 'lock/UPDATE_LOCK_NAME'
 export const WITHDRAW_FROM_LOCK = 'lock/WITHDRAW_FROM_LOCK'
 
 export const createLock = lock => ({
@@ -38,10 +37,4 @@ export const updateKeyPrice = (address, price) => ({
   type: UPDATE_LOCK_KEY_PRICE,
   address,
   price,
-})
-
-export const updateLockName = (address, name) => ({
-  type: UPDATE_LOCK_NAME,
-  address,
-  name,
 })

--- a/unlock-app/src/components/creator/CreatorLock.js
+++ b/unlock-app/src/components/creator/CreatorLock.js
@@ -23,7 +23,7 @@ import {
   DoubleHeightCell,
   BalanceContainer,
 } from './LockStyles'
-import { updateKeyPrice, updateLockName, updateLock } from '../../actions/lock'
+import { updateKeyPrice, updateLock } from '../../actions/lock'
 
 import { INFINITY } from '../../constants'
 
@@ -159,11 +159,6 @@ export const mapDispatchToProps = (dispatch, { lock }) => {
       // If the price has changed
       if (lock.keyPrice !== newLock.keyPrice) {
         dispatch(updateKeyPrice(lock.address, newLock.keyPrice))
-      }
-
-      // If the name has changed
-      if (lock.name !== newLock.name) {
-        dispatch(updateLockName(lock.address, newLock.name))
       }
 
       // Reflect all changes

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -262,6 +262,7 @@ export class CreatorLockForm extends React.Component {
             defaultValue={name}
             data-valid={valid.name}
             required={isNew}
+            disabled={!isNew}
           />
         </FormLockName>
         <FormLockDuration>

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -4,7 +4,7 @@ import {
   createAccountAndPasswordEncryptKey,
   reEncryptPrivateKey,
 } from '@unlock-protocol/unlock-js'
-import { UPDATE_LOCK, updateLock, UPDATE_LOCK_NAME } from '../actions/lock'
+import { UPDATE_LOCK, updateLock } from '../actions/lock'
 
 import { startLoading, doneLoading } from '../actions/loading'
 
@@ -12,7 +12,6 @@ import { StorageService, success, failure } from '../services/storageService'
 
 import { NEW_TRANSACTION, addTransaction } from '../actions/transaction'
 import { SET_ACCOUNT, setAccount } from '../actions/accounts'
-import UnlockLock from '../structured_data/unlockLock'
 import { SIGNED_DATA, signData } from '../actions/signature'
 import {
   LOGIN_CREDENTIALS,
@@ -168,18 +167,6 @@ const storageMiddleware = config => {
             // Once signed, let's save it!
             storageService.updateUser(email, action.data, action.signature)
           }
-        }
-
-        if (action.type === UPDATE_LOCK_NAME) {
-          const lock = getState().locks[action.address]
-          // Build the data to sign
-          let data = UnlockLock.build({
-            name: action.name,
-            owner: lock.owner,
-            address: lock.address,
-          })
-          // Ask someone to sign it!
-          dispatch(signData(data))
         }
 
         if (action.type === SIGNUP_CREDENTIALS) {

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -7,7 +7,6 @@ import {
   deleteLock,
   UPDATE_LOCK_KEY_PRICE,
   updateLock,
-  updateLockName,
 } from '../actions/lock'
 import { PURCHASE_KEY } from '../actions/key'
 import { setAccount } from '../actions/accounts'
@@ -102,11 +101,6 @@ const walletMiddleware = config => {
 
     walletService.on('lock.updated', (address, update) => {
       // This lock is beeing saved to the chain (that is what the update is about)
-      // So we should be able to get its name from the redux store
-      const lock = getState().locks[address]
-      if (lock) {
-        dispatch(updateLockName(address, lock.name))
-      }
       dispatch(updateLock(address, update))
       dispatch(hideForm()) // Close the form
     })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
After #3662, we no longer need to do a signature and send the lock name to locksmith. This PR removes that functionality, clearing the way for a more convenient way of working with signatures (which need only occur on managed accounts).

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
