### PR TITLE
Store email address in UnlockProvider

### DIFF
--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -10,15 +10,17 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
   constructor({ readOnlyProvider }) {
     super(readOnlyProvider)
     this.wallet = null
+    this.emailAddress = null
     this.isUnlock = true
   }
 
   // You should be able to just pass the action for
   // GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD into here
-  async connect({ key, password }) {
+  async connect({ key, password, emailAddress }) {
     try {
       this.wallet = await getAccountFromPrivateKey(key, password)
       this.wallet.connect(this)
+      this.emailAddress = emailAddress
 
       return true
     } catch (err) {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
First part of the work to handle the state-clearing issue revealed in #3609, this PR has `UnlockProvider` store the user's email address, which allows us to move all typed data signature code into the provider, which obviates the app's reliance on the email in state.

Since I was in there, I replaced the hardcoded typed user data in the test with an import of the recently-added structured data builder function.

This is not yet ready for a package bump, I will do that once I have added the code for signatures.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
