### PR TITLE
DRY up ad remover test htmls, add 2 new for integration testing

### DIFF
--- a/paywall/src/__tests__/static/adRemoverUtils.test.js
+++ b/paywall/src/__tests__/static/adRemoverUtils.test.js
@@ -1,0 +1,172 @@
+import {
+  hookupGanache,
+  setupPaywallConfig,
+} from '../../static/adremover/adRemoverUtils'
+
+describe('adRemoverUtils', () => {
+  describe('hookupGanache', () => {
+    let fakeWindow
+    let provider
+    let result
+    let ok
+    let status
+
+    beforeEach(() => {
+      status = 404
+      ok = true
+      fakeWindow = {
+        URL: () => {
+          return {
+            searchParams: {
+              // return the provider we specify, or what the variable
+              // was we asked to retrieve
+              get: askedFor => (provider === undefined ? askedFor : provider),
+            },
+          }
+        },
+      }
+    })
+
+    it('should create a web3 object on window', () => {
+      expect.assertions(1)
+
+      hookupGanache(fakeWindow)
+
+      expect(fakeWindow.web3.currentProvider).toEqual({
+        sendAsync: expect.any(Function),
+      })
+    })
+
+    describe('sendAsync', () => {
+      let json
+      beforeEach(() => {
+        json = jest.fn(() => Promise.resolve(result))
+        fakeWindow = {
+          URL: () => {
+            return {
+              searchParams: {
+                // return the provider we specify, or what the variable
+                // was we asked to retrieve
+                get: askedFor => (provider === undefined ? askedFor : provider),
+              },
+            }
+          },
+          fetch: jest.fn(() =>
+            Promise.resolve({
+              ok,
+              status,
+              json,
+            })
+          ),
+        }
+        hookupGanache(fakeWindow)
+      })
+
+      it('should fetch a payload from ganache', async () => {
+        expect.assertions(1)
+
+        const payload = { method: 'hi', params: [] }
+        await fakeWindow.web3.currentProvider.sendAsync(payload, () => {})
+
+        expect(fakeWindow.fetch).toHaveBeenCalledWith(
+          'provider',
+          expect.objectContaining({
+            method: 'POST',
+            mode: 'cors',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+          })
+        )
+      })
+
+      it('should call the callback with the result', async () => {
+        expect.assertions(1)
+
+        result = { result: 'ok' }
+
+        const web3Cb = jest.fn()
+        const payload = { method: 'hi', params: [] }
+        await fakeWindow.web3.currentProvider.sendAsync(payload, web3Cb)
+
+        expect(web3Cb).toHaveBeenCalledWith(null, result)
+      })
+
+      it('should bail on failure to connect', async () => {
+        expect.assertions(1)
+
+        ok = false
+
+        const web3Cb = jest.fn()
+        const payload = { method: 'hi', params: [] }
+        await fakeWindow.web3.currentProvider.sendAsync(payload, web3Cb)
+
+        expect(web3Cb).toHaveBeenCalledWith(
+          expect.objectContaining({ error: 'Cannot connect', code: status })
+        )
+      })
+
+      it('should bail on malformed json', async () => {
+        expect.assertions(1)
+
+        const web3Cb = jest.fn()
+        const payload = { method: 'hi', params: [] }
+        json = jest.fn(() => Promise.reject(new Error('fail')))
+        await fakeWindow.web3.currentProvider.sendAsync(payload, web3Cb)
+
+        expect(web3Cb).toHaveBeenCalledWith(
+          expect.objectContaining({ error: 'fail' })
+        )
+      })
+    })
+  })
+
+  describe('setupPaywallConfig', () => {
+    let fakeWindow
+    const locks = [
+      { name: 'lock 1', address: '0x123' },
+      { name: 'lock 2', address: '0x456' },
+    ]
+
+    beforeEach(() => {
+      fakeWindow = {
+        document: {
+          location: {},
+        },
+        URL: () => {
+          return {
+            searchParams: {
+              // return the provider we specify, or what the variable
+              // was we asked to retrieve
+              get: () => JSON.stringify(locks),
+            },
+          }
+        },
+      }
+    })
+
+    it('should set unlockProtocolConfig on the window object properly', () => {
+      expect.assertions(1)
+
+      setupPaywallConfig(fakeWindow)
+
+      expect(fakeWindow.unlockProtocolConfig).toEqual({
+        locks: {
+          '0x123': {
+            name: 'lock 1',
+          },
+          '0x456': {
+            name: 'lock 2',
+          },
+        },
+        icon:
+          'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjAwIDI1NiI+CiAgPHBhdGggZD0iTTQ0OS45Mzk4OCwyMzAuMDUzNzFoNTMuMDRWMGgtNTMuMDRaTTIxNS4xMDIsMTUuOTc2MDdIMTU5LjUwNThWNzEuNTgzODZINzAuNjc5NjNWMTUuOTc2MDdIMTUuMDgzVjcxLjU4Mzg2SDBWOTguMDA0MTVIMTUuMDgzdjQxLjYyNTczYzAsNTIuMDgxNTUsNDUuMDUyMjQsOTQuNTc3NjQsMTAwLjMyOTEsOTQuNTc3NjQsNTQuOTU3LDAsOTkuNjg5OTQtNDIuNDk2MDksOTkuNjg5OTQtOTQuNTc3NjRWOTguMDA0MTVoMTQuOTY0VjcxLjU4Mzg2SDIxNS4xMDJaTTE1OS41MDU4LDEzOS42Mjk4OGMwLDI0LjYwMy0xOS40OTA3Miw0NC43MzI0Mi00NC4wOTM3NSw0NC43MzI0MmE0NC44NjM2Nyw0NC44NjM2NywwLDAsMS00NC43MzI0Mi00NC43MzI0MlY5OC4wMDQxNUgxNTkuNTA1OFpNMzQ4LjY1NjY4LDY3LjA5OTEyYy0xOS4xNzEzOSwwLTM3LjcwMzYyLDguNjI3LTQ4LjI0NzU2LDI0LjI4MzJIMjk5Ljc3bC0zLjE5NDgzLTE5LjgxMDA1aC00Ni42NDk5VjIzMC4wNTM3MWg1My4wNHYtODIuNDM2YzAtMTguMjEyNDEsMTQuMDU5MDgtMzIuOTEwMTYsMzAuOTkzNjUtMzIuOTEwMTYsMTcuNTczMjUsMCwzMS4zMTI1LDE0LjY5Nzc1LDMxLjMxMjUsMzIuMjcxNDh2ODMuMDc0NzFoNTMuMDR2LTg4LjE4N0M0MTguMzExNDYsOTkuNjg5OTQsMzkxLjQ3MjExLDY3LjA5OTEyLDM0OC42NTY2OCw2Ny4wOTkxMlptNjgwLjg3Njk1LDc3LjMyMzI0LDY1LjE4MTY0LTcyLjg1MDA5aC02NS41MDFsLTUxLjEyMyw1OS40MzA2NmgtLjk1OVYwaC01My4wNFYyMzAuMDUzNzFoNTMuMDRWMTU3Ljg0MjI5aC45NTlsNTIuNzIwNyw3Mi4yMTE0Mmg2Ni43NzkzWk02MTMuMjA4NDQsNjcuMDk5MTJjLTQ5LjUyNTQsMC05MC40MjM4MywzNy43MDMxMy05MC40MjM4Myw4My43MTM4N3M0MC44OTg0Myw4My4zOTQ1Myw5MC40MjM4Myw4My4zOTQ1Myw5MC40MjM4Mi0zNy4zODM3OSw5MC40MjM4Mi04My4zOTQ1M1M2NjIuNzMzODMsNjcuMDk5MTIsNjEzLjIwODQ0LDY3LjA5OTEyWm0wLDEyMC43NzgzMmMtMjAuMTI5ODksMC0zNy4wNjQ0Ni0xNi45MzQ1Ny0zNy4wNjQ0Ni0zNy4wNjQ0NXMxNi45MzQ1Ny0zNy4wNjQ0NSwzNy4wNjQ0Ni0zNy4wNjQ0NSwzNy4zODM3OCwxNi45MzQ1NywzNy4zODM3OCwzNy4wNjQ0NVM2MzMuMzM4MzIsMTg3Ljg3NzQ0LDYxMy4yMDg0NCwxODcuODc3NDRaTTgxNC44MTg3OSwxMTMuNDI5MmMxNS42NTYyNSwwLDI4LjQzNzUsOC45NDY3OCwzMy4yMzA0NywyMS40MDc3MWg1My45OThjLTUuNDMxNjQtMzcuMDY0LTQxLjUzNzExLTY3LjczNzc5LTg2LjI2OTUzLTY3LjczNzc5LTQ5Ljg0NTcsMC05MS4wNjM1LDM3LjcwMzEzLTkxLjA2MzUsODMuNzEzODdzNDEuMjE3OCw4My4zOTQ1Myw5MS4wNjM1LDgzLjM5NDUzYzQzLjc3MzQ0LDAsODEuMTU3MjMtMjkuMzk2LDg2LjI2OTUzLTY4LjA1NzYyaC01My45OThjLTUuNzUyLDEzLjEwMDEtMTcuNTc0MjIsMjEuNDA3NzItMzMuMjMwNDcsMjEuNDA3NzJBMzYuOTU1MSwzNi45NTUxLDAsMCwxLDc3OC4wNzQ2NSwxNTAuODEzQzc3OC4wNzQ2NSwxMzAuNjgzMTEsNzk0LjM2OTU3LDExMy40MjkyLDgxNC44MTg3OSwxMTMuNDI5MloiLz4KPC9zdmc+Cg==',
+        callToAction: {
+          default:
+            'Enjoy Unlock Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.',
+        },
+      })
+    })
+  })
+})

