### PR TITLE
filter locks returned from data iframe cache to only include those specified in the paywall config

### DIFF
--- a/paywall/src/__tests__/hooks/useBlockchainData.test.js
+++ b/paywall/src/__tests__/hooks/useBlockchainData.test.js
@@ -82,7 +82,7 @@ describe('useBlockchainData hook', () => {
         hash: '',
       },
       console: {
-        error: jest.fn(),
+        warn: jest.fn(),
       },
     }
     paywallConfig = {
@@ -211,7 +211,7 @@ describe('useBlockchainData hook', () => {
     )
   })
 
-  it('should error if the locks sent do not match the paywall config locks', () => {
+  it('should ignore unknown locks and warn about them', () => {
     expect.assertions(2)
 
     const component = rtl.render(<Wrapper />)
@@ -250,11 +250,16 @@ describe('useBlockchainData hook', () => {
       locksUpdater(getPMEvent(POST_MESSAGE_UPDATE_LOCKS, locks))
     })
 
-    expect(component.getByTitle('locks')).toHaveTextContent(JSON.stringify({}))
-    expect(fakeWindow.console.error).toHaveBeenCalledWith(
-      `Internal error: blockchain data out of sync with paywall config. Paywall config locks %o, actual %o`,
-      expect.arrayContaining([address]),
-      expect.arrayContaining([address, address2])
+    expect(component.getByTitle('locks')).toHaveTextContent(
+      JSON.stringify({
+        [address]: {
+          ...locks[address],
+          name: 'hi there!',
+        },
+      })
+    )
+    expect(fakeWindow.console.warn).toHaveBeenCalledWith(
+      'internal error: data iframe returned locks not known to the paywall'
     )
   })
 })

--- a/paywall/src/__tests__/hooks/useBlockchainData.test.js
+++ b/paywall/src/__tests__/hooks/useBlockchainData.test.js
@@ -13,6 +13,7 @@ import {
 
 describe('useBlockchainData hook', () => {
   const { Provider } = ConfigContext
+  const address = '0x1234567890123456789012345678901234567890'
 
   let fakeWindow
   let config
@@ -80,6 +81,13 @@ describe('useBlockchainData hook', () => {
         hash: '',
       },
     }
+    paywallConfig = {
+      locks: {
+        [address]: {
+          name: 'hi there!',
+        },
+      },
+    }
     config = { isServer: false, isInIframe: true, requiredNetworkId: 3 }
   })
 
@@ -107,7 +115,7 @@ describe('useBlockchainData hook', () => {
 
     const component = rtl.render(<Wrapper />)
     const account = {
-      address: '0x1234567890123456789012345678901234567890',
+      address,
       balance: '0',
     }
 
@@ -144,7 +152,7 @@ describe('useBlockchainData hook', () => {
 
     const component = rtl.render(<Wrapper />)
     const account = {
-      address: '0x1234567890123456789012345678901234567890',
+      address,
       balance: '5.3',
     }
 
@@ -167,7 +175,6 @@ describe('useBlockchainData hook', () => {
     expect.assertions(1)
 
     const component = rtl.render(<Wrapper />)
-    const address = '0x1234567890123456789012345678901234567890'
     paywallConfig = {
       locks: {
         [address]: {

--- a/paywall/src/data-iframe/paywallConfig.js
+++ b/paywall/src/data-iframe/paywallConfig.js
@@ -1,0 +1,16 @@
+let paywallConfig
+let paywallConfigLocks
+
+// these are used by the postOffice to filter the locks
+export function setPaywallConfig(newConfig) {
+  paywallConfig = newConfig
+  paywallConfigLocks = Object.keys(newConfig.locks)
+}
+
+export function getPaywallConfig() {
+  return paywallConfig
+}
+
+export function getRelevantLocks() {
+  return paywallConfigLocks
+}

--- a/paywall/src/data-iframe/paywallConfig.js
+++ b/paywall/src/data-iframe/paywallConfig.js
@@ -4,7 +4,11 @@ let paywallConfigLocks
 // these are used by the postOffice to filter the locks
 export function setPaywallConfig(newConfig) {
   paywallConfig = newConfig
-  paywallConfigLocks = Object.keys(newConfig.locks)
+  if (newConfig) {
+    paywallConfigLocks = Object.keys(newConfig.locks)
+  } else {
+    paywallConfigLocks = undefined
+  }
 }
 
 export function getPaywallConfig() {

--- a/paywall/src/data-iframe/postOffice.js
+++ b/paywall/src/data-iframe/postOffice.js
@@ -75,6 +75,11 @@ export default function postOffice(window, requiredConfirmations) {
     const relevantLocks = getRelevantLocks()
     if (!relevantLocks) {
       // this should not happen
+      // this is a boundary check. If POST_MESSAGE_SEND_UPDATES with 'locks'
+      // is sent prior to receiving POST_MESSAGE_CONFIG then this will trigger.
+      // This can only happen if a bug is introduced in unlock.min.js,
+      // but it will be exceedingly difficult to debug in that case.
+      // This is here to make it easier to debug.
       console.error('internal error - locks requested before config') // eslint-disable-line
       return
     }

--- a/paywall/src/hooks/useBlockchainData.js
+++ b/paywall/src/hooks/useBlockchainData.js
@@ -52,24 +52,39 @@ export default function useBlockchainData(window, paywallConfig) {
   // construct the object format expected by the checkout UI
   const account = address ? { address, balance } : null
 
-  // populate lcoks with the lock names, either from the chain
-  // or from the paywall config
-  const locks = Object.keys(blockChainLocks).reduce(
-    (newLocks, lockAddress) => ({
-      ...newLocks,
-      [lockAddress]: {
-        ...blockChainLocks[lockAddress],
-        // we always use the configuration name to provide flexibility
-        // even if the lock has a name set on the contract
-        name: paywallConfig.locks[lockAddress].name,
-      },
-    }),
-    {}
-  )
+  try {
+    // populate locks with the lock names, either from the chain
+    // or from the paywall config
+    const locks = Object.keys(blockChainLocks).reduce(
+      (newLocks, lockAddress) => ({
+        ...newLocks,
+        [lockAddress]: {
+          ...blockChainLocks[lockAddress],
+          // we always use the configuration name to provide flexibility
+          // even if the lock has a name set on the contract
+          name: paywallConfig.locks[lockAddress].name,
+        },
+      }),
+      {}
+    )
 
-  return {
-    account,
-    network,
-    locks,
+    return {
+      account,
+      network,
+      locks,
+    }
+  } catch (e) {
+    // sanity check
+    // eslint-disable-next-line no-console
+    console.error(
+      'Internal error: blockchain data out of sync with paywall config',
+      e.message
+    )
+
+    return {
+      account,
+      network,
+      locks: {},
+    }
   }
 }


### PR DESCRIPTION
# Description

A user may visit several different paywalls. All of them will cache the lock/key information for that paywall and that user. This leads to a mistake: when returning cached locks, the data iframe returns all of them. Instead, it should only return the relevant locks, which are the ones specified in the paywall config passed to the data iframe. This PR fixes that mistake.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3732 
Refs #2903 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
