### PR TITLE
Dial down scrypt/N constant for faster account interaction

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 0.3.8
+- Moved scrypt/N back to the default from Web3 for speed of account interaction
+
 ## 0.3.7
 
 - Add "for" field for key purchase transactions to describe who the key was purchased for

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/constants.js
+++ b/unlock-js/src/constants.js
@@ -28,8 +28,10 @@ export default {
 // for available params; right now a custom value of scrypt/N covers our needs.
 export const walletEncryptionOptions = {
   scrypt: {
-    // web3 used 1 << 13, ethers default is 1 << 18 so this is a nice middle ground
-    N: 1 << 16,
+    // web3 used 1 << 13, ethers default is 1 << 18. We want speedy wallet
+    // decryption, and Unlock accounts should hold no currency so this tradeoff
+    // is acceptable.
+    N: 1 << 13,
   },
 }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR decreases the N constant for user account private key encryption to the level we used to have with Web3. This may be a temporary change depending on how we can enhance account usage/storage, but we do need it at least for the beginning work on V1.

Benchmarking this change showed an order of magnitude decrease in decryption times.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
