### PR TITLE
We also need to store the encrypted key in provider

### DIFF
--- a/unlock-js/src/__tests__/unlockProvider.test.js
+++ b/unlock-js/src/__tests__/unlockProvider.test.js
@@ -61,6 +61,11 @@ describe('Unlock Provider', () => {
       expect.assertions(1)
       expect(provider.emailAddress).toEqual(emailAddress)
     })
+
+    it('should have a property `passwordEncryptedPrivateKey` that is set to the provided key', () => {
+      expect.assertions(1)
+      expect(provider.passwordEncryptedPrivateKey).toEqual(key)
+    })
   })
 
   describe('implemented JSON-RPC calls', () => {

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -10,7 +10,12 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
   constructor({ readOnlyProvider }) {
     super(readOnlyProvider)
     this.wallet = null
+
+    // These properties are retained so that we can use them when generating
+    // signed typed data for the user account
     this.emailAddress = null
+    this.passwordEncryptedPrivateKey = null
+
     this.isUnlock = true
   }
 
@@ -21,6 +26,7 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
       this.wallet = await getAccountFromPrivateKey(key, password)
       this.wallet.connect(this)
       this.emailAddress = emailAddress
+      this.passwordEncryptedPrivateKey = key
 
       return true
     } catch (err) {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Follow-up on #3688, I realized we'll also need to store the encrypted private key. Ideally this should remove the need for the private key reducer in the app, which can be removed in a future PR (will do so in the PR that handles the new signing situation on the `unlock-app` side)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
