### PR TITLE
update configuration for integration testing the ad remover paywall

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -91,9 +91,9 @@ services:
     environment:
       CI: '${CI}'
   rover:
-    image: rover 
+    image: rover
     environment:
-      CI: '${CI}'       
+      CI: '${CI}'
   wedlocks:
     image: wedlocks
     environment:
@@ -109,6 +109,7 @@ services:
       PAYWALL_PORT: '${PAYWALL_PORT}'
       UNLOCK_HOST: '${UNLOCK_HOST}'
       PAYWALL_URL: '${PAYWALL_URL}'
+      READ_ONLY_PROVIDER: '${READ_ONLY_PROVIDER}'
       UNLOCK_STATIC_URL: '${UNLOCK_STATIC_URL}'
     depends_on:
       - ganache-integration

--- a/tests/helpers/url.js
+++ b/tests/helpers/url.js
@@ -1,6 +1,7 @@
 const host = process.env.UNLOCK_HOST || '127.0.0.1'
 const port = process.env.UNLOCK_PORT || 3000
 const paywall = process.env.PAYWALL_URL || 'http://127.0.0.1:3001'
+const provider = process.env.READ_ONLY_PROVIDER || 'http://localhost:8545'
 
 /**
  * Use these helpers to get relative paths inside the main unlock-app and the paywall.
@@ -15,4 +16,5 @@ const paywall = process.env.PAYWALL_URL || 'http://127.0.0.1:3001'
 module.exports = {
   main: (path = '/') => `http://${host}:${port}${path}`,
   paywall: (path = '/') => `${paywall}${path}`,
+  provider,
 }


### PR DESCRIPTION
# Description

The ad remover paywall integration testing for a logged-in user needs to know the URL for ganache in order to make a bridge app that we can use to test whether it interfaces with a web3 wallet properly. This adds that missing piece.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3607 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
