### PR TITLE
allow us to use "_" as a parameter to be ignored

### DIFF
--- a/paywall/.eslintrc.js
+++ b/paywall/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
         vars: 'all',
         args: 'after-used',
         ignoreRestSiblings: true,
+        argsIgnorePattern: /^_$/,
       },
     ],
     'react/prefer-stateless-function': [2],


### PR DESCRIPTION
# Description

This allows us to do stuff like:

```ts
  function blah(_: string, thing: number) {
```

and not use `_` without eslint complaining (copying from `unlock-app`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3970 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