--- a/paywall/src/static/adremover/adRemoverUtils.js
+++ b/paywall/src/static/adremover/adRemoverUtils.js
@@ -1,0 +1,104 @@
+function hookupGanache(window) {
+  const us = new window.URL(document.location)
+  const provider = us.searchParams.get('provider') || 'http://localhost:8545'
+  // create a proxy to the underlying JSON-RPC endpoint
+  // a minimal JSON-RPC provider for use with web3Proxy.js in integration testing
+  window.web3 = {
+    currentProvider: {
+      async sendAsync(payload, web3Cb) {
+        try {
+          const response = await window.fetch(provider, {
+            method: 'POST',
+            mode: 'cors',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+          })
+          if (!response.ok) {
+            web3Cb({ error: 'Cannot connect', code: response.status })
+          }
+          const json = await response.json()
+          web3Cb(null, json)
+        } catch (error) {
+          web3Cb({ error: error.message })
+        }
+      },
+    },
+  }
+}
+
+function setupPaywallConfig(window) {
+  var us = new window.URL(window.document.location)
+  // this is for integration testing only, so we do not do any validation
+  // format is an array like:
+  // [
+  //   { name: '...', address: '0x...' },
+  //   { name: '...', address: '0x...' },
+  //   { name: '...', address: '0x...' },
+  //   ...,
+  // ]
+  var locks = JSON.parse(us.searchParams.get('locks'))
+
+  window.unlockProtocolConfig = {
+    locks: locks.reduce(
+      (allLocks, lock) => ({
+        ...allLocks,
+        [lock.address]: {
+          name: lock.name,
+        },
+      }),
+      {}
+    ),
+    icon:
+      'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjAwIDI1NiI+CiAgPHBhdGggZD0iTTQ0OS45Mzk4OCwyMzAuMDUzNzFoNTMuMDRWMGgtNTMuMDRaTTIxNS4xMDIsMTUuOTc2MDdIMTU5LjUwNThWNzEuNTgzODZINzAuNjc5NjNWMTUuOTc2MDdIMTUuMDgzVjcxLjU4Mzg2SDBWOTguMDA0MTVIMTUuMDgzdjQxLjYyNTczYzAsNTIuMDgxNTUsNDUuMDUyMjQsOTQuNTc3NjQsMTAwLjMyOTEsOTQuNTc3NjQsNTQuOTU3LDAsOTkuNjg5OTQtNDIuNDk2MDksOTkuNjg5OTQtOTQuNTc3NjRWOTguMDA0MTVoMTQuOTY0VjcxLjU4Mzg2SDIxNS4xMDJaTTE1OS41MDU4LDEzOS42Mjk4OGMwLDI0LjYwMy0xOS40OTA3Miw0NC43MzI0Mi00NC4wOTM3NSw0NC43MzI0MmE0NC44NjM2Nyw0NC44NjM2NywwLDAsMS00NC43MzI0Mi00NC43MzI0MlY5OC4wMDQxNUgxNTkuNTA1OFpNMzQ4LjY1NjY4LDY3LjA5OTEyYy0xOS4xNzEzOSwwLTM3LjcwMzYyLDguNjI3LTQ4LjI0NzU2LDI0LjI4MzJIMjk5Ljc3bC0zLjE5NDgzLTE5LjgxMDA1aC00Ni42NDk5VjIzMC4wNTM3MWg1My4wNHYtODIuNDM2YzAtMTguMjEyNDEsMTQuMDU5MDgtMzIuOTEwMTYsMzAuOTkzNjUtMzIuOTEwMTYsMTcuNTczMjUsMCwzMS4zMTI1LDE0LjY5Nzc1LDMxLjMxMjUsMzIuMjcxNDh2ODMuMDc0NzFoNTMuMDR2LTg4LjE4N0M0MTguMzExNDYsOTkuNjg5OTQsMzkxLjQ3MjExLDY3LjA5OTEyLDM0OC42NTY2OCw2Ny4wOTkxMlptNjgwLjg3Njk1LDc3LjMyMzI0LDY1LjE4MTY0LTcyLjg1MDA5aC02NS41MDFsLTUxLjEyMyw1OS40MzA2NmgtLjk1OVYwaC01My4wNFYyMzAuMDUzNzFoNTMuMDRWMTU3Ljg0MjI5aC45NTlsNTIuNzIwNyw3Mi4yMTE0Mmg2Ni43NzkzWk02MTMuMjA4NDQsNjcuMDk5MTJjLTQ5LjUyNTQsMC05MC40MjM4MywzNy43MDMxMy05MC40MjM4Myw4My43MTM4N3M0MC44OTg0Myw4My4zOTQ1Myw5MC40MjM4Myw4My4zOTQ1Myw5MC40MjM4Mi0zNy4zODM3OSw5MC40MjM4Mi04My4zOTQ1M1M2NjIuNzMzODMsNjcuMDk5MTIsNjEzLjIwODQ0LDY3LjA5OTEyWm0wLDEyMC43NzgzMmMtMjAuMTI5ODksMC0zNy4wNjQ0Ni0xNi45MzQ1Ny0zNy4wNjQ0Ni0zNy4wNjQ0NXMxNi45MzQ1Ny0zNy4wNjQ0NSwzNy4wNjQ0Ni0zNy4wNjQ0NSwzNy4zODM3OCwxNi45MzQ1NywzNy4zODM3OCwzNy4wNjQ0NVM2MzMuMzM4MzIsMTg3Ljg3NzQ0LDYxMy4yMDg0NCwxODcuODc3NDRaTTgxNC44MTg3OSwxMTMuNDI5MmMxNS42NTYyNSwwLDI4LjQzNzUsOC45NDY3OCwzMy4yMzA0NywyMS40MDc3MWg1My45OThjLTUuNDMxNjQtMzcuMDY0LTQxLjUzNzExLTY3LjczNzc5LTg2LjI2OTUzLTY3LjczNzc5LTQ5Ljg0NTcsMC05MS4wNjM1LDM3LjcwMzEzLTkxLjA2MzUsODMuNzEzODdzNDEuMjE3OCw4My4zOTQ1Myw5MS4wNjM1LDgzLjM5NDUzYzQzLjc3MzQ0LDAsODEuMTU3MjMtMjkuMzk2LDg2LjI2OTUzLTY4LjA1NzYyaC01My45OThjLTUuNzUyLDEzLjEwMDEtMTcuNTc0MjIsMjEuNDA3NzItMzMuMjMwNDcsMjEuNDA3NzJBMzYuOTU1MSwzNi45NTUxLDAsMCwxLDc3OC4wNzQ2NSwxNTAuODEzQzc3OC4wNzQ2NSwxMzAuNjgzMTEsNzk0LjM2OTU3LDExMy40MjkyLDgxNC44MTg3OSwxMTMuNDI5MloiLz4KPC9zdmc+Cg==',
+    callToAction: {
+      default:
+        'Enjoy Unlock Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.',
+    },
+  }
+}
+
+/**
+ * Shows the ads on the page!
+ */
+function loadAds(document) {
+  // Let's look for all ad elements
+  document.querySelectorAll('.ad').forEach(adElement => {
+    adElement.style.height = `${adElement.attributes['data-height'].value}px`
+    adElement.style.width = `${adElement.attributes['data-width'].value}px`
+    adElement.style['background-color'] = 'red'
+    adElement.style.content = 'ad'
+    adElement.style.display = 'block'
+  })
+}
+
+/**
+ * Hides the ads on the page!
+ */
+function hideAds(document) {
+  document.querySelectorAll('.ad').forEach(adElement => {
+    adElement.style.display = 'none'
+  })
+}
+
+/**
+ * Shows the Unlock checkout page
+ */
+function loadCheckout(window) {
+  window.unlockProtocol && window.unlockProtocol.loadCheckoutModal()
+}
+
+const isNode =
+  typeof process !== 'undefined' &&
+  process.versions != null &&
+  process.versions.node != null
+if (isNode) {
+  module.exports = {
+    hookupGanache,
+    setupPaywallConfig,
+    loadAds,
+    hideAds,
+    loadCheckout,
+  }
+}

