### PR TITLE
refactor web3Proxy to use the new setupMailbox mapHandlers [PLEASE REVIEW]

### DIFF
--- a/paywall/src/__tests__/unlock.js/startup.test.js
+++ b/paywall/src/__tests__/unlock.js/startup.test.js
@@ -171,7 +171,7 @@ describe('unlock.js startup', () => {
 
     // this is a simple way to test whether setupPostOffices was called
     // by checking to see if event listeners for postMessage were set up
-    // The 2 are:
+    // The 3 are:
     // - the data iframe post office (used for web3Proxy as well)
     // - the checkout UI post office
     // - the user accounts UI post office

--- a/paywall/src/__tests__/unlock.js/startup.test.js
+++ b/paywall/src/__tests__/unlock.js/startup.test.js
@@ -175,6 +175,6 @@ describe('unlock.js startup', () => {
     // - the data iframe post office (used for web3Proxy as well)
     // - the checkout UI post office
     // - the user accounts UI post office
-    expect(fakeWindow.addEventListener).toHaveBeenCalledTimes(4)
+    expect(fakeWindow.addEventListener).toHaveBeenCalledTimes(3)
   })
 })

--- a/paywall/src/__tests__/unlock.js/startup.test.js
+++ b/paywall/src/__tests__/unlock.js/startup.test.js
@@ -171,11 +171,10 @@ describe('unlock.js startup', () => {
 
     // this is a simple way to test whether setupPostOffices was called
     // by checking to see if event listeners for postMessage were set up
-    // The 4 are:
-    // - the data iframe post office
+    // The 2 are:
+    // - the data iframe post office (used for web3Proxy as well)
     // - the checkout UI post office
     // - the user accounts UI post office
-    // - the Web3ProxyProvider post office
     expect(fakeWindow.addEventListener).toHaveBeenCalledTimes(4)
   })
 })

--- a/paywall/src/messageTypes.ts
+++ b/paywall/src/messageTypes.ts
@@ -1,5 +1,5 @@
 import { PaywallConfig, Locks, PurchaseKeyRequest } from './unlockTypes'
-import { web3MethodCall, Web3WalletInfo } from './windowTypes'
+import { web3MethodCall, Web3WalletInfo, web3MethodResult } from './windowTypes'
 
 // This file written with HEAVY inspiration from https://artsy.github.io/blog/2018/11/21/conditional-types-in-typescript/
 
