### PR TITLE
add "for" address for key purchase transactions

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.3.7
+
+- Add "for" field for key purchase transactions to describe who the key was purchased for
+
 ## 0.3.6
 
 - Bugfix: using the right default amount on withdraw when no amount has been provided

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/v0/web3Service.test.js
+++ b/unlock-js/src/__tests__/v0/web3Service.test.js
@@ -324,9 +324,10 @@ describe('Web3Service', () => {
           ],
         }
 
-        web3Service.on('transaction.updated', (tHash, lock) => {
+        web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
-          expect(lock).toEqual({
+          expect(transactionUpdate).toEqual({
+            for: checksumLockAddress,
             key: KEY_ID(lockAddress, checksumLockAddress),
             lock: lockAddress,
           })

--- a/unlock-js/src/__tests__/v0/web3Service.test.js
+++ b/unlock-js/src/__tests__/v0/web3Service.test.js
@@ -308,6 +308,7 @@ describe('Web3Service', () => {
         const EventInfo = new ethers.utils.Interface(
           UnlockVersion.PublicLock.abi
         )
+        const owner = checksumLockAddress
         const receipt = {
           blockNumber: 123,
           logs: [
@@ -327,16 +328,16 @@ describe('Web3Service', () => {
         web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
           expect(transactionUpdate).toEqual({
-            for: checksumLockAddress,
-            key: KEY_ID(lockAddress, checksumLockAddress),
+            for: owner,
+            key: KEY_ID(lockAddress, owner),
             lock: lockAddress,
           })
         })
         web3Service.on('key.saved', (id, key) => {
-          expect(id).toBe(KEY_ID(lockAddress, checksumLockAddress))
+          expect(id).toBe(KEY_ID(lockAddress, owner))
           expect(key).toEqual({
             lock: lockAddress,
-            owner: checksumLockAddress,
+            owner,
           })
         })
 

--- a/unlock-js/src/__tests__/v01/web3Service.test.js
+++ b/unlock-js/src/__tests__/v01/web3Service.test.js
@@ -324,9 +324,10 @@ describe('Web3Service', () => {
           ],
         }
 
-        web3Service.on('transaction.updated', (tHash, lock) => {
+        web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
-          expect(lock).toEqual({
+          expect(transactionUpdate).toEqual({
+            for: checksumLockAddress,
             key: KEY_ID(lockAddress, checksumLockAddress),
             lock: lockAddress,
           })

--- a/unlock-js/src/__tests__/v01/web3Service.test.js
+++ b/unlock-js/src/__tests__/v01/web3Service.test.js
@@ -308,6 +308,7 @@ describe('Web3Service', () => {
         const EventInfo = new ethers.utils.Interface(
           UnlockVersion.PublicLock.abi
         )
+        const owner = checksumLockAddress
         const receipt = {
           blockNumber: 123,
           logs: [
@@ -327,16 +328,16 @@ describe('Web3Service', () => {
         web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
           expect(transactionUpdate).toEqual({
-            for: checksumLockAddress,
-            key: KEY_ID(lockAddress, checksumLockAddress),
+            for: owner,
+            key: KEY_ID(lockAddress, owner),
             lock: lockAddress,
           })
         })
         web3Service.on('key.saved', (id, key) => {
-          expect(id).toBe(KEY_ID(lockAddress, checksumLockAddress))
+          expect(id).toBe(KEY_ID(lockAddress, owner))
           expect(key).toEqual({
             lock: lockAddress,
-            owner: checksumLockAddress,
+            owner,
           })
         })
 

--- a/unlock-js/src/__tests__/v02/web3Service.test.js
+++ b/unlock-js/src/__tests__/v02/web3Service.test.js
@@ -324,9 +324,10 @@ describe('Web3Service', () => {
           ],
         }
 
-        web3Service.on('transaction.updated', (tHash, lock) => {
+        web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
-          expect(lock).toEqual({
+          expect(transactionUpdate).toEqual({
+            for: checksumLockAddress,
             key: KEY_ID(lockAddress, checksumLockAddress),
             lock: lockAddress,
           })

--- a/unlock-js/src/__tests__/v02/web3Service.test.js
+++ b/unlock-js/src/__tests__/v02/web3Service.test.js
@@ -308,6 +308,7 @@ describe('Web3Service', () => {
         const EventInfo = new ethers.utils.Interface(
           UnlockVersion.PublicLock.abi
         )
+        const owner = checksumLockAddress
         const receipt = {
           blockNumber: 123,
           logs: [
@@ -327,16 +328,16 @@ describe('Web3Service', () => {
         web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
           expect(transactionUpdate).toEqual({
-            for: checksumLockAddress,
-            key: KEY_ID(lockAddress, checksumLockAddress),
+            for: owner,
+            key: KEY_ID(lockAddress, owner),
             lock: lockAddress,
           })
         })
         web3Service.on('key.saved', (id, key) => {
-          expect(id).toBe(KEY_ID(lockAddress, checksumLockAddress))
+          expect(id).toBe(KEY_ID(lockAddress, owner))
           expect(key).toEqual({
             lock: lockAddress,
-            owner: checksumLockAddress,
+            owner,
           })
         })
 

--- a/unlock-js/src/__tests__/v10/web3Service.test.js
+++ b/unlock-js/src/__tests__/v10/web3Service.test.js
@@ -324,9 +324,10 @@ describe('Web3Service', () => {
           ],
         }
 
-        web3Service.on('transaction.updated', (tHash, lock) => {
+        web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
-          expect(lock).toEqual({
+          expect(transactionUpdate).toEqual({
+            for: checksumLockAddress,
             key: KEY_ID(lockAddress, checksumLockAddress),
             lock: lockAddress,
           })

--- a/unlock-js/src/__tests__/v10/web3Service.test.js
+++ b/unlock-js/src/__tests__/v10/web3Service.test.js
@@ -308,6 +308,7 @@ describe('Web3Service', () => {
         const EventInfo = new ethers.utils.Interface(
           UnlockVersion.PublicLock.abi
         )
+        const owner = checksumLockAddress
         const receipt = {
           blockNumber: 123,
           logs: [
@@ -327,16 +328,16 @@ describe('Web3Service', () => {
         web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
           expect(transactionUpdate).toEqual({
-            for: checksumLockAddress,
-            key: KEY_ID(lockAddress, checksumLockAddress),
+            for: owner,
+            key: KEY_ID(lockAddress, owner),
             lock: lockAddress,
           })
         })
         web3Service.on('key.saved', (id, key) => {
-          expect(id).toBe(KEY_ID(lockAddress, checksumLockAddress))
+          expect(id).toBe(KEY_ID(lockAddress, owner))
           expect(key).toEqual({
             lock: lockAddress,
-            owner: checksumLockAddress,
+            owner,
           })
         })
 

--- a/unlock-js/src/__tests__/v11/web3Service.test.js
+++ b/unlock-js/src/__tests__/v11/web3Service.test.js
@@ -324,9 +324,10 @@ describe('Web3Service', () => {
           ],
         }
 
-        web3Service.on('transaction.updated', (tHash, lock) => {
+        web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
-          expect(lock).toEqual({
+          expect(transactionUpdate).toEqual({
+            for: checksumLockAddress,
             key: KEY_ID(lockAddress, checksumLockAddress),
             lock: lockAddress,
           })

--- a/unlock-js/src/__tests__/v11/web3Service.test.js
+++ b/unlock-js/src/__tests__/v11/web3Service.test.js
@@ -308,6 +308,7 @@ describe('Web3Service', () => {
         const EventInfo = new ethers.utils.Interface(
           UnlockVersion.PublicLock.abi
         )
+        const owner = checksumLockAddress
         const receipt = {
           blockNumber: 123,
           logs: [
@@ -327,16 +328,16 @@ describe('Web3Service', () => {
         web3Service.on('transaction.updated', (tHash, transactionUpdate) => {
           expect(tHash).toBe('hash')
           expect(transactionUpdate).toEqual({
-            for: checksumLockAddress,
-            key: KEY_ID(lockAddress, checksumLockAddress),
+            for: owner,
+            key: KEY_ID(lockAddress, owner),
             lock: lockAddress,
           })
         })
         web3Service.on('key.saved', (id, key) => {
-          expect(id).toBe(KEY_ID(lockAddress, checksumLockAddress))
+          expect(id).toBe(KEY_ID(lockAddress, owner))
           expect(key).toEqual({
             lock: lockAddress,
-            owner: checksumLockAddress,
+            owner,
           })
         })
 

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -40,6 +40,7 @@ export default class Web3Service extends UnlockService {
         const owner = args._to
         this.emit('transaction.updated', transactionHash, {
           key: KEY_ID(contractAddress, owner),
+          for: owner, // this is not necessarily the same as the "from" address
           lock: contractAddress,
         })
         return this.emit('key.saved', KEY_ID(contractAddress, owner), {


### PR DESCRIPTION
# Description

This turned out to be incredibly simple: we just take the `owner` we already use for the key id, and pass it as `for`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #4009 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
