### PR TITLE
Add action and reducer case to set key price in cart

### DIFF
--- a/unlock-app/src/__tests__/actions/keyPurchase.test.ts
+++ b/unlock-app/src/__tests__/actions/keyPurchase.test.ts
@@ -1,4 +1,9 @@
-import { ADD_TO_CART, addToCart } from '../../actions/keyPurchase'
+import {
+  ADD_TO_CART,
+  addToCart,
+  UPDATE_PRICE,
+  updatePrice,
+} from '../../actions/keyPurchase'
 
 describe('keyPurchase actions', () => {
   it('should create an action to add a lock to the cart', () => {
@@ -10,6 +15,16 @@ describe('keyPurchase actions', () => {
         type: ADD_TO_CART,
         lock,
         tip,
+      })
+    )
+  })
+
+  it('should create an action to update the cart with the price of a key to the lock', () => {
+    expect.assertions(1)
+    expect(updatePrice(5.5)).toEqual(
+      expect.objectContaining({
+        type: UPDATE_PRICE,
+        price: 5.5,
       })
     )
   })

--- a/unlock-app/src/__tests__/reducers/cartReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/cartReducer.test.ts
@@ -1,5 +1,5 @@
 import reducer from '../../reducers/cartReducer'
-import { addToCart } from '../../actions/keyPurchase'
+import { addToCart, updatePrice } from '../../actions/keyPurchase'
 
 describe('cartReducer', () => {
   it('should set state when receiving ADD_TO_CART', () => {
@@ -9,6 +9,22 @@ describe('cartReducer', () => {
     expect(reducer(undefined, addToCart({ lock, tip }))).toEqual({
       lock,
       tip,
+    })
+  })
+
+  it('should update existing state with a price when receiving UPDATE_PRICE', () => {
+    expect.assertions(1)
+    const lock = 'a lock'
+    const tip = 'a tip'
+    const currentState = {
+      lock,
+      tip,
+    }
+    const price = 5.5
+    expect(reducer(currentState, updatePrice(5.5))).toEqual({
+      lock,
+      tip,
+      price,
     })
   })
 

--- a/unlock-app/src/actions/keyPurchase.ts
+++ b/unlock-app/src/actions/keyPurchase.ts
@@ -1,7 +1,13 @@
 export const ADD_TO_CART = 'keyPurchase/ADD_TO_CART'
+export const UPDATE_PRICE = 'keyPurchase/UPDATE_PRICE'
 
 export const addToCart = ({ lock, tip }: any) => ({
   type: ADD_TO_CART,
   lock,
   tip,
+})
+
+export const updatePrice = (price: number) => ({
+  type: UPDATE_PRICE,
+  price,
 })

--- a/unlock-app/src/reducers/cartReducer.ts
+++ b/unlock-app/src/reducers/cartReducer.ts
@@ -1,4 +1,4 @@
-import { ADD_TO_CART } from '../actions/keyPurchase'
+import { ADD_TO_CART, UPDATE_PRICE } from '../actions/keyPurchase'
 import { Action } from '../unlockTypes'
 
 // Right now, the "cart" can only contain one lock at a time. It only responds
@@ -7,6 +7,7 @@ import { Action } from '../unlockTypes'
 interface State {
   lock: any
   tip: any
+  price?: number
 }
 
 export const initialState: State = {
@@ -18,6 +19,9 @@ const cartReducer = (state = initialState, action: Action) => {
   if (action.type === ADD_TO_CART) {
     const { lock, tip } = action
     state = { lock, tip }
+  } else if (action.type === UPDATE_PRICE) {
+    const { price } = action
+    state = Object.assign({}, state, { price })
   }
 
   return state


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR adds an action and a case in the cart reducer to update a given lock with its key price in dollars. A follow-up PR will add the relevant method to storageService and dispatch this action once we receive a lock.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
