### PR TITLE
Add getCards to storageService

### DIFF
--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -463,7 +463,7 @@ describe('StorageService', () => {
   })
 
   describe('Retrieve user payment details', () => {
-    describe('When a request succeeds', () => {
+    describe('When a request succeeds with at least one card', () => {
       it('emits a success', done => {
         expect.assertions(2)
         const emailAddress = 'geoff@bitconnect.gov'
@@ -473,6 +473,25 @@ describe('StorageService', () => {
 
         storageService.on(success.getCards, cards => {
           expect(cards[0].id).toEqual('a card object')
+          done()
+        })
+
+        expect(axios.get).toHaveBeenCalledWith(
+          `${serviceHost}/users/${encodeURIComponent(emailAddress)}/cards`
+        )
+      })
+    })
+
+    describe('When a request succeeds without a card', () => {
+      it('emits a success', done => {
+        expect.assertions(2)
+        const emailAddress = 'geoff@bitconnect.gov'
+        axios.get.mockReturnValue({ data: [] })
+
+        storageService.getCards(emailAddress)
+
+        storageService.on(success.getCards, cards => {
+          expect(cards).toHaveLength(0)
           done()
         })
 

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -462,6 +462,42 @@ describe('StorageService', () => {
     })
   })
 
+  describe('Retrieve user payment details', () => {
+    describe('When a request succeeds', () => {
+      it('emits a success', done => {
+        expect.assertions(2)
+        const emailAddress = 'geoff@bitconnect.gov'
+        axios.get.mockReturnValue({ data: [{ id: 'a card object' }] })
+
+        storageService.getCards(emailAddress)
+
+        storageService.on(success.getCards, cards => {
+          expect(cards[0].id).toEqual('a card object')
+          done()
+        })
+
+        expect(axios.get).toHaveBeenCalledWith(
+          `${serviceHost}/users/${encodeURIComponent(emailAddress)}/cards`
+        )
+      })
+    })
+
+    describe('When a request fails', () => {
+      it('emits a failure', done => {
+        expect.assertions(1)
+        const emailAddress = 'geoff@bitconnect.gov'
+        axios.get.mockRejectedValue('Could not fulfill request due to sunspots')
+
+        storageService.getCards(emailAddress)
+
+        storageService.on(failure.getCards, ({ error }) => {
+          expect(error).toEqual('Could not fulfill request due to sunspots')
+          done()
+        })
+      })
+    })
+  })
+
   describe('Retrieve a user recovery phrase', () => {
     describe('When a recovery phrase can be retrieved', () => {
       it('emits a success', done => {

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -15,6 +15,7 @@ export const success = {
   updateUser: 'updateUser.success',
   getUserPrivateKey: 'getUserPrivateKey.success',
   getUserRecoveryPhrase: 'getUserRecoveryPhrase.success',
+  getCards: 'getCards.success',
 }
 
 export const failure = {
@@ -27,6 +28,7 @@ export const failure = {
   updateUser: 'updateUser.failure',
   getUserPrivateKey: 'getUserPrivateKey.failure',
   getUserRecoveryPhrase: 'getUserRecoveryPhrase.failure',
+  getCards: 'getCards.failure',
 }
 
 export class StorageService extends EventEmitter {
@@ -259,6 +261,22 @@ export class StorageService extends EventEmitter {
       }
     } catch (error) {
       this.emit(failure.getUserRecoveryPhrase, { emailAddress, error })
+    }
+  }
+
+  /**
+   * Given a user's email address, retrieves the payment methods associated with
+   * their account. Except in event of error, will always respond with an array
+   * of 0 or more elements.
+   */
+  async getCards(emailAddress) {
+    try {
+      const response = await axios.get(
+        `${this.host}/users/${encodeURIComponent(emailAddress)}/cards`
+      )
+      this.emit(success.getCards, response.data)
+    } catch (error) {
+      this.emit(failure.getCards, { error })
     }
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
In order to know if a user has stored payment details (for use in the key purchase screen), we need to be able to query locksmith for the data. This PR adds a method to enable that.

I intend for storageMiddleware to listen for `UPDATE_ACCOUNT` events that include an email address. Those signal that a user account has successfully logged in, so we should go and fetch payment details. Additonally, it should listen for when a new payment is successfully added because we'll need to update the state to reflect that data. When it receives a card, it will dispatch `UPDATE_ACCOUNT` itself to add the payment details to the account stored in state.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #3763 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
