### PR TITLE
add missing tests config, and catch for errors in startup

### DIFF
--- a/paywall/src/data-iframe/index.js
+++ b/paywall/src/data-iframe/index.js
@@ -8,6 +8,14 @@ const constants = {
     locksmithHost: process.env.LOCKSMITH_URI || 'http://localhost:8080',
     readOnlyProvider: process.env.READ_ONLY_PROVIDER || 'http://localhost:8545',
   },
+  test: {
+    unlockAddress: '0x885EF47c3439ADE0CB9b33a4D3c534C99964Db93',
+    blockTime: 3000,
+    requiredConfirmations: 6,
+    locksmithHost: process.env.LOCKSMITH_URI || 'http://locksmith:8080',
+    readOnlyProvider:
+      process.env.READ_ONLY_PROVIDER || 'http://ganache-integration:8545',
+  },
   staging: {
     unlockAddress: '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b',
     blockTime: 8000,
@@ -24,4 +32,6 @@ const constants = {
   },
 }
 
-start(window, constants[process.env.UNLOCK_ENV])
+start(window, constants[process.env.UNLOCK_ENV]).catch(e => {
+  console.error('startup error', e) // eslint-disable-line
+})


### PR DESCRIPTION
# Description

This adds 2 crucial missing pieces to the ad remover paywall data iframe which are needed for integration testing. One is a configuration unique to tests, the other is a catch-all for any errors thrown in the async startup. Without the catch-all, errors show in integration tests as a generic "An error was caught by jasmine". With the catch-all, we can use `debug.debugPage` from the debugging helpers to show the error message and debug it.

Note that the environment variables are guaranteed to be set, the defaults are only there to help make it clear that this is for integration testing.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3607 #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
