### PR TITLE
new cache drivers for abstracting low-level cache access

### DIFF
--- a/paywall/.eslintrc.js
+++ b/paywall/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
         vars: 'all',
         args: 'after-used',
         ignoreRestSiblings: true,
+        argsIgnorePattern: /^_$/,
       },
     ],
     'react/prefer-stateless-function': [2],

--- a/paywall/src/__tests__/data-iframe/cache/drivers/allDrivers.test.ts
+++ b/paywall/src/__tests__/data-iframe/cache/drivers/allDrivers.test.ts
@@ -1,0 +1,158 @@
+import LocalStorageDriver from '../../../../data-iframe/cache/drivers/localStorage'
+import InMemoryDriver from '../../../../data-iframe/cache/drivers/memory'
+import CacheDriver from '../../../../data-iframe/cache/drivers/driverInterface'
+import { LocalStorageWindow } from '../../../../windowTypes'
+
+describe('common functionality between all drivers', () => {
+  let storage: any = {}
+  const fakeWindow: LocalStorageWindow = {
+    localStorage: {
+      length: 1,
+      clear: () => {
+        storage = {}
+      },
+      getItem(key: string) {
+        return storage[key] || null
+      },
+      key(_: number) {
+        return '' // unused but required for the interface
+      },
+      removeItem(key: string) {
+        delete storage[key]
+      },
+      setItem(key: string, value: string) {
+        storage[key] = value
+      },
+    },
+  }
+
+  type eachThing = Array<[string, CacheDriver]>
+  const theEach: eachThing = [
+    ['localStorage', new LocalStorageDriver(fakeWindow)],
+    ['memory', new InMemoryDriver()],
+  ]
+  describe.each(theEach)('%s driver', (_, driver) => {
+    function clearCache() {
+      storage = {}
+      if (driver.__clear) driver.__clear()
+    }
+    describe('getKeyedItem/saveKeyedItem', () => {
+      beforeEach(() => {
+        clearCache()
+      })
+
+      it('should save/retrieve items for the same account/same network', async () => {
+        expect.assertions(3)
+        await driver.saveKeyedItem(1, 'hi', '1-hi')
+        await driver.saveKeyedItem(2, 'hi', '2-hi')
+        await driver.saveKeyedItem(1, 'another', '1-another')
+        const test1hi = await driver.getKeyedItem(1, 'hi')
+        const test2hi = await driver.getKeyedItem(2, 'hi')
+        const test1another = await driver.getKeyedItem(1, 'another')
+
+        expect(test1hi).toBe('1-hi')
+        expect(test2hi).toBe('2-hi')
+        expect(test1another).toBe('1-another')
+      })
+
+      it('should save/retrieve items with their original type', async () => {
+        expect.assertions(4)
+
+        await driver.saveKeyedItem(1, '1', 3)
+        await driver.saveKeyedItem(1, '2', { hi: 'there' })
+        await driver.saveKeyedItem(1, '3', [1, '2'])
+        await driver.saveKeyedItem(1, '4', 'string')
+
+        const test1 = await driver.getKeyedItem(1, '1')
+        const test2 = await driver.getKeyedItem(1, '2')
+        const test3 = await driver.getKeyedItem(1, '3')
+        const test4 = await driver.getKeyedItem(1, '4')
+
+        expect(test1).toBe(3)
+        expect(test2).toEqual({ hi: 'there' })
+        expect(test3).toEqual([1, '2'])
+        expect(test4).toBe('string')
+      })
+
+      it('should not retrieve items for the different account/same network', async () => {
+        expect.assertions(1)
+        await driver.saveKeyedItem(1, 'hi', '1-hi')
+        const test1another = await driver.getKeyedItem(1, 'another')
+
+        expect(test1another).toBeNull()
+      })
+
+      it('should not retrieve items for the different network/same account', async () => {
+        expect.assertions(1)
+        await driver.saveKeyedItem(1, 'hi', '1-hi')
+        const test2hi = await driver.getKeyedItem(2, 'hi')
+
+        expect(test2hi).toBeNull()
+      })
+    })
+
+    describe('getUnkeyedItem/saveUnkeyedItem', () => {
+      beforeEach(() => {
+        clearCache()
+      })
+
+      it('should save/retrieve items', async () => {
+        expect.assertions(2)
+
+        await driver.saveUnkeyedItem('account', 'account')
+        await driver.saveUnkeyedItem('network', 1)
+
+        const account = await driver.getUnkeyedItem('account')
+        const network = await driver.getUnkeyedItem('network')
+
+        expect(account).toBe('account')
+        expect(network).toBe(1)
+      })
+    })
+
+    describe('clearKeyedCache', () => {
+      beforeEach(() => {
+        clearCache()
+      })
+
+      it('should clear cache for the same account/network', async () => {
+        expect.assertions(1)
+
+        await driver.saveKeyedItem(1, 'hi', 'there')
+        await driver.clearKeyedCache(1, 'hi')
+
+        const test = await driver.getKeyedItem(1, 'hi')
+
+        expect(test).toBeNull()
+      })
+
+      it('should not clear cache for the different account/same network', async () => {
+        expect.assertions(2)
+
+        await driver.saveKeyedItem(1, 'hi', 'there')
+        await driver.saveKeyedItem(1, 'another', 'another')
+        await driver.clearKeyedCache(1, 'hi')
+
+        const test1hi = await driver.getKeyedItem(1, 'hi')
+        const test1another = await driver.getKeyedItem(1, 'another')
+
+        expect(test1hi).toBeNull()
+        expect(test1another).toBe('another')
+      })
+
+      it('should not clear cache for the different network/same account', async () => {
+        expect.assertions(2)
+
+        await driver.saveKeyedItem(1, 'hi', 'there')
+        await driver.saveKeyedItem(2, 'hi', 'another')
+        await driver.clearKeyedCache(1, 'hi')
+
+        const test1hi = await driver.getKeyedItem(1, 'hi')
+        const test2hi = await driver.getKeyedItem(2, 'hi')
+
+        expect(test1hi).toBeNull()
+        expect(test2hi).toBe('another')
+      })
+    })
+  })
+})

