### PR TITLE
gets locks from locksmith

### DIFF
--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -610,4 +610,74 @@ describe('StorageService', () => {
       })
     })
   })
+
+  describe('getLockAddressesForUser', () => {
+    it('should retrieve the list of locks for a user and emit emit success.getLockAddressesForUser', done => {
+      expect.assertions(2)
+      const user = '0xabc'
+      const locks = [
+        {
+          name: 'The named lock',
+          address: '0xAB4723090f6ea6bE32A1aDF4933EC901d315Ff0b',
+          owner: '0x3CA206264762Caf81a8F0A843bbB850987B41e16',
+          createdAt: '2019-02-06T23:16:16.505Z',
+          updatedAt: '2019-02-06T23:16:16.505Z',
+        },
+        {
+          name: 'A lock with a name',
+          address: '0xFa8b435a51E074Dd5FBCa54679d32c960C3CBDFb',
+          owner: '0x3CA206264762Caf81a8F0A843bbB850987B41e16',
+          createdAt: '2019-03-05T01:23:13.545Z',
+          updatedAt: '2019-03-05T01:23:13.545Z',
+        },
+      ]
+      axios.get.mockReturnValue({
+        data: {
+          locks,
+        },
+      })
+
+      storageService.on(success.getLockAddressesForUser, addresses => {
+        expect(addresses).toEqual(locks.map(lock => lock.address))
+        done()
+      })
+
+      storageService.getLockAddressesForUser(user)
+
+      expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/${user}/locks`)
+    })
+
+    it('should emit failure.getLockAddressesForUser if the data does not have the expected format', done => {
+      expect.assertions(2)
+      const user = '0xabc'
+      axios.get.mockReturnValue({
+        data: {},
+      })
+
+      storageService.getLockAddressesForUser(user)
+
+      storageService.on(failure.getLockAddressesForUser, error => {
+        expect(error).toBe('We could not retrieve lock addresses for that user')
+        done()
+      })
+
+      expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/${user}/locks`)
+    })
+
+    it('should emit failure.getLockAddressesForUser if there was an error', done => {
+      expect.assertions(2)
+      const user = '0xabc'
+      const httpError = 'An Error'
+      axios.get.mockRejectedValue(httpError)
+
+      storageService.getLockAddressesForUser(user)
+
+      storageService.on(failure.getLockAddressesForUser, error => {
+        expect(error).toBe(httpError)
+        done()
+      })
+
+      expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/${user}/locks`)
+    })
+  })
 })

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -9,6 +9,7 @@ export const success = {
   addPaymentMethod: 'addPaymentMethod.success',
   storeTransaction: 'storeTransaction.success',
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.success',
+  getLockAddressesForUser: 'getLockAddressesForUser.success',
   lockLookUp: 'lockLookUp.success',
   storeLockDetails: 'storeLockDetails.success',
   createUser: 'createUser.success',
@@ -23,6 +24,7 @@ export const failure = {
   addPaymentMethod: 'addPaymentMethod.failure',
   storeTransaction: 'storeTransaction.failure',
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.failure',
+  getLockAddressesForUser: 'getLockAddressesForUser.failure',
   lockLookUp: 'lockLookUp.failure',
   storeLockDetails: 'storeLockDetails.failure',
   createUser: 'createUser.failure',
@@ -296,6 +298,30 @@ export class StorageService extends EventEmitter {
       )
     } catch (error) {
       this.emit(failure.keyPurchase, error)
+    }
+  }
+
+  /**
+   * Retrieves the list of known lock adresses for this user
+   * [Note: locksmith may not know of all the locks by a user at a given point as the lock may not be deployed yet, or the lock might have been transfered]
+   * @param {*} address
+   */
+  async getLockAddressesForUser(address) {
+    try {
+      const result = await axios.get(`${this.host}/${address}/locks`)
+      if (result.data && result.data.locks) {
+        this.emit(
+          success.getLockAddressesForUser,
+          result.data.locks.map(lock => lock.address)
+        )
+      } else {
+        this.emit(
+          failure.getLockAddressesForUser,
+          'We could not retrieve lock addresses for that user'
+        )
+      }
+    } catch (error) {
+      this.emit(failure.getLockAddressesForUser, error)
     }
   }
 }


### PR DESCRIPTION
# Description

We now retrieve the lock addresses from locksmith on the dashboard.
This has 2 benefits:
1. faster loading (we do not have to get the transactions before being able to get these locks)
2. locks which have been transfered are now also loaded on the dashboard.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread