### PR TITLE
Suspending react/display-name for ticket tests

### DIFF
--- a/tickets/src/__tests__/components/content/CreateContent.test.js
+++ b/tickets/src/__tests__/components/content/CreateContent.test.js
@@ -1,4 +1,4 @@
-/* eslint react/prop-types: 0 */
+/* eslint react/prop-types: 0, react/display-name: 0 */
 import React from 'react'
 import { Provider } from 'react-redux'
 import * as rtl from 'react-testing-library'

--- a/tickets/src/__tests__/components/interface/DatePicker.test.js
+++ b/tickets/src/__tests__/components/interface/DatePicker.test.js
@@ -1,4 +1,4 @@
-/* eslint react/prop-types: 0 */
+/* eslint react/prop-types: 0, react/display-name: 0 */
 import React from 'react'
 import * as rtl from 'react-testing-library'
 import 'jest-dom/extend-expect'

--- a/tickets/src/__tests__/components/interface/TimePicker.test.js
+++ b/tickets/src/__tests__/components/interface/TimePicker.test.js
@@ -1,4 +1,4 @@
-/* eslint react/prop-types: 0 */
+/* eslint react/prop-types: 0, react/display-name: 0 */
 import React from 'react'
 import * as rtl from 'react-testing-library'
 import 'jest-dom/extend-expect'


### PR DESCRIPTION
# Description

The react-select mock in some ticket tests is blocking the eslint-plugin-react upgrade in #3814. This update fixes the errors by suspending the react/display-name rule for three tests.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
