### PR TITLE
Be able to access Stripe environment variables

### DIFF
--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -22,6 +22,7 @@ let requiredConfigVariables = {
   base64WedlocksPublicKey: process.env.BASE64_WEDLOCKS_PUBLIC_KEY,
   erc20ContractSymbol: process.env.ERC20_CONTRACT_SYMBOL,
   erc20ContractAddress: process.env.ERC20_CONTRACT_ADDRESS,
+  stripeApiKey: process.env.STRIPE_KEY,
 }
 
 let optionalConfigVariables = {

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -58,6 +58,9 @@ export default function configure(
   let chainExplorerUrlBuilders = {
     etherScan: () => '',
   }
+  // Publishable key from Stripe dashboard, make sure to use the test key when
+  // developing.
+  let stripeApiKey = runtimeConfig.stripeApiKey
 
   services['currencyPriceLookup'] =
     'https://api.coinbase.com/v2/prices/ETH-USD/buy'
@@ -174,5 +177,6 @@ export default function configure(
     supportedProviders,
     unlockStaticUrl,
     chainExplorerUrlBuilders,
+    stripeApiKey,
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR adds the Stripe environment variables to `unlock-app` config so that we can use them when generating customer/card tokens to pass to `locksmith`

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
