### PR TITLE
fetching the lock info to handle ADD_LOCK

### DIFF
--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -508,4 +508,21 @@ describe('Lock middleware', () => {
       expect(mockWeb3Service.generateLockAddress).not.toHaveBeenCalled()
     })
   })
+
+  describe('ADD_LOCK', () => {
+    it('should retrieve the locks using web3Service', () => {
+      expect.assertions(2)
+      const { next, invoke } = create()
+      const address = '0x123'
+      const lock = {
+        address,
+      }
+      const action = { type: ADD_LOCK, address, lock }
+      mockWeb3Service.getLock = jest.fn()
+
+      invoke(action)
+      expect(next).toHaveBeenCalled()
+      expect(mockWeb3Service.getLock).toHaveBeenCalledWith(address)
+    })
+  })
 })

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -1,7 +1,13 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import { Web3Service } from '@unlock-protocol/unlock-js'
-import { CREATE_LOCK, addLock, updateLock, createLock } from '../actions/lock'
+import {
+  CREATE_LOCK,
+  ADD_LOCK,
+  addLock,
+  updateLock,
+  createLock,
+} from '../actions/lock'
 
 import { startLoading, doneLoading } from '../actions/loading'
 import { updateKey, addKey } from '../actions/key'
@@ -150,6 +156,10 @@ const web3Middleware = config => {
             action.lock.address = address
             dispatch(createLock(action.lock))
           })
+        }
+
+        if (action.type === ADD_LOCK) {
+          web3Service.getLock(action.address)
         }
 
         next(action)


### PR DESCRIPTION
# Description

Last step to fetch the locks from web3Service where locksmith yielded their addresses (see #4102 and #4101)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->