--- a/paywall/src/static/adremover/adremover.css
+++ b/paywall/src/static/adremover/adremover.css
@@ -1,0 +1,35 @@
+body {
+  font-family: Verdana, Geneva, Tahoma, sans-serif;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-gap: 1em;
+}
+
+header {
+  grid-column: 1 / span 5;
+}
+
+main {
+  grid-column: 1 / span 3;
+}
+
+aside {
+  grid-column: span 2;
+}
+
+@media (max-width: 700px) {
+  main,
+  aside {
+    grid-column: 1 / span 5;
+  }
+}
+
+body {
+  margin: 0 auto;
+  max-width: 56em;
+  padding: 1em 0;
+}
+
+header {
+  height: 10vw;
+}

--- a/paywall/src/static/adremover/index.html
+++ b/paywall/src/static/adremover/index.html
@@ -33,49 +33,8 @@
         },
       }
     </script>
+    <link rel="stylesheet" href="adremover.css" type="text/css" />
   </head>
-  <style>
-    body {
-      font-family: Verdana, Geneva, Tahoma, sans-serif;
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      grid-gap: 1em;
-    }
-
-    header {
-      grid-column: 1 / span 5;
-    }
-
-    main {
-      grid-column: 1 / span 3;
-    }
-
-    aside {
-      grid-column: span 2;
-    }
-
-    @media (max-width: 700px) {
-      main,
-      aside {
-        grid-column: 1 / span 5;
-      }
-    }
-
-    body {
-      margin: 0 auto;
-      max-width: 56em;
-      padding: 1em 0;
-    }
-
-    header,
-    main,
-    aside {
-    }
-
-    header {
-      height: 10vw;
-    }
-  </style>
 
   <script>
     let unlocked = false

