### PR TITLE
add the checkout iframe after the accounts iframe

### DIFF
--- a/paywall/src/__tests__/unlock.js/startup.test.js
+++ b/paywall/src/__tests__/unlock.js/startup.test.js
@@ -146,7 +146,7 @@ describe('unlock.js startup', () => {
       )
       expect(
         fakeWindow.document.body.insertAdjacentElement
-      ).toHaveBeenNthCalledWith(2, 'afterbegin', fakeCheckoutIframe)
+      ).toHaveBeenNthCalledWith(3, 'afterbegin', fakeCheckoutIframe)
     })
 
     it('should create a User Accounts UI iframe with the correct URL', () => {
@@ -160,7 +160,7 @@ describe('unlock.js startup', () => {
       )
       expect(
         fakeWindow.document.body.insertAdjacentElement
-      ).toHaveBeenNthCalledWith(2, 'afterbegin', fakeCheckoutIframe)
+      ).toHaveBeenNthCalledWith(2, 'afterbegin', fakeUserAccountsIframe)
     })
   })
 

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -29,17 +29,17 @@ export default function startup(window: UnlockWindow) {
     window,
     process.env.PAYWALL_URL + '/static/data-iframe.1.0.html' + origin
   )
-  addIframeToDocument(window, dataIframe)
   const checkoutIframe = makeIframe(
     window,
     process.env.PAYWALL_URL + '/checkout' + origin
   )
-  addIframeToDocument(window, checkoutIframe)
   const userAccountsIframe = makeIframe(
     window,
     process.env.USER_IFRAME_URL + origin
   )
+  addIframeToDocument(window, dataIframe)
   addIframeToDocument(window, userAccountsIframe)
+  addIframeToDocument(window, checkoutIframe)
 
   setupPostOffices(window, dataIframe, checkoutIframe, userAccountsIframe)
 }

--- a/tests/helpers/iframes.js
+++ b/tests/helpers/iframes.js
@@ -1,0 +1,7 @@
+// This file is a helper to abstract the retrieval of the iframes on the paywall,
+// so that any re-ordering of frames is controlled in a single location
+
+module.exports = {
+  checkoutIframe: page => page.mainFrame().childFrames()[2],
+  accountsIframe: page => page.mainFrame().childFrames()[1],
+}

--- a/tests/test/adremover-loggedin.test.js
+++ b/tests/test/adremover-loggedin.test.js
@@ -1,9 +1,10 @@
 const url = require('../helpers/url')
 const dashboard = require('../helpers/dashboard')
 const wait = require('../helpers/wait')
-//const debug = require('../helpers/debugging')
+// const debug = require('../helpers/debugging')
+const iframes = require('../helpers/iframes')
 
-//const sit = debug.screenshotOnFail(page)
+// const it = debug.screenshotOnFail(page)
 
 let lockSelectors
 
@@ -93,7 +94,7 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
   it('should show the logo on the checkout UI', async () => {
     expect.assertions(0)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(
       unlockIcon => {
         return !!document.body.querySelector(`img[src="${unlockIcon}"]`)
@@ -106,7 +107,7 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
   it('should show the 3 locks', async () => {
     expect.assertions(0)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(
       lock1 => {
         return !!document.body.querySelector(lock1)
@@ -133,7 +134,7 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
   it('should attempt a key purchase when clicking on a lock, and hide the ads', async () => {
     expect.assertions(2)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     const checkoutBody = await checkoutIframe.$('body')
     await expect(checkoutBody).toClick(lockSelectors[0](''))
     await checkoutIframe.waitForFunction(
@@ -161,7 +162,7 @@ describe('The Unlock Ad Remover Paywall (logged in user)', () => {
     await expect(page).toClick('button', {
       text: 'Unlock the ads free experience!',
     })
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(
       lock1 => {
         const lock = document.body.querySelector(lock1)

--- a/tests/test/adremover-loggedout.test.js
+++ b/tests/test/adremover-loggedout.test.js
@@ -1,6 +1,7 @@
 const url = require('../helpers/url')
 const dashboard = require('../helpers/dashboard')
 const wait = require('../helpers/wait')
+const iframes = require('../helpers/iframes')
 //const debug = require('../helpers/debugging')
 
 //const sit = debug.screenshotOnFail(page)
@@ -62,7 +63,7 @@ describe('The Unlock Ad Remover Paywall (logged out user)', () => {
   it('should show the logo on the checkout UI', async () => {
     expect.assertions(0)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(
       unlockIcon => {
         return !!document.body.querySelector(`img[src="${unlockIcon}"]`)
@@ -75,7 +76,7 @@ describe('The Unlock Ad Remover Paywall (logged out user)', () => {
   it('should show the "no wallet" page', async () => {
     expect.assertions(0)
     await wait.forIframe(2) // wait for 2 iframes to be loaded, the data and checkout iframes
-    const checkoutIframe = page.mainFrame().childFrames()[1]
+    const checkoutIframe = iframes.checkoutIframe(page)
     await checkoutIframe.waitForFunction(() => {
       const text = document.body.querySelector('p').innerText
       return (


### PR DESCRIPTION
# Description

This is a slice-and-dice of #4002.

This changes the ordering of the accounts and checkout iframe so that the checkout iframe will always be beneath the user accounts iframe.

This is necessary because we need user login to be above any checkout. Once the user has logged in, the checkout iframe will still be visible, and can then be used to initiate a key purchase. At this point, the accounts iframe will pop up again to do the credit card purchase, and then once it hides, the checkout iframe can do its transaction monitoring/flag displaying thing.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3767 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
