### PR TITLE
Adding some state and actions around user account key purchase

### DIFF
--- a/unlock-app/src/__tests__/actions/keyPurchase.test.ts
+++ b/unlock-app/src/__tests__/actions/keyPurchase.test.ts
@@ -1,0 +1,16 @@
+import { ADD_TO_CART, addToCart } from '../../actions/keyPurchase'
+
+describe('keyPurchase actions', () => {
+  it('should create an action to add a lock to the cart', () => {
+    expect.assertions(1)
+    const lock = 'a lock'
+    const tip = 'a tip'
+    expect(addToCart({ lock, tip })).toEqual(
+      expect.objectContaining({
+        type: ADD_TO_CART,
+        lock,
+        tip,
+      })
+    )
+  })
+})

--- a/unlock-app/src/__tests__/actions/user.test.ts
+++ b/unlock-app/src/__tests__/actions/user.test.ts
@@ -35,6 +35,8 @@ import {
   signPurchaseData,
   SIGNED_PURCHASE_DATA,
   signedPurchaseData,
+  KEY_PURCHASE_INITIATED,
+  keyPurchaseInitiated,
 } from '../../actions/user'
 
 const key = {
@@ -260,6 +262,9 @@ describe('user account actions', () => {
 
       expect(signedPaymentData({ data, sig })).toEqual(expectedAction)
     })
+  })
+
+  describe('user transaction actions', () => {
     it('should create an action requesting the signature for a key purchase', () => {
       expect.assertions(1)
       const data = {
@@ -295,6 +300,15 @@ describe('user account actions', () => {
       }
 
       expect(signedPurchaseData({ data, sig })).toEqual(expectedAction)
+    })
+
+    it('should create an action indicating that locksmith has accepted a key purchase request', () => {
+      expect.assertions(1)
+      const expectedAction = {
+        type: KEY_PURCHASE_INITIATED,
+      }
+
+      expect(keyPurchaseInitiated()).toEqual(expectedAction)
     })
   })
 

--- a/unlock-app/src/__tests__/reducers/cartReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/cartReducer.test.ts
@@ -1,0 +1,25 @@
+import reducer from '../../reducers/cartReducer'
+import { addToCart } from '../../actions/keyPurchase'
+
+describe('cartReducer', () => {
+  it('should set state when receiving ADD_TO_CART', () => {
+    expect.assertions(1)
+    const lock = 'a lock'
+    const tip = 'a tip'
+    expect(reducer(undefined, addToCart({ lock, tip }))).toEqual({
+      lock,
+      tip,
+    })
+  })
+
+  it('should return current state for other actions', () => {
+    expect.assertions(1)
+    const currentState = {
+      lock: 'another lock',
+      tip: 'another tip',
+    }
+    expect(reducer(currentState, { type: 'JUST_SOME_ACTION' })).toEqual(
+      currentState
+    )
+  })
+})

--- a/unlock-app/src/actions/keyPurchase.ts
+++ b/unlock-app/src/actions/keyPurchase.ts
@@ -1,0 +1,7 @@
+export const ADD_TO_CART = 'keyPurchase/ADD_TO_CART'
+
+export const addToCart = ({ lock, tip }: any) => ({
+  type: ADD_TO_CART,
+  lock,
+  tip,
+})

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -20,6 +20,7 @@ export const SIGNED_PAYMENT_DATA = 'userCredentials/SIGNED_PAYMENT_DATA'
 export const SIGN_PURCHASE_DATA = 'userCredentials/SIGN_PURCHASE_DATA'
 export const SIGNED_PURCHASE_DATA = 'userCredentials/SIGNED_PURCHASE_DATA'
 export const GET_STORED_PAYMENT_DETAILS = 'userAccount/GET_PAYMENT_DETAILS'
+export const KEY_PURCHASE_INITIATED = 'userAccount/KEY_PURCHASE_INITIATED'
 
 export interface Credentials {
   emailAddress: string
@@ -180,4 +181,8 @@ export const signedPurchaseData = ({ data, sig }: SignedPurchaseData) => ({
   type: SIGNED_PURCHASE_DATA,
   data,
   sig,
+})
+
+export const keyPurchaseInitiated = () => ({
+  type: KEY_PURCHASE_INITIATED,
 })

--- a/unlock-app/src/reducers/cartReducer.ts
+++ b/unlock-app/src/reducers/cartReducer.ts
@@ -1,0 +1,24 @@
+import { ADD_TO_CART } from '../actions/keyPurchase'
+import { Action } from '../unlockTypes'
+
+// Right now, the "cart" can only contain one lock at a time
+interface State {
+  lock: any
+  tip: any
+}
+
+export const initialState: State = {
+  lock: null,
+  tip: null,
+}
+
+const cartReducer = (state = initialState, action: Action) => {
+  if (action.type === ADD_TO_CART) {
+    const { lock, tip } = action
+    state = { lock, tip }
+  }
+
+  return state
+}
+
+export default cartReducer

--- a/unlock-app/src/reducers/cartReducer.ts
+++ b/unlock-app/src/reducers/cartReducer.ts
@@ -1,7 +1,9 @@
 import { ADD_TO_CART } from '../actions/keyPurchase'
 import { Action } from '../unlockTypes'
 
-// Right now, the "cart" can only contain one lock at a time
+// Right now, the "cart" can only contain one lock at a time. It only responds
+// to an action created by the postOfficeMiddleware while a user account key
+// purchase is in progress
 interface State {
   lock: any
   tip: any


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR adds some state and actions to help with the process of purchasing keys using a user account through the iframe that the paywall embeds.

In particular, this includes a way to store lock information so the frontend can use it to create purchase requests, as well as a way to indicate that the key purchase has been initiated.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
