### PR TITLE
Ensure return from Payment request prior to proceeding

### DIFF
--- a/locksmith/__tests__/payment/paymentProcessor.test.ts
+++ b/locksmith/__tests__/payment/paymentProcessor.test.ts
@@ -173,8 +173,8 @@ describe('PaymentProcessor', () => {
     beforeAll(() => {
       paymentProcessor.chargeUser = jest
         .fn()
-        .mockReturnValueOnce({})
-        .mockReturnValueOnce(null)
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce(null)
     })
 
     afterEach(() => {
@@ -182,9 +182,9 @@ describe('PaymentProcessor', () => {
     })
 
     describe('when the user was successfully charged', () => {
-      it('dispatches the purchase', () => {
+      it('dispatches the purchase', async () => {
         expect.assertions(1)
-        paymentProcessor.initiatePurchase(
+        await paymentProcessor.initiatePurchase(
           'recipient',
           'lock',
           'credentials',
@@ -200,9 +200,9 @@ describe('PaymentProcessor', () => {
     })
 
     describe('when the user was unsuccessfully charged', () => {
-      it('does not dispatch the purchase', () => {
+      it('does not dispatch the purchase', async () => {
         expect.assertions(1)
-        paymentProcessor.initiatePurchase(
+        await paymentProcessor.initiatePurchase(
           'recipient',
           'lock',
           'credentials',

--- a/locksmith/src/payment/paymentProcessor.ts
+++ b/locksmith/src/payment/paymentProcessor.ts
@@ -102,7 +102,7 @@ export class PaymentProcessor {
     providerHost: string,
     buyer: ethereumAddress
   ) {
-    let successfulCharge = this.chargeUser(recipient, lock)
+    let successfulCharge = await this.chargeUser(recipient, lock)
     if (successfulCharge) {
       let fulfillmentDispatcher = new Dispatcher(
         'unlockAddress',


### PR DESCRIPTION
# Description

As part of discovery around our dry run of purchasing we discovered that we werent blocking on receipt of payment.  Adjusting here to ensure behavior is as we expect. 


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
