### PR TITLE
Add time remaining and null lock handling to KeyPurchaseConfirmation

### DIFF
--- a/unlock-app/src/__tests__/components/interface/user-account/KeyPurchaseConfirmation.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/user-account/KeyPurchaseConfirmation.test.tsx
@@ -8,6 +8,35 @@ import {
 } from '../../../../components/interface/user-account/KeyPurchaseConfirmation'
 import { PurchaseData } from '../../../../actions/user'
 
+const cards: stripe.Card[] = [
+  {
+    id: 'card_1Eox8QIsiZS2oQBMkU2KqFnq',
+    brand: 'Visa',
+    exp_month: 8,
+    exp_year: 2020,
+    last4: '4242',
+    country: 'United States',
+    object: '',
+    dynamic_last4: '4242',
+    fingerprint: '',
+    funding: 'credit',
+    metadata: {},
+  },
+  {
+    id: 'card_1EoxVMIsiZS2oQBMFzQ3ToR5',
+    brand: 'American Express',
+    exp_month: 12,
+    exp_year: 2020,
+    last4: '0005',
+    country: 'United States',
+    object: '',
+    dynamic_last4: '0005',
+    fingerprint: '',
+    funding: 'credit',
+    metadata: {},
+  },
+]
+
 const key: Key = {
   expiration: 123456789000,
   transactions: [],
@@ -37,6 +66,7 @@ describe('KeyPurchaseConfirmation', () => {
           address={address}
           emailAddress={emailAddress}
           signPurchaseData={signPurchaseData}
+          cards={cards}
           lock={lock}
         />
       )
@@ -54,6 +84,7 @@ describe('KeyPurchaseConfirmation', () => {
         <KeyPurchaseConfirmation
           address=""
           emailAddress=""
+          cards={cards}
           signPurchaseData={signPurchaseData}
         />
       )
@@ -87,6 +118,7 @@ describe('KeyPurchaseConfirmation', () => {
         account: {
           emailAddress,
           address,
+          cards,
         },
         cart: {
           lock,
@@ -94,6 +126,7 @@ describe('KeyPurchaseConfirmation', () => {
       }
 
       expect(mapStateToProps(state)).toEqual({
+        cards,
         emailAddress,
         address,
         lock,
@@ -109,6 +142,7 @@ describe('KeyPurchaseConfirmation', () => {
       expect(mapStateToProps(state)).toEqual({
         emailAddress: '',
         address: '',
+        cards: [],
       })
     })
   })

--- a/unlock-app/src/__tests__/components/interface/user-account/KeyPurchaseConfirmation.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/user-account/KeyPurchaseConfirmation.test.tsx
@@ -1,11 +1,31 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
+import { Key, Lock } from '../../../../unlockTypes'
 import {
   KeyPurchaseConfirmation,
   mapDispatchToProps,
   mapStateToProps,
 } from '../../../../components/interface/user-account/KeyPurchaseConfirmation'
 import { PurchaseData } from '../../../../actions/user'
+
+const key: Key = {
+  expiration: 123456789000,
+  transactions: [],
+  status: 'confirming',
+  confirmations: 0,
+  lock: 'not a real address',
+  owner: null,
+}
+const lock: Lock = {
+  name: 'My ERC20 Lock',
+  address: 'not a real address',
+  keyPrice: '0.2',
+  expirationDuration: 123456789000,
+  currencyContractAddress: 'not a real currency contract address',
+  key,
+}
+const emailAddress = 'gaben@valve.hats'
+const address = '0xe29ec42F0b620b1c9A716f79A02E9DC5A5f5F98a'
 
 describe('KeyPurchaseConfirmation', () => {
   describe('component', () => {
@@ -14,8 +34,10 @@ describe('KeyPurchaseConfirmation', () => {
       const signPurchaseData = jest.fn((_: PurchaseData) => true)
       const wrapper = rtl.render(
         <KeyPurchaseConfirmation
-          emailAddress="gaben@valve.hats"
+          address={address}
+          emailAddress={emailAddress}
           signPurchaseData={signPurchaseData}
+          lock={lock}
         />
       )
       const submitButton = wrapper.container.getElementsByTagName('button')[0]
@@ -23,6 +45,25 @@ describe('KeyPurchaseConfirmation', () => {
         rtl.fireEvent.click(submitButton)
       }
       expect(signPurchaseData).toHaveBeenCalled()
+    })
+
+    it('is disabled when no lock can be found', () => {
+      expect.assertions(2)
+      const signPurchaseData = jest.fn((_: PurchaseData) => true)
+      const { container, getByText } = rtl.render(
+        <KeyPurchaseConfirmation
+          address=""
+          emailAddress=""
+          signPurchaseData={signPurchaseData}
+        />
+      )
+
+      expect(getByText('No lock found')).not.toBe(null)
+      const submitButton = container.getElementsByTagName('button')[0]
+      if (submitButton) {
+        rtl.fireEvent.click(submitButton)
+      }
+      expect(signPurchaseData).not.toHaveBeenCalled()
     })
   })
 
@@ -40,16 +81,34 @@ describe('KeyPurchaseConfirmation', () => {
   })
 
   describe('mapStateToProps', () => {
-    it('returns the email if in state', () => {
+    it('passes through the present values', () => {
       expect.assertions(1)
       const state = {
         account: {
-          emailAddress: 'gaben@valve.hats',
+          emailAddress,
+          address,
+        },
+        cart: {
+          lock,
         },
       }
 
       expect(mapStateToProps(state)).toEqual({
-        emailAddress: 'gaben@valve.hats',
+        emailAddress,
+        address,
+        lock,
+      })
+    })
+
+    it('provides defaults when values are not available', () => {
+      expect.assertions(1)
+      const state = {
+        account: {},
+        cart: {},
+      }
+      expect(mapStateToProps(state)).toEqual({
+        emailAddress: '',
+        address: '',
       })
     })
   })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -59413,7 +59413,7 @@ Object {
 }
 `;
 
-exports[`Storyshots User Account/Components KeyPurchaseConfirmation, no lock info 1`] = `
+exports[`Storyshots User Account/Components KeyPurchaseConfirmation, no info provided 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -59585,7 +59585,7 @@ Object {
           <span
             class="c4"
           >
-            Visa ending in 5869
+            -
           </span>
         </div>
         <div
@@ -59650,7 +59650,7 @@ Object {
         <span
           class="sc-iwsKbI eRMzSD"
         >
-          Visa ending in 5869
+          -
         </span>
       </div>
       <div
@@ -59738,7 +59738,7 @@ Object {
 }
 `;
 
-exports[`Storyshots User Account/Components KeyPurchaseConfirmation, with lock info 1`] = `
+exports[`Storyshots User Account/Components KeyPurchaseConfirmation, with info 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -59908,7 +59908,7 @@ Object {
           <span
             class="c4"
           >
-            Visa ending in 5869
+            Visa ending in 4242
           </span>
         </div>
         <div
@@ -59973,7 +59973,7 @@ Object {
         <span
           class="sc-iwsKbI eRMzSD"
         >
-          Visa ending in 5869
+          Visa ending in 4242
         </span>
       </div>
       <div

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -59413,7 +59413,332 @@ Object {
 }
 `;
 
-exports[`Storyshots User Account/Components KeyPurchaseConfirmation 1`] = `
+exports[`Storyshots User Account/Components KeyPurchaseConfirmation, no lock info 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c0 {
+  max-width: 896px;
+  display: grid;
+  grid-template-columns: repeat(12,[col-start] 1fr);
+  grid-gap: 16px;
+}
+
+.c0 > * {
+  grid-column: col-start / span 12;
+}
+
+.c1 {
+  font-family: IBM Plex Sans;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 15px;
+  line-height: 19px;
+  color: var(--slate);
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c2 > :first-child {
+  margin-top: auto;
+}
+
+.c3 {
+  font-family: IBM Plex Sans;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 10px;
+  line-height: 13px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--darkgrey);
+}
+
+.c4 {
+  margin: 1rem 0.5rem;
+  height: 21px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: var(--slate);
+}
+
+.c6 {
+  font-family: IBM Plex Sans;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 30px;
+  line-height: 39px;
+  color: var(--slate);
+}
+
+.c7 {
+  font-family: IBM Plex Sans;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 20px;
+  line-height: 26px;
+  color: var(--grey);
+}
+
+.c5 {
+  text-align: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c8 {
+  height: 60px;
+  border: none;
+  background-color: var(--green);
+  border-radius: 0 0 4px 4px;
+  margin-bottom: 1rem;
+  margin-top: 13px;
+  font-size: 16px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  text-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: var(--darkgrey);
+  cursor: disabled;
+  background-color: var(--grey);
+}
+
+@media (min-width:500px) {
+  .c2 {
+    grid-column: span 12;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <span
+          class="c1"
+        >
+          Confirm Purchase
+        </span>
+        <div
+          class="c2"
+        >
+          <span
+            class="c3"
+          >
+            Account
+          </span>
+          <span
+            class="c4"
+          >
+            jenny@googlemail.com
+          </span>
+        </div>
+        <div
+          class="c2"
+        >
+          <span
+            class="c3"
+          >
+            Credit Card
+          </span>
+          <span
+            class="c4"
+          >
+            Visa ending in 5869
+          </span>
+        </div>
+        <div
+          class="c5"
+        >
+          <span
+            class="c6"
+          >
+            $17.19
+          </span>
+          <span
+            class="c7"
+          >
+            <span>
+               - 
+            </span>
+          </span>
+        </div>
+        <button
+          class="c8"
+        >
+          No lock found
+        </button>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-bZQynM heNffj"
+    >
+      <span
+        class="sc-gzVnrw YDiHD"
+      >
+        Confirm Purchase
+      </span>
+      <div
+        class="sc-htoDjs kZXlpS"
+      >
+        <span
+          class="sc-dnqmqq dDvJNJ"
+        >
+          Account
+        </span>
+        <span
+          class="sc-iwsKbI eRMzSD"
+        >
+          jenny@googlemail.com
+        </span>
+      </div>
+      <div
+        class="sc-htoDjs kZXlpS"
+      >
+        <span
+          class="sc-dnqmqq dDvJNJ"
+        >
+          Credit Card
+        </span>
+        <span
+          class="sc-iwsKbI eRMzSD"
+        >
+          Visa ending in 5869
+        </span>
+      </div>
+      <div
+        class="sc-cSHVUG bQaomI"
+      >
+        <span
+          class="sc-fjdhpX dlCkby"
+        >
+          $17.19
+        </span>
+        <span
+          class="sc-jzJRlG htVUTN"
+        >
+          <span>
+             - 
+          </span>
+        </span>
+      </div>
+      <button
+        class="sc-VigVT sc-kAzzGY dELYty"
+      >
+        No lock found
+      </button>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots User Account/Components KeyPurchaseConfirmation, with lock info 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -59597,7 +59922,9 @@ Object {
           <span
             class="c7"
           >
-            30 Days
+            <span>
+              143 days
+            </span>
           </span>
         </div>
         <button
@@ -59660,7 +59987,9 @@ Object {
         <span
           class="sc-jzJRlG htVUTN"
         >
-          30 Days
+          <span>
+            143 days
+          </span>
         </span>
       </div>
       <button

--- a/unlock-app/src/components/interface/user-account/KeyPurchaseConfirmation.tsx
+++ b/unlock-app/src/components/interface/user-account/KeyPurchaseConfirmation.tsx
@@ -17,6 +17,7 @@ interface KeyPurchaseConfirmationProps {
   address: string
   emailAddress: string
   lock?: Lock
+  cards: stripe.Card[]
   signPurchaseData: (d: PurchaseData) => any
 }
 
@@ -26,6 +27,7 @@ export const KeyPurchaseConfirmation = ({
   address,
   emailAddress,
   lock,
+  cards,
   signPurchaseData,
 }: KeyPurchaseConfirmationProps) => {
   const data: PurchaseData = {
@@ -35,6 +37,12 @@ export const KeyPurchaseConfirmation = ({
   const timeRemaining = (
     <Duration seconds={(lock && lock.expirationDuration) || null} round />
   )
+  let card = '-'
+  if (cards.length) {
+    const { brand, last4 } = cards[0]
+    card = `${brand} ending in ${last4}`
+  }
+
   return (
     <Grid>
       <SectionHeader>Confirm Purchase</SectionHeader>
@@ -42,7 +50,7 @@ export const KeyPurchaseConfirmation = ({
         <ItemValue>{emailAddress}</ItemValue>
       </Item>
       <Item title="Credit Card" size="full">
-        <ItemValue>Visa ending in 5869</ItemValue>
+        <ItemValue>{card}</ItemValue>
       </Item>
       <LockInfo price="$17.19" timeRemaining={timeRemaining} />
       {!!lock && (
@@ -63,16 +71,21 @@ interface ReduxState {
   account: {
     emailAddress?: string
     address?: string
+    cards?: stripe.Card[]
   }
   cart: {
     lock?: Lock
   }
 }
-export const mapStateToProps = (state: ReduxState) => ({
-  emailAddress: state.account.emailAddress || '',
-  address: state.account.address || '',
-  lock: state.cart.lock || undefined,
-})
+export const mapStateToProps = (state: ReduxState) => {
+  const { account, cart } = state
+  return {
+    emailAddress: account.emailAddress || '',
+    address: account.address || '',
+    lock: cart.lock || undefined,
+    cards: account.cards || [],
+  }
+}
 
 export default connect(
   mapStateToProps,

--- a/unlock-app/src/components/interface/user-account/KeyPurchaseConfirmation.tsx
+++ b/unlock-app/src/components/interface/user-account/KeyPurchaseConfirmation.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { signPurchaseData, PurchaseData } from '../../../actions/user'
+import { Lock } from '../../../unlockTypes'
 import {
   Grid,
   Item,
@@ -8,23 +9,27 @@ import {
   SectionHeader,
   SubmitButton,
   LockInfo,
+  DisabledButton,
 } from './styles'
 
 interface KeyPurchaseConfirmationProps {
+  address: string
   emailAddress: string
+  lock?: Lock
   signPurchaseData: (d: PurchaseData) => any
 }
 
 // TODO: get credit card in state, pass in here for use
 // TODO: get lock information, use in here
 export const KeyPurchaseConfirmation = ({
+  address,
   emailAddress,
+  lock,
   signPurchaseData,
 }: KeyPurchaseConfirmationProps) => {
-  // TODO: replace this with values from paywall postMessage
   const data: PurchaseData = {
-    recipient: '',
-    lock: '',
+    recipient: address,
+    lock: (lock && lock.address) || '',
   }
   return (
     <Grid>
@@ -36,9 +41,12 @@ export const KeyPurchaseConfirmation = ({
         <ItemValue>Visa ending in 5869</ItemValue>
       </Item>
       <LockInfo price="$17.19" timeRemaining="30 Days" />
-      <SubmitButton onClick={() => signPurchaseData(data)} roundBottomOnly>
-        Confirm Purchase
-      </SubmitButton>
+      {!!lock && (
+        <SubmitButton onClick={() => signPurchaseData(data)} roundBottomOnly>
+          Confirm Purchase
+        </SubmitButton>
+      )}
+      {!lock && <DisabledButton roundBottomOnly>No lock found</DisabledButton>}
     </Grid>
   )
 }
@@ -50,10 +58,16 @@ export const mapDispatchToProps = (dispatch: any) => ({
 interface ReduxState {
   account: {
     emailAddress?: string
+    address?: string
+  }
+  cart: {
+    lock?: Lock
   }
 }
 export const mapStateToProps = (state: ReduxState) => ({
   emailAddress: state.account.emailAddress || '',
+  address: state.account.address || '',
+  lock: state.cart.lock || undefined,
 })
 
 export default connect(

--- a/unlock-app/src/components/interface/user-account/KeyPurchaseConfirmation.tsx
+++ b/unlock-app/src/components/interface/user-account/KeyPurchaseConfirmation.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { signPurchaseData, PurchaseData } from '../../../actions/user'
+import Duration from '../../helpers/Duration'
 import { Lock } from '../../../unlockTypes'
 import {
   Grid,
@@ -31,6 +32,9 @@ export const KeyPurchaseConfirmation = ({
     recipient: address,
     lock: (lock && lock.address) || '',
   }
+  const timeRemaining = (
+    <Duration seconds={(lock && lock.expirationDuration) || null} round />
+  )
   return (
     <Grid>
       <SectionHeader>Confirm Purchase</SectionHeader>
@@ -40,7 +44,7 @@ export const KeyPurchaseConfirmation = ({
       <Item title="Credit Card" size="full">
         <ItemValue>Visa ending in 5869</ItemValue>
       </Item>
-      <LockInfo price="$17.19" timeRemaining="30 Days" />
+      <LockInfo price="$17.19" timeRemaining={timeRemaining} />
       {!!lock && (
         <SubmitButton onClick={() => signPurchaseData(data)} roundBottomOnly>
           Confirm Purchase

--- a/unlock-app/src/components/interface/user-account/styles.tsx
+++ b/unlock-app/src/components/interface/user-account/styles.tsx
@@ -133,7 +133,7 @@ export const CenterRow = styled.div`
 
 interface LockInfoProps {
   price: string
-  timeRemaining: string
+  timeRemaining: string | JSX.Element
 }
 export const LockInfo = ({ price, timeRemaining }: LockInfoProps) => (
   <CenterRow>

--- a/unlock-app/src/stories/interface/UserAccount.stories.js
+++ b/unlock-app/src/stories/interface/UserAccount.stories.js
@@ -56,20 +56,22 @@ storiesOf('User Account/Components', module)
   .add('ChangePassword', () => {
     return <ChangePassword changePassword={changePassword} />
   })
-  .add('KeyPurchaseConfirmation, no lock info', () => {
+  .add('KeyPurchaseConfirmation, no info provided', () => {
     return (
       <KeyPurchaseConfirmation
         emailAddress="jenny@googlemail.com"
         signPurchaseData={signPurchaseData}
+        cards={[]}
       />
     )
   })
-  .add('KeyPurchaseConfirmation, with lock info', () => {
+  .add('KeyPurchaseConfirmation, with info', () => {
     return (
       <KeyPurchaseConfirmation
         emailAddress="jenny@googlemail.com"
         signPurchaseData={signPurchaseData}
         lock={lock}
+        cards={cards}
       />
     )
   })

--- a/unlock-app/src/stories/interface/UserAccount.stories.js
+++ b/unlock-app/src/stories/interface/UserAccount.stories.js
@@ -24,6 +24,23 @@ const cards = [
   },
 ]
 
+const key = {
+  expiration: 12345678,
+  transactions: [],
+  status: 'confirming',
+  confirmations: 0,
+  lock: 'not a real address',
+  owner: null,
+}
+const lock = {
+  name: 'My ERC20 Lock',
+  address: 'not a real address',
+  keyPrice: '0.2',
+  expirationDuration: 12345678,
+  currencyContractAddress: 'not a real currency contract address',
+  key,
+}
+
 storiesOf('User Account/Components', module)
   .add('AccountInfo, no info', () => {
     return <AccountInfo email="" address="" />
@@ -39,11 +56,20 @@ storiesOf('User Account/Components', module)
   .add('ChangePassword', () => {
     return <ChangePassword changePassword={changePassword} />
   })
-  .add('KeyPurchaseConfirmation', () => {
+  .add('KeyPurchaseConfirmation, no lock info', () => {
     return (
       <KeyPurchaseConfirmation
         emailAddress="jenny@googlemail.com"
         signPurchaseData={signPurchaseData}
+      />
+    )
+  })
+  .add('KeyPurchaseConfirmation, with lock info', () => {
+    return (
+      <KeyPurchaseConfirmation
+        emailAddress="jenny@googlemail.com"
+        signPurchaseData={signPurchaseData}
+        lock={lock}
       />
     )
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR makes more parts of `KeyPurchaseConfirmation` real. We now grab a lock if available from the cart and use it to display the amount of time remaining. Additionally, the UI handles the case when a lock is not found by disabling the submit button.

~~At this point, the two remaining pieces for this component are price (need to fetch the price in dollars when we receive a lock in the cart) and cards (need to get cards when a user logs in) both of which are inbound shortly.~~

Cards are available in state, so this PR has been updated to use them. Key price will be fetched when we receive a lock in future work.

<img width="926" alt="image" src="https://user-images.githubusercontent.com/9300702/60822165-e57c8f00-a172-11e9-93d5-23395869879b.png">

<img width="908" alt="image" src="https://user-images.githubusercontent.com/9300702/60822176-f1685100-a172-11e9-8fb7-4b3e6b681c1c.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
