### PR TITLE
Revert "Update dependency eslint-config-prettier to v6 (#4078)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,9 +1880,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",
-      "integrity": "sha512-vDrcCFE3+2ixNT5H83g28bO/uYAwibJxerXPj+E7op4qzBCsAV36QfvdAyVOoNxKAH2Os/e01T/2x++V0LPukA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz",
+      "integrity": "sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==",
       "requires": {
         "get-stdin": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "babel-jest": "24.8.0",
     "eslint": "5.16.0",
     "eslint-config-airbnb": "17.1.0",
-    "eslint-config-prettier": "6.0.0",
+    "eslint-config-prettier": "4.3.0",
     "eslint-config-standard": "12.0.0",
     "eslint-import-resolver-typescript": "1.1.1",
     "eslint-plugin-import": "2.18.0",


### PR DESCRIPTION
This reverts commit 756b9712049e6d40e42b37adb8487d113ae5d53d.
That commit broke the build