### PR TITLE
fix linting for unused vars

### DIFF
--- a/unlock-app/.eslintrc.js
+++ b/unlock-app/.eslintrc.js
@@ -6,6 +6,16 @@ module.exports = {
     },
   },
   rules: {
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        vars: 'all',
+        args: 'after-used',
+        ignoreRestSiblings: true,
+        argsIgnorePattern: /^_$/,
+      },
+    ],
     'react/prefer-stateless-function': [2],
     'react/forbid-prop-types': 2,
     'jsx-a11y/anchor-is-valid': [

--- a/unlock-app/src/__tests__/components/interface/FinishSignup.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/FinishSignup.test.tsx
@@ -5,7 +5,7 @@ import {
   mapDispatchToProps,
   validatePassword,
   FinishSignup,
-  Credentials, // eslint-disable-line no-unused-vars
+  Credentials,
 } from '../../../components/interface/FinishSignup'
 
 let signupCredentials = jest.fn((credentials: Credentials) => credentials)

--- a/unlock-app/src/__tests__/components/interface/SignUp.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/SignUp.test.tsx
@@ -63,8 +63,8 @@ describe('Sign Up Page', () => {
             replace: () => {},
             ancestorOrigins: {
               length: 0,
-              contains: (_: string) => false, // eslint-disable-line no-unused-vars
-              item: (_: number) => null, // eslint-disable-line no-unused-vars
+              contains: (_: string) => false,
+              item: (_: number) => null,
             },
           },
         },
@@ -94,8 +94,8 @@ describe('Sign Up Page', () => {
             replace: () => {},
             ancestorOrigins: {
               length: 0,
-              contains: (_: string) => false, // eslint-disable-line no-unused-vars
-              item: (_: number) => null, // eslint-disable-line no-unused-vars
+              contains: (_: string) => false,
+              item: (_: number) => null,
             },
           },
         },
@@ -124,8 +124,8 @@ describe('Sign Up Page', () => {
             replace: () => {},
             ancestorOrigins: {
               length: 0,
-              contains: (_: string) => false, // eslint-disable-line no-unused-vars
-              item: (_: number) => null, // eslint-disable-line no-unused-vars
+              contains: (_: string) => false,
+              item: (_: number) => null,
             },
           },
         },
@@ -156,8 +156,8 @@ describe('Sign Up Page', () => {
             replace: () => {},
             ancestorOrigins: {
               length: 0,
-              contains: (_: string) => false, // eslint-disable-line no-unused-vars
-              item: (_: number) => null, // eslint-disable-line no-unused-vars
+              contains: (_: string) => false,
+              item: (_: number) => null,
             },
           },
         },
@@ -196,8 +196,8 @@ describe('Sign Up Page', () => {
             replace: () => {},
             ancestorOrigins: {
               length: 0,
-              contains: (_: string) => false, // eslint-disable-line no-unused-vars
-              item: (_: number) => null, // eslint-disable-line no-unused-vars
+              contains: (_: string) => false,
+              item: (_: number) => null,
             },
           },
         },
@@ -239,8 +239,8 @@ describe('Sign Up Page', () => {
             replace: () => {},
             ancestorOrigins: {
               length: 0,
-              contains: (_: string) => false, // eslint-disable-line no-unused-vars
-              item: (_: number) => null, // eslint-disable-line no-unused-vars
+              contains: (_: string) => false,
+              item: (_: number) => null,
             },
           },
         },

--- a/unlock-app/src/__tests__/components/interface/modal-templates/PasswordPrompt.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/modal-templates/PasswordPrompt.test.tsx
@@ -8,7 +8,7 @@ let dispatch: (_: any) => boolean
 
 describe('Password Prompt', () => {
   beforeEach(() => {
-    dispatch = jest.fn((_: any) => true) // eslint-disable-line no-unused-vars
+    dispatch = jest.fn((_: any) => true)
   })
 
   it('should dismiss when the cancel button is clicked', () => {

--- a/unlock-app/src/__tests__/components/interface/modal-templates/ResetPasswordPrompt.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/modal-templates/ResetPasswordPrompt.test.tsx
@@ -9,7 +9,7 @@ const email = 'geoff@bitconnect.gov'
 
 describe('Reset Password Prompt', () => {
   beforeEach(() => {
-    dispatch = jest.fn((_: any) => true) // eslint-disable-line no-unused-vars
+    dispatch = jest.fn((_: any) => true)
   })
 
   it("should render a form including user's email address", () => {

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -1,4 +1,4 @@
-import { EncryptedPrivateKey } from '../unlockTypes' // eslint-disable-line no-unused-vars
+import { EncryptedPrivateKey } from '../unlockTypes'
 
 export const LOGIN_CREDENTIALS = 'login/GOT_CREDENTIALS'
 export const LOGIN_SUCCEEDED = 'login/SUCCESS'

--- a/unlock-app/src/components/interface/Account.tsx
+++ b/unlock-app/src/components/interface/Account.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Jazzicon from 'react-jazzicon'
 
-import * as UnlockTypes from '../../unlockTypes' // eslint-disable-line no-unused-vars
+import * as UnlockTypes from '../../unlockTypes'
 import { ETHEREUM_NETWORKS_NAMES } from '../../constants'
 
 import Media from '../../theme/media'

--- a/unlock-app/src/components/interface/SignUp.tsx
+++ b/unlock-app/src/components/interface/SignUp.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import { signupEmail } from '../../actions/user'
 import InvalidLink from './InvalidLink'
 import SignupSuccess from './SignupSuccess'
-import { Router, Account } from '../../unlockTypes' // eslint-disable-line no-unused-vars
+import { Router, Account } from '../../unlockTypes'
 import FinishSignUp from './FinishSignup'
 import { verifyEmailSignature } from '../../utils/wedlocks'
 

--- a/unlock-app/src/middlewares/wedlocksMiddleware.ts
+++ b/unlock-app/src/middlewares/wedlocksMiddleware.ts
@@ -1,6 +1,6 @@
 import WedlockService from '../services/wedlockService'
 import { SIGNUP_EMAIL } from '../actions/user'
-import { Action } from '../unlockTypes' // eslint-disable-line no-unused-vars
+import { Action } from '../unlockTypes'
 
 const wedlocksMiddleware = (config: any) => {
   const { services } = config

--- a/unlock-app/src/reducers/fullScreenModalsReducer.ts
+++ b/unlock-app/src/reducers/fullScreenModalsReducer.ts
@@ -1,6 +1,6 @@
 import { LAUNCH_MODAL, DISMISS_MODAL } from '../actions/fullScreenModals'
 
-import { KindOfModal, Action } from '../unlockTypes' // eslint-disable-line no-unused-vars
+import { KindOfModal, Action } from '../unlockTypes'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 import { SET_ACCOUNT } from '../actions/accounts'

--- a/unlock-app/src/reducers/privateKeyReducer.ts
+++ b/unlock-app/src/reducers/privateKeyReducer.ts
@@ -2,7 +2,7 @@ import { SET_ENCRYPTED_PRIVATE_KEY } from '../actions/user'
 import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 import { SET_ACCOUNT } from '../actions/accounts'
-import { Action, EncryptedPrivateKey } from '../unlockTypes' // eslint-disable-line no-unused-vars
+import { Action, EncryptedPrivateKey } from '../unlockTypes'
 
 type State = { key: EncryptedPrivateKey; email: string } | null
 export const initialState: State = null


### PR DESCRIPTION
# Description

This fixes linting for unused variables in unlock-app. It does it by adding:

```js
    'no-unused-vars': 'off',
    '@typescript-eslint/no-unused-vars': [
      'error',
      {
        vars: 'all',
        args: 'after-used',
        ignoreRestSiblings: true,
        argsIgnorePattern: /^_$/,
      },
    ],
```

to the `.eslintrc.js`

The last line allows patterns like:

```js

let dispatch: (_: any) => any
const email = 'geoff@bitconnect.gov'

describe('Reset Password Prompt', () => {
  beforeEach(() => {
    dispatch = jest.fn((_: any) => true)
  })
``` 

to not trigger a lint error.

After this is merged, imported types will not trigger lint errors. This will allow me to copy the postOffice.ts file as-is from `paywall/` to `unlock-app/` in a follow-up PR

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3764 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
