### PR TITLE
Add stripe as a dependency for injection in tests

### DIFF
--- a/unlock-app/package-lock.json
+++ b/unlock-app/package-lock.json
@@ -15940,6 +15940,18 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "stripe": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.2.0.tgz",
+      "integrity": "sha512-kpWYEXV5syPXVyTNtzdHEg6yFvVPwDJze5gu1KG9xWoSHaaPP2hJx1ihniRVNh0NZfS/PRPXIhLfPEifaq62Ng==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6",
+        "qs": "^6.6.0",
+        "safe-buffer": "^5.1.1",
+        "uuid": "^3.3.2"
+      }
+    },
     "style-loader": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",

--- a/unlock-app/package-lock.json
+++ b/unlock-app/package-lock.json
@@ -15944,7 +15944,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.2.0.tgz",
       "integrity": "sha512-kpWYEXV5syPXVyTNtzdHEg6yFvVPwDJze5gu1KG9xWoSHaaPP2hJx1ihniRVNh0NZfS/PRPXIhLfPEifaq62Ng==",
-      "dev": true,
       "requires": {
         "lodash.isplainobject": "^4.0.6",
         "qs": "^6.6.0",

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -54,6 +54,7 @@
     "rss": "1.2.2",
     "run-script-os": "1.0.5",
     "storybook-chromatic": "1.3.3",
+    "stripe": "7.2.0",
     "styled-components": "4.3.1",
     "ts-jest": "24.0.2",
     "typescript": "3.5.2"
@@ -61,8 +62,7 @@
   "devDependencies": {
     "@svgr/cli": "4.3.0",
     "nodemon": "1.19.1",
-    "npm-check": "5.9.0",
-    "stripe": "7.2.0"
+    "npm-check": "5.9.0"
   },
   "engines": {
     "node": "=8.11.4"

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -61,7 +61,8 @@
   "devDependencies": {
     "@svgr/cli": "4.3.0",
     "nodemon": "1.19.1",
-    "npm-check": "5.9.0"
+    "npm-check": "5.9.0",
+    "stripe": "7.2.0"
   },
   "engines": {
     "node": "=8.11.4"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR adds `stripe` as a dependency so that we can inject it into the stripe provider in tests and stories so our elements will render.

Tested this like so:
```javascript
import Stripe from 'stripe'
const stripe = Stripe('not a real api key')
console.log(stripe)
```

This didn't error, and did appear to produce a valid object. So in stories and tests we should be able to render elements at least, and perhaps just mock out any methods on this object that perform network requests.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
