### PR TITLE
Responsive code blocks for blog post

### DIFF
--- a/unlock-protocol.com/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-protocol.com/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -1771,6 +1771,17 @@ Object {
   max-width: 100%;
 }
 
+.c18 pre,
+.c18 code {
+  max-width: 90vw;
+  overflow-x: scroll;
+}
+
+.c18 pre {
+  background-color: var(--lightgrey);
+  padding: 20px;
+}
+
 .c16 {
   font-family: 'IBM Plex Serif';
   font-weight: 300;
@@ -2547,7 +2558,7 @@ are intentionally not generated from this file date, in case we want to override
             </div>
           </div>
           <div
-            class="b1qsww-6 imLyLP"
+            class="b1qsww-6 llwqIY"
           >
             <div>
               <p>
@@ -3753,6 +3764,17 @@ Object {
   max-width: 100%;
 }
 
+.c6 pre,
+.c6 code {
+  max-width: 90vw;
+  overflow-x: scroll;
+}
+
+.c6 pre {
+  background-color: var(--lightgrey);
+  padding: 20px;
+}
+
 .c4 {
   font-family: 'IBM Plex Serif';
   font-weight: 300;
@@ -4029,7 +4051,7 @@ genuinely collaborative ecosystem, where many companies and services can operate
         </div>
       </div>
       <div
-        class="b1qsww-6 imLyLP"
+        class="b1qsww-6 llwqIY"
       >
         <div>
           <p>
@@ -4342,6 +4364,17 @@ Object {
   max-width: 100%;
 }
 
+.c5 pre,
+.c5 code {
+  max-width: 90vw;
+  overflow-x: scroll;
+}
+
+.c5 pre {
+  background-color: var(--lightgrey);
+  padding: 20px;
+}
+
 .c3 {
   font-family: 'IBM Plex Serif';
   font-weight: 300;
@@ -4610,7 +4643,7 @@ genuinely collaborative ecosystem, where many companies and services can operate
         </div>
       </div>
       <div
-        class="b1qsww-6 imLyLP"
+        class="b1qsww-6 llwqIY"
       >
         <div>
           <p>
@@ -4923,6 +4956,17 @@ Object {
   max-width: 100%;
 }
 
+.c5 pre,
+.c5 code {
+  max-width: 90vw;
+  overflow-x: scroll;
+}
+
+.c5 pre {
+  background-color: var(--lightgrey);
+  padding: 20px;
+}
+
 .c3 {
   font-family: 'IBM Plex Serif';
   font-weight: 300;
@@ -5191,7 +5235,7 @@ genuinely collaborative ecosystem, where many companies and services can operate
         </div>
       </div>
       <div
-        class="b1qsww-6 imLyLP"
+        class="b1qsww-6 llwqIY"
       >
         <div>
           <p>
@@ -5513,6 +5557,17 @@ Object {
   max-width: 100%;
 }
 
+.c6 pre,
+.c6 code {
+  max-width: 90vw;
+  overflow-x: scroll;
+}
+
+.c6 pre {
+  background-color: var(--lightgrey);
+  padding: 20px;
+}
+
 .c4 {
   font-family: 'IBM Plex Serif';
   font-weight: 300;
@@ -5789,7 +5844,7 @@ genuinely collaborative ecosystem, where many companies and services can operate
         </div>
       </div>
       <div
-        class="b1qsww-6 imLyLP"
+        class="b1qsww-6 llwqIY"
       >
         <div>
           <p>

--- a/unlock-protocol.com/src/components/content/BlogPost.js
+++ b/unlock-protocol.com/src/components/content/BlogPost.js
@@ -167,6 +167,17 @@ const Body = styled.div`
   img {
     max-width: 100%;
   }
+
+  pre,
+  code {
+    max-width: 90vw;
+    overflow-x: scroll;
+  }
+
+  pre {
+    background-color: var(--lightgrey);
+    padding: 20px;
+  }
 `
 
 export const AuthorName = styled.h3`


### PR DESCRIPTION
# Description

Whoops! As @smombartz pointed out, heavy code blocks don't look great on mobile. We're going to want to do many more of those sorts of posts, so I added a fix so they don't break the layout.

* Code blocks horizontally scroll when required
* They now have a visible background, to make it more obvious that you can scroll them

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

<img width="843" alt="Screen Shot 2019-07-02 at 4 19 59 PM" src="https://user-images.githubusercontent.com/624104/60553000-0ca40e00-9ce6-11e9-8296-6c4b0ac368e7.png">
<img width="820" alt="Screen Shot 2019-07-02 at 4 20 06 PM" src="https://user-images.githubusercontent.com/624104/60553001-10d02b80-9ce6-11e9-9925-b0f9053d2d90.png">
<img width="290" alt="Screen Shot 2019-07-02 at 4 20 24 PM" src="https://user-images.githubusercontent.com/624104/60553002-13328580-9ce6-11e9-9222-deb253b9d546.png">
