### PR TITLE
app-side postMessage handling now conformant with expectations

### DIFF
--- a/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
@@ -103,13 +103,17 @@ describe('postOfficeMiddleware', () => {
 
       const { store } = makeMiddleware()
       const lock = 'a lock'
-      const tip = 'a tip'
+      const tip = '0'
 
+      mockPostOfficeService.emit(PostOfficeEvents.LockUpdate, {
+        'a lock': 'this is the lock payload',
+      })
       mockPostOfficeService.emit(PostOfficeEvents.KeyPurchase, lock, tip)
+
       expect(mockPostOfficeService.showAccountModal).toHaveBeenCalled()
       expect(store.dispatch).toHaveBeenCalledWith({
         type: ADD_TO_CART,
-        lock,
+        lock: 'this is the lock payload',
         tip,
       })
     })
@@ -117,7 +121,7 @@ describe('postOfficeMiddleware', () => {
 
   describe('handling actions', () => {
     it('should tell the paywall about account changes', () => {
-      expect.assertions(1)
+      expect.assertions(2)
       const { invoke } = makeMiddleware()
       const action = {
         type: SET_ACCOUNT,
@@ -129,6 +133,7 @@ describe('postOfficeMiddleware', () => {
       invoke(action)
 
       expect(mockPostOfficeService.setAccount).toHaveBeenCalledWith('0x123abc')
+      expect(mockPostOfficeService.hideAccountModal).toHaveBeenCalled()
     })
 
     it('should tell the paywall about a purchase and dismiss itself when receiving KEY_PURCHASE_INITIATED', () => {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR makes the unlock-app side of a user account key purchase act the way the paywall needs it to.

1. On load, it sends a ready (handled by postOfficeService) and a null account.
2. When receiving a lock update, it stores the lock information locally to the middleware. (no reducer because the locks object is only ever needed in this middleware)
3. After a user logs in, the account address is sent to the paywall and the account iframe disappears.
4. When it receives a key purchase request, it selects the appropriate lock from the object in [2], and dispatches ADD_TO_CART
5. After the key purchase is confirmed, it sends the transaction initiated postmessage and hides itself.


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4173, #4164 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
