### PR TITLE
auto-show the checkout UI on paywall

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2440,7 +2440,7 @@ Object {
         class="c0"
       >
         <a
-          class="c1 c2"
+          class="closeButton c1 c2"
         >
           <svg
             viewBox="0 0 24 24"
@@ -2550,7 +2550,7 @@ Object {
       class="sc-gZMcBi hbowKy"
     >
       <a
-        class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+        class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
       >
         <svg
           viewBox="0 0 24 24"
@@ -2954,7 +2954,7 @@ Object {
         class="c0"
       >
         <a
-          class="c1 c2"
+          class="closeButton c1 c2"
         >
           <svg
             viewBox="0 0 24 24"
@@ -3146,7 +3146,7 @@ Object {
       class="sc-gZMcBi hbowKy"
     >
       <a
-        class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+        class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
       >
         <svg
           viewBox="0 0 24 24"
@@ -3753,7 +3753,7 @@ Object {
         class="c0"
       >
         <a
-          class="c1 c2"
+          class="closeButton c1 c2"
         >
           <svg
             viewBox="0 0 24 24"
@@ -3949,7 +3949,7 @@ Object {
       class="sc-gZMcBi hbowKy"
     >
       <a
-        class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+        class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
       >
         <svg
           viewBox="0 0 24 24"
@@ -4560,7 +4560,7 @@ Object {
         class="c0"
       >
         <a
-          class="c1 c2"
+          class="closeButton c1 c2"
         >
           <svg
             viewBox="0 0 24 24"
@@ -4752,7 +4752,7 @@ Object {
       class="sc-gZMcBi hbowKy"
     >
       <a
-        class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+        class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
       >
         <svg
           viewBox="0 0 24 24"
@@ -5359,7 +5359,7 @@ Object {
         class="c0"
       >
         <a
-          class="c1 c2"
+          class="closeButton c1 c2"
         >
           <svg
             viewBox="0 0 24 24"
@@ -5551,7 +5551,7 @@ Object {
       class="sc-gZMcBi hbowKy"
     >
       <a
-        class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+        class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
       >
         <svg
           viewBox="0 0 24 24"
@@ -6241,7 +6241,7 @@ Object {
         class="c0"
       >
         <a
-          class="c1 c2"
+          class="closeButton c1 c2"
         >
           <svg
             viewBox="0 0 24 24"
@@ -6464,7 +6464,7 @@ Object {
       class="sc-gZMcBi hbowKy"
     >
       <a
-        class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+        class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
       >
         <svg
           viewBox="0 0 24 24"
@@ -6992,7 +6992,7 @@ Object {
           class="c1"
         >
           <a
-            class="c2 c3"
+            class="closeButton c2 c3"
           >
             <svg
               viewBox="0 0 24 24"
@@ -8557,7 +8557,7 @@ Object {
         class="sc-gZMcBi hbowKy"
       >
         <a
-          class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+          class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
         >
           <svg
             viewBox="0 0 24 24"
@@ -10424,7 +10424,7 @@ Object {
           class="c1"
         >
           <a
-            class="c2 c3"
+            class="closeButton c2 c3"
           >
             <svg
               viewBox="0 0 24 24"
@@ -11989,7 +11989,7 @@ Object {
         class="sc-gZMcBi hbowKy"
       >
         <a
-          class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+          class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
         >
           <svg
             viewBox="0 0 24 24"
@@ -13856,7 +13856,7 @@ Object {
           class="c1"
         >
           <a
-            class="c2 c3"
+            class="closeButton c2 c3"
           >
             <svg
               viewBox="0 0 24 24"
@@ -15421,7 +15421,7 @@ Object {
         class="sc-gZMcBi hbowKy"
       >
         <a
-          class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+          class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
         >
           <svg
             viewBox="0 0 24 24"

--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -17288,7 +17288,7 @@ Object {
           class="c1"
         >
           <a
-            class="c2 c3"
+            class="closeButton c2 c3"
           >
             <svg
               viewBox="0 0 24 24"
@@ -18853,7 +18853,7 @@ Object {
         class="sc-gZMcBi hbowKy"
       >
         <a
-          class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+          class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
         >
           <svg
             viewBox="0 0 24 24"
@@ -20720,7 +20720,7 @@ Object {
           class="c1"
         >
           <a
-            class="c2 c3"
+            class="closeButton c2 c3"
           >
             <svg
               viewBox="0 0 24 24"
@@ -22285,7 +22285,7 @@ Object {
         class="sc-gZMcBi hbowKy"
       >
         <a
-          class="sc-iwsKbI kwnnhM is925m-0 bYsUmJ"
+          class="sc-iwsKbI closeButton kwnnhM is925m-0 bYsUmJ"
         >
           <svg
             viewBox="0 0 24 24"

--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
@@ -178,6 +178,18 @@ describe('setupPostOffice', () => {
     )
   })
 
+  it('responds to POST_MESSAGE_READY by showing the checkout UI if the paywall type is "paywall"', () => {
+    expect.assertions(1)
+
+    fakeWindow.unlockProtocolConfig = {
+      type: 'paywall',
+    }
+
+    sendMessage(fakeUIIframe, POST_MESSAGE_READY)
+
+    expect(fakeUIIframe.className).toBe('unlock start show')
+  })
+
   it('responds to POST_MESSAGE_UNLOCKED by sending unlocked to the UI iframe', () => {
     expect.assertions(1)
 
@@ -223,23 +235,6 @@ describe('setupPostOffice', () => {
     sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
 
     expect(fakeUIIframe.className).toBe('unlock start show')
-  })
-
-  it('responds to POST_MESSAGE_UNLOCKED by hiding the checkout UI if the key is confirmed', () => {
-    expect.assertions(1)
-
-    fakeUIIframe.className = 'unlock start show'
-
-    sendMessage(fakeDataIframe, POST_MESSAGE_UPDATE_LOCKS, {
-      lock: {
-        key: {
-          status: 'valid',
-        },
-      },
-    })
-    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
-
-    expect(fakeUIIframe.className).toBe('unlock start')
   })
 
   it('responds to POST_MESSAGE_LOCKED by sending locked to the UI iframe', () => {

--- a/paywall/src/components/checkout/CheckoutWrapper.tsx
+++ b/paywall/src/components/checkout/CheckoutWrapper.tsx
@@ -39,7 +39,9 @@ const CheckoutWrapper = ({
 
 export default CheckoutWrapper
 
-const CloseButton = styled(Close)`
+const CloseButton = styled(Close).attrs(() => ({
+  className: 'closeButton',
+}))`
   position: absolute;
   top: 24px;
   right: 24px;

--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useState, useEffect, useCallback } from 'react'
 import Head from 'next/head'
 
 import { pageTitle, ETHEREUM_NETWORKS_NAMES } from '../../constants'
@@ -9,7 +9,7 @@ import useBlockchainData from '../../hooks/useBlockchainData'
 import useWindow from '../../hooks/browser/useWindow'
 import usePaywallConfig from '../../hooks/usePaywallConfig'
 import usePostMessage from '../../hooks/browser/usePostMessage'
-import { Key } from '../../unlockTypes'
+import { Key, Locks, PaywallConfig, Account } from '../../unlockTypes'
 import {
   POST_MESSAGE_PURCHASE_KEY,
   POST_MESSAGE_DISMISS_CHECKOUT,
@@ -24,6 +24,18 @@ import useListenForPostMessage from '../../hooks/browser/useListenForPostMessage
 interface networkNames {
   [key: number]: string[]
 }
+
+// TODO: move useBlockchainData to ts and remove these defs
+interface blockchainData {
+  account: Account | null
+  network: number
+  locks: Locks
+}
+type useBlockchainDataFunc = (
+  window: any,
+  paywallConfig: PaywallConfig
+) => blockchainData
+
 /**
  * This is the data handler for the Checkout component
  */
@@ -34,14 +46,25 @@ export default function CheckoutContent() {
   // the paywall configuration passed as window.unlockProtocolConfig in the main window
   const paywallConfig = usePaywallConfig()
   // the blockchain data returned from the data iframe
-  const { account, network, locks } = useBlockchainData(window, paywallConfig)
+  const {
+    account,
+    network,
+    locks,
+  }: blockchainData = (useBlockchainData as useBlockchainDataFunc)(
+    window,
+    paywallConfig
+  )
   const currentNetwork: string = (ETHEREUM_NETWORKS_NAMES as networkNames)[
     network
   ][0]
   // for sending purchase requests, hiding the checkout iframe
   const { postMessage } = usePostMessage('Checkout UI')
+  const [userInitiatedPurchase, initiatePurchase] = useState(false)
   // purchase a key with this callback
   const purchaseKey = (key: Key) => {
+    // record the fact that the purchase was initiated in this process
+    // so that we will not automatically dismiss the Checkout UI
+    initiatePurchase(true)
     postMessage({
       type: POST_MESSAGE_PURCHASE_KEY,
       payload: {
@@ -69,12 +92,22 @@ export default function CheckoutContent() {
     allowClosingCheckout = true
   }
   // hide the checkout iframe
-  const hideCheckout = () => {
+  const hideCheckout = useCallback(() => {
     postMessage({
       type: POST_MESSAGE_DISMISS_CHECKOUT,
       payload: undefined, // this must be set to trigger a response in unlock.min.js
     })
-  }
+  }, [postMessage])
+
+  // get a list of locks that have valid keys
+  const activeLocks = Object.keys(locks as Locks).filter(
+    (lockAddress: string) => locks[lockAddress].key.status === 'valid'
+  )
+  useEffect(() => {
+    if (activeLocks.length && !userInitiatedPurchase) {
+      hideCheckout()
+    }
+  }, [activeLocks.length, hideCheckout, userInitiatedPurchase])
 
   let child: React.ReactNode
   let bgColor = 'var(--offwhite)'

--- a/paywall/src/unlock.js/setupPostOffices.js
+++ b/paywall/src/unlock.js/setupPostOffices.js
@@ -123,13 +123,16 @@ export default function setupPostOffices(window, dataIframe, CheckoutUIIframe) {
       dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'account')
       dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'balance')
       dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'locks')
+      if (window.unlockProtocolConfig.type === 'paywall') {
+        // always show the checkout modal on start for the paywall app
+        showIframe(window, CheckoutUIIframe)
+      }
     }
   })
 
   // set up the main window side of Web3ProxyProvider
   web3Proxy(window, dataIframe, process.env.PAYWALL_URL)
 
-  let savedLocks = {}
   // relay the unlocked event both to the main window
   // and to the checkout UI
   addDataMessageHandler(POST_MESSAGE_UNLOCKED, locks => {
@@ -148,17 +151,6 @@ export default function setupPostOffices(window, dataIframe, CheckoutUIIframe) {
       // ignore
     }
     CheckoutUIPostOffice(POST_MESSAGE_UNLOCKED, locks)
-    if (
-      locks.filter(address => {
-        return (
-          savedLocks[address] &&
-          savedLocks[address].key &&
-          savedLocks[address].key.status === 'valid'
-        )
-      }).length
-    ) {
-      hideCheckoutModal()
-    }
   })
 
   // if the user chooses to close the checkout modal, we hide the iframe
@@ -212,7 +204,6 @@ export default function setupPostOffices(window, dataIframe, CheckoutUIIframe) {
 
   // relay the most current lock objects to the checkout UI
   addDataMessageHandler(POST_MESSAGE_UPDATE_LOCKS, locks => {
-    savedLocks = locks // to use for determining when to hide the checkout iframe
     CheckoutUIPostOffice(POST_MESSAGE_UPDATE_LOCKS, locks)
   })
 

--- a/tests/test/adremover-loggedin.test.js
+++ b/tests/test/adremover-loggedin.test.js
@@ -180,11 +180,10 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
     expect(adDisplay).toEqual(['none', 'none'])
   })
 
-  it('should hide the iframe when purchase is confirmed and user clicks to dismiss, ads still hidden', async () => {
+  it('should hide the iframe when purchase is confirmed, ads still hidden', async () => {
     expect.assertions(2)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
     const checkoutIframe = page.mainFrame().childFrames()[1]
-    const checkoutBody = await checkoutIframe.$('body')
     await checkoutIframe.waitForFunction(
       lock1 => {
         const lock = document.body.querySelector(lock1)
@@ -193,10 +192,9 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
       {},
       lockSelectors[0]('footer')
     )
-    // dismiss the modal
-    await expect(checkoutBody).toClick('.closeButton')
     // "show" is the classname that shows the checkout UI
-    await wait.untilIsGone('iframe[class="unlock start show"]')
+    const visibleIframes = await page.$$('iframe[class="unlock start show"]')
+    expect(visibleIframes).toEqual([])
     const adDisplay = await page.$$eval('.ad', ads => {
       return ads.map(ad => ad.style.display)
     })

--- a/tests/test/adremover-loggedin.test.js
+++ b/tests/test/adremover-loggedin.test.js
@@ -180,10 +180,11 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
     expect(adDisplay).toEqual(['none', 'none'])
   })
 
-  it('should hide the iframe when purchase is confirmed, ads still hidden', async () => {
+  it('should hide the iframe when purchase is confirmed and user clicks to dismiss, ads still hidden', async () => {
     expect.assertions(2)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
     const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutBody = await checkoutIframe.$('body')
     await checkoutIframe.waitForFunction(
       lock1 => {
         const lock = document.body.querySelector(lock1)
@@ -192,9 +193,10 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
       {},
       lockSelectors[0]('footer')
     )
+    // dismiss the modal
+    await expect(checkoutBody).toClick('.closeButton')
     // "show" is the classname that shows the checkout UI
-    const visibleIframes = await page.$$('iframe[class="unlock start show"]')
-    expect(visibleIframes).toEqual([])
+    await wait.untilIsGone('iframe[class="unlock start show"]')
     const adDisplay = await page.$$eval('.ad', ads => {
       return ads.map(ad => ad.style.display)
     })


### PR DESCRIPTION
# Description

This PR does 2 things:

1. always show the Checkout UI when the page is loaded, even if the user has a key
2. don't auto-hide the Checkout UI. (This was causing all kinds of annoying UI issues and is unnecessary, the user can just click/tap to hide)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3860 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
