### PR TITLE
introducing proxyProvider

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
@@ -142,27 +142,6 @@ describe('setupPostOffice', () => {
     expect(fakeUIIframe.className).toBe('unlock start show')
   })
 
-  it('responds to PostMessages.READY_WEB3 by sending PostMessages.WALLET_INFO', async () => {
-    expect.assertions(2)
-
-    sendMessage(fakeDataIframe, PostMessages.READY_WEB3)
-
-    await Promise.resolve() // sync the Promise queue
-
-    expect(fakeUIIframe.contentWindow.postMessage).not.toHaveBeenCalled()
-    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledWith(
-      {
-        type: PostMessages.WALLET_INFO,
-        payload: {
-          noWallet: true,
-          notEnabled: false,
-          isMetamask: false,
-        },
-      },
-      'http://paywall'
-    )
-  })
-
   it('responds to PostMessages.READY by sending the config to both iframes', () => {
     expect.assertions(8)
 
@@ -440,6 +419,38 @@ describe('setupPostOffice', () => {
         payload: locks,
       },
       'http://paywall'
+    )
+  })
+
+  it('relays PostMessages.UPDATE_LOCKS to the account UI', () => {
+    expect.assertions(1)
+
+    const locks = {
+      lock: {
+        address: 'lock',
+        name: 'string',
+        keyPrice: '1',
+        expirationDuration: 1,
+        key: {
+          expiration: 1,
+          transactions: [],
+          status: 'none',
+          confirmations: 0,
+          owner: null,
+          lock: 'lock',
+        },
+        currencyContractAddress: null,
+      },
+    }
+
+    sendMessage(fakeDataIframe, PostMessages.UPDATE_LOCKS, locks)
+
+    expect(fakeAccountIframe.contentWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: PostMessages.UPDATE_LOCKS,
+        payload: locks,
+      },
+      'http://unlock-app.com'
     )
   })
 })

--- a/paywall/src/__tests__/unlock.js/startup.test.js
+++ b/paywall/src/__tests__/unlock.js/startup.test.js
@@ -146,7 +146,7 @@ describe('unlock.js startup', () => {
       )
       expect(
         fakeWindow.document.body.insertAdjacentElement
-      ).toHaveBeenNthCalledWith(2, 'afterbegin', fakeCheckoutIframe)
+      ).toHaveBeenNthCalledWith(3, 'afterbegin', fakeCheckoutIframe)
     })
 
     it('should create a User Accounts UI iframe with the correct URL', () => {
@@ -160,7 +160,7 @@ describe('unlock.js startup', () => {
       )
       expect(
         fakeWindow.document.body.insertAdjacentElement
-      ).toHaveBeenNthCalledWith(2, 'afterbegin', fakeCheckoutIframe)
+      ).toHaveBeenNthCalledWith(2, 'afterbegin', fakeUserAccountsIframe)
     })
   })
 

--- a/paywall/src/messageTypes.ts
+++ b/paywall/src/messageTypes.ts
@@ -94,7 +94,7 @@ export type Message =
     }
   | {
       type: PostMessages.UPDATE_ACCOUNT
-      payload: string
+      payload: string | null
     }
   | {
       type: PostMessages.UPDATE_ACCOUNT_BALANCE

--- a/paywall/src/messageTypes.ts
+++ b/paywall/src/messageTypes.ts
@@ -30,6 +30,9 @@ export enum PostMessages {
   PURCHASE_KEY = 'purchaseKey',
   DISMISS_CHECKOUT = 'dismiss/checkout',
   INITIATED_TRANSACTION = 'initiated/transaction',
+
+  SHOW_ACCOUNTS_MODAL = 'show/accountsModal',
+  HIDE_ACCOUNT_MODAL = 'hide/accountsModal',
 }
 // all the possible message types
 export type Message =
@@ -123,6 +126,14 @@ export type Message =
     }
   | {
       type: PostMessages.INITIATED_TRANSACTION
+      payload: undefined
+    }
+  | {
+      type: PostMessages.SHOW_ACCOUNTS_MODAL
+      payload: undefined
+    }
+  | {
+      type: PostMessages.HIDE_ACCOUNT_MODAL
       payload: undefined
     }
 

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -152,13 +152,7 @@ export default function setupPostOffices(
         hideCheckoutModal()
       }
     },
-    [PostMessages.PURCHASE_KEY]: send => {
-      return details => {
-        // relay a request to purchase a key to the data iframe
-        // as the user has clicked on a key in the checkout UI
-        send('data', PostMessages.PURCHASE_KEY, details)
-      }
-    },
+    // purchaseKey is now handled inside the web3Proxy
   }
 
   mapHandlers('data', dataHandlers)

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -124,6 +124,8 @@ export default function setupPostOffices(
       return locks => {
         // relay the most current lock objects to the checkout UI
         send('checkout', PostMessages.UPDATE_LOCKS, locks)
+        // relay the most current lock objects to the account UI
+        send('account', PostMessages.UPDATE_LOCKS, locks)
       }
     },
   }

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -29,17 +29,17 @@ export default function startup(window: UnlockWindow) {
     window,
     process.env.PAYWALL_URL + '/static/data-iframe.1.0.html' + origin
   )
