### PR TITLE
refactor post office to use the new stricter type validation

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.js
@@ -1,20 +1,5 @@
 import setupPostOffices from '../../unlock.js/setupPostOffices'
-import {
-  POST_MESSAGE_READY,
-  POST_MESSAGE_CONFIG,
-  POST_MESSAGE_UNLOCKED,
-  POST_MESSAGE_LOCKED,
-  POST_MESSAGE_PURCHASE_KEY,
-  POST_MESSAGE_UPDATE_NETWORK,
-  POST_MESSAGE_UPDATE_ACCOUNT,
-  POST_MESSAGE_UPDATE_ACCOUNT_BALANCE,
-  POST_MESSAGE_UPDATE_LOCKS,
-  POST_MESSAGE_WALLET_INFO,
-  POST_MESSAGE_ERROR,
-  POST_MESSAGE_UPDATE_WALLET,
-  POST_MESSAGE_READY_WEB3,
-  POST_MESSAGE_SEND_UPDATES,
-} from '../../paywall-builder/constants'
+import { PostMessages } from '../../messageTypes'
 
 describe('setupPostOffice', () => {
   let fakeWindow
@@ -99,17 +84,17 @@ describe('setupPostOffice', () => {
     expect(fakeUIIframe.className).toBe('unlock start show')
   })
 
-  it('responds to POST_MESSAGE_READY_WEB3 by sending POST_MESSAGE_WALLET_INFO', () => {
+  it('responds to PostMessages.READY_WEB3 by sending PostMessages.WALLET_INFO', () => {
     expect.assertions(2)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_READY_WEB3, {
+    sendMessage(fakeDataIframe, PostMessages.READY_WEB3, {
       lock: { address: 'lock' },
     })
 
     expect(fakeUIIframe.contentWindow.postMessage).not.toHaveBeenCalled()
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_WALLET_INFO,
+        type: PostMessages.WALLET_INFO,
         payload: {
           noWallet: false,
           notEnabled: true,
@@ -120,17 +105,17 @@ describe('setupPostOffice', () => {
     )
   })
 
-  it('responds to POST_MESSAGE_READY by sending the config to both iframes', () => {
+  it('responds to PostMessages.READY by sending the config to both iframes', () => {
     expect.assertions(8)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_READY)
-    sendMessage(fakeUIIframe, POST_MESSAGE_READY)
+    sendMessage(fakeDataIframe, PostMessages.READY)
+    sendMessage(fakeUIIframe, PostMessages.READY)
 
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledTimes(5)
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
       1,
       {
-        type: POST_MESSAGE_CONFIG,
+        type: PostMessages.CONFIG,
         payload: fakeWindow.unlockProtocolConfig,
       },
       'http://paywall'
@@ -138,7 +123,7 @@ describe('setupPostOffice', () => {
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
       2,
       {
-        type: POST_MESSAGE_SEND_UPDATES,
+        type: PostMessages.SEND_UPDATES,
         payload: 'network',
       },
       'http://paywall'
@@ -146,7 +131,7 @@ describe('setupPostOffice', () => {
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
       3,
       {
-        type: POST_MESSAGE_SEND_UPDATES,
+        type: PostMessages.SEND_UPDATES,
         payload: 'account',
       },
       'http://paywall'
@@ -154,7 +139,7 @@ describe('setupPostOffice', () => {
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
       4,
       {
-        type: POST_MESSAGE_SEND_UPDATES,
+        type: PostMessages.SEND_UPDATES,
         payload: 'balance',
       },
       'http://paywall'
@@ -162,7 +147,7 @@ describe('setupPostOffice', () => {
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
       5,
       {
-        type: POST_MESSAGE_SEND_UPDATES,
+        type: PostMessages.SEND_UPDATES,
         payload: 'locks',
       },
       'http://paywall'
@@ -171,43 +156,43 @@ describe('setupPostOffice', () => {
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledTimes(1)
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_CONFIG,
+        type: PostMessages.CONFIG,
         payload: fakeWindow.unlockProtocolConfig,
       },
       'http://paywall'
     )
   })
 
-  it('responds to POST_MESSAGE_READY by showing the checkout UI if the paywall type is "paywall"', () => {
+  it('responds to PostMessages.READY by showing the checkout UI if the paywall type is "paywall"', () => {
     expect.assertions(1)
 
     fakeWindow.unlockProtocolConfig = {
       type: 'paywall',
     }
 
-    sendMessage(fakeUIIframe, POST_MESSAGE_READY)
+    sendMessage(fakeUIIframe, PostMessages.READY)
 
     expect(fakeUIIframe.className).toBe('unlock start show')
   })
 
-  it('responds to POST_MESSAGE_UNLOCKED by sending unlocked to the UI iframe', () => {
+  it('responds to PostMessages.UNLOCKED by sending unlocked to the UI iframe', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
+    sendMessage(fakeDataIframe, PostMessages.UNLOCKED, ['lock'])
 
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_UNLOCKED,
+        type: PostMessages.UNLOCKED,
         payload: ['lock'],
       },
       'http://paywall'
     )
   })
 
-  it('responds to POST_MESSAGE_UNLOCKED by dispatching unlockProtocol event', () => {
+  it('responds to PostMessages.UNLOCKED by dispatching unlockProtocol event', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
+    sendMessage(fakeDataIframe, PostMessages.UNLOCKED, ['lock'])
 
     expect(fakeWindow.dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -217,44 +202,44 @@ describe('setupPostOffice', () => {
     )
   })
 
-  it('responds to POST_MESSAGE_UNLOCKED by storing in localStorage for quick recovery on next visit', () => {
+  it('responds to PostMessages.UNLOCKED by storing in localStorage for quick recovery on next visit', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
+    sendMessage(fakeDataIframe, PostMessages.UNLOCKED, ['lock'])
 
     expect(fakeWindow.storage).toEqual({
       '__unlockProtocol.locked': 'false',
     })
   })
 
-  it('responds to POST_MESSAGE_UNLOCKED by not hiding the checkout UI if the key is not confirmed', () => {
+  it('responds to PostMessages.UNLOCKED by not hiding the checkout UI if the key is not confirmed', () => {
     expect.assertions(1)
 
     fakeUIIframe.className = 'unlock start show'
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UNLOCKED, ['lock'])
+    sendMessage(fakeDataIframe, PostMessages.UNLOCKED, ['lock'])
 
     expect(fakeUIIframe.className).toBe('unlock start show')
   })
 
-  it('responds to POST_MESSAGE_LOCKED by sending locked to the UI iframe', () => {
+  it('responds to PostMessages.LOCKED by sending locked to the UI iframe', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_LOCKED)
+    sendMessage(fakeDataIframe, PostMessages.LOCKED)
 
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_LOCKED,
+        type: PostMessages.LOCKED,
         payload: undefined,
       },
       'http://paywall'
     )
   })
 
-  it('responds to POST_MESSAGE_LOCKED by dispatching unlockProtocol event', () => {
+  it('responds to PostMessages.LOCKED by dispatching unlockProtocol event', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_LOCKED)
+    sendMessage(fakeDataIframe, PostMessages.LOCKED)
 
     expect(fakeWindow.dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -264,113 +249,113 @@ describe('setupPostOffice', () => {
     )
   })
 
-  it('responds to POST_MESSAGE_LOCKED by storing in localStorage for quick recovery on next visit', () => {
+  it('responds to PostMessages.LOCKED by storing in localStorage for quick recovery on next visit', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_LOCKED, ['lock'])
+    sendMessage(fakeDataIframe, PostMessages.LOCKED, ['lock'])
 
     expect(fakeWindow.storage).toEqual({
       '__unlockProtocol.locked': 'true',
     })
   })
 
-  it('responds to POST_MESSAGE_ERROR by sending error messages to the UI iframe', () => {
+  it('responds to PostMessages.ERROR by sending error messages to the UI iframe', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_ERROR, 'fail')
+    sendMessage(fakeDataIframe, PostMessages.ERROR, 'fail')
 
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_ERROR,
+        type: PostMessages.ERROR,
         payload: 'fail',
       },
       'http://paywall'
     )
   })
 
-  it('responds to POST_MESSAGE_UPDATE_WALLET by sending modal info to the UI iframe', () => {
+  it('responds to PostMessages.UPDATE_WALLET by sending modal info to the UI iframe', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UPDATE_WALLET, true)
+    sendMessage(fakeDataIframe, PostMessages.UPDATE_WALLET, true)
 
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_UPDATE_WALLET,
+        type: PostMessages.UPDATE_WALLET,
         payload: true,
       },
       'http://paywall'
     )
   })
 
-  it('relays POST_MESSAGE_PURCHASE_KEY to the data iframe', () => {
+  it('relays PostMessages.PURCHASE_KEY to the data iframe', () => {
     expect.assertions(1)
 
-    sendMessage(fakeUIIframe, POST_MESSAGE_PURCHASE_KEY, {
+    sendMessage(fakeUIIframe, PostMessages.PURCHASE_KEY, {
       lock: 'lock',
       extraTip: '0',
     })
 
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_PURCHASE_KEY,
+        type: PostMessages.PURCHASE_KEY,
         payload: { lock: 'lock', extraTip: '0' },
       },
       'http://paywall'
     )
   })
 
-  it('relays POST_MESSAGE_UPDATE_NETWORK to the checkout UI', () => {
+  it('relays PostMessages.UPDATE_NETWORK to the checkout UI', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UPDATE_NETWORK, 2)
+    sendMessage(fakeDataIframe, PostMessages.UPDATE_NETWORK, 2)
 
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_UPDATE_NETWORK,
+        type: PostMessages.UPDATE_NETWORK,
         payload: 2,
       },
       'http://paywall'
     )
   })
 
-  it('relays POST_MESSAGE_UPDATE_ACCOUNT to the checkout UI', () => {
+  it('relays PostMessages.UPDATE_ACCOUNT to the checkout UI', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UPDATE_ACCOUNT, 'account')
+    sendMessage(fakeDataIframe, PostMessages.UPDATE_ACCOUNT, 'account')
 
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_UPDATE_ACCOUNT,
+        type: PostMessages.UPDATE_ACCOUNT,
         payload: 'account',
       },
       'http://paywall'
     )
   })
 
-  it('relays POST_MESSAGE_UPDATE_ACCOUNT_BALANCE to the checkout UI', () => {
+  it('relays PostMessages.UPDATE_ACCOUNT_BALANCE to the checkout UI', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UPDATE_ACCOUNT_BALANCE, '1')
+    sendMessage(fakeDataIframe, PostMessages.UPDATE_ACCOUNT_BALANCE, '1')
 
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_UPDATE_ACCOUNT_BALANCE,
+        type: PostMessages.UPDATE_ACCOUNT_BALANCE,
         payload: '1',
       },
       'http://paywall'
     )
   })
 
-  it('relays POST_MESSAGE_UPDATE_LOCKS to the checkout UI', () => {
+  it('relays PostMessages.UPDATE_LOCKS to the checkout UI', () => {
     expect.assertions(1)
 
-    sendMessage(fakeDataIframe, POST_MESSAGE_UPDATE_LOCKS, {
+    sendMessage(fakeDataIframe, PostMessages.UPDATE_LOCKS, {
       lock: { address: 'lock' },
     })
 
     expect(fakeUIIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
-        type: POST_MESSAGE_UPDATE_LOCKS,
+        type: PostMessages.UPDATE_LOCKS,
         payload: {
           lock: { address: 'lock' },
         },

--- a/paywall/src/__tests__/utils/postOffice.test.ts
+++ b/paywall/src/__tests__/utils/postOffice.test.ts
@@ -8,6 +8,7 @@ import {
   IframePostOfficeWindow,
   Iframe,
 } from '../../utils/postOffice'
+import { PostMessages } from '../../messageTypes'
 
 describe('postOffice', () => {
   const fakeResponder = () => {}
@@ -69,11 +70,11 @@ describe('postOffice', () => {
       )
 
       expect(postMessage).toBeInstanceOf(Function)
-      postMessage('hi', 'there')
+      postMessage(PostMessages.ACCOUNT, 'there')
 
       expect(fakeTarget.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'hi',
+          type: PostMessages.ACCOUNT,
           payload: 'there',
         }),
         'hi'
@@ -416,10 +417,10 @@ describe('postOffice', () => {
       const { addHandler, postMessage } = iframePostOffice(fakeWindow, '', '')
       addHandler('hi', listener)
 
-      postMessage('type', 'response')
+      postMessage(PostMessages.ACCOUNT, 'response')
 
       expect(fakeTarget.postMessage).toHaveBeenCalledWith(
-        { type: 'type', payload: 'response' },
+        { type: PostMessages.ACCOUNT, payload: 'response' },
         'http://fun.times'
       )
     })
@@ -491,10 +492,10 @@ describe('postOffice', () => {
       )
       addHandler('hi', listener)
 
-      postMessage('type', 'response')
+      postMessage(PostMessages.ACCOUNT, 'response')
 
       expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
-        { type: 'type', payload: 'response' },
+        { type: PostMessages.ACCOUNT, payload: 'response' },
         'http://fun.times'
       )
     })

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -1,24 +1,10 @@
 import { mainWindowPostOffice } from '../utils/postOffice'
-import {
-  POST_MESSAGE_READY,
-  POST_MESSAGE_CONFIG,
-  POST_MESSAGE_LOCKED,
-  POST_MESSAGE_UNLOCKED,
-  POST_MESSAGE_PURCHASE_KEY,
-  POST_MESSAGE_UPDATE_ACCOUNT,
-  POST_MESSAGE_UPDATE_ACCOUNT_BALANCE,
-  POST_MESSAGE_UPDATE_LOCKS,
-  POST_MESSAGE_UPDATE_NETWORK,
-  POST_MESSAGE_ERROR,
-  POST_MESSAGE_UPDATE_WALLET,
-  POST_MESSAGE_DISMISS_CHECKOUT,
-  POST_MESSAGE_SEND_UPDATES,
-} from '../paywall-builder/constants'
 import dispatchEvent from './dispatchEvent'
 import web3Proxy from './web3Proxy'
 import { showIframe } from './iframeManager'
 import { IframeType, UnlockWindow } from '../windowTypes'
 import setupUnlockProtocolVariable from './setupUnlockProtocolVariable'
+import { PostMessages } from '../messageTypes'
 
 interface process {
   env: any
@@ -66,21 +52,21 @@ export default function setupPostOffices(
   )
 
   // send the configuration to the data iframe
-  addDataMessageHandler(POST_MESSAGE_READY, (_, respond) => {
+  addDataMessageHandler(PostMessages.READY, (_, respond) => {
     if (window.unlockProtocolConfig) {
-      respond(POST_MESSAGE_CONFIG, window.unlockProtocolConfig)
+      respond(PostMessages.CONFIG, window.unlockProtocolConfig)
     }
   })
 
   // send the configuration to the checkout iframe
-  addCheckoutMessageHandler(POST_MESSAGE_READY, (_, respond) => {
+  addCheckoutMessageHandler(PostMessages.READY, (_, respond) => {
     if (window.unlockProtocolConfig) {
-      respond(POST_MESSAGE_CONFIG, window.unlockProtocolConfig)
+      respond(PostMessages.CONFIG, window.unlockProtocolConfig)
       // trigger a send of the current state
-      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'network')
-      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'account')
-      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'balance')
-      dataPostOffice(POST_MESSAGE_SEND_UPDATES, 'locks')
+      dataPostOffice(PostMessages.SEND_UPDATES, 'network')
+      dataPostOffice(PostMessages.SEND_UPDATES, 'account')
+      dataPostOffice(PostMessages.SEND_UPDATES, 'balance')
+      dataPostOffice(PostMessages.SEND_UPDATES, 'locks')
       if (window.unlockProtocolConfig.type === 'paywall') {
         // always show the checkout modal on start for the paywall app
         showIframe(window, CheckoutUIIframe)
@@ -93,7 +79,7 @@ export default function setupPostOffices(
 
   // relay the unlocked event both to the main window
   // and to the checkout UI
-  addDataMessageHandler(POST_MESSAGE_UNLOCKED, locks => {
+  addDataMessageHandler(PostMessages.UNLOCKED, locks => {
     dispatchEvent(window, 'unlocked')
     try {
       // this is a fast cache. The value will only be used
@@ -108,17 +94,17 @@ export default function setupPostOffices(
     } catch (e) {
       // ignore
     }
-    CheckoutUIPostOffice(POST_MESSAGE_UNLOCKED, locks)
+    CheckoutUIPostOffice(PostMessages.UNLOCKED, locks)
   })
 
   // if the user chooses to close the checkout modal, we hide the iframe
-  addCheckoutMessageHandler(POST_MESSAGE_DISMISS_CHECKOUT, () => {
+  addCheckoutMessageHandler(PostMessages.DISMISS_CHECKOUT, () => {
     hideCheckoutModal()
   })
 
   // relay the locked event both to the main window
   // and to the checkout UI
-  addDataMessageHandler(POST_MESSAGE_LOCKED, () => {
+  addDataMessageHandler(PostMessages.LOCKED, () => {
     dispatchEvent(window, 'locked')
     try {
       // reset the cache to locked for the next page view
@@ -129,45 +115,45 @@ export default function setupPostOffices(
     } catch (e) {
       // ignore
     }
-    CheckoutUIPostOffice(POST_MESSAGE_LOCKED)
+    CheckoutUIPostOffice(PostMessages.LOCKED, undefined)
   })
 
   // relay error messages to the checkout UI
-  addDataMessageHandler(POST_MESSAGE_ERROR, error => {
-    CheckoutUIPostOffice(POST_MESSAGE_ERROR, error)
+  addDataMessageHandler(PostMessages.ERROR, error => {
+    CheckoutUIPostOffice(PostMessages.ERROR, error)
   })
 
   // relay the fact that action is needed to confirm
   // a key purchase transaction in the user's wallet
   // to the checkout UI in order to display a modal
-  addDataMessageHandler(POST_MESSAGE_UPDATE_WALLET, update => {
-    CheckoutUIPostOffice(POST_MESSAGE_UPDATE_WALLET, update)
+  addDataMessageHandler(PostMessages.UPDATE_WALLET, update => {
+    CheckoutUIPostOffice(PostMessages.UPDATE_WALLET, update)
   })
 
   // relay a request to purchase a key to the data iframe
   // as the user has clicked on a key in the checkout UI
-  addCheckoutMessageHandler(POST_MESSAGE_PURCHASE_KEY, details => {
-    dataPostOffice(POST_MESSAGE_PURCHASE_KEY, details)
+  addCheckoutMessageHandler(PostMessages.PURCHASE_KEY, details => {
+    dataPostOffice(PostMessages.PURCHASE_KEY, details)
   })
 
   // relay the most current account address to the checkout UI
-  addDataMessageHandler(POST_MESSAGE_UPDATE_ACCOUNT, account => {
-    CheckoutUIPostOffice(POST_MESSAGE_UPDATE_ACCOUNT, account)
+  addDataMessageHandler(PostMessages.UPDATE_ACCOUNT, account => {
+    CheckoutUIPostOffice(PostMessages.UPDATE_ACCOUNT, account)
   })
 
   // relay the most current account balance to the checkout UI
-  addDataMessageHandler(POST_MESSAGE_UPDATE_ACCOUNT_BALANCE, balance => {
-    CheckoutUIPostOffice(POST_MESSAGE_UPDATE_ACCOUNT_BALANCE, balance)
+  addDataMessageHandler(PostMessages.UPDATE_ACCOUNT_BALANCE, balance => {
+    CheckoutUIPostOffice(PostMessages.UPDATE_ACCOUNT_BALANCE, balance)
   })
 
   // relay the most current lock objects to the checkout UI
-  addDataMessageHandler(POST_MESSAGE_UPDATE_LOCKS, locks => {
-    CheckoutUIPostOffice(POST_MESSAGE_UPDATE_LOCKS, locks)
+  addDataMessageHandler(PostMessages.UPDATE_LOCKS, locks => {
+    CheckoutUIPostOffice(PostMessages.UPDATE_LOCKS, locks)
   })
 
   // relay the user's wallet's current network, in order to
   // display errors if it is on the wrong network
-  addDataMessageHandler(POST_MESSAGE_UPDATE_NETWORK, network => {
-    CheckoutUIPostOffice(POST_MESSAGE_UPDATE_NETWORK, network)
+  addDataMessageHandler(PostMessages.UPDATE_NETWORK, network => {
+    CheckoutUIPostOffice(PostMessages.UPDATE_NETWORK, network)
   })
 }


### PR DESCRIPTION
# Description

This PR simply migrates the `postMessage` function returned from the `postOffice` to have strict type validation, and move to the enum away from constants.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3862 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