--- a/paywall/src/static/adremover/integrationtesting-loggedin.html
+++ b/paywall/src/static/adremover/integrationtesting-loggedin.html
@@ -23,49 +23,8 @@
     <script>
       setupPaywallConfig(window)
     </script>
+    <link rel="stylesheet" href="adremover.css" type="text/css" />
   </head>
-  <style>
-    body {
-      font-family: Verdana, Geneva, Tahoma, sans-serif;
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      grid-gap: 1em;
-    }
-
-    header {
-      grid-column: 1 / span 5;
-    }
-
-    main {
-      grid-column: 1 / span 3;
-    }
-
-    aside {
-      grid-column: span 2;
-    }
-
-    @media (max-width: 700px) {
-      main,
-      aside {
-        grid-column: 1 / span 5;
-      }
-    }
-
-    body {
-      margin: 0 auto;
-      max-width: 56em;
-      padding: 1em 0;
-    }
-
-    header,
-    main,
-    aside {
-    }
-
-    header {
-      height: 10vw;
-    }
-  </style>
 
   <script>
     let unlocked = false

--- a/paywall/src/static/adremover/integrationtesting-loggedin.html
+++ b/paywall/src/static/adremover/integrationtesting-loggedin.html
@@ -5,33 +5,23 @@
     <title>Lorem Ipsum Daily</title>
     <script src="adRemoverUtils.js"></script>
     <script>
+      var us = new URL(document.location)
+      const loginafter = +us.searchParams.get('logindelay') || 0
+      if (!loginafter) {
+        hookupGanache(window)
+      } else {
+        // log into ganache after a delay
+        setTimeout(() => hookupGanache(window), loginafter * 1000)
+      }
       ;(function(d, s) {
         var js = d.createElement(s),
           sc = d.getElementsByTagName(s)[0]
-        js.src = 'http://localhost:3001/static/unlock.1.0.min.js'
+        js.src = `${us.searchParams.get('paywall')}/static/unlock.1.0.min.js`
         sc.parentNode.insertBefore(js, sc)
       })(document, 'script')
     </script>
     <script>
