### PR TITLE
Add ability to sign key purchase requests to UnlockProvider

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## Next version
+- UnlockProvider gains the capability to sign key purchase requests
+
 ## 0.3.2
 - UnlockProvider gains a `signPaymentData` method that will allow it to sign
   payment details in a way that locksmith can verify and associate with the user

--- a/unlock-js/src/__tests__/unlockProvider.test.js
+++ b/unlock-js/src/__tests__/unlockProvider.test.js
@@ -101,6 +101,21 @@ describe('Unlock Provider', () => {
         )
       })
     })
+
+    describe('signKeyPurchaseRequestData', () => {
+      it('should sign a key purchase request', () => {
+        expect.assertions(1)
+        const input = {
+          recipient: publicKey,
+          lock: '0xaC6b4470B0cba92b823aB96762972e67a1C851d5',
+        }
+        const output = provider.signKeyPurchaseRequestData(input)
+
+        expect(sigUtil.recoverTypedSignature(output)).toEqual(
+          publicKey.toLowerCase()
+        )
+      })
+    })
   })
 
   describe('implemented JSON-RPC calls', () => {

--- a/unlock-js/src/structured_data/keyPurchaseRequest.js
+++ b/unlock-js/src/structured_data/keyPurchaseRequest.js
@@ -1,0 +1,40 @@
+export default class KeyPurchaseRequest {
+  static build(input) {
+    let domain = [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+    ]
+
+    let keyPurchaseRequest = [
+      { name: 'recipient', type: 'address' },
+      { name: 'lock', type: 'address' },
+      { name: 'expiry', type: 'uint256' },
+    ]
+
+    let domainData = {
+      name: 'Unlock Dashboard',
+      version: '1',
+    }
+
+    let message = {
+      request: {
+        recipient: input.recipient,
+        lock: input.lock,
+        expiry: 60, // default to one-minute expiry of signature
+      },
+    }
+
+    return {
+      types: {
+        EIP712Domain: domain,
+        KeyPurchaseRequest: keyPurchaseRequest,
+      },
+      domain: domainData,
+      primaryType: 'KeyPurchaseRequest',
+      message: message,
+    }
+  }
+}

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -4,6 +4,7 @@ import { toBuffer } from 'ethereumjs-utils'
 import { getAccountFromPrivateKey } from './accounts'
 import UnlockUser from './structured_data/unlockUser'
 import UnlockPaymentDetails from './structured_data/unlockPaymentDetails'
+import KeyPurchaseRequest from './structured_data/keyPurchaseRequest'
 
 // UnlockProvider implements a subset of Web3 provider functionality, sufficient
 // to allow us to use it as a stand-in for MetaMask or other Web3 integration in
@@ -88,6 +89,12 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
       publicKey: this.wallet.address,
       stripeTokenId,
     })
+    return this.signData(data)
+  }
+
+  // input contains recipient and lock addresses
+  signKeyPurchaseRequestData(input) {
+    const data = KeyPurchaseRequest.build(input)
     return this.signData(data)
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR allows `UnlockProvider` to sign key purchase requests, a necessary prerequisite for triggering `locksmith`'s key purchases.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #3763 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
