### PR TITLE
fix assorted bugs

### DIFF
--- a/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
+++ b/paywall/src/__tests__/data-iframe/cache/localStorage.test.js
@@ -264,7 +264,7 @@ describe('localStorage cache', () => {
       )
     })
 
-    it('replaces an existing sub-value', async () => {
+    it('merges an existing sub-value', async () => {
       expect.assertions(1)
 
       const key2 = {
@@ -292,7 +292,10 @@ describe('localStorage cache', () => {
         JSON.stringify({
           keys: {
             key1: keys.key1,
-            key2,
+            key2: {
+              ...keys.key2,
+              ...key2,
+            },
           },
         })
       )
@@ -380,7 +383,7 @@ describe('localStorage cache', () => {
       )
     })
 
-    it('replaces an existing sub-value, non-account-specific', async () => {
+    it('merges an existing sub-value, non-account-specific', async () => {
       expect.assertions(1)
 
       const key2 = {
@@ -406,7 +409,10 @@ describe('localStorage cache', () => {
         JSON.stringify({
           keys: {
             key1: keys.key1,
-            key2,
+            key2: {
+              ...keys.key2,
+              ...key2,
+            },
           },
         })
       )

--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -85,11 +85,15 @@ describe('cacheHandler', () => {
         await setKeys(fakeWindow, myKeys)
         await setKey(fakeWindow, {
           lock: 'lock2',
+          expiration: 5,
         })
 
         expect(await getKeys(fakeWindow)).toEqual({
           ...myKeys,
-          lock2: { lock: 'lock2' },
+          lock2: {
+            ...myKeys.lock2,
+            expiration: 5,
+          },
         })
       })
 
@@ -104,7 +108,7 @@ describe('cacheHandler', () => {
 
         expect(await getKeys(fakeWindow)).toEqual({
           ...myKeys,
-          lock: { lock: 'lock', new: 'guy' },
+          lock: { ...myKeys.lock, new: 'guy' },
         })
       })
     })
@@ -150,7 +154,10 @@ describe('cacheHandler', () => {
         })
 
         expect(await getTransactions(fakeWindow)).toEqual({
-          myTransaction: { hash: 'myTransaction', new: 'guy' },
+          myTransaction: {
+            ...myTransactions.myTransaction,
+            new: 'guy',
+          },
         })
       })
     })

--- a/paywall/src/__tests__/data-iframe/start/makeSetConfig.test.js
+++ b/paywall/src/__tests__/data-iframe/start/makeSetConfig.test.js
@@ -163,7 +163,7 @@ describe('makeSetConfig', () => {
           },
         }
 
-        onChange(update)
+        await onChange(update)
 
         expect(await getLocks(fakeWindow)).toEqual(update.locks)
       })

--- a/paywall/src/data-iframe/cache/localStorage.js
+++ b/paywall/src/data-iframe/cache/localStorage.js
@@ -126,7 +126,11 @@ export async function merge({
     delete container[type][subType]
   } else {
     container[type] = container[type] || {}
-    container[type][subType] = value
+    const oldType = container[type][subType] || {}
+    container[type][subType] = {
+      ...oldType,
+      ...value,
+    }
   }
 
   window.localStorage.setItem(key, JSON.stringify(container))

--- a/paywall/src/data-iframe/cache/localStorage.js
+++ b/paywall/src/data-iframe/cache/localStorage.js
@@ -126,9 +126,9 @@ export async function merge({
     delete container[type][subType]
   } else {
     container[type] = container[type] || {}
-    const oldType = container[type][subType] || {}
+    const oldValue = container[type][subType] || {}
     container[type][subType] = {
-      ...oldType,
+      ...oldValue,
       ...value,
     }
   }

--- a/paywall/src/data-iframe/cacheHandler.js
+++ b/paywall/src/data-iframe/cacheHandler.js
@@ -45,7 +45,9 @@ async function _merge(window, key, subType, value) {
 
 export async function createMissingKeys(window, locks, keys) {
   const account = (await getAccount(window)) || nullAccount
-  Object.keys(locks).forEach(async lockAddress => {
+  const lockKeys = Object.keys(locks)
+  for (let i = 0; i < lockKeys.length; i++) {
+    const lockAddress = lockKeys[i]
     if (!keys[lockAddress]) {
       // can't use setKey, triggers an infinite loop because of notifications
       await _merge(window, 'keys', lockAddress, {
@@ -55,7 +57,7 @@ export async function createMissingKeys(window, locks, keys) {
         expiration: 0,
       })
     }
-  })
+  }
 }
 
 export async function getKeys(window) {

--- a/paywall/src/data-iframe/postOffice.js
+++ b/paywall/src/data-iframe/postOffice.js
@@ -127,7 +127,8 @@ export default function postOffice(window, requiredConfirmations) {
           lockHandler(window, cachedData, actions)
           break
         case 'network':
-          if (cachedData.networkId === null) return
+          // all network ids are > 0
+          if (!cachedData.networkId) return
           actions.network(cachedData.networkId)
           break
         case 'walletModal':

--- a/paywall/src/data-iframe/start/makeSetConfig.js
+++ b/paywall/src/data-iframe/start/makeSetConfig.js
@@ -34,7 +34,7 @@ const makeSetConfig = (
 
     // bridge from the blockchain to the cache
     // and to the main window for errors/wallet modal
-    const onChange = updates => {
+    const onChange = async updates => {
       // pass errors on directly
       if (updates.error) {
         updater('error', updates.error)
@@ -47,7 +47,7 @@ const makeSetConfig = (
       }
       // for everything else, it stores it in the cache
       // cache listeners will transmit it to the script
-      syncToCache(window, updates)
+      return syncToCache(window, updates)
     }
     try {
       const retrieveChainData = await connectToBlockchain({

--- a/paywall/src/data-iframe/start/syncToCache.js
+++ b/paywall/src/data-iframe/start/syncToCache.js
@@ -18,7 +18,7 @@ import {
  * directly relayed to the main window via the `onChange` handler in `makeSetConfig`
  * @param {object} updates updates from the blockchain
  */
-export default function syncToCache(window, updates) {
+export default async function syncToCache(window, updates) {
   const methods = {
     locks: setLocks,
     key: setKey,
@@ -29,12 +29,14 @@ export default function syncToCache(window, updates) {
     balance: setAccountBalance,
     network: setNetwork,
   }
-  return Promise.all(
-    Object.keys(updates).map(type => {
-      if (!methods[type]) {
-        throw new Error(`internal error, no cache handler for "${type}"`)
-      }
-      return methods[type](window, updates[type])
-    })
-  )
+
+  const updateKeys = Object.keys(updates)
+  for (let i = 0; i < updateKeys.length; i++) {
+    const updateType = updateKeys[i]
+    const update = updates[updateType]
+    if (!methods[updateType]) {
+      throw new Error(`internal error, no cache handler for "${updateType}"`)
+    }
+    await methods[updateType](window, update)
+  }
 }


### PR DESCRIPTION
# Description

This is a hodge-podge of fixes to the data iframe, mostly small changes.

1. because `'transaction.updated'` from `web3Service` never emits the full transaction, we need to merge its value with the previous one. This changes merge to have this behavior.
2. makeSetConfig needs to wait for the `onChange` handler to finish before passing control back to avoid race conditions
3. The cacheHandler was running updates for `keys` and `transactions` in parallel using `Promise.all`. This would cause them both to use old versions of local storage, and one would overwrite the other's update with a stale value. This changes it to run the updates in sequence instead.
4. The same bug struck `syncToCache` - we can't use `Promise.all` here.
5. the check for networkId in the post office was too strict (`=== null`) when checking for falsy suffices, because a `0` network does not exist.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3970 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
