### PR TITLE
beginning refactor: proxyProvider for user accounts

### DIFF
--- a/paywall/src/__tests__/unlock.js/proxyProvider.test.ts
+++ b/paywall/src/__tests__/unlock.js/proxyProvider.test.ts
@@ -1,0 +1,164 @@
+import {
+  validateMethodCall,
+  proxyProvider,
+  UnvalidatedPayload,
+} from '../../unlock.js/proxyProvider'
+import { MessageTypes, PostMessages } from '../../messageTypes'
+import { PostMessageToIframe } from '../../unlock.js/setupIframeMailbox'
+import { waitFor } from '../../utils/promises'
+
+describe('user accounts proxy provider', () => {
+  describe('validateMethodCall', () => {
+    describe('failures', () => {
+      it('should fail on invalid method calls', () => {
+        expect.assertions(19)
+
+        const badCalls = [
+          false,
+          null,
+          0,
+          NaN,
+          'hi',
+          {},
+          { method: 1 },
+          { method: [] },
+          { method: null },
+          { method: {} },
+          { method: 'hi' },
+          { method: 'hi', params: 1 },
+          { method: 'hi', params: 'oops' },
+          { method: 'hi', params: {} },
+          { method: 'hi', params: [] },
+          { method: 'hi', params: [], id: NaN },
+          { method: 'hi', params: [], id: 'oops' },
+          { method: 'hi', params: [], id: {} },
+          { method: 'hi', params: [], id: [] },
+        ]
+
+        badCalls.forEach((input: any) => {
+          expect(validateMethodCall(input)).toBe(false)
+        })
+      })
+
+      it('should succeed on a valid method call', () => {
+        expect.assertions(1)
+
+        expect(
+          validateMethodCall({
+            method: 'hi',
+            params: [1],
+            id: 1,
+          })
+        ).toBe(true)
+      })
+    })
+  })
+
+  describe('proxyProvider', () => {
+    interface MockMessage extends PostMessageToIframe<MessageTypes> {
+      mock?: any
+    }
+    const proxyAccount = 'hi'
+    const proxyNetwork = 2
+    let postMessage: MockMessage
+
+    async function callProxyProvider(payload: UnvalidatedPayload) {
+      proxyProvider({
+        proxyAccount,
+        proxyNetwork,
+        postMessage,
+        payload,
+      })
+
+      await waitFor(() => postMessage.mock.calls.length)
+    }
+
+    beforeEach(() => {
+      postMessage = jest.fn()
+    })
+
+    it('should do nothing with an invalid method call', async () => {
+      expect.assertions(1)
+
+      proxyProvider({
+        proxyAccount,
+        proxyNetwork,
+        postMessage,
+        payload: {
+          method: 'eth_accounts',
+          id: 2,
+          jsonrpc: '2.0',
+          params: {},
+        },
+      })
+
+      // ensure we have run the course without responding
+      await new Promise(resolve => setTimeout(resolve, 1000))
+
+      expect(postMessage).not.toHaveBeenCalled()
+    })
+
+    it('should post a reply with the proxy account for eth_accounts', async () => {
+      expect.assertions(1)
+
+      await callProxyProvider({
+        method: 'eth_accounts',
+        id: 2,
+        jsonrpc: '2.0',
+        params: [],
+      })
+
+      expect(postMessage).toHaveBeenCalledWith(
+        'data',
+        PostMessages.WEB3_RESULT,
+        {
+          id: 2,
+          error: null,
+          result: { id: 2, jsonrpc: '2.0', result: [proxyAccount] },
+        }
+      )
+    })
+
+    it('should post a reply with the proxy network for net_version', async () => {
+      expect.assertions(1)
+
+      await callProxyProvider({
+        method: 'net_version',
+        id: 23,
+        jsonrpc: '2.0',
+        params: [],
+      })
+
+      expect(postMessage).toHaveBeenCalledWith(
+        'data',
+        PostMessages.WEB3_RESULT,
+        {
+          id: 23,
+          error: null,
+          result: { id: 23, jsonrpc: '2.0', result: proxyNetwork },
+        }
+      )
+    })
+
+    it('should post an error reply for any other method call', async () => {
+      expect.assertions(1)
+
+      await callProxyProvider({
+        method: 'gibberish',
+        id: 23,
+        jsonrpc: '2.0',
+        params: [],
+      })
+
+      expect(postMessage).toHaveBeenCalledWith(
+        'data',
+        PostMessages.WEB3_RESULT,
+        {
+          id: 23,
+          error: '"gibberish" is not supported',
+          result: null,
+        }
+      )
+    })
+  })
+})

--- a/paywall/src/unlock.js/proxyProvider.ts
+++ b/paywall/src/unlock.js/proxyProvider.ts
@@ -1,0 +1,65 @@
+import { PostMessageToIframe } from './setupIframeMailbox'
+import { MessageTypes, PostMessages } from '../messageTypes'
+import { web3MethodCall } from '../windowTypes'
+
+export interface UnvalidatedPayload {
+  method?: any
+  id?: any
+  params?: any
+  jsonrpc?: '2.0'
+}
+
+export function validateMethodCall(payload: UnvalidatedPayload) {
+  if (!payload || typeof payload !== 'object') return false
+  if (!payload.method || typeof payload.method !== 'string') {
+    return false
+  }
+  if (!payload.params || !Array.isArray(payload.params)) {
+    return false
+  }
+  if (typeof payload.id !== 'number' || Math.round(payload.id) !== payload.id) {
+    return false
+  }
+  return true
+}
+
+/**
+ * This is the fake web3 provider we use for user accounts. It knows only
+ * 2 kinds of method calls, account and network.
+ */
+export function proxyProvider({
+  payload,
+  proxyAccount,
+  proxyNetwork,
+  postMessage,
+}: {
+  payload: UnvalidatedPayload
+  proxyAccount: string | null
+  proxyNetwork: string | number
+  postMessage: PostMessageToIframe<MessageTypes>
+}) {
+  if (!validateMethodCall(payload)) return
+  const { method, id } = payload as web3MethodCall
+  switch (method) {
+    case 'eth_accounts':
+      postMessage('data', PostMessages.WEB3_RESULT, {
+        id,
+        error: null,
+        result: { id, jsonrpc: '2.0', result: [proxyAccount] },
+      })
+      break
+    case 'net_version':
+      postMessage('data', PostMessages.WEB3_RESULT, {
+        id,
+        error: null,
+        result: { id, jsonrpc: '2.0', result: proxyNetwork },
+      })
+      break
+    default:
+      postMessage('data', PostMessages.WEB3_RESULT, {
+        id,
+        error: `"${method}" is not supported`,
+        result: null,
+      })
+  }
+}


### PR DESCRIPTION
# Description

This is the actual web3 proxy provider for user accounts. By extracting into its own isolated file, this is simple to test, and simple to reason through. Follow-up will be a `web3ProxyUserAccounts.ts` that uses this to do its thing, and finally a `web3Router` that has the logic to choose between the wallet-based `web3Proxy` and the user-account-based `web3ProxyUserAccounts.ts`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3767 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
