### PR TITLE
Fetch payment details when logging in

### DIFF
--- a/unlock-app/src/__tests__/actions/user.test.ts
+++ b/unlock-app/src/__tests__/actions/user.test.ts
@@ -31,6 +31,8 @@ import {
   signedPaymentData,
   CONFIRM_KEY_PURCHASE,
   confirmKeyPurchase,
+  GET_STORED_PAYMENT_DETAILS,
+  getStoredPaymentDetails,
 } from '../../actions/user'
 
 const key = {
@@ -116,6 +118,18 @@ describe('user account actions', () => {
       expect(
         gotEncryptedPrivateKeyPayload(key, emailAddress, password)
       ).toEqual(expectedAction)
+    })
+
+    it('should create an action requesting stored payment details', () => {
+      expect.assertions(1)
+
+      const emailAddress = 'jenny@8675.309'
+      const expectedAction = {
+        type: GET_STORED_PAYMENT_DETAILS,
+        emailAddress,
+      }
+
+      expect(getStoredPaymentDetails(emailAddress)).toEqual(expectedAction)
     })
   })
 

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -5,7 +5,7 @@ import storageMiddleware, {
 } from '../../middlewares/storageMiddleware'
 import { UPDATE_LOCK, updateLock } from '../../actions/lock'
 import { addTransaction, NEW_TRANSACTION } from '../../actions/transaction'
-import { SET_ACCOUNT, setAccount } from '../../actions/accounts'
+import { SET_ACCOUNT, setAccount, UPDATE_ACCOUNT } from '../../actions/accounts'
 import { startLoading, doneLoading } from '../../actions/loading'
 import configure from '../../config'
 import {
@@ -16,6 +16,7 @@ import {
   SIGN_USER_DATA,
   SIGNED_USER_DATA,
   SIGNED_PAYMENT_DATA,
+  GET_STORED_PAYMENT_DETAILS,
 } from '../../actions/user'
 import { success, failure } from '../../services/storageService'
 import Error from '../../utils/Error'
@@ -470,6 +471,46 @@ describe('Storage middleware', () => {
           }),
         })
       )
+    })
+  })
+
+  describe('GET_STORED_PAYMENT_DETAILS', () => {
+    it('should call storageService', () => {
+      expect.assertions(1)
+      const { invoke } = create()
+      const action = {
+        type: GET_STORED_PAYMENT_DETAILS,
+        emailAddress: 'name@domain.com',
+      }
+      mockStorageService.getCards = jest.fn()
+      invoke(action)
+
+      expect(mockStorageService.getCards).toHaveBeenCalledWith(
+        'name@domain.com'
+      )
+    })
+
+    it('should handle success.getCards when a user has payment methods', () => {
+      expect.assertions(1)
+      const { store } = create()
+      const cards = [{ id: 'I am a card' }]
+      mockStorageService.emit(success.getCards, cards)
+
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: UPDATE_ACCOUNT,
+        update: {
+          cards,
+        },
+      })
+    })
+
+    it('should do nothing with success.getCards when a user has no payment methods', () => {
+      expect.assertions(1)
+      const { store } = create()
+      const cards = []
+      mockStorageService.emit(success.getCards, cards)
+
+      expect(store.dispatch).not.toHaveBeenCalled()
     })
   })
 })

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -22,6 +22,7 @@ import {
   FATAL_WRONG_NETWORK,
 } from '../../errors'
 import { HIDE_FORM } from '../../actions/lockFormVisibility'
+import { GET_STORED_PAYMENT_DETAILS } from '../../actions/user'
 
 let mockConfig
 
@@ -125,36 +126,46 @@ beforeEach(() => {
 })
 
 describe('Wallet middleware', () => {
-  it('should handle account.updated events triggered by the walletService', () => {
-    expect.assertions(1)
-    const { store } = create()
-    const emailAddress = 'geoff@bitconnect.gov'
-    const update = {
-      emailAddress,
-    }
+  describe('when receiving account.updated events triggered by the walletService', () => {
+    it('should handle non-redundant account.updated events', () => {
+      expect.assertions(2)
+      const { store } = create()
+      const emailAddress = 'geoff@bitconnect.gov'
+      const update = {
+        emailAddress,
+      }
 
-    mockWalletService.emit('account.updated', update)
+      mockWalletService.emit('account.updated', update)
 
-    expect(store.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: UPDATE_ACCOUNT,
-        update: {
-          emailAddress,
-        },
-      })
-    )
-  })
+      expect(store.dispatch).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          type: UPDATE_ACCOUNT,
+          update: {
+            emailAddress,
+          },
+        })
+      )
 
-  it('should not dispatch redundant updates triggered by the walletService', () => {
-    expect.assertions(1)
-    const { store } = create()
-    const update = {
-      address: '0xabc',
-    }
+      expect(store.dispatch).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          type: GET_STORED_PAYMENT_DETAILS,
+        })
+      )
+    })
 
-    mockWalletService.emit('account.updated', update)
+    it('should not dispatch redundant updates triggered by the walletService', () => {
+      expect.assertions(1)
+      const { store } = create()
+      const update = {
+        address: '0xabc',
+      }
 
-    expect(store.dispatch).not.toHaveBeenCalled()
+      mockWalletService.emit('account.updated', update)
+
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
   })
 
   it('should handle account.changed events triggered by the walletService', () => {

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -144,6 +144,19 @@ describe('Wallet middleware', () => {
       })
     )
   })
