### PR TITLE
Prepare the currency switcher to be integration testable

### DIFF
--- a/tests/helpers/dashboard.js
+++ b/tests/helpers/dashboard.js
@@ -17,7 +17,8 @@ const deployLock = async (
   name,
   expirationDuration,
   maxNumberOfKeys,
-  keyPrice
+  keyPrice,
+  useERC20 = false
 ) => {
   await page.goto(url.main('/dashboard'), { waitUntil: 'networkidle2' })
 
@@ -34,6 +35,13 @@ const deployLock = async (
   )
   await expect(page).toFill('input[name="maxNumberOfKeys"]', maxNumberOfKeys)
   await expect(page).toFill('input[name="keyPrice"]', keyPrice)
+  if (useERC20) {
+    // TODO - we should NOT be using div for clickable elements
+    await expect(page).toClick('div.currency')
+    // it takes a split second for the javascript to run,
+    // this ensures we have changed the currency before we create the lock
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
   await expect(page).toClick('button', { text: 'Submit' })
   await wait.untilIsGone('.lockForm')
 

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -15568,10 +15568,9 @@ Object {
             value="0.01"
           />
           <div
-            class="c7"
+            class="currency c7"
           >
-            Use 
-            DEV
+            Use DEV
           </div>
         </span>
         <div>
@@ -15732,10 +15731,9 @@ Object {
           value="0.01"
         />
         <div
-          class="mlglvd-1 sc-1u8ov25-1 wqxwA"
+          class="mlglvd-1 sc-1u8ov25-1 currency wqxwA"
         >
-          Use 
-          DEV
+          Use DEV
         </div>
       </span>
       <div>
@@ -17339,10 +17337,9 @@ Object {
             value="0.01"
           />
           <div
-            class="c7"
+            class="currency c7"
           >
-            Use 
-            DEV
+            Use DEV
           </div>
         </span>
         <div>
@@ -17503,10 +17500,9 @@ Object {
           value="0.01"
         />
         <div
-          class="mlglvd-1 sc-1u8ov25-1 wqxwA"
+          class="mlglvd-1 sc-1u8ov25-1 currency wqxwA"
         >
-          Use 
-          DEV
+          Use DEV
         </div>
       </span>
       <div>
@@ -17952,10 +17948,9 @@ Object {
             value="-1"
           />
           <div
-            class="c7"
+            class="currency c7"
           >
-            Use 
-            DEV
+            Use DEV
           </div>
         </span>
         <div>
@@ -18116,10 +18111,9 @@ Object {
           value="-1"
         />
         <div
-          class="mlglvd-1 sc-1u8ov25-1 wqxwA"
+          class="mlglvd-1 sc-1u8ov25-1 currency wqxwA"
         >
-          Use 
-          DEV
+          Use DEV
         </div>
       </span>
       <div>
@@ -18565,10 +18559,9 @@ Object {
             value="0.01"
           />
           <div
-            class="c7"
+            class="currency c7"
           >
-            Use 
-            DEV
+            Use DEV
           </div>
         </span>
         <div>
@@ -18729,10 +18722,9 @@ Object {
           value="0.01"
         />
         <div
-          class="mlglvd-1 sc-1u8ov25-1 wqxwA"
+          class="mlglvd-1 sc-1u8ov25-1 currency wqxwA"
         >
-          Use 
-          DEV
+          Use DEV
         </div>
       </span>
       <div>
@@ -19178,10 +19170,9 @@ Object {
             value="0.01"
           />
           <div
-            class="c7"
+            class="currency c7"
           >
-            Use 
-            DEV
+            Use DEV
           </div>
         </span>
         <div>
@@ -19342,10 +19333,9 @@ Object {
           value="0.01"
         />
         <div
-          class="mlglvd-1 sc-1u8ov25-1 wqxwA"
+          class="mlglvd-1 sc-1u8ov25-1 currency wqxwA"
         >
-          Use 
-          DEV
+          Use DEV
         </div>
       </span>
       <div>
@@ -24466,10 +24456,9 @@ Object {
               value="0.01"
             />
             <div
-              class="c14"
+              class="currency c14"
             >
-              Use 
-              DEV
+              Use DEV
             </div>
           </span>
           <div>
@@ -24677,10 +24666,9 @@ Object {
             value="0.01"
           />
           <div
-            class="mlglvd-1 sc-1u8ov25-1 wqxwA"
+            class="mlglvd-1 sc-1u8ov25-1 currency wqxwA"
           >
-            Use 
-            DEV
+            Use DEV
           </div>
         </span>
         <div>

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -325,14 +325,9 @@ export class CreatorLockForm extends React.Component {
             data-valid={valid.keyPrice}
             required
           />
-          {isNew && !currency && (
+          {isNew && (
             <LockLabelCurrency onClick={this.toggleCurrency}>
-              Use {ERC20Contract.name}
-            </LockLabelCurrency>
-          )}
-          {isNew && !!currency && (
-            <LockLabelCurrency onClick={this.toggleCurrency}>
-              Use Ether
+              {`Use ${!currency ? ERC20Contract.name : 'Ether'}`}
             </LockLabelCurrency>
           )}
         </FormBalanceWithUnit>
@@ -384,7 +379,9 @@ const LockLabelUnlimited = styled(LockLabel)`
   padding: 5px;
 `
 
-const LockLabelCurrency = styled(LockLabel)`
+const LockLabelCurrency = styled(LockLabel).attrs(() => ({
+  className: 'currency',
+}))`
   font-size: 11px;
   width: 100%;
   padding: 5px;

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -325,9 +325,14 @@ export class CreatorLockForm extends React.Component {
             data-valid={valid.keyPrice}
             required
           />
-          {isNew && (
+          {isNew && !currency && (
             <LockLabelCurrency onClick={this.toggleCurrency}>
-              {`Use ${!currency ? ERC20Contract.name : 'Ether'}`}
+              {`Use ${ERC20Contract.name}`}
+            </LockLabelCurrency>
+          )}
+          {isNew && !!currency && (
+            <LockLabelCurrency onClick={this.toggleCurrency}>
+              Use Ether
             </LockLabelCurrency>
           )}
         </FormBalanceWithUnit>


### PR DESCRIPTION
# Description

This allows us to use the dashboard helper to make new erc20 locks for use by integration tests for the paywall.

It also simplifies the logic of displaying currency, and makes sure that we only have 1 text node `Use DAI` instead of 2, which makes selecting the element to click it in Puppeteer possible.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3848 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
