### PR TITLE
down the docker file at the conclusion of integration tests

### DIFF
--- a/scripts/local-docker-integration-tests.sh
+++ b/scripts/local-docker-integration-tests.sh
@@ -34,7 +34,8 @@ docker build -t unlock-protocol-com -f $REPO_ROOT/docker/unlock-protocol-com.doc
 docker build -t integration-tests -f $REPO_ROOT/docker/integration-tests.dockerfile $REPO_ROOT &
 wait
 
-
 # Run the tests
 $REPO_ROOT/scripts/integration-tests.sh $EXTRA_ARGS
 
+# shut down the docker file in case we want to do any local dev
+docker-compose -f $DOCKER_COMPOSE_FILE down


### PR DESCRIPTION
# Description

This adds a simple command to shut down the docker image for integration tests when they conclude in local testing. I've had some weird issues since the image exposes public ports when trying to run `npm run dev` after running integration tests. In some cases, `localhost:3001` pulls from the integration test docker image instead of our actual localhost. This fixes that issue

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
