### PR TITLE
migrate the rest of unlock.1.0.min.js to typescript

### DIFF
--- a/paywall/src/unlock.js/index.ts
+++ b/paywall/src/unlock.js/index.ts
@@ -1,15 +1,16 @@
 import startup from './startup'
 import '../paywall-builder/iframe.css'
+import { UnlockWindow } from '../windowTypes'
 
 let started = false
 if (document.readyState !== 'loading') {
   // in most cases, we will start up after the document is interactive
   // so listening for the DOMContentLoaded or load events is superfluous
-  startup(window)
+  startup((window as unknown) as UnlockWindow)
   started = true
 } else {
   const begin = () => {
-    if (!started) startup(window)
+    if (!started) startup((window as unknown) as UnlockWindow)
     started = true
   }
   // if we reach here, the page is sitll loading

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -8,9 +8,14 @@ export default function startup(window: UnlockWindow) {
   // of the data iframe. The data iframe will then send down the current
   // value, overriding this. A bit later, the blockchain handler will update
   // with the actual value, so this is only used for a few milliseconds
-  const locked = JSON.parse(
-    window.localStorage.getItem('__unlockProtocol.locked') || '"ignore"'
-  )
+  let locked
+  try {
+    locked = JSON.parse(
+      window.localStorage.getItem('__unlockProtocol.locked') || '"ignore"'
+    )
+  } catch (_) {
+    locked = 'ignore'
+  }
   if (locked === true) {
     dispatchEvent(window, 'locked')
   }

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -1,24 +1,21 @@
 import { makeIframe, addIframeToDocument } from './iframeManager'
 import setupPostOffices from './setupPostOffices'
 import dispatchEvent from './dispatchEvent'
+import { UnlockWindow } from '../windowTypes'
 
-export default function startup(window) {
-  try {
-    // this is a cache for the time between script startup and the full load
-    // of the data iframe. The data iframe will then send down the current
-    // value, overriding this. A bit later, the blockchain handler will update
-    // with the actual value, so this is only used for a few milliseconds
-    const locked = JSON.parse(
-      window.localStorage.getItem('__unlockProtocol.locked')
-    )
-    if (locked === true) {
-      dispatchEvent(window, 'locked')
-    }
-    if (locked === false) {
-      dispatchEvent(window, 'unlocked')
-    }
-  } catch (e) {
-    // ignore
+export default function startup(window: UnlockWindow) {
+  // this is a cache for the time between script startup and the full load
+  // of the data iframe. The data iframe will then send down the current
+  // value, overriding this. A bit later, the blockchain handler will update
+  // with the actual value, so this is only used for a few milliseconds
+  const locked = JSON.parse(
+    window.localStorage.getItem('__unlockProtocol.locked') || '"ignore"'
+  )
+  if (locked === true) {
+    dispatchEvent(window, 'locked')
+  }
+  if (locked === false) {
+    dispatchEvent(window, 'unlocked')
   }
 
   const origin = '?origin=' + encodeURIComponent(window.origin)

--- a/paywall/unlock.1.0.js.webpack.config.js
+++ b/paywall/unlock.1.0.js.webpack.config.js
@@ -34,7 +34,7 @@ module.exports = () => {
     cache: false,
     mode: 'production',
     devtool: 'source-map',
-    entry: path.resolve(__dirname, 'src', 'unlock.js', 'index.js'),
+    entry: path.resolve(__dirname, 'src', 'unlock.js', 'index.ts'),
     output: {
       path: path.resolve(__dirname, 'src', 'static'),
       filename: 'unlock.1.0.min.js',


### PR DESCRIPTION
# Description

This completes the move to typescript.

Note: typescript complained about the usage of try/catch around JSON.parse, so instead of allowing it to throw if localStorage returns null, we just pass in a `JSON.stringify()`ied version of `'ignore'` which will cause the rest of the code to ignore it. Otherwise, if the value is invalid JSON, we catch and use `'ignore'` directly.

Note 2: the weird `((window as unknown) as UnlockWindow)` construct is required because of a conflict between definitions of Window and UnlockWindow. Ours is more restrictive and so doesn't match Window's looser definition.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3862 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
