### PR TITLE
Sign typed data directly with provider

### DIFF
--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -2,6 +2,7 @@ import { providers } from 'ethers'
 import sigUtil from 'eth-sig-util'
 import { toBuffer } from 'ethereumjs-utils'
 import { getAccountFromPrivateKey } from './accounts'
+import UnlockUser from './structured_data/unlockUser'
 
 // UnlockProvider implements a subset of Web3 provider functionality, sufficient
 // to allow us to use it as a stand-in for MetaMask or other Web3 integration in
@@ -44,14 +45,6 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
     return []
   }
 
-  async eth_signTypedData(params) {
-    // params is [ account, data ]
-    // we don't need account
-    const data = params[1]
-    const privateKey = toBuffer(this.wallet.privateKey)
-    return sigUtil.signTypedData(privateKey, data)
-  }
-
   async send(method, params) {
     if (typeof this[method] === 'undefined') {
       // We haven't implemented this method, defer to the fallback provider.
@@ -60,5 +53,25 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
     }
 
     return this[method](params)
+  }
+
+  // Signature methods
+  // TODO: move these into their own module so they aren't directly accessible
+  // on the provider?
+  signData(data) {
+    const privateKey = toBuffer(this.wallet.privateKey)
+    return sigUtil.signTypedData(privateKey, data)
+  }
+
+  // input conforms to unlockUser structured_data; missing properties default to
+  // those stored on provider
+  signUserData(input) {
+    const user = Object.assign({}, input)
+    user.emailAddress = user.emailAddress || this.emailAddress
+    user.publicKey = user.publicKey || this.wallet.address
+    user.passwordEncryptedPrivateKey =
+      user.passwordEncryptedPrivateKey || this.passwordEncryptedPrivateKey
+
+    return this.signData(UnlockUser.build(user))
   }
 }

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -60,7 +60,7 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
   // on the provider?
   signData(data) {
     const privateKey = toBuffer(this.wallet.privateKey)
-    return sigUtil.signTypedData(privateKey, data)
+    return sigUtil.signTypedData(privateKey, { data })
   }
 
   // input conforms to unlockUser structured_data; missing properties default to
@@ -72,6 +72,11 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
     user.passwordEncryptedPrivateKey =
       user.passwordEncryptedPrivateKey || this.passwordEncryptedPrivateKey
 
-    return this.signData(UnlockUser.build(user))
+    const data = UnlockUser.build(user)
+    const sig = this.signData(data)
+    return {
+      data,
+      sig,
+    }
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Because the unlock provider itself is responsible for some of the input to signing typed data now (which we only use in the context of user accounts), rather than intercepting the `eth_signTypedData` method call, we have methods on the provider that will generate a structured data object and a signature. Right now only `UnlockUser` is implemented, since that's the only one our current code relies on but we'll have to add the others as needed (key purchase, etc.).

Still not quite ready to bump the `unlock-js` version, I think this necessitates shuffling the `reEncryptPrivateKey` helper function at least, which I will do in a follow-up PR.

Then I will bump and publish, and update the app to use the new code, then finally merge the settings branch.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