@@ -14,6 +14,7 @@ export enum PostMessages {
   CONFIG = 'config',
   ACCOUNT = 'account',
   WEB3 = 'web3',
+  WEB3_RESULT = 'web3', // this is the same as WEB3 because the exchange is 1-way
   READY_WEB3 = 'ready/web3',
   WALLET_INFO = 'walletInfo',
 
@@ -71,6 +72,10 @@ export type Message =
   | {
       type: PostMessages.WEB3
       payload: web3MethodCall
+    }
+  | {
+      type: PostMessages.WEB3_RESULT
+      payload: web3MethodResult
     }
   | {
       type: PostMessages.READY_WEB3

--- a/paywall/src/unlock.js/setupIframeMailbox.ts
+++ b/paywall/src/unlock.js/setupIframeMailbox.ts
@@ -25,6 +25,10 @@ export type MessageHandlerTemplate<T extends MessageTypes> = (
 export type MessageHandlerTemplates<T extends MessageTypes> = {
   [key in T]?: MessageHandlerTemplate<T>
 }
+export type MapHandlers = (
+  forIframe: IframeNames,
+  handlers: MessageHandlerTemplates<MessageTypes>
+) => void
 
 /**
  * Set up all of the post offices for each iframe.

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -165,5 +165,5 @@ export default function setupPostOffices(
   mapHandlers('checkout', checkoutHandlers)
 
   // set up the main window side of Web3ProxyProvider
-  web3Proxy(window, dataIframe, process.env.PAYWALL_URL)
+  web3Proxy(window, mapHandlers)
 }

--- a/paywall/src/unlock.js/web3Proxy.ts
+++ b/paywall/src/unlock.js/web3Proxy.ts
@@ -1,13 +1,25 @@
-import { enable } from '../paywall-builder/config'
-import { mainWindowPostOffice } from '../utils/postOffice'
-import {
-  POST_MESSAGE_WEB3,
-  POST_MESSAGE_READY_WEB3,
-  POST_MESSAGE_WALLET_INFO,
-} from '../paywall-builder/constants'
-import { Web3Window, IframeType, web3MethodCall } from '../windowTypes'
+import { Web3Window, web3MethodCall } from '../windowTypes'
+import { MapHandlers, MessageHandlerTemplates } from './setupIframeMailbox'
+import { PostMessages, MessageTypes } from '../messageTypes'
 
 let hasWeb3 = true
+
+export function enable(window: Web3Window) {
+  return new window.Promise((resolve, reject) => {
+    if (!window.web3 || !window.web3.currentProvider) {
+      return reject(new ReferenceError('no web3 wallet exists'))
+    }
+    if (!window.web3.currentProvider.enable) return resolve()
+    window.web3.currentProvider
+      .enable()
+      .then(() => {
+        return resolve()
+      })
+      .catch((e: any) => {
+        reject(e)
+      })
+  })
+}
 
 /**
  * Proxy calls to web3 from postMessage
@@ -18,90 +30,93 @@ let hasWeb3 = true
  */
 export default function web3Proxy(
   window: Web3Window,
-  iframe: IframeType,
-  origin: string
+  mapHandlers: MapHandlers
 ) {
-  const { addHandler } = mainWindowPostOffice(
-    window,
-    iframe,
-    origin,
-    'web3 proxy',
-    'Web3ProxyProvider'
-  )
   // use sendAsync if available, otherwise we will use send
   const send =
     window.web3 &&
     window.web3.currentProvider &&
     (window.web3.currentProvider.sendAsync || window.web3.currentProvider.send)
 
-  // handler for the actual web3 calls
-  addHandler(POST_MESSAGE_WEB3, (payload, respond) => {
-    if (!hasWeb3 || !window.web3) {
-      return respond(POST_MESSAGE_WEB3, {
-        id: payload.id,
-        error: 'No web3 wallet is available',
-        result: null,
-      })
-    }
-
-    if (!payload || typeof payload !== 'object') return
-    if (!payload.method || typeof payload.method !== 'string') {
-      return
-    }
-    if (!payload.params || !Array.isArray(payload.params)) {
-      return
-    }
-    if (
-      typeof payload.id !== 'number' ||
-      Math.round(payload.id) !== payload.id
-    ) {
-      return
-    }
-
-    const { method, params, id }: web3MethodCall = payload
-    // we use call to bind the call to the current provider
-    send &&
-      send.call(
-        window.web3.currentProvider,
-        {
-          method,
-          params,
-          jsonrpc: '2.0',
-          id,
-        },
-        (error, result) => {
-          respond(POST_MESSAGE_WEB3, { id, error, result })
+  const handlers: MessageHandlerTemplates<MessageTypes> = {
+    [PostMessages.READY_WEB3]: postMessage => {
+      return async () => {
+        // initialize, we do this once the iframe is ready to receive information on the wallet
+        // we need to tell the iframe if the wallet is metamask
+        // TODO: pass the name of the wallet if we know it? (secondary importance right now, so omitting)
+        const isMetamask = !!(
+          window.web3 &&
+          window.web3.currentProvider &&
+          window.web3.currentProvider.isMetamask
+        )
+        try {
+          await enable(window)
+          hasWeb3 = true
+          postMessage('data', PostMessages.WALLET_INFO, {
+            noWallet: false,
+            notEnabled: false,
+            isMetamask, // this is used for some decisions in signing
+          })
+        } catch (e) {
+          // we don't have web3
+          hasWeb3 = false
+          const noWallet = e instanceof ReferenceError
+          const notEnabled = !noWallet
+          postMessage('data', PostMessages.WALLET_INFO, {
+            noWallet,
+            notEnabled,
+            isMetamask,
+          })
         }
-      )
-  })
+      }
+    },
+    [PostMessages.WEB3]: postMessage => {
+      return async payload => {
+        // handler for the actual web3 calls
+        if (!hasWeb3 || !window.web3) {
+          return postMessage('data', PostMessages.WEB3, {
+            id: payload.id,
+            error: 'No web3 wallet is available',
+            result: null,
+          })
+        }
 
-  // initialize, we do this once the iframe is ready to receive information on the wallet
-  // we need to tell the iframe if the wallet is metamask
-  // TODO: pass the name of the wallet if we know it? (secondary importance right now, so omitting)
-  addHandler(POST_MESSAGE_READY_WEB3, async (_, respond) => {
-    const isMetamask = !!(
-      window.web3 &&
-      window.web3.currentProvider &&
-      window.web3.currentProvider.isMetamask
-    )
-    try {
-      await enable(window)
-      hasWeb3 = true
-      respond(POST_MESSAGE_WALLET_INFO, {
-        noWallet: false,
-        notEnabled: false,
-        isMetamask, // this is used for some decisions in signing
-      })
-    } catch (e) {
-      // we don't have web3
-      hasWeb3 = false
-      const noWallet = e instanceof ReferenceError
-      const notEnabled = !noWallet
-      respond(POST_MESSAGE_WALLET_INFO, {
-        noWallet,
-        notEnabled,
-        isMetamask,
-      })
-    }
-  })
+        if (!payload || typeof payload !== 'object') return
+        if (!payload.method || typeof payload.method !== 'string') {
+          return
+        }
+        if (!payload.params || !Array.isArray(payload.params)) {
+          return
+        }
+        if (
+          typeof payload.id !== 'number' ||
+          Math.round(payload.id) !== payload.id
+        ) {
+          return
+        }
+
+        const { method, params, id }: web3MethodCall = payload
+        // we use call to bind the call to the current provider
+        send &&
+          send.call(
+            window.web3.currentProvider,
+            {
+              method,
+              params,
+              jsonrpc: '2.0',
+              id,
+            },
+            (error: string | null, result: any) => {
+              postMessage('data', PostMessages.WEB3_RESULT, {
+                id,
+                error,
+                result,
+              })
+            }
+          )
+      }
+    },
+  }
+
+  mapHandlers('data', handlers)
 }

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -54,9 +54,9 @@ export interface ChainExplorerURLBuilders {
 
 export interface PaywallCallToAction {
   default: string
-  expired: string
-  pending: string
-  confirmed: string
+  expired?: string
+  pending?: string
+  confirmed?: string
 }
 
 export interface PaywallConfigLocks {

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -54,9 +54,9 @@ export interface ChainExplorerURLBuilders {
 
 export interface PaywallCallToAction {
   default: string
-  expired?: string
-  pending?: string
-  confirmed?: string
+  expired: string
+  pending: string
+  confirmed: string
 }
 
 export interface PaywallConfigLocks {


### PR DESCRIPTION
# Description

In preparation for the final PR enabling the user accounts proxyProvider, this moves the `web3Proxy` to use the new setupMailbox `mapHandlers` API

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3767 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
