### PR TITLE
Provides the ability to filter transactions by sender and recipient (locksmith)

### DIFF
--- a/locksmith/__tests__/controllers/transactionController.test.js
+++ b/locksmith/__tests__/controllers/transactionController.test.js
@@ -8,17 +8,22 @@ describe('transactionController', () => {
       {
         transactionHash: '0x345546565',
         sender: '0xcAFe',
-        recipient: '0xbeefe',
+        recipient: '0xBeeFE',
       },
       {
         transactionHash: '0x445546565',
         sender: '0xcAFe',
-        recipient: '0xbeefe',
+        recipient: '0xBeeFE',
       },
       {
         transactionHash: '0x545546565',
-        sender: '0xcafe2',
-        recipient: '0xbeefe',
+        sender: '0xcAFe2',
+        recipient: '0xBeeFE',
+      },
+      {
+        transactionHash: '0x645546565',
+        sender: '0xcAFe2',
+        recipient: '0xBeeFB',
       },
     ])
   })
@@ -50,6 +55,20 @@ describe('transactionController', () => {
           .set('Accept', /json/)
 
         expect(response.body.transactions.length).toEqual(2)
+      })
+    })
+
+    describe('when the address has transactions to the recipient', () => {
+      it("returns the addresses' transactions", async () => {
+        expect.assertions(1)
+        let sender = '0xcAFe2'
+
+        let response = await request(app)
+          .get('/transactions')
+          .query({ sender: sender, recipient: ['0xBeeFE', '0x4565t'] })
+          .set('Accept', /json/)
+
+        expect(response.body.transactions.length).toEqual(1)
       })
     })
   })
@@ -91,7 +110,7 @@ describe('transactionController', () => {
           .send({
             transactionHash: '0x345546565',
             sender: '0xcAFe',
-            recipient: '0xbeefe',
+            recipient: '0xBeeFE',
           })
 
         expect(response.statusCode).toBe(202)

--- a/locksmith/__tests__/operations/transactionOperations.test.js
+++ b/locksmith/__tests__/operations/transactionOperations.test.js
@@ -56,8 +56,32 @@ describe('lockOperations', () => {
           '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
         )
       })
-      await getTransactionsBySender(sender)
+      await getTransactionsBySender({ sender: sender })
       expect(Transaction.findAll).toHaveBeenCalled()
+    })
+
+    describe('when passed a recipient filter', () => {
+      it('only returns transactions for the appropriate recipient', async () => {
+        expect.assertions(2)
+        const sender = '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
+        Transaction.findAll = jest.fn(query => {
+          expect(query.where.sender[Op.eq]).toEqual(
+            '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
+          )
+        })
+        await getTransactionsBySender({
+          sender: sender,
+          recipient: ['0xCA750f9232C1c38e34D27e77534e1631526eC99e'],
+        })
+        expect(Transaction.findAll).toHaveBeenCalledWith({
+          where: {
+            recipient: {
+              [Op.in]: ['0xCA750f9232C1c38e34D27e77534e1631526eC99e'],
+            },
+            sender: { [Op.eq]: '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5' },
+          },
+        })
+      })
     })
   })
 })

--- a/locksmith/src/controllers/transactionController.js
+++ b/locksmith/src/controllers/transactionController.js
@@ -24,10 +24,28 @@ const transactionCreate = async (req, res) => {
 
 const transactionsGet = async (req, res) => {
   let transactions = []
-  if (req.query.sender) {
-    transactions = await getTransactionsBySender(req.query.sender)
+
+  let filter = buildFilter(req)
+
+  if (filter.sender || filter.recipients) {
+    transactions = await getTransactionsBySender(filter)
   }
+
   res.json({ transactions: transactions })
+}
+
+const buildFilter = req => {
+  let filter = {}
+
+  if (req.query.sender) {
+    filter.sender = req.query.sender
+  }
+
+  if (req.query.recipient) {
+    filter.recipient = req.query.recipient
+  }
+
+  return filter
 }
 
 /**

--- a/locksmith/src/operations/transactionOperations.ts
+++ b/locksmith/src/operations/transactionOperations.ts
@@ -28,11 +28,28 @@ export const findOrCreateTransaction = async (transaction: Transaction) => {
  * get all the transactions sent by a given address
  * @param {*} _sender
  */
-export const getTransactionsBySender = async (_sender: string) => {
-  const sender = ethJsUtil.toChecksumAddress(_sender)
+// export const getTransactionsBySender = async (_sender: string, filter: any) => {
+export const getTransactionsBySender = async (filter: any) => {
   return await Transaction.findAll({
-    where: {
-      sender: { [Op.eq]: sender },
-    },
+    where: queryFilter(filter),
   })
+}
+
+const queryFilter = (filter: any) => {
+  const sender = ethJsUtil.toChecksumAddress(filter.sender)
+
+  if (filter.recipient) {
+    return {
+      sender: { [Op.eq]: sender },
+      recipient: {
+        [Op.in]: filter.recipient.map((recipient: string) =>
+          ethJsUtil.toChecksumAddress(recipient)
+        ),
+      },
+    }
+  } else {
+    return {
+      sender: { [Op.eq]: sender },
+    }
+  }
 }


### PR DESCRIPTION
# Description

Provides the ability to filter transaction by sender and recipient when applicable

The general idea here is that callers will continue to provide sender as a query parameter, but can reduce the data by passing an additional parameter of `recipient` as an array containing the relevant recipients





<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
