### PR TITLE
Get key price in cents for user account checkout

### DIFF
--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -509,6 +509,50 @@ describe('StorageService', () => {
     })
   })
 
+  describe('Retrieve a key price', () => {
+    describe('When a request succeeds', () => {
+      it('emits a success', done => {
+        expect.assertions(1)
+        const lockAddress = '0x8276A24C03B7ff9307c5bb9c0f31aa60d284375f'
+        axios.get.mockReturnValue({
+          data: {
+            creditCardProcessing: 450,
+            gasFee: 30,
+            keyPrice: 100,
+            unlockServiceFee: 20,
+          },
+        })
+
+        storageService.getKeyPrice(lockAddress)
+
+        storageService.on(success.getKeyPrice, data => {
+          expect(data).toEqual({
+            creditCardProcessing: 450,
+            gasFee: 30,
+            keyPrice: 100,
+            unlockServiceFee: 20,
+          })
+          done()
+        })
+      })
+    })
+
+    describe('When a request fails', () => {
+      it('emits a failure', done => {
+        expect.assertions(1)
+        const lockAddress = '0x8276A24C03B7ff9307c5bb9c0f31aa60d284375f'
+        axios.get.mockRejectedValue('could not communicate with server')
+
+        storageService.getKeyPrice(lockAddress)
+
+        storageService.on(failure.getKeyPrice, error => {
+          expect(error).toEqual('could not communicate with server')
+          done()
+        })
+      })
+    })
+  })
+
   describe('Retrieve a user recovery phrase', () => {
     describe('When a recovery phrase can be retrieved', () => {
       it('emits a success', done => {

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -329,6 +329,8 @@ export class StorageService extends EventEmitter {
 
   /**
    * Given a lock address (ERC20), return the price of a key for that lock in dollars
+   * On success returns an object of { creditCardProcessing, gasFee, keyPrice, unlockServiceFee }
+   * all denominated in cents.
    * @param {string} lockAddress
    */
   async getKeyPrice(lockAddress) {

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -18,6 +18,7 @@ export const success = {
   getUserRecoveryPhrase: 'getUserRecoveryPhrase.success',
   getCards: 'getCards.success',
   keyPurchase: 'keyPurchase.success',
+  getKeyPrice: 'getKeyPrice.success',
 }
 
 export const failure = {
@@ -33,6 +34,7 @@ export const failure = {
   getUserRecoveryPhrase: 'getUserRecoveryPhrase.failure',
   getCards: 'getCards.failure',
   keyPurchase: 'keyPurchase.failure',
+  getKeyPrice: 'getKeyPrice.failure',
 }
 
 export class StorageService extends EventEmitter {
@@ -322,6 +324,19 @@ export class StorageService extends EventEmitter {
       }
     } catch (error) {
       this.emit(failure.getLockAddressesForUser, error)
+    }
+  }
+
+  /**
+   * Given a lock address (ERC20), return the price of a key for that lock in dollars
+   * @param {string} lockAddress
+   */
+  async getKeyPrice(lockAddress) {
+    try {
+      const result = await axios.get(`${this.host}/price/${lockAddress}`)
+      this.emit(success.getKeyPrice, result.data)
+    } catch (error) {
+      this.emit(failure.getKeyPrice, error)
     }
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds the `getKeyPrice` method to storageService and integrates it with storageMiddleware so that we can display key prices to users in the checkout process.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
