### PR TITLE
More correctly named method in storageService for user update

### DIFF
--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -233,20 +233,20 @@ describe('Storage middleware', () => {
       const emailAddress = 'geoff@bitconnect.gov'
       const data = {
         message: {
-          emailAddress,
+          user: {
+            emailAddress,
+          },
         },
       }
       const sig = {}
       const { next, invoke } = create()
       const action = { type: SIGNED_USER_DATA, data, sig }
-      mockStorageService.updateUser = jest.fn()
+      mockStorageService.updateUserEncryptedPrivateKey = jest.fn()
 
       invoke(action)
-      expect(mockStorageService.updateUser).toHaveBeenCalledWith(
-        emailAddress,
-        data,
-        sig
-      )
+      expect(
+        mockStorageService.updateUserEncryptedPrivateKey
+      ).toHaveBeenCalledWith(emailAddress, data, sig)
       expect(next).toHaveBeenCalledTimes(1)
     })
   })

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -311,7 +311,11 @@ describe('StorageService', () => {
       it('emits a success', done => {
         expect.assertions(2)
         axios.put.mockReturnValue()
-        storageService.updateUser('hello@unlock-protocol.com', user, null)
+        storageService.updateUserEncryptedPrivateKey(
+          'hello@unlock-protocol.com',
+          user,
+          null
+        )
 
         storageService.on(success.updateUser, ({ emailAddress }) => {
           expect(emailAddress).toBe('hello@unlock-protocol.com')
@@ -321,7 +325,7 @@ describe('StorageService', () => {
         expect(axios.put).toHaveBeenCalledWith(
           `${serviceHost}/users/${encodeURIComponent(
             'hello@unlock-protocol.com'
-          )}`,
+          )}/passwordEncryptedPrivateKey`,
           user,
           {}
         )
@@ -332,7 +336,11 @@ describe('StorageService', () => {
       it('emits a failure', done => {
         expect.assertions(3)
         axios.put.mockRejectedValue('Egads! An Error')
-        storageService.updateUser('hello@unlock-protocol.com', user, null)
+        storageService.updateUserEncryptedPrivateKey(
+          'hello@unlock-protocol.com',
+          user,
+          null
+        )
 
         storageService.on(failure.updateUser, ({ emailAddress, error }) => {
           expect(emailAddress).toBe('hello@unlock-protocol.com')
@@ -343,7 +351,7 @@ describe('StorageService', () => {
         expect(axios.put).toHaveBeenCalledWith(
           `${serviceHost}/users/${encodeURIComponent(
             'hello@unlock-protocol.com'
-          )}`,
+          )}/passwordEncryptedPrivateKey`,
           user,
           {}
         )

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -157,7 +157,11 @@ const storageMiddleware = config => {
 
         if (action.type === SIGNED_USER_DATA) {
           const { data, sig } = action
-          storageService.updateUser(data.message.emailAddress, data, sig)
+          storageService.updateUserEncryptedPrivateKey(
+            data.message.user.emailAddress,
+            data,
+            sig
+          )
         }
 
         if (action.type === SIGNUP_CREDENTIALS) {

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -150,15 +150,15 @@ export class StorageService extends EventEmitter {
   }
 
   /**
-   * Updates a user, using their email address as key. In the case of failure a rejected promise
-   * is returned to the caller.
+   * Updates a user's private key, using their email address as key. In the case
+   * of failure a rejected promise is returned to the caller.
    *
    * @param {*} email
    * @param {*} user
    * @param {*} token
    * @returns {Promise<*>}
    */
-  async updateUser(emailAddress, user, token) {
+  async updateUserEncryptedPrivateKey(emailAddress, user, token) {
     const opts = {}
     if (token) {
       // TODO: tokens aren't optional
@@ -166,7 +166,9 @@ export class StorageService extends EventEmitter {
     }
     try {
       await axios.put(
-        `${this.host}/users/${encodeURIComponent(emailAddress)}`,
+        `${this.host}/users/${encodeURIComponent(
+          emailAddress
+        )}/passwordEncryptedPrivateKey`,
         user,
         opts
       )


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
In the process of working on #3609, I found that the `updateUser` method in `storageService` isn't a general user update method, but one that only allows for updating the user's email address. At the moment, we don't support that functionality in the app. I have replaced it with `updateUserEncryptedPrivateKey` which specifically hits the private key endpoint as a prelude to #3609. As we support more aspects of user accounts, we'll have to implement methods for each endpoint (ideally as part of pulling all user account interaction into UnlockProvider).

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
