### PR TITLE
listen for USERS_IFRAME_URL in order to link to the user accounts page

### DIFF
--- a/paywall/unlock.1.0.js.webpack.config.js
+++ b/paywall/unlock.1.0.js.webpack.config.js
@@ -13,6 +13,7 @@ dotenv.config({
 const requiredConfigVariables = {
   unlockEnv,
   paywallUrl: process.env.PAYWALL_URL,
+  usersIframeUrl: process.env.USERS_IFRAME_URL,
 }
 
 Object.keys(requiredConfigVariables).forEach(configVariableName => {
@@ -53,6 +54,8 @@ module.exports = () => {
         'process.env.DEBUG': debug,
         'process.env.PAYWALL_URL':
           "'" + requiredConfigVariables.paywallUrl + "'",
+        'process.env.USER_IFRAME_URL':
+          "'" + requiredConfigVariables.usersIframeUrl + "'",
       }),
     ],
   }


### PR DESCRIPTION
# Description

In order to properly load the user accounts iframe from `unlock-app`, we need to know where it is. This PR adds the replacing of `process.env.USERS_IFRAME_URL` inside the `unlock.1.0.min.js` script with the environment variable value.

Note that Circle already has the needed environment variables declared, so this should deploy properly

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3879 


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
