### PR TITLE
add listener for transaction init inside the data iframe

### DIFF
--- a/paywall/src/__tests__/data-iframe/start/connectToBlockchain.test.js
+++ b/paywall/src/__tests__/data-iframe/start/connectToBlockchain.test.js
@@ -149,15 +149,15 @@ describe('connectToBlockchain', () => {
       )
     })
 
-    it('should retrieve chain data', async () => {
-      expect.assertions(1)
+    it('should return a function to retrieve chain data', async () => {
+      expect.assertions(2)
 
       const walletService = 'walletService'
       const web3Service = 'web3Service'
       setupWalletService.mockImplementationOnce(() => walletService)
       setupWeb3Service.mockImplementationOnce(() => web3Service)
 
-      await connectToBlockchain({
+      const retrieveData = await connectToBlockchain({
         unlockAddress,
         config,
         window,
@@ -168,6 +168,9 @@ describe('connectToBlockchain', () => {
         onChange,
       })
 
+      expect(retrieveData).toBeInstanceOf(Function)
+
+      await retrieveData()
       expect(retrieveChainData).toHaveBeenCalledWith(
         expect.objectContaining({
           locksToRetrieve: ['0x123', '0x456'],
@@ -192,7 +195,7 @@ describe('connectToBlockchain', () => {
         Promise.resolve('chain data')
       )
 
-      const result = await connectToBlockchain({
+      const retrieveData = await connectToBlockchain({
         unlockAddress,
         config,
         window,
@@ -202,6 +205,7 @@ describe('connectToBlockchain', () => {
         locksmithHost,
         onChange,
       })
+      const result = await retrieveData()
 
       expect(result).toBe('chain data')
     })

--- a/paywall/src/data-iframe/start/connectToBlockchain.js
+++ b/paywall/src/data-iframe/start/connectToBlockchain.js
@@ -83,13 +83,15 @@ export default async function connectToBlockchain({
     window,
   })
   // at this point the blockchain handler is live!
-  return retrieveChainData({
-    locksToRetrieve,
-    web3Service,
-    walletService,
-    window,
-    locksmithHost,
-    onChange,
-    requiredConfirmations,
-  })
+  return async () => {
+    return retrieveChainData({
+      locksToRetrieve,
+      web3Service,
+      walletService,
+      window,
+      locksmithHost,
+      onChange,
+      requiredConfirmations,
+    })
+  }
 }

--- a/paywall/src/data-iframe/start/index.js
+++ b/paywall/src/data-iframe/start/index.js
@@ -3,6 +3,7 @@ import { addListener } from '../cacheHandler'
 import postOffice from '../postOffice'
 import { purchaseKey } from './purchaseKeySetup'
 import makeSetConfig from './makeSetConfig'
+import { POST_MESSAGE_INITIATED_TRANSACTION } from '../../paywall-builder/constants'
 
 /**
  * @param {window} window the global context (window, self, or global)
@@ -25,12 +26,30 @@ export default async function start(window, constants) {
   )
   // when the cache changes, we send the new information to the main window
   addListener(blockChainUpdater)
+  // create the listener setup function for POST_MESSAGE_INITIATED_TRANSACTION
+  // this listener cannot be added until the paywall config has been retrieved,
+  // the blockchain has been loaded, and we have a closure created that
+  // can be used to refresh data from the chain.
+  // This is used when a user with an unlock account initiates a key purchase
+  // transaction in the unlock-app iframe. At this stage, we will need to
+  // refresh the transactions in order to monitor the transaction
+  const addTransactionInitiatedListener = retrieveChainData => {
+    addHandler(POST_MESSAGE_INITIATED_TRANSACTION, () => {
+      // retrieve the most up-to-date transactions and chain data
+      retrieveChainData()
+    })
+  }
   // listen for events from the main window, which include requests for blockchain
   // data (currently not used, we just push), and requests to purchase a key
   setupPostOfficeListener(
     window,
     blockChainUpdater,
-    makeSetConfig(window, blockChainUpdater, constants),
+    makeSetConfig(
+      window,
+      blockChainUpdater,
+      constants,
+      addTransactionInitiatedListener
+    ),
     purchaseKey,
     addHandler
   )

--- a/paywall/src/data-iframe/start/makeSetConfig.js
+++ b/paywall/src/data-iframe/start/makeSetConfig.js
@@ -19,7 +19,12 @@ import syncToCache from './syncToCache'
  *                           - requiredConfirmations
  *                           - locksmithHost
  */
-const makeSetConfig = (window, updater, constants) =>
+const makeSetConfig = (
+  window,
+  updater,
+  constants,
+  addTransactionInitiatedListener
+) =>
   async function setConfig(configValue) {
     // now we can retrieve the cached data
     updater('network')
@@ -45,14 +50,16 @@ const makeSetConfig = (window, updater, constants) =>
       syncToCache(window, updates)
     }
     try {
-      onChange(
-        await connectToBlockchain({
-          ...constants,
-          config: configValue,
-          window,
-          onChange,
-        })
-      )
+      const retrieveChainData = await connectToBlockchain({
+        ...constants,
+        config: configValue,
+        window,
+        onChange,
+      })
+      // get the initial set of blockchain data
+      onChange(await retrieveChainData())
+      // set up the listener for future retrievals
+      addTransactionInitiatedListener(retrieveChainData)
     } catch (error) {
       onChange({ error })
     }

--- a/paywall/src/paywall-builder/constants.js
+++ b/paywall/src/paywall-builder/constants.js
@@ -22,3 +22,4 @@ export const POST_MESSAGE_SEND_UPDATES = 'send/updates'
 
 export const POST_MESSAGE_PURCHASE_KEY = 'purchaseKey'
 export const POST_MESSAGE_DISMISS_CHECKOUT = 'dismiss/checkout'
+export const POST_MESSAGE_INITIATED_TRANSACTION = 'initiated/transaction'


### PR DESCRIPTION
# Description

This adds the data-iframe side of the solution for #3862 by adding a new `POST_MESSAGE_INITIATED_TRANSACTION` message type.

Changes needed to make this work:

1. `connectToBlockchain` now returns a function that can be used to retrieve locks, keys, and transactions
2. this function is used in a new postOffice listener for the `POST_MESSAGE_INITIATED_TRANSACTION` message
3. There is a timing issue: most post office actions can be set up immediately, but this one can only be set up once the blockchain handler chunk has loaded, as we can't reference code that is lazy-loading until it's loaded. I considered other options, but we not only have to load the code, but also need to initialize both `web3Service` and `walletService`. This happens in `connectToBlockchain`, so the most logical place to set up the listener is at the end of this function.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3862 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
