### PR TITLE
reset cache if wallet is not present or connection fails

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/index.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/index.test.js
@@ -58,6 +58,33 @@ describe('blockchain handler index', () => {
         provider: fakeProvider,
       })
     })
+
+    it('should reset account if provider is not present or connection fails', done => {
+      expect.assertions(2)
+
+      const error = new Error('fail')
+      const onChange = params => {
+        expect(params).toEqual({
+          error,
+          account: null,
+        })
+        done()
+      }
+
+      const fakeProvider = {
+        send(_, callback) {
+          callback(error)
+        },
+      }
+
+      const walletService = setupWalletService({
+        unlockAddress: '0x1234567890123456789012345678901234567890',
+        provider: fakeProvider,
+        onChange,
+      })
+
+      expect(walletService).toBeInstanceOf(WalletService)
+    })
   })
 
   describe('setupWeb3Service', () => {

--- a/paywall/src/__tests__/data-iframe/start/connectToBlockchain.test.js
+++ b/paywall/src/__tests__/data-iframe/start/connectToBlockchain.test.js
@@ -59,6 +59,7 @@ describe('connectToBlockchain', () => {
         expect.objectContaining({
           unlockAddress,
           provider: mockWeb3ProxyProvider,
+          onChange,
         })
       )
     })

--- a/paywall/src/data-iframe/blockchainHandler/index.js
+++ b/paywall/src/data-iframe/blockchainHandler/index.js
@@ -10,13 +10,19 @@ import web3ServiceHub from './web3ServiceHub'
 /**
  * @param {string} unlockAddress the ethereum address of the current Unlock contract
  * @param {string|provider} provider the address of a JSON-RPC endpoint or a web3 provider
+ * @param {Function} onChange the callback to use when there is no provider
  * @returns {walletService}
  */
-export function setupWalletService({ unlockAddress, provider }) {
+export function setupWalletService({ unlockAddress, provider, onChange }) {
   const walletService = new WalletService({ unlockAddress })
-  walletService.connect(provider).then(() => {
-    walletService.getAccount()
-  })
+  walletService
+    .connect(provider)
+    .then(() => {
+      walletService.getAccount()
+    })
+    .catch(error => {
+      onChange({ error, account: null })
+    })
 
   return walletService
 }

--- a/paywall/src/data-iframe/start/connectToBlockchain.js
+++ b/paywall/src/data-iframe/start/connectToBlockchain.js
@@ -51,7 +51,11 @@ export default async function connectToBlockchain({
   const locksToRetrieve = Object.keys(config.locks)
 
   const provider = new Web3ProxyProvider(window)
-  const walletService = setupWalletService({ unlockAddress, provider })
+  const walletService = setupWalletService({
+    unlockAddress,
+    provider,
+    onChange,
+  })
   const web3Service = setupWeb3Service({
     unlockAddress,
     readOnlyProvider,


### PR DESCRIPTION
# Description

This bug is actually the cause of integration test failures in #4002 and #4003. As for why it is not failing in master, I suspect a combination of factors, including some subtle bugs in the existing cache that are fixed in #4003 and some subtle differences in the way logged-out state is handled in #4002. However, the important thing is that this will provide a much-needed cache invalidation when the user's wallet is in an error state.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3006

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
