### PR TITLE
Key purchase request signatures are no longer always expired

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 0.3.5
+- Bugfix: key purchase request signatures are no longer always expired
+
 ## 0.3.4
 - Bugfix: using correctly formatted structured data for key purchase requests
 

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/unlockProvider.test.js
+++ b/unlock-js/src/__tests__/unlockProvider.test.js
@@ -103,17 +103,22 @@ describe('Unlock Provider', () => {
     })
 
     describe('signKeyPurchaseRequestData', () => {
-      it('should sign a key purchase request', () => {
-        expect.assertions(1)
+      it('should sign a key purchase request with a valid expiration time', () => {
+        expect.assertions(2)
         const input = {
           recipient: publicKey,
           lock: '0xaC6b4470B0cba92b823aB96762972e67a1C851d5',
         }
         const output = provider.signKeyPurchaseRequestData(input)
+        const currentTime = Math.floor(Date.now() / 1000)
 
         expect(sigUtil.recoverTypedSignature(output)).toEqual(
           publicKey.toLowerCase()
         )
+        // Expiration must be some amount of time after right now
+        expect(
+          output.data.message.purchaseRequest.expiry > currentTime
+        ).toBeTruthy()
       })
     })
   })

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -94,9 +94,11 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
 
   // input contains recipient and lock addresses
   signKeyPurchaseRequestData(input) {
+    // default signature expiration to now + 60 seconds
+    const expiry = Date.now() / 1000 + 60
     const purchaseRequest = Object.assign(
       {
-        expiry: 60, // default signature expiration to 60 seconds
+        expiry,
       },
       input
     )

--- a/unlock-js/src/unlockProvider.js
+++ b/unlock-js/src/unlockProvider.js
@@ -95,7 +95,7 @@ export default class UnlockProvider extends providers.JsonRpcProvider {
   // input contains recipient and lock addresses
   signKeyPurchaseRequestData(input) {
     // default signature expiration to now + 60 seconds
-    const expiry = Date.now() / 1000 + 60
+    const expiry = Math.floor(Date.now() / 1000) + 60
     const purchaseRequest = Object.assign(
       {
         expiry,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR fixes a bug in the signature generation for key purchase requests. Previously, the expiration time of the signature was always in the past. This PR rectifies that, and adds a regression test.

I'll wait to publish `unlock-js` until this is approved

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
