### PR TITLE
augment the wait.forIframe to allow waiting for multiple iframes

### DIFF
--- a/tests/helpers/wait.js
+++ b/tests/helpers/wait.js
@@ -45,10 +45,14 @@ const untilIsGone = async selector =>
  */
 const forLoadingDone = async () => untilIsGone('svg[alt="loading"]')
 
-const forIframe = async () => {
-  return page.waitForFunction(() => {
-    return window.frames.length
-  })
+const forIframe = async (length = 1) => {
+  return page.waitForFunction(
+    length => {
+      return window.frames.length >= length
+    },
+    {},
+    length
+  )
 }
 
 module.exports = {


### PR DESCRIPTION
# Description

In order to test the ad remover iframe, this augments the `wait.forIframe` helper so that we can specify the number of iframes that should exist, defaulting to 1, so that it does not break existing tests.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3607

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
