### PR TITLE
move purchaseKey to web3Proxy, send locks to the account iframe

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
@@ -142,27 +142,6 @@ describe('setupPostOffice', () => {
     expect(fakeUIIframe.className).toBe('unlock start show')
   })
 
-  it('responds to PostMessages.READY_WEB3 by sending PostMessages.WALLET_INFO', async () => {
-    expect.assertions(2)
-
-    sendMessage(fakeDataIframe, PostMessages.READY_WEB3)
-
-    await Promise.resolve() // sync the Promise queue
-
-    expect(fakeUIIframe.contentWindow.postMessage).not.toHaveBeenCalled()
-    expect(fakeDataIframe.contentWindow.postMessage).toHaveBeenCalledWith(
-      {
-        type: PostMessages.WALLET_INFO,
-        payload: {
-          noWallet: true,
-          notEnabled: false,
-          isMetamask: false,
-        },
-      },
-      'http://paywall'
-    )
-  })
-
   it('responds to PostMessages.READY by sending the config to both iframes', () => {
     expect.assertions(8)
 
@@ -440,6 +419,38 @@ describe('setupPostOffice', () => {
         payload: locks,
       },
       'http://paywall'
+    )
+  })
+
+  it('relays PostMessages.UPDATE_LOCKS to the account UI', () => {
+    expect.assertions(1)
+
+    const locks = {
+      lock: {
+        address: 'lock',
+        name: 'string',
+        keyPrice: '1',
+        expirationDuration: 1,
+        key: {
+          expiration: 1,
+          transactions: [],
+          status: 'none',
+          confirmations: 0,
+          owner: null,
+          lock: 'lock',
+        },
+        currencyContractAddress: null,
+      },
+    }
+
+    sendMessage(fakeDataIframe, PostMessages.UPDATE_LOCKS, locks)
+
+    expect(fakeAccountIframe.contentWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: PostMessages.UPDATE_LOCKS,
+        payload: locks,
+      },
+      'http://unlock-app.com'
     )
   })
 })

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -124,6 +124,8 @@ export default function setupPostOffices(
       return locks => {
         // relay the most current lock objects to the checkout UI
         send('checkout', PostMessages.UPDATE_LOCKS, locks)
+        // relay the most current lock objects to the account UI
+        send('account', PostMessages.UPDATE_LOCKS, locks)
       }
     },
   }
@@ -152,13 +154,7 @@ export default function setupPostOffices(
         hideCheckoutModal()
       }
     },
-    [PostMessages.PURCHASE_KEY]: send => {
-      return details => {
-        // relay a request to purchase a key to the data iframe
-        // as the user has clicked on a key in the checkout UI
-        send('data', PostMessages.PURCHASE_KEY, details)
-      }
-    },
+    // purchaseKey is now handled inside the web3Proxy
   }
 
   mapHandlers('data', dataHandlers)

--- a/paywall/src/unlock.js/web3Proxy.ts
+++ b/paywall/src/unlock.js/web3Proxy.ts
@@ -118,5 +118,16 @@ export default function web3Proxy(
     },
   }
 
+  const checkoutHandlers: MessageHandlerTemplates<MessageTypes> = {
+    [PostMessages.PURCHASE_KEY]: postMessage => {
+      return details => {
+        // relay a request to purchase a key to the data iframe
+        // as the user has clicked on a key in the checkout UI
+        postMessage('data', PostMessages.PURCHASE_KEY, details)
+      }
+    },
+  }
+
   mapHandlers('data', handlers)
+  mapHandlers('checkout', checkoutHandlers)
 }


### PR DESCRIPTION
# Description

This is a slice/dice of #4002

It moves purchaseKey handling to `web3Proxy`, and sends locks to the account iframe as well as the checkout iframe.

Note: after #4135 is merged and this is rebased, the diff will be significantly smaller in web3Proxy.test.ts

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3767 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