-      var unlockProtocolConfig = {
-        locks: {
-          '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267': {
-            name: 'One Week',
-          },
-          '0x8276A24C03B7ff9307c5bb9c0f31aa60d284375f': {
-            name: 'One Month',
-          },
-          '0x45DeBF700aB8120aC0665119467EA82BDB45E00b': {
-            name: 'One Year',
-          },
-        },
-        icon:
-          'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjAwIDI1NiI+CiAgPHBhdGggZD0iTTQ0OS45Mzk4OCwyMzAuMDUzNzFoNTMuMDRWMGgtNTMuMDRaTTIxNS4xMDIsMTUuOTc2MDdIMTU5LjUwNThWNzEuNTgzODZINzAuNjc5NjNWMTUuOTc2MDdIMTUuMDgzVjcxLjU4Mzg2SDBWOTguMDA0MTVIMTUuMDgzdjQxLjYyNTczYzAsNTIuMDgxNTUsNDUuMDUyMjQsOTQuNTc3NjQsMTAwLjMyOTEsOTQuNTc3NjQsNTQuOTU3LDAsOTkuNjg5OTQtNDIuNDk2MDksOTkuNjg5OTQtOTQuNTc3NjRWOTguMDA0MTVoMTQuOTY0VjcxLjU4Mzg2SDIxNS4xMDJaTTE1OS41MDU4LDEzOS42Mjk4OGMwLDI0LjYwMy0xOS40OTA3Miw0NC43MzI0Mi00NC4wOTM3NSw0NC43MzI0MmE0NC44NjM2Nyw0NC44NjM2NywwLDAsMS00NC43MzI0Mi00NC43MzI0MlY5OC4wMDQxNUgxNTkuNTA1OFpNMzQ4LjY1NjY4LDY3LjA5OTEyYy0xOS4xNzEzOSwwLTM3LjcwMzYyLDguNjI3LTQ4LjI0NzU2LDI0LjI4MzJIMjk5Ljc3bC0zLjE5NDgzLTE5LjgxMDA1aC00Ni42NDk5VjIzMC4wNTM3MWg1My4wNHYtODIuNDM2YzAtMTguMjEyNDEsMTQuMDU5MDgtMzIuOTEwMTYsMzAuOTkzNjUtMzIuOTEwMTYsMTcuNTczMjUsMCwzMS4zMTI1LDE0LjY5Nzc1LDMxLjMxMjUsMzIuMjcxNDh2ODMuMDc0NzFoNTMuMDR2LTg4LjE4N0M0MTguMzExNDYsOTkuNjg5OTQsMzkxLjQ3MjExLDY3LjA5OTEyLDM0OC42NTY2OCw2Ny4wOTkxMlptNjgwLjg3Njk1LDc3LjMyMzI0LDY1LjE4MTY0LTcyLjg1MDA5aC02NS41MDFsLTUxLjEyMyw1OS40MzA2NmgtLjk1OVYwaC01My4wNFYyMzAuMDUzNzFoNTMuMDRWMTU3Ljg0MjI5aC45NTlsNTIuNzIwNyw3Mi4yMTE0Mmg2Ni43NzkzWk02MTMuMjA4NDQsNjcuMDk5MTJjLTQ5LjUyNTQsMC05MC40MjM4MywzNy43MDMxMy05MC40MjM4Myw4My43MTM4N3M0MC44OTg0Myw4My4zOTQ1Myw5MC40MjM4Myw4My4zOTQ1Myw5MC40MjM4Mi0zNy4zODM3OSw5MC40MjM4Mi04My4zOTQ1M1M2NjIuNzMzODMsNjcuMDk5MTIsNjEzLjIwODQ0LDY3LjA5OTEyWm0wLDEyMC43NzgzMmMtMjAuMTI5ODksMC0zNy4wNjQ0Ni0xNi45MzQ1Ny0zNy4wNjQ0Ni0zNy4wNjQ0NXMxNi45MzQ1Ny0zNy4wNjQ0NSwzNy4wNjQ0Ni0zNy4wNjQ0NSwzNy4zODM3OCwxNi45MzQ1NywzNy4zODM3OCwzNy4wNjQ0NVM2MzMuMzM4MzIsMTg3Ljg3NzQ0LDYxMy4yMDg0NCwxODcuODc3NDRaTTgxNC44MTg3OSwxMTMuNDI5MmMxNS42NTYyNSwwLDI4LjQzNzUsOC45NDY3OCwzMy4yMzA0NywyMS40MDc3MWg1My45OThjLTUuNDMxNjQtMzcuMDY0LTQxLjUzNzExLTY3LjczNzc5LTg2LjI2OTUzLTY3LjczNzc5LTQ5Ljg0NTcsMC05MS4wNjM1LDM3LjcwMzEzLTkxLjA2MzUsODMuNzEzODdzNDEuMjE3OCw4My4zOTQ1Myw5MS4wNjM1LDgzLjM5NDUzYzQzLjc3MzQ0LDAsODEuMTU3MjMtMjkuMzk2LDg2LjI2OTUzLTY4LjA1NzYyaC01My45OThjLTUuNzUyLDEzLjEwMDEtMTcuNTc0MjIsMjEuNDA3NzItMzMuMjMwNDcsMjEuNDA3NzJBMzYuOTU1MSwzNi45NTUxLDAsMCwxLDc3OC4wNzQ2NSwxNTAuODEzQzc3OC4wNzQ2NSwxMzAuNjgzMTEsNzk0LjM2OTU3LDExMy40MjkyLDgxNC44MTg3OSwxMTMuNDI5MloiLz4KPC9zdmc+Cg==',
-        callToAction: {
-          default:
-            'Enjoy Unlock Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.',
-        },
-      }
+      setupPaywallConfig(window)
     </script>
   </head>
   <style>

