### PR TITLE
Fleshing out postOfficeMiddleware

### DIFF
--- a/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
@@ -11,6 +11,7 @@ class MockPostOfficeService extends EventEmitter {
   constructor() {
     super()
   }
+  showAccountModal = jest.fn()
 }
 
 let mockPostOfficeService = new MockPostOfficeService()
@@ -89,6 +90,20 @@ describe('postOfficeMiddleware', () => {
           },
         })
       )
+    })
+
+    it('should dispatch paywallLock when receiving KeyPurchase', () => {
+      expect.assertions(2)
+
+      const { store } = makeMiddleware()
+
+      mockPostOfficeService.emit(
+        PostOfficeEvents.KeyPurchase,
+        'a lock',
+        'a tip'
+      )
+      expect(mockPostOfficeService.showAccountModal).toHaveBeenCalled()
+      expect(store.dispatch).toHaveBeenCalledWith('something')
     })
   })
 

--- a/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
@@ -79,7 +79,16 @@ describe('postOfficeMiddleware', () => {
 
       mockPostOfficeService.emit(PostOfficeEvents.Error, 'this is an error')
 
-      expect(store.dispatch).toHaveBeenCalled()
+      expect(store.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error/SET_ERROR',
+          error: {
+            kind: 'PostOffice',
+            level: 'Diagnostic',
+            message: 'this is an error',
+          },
+        })
+      )
     })
   })
 

--- a/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
@@ -1,9 +1,31 @@
+import { EventEmitter } from 'events'
 import {
   IframePostOfficeWindow,
   PostMessageListener,
   PostMessageTarget,
 } from '../../utils/postOffice'
+import { PostOfficeEvents } from '../../services/postOfficeService'
 import postOfficeMiddleware from '../../middlewares/postOfficeMiddleware'
