### PR TITLE
Adding an action to explicitly get a lock

### DIFF
--- a/unlock-app/src/__tests__/actions/lock.test.js
+++ b/unlock-app/src/__tests__/actions/lock.test.js
@@ -2,12 +2,14 @@ import {
   addLock,
   createLock,
   deleteLock,
+  getLock,
   updateLock,
   withdrawFromLock,
   updateKeyPrice,
   CREATE_LOCK,
   ADD_LOCK,
   DELETE_LOCK,
+  GET_LOCK,
   UPDATE_LOCK,
   WITHDRAW_FROM_LOCK,
   UPDATE_LOCK_KEY_PRICE,
@@ -46,6 +48,16 @@ describe('lock actions', () => {
       lock,
     }
     expect(addLock(address, lock)).toEqual(expectedAction)
+  })
+
+  it('should create an action to get the lock', () => {
+    expect.assertions(1)
+    const address = '0x123'
+    const expectedAction = {
+      type: GET_LOCK,
+      address,
+    }
+    expect(getLock(address)).toEqual(expectedAction)
   })
 
   it('should create an action to delete a lock', () => {

--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -1,7 +1,12 @@
 import UnlockJs from '@unlock-protocol/unlock-js'
 import EventEmitter from 'events'
 import web3Middleware from '../../middlewares/web3Middleware'
-import { ADD_LOCK, UPDATE_LOCK, CREATE_LOCK } from '../../actions/lock'
+import {
+  ADD_LOCK,
+  GET_LOCK,
+  UPDATE_LOCK,
+  CREATE_LOCK,
+} from '../../actions/lock'
 import { UPDATE_KEY } from '../../actions/key'
 import { UPDATE_ACCOUNT, setAccount } from '../../actions/accounts'
 import {
@@ -506,6 +511,23 @@ describe('Lock middleware', () => {
       invoke(action)
       expect(next).toHaveBeenCalled()
       expect(mockWeb3Service.generateLockAddress).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('GET_LOCK', () => {
+    it('should retrieve the locks using web3Service', () => {
+      expect.assertions(2)
+      const { next, invoke } = create()
+      const address = '0x123'
+      const lock = {
+        address,
+      }
+      const action = { type: GET_LOCK, address, lock }
+      mockWeb3Service.getLock = jest.fn()
+
+      invoke(action)
+      expect(next).toHaveBeenCalled()
+      expect(mockWeb3Service.getLock).toHaveBeenCalledWith(address)
     })
   })
 })

--- a/unlock-app/src/actions/lock.js
+++ b/unlock-app/src/actions/lock.js
@@ -1,6 +1,7 @@
 export const ADD_LOCK = 'lock/ADD_LOCK'
 export const CREATE_LOCK = 'lock/CREATE_LOCK'
 export const DELETE_LOCK = 'lock/DELETE_LOCK'
+export const GET_LOCK = 'lock/GET_LOCK'
 export const UPDATE_LOCK = 'lock/UPDATE_LOCK'
 export const UPDATE_LOCK_KEY_PRICE = 'lock/UPDATE_LOCK_KEY_PRICE'
 export const WITHDRAW_FROM_LOCK = 'lock/WITHDRAW_FROM_LOCK'
@@ -18,6 +19,11 @@ export const addLock = (address, lock) => ({
 
 export const deleteLock = address => ({
   type: DELETE_LOCK,
+  address,
+})
+
+export const getLock = address => ({
+  type: GET_LOCK,
   address,
 })
 

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -1,7 +1,13 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import { Web3Service } from '@unlock-protocol/unlock-js'
-import { CREATE_LOCK, addLock, updateLock, createLock } from '../actions/lock'
+import {
+  CREATE_LOCK,
+  GET_LOCK,
+  addLock,
+  updateLock,
+  createLock,
+} from '../actions/lock'
 
 import { startLoading, doneLoading } from '../actions/loading'
 import { updateKey, addKey } from '../actions/key'
@@ -150,6 +156,10 @@ const web3Middleware = config => {
             action.lock.address = address
             dispatch(createLock(action.lock))
           })
+        }
+
+        if (action.type === GET_LOCK) {
+          web3Service.getLock(action.address)
         }
 
         next(action)


### PR DESCRIPTION
# Description

The previous approach using `addLock` was causing issues because `addLock` was used in another context.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread