### PR TITLE
Adding GA events to membership dialog

### DIFF
--- a/unlock-protocol.com/src/constants.js
+++ b/unlock-protocol.com/src/constants.js
@@ -24,3 +24,13 @@ export const MAX_DEVICE_WIDTHS = {
   TABLET: 1000,
   DESKTOP: false,
 }
+
+export const GA_LABELS = {
+  MEMBERSHIP: 'membership',
+}
+
+export const GA_ACTIONS = {
+  UNLOCKED: 'unlockProtocol unlocked',
+  LOCKED: 'unlockProtocol locked',
+  MEMBERSHIP_BANNER_CLICKED: 'membership banner clicked',
+}

--- a/unlock-protocol.com/src/pages/_app.js
+++ b/unlock-protocol.com/src/pages/_app.js
@@ -7,6 +7,7 @@ import getConfig from 'next/config'
 import GlobalStyle from '../theme/globalStyle'
 import Membership from '../components/interface/Membership'
 import { MembershipContext } from '../membershipContext'
+import { GA_LABELS, GA_ACTIONS } from '../constants'
 
 const config = getConfig().publicRuntimeConfig
 
@@ -61,8 +62,8 @@ The Unlock team
     if (process.browser) {
       this.state.becomeMember = () => {
         ReactGA.event({
-          category: 'Membership',
-          action: 'Clicked membership banner',
+          category: GA_LABELS.MEMBERSHIP,
+          action: GA_ACTIONS.MEMBERSHIP_BANNER_CLICKED,
         })
         return (
           window.unlockProtocol && window.unlockProtocol.loadCheckoutModal()
@@ -72,8 +73,8 @@ The Unlock team
       window.addEventListener('unlockProtocol', event => {
         if (event.detail === 'unlocked') {
           ReactGA.event({
-            category: 'Membership',
-            action: 'unlockProtocol unlocked',
+            category: GA_LABELS.MEMBERSHIP,
+            action: GA_ACTIONS.UNLOCKED,
           })
           this.setState(state => ({
             ...state,
@@ -82,8 +83,8 @@ The Unlock team
         }
         if (event.detail === 'locked') {
           ReactGA.event({
-            category: 'Membership',
-            action: 'unlockProtocol locked',
+            category: GA_LABELS.MEMBERSHIP,
+            action: GA_ACTIONS.LOCKED,
           })
           this.setState(state => ({
             ...state,

--- a/unlock-protocol.com/src/pages/_app.js
+++ b/unlock-protocol.com/src/pages/_app.js
@@ -3,6 +3,7 @@ import App, { Container } from 'next/app'
 import React from 'react'
 import Intercom from 'react-intercom'
 import getConfig from 'next/config'
+
 import GlobalStyle from '../theme/globalStyle'
 import Membership from '../components/interface/Membership'
 import { MembershipContext } from '../membershipContext'
@@ -58,17 +59,32 @@ The Unlock team
 
     // Listen to Unlock events
     if (process.browser) {
-      this.state.becomeMember = () =>
-        window.unlockProtocol && window.unlockProtocol.loadCheckoutModal()
+      this.state.becomeMember = () => {
+        ReactGA.event({
+          category: 'Membership',
+          action: 'Clicked membership banner',
+        })
+        return (
+          window.unlockProtocol && window.unlockProtocol.loadCheckoutModal()
+        )
+      }
 
       window.addEventListener('unlockProtocol', event => {
         if (event.detail === 'unlocked') {
+          ReactGA.event({
+            category: 'Membership',
+            action: 'unlockProtocol unlocked',
+          })
           this.setState(state => ({
             ...state,
             isMember: 'yes',
           }))
         }
         if (event.detail === 'locked') {
+          ReactGA.event({
+            category: 'Membership',
+            action: 'unlockProtocol locked',
+          })
           this.setState(state => ({
             ...state,
             isMember: 'no',


### PR DESCRIPTION
# Description

This PR adds some simple Google Analytics events to the act of clicking on the membership banner, as well as locked and unlock status.

# Issues

Refs #3971

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
