### PR TITLE
Add stripe-v3 types to use in payment details

### DIFF
--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -16,6 +16,7 @@
     "@types/react-redux": "7.1.0",
     "@types/react-stripe-elements": "^1.1.10",
     "@types/storybook__react": "4.0.2",
+    "@types/stripe-v3": "3.1.2",
     "@types/styled-components": "4.1.16",
     "@unlock-protocol/unlock-js": "0.3.2",
     "@zeit/next-source-maps": "0.0.3",


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
There are a few places (SettingsContent, PaymentDetails) where we have the main stripe object as an `any`. Adding these type definitions will add a globally scoped namespace, `stripe`. We'll then be able to type those objects as `stripe.Stripe`, which I will do in a follow-up PR

(this is also a dependency we already download as a dep of `react-stripe-elements` types, adding to package.json just allows us to reference it)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