--- a/paywall/src/data-iframe/cache/drivers/driverInterface.ts
+++ b/paywall/src/data-iframe/cache/drivers/driverInterface.ts
@@ -1,0 +1,13 @@
+export default interface CacheDriver {
+  getKeyedItem(networkId: number, accountAddress: string): Promise<any>
+  available(): boolean
+  getUnkeyedItem(key: 'account' | 'network'): Promise<any>
+  saveKeyedItem(
+    networkId: number,
+    accountAddress: string,
+    value: any
+  ): Promise<void>
+  saveUnkeyedItem(key: 'account' | 'network', value: any): Promise<void>
+  clearKeyedCache(networkId: number, accountAddress: string): Promise<void>
+  __clear?: () => void
+}

--- a/paywall/src/data-iframe/cache/drivers/localStorage.ts
+++ b/paywall/src/data-iframe/cache/drivers/localStorage.ts
@@ -1,0 +1,61 @@
+import localStorageAvailable from '../../../utils/localStorage'
+import CacheDriver from './driverInterface'
+import { LocalStorageWindow } from '../../../windowTypes'
+
+export function storageId(networkId: number, accountAddress: string) {
+  return `unlock-protocol/${networkId}/${accountAddress}`
+}
+
+export default class LocalStorageDriver implements CacheDriver {
+  private window: LocalStorageWindow
+  constructor(window: LocalStorageWindow) {
+    this.window = window
+  }
+
+  async getKeyedItem(networkId: number, accountAddress: string) {
+    const item = this.window.localStorage.getItem(
+      storageId(networkId, accountAddress)
+    )
+    // not present in localStorage
+    if (!item) return null
+    try {
+      const container = JSON.parse(item)
+      return container
+    } catch (_) {
+      return null
+    }
+  }
+
+  available() {
+    return localStorageAvailable(this.window)
+  }
+
+  async getUnkeyedItem(key: 'account' | 'network') {
+    const item = this.window.localStorage.getItem(`__unlockProtocol.${key}`)
+    if (!item) return null
+    try {
+      const container = JSON.parse(item)
+      return container
+    } catch (_) {
+      return null
+    }
+  }
+
+  async saveKeyedItem(networkId: number, accountAddress: string, value: any) {
+    this.window.localStorage.setItem(
+      storageId(networkId, accountAddress),
+      JSON.stringify(value)
+    )
+  }
+
+  async saveUnkeyedItem(key: 'account' | 'network', value: any) {
+    this.window.localStorage.setItem(
+      `__unlockProtocol.${key}`,
+      JSON.stringify(value)
+    )
+  }
+
+  async clearKeyedCache(networkId: number, accountAddress: string) {
+    this.window.localStorage.removeItem(storageId(networkId, accountAddress))
+  }
+}

--- a/paywall/src/data-iframe/cache/drivers/memory.ts
+++ b/paywall/src/data-iframe/cache/drivers/memory.ts
@@ -1,0 +1,50 @@
+import CacheDriver from './driverInterface'
+
+interface InMemoryCache {
+  account?: string
+  network?: number
+  [network: number]: {
+    [account: string]: {
+      [key: string]: any
+    }
+  }
+}
+
+export default class InMemoryDriver implements CacheDriver {
+  private cache: InMemoryCache = {}
+
+  async getKeyedItem(networkId: number, accountAddress: string) {
+    const container =
+      this.cache[networkId] && this.cache[networkId][accountAddress]
+    if (!container) return null
+    return container
+  }
+
+  available() {
+    return true
+  }
+
+  async getUnkeyedItem(key: 'account' | 'network') {
+    const item = this.cache[key]
+    if (!item) return null
+    return item
+  }
+
+  async saveKeyedItem(networkId: number, accountAddress: string, value: any) {
+    this.cache[networkId] = this.cache[networkId] || {}
+    this.cache[networkId][accountAddress] = value
+  }
+
+  async saveUnkeyedItem(key: 'account' | 'network', value: any) {
+    this.cache[key] = value
+  }
+
+  async clearKeyedCache(networkId: number, accountAddress: string) {
+    if (!this.cache[networkId]) return
+    delete this.cache[networkId][accountAddress]
+  }
+
+  __clear() {
+    this.cache = {}
+  }
+}


### PR DESCRIPTION
# Description

When `localStorage` is unavailable, we will need to fall back to a temporary in-memory cache. In order to simplify the design, this abstracts the lowest level access to the cache by using the driver pattern.

We have an interface that a driver must implement, and 2 drivers, `LocalStorageDriver` and `InMemoryDriver`. The test runs the exact same operations on each driver, guaranteeing that any tested behavior is the same.

A follow-up PR will introduce the generic `cache` that uses the driver. It will have a simple function which selects the driver to use based on the presence of `localStorage`.

This will need to be rebased on #3990 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3970 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
