### PR TITLE
fix handling of eth_accounts, and correct the web3 return

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/account.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/account.test.js
@@ -1,4 +1,3 @@
-import ensureWalletReady from '../../../data-iframe/blockchainHandler/ensureWalletReady'
 import pollForChanges from '../../../data-iframe/blockchainHandler/pollForChanges'
 import {
   pollForAccountChange,
@@ -8,9 +7,6 @@ import {
 import { POLLING_INTERVAL } from '../../../constants'
 
 let mockPoll
-jest.mock('../../../data-iframe/blockchainHandler/ensureWalletReady', () =>
-  jest.fn().mockResolvedValue()
-)
 jest.mock('../../../data-iframe/blockchainHandler/pollForChanges', () => {
   mockPoll = jest.fn()
   return mockPoll
@@ -29,17 +25,6 @@ describe('blockchainHandler account handling', () => {
       fakeWeb3Service = {
         getAddressBalance: jest.fn(() => '123'),
       }
-    })
-
-    it('waits for the wallet to be ready', async () => {
-      expect.assertions(1)
-      await pollForAccountChange(
-        fakeWalletService,
-        fakeWeb3Service,
-        onAccountChange
-      )
-
-      expect(ensureWalletReady).toBeCalledWith(fakeWalletService)
     })
 
     it('polls for account changes', async () => {

--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
@@ -44,6 +44,11 @@ describe('setupPostOffice', () => {
     const unlockOrigin = 'http://unlock-app.com'
     fakeWindow = {
       Promise,
+      web3: {
+        currentProvider: {
+          send: jest.fn(),
+        },
+      },
       setInterval: jest.fn(),
       unlockProtocol: {
         loadCheckoutModal: jest.fn(),

--- a/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
+++ b/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
@@ -671,7 +671,7 @@ describe('web3Proxy', () => {
           type: PostMessages.WEB3_RESULT,
           payload: {
             id: 1,
-            error: null,
+            jsonrpc: '2.0',
             result: { id: 1, jsonrpc: '2.0', result: [unlockAccountAddress] },
           },
         })
@@ -701,7 +701,7 @@ describe('web3Proxy', () => {
           type: PostMessages.WEB3_RESULT,
           payload: {
             id: 1,
-            error: null,
+            jsonrpc: '2.0',
             result: { id: 1, jsonrpc: '2.0', result: 1 },
           },
         })
@@ -733,8 +733,8 @@ describe('web3Proxy', () => {
           type: PostMessages.WEB3_RESULT,
           payload: {
             id: 1,
+            jsonrpc: '2.0',
             error: '"unknown_method" is not supported',
-            result: null,
           },
         })
         expect(givenOrigin).toBe('http://fun.times')
@@ -967,7 +967,7 @@ describe('web3Proxy', () => {
           type: PostMessages.WEB3_RESULT,
           payload: {
             id: 1,
-            error: null,
+            jsonrpc: '2.0',
             result: ['hi'],
           },
         })
@@ -1332,12 +1332,13 @@ describe('web3Proxy', () => {
         it('posts the result to the iframe', () => {
           expect.assertions(1)
 
-          expect(fakeIframe.contentWindow.postMessage).toHaveBeenCalledWith(
+          expect(fakeIframe.contentWindow.postMessage).toHaveBeenNthCalledWith(
+            2,
             {
               payload: {
                 error: 'error',
                 id: 1,
-                result: 'result',
+                jsonrpc: '2.0',
               },
               type: PostMessages.WEB3,
             },

--- a/paywall/src/data-iframe/blockchainHandler/account.js
+++ b/paywall/src/data-iframe/blockchainHandler/account.js
@@ -1,4 +1,3 @@
-import ensureWalletReady from './ensureWalletReady'
 import pollForChanges from './pollForChanges'
 import { POLLING_INTERVAL } from '../../constants'
 
@@ -26,10 +25,8 @@ export async function pollForAccountChange(
   web3Service,
   onAccountChange = () => {}
 ) {
-  await ensureWalletReady(walletService)
-
   pollForChanges(
-    async () => await walletService.getAccount() /* getFunc */,
+    () => walletService.getAccount() /* getFunc */,
     (before, after) => before !== after /* hasValueChanged */,
     () => 1 /* continuePolling */,
     async newAccount => {

--- a/paywall/src/data-iframe/blockchainHandler/index.js
+++ b/paywall/src/data-iframe/blockchainHandler/index.js
@@ -155,6 +155,7 @@ export async function listenForAccountNetworkChanges({
     }
   })
 
+  // TODO: investigate whether this can be safely removed
   await ensureWalletReady(walletService)
   const account = await walletService.getAccount()
   const balance = await web3Service.getAddressBalance(account)

--- a/paywall/src/data-iframe/blockchainHandler/index.js
+++ b/paywall/src/data-iframe/blockchainHandler/index.js
@@ -132,14 +132,6 @@ export async function listenForAccountNetworkChanges({
     onChange({ network: id })
   })
 
-  await ensureWalletReady(walletService)
-  const account = await walletService.getAccount()
-  const balance = await web3Service.getAddressBalance(account)
-  setAccount(account)
-  onChange({ account })
-  setAccountBalance(balance)
-  onChange({ balance })
-
   pollForAccountChange(walletService, web3Service, async (account, balance) => {
     setAccount(account)
     onChange({ account })
@@ -162,4 +154,12 @@ export async function listenForAccountNetworkChanges({
       onChange({ keys: {}, transactions: {} })
     }
   })
+
+  await ensureWalletReady(walletService)
+  const account = await walletService.getAccount()
+  const balance = await web3Service.getAddressBalance(account)
+  setAccount(account)
+  onChange({ account })
+  setAccountBalance(balance)
+  onChange({ balance })
 }

--- a/paywall/src/providers/Web3ProxyProvider.js
+++ b/paywall/src/providers/Web3ProxyProvider.js
@@ -42,13 +42,13 @@ export default class Web3ProxyProvider {
     // this is the postMessage version of the callback for sendAsync
     addHandler(POST_MESSAGE_WEB3, web3Result => {
       if (
-        !web3Result.hasOwnProperty('error') ||
+        !web3Result.hasOwnProperty('error') &&
         !web3Result.hasOwnProperty('result')
       ) {
         return
       }
-      const { result, error } = web3Result
-      const id = result.id
+      const { result, error = null } = web3Result
+      const id = web3Result.id
       if (!this.requests[id]) {
         // no pending request with that id
         return
@@ -72,6 +72,7 @@ export default class Web3ProxyProvider {
    */
   async sendAsync({ method, params }, callback) {
     // don't do anything until we have heard back on the wallet status
+    const id = ++this.id // ethers always uses 42, so we will use our own id
     await waitFor(() => !this.waiting)
     if (this.noWallet) {
       callback(new Error('no ethereum wallet is available'))
@@ -81,7 +82,6 @@ export default class Web3ProxyProvider {
       callback(new Error('user declined to enable the ethereum wallet'))
       return
     }
-    const id = ++this.id // ethers always uses 42, so we will use our own id
     this.requests[id] = callback
     const payload = { method, params, id }
     this.postMessage(POST_MESSAGE_WEB3, payload)

--- a/paywall/src/providers/Web3ProxyProvider.js
+++ b/paywall/src/providers/Web3ProxyProvider.js
@@ -47,8 +47,7 @@ export default class Web3ProxyProvider {
       ) {
         return
       }
-      const { result, error = null } = web3Result
-      const id = web3Result.id
+      const { result, error = null, id } = web3Result
       if (!this.requests[id]) {
         // no pending request with that id
         return

--- a/paywall/src/unlock.js/web3Proxy.ts
+++ b/paywall/src/unlock.js/web3Proxy.ts
@@ -74,22 +74,27 @@ export function handleWeb3Call({
     case 'eth_accounts':
       postMessage('data', PostMessages.WEB3_RESULT, {
         id,
-        error: null,
-        result: { id, jsonrpc: '2.0', result: [proxyAccount] },
+        jsonrpc: '2.0',
+        result: {
+          id,
+          jsonrpc: '2.0',
+          // if account is null, we have no account, so return []
+          result: proxyAccount ? [proxyAccount] : [],
+        },
       })
       break
     case 'net_version':
       postMessage('data', PostMessages.WEB3_RESULT, {
         id,
-        error: null,
+        jsonrpc: '2.0',
         result: { id, jsonrpc: '2.0', result: proxyNetwork },
       })
       break
     default:
       postMessage('data', PostMessages.WEB3_RESULT, {
         id,
+        jsonrpc: '2.0',
         error: `"${method}" is not supported`,
-        result: null,
       })
   }
 }
@@ -117,8 +122,7 @@ export default function web3Proxy(
   let canUseUserAccounts: boolean = !window.web3
   let hasNativeWeb3Wallet = !!window.web3
 
-  const useUnlockAccount = () =>
-    !hasNativeWeb3Wallet && proxyAccount && canUseUserAccounts
+  const useUnlockAccount = () => !hasNativeWeb3Wallet && canUseUserAccounts
 
   // we need to listen for the account iframe's READY event, and request the current account and network
   const accountHandlers: MessageHandlerTemplates<MessageTypes> = {
@@ -252,8 +256,8 @@ export default function web3Proxy(
         if (!hasWeb3) {
           return postMessage('data', PostMessages.WEB3, {
             id: payload.id,
+            jsonrpc: '2.0',
             error: 'No web3 wallet is available',
-            result: null,
           })
         }
 
@@ -281,11 +285,21 @@ export default function web3Proxy(
               id,
             },
             (error: string | null, result: any) => {
-              postMessage('data', PostMessages.WEB3_RESULT, {
-                id,
-                error,
-                result,
-              })
+              postMessage(
+                'data',
+                PostMessages.WEB3_RESULT,
+                error
+                  ? {
+                      id,
+                      error,
+                      jsonrpc: '2.0',
+                    }
+                  : {
+                      id,
+                      result,
+                      jsonrpc: '2.0',
+                    }
+              )
             }
           )
       }

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -53,11 +53,23 @@ export interface web3MethodCall {
   id: number
 }
 
-export interface web3MethodResult {
+interface web3MethodErrorResult {
   id: number
-  error: null | string
-  result: any
+  error: string
+  jsonrpc: '2.0'
 }
+
+interface web3MethodSuccessResult {
+  id: number
+  jsonrpc: '2.0'
+  result: {
+    id: number
+    jsonrpc: '2.0'
+    result: any
+  }
+}
+
+export type web3MethodResult = web3MethodErrorResult | web3MethodSuccessResult
 export type web3Callback = (error: string | null, result: any) => void
 export type web3Send = (
   methodCall: web3MethodCall,


### PR DESCRIPTION
# Description

In order to fix handling of eth_accounts, this does 3 things:

1. remove the requirement that an account exist to do account polling
2. fix the shape of the object returned from our proxyProvider
3. return `[]` instead of `[null]` when there is no account.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #4165

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
