### PR TITLE
adding the ability to not convert in BalanceProvider

### DIFF
--- a/paywall/src/__tests__/components/helpers/BalanceProvider.test.js
+++ b/paywall/src/__tests__/components/helpers/BalanceProvider.test.js
@@ -4,15 +4,35 @@ import * as rtl from 'react-testing-library'
 import { BalanceProvider } from '../../../components/helpers/BalanceProvider'
 
 describe('BalanceProvider Component', () => {
-  function renderIt({ amount, conversion = { USD: 195.99 }, render }) {
+  function renderIt({
+    amount,
+    conversion = { USD: 195.99 },
+    convertCurrency = true,
+    render,
+  }) {
     return rtl.render(
       <BalanceProvider
         amount={amount}
         conversion={conversion}
         render={render}
+        convertCurrency={convertCurrency}
       />
     )
   }
+
+  it('does not convert is convertCurrency is false', () => {
+    expect.assertions(2)
+    renderIt({
+      amount: null,
+      conversion: {},
+      convertCurrency: false,
+      render: (ethValue, fiatValue) => {
+        expect(ethValue).toEqual(' - ')
+        expect(fiatValue).toEqual(' - ')
+      },
+    })
+  })
+
   it('renders with - when amount is null (probably unset)', () => {
     expect.assertions(2)
     renderIt({

--- a/paywall/src/__tests__/components/helpers/BalanceProvider.test.js
+++ b/paywall/src/__tests__/components/helpers/BalanceProvider.test.js
@@ -20,7 +20,7 @@ describe('BalanceProvider Component', () => {
     )
   }
 
-  it('does not convert is convertCurrency is false', () => {
+  it('does not convert if convertCurrency is false', () => {
     expect.assertions(2)
     renderIt({
       amount: null,

--- a/paywall/src/components/helpers/BalanceProvider.js
+++ b/paywall/src/components/helpers/BalanceProvider.js
@@ -9,18 +9,30 @@ import { formatCurrency } from '../../selectors/currency'
  * This is useful to display balance in different ways.
  * amount is always in eth
  */
-export const BalanceProvider = ({ amount, conversion, render }) => {
+export const BalanceProvider = ({
+  amount,
+  conversion,
+  convertCurrency,
+  render,
+}) => {
   if (typeof amount === 'undefined' || amount === null) {
     return render(' - ', ' - ') || null
   }
+
   let currency = parseFloat(amount)
   const ethWithPresentation = formatCurrency(currency)
   let convertedUSDValue
+
+  if (!convertCurrency) {
+    return render(ethWithPresentation) || null
+  }
+
   if (!conversion.USD) {
     convertedUSDValue = '---'
   } else {
     convertedUSDValue = formatCurrency(currency * conversion.USD)
   }
+
   return render(ethWithPresentation, convertedUSDValue) || null
 }
 


### PR DESCRIPTION
# Description

This will be useful for ERC20 locks for which we do not have conversion rates.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread