### PR TITLE
new expirationAsText function, fix durationsAsArrayFromSeconds for partial seconds

### DIFF
--- a/paywall/src/__tests__/utils/durations.test.js
+++ b/paywall/src/__tests__/utils/durations.test.js
@@ -61,9 +61,18 @@ describe('duration utilities', () => {
     it('should return "Expires ..." for large values', () => {
       expect.assertions(1)
 
-      expect(expirationAsText(new Date('2100-01-01').getTime() / 1000)).toEqual(
-        'Expires Dec 31, 2099'
+      const now = new Date()
+      const then = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate(),
+        0,
+        0,
+        0
       )
+      const seconds = (now.getTime() - then.getTime()) / 1000
+      const future = new Date('2100-01-01 00:00:00').getTime() / 1000 + seconds
+      expect(expirationAsText(future)).toEqual('Expires Jan 1, 2100')
     })
   })
 })

--- a/paywall/src/__tests__/utils/durations.test.js
+++ b/paywall/src/__tests__/utils/durations.test.js
@@ -1,6 +1,7 @@
 import {
   durationsAsTextFromSeconds,
   durationsAsArrayFromSeconds,
+  expirationAsText,
 } from '../../utils/durations'
 
 describe('duration utilities', () => {
@@ -29,6 +30,40 @@ describe('duration utilities', () => {
       expect(
         durationsAsArrayFromSeconds(60 * 60 * 24 * 3 + 60 * 60 * 12 + 60 * 30)
       ).toEqual(['3 days', '12 hours', '30 minutes'])
+    })
+
+    it('should round down', () => {
+      expect.assertions(3)
+      expect(durationsAsArrayFromSeconds(60.45)).toEqual(['1 minute'])
+      expect(durationsAsArrayFromSeconds(61.45)).toEqual([
+        '1 minute',
+        '1 second',
+      ])
+      expect(durationsAsArrayFromSeconds(62.88)).toEqual([
+        '1 minute',
+        '2 seconds',
+      ])
+    })
+  })
+
+  describe('expirationAsText', () => {
+    it('should return "Expires in ..." for small values', () => {
+      expect.assertions(2)
+
+      expect(
+        expirationAsText(new Date().getTime() / 1000 + 60 * 60 * 12)
+      ).toEqual('Expires in 12 hours')
+      expect(
+        expirationAsText(new Date().getTime() / 1000 + 60 * 60 * 12 + 60)
+      ).toEqual('Expires in 12 hours and 1 minute')
+    })
+
+    it('should return "Expires ..." for large values', () => {
+      expect.assertions(1)
+
+      expect(expirationAsText(new Date('2100-01-01').getTime() / 1000)).toEqual(
+        'Expires Dec 31, 2099'
+      )
     })
   })
 })

--- a/paywall/src/utils/durations.js
+++ b/paywall/src/utils/durations.js
@@ -63,6 +63,7 @@ export function durationsAsArrayFromSeconds(seconds) {
   const d = durations(seconds, {})
   const asArrayOfValues = Object.keys(d).map(duration => {
     const durationFloor = Math.floor(d[duration])
+    // map to an empty string to avoid "0 seconds"
     if (durationFloor === 0) return ''
     if (durationFloor !== 1) {
       // Singular should only be used when there is exactly 1; otherwise plural is needed
@@ -70,6 +71,7 @@ export function durationsAsArrayFromSeconds(seconds) {
     }
     return `${durationFloor} ${duration.slice(0, -1)}` // remove the s!
   })
+  // remove the "0 seconds" etc. entries that mapped to ""
   return asArrayOfValues.filter(a => a) // remove empty entries
 }
 
@@ -80,6 +82,10 @@ export function durationsAsArrayFromSeconds(seconds) {
  */
 export function secondsAsDays(seconds) {
   return Math.ceil(seconds / 86400).toString()
+}
+
+function isLessThanADay(timestamp) {
+  return timestamp - new Date().getTime() / 1000 < 86400
 }
 
 /**
@@ -97,7 +103,7 @@ export function expirationAsDate(timestamp) {
     return 'Expired'
   }
 
-  if (timestamp - new Date().getTime() / 1000 < 86400) {
+  if (isLessThanADay(timestamp)) {
     // If it is less than a day from now we provide more granular details, from now
     const secondsFromNow = timestamp - Math.floor(new Date().getTime() / 1000)
     return durationsAsTextFromSeconds(secondsFromNow)
@@ -114,7 +120,7 @@ export function expirationAsDate(timestamp) {
 
 export function expirationAsText(timestamp) {
   const text = expirationAsDate(timestamp)
-  if (timestamp - new Date().getTime() / 1000 < 86400) {
+  if (isLessThanADay(timestamp)) {
     return `Expires in ${text}`
   }
   return `Expires ${text}`

--- a/paywall/src/utils/durations.js
+++ b/paywall/src/utils/durations.js
@@ -62,13 +62,15 @@ export function durationsAsTextFromSeconds(seconds) {
 export function durationsAsArrayFromSeconds(seconds) {
   const d = durations(seconds, {})
   const asArrayOfValues = Object.keys(d).map(duration => {
-    if (d[duration] !== 1) {
+    const durationFloor = Math.floor(d[duration])
+    if (durationFloor === 0) return ''
+    if (durationFloor !== 1) {
       // Singular should only be used when there is exactly 1; otherwise plural is needed
-      return `${d[duration]} ${duration}`
+      return `${durationFloor} ${duration}`
     }
-    return `${d[duration]} ${duration.slice(0, -1)}` // remove the s!
+    return `${durationFloor} ${duration.slice(0, -1)}` // remove the s!
   })
-  return asArrayOfValues
+  return asArrayOfValues.filter(a => a) // remove empty entries
 }
 
 /**
@@ -108,4 +110,12 @@ export function expirationAsDate(timestamp) {
   let year = expirationDate.getFullYear()
 
   return MONTH_NAMES[month] + ' ' + day + ', ' + year
+}
+
+export function expirationAsText(timestamp) {
+  const text = expirationAsDate(timestamp)
+  if (timestamp - new Date().getTime() / 1000 < 86400) {
+    return `Expires in ${text}`
+  }
+  return `Expires ${text}`
 }

--- a/paywall/src/utils/durations.js
+++ b/paywall/src/utils/durations.js
@@ -61,18 +61,19 @@ export function durationsAsTextFromSeconds(seconds) {
  */
 export function durationsAsArrayFromSeconds(seconds) {
   const d = durations(seconds, {})
-  const asArrayOfValues = Object.keys(d).map(duration => {
+  // remove all values that would map to "0"
+  const filteredValues = Object.keys(d).filter(duration =>
+    Math.floor(d[duration])
+  )
+  const asArrayOfValues = filteredValues.map(duration => {
     const durationFloor = Math.floor(d[duration])
-    // map to an empty string to avoid "0 seconds"
-    if (durationFloor === 0) return ''
     if (durationFloor !== 1) {
       // Singular should only be used when there is exactly 1; otherwise plural is needed
       return `${durationFloor} ${duration}`
     }
     return `${durationFloor} ${duration.slice(0, -1)}` // remove the s!
   })
-  // remove the "0 seconds" etc. entries that mapped to ""
-  return asArrayOfValues.filter(a => a) // remove empty entries
+  return asArrayOfValues
 }
 
 /**


### PR DESCRIPTION
# Description

In preparation for displaying the key expiration on confirmed lock, this fixes a hilarious situation where we would display the number of seconds left - up to 12 decimal places :)

This also adds a function to format the expiration in better English, so we use "Expires in" for time values and "Expires" for dates.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3458

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
