### PR TITLE
Stop typing stripe as any

### DIFF
--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -21,7 +21,7 @@ interface SettingsContentProps {
   }
 }
 interface SettingsContentState {
-  stripe: any
+  stripe: stripe.Stripe | null
 }
 
 export class SettingsContent extends React.Component<

--- a/unlock-app/src/components/interface/user-account/PaymentDetails.tsx
+++ b/unlock-app/src/components/interface/user-account/PaymentDetails.tsx
@@ -12,7 +12,7 @@ import { SectionHeader, Column, Grid, SubmitButton } from './styles'
 import { signPaymentData } from '../../../actions/user'
 
 interface PaymentDetailsProps {
-  stripe: any
+  stripe: stripe.Stripe | null
   signPaymentData: (stripeTokenId: string) => any
 }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Not a huge change, but this reduces the use of `any` in the settings page and credit card payment form.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
