### PR TITLE
add currencyContractAddress to validation

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -1017,6 +1017,35 @@ describe('Form field validators', () => {
           })
         ).toBe(false)
       })
+
+      it('should fail on invalid lock currencyContractAddress', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: 9,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: undefined,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: {},
+          })
+        ).toBe(false)
+      })
     })
 
     describe('valid locks', () => {
@@ -1037,8 +1066,29 @@ describe('Form field validators', () => {
             outstandingKeys: 0,
             balance: '0',
             owner: '0x1234567890123456789012345678901234567890',
+            publicLockVersion: 4,
             currencyContractAddress:
               '0x9876543210987654321098765432109876543210',
+            some: 'random',
+            fields: 'we do not know about',
+          })
+        ).toBe(true)
+      })
+
+      it('should accept valid currency contract address', () => {
+        expect.assertions(2)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress:
+              '0x9876543210987654321098765432109876543210',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: null,
           })
         ).toBe(true)
       })
@@ -1102,12 +1152,18 @@ describe('Form field validators', () => {
     })
 
     it('should fail on any invalid locks', () => {
-      expect.assertions(1)
+      expect.assertions(2)
 
       expect(
         validators.isValidLocks({
           [validLock.address]: validLock,
           invalidLock,
+        })
+      ).toBe(false)
+      expect(
+        validators.isValidLocks({
+          [validLock.address]: invalidLock,
+          [validLock.address.replace('1', '2')]: invalidLock,
         })
       ).toBe(false)
     })

--- a/paywall/src/components/lock/NoKeyLock.js
+++ b/paywall/src/components/lock/NoKeyLock.js
@@ -9,6 +9,10 @@ import { UNLIMITED_KEYS_COUNT } from '../../constants'
 import withConfig from '../../utils/withConfig'
 import { currencySymbolForLock } from '../../utils/locks'
 
+// WARNING: if you use any new fields of a lock here
+// it *must* be added to validation in isValidLock
+// src/utils/validators.js or it opens a potential
+// security hole
 export const NoKeyLock = ({
   account,
   lock,

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -20,11 +20,11 @@ export const isPositiveNumber = val => {
 }
 
 export const isAccountOrNull = val => {
-  return val === null || val.match(ACCOUNT_REGEXP)
+  return val === null || (typeof val === 'string' && val.match(ACCOUNT_REGEXP))
 }
 
 export const isAccount = val => {
-  return val && val.match(ACCOUNT_REGEXP)
+  return val && typeof val === 'string' && val.match(ACCOUNT_REGEXP)
 }
 
 /**
@@ -114,14 +114,12 @@ export const isValidPaywallConfig = config => {
  *
  * No assertion on the types of the values is done here
  */
-function isValidObject(obj, validKeys, optionalKeys = []) {
+function isValidObject(obj, validKeys) {
   if (!obj || typeof obj !== 'object') return false
   const keys = Object.keys(obj)
 
-  if (keys.length > validKeys.length + optionalKeys.length) return false
-  if (keys.filter(key => !validKeys.includes(key)).length) {
-    if (optionalKeys.filter(key => !key.includes(key)).length) return false
-  }
+  if (keys.length < validKeys.length) return false
+  if (validKeys.filter(key => !keys.includes(key)).length) return false
   return true
 }
 
@@ -130,18 +128,14 @@ function isValidObject(obj, validKeys, optionalKeys = []) {
  */
 export const isValidKey = key => {
   if (
-    !isValidObject(
-      key,
-      [
-        'expiration',
-        'transactions',
-        'status',
-        'confirmations',
-        'owner',
-        'lock',
-      ],
-      ['id']
-    )
+    !isValidObject(key, [
+      'expiration',
+      'transactions',
+      'status',
+      'confirmations',
+      'owner',
+      'lock',
+    ])
   ) {
     return false
   }
@@ -195,24 +189,18 @@ export const isValidKey = key => {
  */
 export const isValidLock = lock => {
   if (
-    !isValidObject(
-      lock,
-      ['address', 'keyPrice', 'expirationDuration', 'key'],
-      [
-        'name',
-        'asOf',
-        'maxNumberOfKeys',
-        'outstandingKeys',
-        'balance',
-        'owner',
-        'currencyContractAddress',
-      ]
-    )
+    !isValidObject(lock, ['address', 'keyPrice', 'expirationDuration', 'key'])
   ) {
     return false
   }
 
   if (lock.hasOwnProperty('name') && typeof lock.name !== 'string') return false
+  if (
+    lock.hasOwnProperty('currencyContractAddress') &&
+    !isAccountOrNull(lock.currencyContractAddress)
+  ) {
+    return false
+  }
   if (typeof lock.address !== 'string' || !isAccount(lock.address)) return false
   if (typeof lock.keyPrice !== 'string' || !isDecimal(lock.keyPrice)) {
     return false


### PR DESCRIPTION
# Description

As it turns out, `currencyContractAddress` is not currently validated. Because the current ad remover paywall is more restrictive, this also means that it does not work any more.

This PR fixes both the code and the social issue. The code fix is that `isValidLock` is more permissive. It also now validates `currencyContractAddress` to ensure its format is correct.

The social fix is a big warning label in `NoKeyLock` for future changes.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
