### PR TITLE
fixing the title of the deploys based on whether they are automated or manual

### DIFF
--- a/scripts/automated-production-pr.sh
+++ b/scripts/automated-production-pr.sh
@@ -66,6 +66,7 @@ echo "Push new production branch"
 git push origin $BRANCH --no-verify
 
 echo "Open pull request"
+PROD_DEPLOY_TYPE="automated"
 source "${BASH_SOURCE%/*}/production-pull-request-template.sh"
 
 DOY=$(date +%j)

--- a/scripts/manual-production-pr.sh
+++ b/scripts/manual-production-pr.sh
@@ -69,6 +69,7 @@ echo "Push new production branch"
 git push origin $BRANCH --no-verify
 
 echo "Open pull request"
+PROD_DEPLOY_TYPE="manual"
 source "${BASH_SOURCE%/*}/production-pull-request-template.sh"
 GITHUB_TOKEN=$GITHUB_API_TOKEN hub pull-request -b production -h $BRANCH --message "$MESSAGE" -r $REVIEWER
 

--- a/scripts/production-pull-request-template.sh
+++ b/scripts/production-pull-request-template.sh
@@ -1,4 +1,4 @@
-export MESSAGE="Production Automated Deploy $BRANCH
+export MESSAGE="Production $PROD_DEPLOY_TYPE Deploy $BRANCH
 
 This is a production deployment. Please treat with great caution!
 This deploys the code from master as of commit $COMMIT_TO_DEPLOY.


### PR DESCRIPTION
# Description

This is a minor fix to make sure our PR title make a distinction between the 2 branches!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->