--- a/paywall/src/static/adremover/integrationtesting-loggedout.html
+++ b/paywall/src/static/adremover/integrationtesting-loggedout.html
@@ -16,49 +16,8 @@
     <script>
       setupPaywallConfig(window)
     </script>
+    <link rel="stylesheet" href="adremover.css" type="text/css" />
   </head>
-  <style>
-    body {
-      font-family: Verdana, Geneva, Tahoma, sans-serif;
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      grid-gap: 1em;
-    }
-
-    header {
-      grid-column: 1 / span 5;
-    }
-
-    main {
-      grid-column: 1 / span 3;
-    }
-
-    aside {
-      grid-column: span 2;
-    }
-
-    @media (max-width: 700px) {
-      main,
-      aside {
-        grid-column: 1 / span 5;
-      }
-    }
-
-    body {
-      margin: 0 auto;
-      max-width: 56em;
-      padding: 1em 0;
-    }
-
-    header,
-    main,
-    aside {
-    }
-
-    header {
-      height: 10vw;
-    }
-  </style>
 
   <script>
     /**

--- a/paywall/src/static/adremover/integrationtesting-loggedout.html
+++ b/paywall/src/static/adremover/integrationtesting-loggedout.html
@@ -5,33 +5,16 @@
     <title>Lorem Ipsum Daily</title>
     <script src="adRemoverUtils.js"></script>
     <script>
+      var us = new URL(document.location)
       ;(function(d, s) {
         var js = d.createElement(s),
           sc = d.getElementsByTagName(s)[0]
-        js.src = 'http://localhost:3001/static/unlock.1.0.min.js'
+        js.src = `${us.searchParams.get('paywall')}/static/unlock.1.0.min.js`
         sc.parentNode.insertBefore(js, sc)
       })(document, 'script')
     </script>
     <script>
-      var unlockProtocolConfig = {
-        locks: {
-          '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267': {
-            name: 'One Week',
-          },
-          '0x8276A24C03B7ff9307c5bb9c0f31aa60d284375f': {
-            name: 'One Month',
-          },
-          '0x45DeBF700aB8120aC0665119467EA82BDB45E00b': {
-            name: 'One Year',
-          },
-        },
-        icon:
-          'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjAwIDI1NiI+CiAgPHBhdGggZD0iTTQ0OS45Mzk4OCwyMzAuMDUzNzFoNTMuMDRWMGgtNTMuMDRaTTIxNS4xMDIsMTUuOTc2MDdIMTU5LjUwNThWNzEuNTgzODZINzAuNjc5NjNWMTUuOTc2MDdIMTUuMDgzVjcxLjU4Mzg2SDBWOTguMDA0MTVIMTUuMDgzdjQxLjYyNTczYzAsNTIuMDgxNTUsNDUuMDUyMjQsOTQuNTc3NjQsMTAwLjMyOTEsOTQuNTc3NjQsNTQuOTU3LDAsOTkuNjg5OTQtNDIuNDk2MDksOTkuNjg5OTQtOTQuNTc3NjRWOTguMDA0MTVoMTQuOTY0VjcxLjU4Mzg2SDIxNS4xMDJaTTE1OS41MDU4LDEzOS42Mjk4OGMwLDI0LjYwMy0xOS40OTA3Miw0NC43MzI0Mi00NC4wOTM3NSw0NC43MzI0MmE0NC44NjM2Nyw0NC44NjM2NywwLDAsMS00NC43MzI0Mi00NC43MzI0MlY5OC4wMDQxNUgxNTkuNTA1OFpNMzQ4LjY1NjY4LDY3LjA5OTEyYy0xOS4xNzEzOSwwLTM3LjcwMzYyLDguNjI3LTQ4LjI0NzU2LDI0LjI4MzJIMjk5Ljc3bC0zLjE5NDgzLTE5LjgxMDA1aC00Ni42NDk5VjIzMC4wNTM3MWg1My4wNHYtODIuNDM2YzAtMTguMjEyNDEsMTQuMDU5MDgtMzIuOTEwMTYsMzAuOTkzNjUtMzIuOTEwMTYsMTcuNTczMjUsMCwzMS4zMTI1LDE0LjY5Nzc1LDMxLjMxMjUsMzIuMjcxNDh2ODMuMDc0NzFoNTMuMDR2LTg4LjE4N0M0MTguMzExNDYsOTkuNjg5OTQsMzkxLjQ3MjExLDY3LjA5OTEyLDM0OC42NTY2OCw2Ny4wOTkxMlptNjgwLjg3Njk1LDc3LjMyMzI0LDY1LjE4MTY0LTcyLjg1MDA5aC02NS41MDFsLTUxLjEyMyw1OS40MzA2NmgtLjk1OVYwaC01My4wNFYyMzAuMDUzNzFoNTMuMDRWMTU3Ljg0MjI5aC45NTlsNTIuNzIwNyw3Mi4yMTE0Mmg2Ni43NzkzWk02MTMuMjA4NDQsNjcuMDk5MTJjLTQ5LjUyNTQsMC05MC40MjM4MywzNy43MDMxMy05MC40MjM4Myw4My43MTM4N3M0MC44OTg0Myw4My4zOTQ1Myw5MC40MjM4Myw4My4zOTQ1Myw5MC40MjM4Mi0zNy4zODM3OSw5MC40MjM4Mi04My4zOTQ1M1M2NjIuNzMzODMsNjcuMDk5MTIsNjEzLjIwODQ0LDY3LjA5OTEyWm0wLDEyMC43NzgzMmMtMjAuMTI5ODksMC0zNy4wNjQ0Ni0xNi45MzQ1Ny0zNy4wNjQ0Ni0zNy4wNjQ0NXMxNi45MzQ1Ny0zNy4wNjQ0NSwzNy4wNjQ0Ni0zNy4wNjQ0NSwzNy4zODM3OCwxNi45MzQ1NywzNy4zODM3OCwzNy4wNjQ0NVM2MzMuMzM4MzIsMTg3Ljg3NzQ0LDYxMy4yMDg0NCwxODcuODc3NDRaTTgxNC44MTg3OSwxMTMuNDI5MmMxNS42NTYyNSwwLDI4LjQzNzUsOC45NDY3OCwzMy4yMzA0NywyMS40MDc3MWg1My45OThjLTUuNDMxNjQtMzcuMDY0LTQxLjUzNzExLTY3LjczNzc5LTg2LjI2OTUzLTY3LjczNzc5LTQ5Ljg0NTcsMC05MS4wNjM1LDM3LjcwMzEzLTkxLjA2MzUsODMuNzEzODdzNDEuMjE3OCw4My4zOTQ1Myw5MS4wNjM1LDgzLjM5NDUzYzQzLjc3MzQ0LDAsODEuMTU3MjMtMjkuMzk2LDg2LjI2OTUzLTY4LjA1NzYyaC01My45OThjLTUuNzUyLDEzLjEwMDEtMTcuNTc0MjIsMjEuNDA3NzItMzMuMjMwNDcsMjEuNDA3NzJBMzYuOTU1MSwzNi45NTUxLDAsMCwxLDc3OC4wNzQ2NSwxNTAuODEzQzc3OC4wNzQ2NSwxMzAuNjgzMTEsNzk0LjM2OTU3LDExMy40MjkyLDgxNC44MTg3OSwxMTMuNDI5MloiLz4KPC9zdmc+Cg==',
-        callToAction: {
-          default:
-            'Enjoy Unlock Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.',
-        },
-      }
+      setupPaywallConfig(window)
     </script>
   </head>
   <style>
@@ -78,6 +61,13 @@
   </style>
 
   <script>
+    /**
+     * Shows the Unlock checkout page
+     */
+    function loadCheckout() {
+      window.unlockProtocol && unlockProtocol.loadCheckoutModal()
+    }
+
     let unlocked = false
     // Once the doc has been loaded
     window.addEventListener('DOMContentLoaded', event => {
@@ -99,9 +89,7 @@
   <body>
     <header>
       <h1>Lorem Ipsum Daily</h1>
-      <button onclick="loadCheckout(window)">
-        Unlock the ads free experience!
-      </button>
+      <button onclick="loadCheckout()">Unlock the ads free experience!</button>
     </header>
     <main>
       <p>

--- a/paywall/src/static/adremover/prod.html
+++ b/paywall/src/static/adremover/prod.html
@@ -32,7 +32,6 @@
         },
       }
     </script>