+
+  it('should not dispatch redundant updates triggered by the walletService', () => {
+    expect.assertions(1)
+    const { store } = create()
+    const update = {
+      address: '0xabc',
+    }
+
+    mockWalletService.emit('account.updated', update)
+
+    expect(store.dispatch).not.toHaveBeenCalled()
+  })
+
   it('should handle account.changed events triggered by the walletService', () => {
     expect.assertions(3)
     const { store } = create()

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -151,6 +151,7 @@ describe('Wallet middleware', () => {
         2,
         expect.objectContaining({
           type: GET_STORED_PAYMENT_DETAILS,
+          emailAddress,
         })
       )
     })

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -18,6 +18,7 @@ export const SIGNED_USER_DATA = 'userCredentials/SIGNED_USER_DATA'
 export const SIGN_PAYMENT_DATA = 'userCredentials/SIGN_PAYMENT_DATA'
 export const SIGNED_PAYMENT_DATA = 'userCredentials/SIGNED_PAYMENT_DATA'
 export const CONFIRM_KEY_PURCHASE = 'userAccount/CONFIRM_KEY_PURCHASE'
+export const GET_STORED_PAYMENT_DETAILS = 'userAccount/GET_PAYMENT_DETAILS'
 
 export interface Credentials {
   emailAddress: string
@@ -149,4 +150,9 @@ export const signedPaymentData = ({ data, sig }: SignedPaymentData) => ({
 // TODO: determine payload for this action
 export const confirmKeyPurchase = () => ({
   type: CONFIRM_KEY_PURCHASE,
+})
+
+export const getStoredPaymentDetails = (emailAddress: string) => ({
+  type: GET_STORED_PAYMENT_DETAILS,
+  emailAddress,
 })

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -11,7 +11,7 @@ import { startLoading, doneLoading } from '../actions/loading'
 import { StorageService, success, failure } from '../services/storageService'
 
 import { NEW_TRANSACTION, addTransaction } from '../actions/transaction'
-import { SET_ACCOUNT, setAccount } from '../actions/accounts'
+import { SET_ACCOUNT, setAccount, updateAccount } from '../actions/accounts'
 import {
   LOGIN_CREDENTIALS,
   SIGNUP_CREDENTIALS,
@@ -21,6 +21,7 @@ import {
   signUserData,
   SIGNED_USER_DATA,
   SIGNED_PAYMENT_DATA,
+  GET_STORED_PAYMENT_DETAILS,
 } from '../actions/user'
 import UnlockUser from '../structured_data/unlockUser'
 import { Storage } from '../utils/Error'
@@ -132,6 +133,19 @@ const storageMiddleware = config => {
       )
     })
 
+    storageService.on(success.getCards, cards => {
+      if (cards.length > 0) {
+        dispatch(
+          updateAccount({
+            cards,
+          })
+        )
+      }
+    })
+    storageService.on(failure.getCards, () => {
+      dispatch(setError(Storage.Warning('Unable to retrieve payment methods.')))
+    })
+
     return next => {
       return action => {
         if (action.type === NEW_TRANSACTION) {
@@ -211,6 +225,11 @@ const storageMiddleware = config => {
             storageService,
             dispatch,
           })
+        }
+
+        if (action.type === GET_STORED_PAYMENT_DETAILS) {
+          const { emailAddress } = action
+          storageService.getCards(emailAddress)
         }
 
         next(action)

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -1,6 +1,7 @@
 /* eslint promise/prefer-await-to-then: 0 */
 import { WalletService } from '@unlock-protocol/unlock-js'
 
+import { diff } from 'deep-object-diff'
 import {
   CREATE_LOCK,
   WITHDRAW_FROM_LOCK,
@@ -48,8 +49,15 @@ const walletMiddleware = config => {
     }
 
     walletService.on('account.updated', update => {
-      // TODO: only  update if there's a difference?
-      dispatch(updateAccount(update))
+      if (!getState().account) return
+
+      const currentAccount = getState().account
+      const updatedAccount = Object.assign({}, currentAccount, update)
+      const difference = diff(currentAccount, updatedAccount)
+
+      if (Object.keys(difference).length > 0) {
+        dispatch(updateAccount(update))
+      }
     })
 
     /**

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -63,7 +63,7 @@ const walletMiddleware = config => {
           // if the update contains an email address, that means a user has
           // successfully logged in. We should fetch any extra information
           // (payment details...) that locksmith has on them.
-          dispatch(getStoredPaymentDetails())
+          dispatch(getStoredPaymentDetails(difference['emailAddress']))
         }
       }
     })

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -28,6 +28,7 @@ import {
 import { TransactionType } from '../unlockTypes'
 import { hideForm } from '../actions/lockFormVisibility'
 import { transactionTypeMapping } from '../utils/types' // TODO change POLLING_INTERVAL into ACCOUNT_POLLING_INTERVAL
+import { getStoredPaymentDetails } from '../actions/user'
 
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
@@ -57,6 +58,13 @@ const walletMiddleware = config => {
 
       if (Object.keys(difference).length > 0) {
         dispatch(updateAccount(update))
+
+        if (difference['emailAddress']) {
+          // if the update contains an email address, that means a user has
+          // successfully logged in. We should fetch any extra information
+          // (payment details...) that locksmith has on them.
+          dispatch(getStoredPaymentDetails())
+        }
       }
     })
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
In order to purchase keys with a user account, we need to know which payment methods (if any) are available for use. This PR queries locksmith for payment methods associated with an account after a user logs in.

As part of that, to avoid frequent locksmith calls and to clear up the redux logs, `UPDATE_ACCOUNT` actions are only sent when the update is different from what already exists in state.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #3942, #3763 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
