### PR TITLE
fixing unlockConfigTag

### DIFF
--- a/unlock-protocol.com/src/pages/_document.js
+++ b/unlock-protocol.com/src/pages/_document.js
@@ -31,7 +31,7 @@ export default class MyDocument extends Document {
         icon: 'https://unlock-protocol.com/static/images/svg/unlock-word-mark.svg',
         callToAction: {
           default:
-            'Unlock lets you easily offer paid memberships to your website or application. On this website, members can leave comments and participate in discussion. It's free to try! Just click "purchase" below.',
+            'Unlock lets you easily offer paid memberships to your website or application. On this website, members can leave comments and participate in discussion. It is free to try! Just click "purchase" below.',
         },
       }`,
     }


### PR DESCRIPTION
# Description

There was an issue with the `'` which broke the behavior...

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread