### PR TITLE
introducing the proxyProvider

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
@@ -142,27 +142,6 @@ describe('setupPostOffice', () => {
     expect(fakeUIIframe.className).toBe('unlock start show')
   })
 
-  it('responds to PostMessages.READY_WEB3 by sending PostMessages.WALLET_INFO', async () => {
-    expect.assertions(2)
-
-    sendMessage(fakeDataIframe, PostMessages.READY_WEB3)
-
-    await Promise.resolve() // sync the Promise queue
-
-    expect(fakeUIIframe.contentWindow.postMessage).not.toHaveBeenCalled()
-    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledWith(
-      {
-        type: PostMessages.WALLET_INFO,
-        payload: {
-          noWallet: true,
-          notEnabled: false,
-          isMetamask: false,
-        },
-      },
-      'http://paywall'
-    )
-  })
-
   it('responds to PostMessages.READY by sending the config to both iframes', () => {
     expect.assertions(8)
 
@@ -440,6 +419,38 @@ describe('setupPostOffice', () => {
         payload: locks,
       },
       'http://paywall'
+    )
+  })
+
+  it('relays PostMessages.UPDATE_LOCKS to the account UI', () => {
+    expect.assertions(1)
+
+    const locks = {
+      lock: {
+        address: 'lock',
+        name: 'string',
+        keyPrice: '1',
+        expirationDuration: 1,
+        key: {
+          expiration: 1,
+          transactions: [],
+          status: 'none',
+          confirmations: 0,
+          owner: null,
+          lock: 'lock',
+        },
+        currencyContractAddress: null,
+      },
+    }
+
+    sendMessage(fakeDataIframe, PostMessages.UPDATE_LOCKS, locks)
+
+    expect(fakeAccountIframe.contentWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: PostMessages.UPDATE_LOCKS,
+        payload: locks,
+      },
+      'http://unlock-app.com'
     )
   })
 })

--- a/paywall/src/messageTypes.ts
+++ b/paywall/src/messageTypes.ts
@@ -94,7 +94,7 @@ export type Message =
     }
   | {
       type: PostMessages.UPDATE_ACCOUNT
-      payload: string
+      payload: string | null
     }
   | {
       type: PostMessages.UPDATE_ACCOUNT_BALANCE

--- a/paywall/src/messageTypes.ts
+++ b/paywall/src/messageTypes.ts
@@ -30,6 +30,9 @@ export enum PostMessages {
   PURCHASE_KEY = 'purchaseKey',
   DISMISS_CHECKOUT = 'dismiss/checkout',
   INITIATED_TRANSACTION = 'initiated/transaction',
+
+  SHOW_ACCOUNTS_MODAL = 'show/accountsModal',
+  HIDE_ACCOUNT_MODAL = 'hide/accountsModal',
 }
 // all the possible message types
 export type Message =
@@ -123,6 +126,14 @@ export type Message =
     }
   | {
       type: PostMessages.INITIATED_TRANSACTION
+      payload: undefined
+    }
+  | {
+      type: PostMessages.SHOW_ACCOUNTS_MODAL
+      payload: undefined
+    }
+  | {
+      type: PostMessages.HIDE_ACCOUNT_MODAL
       payload: undefined
     }
 

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -152,13 +152,7 @@ export default function setupPostOffices(
         hideCheckoutModal()
       }
     },
-    [PostMessages.PURCHASE_KEY]: send => {
-      return details => {
-        // relay a request to purchase a key to the data iframe
-        // as the user has clicked on a key in the checkout UI
-        send('data', PostMessages.PURCHASE_KEY, details)
-      }
-    },
+    // purchaseKey is now handled inside the web3Proxy
   }
 
   mapHandlers('data', dataHandlers)

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -124,6 +124,8 @@ export default function setupPostOffices(
       return locks => {
         // relay the most current lock objects to the checkout UI
         send('checkout', PostMessages.UPDATE_LOCKS, locks)
+        // relay the most current lock objects to the account UI
+        send('account', PostMessages.UPDATE_LOCKS, locks)
       }
     },
   }

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -64,7 +64,7 @@ export type web3Send = (
   callback: web3Callback
 ) => void
 
-export interface Web3Window extends PostOfficeWindow {
+export interface Web3Window extends PostOfficeWindow, IframeManagingWindow {
   Promise: PromiseConstructor
   web3?: {
     currentProvider: {


### PR DESCRIPTION
# Description

This implements the proxyProvider. It adds:

1. new listeners for `READY`, `UPDATE_ACCOUNT`, `UPDATE_NETWORK`, and the show/hide messages coming from the account iframe to the main window. We auto-show the account iframe if the user has not logged in and has no wallet.
2. a check for proxy account if we have no wallet. It waits for the account iframe to send its account info downstream in this case (TODO: improve loading speed of account iframe)
3. when receiving a request from `walletService` for the current account and network, it intercepts and returns our proxy account/network instead.
4. interception of `PURCHASE_KEY` from the checkout UI and sends it to account iframe instead of the data iframe if we are using a user account.
5. we now also relay locks to the account iframe

This is a big PR, most of the bulk is in the test, which has been reorganized to be a bit easier to modify in the future.

TODO:

1. use the locks values to determine whether to use user accounts. I.e. we need to check to be sure that there are any ERC-20 locks on the page prior to using the accounts iframe.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3767 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
