### PR TITLE
add new configuration field "type" for paywall config

### DIFF
--- a/paywall/src/__tests__/hooks/usePaywallConfig.test.js
+++ b/paywall/src/__tests__/hooks/usePaywallConfig.test.js
@@ -93,6 +93,7 @@ describe('usePaywallConfig hook', () => {
 
     const myConfig = {
       ...defaultValue,
+      type: 'paywall',
       locks: {
         '0x1234567890123456789012345678901234567890': {
           name: 'my lock',

--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -371,7 +371,7 @@ describe('Form field validators', () => {
         ).toBe(false)
       })
 
-      it('should fail when type is not an string', () => {
+      it('should fail when type is not a string', () => {
         expect.assertions(2)
 
         expect(

--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -371,6 +371,34 @@ describe('Form field validators', () => {
         ).toBe(false)
       })
 
+      it('should fail when type is not an string', () => {
+        expect.assertions(2)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            type: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            type: [],
+          })
+        ).toBe(false)
+      })
+
+      it('should fail when type is not a valid paywall type', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            type: 'qio347tyao8g43aouygto*&#Y$@*',
+          })
+        ).toBe(false)
+      })
+
       it('locks is not an object', () => {
         expect.assertions(3)
 
@@ -562,7 +590,7 @@ describe('Form field validators', () => {
 
     describe('valid cases', () => {
       it('is valid config', () => {
-        expect.assertions(8)
+        expect.assertions(10)
 
         expect(validators.isValidPaywallConfig(validConfig)).toBe(true)
         expect(
@@ -614,6 +642,18 @@ describe('Form field validators', () => {
           validators.isValidPaywallConfig({
             ...validConfig,
             icon: 'ftp://example.com/img.png',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            type: 'adblock',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            type: 'paywall',
           })
         ).toBe(true)
       })

--- a/paywall/src/hooks/usePaywallConfig.js
+++ b/paywall/src/hooks/usePaywallConfig.js
@@ -28,6 +28,7 @@ export function getValue(value, defaults) {
 
 export const defaultValue = {
   locks: {},
+  type: 'adblock',
   icon: false,
   callToAction: {
     default:

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -67,12 +67,12 @@ export interface PaywallConfigLock {
   name: string
 }
 
-export type PaywallTypes = 'adblock' | 'paywall'
+export type PaywallAppKind = 'adblock' | 'paywall'
 
 // This interface describes an individual paywall's config
 export interface PaywallConfig {
   icon: string
-  type: PaywallTypes
+  type: PaywallAppKind
   callToAction: PaywallCallToAction
   locks: PaywallConfigLocks
 }

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -67,9 +67,12 @@ export interface PaywallConfigLock {
   name: string
 }
 
+export type PaywallTypes = 'adblock' | 'paywall'
+
 // This interface describes an individual paywall's config
 export interface PaywallConfig {
   icon: string
+  type: PaywallTypes
   callToAction: PaywallCallToAction
   locks: PaywallConfigLocks
 }

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -57,12 +57,7 @@ export const isAccount = val => {
  */
 export const isValidPaywallConfig = config => {
   if (!config) return false
-  if (typeof config !== 'object') return false
-  const keys = Object.keys(config)
-  if (keys.length !== 3) return false
-  keys.sort()
-  const testKeys = ['callToAction', 'icon', 'locks']
-  if (keys.filter((key, index) => testKeys[index] !== key).length) return false
+  if (!isValidObject(config, ['callToAction', 'locks'])) return false
   // allow false for icon
   if (config.icon) {
     if (typeof config.icon !== 'string') return false
@@ -77,6 +72,13 @@ export const isValidPaywallConfig = config => {
     ) {
       return false
     }
+  }
+  // allow type to be empty (empty is assumed to be "adblock")
+  if (config.type) {
+    if (typeof config.type !== 'string') return false
+    const allowedTypes = ['adblock', 'paywall']
+
+    if (!allowedTypes.includes(config.type)) return false
   }
   if (!config.callToAction || typeof config.callToAction !== 'object')
     return false


### PR DESCRIPTION
# Description

This adds a new optional field to the paywall configuration, `type` which if not present defaults to `'adblock'` and can be one of two values: `'adblock'` or `'paywall'`.

It updates both the unlock.min.js side and the checkout UI side. The first step is adding it to validation, the next is to the typescript definition, the last is adding the default value to `usePaywallConfig`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3859 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
