### PR TITLE
fix way-too-many-calls to transactions/keys

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/index.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/index.test.js
@@ -14,6 +14,7 @@ import {
 import { getNetwork } from '../../../data-iframe/blockchainHandler/network'
 import ensureWalletReady from '../../../data-iframe/blockchainHandler/ensureWalletReady'
 import web3ServiceHub from '../../../data-iframe/blockchainHandler/web3ServiceHub'
+import { setPaywallConfig } from '../../../data-iframe/paywallConfig'
 
 jest.mock('../../../data-iframe/blockchainHandler/ensureWalletReady')
 jest.mock('../../../data-iframe/blockchainHandler/account')
@@ -139,6 +140,11 @@ describe('blockchain handler index', () => {
         })),
       }
       pollForAccountChange.mockReset()
+      setPaywallConfig({
+        locks: {
+          '0x123': { name: 'hi' },
+        },
+      })
     })
 
     it('calls getLocks', async () => {
@@ -222,7 +228,7 @@ describe('blockchain handler index', () => {
       })
 
       expect(fakeWindow.fetch).toHaveBeenCalledWith(
-        'http://locksmith/transactions?sender=account'
+        'http://locksmith/transactions?sender=account&recipient[]=0x123'
       )
     })
   })
@@ -261,6 +267,11 @@ describe('blockchain handler index', () => {
         getAccount: jest.fn(() => 'account'),
       }
       pollForAccountChange.mockReset()
+      setPaywallConfig({
+        locks: {
+          '0x123': { name: 'hi' },
+        },
+      })
     })
 
     it('listens for network.changed', async () => {
@@ -275,66 +286,6 @@ describe('blockchain handler index', () => {
         walletService: fakeWalletService,
         web3Service: fakeWeb3Service,
         onChange: () => {},
-      })
-    })
-
-    it('listens for account.changed', async () => {
-      expect.assertions(1)
-
-      fakeWalletService.on = type => {
-        if (type !== 'account.changed') return
-        expect(type).toBe('account.changed')
-      }
-
-      await listenForAccountNetworkChanges({
-        walletService: fakeWalletService,
-        web3Service: fakeWeb3Service,
-        onChange: () => {},
-      })
-    })
-
-    it('should set account on getting account.changed event', async done => {
-      expect.assertions(1)
-
-      const locksToRetrieve = ['locks']
-      fakeWalletService.on = async (type, listener) => {
-        if (type !== 'account.changed') return
-        await listener('new account')
-        expect(setAccount).toHaveBeenCalledWith('new account')
-        done()
-      }
-
-      await listenForAccountNetworkChanges({
-        walletService: fakeWalletService,
-        web3Service: fakeWeb3Service,
-        onChange: () => {},
-        window: fakeWindow,
-        locksmithHost: 'locksmith',
-        locksToRetrieve,
-      })
-    })
-
-    it('should retrieve new keys ands transactions on getting account.changed event', async done => {
-      expect.assertions(2)
-
-      const locksToRetrieve = ['locks']
-      fakeWalletService.on = async (type, listener) => {
-        if (type !== 'account.changed') return
-        await listener('new account')
-        // this is called when we retrieve new keys
-        expect(fakeWeb3Service.getKeyByLockForOwner).toHaveBeenCalled()
-        // this is called when we retrieve transactions from locksmith
-        expect(fakeWindow.fetch).toHaveBeenCalled()
-        done()
-      }
-
-      await listenForAccountNetworkChanges({
-        walletService: fakeWalletService,
-        web3Service: fakeWeb3Service,
-        onChange: () => {},
-        window: fakeWindow,
-        locksmithHost: 'locksmith',
-        locksToRetrieve,
       })
     })
 
