### PR TITLE
Adds initial pass at Lock Ownership library

### DIFF
--- a/locksmith/__tests__/data/lockOwnership.test.ts
+++ b/locksmith/__tests__/data/lockOwnership.test.ts
@@ -1,0 +1,63 @@
+import LockOwnership from '../../src/data/lockOwnership'
+
+const Lock = require('../../src/models').Lock
+
+let mockWeb3Service: { getLock: any }
+
+mockWeb3Service = {
+  getLock: jest.fn().mockResolvedValueOnce({
+    asOf: 227,
+    balance: '0.01',
+    expirationDuration: 2592000,
+    keyPrice: '0.01',
+    maxNumberOfKeys: 10,
+    outstandingKeys: 1,
+    name: 'a mighty fine lock',
+    address: '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267',
+    owner: '0xb43333',
+  }),
+}
+
+jest.mock('@unlock-protocol/unlock-js', () => ({
+  Web3Service: function() {
+    return mockWeb3Service
+  },
+}))
+
+describe('Lock Ownership', () => {
+  let host = 'http://localhost:8545'
+  const ownedLocks = [
+    {
+      name: 'a mighty fine lock',
+      address: '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267',
+      owner: '0x423893453',
+    },
+    {
+      name: 'A random other lock',
+      address: '0x8276A24C03B7ff9307c5bb9c0f31aa60d284375f',
+      owner: '0x423893453',
+    },
+  ]
+
+  beforeAll(async () => {
+    await Lock.bulkCreate(ownedLocks)
+  })
+
+  afterAll(async () => {
+    await Lock.truncate()
+  })
+
+  describe('when the locks are found', () => {
+    it('persists the current state of ownership for the requested Locks', async () => {
+      expect.assertions(1)
+      await LockOwnership.update(host, [
+        '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267',
+      ])
+
+      let lock = await Lock.findOne({
+        where: { address: '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267' },
+      })
+      expect(lock.owner.toLowerCase()).toEqual('0xb43333')
+    })
+  })
+})

--- a/locksmith/src/data/lockOwnership.ts
+++ b/locksmith/src/data/lockOwnership.ts
@@ -1,0 +1,24 @@
+import { Web3Service } from '@unlock-protocol/unlock-js'
+
+const lockOperations = require('../operations/lockOperations')
+
+const { updateLockOwnership } = lockOperations
+
+export default class LockOwnership {
+  static async update(host: string, addresses: string[]) {
+    let readOnlyEthereumAccess = new Web3Service({
+      readOnlyProvider: host,
+    })
+
+    for (var address of addresses) {
+      await this.fetchAndUpdate(readOnlyEthereumAccess, address)
+    }
+  }
+
+  static async fetchAndUpdate(readOnlyInstance: any, address: string) {
+    let lock = await readOnlyInstance.getLock(address)
+    if (lock) {
+      await updateLockOwnership(address, lock.owner)
+    }
+  }
+}

--- a/locksmith/src/operations/lockOperations.js
+++ b/locksmith/src/operations/lockOperations.js
@@ -42,8 +42,20 @@ const getLocksByOwner = async owner => {
   })
 }
 
+const updateLockOwnership = async (address, owner) => {
+  return Lock.update(
+    { owner: ethJsUtil.toChecksumAddress(owner) },
+    {
+      where: {
+        address: { [Op.eq]: ethJsUtil.toChecksumAddress(address) },
+      },
+    }
+  )
+}
+
 module.exports = {
   createLock,
   getLocksByOwner,
   getLockByAddress,
+  updateLockOwnership,
 }


### PR DESCRIPTION
# Description

This library is quite blocky, general idea is that this will be run out of bound when requesting a lock owner's locks

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
