### PR TITLE
add a helpful debugging message in debug mode if validation fails

### DIFF
--- a/paywall/src/hooks/browser/useListenForPostMessage.js
+++ b/paywall/src/hooks/browser/useListenForPostMessage.js
@@ -85,6 +85,16 @@ export default function useListenForPostMessage({
         if (JSON.stringify(newValue) === JSON.stringify(data)) return
         // this triggers a re-render if and only if the value is different
         setData(newValue)
+      } else {
+        if (debugMode) {
+          //eslint-disable-next-line no-console
+          console.log(
+            `[uLFPM] validation failed!`,
+            type,
+            event.data.payload,
+            origin
+          )
+        }
       }
     }
 


### PR DESCRIPTION
# Description

debug mode is very helpful for debugging the ad remover paywall. This adds an additional message if data sent from the main window to the checkout UI does not validate. As with all debugMode messages, this code is completely stripped out in production

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