-          grid-column: 1 / span 5;
     <link rel="stylesheet" href="adremover.css" type="text/css" />
     <script>
       let unlocked = false

--- a/paywall/src/static/adremover/prod.html
+++ b/paywall/src/static/adremover/prod.html
@@ -4,6 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta charset="utf-8" />
     <title>Lorem Ipsum Daily</title>
+    <script src="adRemoverUtils.js"></script>
     <script>
       ;(function(d, s) {
         var js = d.createElement(s),
@@ -74,54 +75,20 @@
       }
     </style>
     <script>
-      /**
-       * Shows the ads on the page!
-       */
-      function loadAds() {
-        // Let's look for all ad elements
-        document.querySelectorAll('.ad').forEach(adElement => {
-          adElement.style.height = `${
-            adElement.attributes['data-height'].value
-          }px`
-          adElement.style.width = `${
-            adElement.attributes['data-width'].value
-          }px`
-          adElement.style['background-color'] = 'red'
-          adElement.style.content = 'ad'
-          adElement.style.display = 'block'
-        })
-      }
-
-      /**
-       * Hides the ads on the page!
-       */
-      function hideAds() {
-        document.querySelectorAll('.ad').forEach(adElement => {
-          adElement.style.display = 'none'
-        })
-      }
-
-      /**
-       * Shows the Unlock checkout page
-       */
-      function loadCheckout() {
-        window.unlockProtocol && unlockProtocol.loadCheckoutModal()
-      }
-
       let unlocked = false
       // Once the doc has been loaded
       window.addEventListener('DOMContentLoaded', event => {
         //loadAds()
-        setTimeout(() => !unlocked && loadAds(), 100)
+        setTimeout(() => !unlocked && loadAds(document), 100)
       })
 
       window.addEventListener('unlockProtocol', function(e) {
         var state = e.detail
         if (state === 'locked') {
-          loadAds()
+          loadAds(document)
         } else if (state === 'unlocked') {
           unlocked = true
-          hideAds()
+          hideAds(document)
         }
       })
     </script>
@@ -130,7 +97,9 @@
   <body>
     <header>
       <h1>Lorem Ipsum Daily</h1>
-      <button onclick="loadCheckout()">Unlock the ads free experience!</button>
+      <button onclick="loadCheckout(window)">
+        Unlock the ads free experience!
+      </button>
     </header>
     <main>
       <p>

--- a/paywall/src/static/adremover/prod.html
+++ b/paywall/src/static/adremover/prod.html
@@ -32,48 +32,8 @@
         },
       }
     </script>
