### PR TITLE
Renaming getTransactionsBySender to getTransactionsByFilter

### DIFF
--- a/locksmith/__tests__/controllers/transactionController.test.js
+++ b/locksmith/__tests__/controllers/transactionController.test.js
@@ -23,12 +23,12 @@ describe('transactionController', () => {
       {
         transactionHash: '0x645546565',
         sender: '0xcAFe2',
-        recipient: '0xBeeFB',
+        recipient: '0xBEefb',
       },
       {
         transactionHash: '0x645546567',
         sender: '0xcAFe2',
-        recipient: '0xBeeFB',
+        recipient: '0xBEefb',
         for: '0xcAFe2',
       },
     ])
@@ -87,6 +87,24 @@ describe('transactionController', () => {
           .get('/transactions')
           .query({
             sender: sender,
+            for: '0xcAFe2',
+          })
+          .set('Accept', /json/)
+
+        expect(response.body.transactions.length).toEqual(1)
+        expect(response.body.transactions[0].transactionHash).toEqual(
+          '0x645546567'
+        )
+      })
+    })
+
+    describe('when filtering on for -> recipients', () => {
+      it('returns the matching transactions', async () => {
+        expect.assertions(2)
+        let response = await request(app)
+          .get('/transactions')
+          .query({
+            recipient: ['0xBeeFB', '0xBeeFB'],
             for: '0xcAFe2',
           })
           .set('Accept', /json/)

--- a/locksmith/__tests__/operations/transactionOperations.test.js
+++ b/locksmith/__tests__/operations/transactionOperations.test.js
@@ -1,6 +1,6 @@
 import {
   findOrCreateTransaction,
-  getTransactionsBySender,
+  getTransactionsByFilter,
 } from '../../src/operations/transactionOperations'
 
 const Sequelize = require('sequelize')
@@ -47,7 +47,7 @@ describe('lockOperations', () => {
     })
   })
 
-  describe('getTransactionsBySender', () => {
+  describe('getTransactionsByFilter', () => {
     it('should get the list of transactions by that sender after having checksummed the address', async () => {
       expect.assertions(2)
       const sender = '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
@@ -56,7 +56,7 @@ describe('lockOperations', () => {
           '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
         )
       })
-      await getTransactionsBySender({ sender: sender })
+      await getTransactionsByFilter({ sender: sender })
       expect(Transaction.findAll).toHaveBeenCalled()
     })
 
@@ -69,7 +69,7 @@ describe('lockOperations', () => {
             '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
           )
         })
-        await getTransactionsBySender({
+        await getTransactionsByFilter({
           sender: sender,
           recipient: ['0xCA750f9232C1c38e34D27e77534e1631526eC99e'],
         })

--- a/locksmith/src/controllers/transactionController.js
+++ b/locksmith/src/controllers/transactionController.js
@@ -2,7 +2,7 @@ const transactionOperations = require('../operations/transactionOperations')
 
 const {
   findOrCreateTransaction,
-  getTransactionsBySender,
+  getTransactionsByFilter,
 } = transactionOperations
 
 const transactionCreate = async (req, res) => {
@@ -28,7 +28,7 @@ const transactionsGet = async (req, res) => {
   let filter = buildFilter(req)
 
   if (filter.sender || filter.recipients || filter.for) {
-    transactions = await getTransactionsBySender(filter)
+    transactions = await getTransactionsByFilter(filter)
   }
 
   res.json({ transactions: transactions })

--- a/locksmith/src/operations/transactionOperations.ts
+++ b/locksmith/src/operations/transactionOperations.ts
@@ -33,18 +33,14 @@ const transactionForPackaging = (transactionFor: string) => {
  * get all the transactions sent by a given address
  * @param {*} _sender
  */
-// export const getTransactionsBySender = async (_sender: string, filter: any) => {
-export const getTransactionsBySender = async (filter: any) => {
+export const getTransactionsByFilter = async (filter: any) => {
   return await Transaction.findAll({
     where: queryFilter(filter),
   })
 }
 
 const queryFilter = (filter: any) => {
-  const sender = ethJsUtil.toChecksumAddress(filter.sender)
-
   var target: any = {}
-  target.sender = { [Op.eq]: sender }
 
   if (filter.recipient) {
     target.recipient = {
@@ -56,6 +52,10 @@ const queryFilter = (filter: any) => {
 
   if (filter.for) {
     target.for = { [Op.eq]: ethJsUtil.toChecksumAddress(filter.for) }
+  }
+
+  if (filter.sender) {
+    target.sender = { [Op.eq]: ethJsUtil.toChecksumAddress(filter.sender) }
   }
 
   return target


### PR DESCRIPTION
# Description

Renaming getTransactionsBySender to getTransactionsByFilter to handld filtered queries

As it was previously, some filter criteria is required.  The main case is to support for -> recipient purchases to handle delegated purchases

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