@@ -381,6 +332,8 @@ describe('blockchain handler index', () => {
         walletService: fakeWalletService,
         web3Service: fakeWeb3Service,
         onChange,
+        locksToRetrieve: ['0x123'],
+        window: fakeWindow,
       })
 
       expect(onChange).toHaveBeenNthCalledWith(
@@ -415,6 +368,8 @@ describe('blockchain handler index', () => {
         walletService: fakeWalletService,
         web3Service: fakeWeb3Service,
         onChange,
+        locksToRetrieve: ['0x123'],
+        window: fakeWindow,
       })
 
       expect(pollForAccountChange).toHaveBeenCalledWith(
@@ -440,6 +395,85 @@ describe('blockchain handler index', () => {
         2,
         expect.objectContaining({ balance: '1' })
       )
+    })
+
+    it('should retrieve keys and transactions for changed user account', async () => {
+      expect.assertions(2)
+      const onChange = jest.fn()
+
+      const actualAccount = require.requireActual(
+        '../../../data-iframe/blockchainHandler/account'
+      )
+
+      setAccount.mockImplementationOnce(actualAccount.setAccount)
+      getAccount.mockImplementationOnce(actualAccount.getAccount)
+
+      await listenForAccountNetworkChanges({
+        walletService: fakeWalletService,
+        web3Service: fakeWeb3Service,
+        onChange,
+        window: fakeWindow,
+        locksToRetrieve: ['0x123'],
+      })
+
+      expect(pollForAccountChange).toHaveBeenCalledWith(
+        fakeWalletService,
+        fakeWeb3Service,
+        expect.any(Function)
+      )
+      const accountChanged = pollForAccountChange.mock.calls[0][2]
+
+      onChange.mockReset()
+      setAccount.mockReset()
+      setAccountBalance.mockReset()
+
+      await accountChanged('hi', '1')
+
+      expect(onChange).toHaveBeenNthCalledWith(3, {
+        keys: {
+          '0x123': {
+            expiration: expect.any(Number),
+            id: '0x123-account',
+            lock: '0x123',
+            owner: 'account',
+          },
+        },
+      })
+    })
+
+    it('should reset keys and transactions for user logout', async () => {
+      expect.assertions(2)
+      const onChange = jest.fn()
+
+      const actualAccount = require.requireActual(
+        '../../../data-iframe/blockchainHandler/account'
+      )
+
+      setAccount.mockImplementationOnce(actualAccount.setAccount)
+      getAccount.mockImplementationOnce(actualAccount.getAccount)
+      await listenForAccountNetworkChanges({
+        walletService: fakeWalletService,
+        web3Service: fakeWeb3Service,
+        onChange,
+        window: fakeWindow,
+        locksToRetrieve: ['0x123'],
+      })
+
+      expect(pollForAccountChange).toHaveBeenCalledWith(
+        fakeWalletService,
+        fakeWeb3Service,
+        expect.any(Function)
+      )
+      const accountChanged = pollForAccountChange.mock.calls[0][2]
+
+      onChange.mockReset()
+
+      await accountChanged(null, '0')
+
+      expect(onChange).toHaveBeenNthCalledWith(3, {
+        keys: {},
+        transactions: {},
+      })
     })
   })
 })

--- a/paywall/src/data-iframe/blockchainHandler/index.js
+++ b/paywall/src/data-iframe/blockchainHandler/index.js
@@ -121,20 +121,6 @@ export async function listenForAccountNetworkChanges({
   onChange,
   window,
 }) {
-  walletService.on('account.changed', async address => {
-    setAccount(address)
-    // account has changed, it is time to update transactions and keys
-    // keys will be returned and passed to the cache
-    onChange(
-      await getKeysAndTransactions({
-        walletService,
-        locks: locksToRetrieve,
-        web3Service,
-        window,
-        locksmithHost,
-      })
-    )
-  })
   walletService.on('network.changed', id => {
     setNetwork(id)
     onChange({ network: id })
@@ -148,10 +134,26 @@ export async function listenForAccountNetworkChanges({
   setAccountBalance(balance)
   onChange({ balance })
 
-  pollForAccountChange(walletService, web3Service, (account, balance) => {
+  pollForAccountChange(walletService, web3Service, async (account, balance) => {
     setAccount(account)
     onChange({ account })
     setAccountBalance(balance)
     onChange({ balance })
+    // account has changed, it is time to update transactions and keys
+    // keys will be returned and passed to the cache
+    if (account) {
+      onChange(
+        await getKeysAndTransactions({
+          walletService,
+          locks: locksToRetrieve,
+          web3Service,
+          window,
+          locksmithHost,
+        })
+      )
+    } else {
+      // ensure we have no keys or transactions for logged out user
+      onChange({ keys: {}, transactions: {} })
+    }
   })
 }

--- a/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
+++ b/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
@@ -1,6 +1,7 @@
 import ensureWalletReady from './ensureWalletReady'
 import { getAccount } from './account'
 import { getNetwork } from './network'
+import { getRelevantLocks } from '../paywallConfig'
 
 /**
  * sync a new transaction to locksmith
@@ -62,8 +63,18 @@ export default async function locksmithTransactions({
   await ensureWalletReady(walletService)
   const account = getAccount()
   const network = getNetwork()
+  const lockAddresses = getRelevantLocks()
 
-  const url = `${locksmithHost}/transactions?sender=${account.toLowerCase()}`
+  // filter the transactions we request to only include the
+  // transactions relevant to locks. In most cases this will be
+  // key purchases
+  const filterLocks = lockAddresses
+    .map(lockAddress => `recipient[]=${encodeURIComponent(lockAddress)}`)
+    .join('&')
+
+  const url = `${locksmithHost}/transactions?sender=${account.toLowerCase()}${
+    filterLocks ? `&${filterLocks}` : ''
+  }`
 
   const response = await window.fetch(url)
   const result = await response.json()


### PR DESCRIPTION
# Description

There were 2 issues that caused the 5000% increase in calls to alchemy last week.

1. The call to update transactions and keys for a new user account was happening on `walletService.on('account.updated')` - which triggers every time we request the current account (side note: this action REALLY needs to be renamed to `'account.retrieved'`, I have made this mistake at least twice before)
2. we were retrieving all transactions by the user, not just the ones relevant to locks on the current paywall.

This PR implements a fix for (1) by moving the call to update transactions to the *correct* location 10 lines lower into the handler that is called by `pollForAccountChanges` when the account actually changes. When I added the code that is being removed it was one of my stupider moments :)

The fix for (2) is also quite simple, we take the lock addresses from the configuration and pass them as `recipient` to the call to locksmith to retrieve transactions.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3773 


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