-  addIframeToDocument(window, dataIframe)
   const checkoutIframe = makeIframe(
     window,
     process.env.PAYWALL_URL + '/checkout' + origin
   )
-  addIframeToDocument(window, checkoutIframe)
   const userAccountsIframe = makeIframe(
     window,
     process.env.USER_IFRAME_URL + origin
   )
+  addIframeToDocument(window, dataIframe)
   addIframeToDocument(window, userAccountsIframe)
+  addIframeToDocument(window, checkoutIframe)
 
   setupPostOffices(window, dataIframe, checkoutIframe, userAccountsIframe)
 }

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -64,7 +64,7 @@ export type web3Send = (
   callback: web3Callback
 ) => void
 
-export interface Web3Window extends PostOfficeWindow {
+export interface Web3Window extends PostOfficeWindow, IframeManagingWindow {
   Promise: PromiseConstructor
   web3?: {
     currentProvider: {

--- a/tests/helpers/iframes.js
+++ b/tests/helpers/iframes.js
@@ -1,0 +1,7 @@
+// This file is a helper to abstract the retrieval of the iframes on the paywall,
+// so that any re-ordering of frames is controlled in a single location
+
+module.exports = {
+  checkoutIframe: page => page.mainFrame().childFrames()[2],
+  accountsIframe: page => page.mainFrame().childFrames()[1],
+}

--- a/tests/test/adremover-loggedin.test.js
+++ b/tests/test/adremover-loggedin.test.js
@@ -1,9 +1,10 @@
 const url = require('../helpers/url')
 const dashboard = require('../helpers/dashboard')
 const wait = require('../helpers/wait')
-//const debug = require('../helpers/debugging')
+// const debug = require('../helpers/debugging')
+const iframes = require('../helpers/iframes')
 
-//const sit = debug.screenshotOnFail(page)
+// const it = debug.screenshotOnFail(page)
 
 let lockSelectors
 
@@ -93,7 +94,7 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
   it('should show the logo on the checkout UI', async () => {
     expect.assertions(0)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(
       unlockIcon => {
         return !!document.body.querySelector(`img[src="${unlockIcon}"]`)
@@ -106,7 +107,7 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
   it('should show the 3 locks', async () => {
     expect.assertions(0)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(
       lock1 => {
         return !!document.body.querySelector(lock1)
@@ -133,7 +134,7 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
   it('should attempt a key purchase when clicking on a lock, and hide the ads', async () => {
     expect.assertions(2)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     const checkoutBody = await checkoutIframe.$('body')
     await expect(checkoutBody).toClick(lockSelectors[0](''))
     await checkoutIframe.waitForFunction(
@@ -161,7 +162,7 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
     await expect(page).toClick('button', {
       text: 'Unlock the ads free experience!',
     })
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(
       lock1 => {
         const lock = document.body.querySelector(lock1)

--- a/tests/test/adremover-loggedout.test.js
+++ b/tests/test/adremover-loggedout.test.js
@@ -1,6 +1,7 @@
 const url = require('../helpers/url')
 const dashboard = require('../helpers/dashboard')
 const wait = require('../helpers/wait')
+const iframes = require('../helpers/iframes')
 //const debug = require('../helpers/debugging')
 
 //const sit = debug.screenshotOnFail(page)
@@ -62,7 +63,7 @@ describe('The Unlock Ad Remover Paywall (logged out user)', () => {
   it('should show the logo on the checkout UI', async () => {
     expect.assertions(0)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(
       unlockIcon => {
         return !!document.body.querySelector(`img[src="${unlockIcon}"]`)
@@ -75,7 +76,7 @@ describe('The Unlock Ad Remover Paywall (logged out user)', () => {
   it('should show the "no wallet" page', async () => {
     expect.assertions(0)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(() => {
       const text = document.body.querySelector('p').innerText
       return (


### PR DESCRIPTION
# Description

This is the final piece of the puzzle on the paywall side for user accounts.

It does these pieces of that puzzle:

1. send locks to the user account iframe
2. if we have any erc20 locks, and no wallet, respond to `eth_accounts` and `net_version` with the user accounts values
3. if we are using user accounts, divert purchase key requests to the user account iframe
4. if a user starts a key purchase transaction, notify the data iframe to refresh transactions for monitoring
5. listens for instructions to show/hide the account iframe
6. shows the account iframe if the user is not logged in on start (and there are ERC20 locks on the page)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3767 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