-    <style>
-      body {
-        font-family: Verdana, Geneva, Tahoma, sans-serif;
-        display: grid;
-        grid-template-columns: repeat(4, 1fr);
-        grid-gap: 1em;
-      }
-
-      header {
-        grid-column: 1 / span 5;
-      }
-
-      main {
-        grid-column: 1 / span 3;
-      }
-
-      aside {
-        grid-column: span 2;
-      }
-
-      @media (max-width: 700px) {
-        main,
-        aside {
           grid-column: 1 / span 5;
-        }
-      }
-
-      body {
-        margin: 0 auto;
-        max-width: 56em;
-        padding: 1em 0;
-      }
-
-      header,
-      main,
-      aside {
-      }
-
-      header {
-        height: 10vw;
-      }
-    </style>
+    <link rel="stylesheet" href="adremover.css" type="text/css" />
     <script>
       let unlocked = false
       // Once the doc has been loaded

--- a/paywall/src/static/adremover/staging.html
+++ b/paywall/src/static/adremover/staging.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Lorem Ipsum Daily</title>
+    <script src="adRemoverUtils.js"></script>
     <script>
       ;(function(d, s) {
         var js = d.createElement(s),
@@ -30,49 +31,8 @@
         },
       }
     </script>
+    <link rel="stylesheet" href="adremover.css" type="text/css" />
   </head>
-  <style>
-    body {
-      font-family: Verdana, Geneva, Tahoma, sans-serif;
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      grid-gap: 1em;
-    }
-
-    header {
-      grid-column: 1 / span 5;
-    }
-
-    main {
-      grid-column: 1 / span 3;
-    }
-
-    aside {
-      grid-column: span 2;
-    }
-
-    @media (max-width: 700px) {
-      main,
-      aside {
-        grid-column: 1 / span 5;
-      }
-    }
-
-    body {
-      margin: 0 auto;
-      max-width: 56em;
-      padding: 1em 0;
-    }
-
-    header,
-    main,
-    aside {
-    }
-
-    header {
-      height: 10vw;
-    }
-  </style>
 
   <script>
     let unlocked = false

--- a/paywall/src/static/adremover/staging.html
+++ b/paywall/src/static/adremover/staging.html
@@ -75,52 +75,20 @@
   </style>
 
   <script>
-    /**
-     * Shows the ads on the page!
-     */
-    function loadAds() {
-      // Let's look for all ad elements
-      document.querySelectorAll('.ad').forEach(adElement => {
-        adElement.style.height = `${
-          adElement.attributes['data-height'].value
-        }px`
-        adElement.style.width = `${adElement.attributes['data-width'].value}px`
-        adElement.style['background-color'] = 'red'
-        adElement.style.content = 'ad'
-        adElement.style.display = 'block'
-      })
-    }
-
-    /**
-     * Hides the ads on the page!
-     */
-    function hideAds() {
-      document.querySelectorAll('.ad').forEach(adElement => {
-        adElement.style.display = 'none'
-      })
-    }
-
-    /**
-     * Shows the Unlock checkout page
-     */
-    function loadCheckout() {
-      window.unlockProtocol && unlockProtocol.loadCheckoutModal()
-    }
-
     let unlocked = false
     // Once the doc has been loaded
     window.addEventListener('DOMContentLoaded', event => {
       //loadAds()
-      setTimeout(() => !unlocked && loadAds(), 100)
+      setTimeout(() => !unlocked && loadAds(document), 100)
     })
 
     window.addEventListener('unlockProtocol', function(e) {
       var state = e.detail
       if (state === 'locked') {
-        loadAds()
+        loadAds(document)
       } else if (state === 'unlocked') {
         unlocked = true
-        hideAds()
+        hideAds(document)
       }
     })
   </script>
@@ -128,7 +96,9 @@
   <body>
     <header>
       <h1>Lorem Ipsum Daily</h1>
-      <button onclick="loadCheckout()">Unlock the ads free experience!</button>
+      <button onclick="loadCheckout(window)">
+        Unlock the ads free experience!
+      </button>
     </header>
     <main>
       <p>


### PR DESCRIPTION
# Description

This is a response to PR feedback on #3737

It extracts the common JS from <script> tags into `adRemoverUtils.js` and adds 2 new html files for testing the ad remover paywall, `integrationtests-loggedout.html` and `integrationtests-loggedin.html`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3607 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
