### PR TITLE
strict typing of postMessages 

### DIFF
--- a/paywall/src/messageTypes.ts
+++ b/paywall/src/messageTypes.ts
@@ -1,0 +1,125 @@
+import { PaywallConfig, Locks, PurchaseKeyRequest } from './unlockTypes'
+import { web3MethodCall, Web3WalletInfo } from './windowTypes'
+
+// This file written with HEAVY inspiration from https://artsy.github.io/blog/2018/11/21/conditional-types-in-typescript/
+
+export enum PostMessages {
+  LOCKED = 'locked',
+  UNLOCKED = 'unlocked',
+  SCROLL_POSITION = 'scrollPosition',
+  REDIRECT = 'redirect',
+  GET_OPTIMISTIC = 'optimistic',
+  GET_PESSIMISTIC = 'pessimistic',
+  READY = 'ready',
+  CONFIG = 'config',
+  ACCOUNT = 'account',
+  WEB3 = 'web3',
+  READY_WEB3 = 'ready/web3',
+  WALLET_INFO = 'walletInfo',
+
+  UPDATE_LOCKS = 'update/locks',
+  UPDATE_ACCOUNT = 'update/account',
+  UPDATE_ACCOUNT_BALANCE = 'update/accountBalance',
+  UPDATE_NETWORK = 'update/network',
+  UPDATE_WALLET = 'update/walletmodal',
+
+  ERROR = 'error',
+  SEND_UPDATES = 'send/updates',
+
+  PURCHASE_KEY = 'purchaseKey',
+  DISMISS_CHECKOUT = 'dismiss/checkout',
+  INITIATED_TRANSACTION = 'initiated/transaction',
+}
+// all the possible message types
+export type Message =
+  | {
+      type: PostMessages.LOCKED
+      payload: undefined
+    }
+  | {
+      type: PostMessages.UNLOCKED
+      payload: string[]
+    }
+  | {
+      type: PostMessages.SCROLL_POSITION
+      payload: number
+    }
+  | {
+      type: PostMessages.REDIRECT
+      payload: undefined
+    }
+  | {
+      type: PostMessages.GET_OPTIMISTIC
+      payload: undefined
+    }
+  | {
+      type: PostMessages.GET_PESSIMISTIC
+      payload: undefined
+    }
+  | {
+      type: PostMessages.READY
+      payload: undefined
+    }
+  | {
+      type: PostMessages.CONFIG
+      payload: PaywallConfig
+    }
+  | {
+      type: PostMessages.ACCOUNT
+      payload: string
+    }
+  | {
+      type: PostMessages.WEB3
+      payload: web3MethodCall
+    }
+  | {
+      type: PostMessages.READY_WEB3
+      payload: undefined
+    }
+  | {
+      type: PostMessages.WALLET_INFO
+      payload: Web3WalletInfo
+    }
+  | {
+      type: PostMessages.UPDATE_LOCKS
+      payload: Locks
+    }
+  | {
+      type: PostMessages.UPDATE_ACCOUNT
+      payload: string
+    }
+  | {
+      type: PostMessages.UPDATE_ACCOUNT_BALANCE
+      payload: string
+    }
+  | {
+      type: PostMessages.UPDATE_NETWORK
+      payload: number
+    }
+  | {
+      type: PostMessages.UPDATE_WALLET
+      payload: undefined
+    }
+  | {
+      type: PostMessages.ERROR
+      payload: string
+    }
+  | {
+      type: PostMessages.SEND_UPDATES
+      payload: 'locks' | 'account' | 'balance' | 'network'
+    }
+  | {
+      type: PostMessages.PURCHASE_KEY
+      payload: PurchaseKeyRequest
+    }
+  | {
+      type: PostMessages.DISMISS_CHECKOUT
+      payload: undefined
+    }
+  | {
+      type: PostMessages.INITIATED_TRANSACTION
+      payload: undefined
+    }
+
+export type MessageTypes = Message['type']
+export type ExtractPayload<TYPE> = Extract<Message, { type: TYPE }>['payload']

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -114,3 +114,8 @@ export interface Key {
   owner: string | null
   lock: string
 }
+
+export interface PurchaseKeyRequest {
+  lock: string // lock address
+  extraTip: string // extra value to add in addition to key price
+}

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -41,6 +41,11 @@ export interface LocalStorageWindow {
 }
 
 // used in web3Proxy.ts
+export interface Web3WalletInfo {
+  noWallet: boolean
+  notEnabled: boolean
+  isMetamask: boolean
+}
 export interface web3MethodCall {
   method: string
   params: any[]


### PR DESCRIPTION
# Description

This adds the groundwork for strict typing of postMessages.

Some explanation:

`messageTypes.ts` introduces a union with every message type and its expected payload type. It also adds an enum to replace `paywall-builder/constants.js`

The most important part, and this is serious TS magic, is this:

```ts
export type MessageTypes = Message['type']
export type ExtractPayload<TYPE> = Extract<Message, { type: TYPE }>['payload']
```

`MessageTypes` is a union of all the message types, and `ExtractPayload` will, given a single message type *or* a union of all message types, return the correct payload type.

This will be used in a subsequent PR to type check parameters to postMessage:

```ts
postMessage(PostMessages.TYPE_NAME, param)
```

typing will instantly fail if it is an unknown type name (it's just a string, so using `'unlocked'` works), or if the type of the payload doesn't match.

This was the least redundant setup I could find, but we will have to add 2 lines for every new message here, 1 for the enum, 1 for the payload type.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3862 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
