### PR TITLE
walletService now emits an `account.updated` event

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.3.1
+- walletService now emits an `account.updated` event with an account's email
+  address if available
+
 ## 0.3.0
 
 - erc20 transfer approval returns immediately

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -13,6 +13,29 @@ import WalletService from '../walletService'
 import { GAS_AMOUNTS } from '../constants'
 import UnlockProvider from '../unlockProvider'
 
+const encryptedPrivateKey = {
+  version: 3,
+  id: 'edbe0942-593b-4027-8688-07b7d3ec56c5',
+  address: '0272742cbe9b4d4c81cffe8dfc0c33b5fb8893e5',
+  crypto: {
+    ciphertext:
+      '6f2a3ed499a2962cc48e6f7f0a90a0c817c83024cc4878f624ad251fccd0b706',
+    cipherparams: { iv: '69f031944591eed34c4d4f5841d283b0' },
+    cipher: 'aes-128-ctr',
+    kdf: 'scrypt',
+    kdfparams: {
+      dklen: 32,
+      salt: '5ac866336768f9613a505acd18dab463f4d10152ffefba5772125f5807539c36',
+      n: 8192,
+      r: 8,
+      p: 1,
+    },
+    mac: 'cc8efad3b534336ecffc0dbf6f51fd558301873d322edc6cbc1c9398ee0953ec',
+  },
+}
+
+const password = 'guest'
+
 const supportedVersions = [v0, v01, v02, v10, v11]
 
 const endpoint = 'http://127.0.0.1:8545'
@@ -149,6 +172,39 @@ describe('WalletService (ethers)', () => {
     })
 
     describe('getAccount', () => {
+      describe('when using UnlockProvider', () => {
+        let provider
+        beforeAll(async () => {
+          provider = new UnlockProvider({ readOnlyProvider: endpoint })
+          await resetTestsAndConnect(provider)
+          await provider.connect({
+            key: encryptedPrivateKey,
+            password,
+            emailAddress: 'geoff@bitconnect.gov',
+          })
+        })
+
+        it('should emit an account, email, and ready event', done => {
+          expect.assertions(3)
+          walletService.once('ready', () => {
+            expect(walletService.ready).toBe(true)
+            done()
+          })
+
+          walletService.on('account.changed', address => {
+            expect(address).toEqual(
+              '0x0272742CbE9b4D4C81cFFE8dFC0c33B5fb8893E5'
+            )
+          })
+
+          walletService.on('account.updated', update => {
+            expect(update.emailAddress).toEqual('geoff@bitconnect.gov')
+          })
+
+          walletService.getAccount()
+        })
+      })
+
       describe('when the node has an unlocked account', () => {
         it('should load a local account and emit the ready event', async done => {
           expect.assertions(2)
@@ -168,6 +224,11 @@ describe('WalletService (ethers)', () => {
             expect(address).toEqual(
               '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2' // checksum-ed address
             )
+          })
+
+          walletService.on('account.updated', () => {
+            // This event should not be emitted
+            expect(false).toBeTruthy()
           })
 
           walletService.getAccount()

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -90,6 +90,9 @@ export default class WalletService extends UnlockService {
     let address = accounts[0]
 
     this.emit('account.changed', address)
+    if (this.provider.emailAddress) {
+      this.emit('account.updated', { emailAddress: this.provider.emailAddress })
+    }
     this.emit('ready')
     return Promise.resolve(address)
   }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
In order to accommodate some changes around the handling of user account data, the new plan is for the `account` object in the Redux state hold the email address (as opposed to the `userDetails` object, which will be removed in the future). As a result, when a provider (in practice `UnlockProvider`) has an `emailAddress` property, `walletService` will emit `account.updated` with the email address.

A future PR will have `unlock-app` respond to this event and store the email address, which will then be available for use on the frontend pages that deal with user accounts.

Once this is approved I will publish the package. (I'll probably wait to rebase #3713 on this)

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
