### PR TITLE
migrate web3Proxy.js to typescript, fix a bug typescript caught

### DIFF
--- a/paywall/src/__tests__/unlock.js/web3Proxy.test.js
+++ b/paywall/src/__tests__/unlock.js/web3Proxy.test.js
@@ -142,6 +142,7 @@ describe('web3Proxy', () => {
         origin: 'http://fun.times',
         data: {
           type: POST_MESSAGE_READY_WEB3,
+          id: 1,
           payload: 'it worked!',
         },
       })
@@ -173,6 +174,7 @@ describe('web3Proxy', () => {
         origin: 'http://fun.times',
         data: {
           type: POST_MESSAGE_READY_WEB3,
+          id: 1,
           payload: 'it worked!',
         },
       })
@@ -197,6 +199,7 @@ describe('web3Proxy', () => {
           origin: 'http://fun.times',
           data: {
             type: POST_MESSAGE_READY_WEB3,
+            id: 1,
             payload: 'it worked!',
           },
         })
@@ -211,6 +214,7 @@ describe('web3Proxy', () => {
             type: POST_MESSAGE_WEB3,
             payload: {
               error: 'No web3 wallet is available',
+              id: 1,
               result: null,
             },
           })


### PR DESCRIPTION
# Description

This one is slightly more complex.

Basically, we were passing `id: undefined` in the case of there being no wallet, so this fixes that. In addition, there was a (remote to impossible) chance that the `send` method would not exist. This would only happen if the data iframe were to send a `POST_MESSAGE_WEB3` message prior to sending `POST_MESSAGE_READY`, i.e. would only happen if there was a bug in the data iframe. However, because it is external input, ensuring `send` exists first is good practice.

The rest of this is adding types.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3862 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
