### PR TITLE
refactor enable to avoid using exceptions for logic flow

### DIFF
--- a/paywall/src/unlock.js/web3Proxy.ts
+++ b/paywall/src/unlock.js/web3Proxy.ts
@@ -7,11 +7,12 @@ import {
 import { PostMessages, MessageTypes } from '../messageTypes'
 
 let hasWeb3 = true
+const NO_WEB3 = 'no web3 wallet'
 
 export function enable(window: Web3Window) {
   return new window.Promise((resolve, reject) => {
     if (!window.web3 || !window.web3.currentProvider) {
-      return resolve('no web3 wallet')
+      return resolve(NO_WEB3)
     }
     if (!window.web3.currentProvider.enable) return resolve()
     window.web3.currentProvider
@@ -74,7 +75,7 @@ export default function web3Proxy(
         )
         try {
           const result = await enable(window)
-          if (result === 'no web3 wallet') {
+          if (result === NO_WEB3) {
             checkForUserAccountWallet(accountIframe, postMessage)
             return
           }


### PR DESCRIPTION
# Description

This is a slice/dice of #4002 

It refactors `enable` to avoid using exceptions for logic flow (H/T to @akeem).

In preparation for #4002 it also extracts the logic for what will become enabling user accounts into a separate function.

As this is a refactor, no functionality changed, and the tests still pass as-is.

Note: the diff for `web3Proxy.test.ts` will get significantly smaller when #4135 is merged and this is rebased

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3767 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
