### PR TITLE
remove blockchain connect timeout from ensureWalletReady

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/ensureWalletReady.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/ensureWalletReady.test.js
@@ -14,15 +14,6 @@ describe('blockchain handler waitForReady', () => {
     }
   })
 
-  it('fails if walletService is not ready after 10 seconds', done => {
-    expect.assertions(1)
-    ensureWalletReady({ once() {} }).catch(e => {
-      expect(e.message).toBe('connecting to blockchain timed out')
-      done()
-    })
-    jest.runAllTimers()
-  })
-
   it('succeeds immediately if walletService is ready', async () => {
     expect.assertions(0)
     await ensureWalletReady({ ready: true })

--- a/paywall/src/data-iframe/blockchainHandler/ensureWalletReady.js
+++ b/paywall/src/data-iframe/blockchainHandler/ensureWalletReady.js
@@ -1,5 +1,4 @@
 export default async function ensureWalletReady(walletService) {
-  let waiting = true
   return new Promise((resolve, reject) => {
     if (!walletService) {
       return reject(
@@ -12,12 +11,7 @@ export default async function ensureWalletReady(walletService) {
       return resolve()
     }
     walletService.once('ready', () => {
-      if (!waiting) return // timed out
       resolve()
     })
-    setTimeout(() => {
-      waiting = false
-      reject(new Error('connecting to blockchain timed out'))
-    }, 10000)
   })
 }


### PR DESCRIPTION
# Description

The timeout turns out to be unnecessary. No resources are used waiting for the blockchain to respond, no animals harmed, but it is an issue if the user takes longer than 10 seconds to connect metamask to the app.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #2903

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
