### PR TITLE
move web3Proxy test to typescript in prep for proxyProvider work

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
@@ -43,6 +43,7 @@ describe('setupPostOffice', () => {
     process.env.USER_IFRAME_URL = 'http://unlock-app.com'
     const unlockOrigin = 'http://unlock-app.com'
     fakeWindow = {
+      Promise,
       setInterval: jest.fn(),
       unlockProtocol: {
         loadCheckoutModal: jest.fn(),
@@ -141,18 +142,20 @@ describe('setupPostOffice', () => {
     expect(fakeUIIframe.className).toBe('unlock start show')
   })
 
-  it('responds to PostMessages.READY_WEB3 by sending PostMessages.WALLET_INFO', () => {
+  it('responds to PostMessages.READY_WEB3 by sending PostMessages.WALLET_INFO', async () => {
     expect.assertions(2)
 
     sendMessage(fakeDataIframe, PostMessages.READY_WEB3)
+
+    await Promise.resolve() // sync the Promise queue
 
     expect(fakeUIIframe.contentWindow.postMessage).not.toHaveBeenCalled()
     expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledWith(
       {
         type: PostMessages.WALLET_INFO,
         payload: {
-          noWallet: false,
-          notEnabled: true,
+          noWallet: true,
+          notEnabled: false,
           isMetamask: false,
         },
       },

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -53,18 +53,25 @@ export interface web3MethodCall {
   id: number
 }
 
-export type web3Callback = (error: Error | string | null, result: any) => void
+export interface web3MethodResult {
+  id: number
+  error: null | string
+  result: any
+}
+export type web3Callback = (error: string | null, result: any) => void
 export type web3Send = (
   methodCall: web3MethodCall,
   callback: web3Callback
 ) => void
 
 export interface Web3Window extends PostOfficeWindow {
+  Promise: PromiseConstructor
   web3?: {
     currentProvider: {
       sendAsync?: web3Send
       send?: web3Send
       isMetamask?: true // is only ever true or undefined
+      enable?: () => Promise<void>
     }
   }
 }
@@ -127,7 +134,8 @@ export interface UnlockWindow
     EventWindow,
     UnlockProtocolWindow,
     LocalStorageWindow,
-    IframeManagingWindow {
+    IframeManagingWindow,
+    Web3Window {
   unlockProtocolConfig?: PaywallConfig
   document: FullDocument
   origin: string


### PR DESCRIPTION
# Description

(Taking a break from unpacking :)

In preparation for refactoring web3Proxy.ts to make it a proxyProvider, this converts the test to typescript.

In the process, discovered a couple of types we need in order to make it work, so it adds this to `windowTypes.ts`.

It also removes the completely unnecessary mocking of `config.js` in favor of mocking the actual `enable` call on the web3 currentProvider, which will allow us to completely change the implementation and still have a passing test.

The rest of this is just a bit of DRYing up and a few typescript-forced changes, such as the awkward insistence that we check for the presence of `web3` on the `fakeWindow` since there is some chance it might be undefined!#@! (typescript can't understand beforeEach() yet, apparently).

This and moving the `handler` for mocking event listeners outside of `fakeWindow` are the bulk of the changes.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3767

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