+
+class MockPostOfficeService extends EventEmitter {
+  constructor() {
+    super()
+  }
+}
+
+let mockPostOfficeService = new MockPostOfficeService()
+
+jest.mock('../../services/postOfficeService', () => {
+  const mockPostOffice = require.requireActual(
+    '../../services/postOfficeService'
+  ) // original module
+  return {
+    ...mockPostOffice,
+    PostOfficeService: function() {
+      return mockPostOfficeService
+    },
+  }
+})
 
 interface store {
   dispatch: (action: any) => void
@@ -17,9 +39,15 @@ describe('postOfficeMiddleware', () => {
   let fakeStore: store
   let fakeState: any
   let next: (action: any) => void
+  const mockConfig = {
+    requiredNetworkId: 1984,
+  }
 
   function makeMiddleware() {
-    return postOfficeMiddleware(fakeWindow)(fakeStore)(next)
+    return {
+      invoke: postOfficeMiddleware(fakeWindow, mockConfig)(fakeStore)(next),
+      store: fakeStore,
+    }
   }
 
   beforeEach(() => {
@@ -44,15 +72,26 @@ describe('postOfficeMiddleware', () => {
     }
   })
 
+  describe('Handling emitted PostOfficeEvents', () => {
+    it('should dispatch setError when receiving Error', () => {
+      expect.assertions(1)
+      const { store } = makeMiddleware()
+
+      mockPostOfficeService.emit(PostOfficeEvents.Error, 'this is an error')
+
+      expect(store.dispatch).toHaveBeenCalled()
+    })
+  })
+
   it('should pass actions on to the next middleware', () => {
     expect.assertions(1)
 
-    const middleware = makeMiddleware()
+    const { invoke } = makeMiddleware()
     const action = {
       type: 'any',
     }
 
-    middleware(action)
+    invoke(action)
 
     expect(next).toHaveBeenCalledWith(action)
   })

--- a/unlock-app/src/__tests__/services/postOfficeService.test.ts
+++ b/unlock-app/src/__tests__/services/postOfficeService.test.ts
@@ -1,4 +1,5 @@
-import PostOfficeService, {
+import {
+  PostOfficeService,
   PostOfficeEvents,
 } from '../../services/postOfficeService'
 import { IframePostOfficeWindow } from '../../windowTypes'

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -4,7 +4,9 @@ import {
   PostOfficeService,
 } from '../services/postOfficeService'
 import { setError } from '../actions/error'
+import { KEY_PURCHASE_INITIATED } from '../actions/user'
 import { PostOffice } from '../utils/Error'
+import { addToCart } from '../actions/keyPurchase'
 
 const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
   const postOfficeService = new PostOfficeService(
@@ -15,10 +17,15 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
     postOfficeService.on(PostOfficeEvents.Error, message => {
       dispatch(setError(PostOffice.Diagnostic(message)))
     })
-    postOfficeService.on(PostOfficeEvents.KeyPurchase, () => {
+    postOfficeService.on(PostOfficeEvents.KeyPurchase, (lock, tip) => {
       postOfficeService.showAccountModal()
+      dispatch(addToCart({ lock, tip }))
     })
     return (next: (action: any) => void) => (action: any) => {
+      if (action.type === KEY_PURCHASE_INITIATED) {
+        postOfficeService.transactionInitiated()
+        postOfficeService.hideAccountModal()
+      }
       next(action)
     }
   }

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -1,10 +1,19 @@
-import { iframePostOffice, IframePostOfficeWindow } from '../utils/postOffice'
+import { IframePostOfficeWindow } from '../utils/postOffice'
+import {
+  PostOfficeEvents,
+  PostOfficeService,
+} from '../services/postOfficeService'
 
-const postOfficeMiddleware = (window: IframePostOfficeWindow) => {
-  const postOffice = iframePostOffice(window, 'Account UI')
+const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
+  const postOfficeService = new PostOfficeService(
+    window,
+    config.requiredNetworkId
+  )
+  postOfficeService.on(PostOfficeEvents.Error, () => {})
+  postOfficeService.on(PostOfficeEvents.LockUpdate, () => {})
+  postOfficeService.on(PostOfficeEvents.KeyPurchase, () => {})
   return (_: any) => {
     //return ({ getState, dispatch }) => {
-    postOffice.addHandler('boilerplate, not used yet', () => {})
     return (next: (action: any) => void) => (action: any) => {
       next(action)
     }

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -15,8 +15,9 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
     postOfficeService.on(PostOfficeEvents.Error, message => {
       dispatch(setError(PostOffice.Diagnostic(message)))
     })
-    postOfficeService.on(PostOfficeEvents.LockUpdate, () => {})
-    postOfficeService.on(PostOfficeEvents.KeyPurchase, () => {})
+    postOfficeService.on(PostOfficeEvents.KeyPurchase, () => {
+      postOfficeService.showAccountModal()
+    })
     return (next: (action: any) => void) => (action: any) => {
       next(action)
     }

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -3,17 +3,20 @@ import {
   PostOfficeEvents,
   PostOfficeService,
 } from '../services/postOfficeService'
+import { setError } from '../actions/error'
+import { PostOffice } from '../utils/Error'
 
 const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
   const postOfficeService = new PostOfficeService(
     window,
     config.requiredNetworkId
   )
-  postOfficeService.on(PostOfficeEvents.Error, () => {})
-  postOfficeService.on(PostOfficeEvents.LockUpdate, () => {})
-  postOfficeService.on(PostOfficeEvents.KeyPurchase, () => {})
-  return (_: any) => {
-    //return ({ getState, dispatch }) => {
+  return ({ dispatch }: any) => {
+    postOfficeService.on(PostOfficeEvents.Error, message => {
+      dispatch(setError(PostOffice.Diagnostic(message)))
+    })
+    postOfficeService.on(PostOfficeEvents.LockUpdate, () => {})
+    postOfficeService.on(PostOfficeEvents.KeyPurchase, () => {})
     return (next: (action: any) => void) => (action: any) => {
       next(action)
     }

--- a/unlock-app/src/services/postOfficeService.ts
+++ b/unlock-app/src/services/postOfficeService.ts
@@ -13,7 +13,7 @@ export enum PostOfficeEvents {
   Error = 'error',
 }
 
-export default class PostOfficeService extends EventEmitter {
+export class PostOfficeService extends EventEmitter {
   private postOffice: PostOffice
   private account: string | null = null
   private network: number

--- a/unlock-app/src/utils/Error.ts
+++ b/unlock-app/src/utils/Error.ts
@@ -14,6 +14,7 @@ type ErrorKind =
   | 'Application'
   | 'FormValidation'
   | 'LogIn'
+  | 'PostOffice'
   | 'SignUp'
   | 'Signature'
   | 'Storage'
@@ -93,6 +94,9 @@ export const FormValidation: ErrorMakers = errorsFor('FormValidation')
 // errors that occur while logging in (wrong password...)
 export const LogIn: ErrorMakers = errorsFor('LogIn')
 
+// errors that happen when posting messages back and forth with the paywall
+export const PostOffice: ErrorMakers = errorsFor('PostOffice')
+
 // errors that occur while signing up/creating accounts
 export const SignUp: ErrorMakers = errorsFor('SignUp')
 
@@ -107,6 +111,7 @@ const constructors: { [key: string]: ErrorMakers } = {
   Signature,
   FormValidation,
   LogIn,
+  PostOffice,
   SignUp,
   Transaction,
   Web3,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR updates `postOfficeMiddleware` to handle some of the events that `PostOfficeService` emits. 3 things can happen:
1. the app receives a `KeyPurchase` message, containing a lock. The middleware then dispatches the `addToCart` action so that the lock is available for the checkout page to use.
2. The app has initiated a key purchase, and so it informs the iframe and requests to be hidden.
3. An error occurred. Send the error off to state (keeping these diagnostic for now)

To enable testing the middleware, some shuffling had to be done to the service so that we could mock it correctly. Additionally I added a new error type for these.

A future PR will staple all this stuff together after I test locally!

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
