### PR TITLE
fix multiple load of the post office

### DIFF
--- a/paywall/src/unlock.js/index.js
+++ b/paywall/src/unlock.js/index.js
@@ -1,12 +1,18 @@
 import startup from './startup'
 import '../paywall-builder/iframe.css'
 
+let started = false
 if (document.readyState !== 'loading') {
   // in most cases, we will start up after the document is interactive
   // so listening for the DOMContentLoaded or load events is superfluous
   startup(window)
+  started = true
 } else {
+  const begin = () => {
+    if (!started) startup(window)
+    started = true
+  }
   // if we reach here, the page is sitll loading
-  window.addEventListener('DOMContentLoaded', () => startup(window))
-  window.addEventListener('load', () => startup(window))
+  window.addEventListener('DOMContentLoaded', begin)
+  window.addEventListener('load', begin)
 }


### PR DESCRIPTION
# Description

It turns out we were in some cases attempting to load the startup twice. The second time would fail to listen to the data iframe. This adds a flag to prevent this case.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3893 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
