### PR TITLE
poll even for unknown transactions (#4149)

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 0.3.9
+- If a transaction is unknown poll immediately for it (#4149)
+
 ## 0.3.8
 - Moved scrypt/N back to the default from Web3 for speed of account interaction
 

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/v0/web3Service.test.js
+++ b/unlock-js/src/__tests__/v0/web3Service.test.js
@@ -687,12 +687,29 @@ describe('Web3Service', () => {
         expect.assertions(1)
         await versionedNockBeforeEach()
         testsSetup()
+        web3Service._watchTransaction = jest.fn()
 
         const result = await web3Service.getTransaction(
           transaction.hash // no defaults, because we refreshed
         )
 
         expect(result).toBeNull()
+      })
+
+      it('should poll for transaction (#4149)', async () => {
+        expect.assertions(1)
+        await versionedNockBeforeEach()
+        testsSetup()
+
+        web3Service._watchTransaction = jest.fn()
+
+        await web3Service.getTransaction(
+          transaction.hash // no defaults, because we refreshed
+        )
+
+        expect(web3Service._watchTransaction).toHaveBeenCalledWith(
+          transaction.hash
+        )
       })
     })
 

--- a/unlock-js/src/__tests__/v01/web3Service.test.js
+++ b/unlock-js/src/__tests__/v01/web3Service.test.js
@@ -687,12 +687,29 @@ describe('Web3Service', () => {
         expect.assertions(1)
         await versionedNockBeforeEach()
         testsSetup()
+        web3Service._watchTransaction = jest.fn()
 
         const result = await web3Service.getTransaction(
           transaction.hash // no defaults, because we refreshed
         )
 
         expect(result).toBeNull()
+      })
+
+      it('should poll for transaction (#4149)', async () => {
+        expect.assertions(1)
+        await versionedNockBeforeEach()
+        testsSetup()
+
+        web3Service._watchTransaction = jest.fn()
+
+        await web3Service.getTransaction(
+          transaction.hash // no defaults, because we refreshed
+        )
+
+        expect(web3Service._watchTransaction).toHaveBeenCalledWith(
+          transaction.hash
+        )
       })
     })
 

--- a/unlock-js/src/__tests__/v02/web3Service.test.js
+++ b/unlock-js/src/__tests__/v02/web3Service.test.js
@@ -687,12 +687,29 @@ describe('Web3Service', () => {
         expect.assertions(1)
         await versionedNockBeforeEach()
         testsSetup()
+        web3Service._watchTransaction = jest.fn()
 
         const result = await web3Service.getTransaction(
           transaction.hash // no defaults, because we refreshed
         )
 
         expect(result).toBeNull()
+      })
+
+      it('should poll for transaction (#4149)', async () => {
+        expect.assertions(1)
+        await versionedNockBeforeEach()
+        testsSetup()
+
+        web3Service._watchTransaction = jest.fn()
+
+        await web3Service.getTransaction(
+          transaction.hash // no defaults, because we refreshed
+        )
+
+        expect(web3Service._watchTransaction).toHaveBeenCalledWith(
+          transaction.hash
+        )
       })
     })
 

--- a/unlock-js/src/__tests__/v10/web3Service.test.js
+++ b/unlock-js/src/__tests__/v10/web3Service.test.js
@@ -687,12 +687,29 @@ describe('Web3Service', () => {
         expect.assertions(1)
         await versionedNockBeforeEach()
         testsSetup()
+        web3Service._watchTransaction = jest.fn()
 
         const result = await web3Service.getTransaction(
           transaction.hash // no defaults, because we refreshed
         )
 
         expect(result).toBeNull()
+      })
+
+      it('should poll for transaction (#4149)', async () => {
+        expect.assertions(1)
+        await versionedNockBeforeEach()
+        testsSetup()
+
+        web3Service._watchTransaction = jest.fn()
+
+        await web3Service.getTransaction(
+          transaction.hash // no defaults, because we refreshed
+        )
+
+        expect(web3Service._watchTransaction).toHaveBeenCalledWith(
+          transaction.hash
+        )
       })
     })
 

--- a/unlock-js/src/__tests__/v11/web3Service.test.js
+++ b/unlock-js/src/__tests__/v11/web3Service.test.js
@@ -689,12 +689,29 @@ describe('Web3Service', () => {
         expect.assertions(1)
         await versionedNockBeforeEach()
         testsSetup()
+        web3Service._watchTransaction = jest.fn()
 
         const result = await web3Service.getTransaction(
           transaction.hash // no defaults, because we refreshed
         )
 
         expect(result).toBeNull()
+      })
+
+      it('should poll for transaction (#4149)', async () => {
+        expect.assertions(1)
+        await versionedNockBeforeEach()
+        testsSetup()
+
+        web3Service._watchTransaction = jest.fn()
+
+        await web3Service.getTransaction(
+          transaction.hash // no defaults, because we refreshed
+        )
+
+        expect(web3Service._watchTransaction).toHaveBeenCalledWith(
+          transaction.hash
+        )
       })
     })
 

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -423,6 +423,9 @@ export default class Web3Service extends UnlockService {
     ]).then(async ([blockNumber, blockTransaction]) => {
       if (!blockTransaction && !defaults) {
         // transaction is pending, but we have refreshed the page
+        // even though the transaction may not exist, we poll for it
+        // in case it is soon to exist
+        this._watchTransaction(transactionHash)
         return null
       }
       // Let's find the type of contract before we can get its version


### PR DESCRIPTION
# Description

This fixes the lack of polling for new transaction that was plaguing the Forbes test page. The package will need to be released and upgraded and a manual deploy. Until then, #4149 will remain open

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #4149
Refs #4148 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
