### PR TITLE
Fix checkout display in Safari

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2385,13 +2385,7 @@ Object {
 }
 
 .c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -2434,12 +2428,6 @@ Object {
 @media only screen and (min-width:257px) and (max-width:736px) {
   .c6 {
     padding-left: 0;
-  }
-}
-
-@media only screen and (min-width:257px) and (max-width:736px) {
-  .c0 {
-    display: grid;
   }
 }
 
@@ -2559,7 +2547,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi jzvTWC"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -2599,7 +2587,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-dnqmqq fINeTX"
+        class="sc-dnqmqq clAVqm"
       >
         <li
           class="sc-1549ebs-0 sc-5sgq84-0 lock bvdsPH"
@@ -2911,13 +2899,7 @@ Object {
 }
 
 .c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -2960,12 +2942,6 @@ Object {
 @media only screen and (min-width:257px) and (max-width:736px) {
   .c6 {
     padding-left: 0;
-  }
-}
-
-@media only screen and (min-width:257px) and (max-width:736px) {
-  .c0 {
-    display: grid;
   }
 }
 
@@ -3167,7 +3143,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi jzvTWC"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -3207,7 +3183,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-dnqmqq fINeTX"
+        class="sc-dnqmqq clAVqm"
       >
         <li
           class="sc-1549ebs-0 sc-5sgq84-0 lock bvdsPH"
@@ -3722,13 +3698,7 @@ Object {
 }
 
 .c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -3771,12 +3741,6 @@ Object {
 @media only screen and (min-width:257px) and (max-width:736px) {
   .c6 {
     padding-left: 0;
-  }
-}
-
-@media only screen and (min-width:257px) and (max-width:736px) {
-  .c0 {
-    display: grid;
   }
 }
 
@@ -3982,7 +3946,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi jzvTWC"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -4022,7 +3986,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-dnqmqq fINeTX"
+        class="sc-dnqmqq clAVqm"
       >
         <li
           class="sc-1549ebs-0 lock NDRQz"
@@ -4541,13 +4505,7 @@ Object {
 }
 
 .c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -4590,12 +4548,6 @@ Object {
 @media only screen and (min-width:257px) and (max-width:736px) {
   .c6 {
     padding-left: 0;
-  }
-}
-
-@media only screen and (min-width:257px) and (max-width:736px) {
-  .c0 {
-    display: grid;
   }
 }
 
@@ -4797,7 +4749,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi jzvTWC"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -4837,7 +4789,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-dnqmqq fINeTX"
+        class="sc-dnqmqq clAVqm"
       >
         <li
           class="sc-1549ebs-0 lock NDRQz"
@@ -5352,13 +5304,7 @@ Object {
 }
 
 .c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -5401,12 +5347,6 @@ Object {
 @media only screen and (min-width:257px) and (max-width:736px) {
   .c6 {
     padding-left: 0;
-  }
-}
-
-@media only screen and (min-width:257px) and (max-width:736px) {
-  .c0 {
-    display: grid;
   }
 }
 
@@ -5608,7 +5548,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi jzvTWC"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -5648,7 +5588,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-dnqmqq fINeTX"
+        class="sc-dnqmqq clAVqm"
       >
         <li
           class="sc-1549ebs-0 sc-5sgq84-0 lock bvdsPH"
@@ -6246,13 +6186,7 @@ Object {
 }
 
 .c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -6295,12 +6229,6 @@ Object {
 @media only screen and (min-width:257px) and (max-width:736px) {
   .c6 {
     padding-left: 0;
-  }
-}
-
-@media only screen and (min-width:257px) and (max-width:736px) {
-  .c0 {
-    display: grid;
   }
 }
 
@@ -6533,7 +6461,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi jzvTWC"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -6573,7 +6501,7 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-dnqmqq fINeTX"
+        class="sc-dnqmqq clAVqm"
       >
         <li
           class="sc-1549ebs-0 lock NDRQz"
@@ -6989,13 +6917,7 @@ Object {
 }
 
 .c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -7040,12 +6962,6 @@ Object {
 .c0 > * {
   max-height: 100%;
   overflow-y: scroll;
-}
-
-@media only screen and (min-width:257px) and (max-width:736px) {
-  .c1 {
-    display: grid;
-  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -8638,7 +8554,7 @@ Object {
       class="sc-cvbbAY eawQXs"
     >
       <section
-        class="sc-gZMcBi jzvTWC"
+        class="sc-gZMcBi hbowKy"
       >
         <a
           class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -8678,7 +8594,7 @@ Object {
           </p>
         </header>
         <ul
-          class="sc-eHgmQL ciLZMU"
+          class="sc-eHgmQL ivyWHt"
         >
           <a
             class="sc-dxgOiQ hMOJfX"
@@ -10433,13 +10349,7 @@ Object {
 }
 
 .c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -10484,12 +10394,6 @@ Object {
 .c0 > * {
   max-height: 100%;
   overflow-y: scroll;
-}
-
-@media only screen and (min-width:257px) and (max-width:736px) {
-  .c1 {
-    display: grid;
-  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -12082,7 +11986,7 @@ Object {
       class="sc-cvbbAY eawQXs"
     >
       <section
-        class="sc-gZMcBi jzvTWC"
+        class="sc-gZMcBi hbowKy"
       >
         <a
           class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -12122,7 +12026,7 @@ Object {
           </p>
         </header>
         <ul
-          class="sc-eHgmQL ciLZMU"
+          class="sc-eHgmQL ivyWHt"
         >
           <a
             class="sc-dxgOiQ hMOJfX"
@@ -13877,13 +13781,7 @@ Object {
 }
 
 .c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;
@@ -13928,12 +13826,6 @@ Object {
 .c0 > * {
   max-height: 100%;
   overflow-y: scroll;
-}
-
-@media only screen and (min-width:257px) and (max-width:736px) {
-  .c1 {
-    display: grid;
-  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -15526,7 +15418,7 @@ Object {
       class="sc-cvbbAY eawQXs"
     >
       <section
-        class="sc-gZMcBi jzvTWC"
+        class="sc-gZMcBi hbowKy"
       >
         <a
           class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -15566,7 +15458,7 @@ Object {
           </p>
         </header>
         <ul
-          class="sc-eHgmQL ciLZMU"
+          class="sc-eHgmQL ivyWHt"
         >
           <a
             class="sc-dxgOiQ hMOJfX"

--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2411,7 +2411,13 @@ Object {
 .c0 {
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   background-color: var(--offwhite);
   color: var(--darkgrey);
   border-radius: 4px;
@@ -2547,7 +2553,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi iGruSu"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -2925,7 +2931,13 @@ Object {
 .c0 {
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   background-color: var(--offwhite);
   color: var(--darkgrey);
   border-radius: 4px;
@@ -3143,7 +3155,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi iGruSu"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -3724,7 +3736,13 @@ Object {
 .c0 {
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   background-color: var(--offwhite);
   color: var(--darkgrey);
   border-radius: 4px;
@@ -3946,7 +3964,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi iGruSu"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -4531,7 +4549,13 @@ Object {
 .c0 {
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   background-color: var(--offwhite);
   color: var(--darkgrey);
   border-radius: 4px;
@@ -4749,7 +4773,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi iGruSu"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -5330,7 +5354,13 @@ Object {
 .c0 {
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   background-color: var(--offwhite);
   color: var(--darkgrey);
   border-radius: 4px;
@@ -5548,7 +5578,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi iGruSu"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -6212,7 +6242,13 @@ Object {
 .c0 {
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   background-color: var(--offwhite);
   color: var(--darkgrey);
   border-radius: 4px;
@@ -6461,7 +6497,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi iGruSu"
+      class="sc-gZMcBi hbowKy"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -6778,7 +6814,13 @@ Object {
 .c1 {
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   background-color: var(--offwhite);
   color: var(--darkgrey);
   border-radius: 4px;
@@ -8554,7 +8596,7 @@ Object {
       class="sc-cvbbAY eawQXs"
     >
       <section
-        class="sc-gZMcBi iGruSu"
+        class="sc-gZMcBi hbowKy"
       >
         <a
           class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -10210,7 +10252,13 @@ Object {
 .c1 {
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   background-color: var(--offwhite);
   color: var(--darkgrey);
   border-radius: 4px;
@@ -11986,7 +12034,7 @@ Object {
       class="sc-cvbbAY eawQXs"
     >
       <section
-        class="sc-gZMcBi iGruSu"
+        class="sc-gZMcBi hbowKy"
       >
         <a
           class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -13642,7 +13690,13 @@ Object {
 .c1 {
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   background-color: var(--offwhite);
   color: var(--darkgrey);
   border-radius: 4px;
@@ -15418,7 +15472,7 @@ Object {
       class="sc-cvbbAY eawQXs"
     >
       <section
-        class="sc-gZMcBi iGruSu"
+        class="sc-gZMcBi hbowKy"
       >
         <a
           class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"

--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2437,6 +2437,12 @@ Object {
   }
 }
 
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    display: grid;
+  }
+}
+
 <div>
       <link
         href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
@@ -2553,7 +2559,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi hbowKy"
+      class="sc-gZMcBi jzvTWC"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -2957,6 +2963,12 @@ Object {
   }
 }
 
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    display: grid;
+  }
+}
+
 <div>
       <link
         href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
@@ -3155,7 +3167,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi hbowKy"
+      class="sc-gZMcBi jzvTWC"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -3762,6 +3774,12 @@ Object {
   }
 }
 
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    display: grid;
+  }
+}
+
 <div>
       <link
         href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
@@ -3964,7 +3982,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi hbowKy"
+      class="sc-gZMcBi jzvTWC"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -4575,6 +4593,12 @@ Object {
   }
 }
 
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    display: grid;
+  }
+}
+
 <div>
       <link
         href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
@@ -4773,7 +4797,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi hbowKy"
+      class="sc-gZMcBi jzvTWC"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -5380,6 +5404,12 @@ Object {
   }
 }
 
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    display: grid;
+  }
+}
+
 <div>
       <link
         href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
@@ -5578,7 +5608,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi hbowKy"
+      class="sc-gZMcBi jzvTWC"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -6268,6 +6298,12 @@ Object {
   }
 }
 
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    display: grid;
+  }
+}
+
 <div>
       <link
         href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
@@ -6497,7 +6533,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-gZMcBi hbowKy"
+      class="sc-gZMcBi jzvTWC"
     >
       <a
         class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -7004,6 +7040,12 @@ Object {
 .c0 > * {
   max-height: 100%;
   overflow-y: scroll;
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c1 {
+    display: grid;
+  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -8596,7 +8638,7 @@ Object {
       class="sc-cvbbAY eawQXs"
     >
       <section
-        class="sc-gZMcBi hbowKy"
+        class="sc-gZMcBi jzvTWC"
       >
         <a
           class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -10445,6 +10487,12 @@ Object {
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
+  .c1 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
   .c9 {
     padding-top: 24px;
   }
@@ -12034,7 +12082,7 @@ Object {
       class="sc-cvbbAY eawQXs"
     >
       <section
-        class="sc-gZMcBi hbowKy"
+        class="sc-gZMcBi jzvTWC"
       >
         <a
           class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
@@ -13883,6 +13931,12 @@ Object {
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
+  .c1 {
+    display: grid;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
   .c9 {
     padding-top: 24px;
   }
@@ -15472,7 +15526,7 @@ Object {
       class="sc-cvbbAY eawQXs"
     >
       <section
-        class="sc-gZMcBi hbowKy"
+        class="sc-gZMcBi jzvTWC"
       >
         <a
           class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"

--- a/paywall/src/components/checkout/Checkout.tsx
+++ b/paywall/src/components/checkout/Checkout.tsx
@@ -101,8 +101,7 @@ const Footer = styled.footer`
 `
 
 const CheckoutLocks = styled.ul`
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;

--- a/paywall/src/components/checkout/CheckoutWrapper.tsx
+++ b/paywall/src/components/checkout/CheckoutWrapper.tsx
@@ -48,7 +48,8 @@ const CloseButton = styled(Close)`
 const Wrapper = styled.section`
   max-width: 800px;
   padding: 10px 40px;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   background-color: ${(props: WrapperStyleProps) => props.bgColor};
   color: var(--darkgrey);
   border-radius: 4px;

--- a/paywall/src/components/checkout/CheckoutWrapper.tsx
+++ b/paywall/src/components/checkout/CheckoutWrapper.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import Media from '../../theme/media'
 import Close from '../interface/buttons/layout/Close'
 
 interface WrapperProps {
@@ -55,8 +54,4 @@ const Wrapper = styled.section`
   color: var(--darkgrey);
   border-radius: 4px;
   position: relative;
-
-  ${Media.phone`
-    display: grid;
-  `}
 `

--- a/paywall/src/components/checkout/CheckoutWrapper.tsx
+++ b/paywall/src/components/checkout/CheckoutWrapper.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import Media from '../../theme/media'
 import Close from '../interface/buttons/layout/Close'
 
 interface WrapperProps {
@@ -54,4 +55,8 @@ const Wrapper = styled.section`
   color: var(--darkgrey);
   border-radius: 4px;
   position: relative;
+
+  ${Media.phone`
+    display: grid;
+  `}
 `

--- a/paywall/src/components/checkout/NoWallet.tsx
+++ b/paywall/src/components/checkout/NoWallet.tsx
@@ -178,8 +178,7 @@ const Footer = styled.footer`
 `
 
 const WalletOptions = styled.ul`
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   list-style: none;
   margin: 0px;
   padding: 0px;

--- a/paywall/src/stories/content/CheckoutContent.stories.js
+++ b/paywall/src/stories/content/CheckoutContent.stories.js
@@ -14,6 +14,7 @@ import {
   POST_MESSAGE_UPDATE_LOCKS,
   POST_MESSAGE_UPDATE_NETWORK,
 } from '../../paywall-builder/constants'
+import configure from '../../config'
 
 const lockAddress1 = '0x1234567890123456789012345678901234567890'
 const lockAddress2 = '0x4567890123456789012345678901234567890123'
@@ -84,6 +85,7 @@ const locks = {
 }
 
 const config = {
+  ...configure(),
   requiredNetworkId: 1,
   isServer: false,
   isInIframe: true,


### PR DESCRIPTION
# Description

Because the `CheckoutWrapper` was using `display: grid` without specifying any grid template, this left too much control to the browser as to how to render the display.

Before:

<img width="1450" alt="Screen Shot 2019-06-13 at 5 20 56 PM" src="https://user-images.githubusercontent.com/98250/59468354-cdc61b00-8dff-11e9-9a04-36dbbcd7a8cd.png">

After (both in Safari and Chrome):

<img width="1450" alt="Screen Shot 2019-06-13 at 5 24 47 PM" src="https://user-images.githubusercontent.com/98250/59468562-6361aa80-8e00-11e9-9487-eace852fd380.png">
<img width="1450" alt="Screen Shot 2019-06-13 at 5 24 37 PM" src="https://user-images.githubusercontent.com/98250/59468563-6361aa80-8e00-11e9-8f21-5c0f2b066626.png">
<img width="1450" alt="Screen Shot 2019-06-13 at 5 24 26 PM" src="https://user-images.githubusercontent.com/98250/59468564-6361aa80-8e00-11e9-8eac-e170a49ebed0.png">
<img width="1450" alt="Screen Shot 2019-06-13 at 5 24 19 PM" src="https://user-images.githubusercontent.com/98250/59468565-6361aa80-8e00-11e9-9f42-09fe666997b1.png">
<img width="1450" alt="Screen Shot 2019-06-13 at 5 24 09 PM" src="https://user-images.githubusercontent.com/98250/59468566-6361aa80-8e00-11e9-9375-ad15c67c4fef.png">
<img width="1450" alt="Screen Shot 2019-06-13 at 5 35 35 PM" src="https://user-images.githubusercontent.com/98250/59469042-b9831d80-8e01-11e9-90c8-15eedf00e4c2.png">
<img width="1450" alt="Screen Shot 2019-06-13 at 5 35 42 PM" src="https://user-images.githubusercontent.com/98250/59469048-bab44a80-8e01-11e9-8eb6-477d4f62a809.png">
<img width="1450" alt="Screen Shot 2019-06-13 at 5 35 51 PM" src="https://user-images.githubusercontent.com/98250/59469050-bc7e0e00-8e01-11e9-95b9-0549d0f52362.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3699 


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
