### PR TITLE
clear stale cached account if we have no wallet present

### DIFF
--- a/paywall/src/__tests__/data-iframe/postOfficeListener.test.js
+++ b/paywall/src/__tests__/data-iframe/postOfficeListener.test.js
@@ -4,7 +4,13 @@ import {
   POST_MESSAGE_SEND_UPDATES,
   POST_MESSAGE_CONFIG,
   POST_MESSAGE_PURCHASE_KEY,
+  POST_MESSAGE_WALLET_INFO,
 } from '../../paywall-builder/constants'
+import {
+  clearListeners,
+  addListener,
+  getAccount,
+} from '../../data-iframe/cacheHandler'
 
 describe('postOffice listener', () => {
   let fakeWindow
@@ -46,6 +52,18 @@ describe('postOffice listener', () => {
     fakePurchase = jest.fn()
 
     fakeWindow = {
+      storage: {},
+      localStorage: {
+        setItem(key, item) {
+          fakeWindow.storage[key] = item
+        },
+        getItem(key) {
+          return fakeWindow.storage[key]
+        },
+        removeItem(key) {
+          delete fakeWindow.storage[key]
+        },
+      },
       console: {
         error: jest.fn(),
       },
@@ -58,6 +76,7 @@ describe('postOffice listener', () => {
         fakeWindow.handlers[type] = handler
       },
     }
+    clearListeners()
   })
 
   it('responds to config message by calling setConfig when the config is valid', () => {
@@ -135,6 +154,47 @@ describe('postOffice listener', () => {
 
     expect(fakeUpdater).toHaveBeenCalledTimes(1)
     expect(fakeUpdater).toHaveBeenCalledWith('network')
+  })
+
+  it('responds to wallet info with missing wallet by resetting account', async () => {
+    expect.assertions(3)
+
+    makePostOffice()
+    addListener(fakeUpdater)
+
+    callListener(POST_MESSAGE_WALLET_INFO, { noWallet: true })
+
+    expect(await getAccount(fakeWindow)).toBe(null)
+    expect(fakeUpdater).toHaveBeenCalledTimes(1)
+    expect(fakeUpdater).toHaveBeenCalledWith('account')
+  })
+
+  it('responds to wallet info with existing wallet by ignoring the payload', async () => {
+    expect.assertions(1)
+
+    makePostOffice()
+    addListener(fakeUpdater)
+
+    callListener(POST_MESSAGE_WALLET_INFO, { noWallet: false })
+
+    expect(fakeUpdater).not.toHaveBeenCalled()
+  })
+
+  it('responds to wallet info with malformed payload by ignoring the payload', () => {
+    expect.assertions(3)
+
+    makePostOffice()
+
+    addListener(fakeUpdater)
+
+    callListener(POST_MESSAGE_WALLET_INFO, [])
+    expect(fakeUpdater).not.toHaveBeenCalled()
+
+    callListener(POST_MESSAGE_WALLET_INFO, false)
+    expect(fakeUpdater).not.toHaveBeenCalled()
+
+    callListener(POST_MESSAGE_WALLET_INFO, 'hi')
+    expect(fakeUpdater).not.toHaveBeenCalled()
   })
 
   it('responds to a malicious data request by logging and bailing', () => {


### PR DESCRIPTION
# Description

This fixes loading a new paywall if the wallet is missing (metamask has been uninstalled, for instance). It also ensures we never use a stale cached account if it isn't verified as present by blockchain

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3735 
Refs #2903 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
