### PR TITLE
ignore events from erc20 contracts, clean up and unify erc20 abi

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.10
 - Add "for" field for pending/submitted key purchase transactions (#4190)
+- ignore events from other contracts (erc20 for instance) (#4187)
 
 ## 0.3.9
 - If a transaction is unknown poll immediately for it (#4149)

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/v0/web3Service.test.js
+++ b/unlock-js/src/__tests__/v0/web3Service.test.js
@@ -11,6 +11,7 @@ import utils from '../../utils'
 import v0 from '../../v0'
 
 import { KEY_ID } from '../../constants'
+import erc20abi from '../../erc20abi'
 
 const account = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
 const blockTime = 3
@@ -224,6 +225,7 @@ describe('Web3Service', () => {
           blockNumber: 123,
           logs: [
             {
+              address: lockAddress,
               data: encoder.encode(
                 ['address', 'address'],
                 [unlockAddress, lockAddress]
@@ -256,7 +258,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.Unlock,
-          receipt
+          receipt,
+          lockAddress
         )
         expect(web3Service.getLock).toHaveBeenCalledWith(checksumLockAddress)
       })
@@ -299,7 +302,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
 
@@ -345,7 +349,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
 
@@ -380,8 +385,41 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
+          receipt,
+          lockAddress
+        )
+      })
+
+      it('ignores events from outside our contract', async () => {
+        expect.assertions(1)
+        await versionedNockBeforeEach()
+        const EventInfo = new ethers.utils.Interface(erc20abi)
+        const receipt = {
+          blockNumber: 123,
+          logs: [
+            {
+              // fake ERC20 contract address
+              address: '0x1234123456789012345678901234567890567890',
+              data: encoder.encode(['uint'], [2]),
+              topics: [
+                EventInfo.events['Transfer(address,address,uint256)'].topic,
+                encoder.encode(['address'], [unlockAddress]),
+                encoder.encode(['address'], [lockAddress]),
+                encoder.encode(['uint'], [2]),
+              ],
+            },
+          ],
+        }
+
+        web3Service.emitContractEvent = jest.fn()
+
+        web3Service._parseTransactionLogsFromReceipt(
+          'hash',
+          UnlockVersion.PublicLock,
           receipt
         )
+
+        expect(web3Service.emitContractEvent).not.toHaveBeenCalled()
       })
     })
   })
@@ -954,7 +992,7 @@ describe('Web3Service', () => {
       })
 
       it('should _parseTransactionLogsFromReceipt with the Unlock abi if the address is one of the Unlock contract', async done => {
-        expect.assertions(5)
+        expect.assertions(6)
         await versionedNockBeforeEach()
         testsSetup()
         const transactionReceipt = {
@@ -976,7 +1014,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt = (
           transactionHash,
           contract,
-          receipt
+          receipt,
+          lockAddress
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
           expect(contract).toEqual(UnlockVersion.Unlock)
@@ -987,6 +1026,7 @@ describe('Web3Service', () => {
             UnlockVersion.Unlock,
             blockTransaction.input
           )
+          expect(lockAddress).toBe(blockTransaction.to)
           done()
         }
         web3Service.unlockContractAddress = blockTransaction.to
@@ -995,7 +1035,7 @@ describe('Web3Service', () => {
       })
 
       it('should _parseTransactionLogsFromReceipt with the Lock abi otherwise', async done => {
-        expect.assertions(5)
+        expect.assertions(6)
         await versionedNockBeforeEach()
         testsSetup()
         const transactionReceipt = {
@@ -1016,7 +1056,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt = (
           transactionHash,
           contract,
-          receipt
+          receipt,
+          lockAddress
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
           expect(contract).toEqual(UnlockVersion.PublicLock)
@@ -1026,6 +1067,7 @@ describe('Web3Service', () => {
             UnlockVersion.PublicLock,
             blockTransaction.input
           )
+          expect(lockAddress).toBe(blockTransaction.to)
           done()
         }
 

--- a/unlock-js/src/__tests__/v01/web3Service.test.js
+++ b/unlock-js/src/__tests__/v01/web3Service.test.js
@@ -224,6 +224,7 @@ describe('Web3Service', () => {
           blockNumber: 123,
           logs: [
             {
+              address: lockAddress,
               data: encoder.encode(
                 ['address', 'address'],
                 [unlockAddress, lockAddress]
@@ -256,7 +257,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.Unlock,
-          receipt
+          receipt,
+          lockAddress
         )
         expect(web3Service.getLock).toHaveBeenCalledWith(checksumLockAddress)
       })
@@ -299,7 +301,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
 
@@ -345,7 +348,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
 
@@ -380,7 +384,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
     })
@@ -954,7 +959,7 @@ describe('Web3Service', () => {
       })
 
       it('should _parseTransactionLogsFromReceipt with the Unlock abi if the address is one of the Unlock contract', async done => {
-        expect.assertions(5)
+        expect.assertions(6)
         await versionedNockBeforeEach()
         testsSetup()
         const transactionReceipt = {
@@ -976,7 +981,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt = (
           transactionHash,
           contract,
-          receipt
+          receipt,
+          lockAddress
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
           expect(contract).toEqual(UnlockVersion.Unlock)
@@ -987,6 +993,7 @@ describe('Web3Service', () => {
             UnlockVersion.Unlock,
             blockTransaction.input
           )
+          expect(lockAddress).toBe(blockTransaction.to)
           done()
         }
         web3Service.unlockContractAddress = blockTransaction.to
@@ -995,7 +1002,7 @@ describe('Web3Service', () => {
       })
 
       it('should _parseTransactionLogsFromReceipt with the Lock abi otherwise', async done => {
-        expect.assertions(5)
+        expect.assertions(6)
         await versionedNockBeforeEach()
         testsSetup()
         const transactionReceipt = {
@@ -1016,7 +1023,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt = (
           transactionHash,
           contract,
-          receipt
+          receipt,
+          lockAddress
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
           expect(contract).toEqual(UnlockVersion.PublicLock)
@@ -1026,6 +1034,7 @@ describe('Web3Service', () => {
             UnlockVersion.PublicLock,
             blockTransaction.input
           )
+          expect(lockAddress).toBe(blockTransaction.to)
           done()
         }
 

--- a/unlock-js/src/__tests__/v02/web3Service.test.js
+++ b/unlock-js/src/__tests__/v02/web3Service.test.js
@@ -20,6 +20,7 @@ const requiredConfirmations = 12
 const unlockAddress = '0xc43efE2C7116CB94d563b5A9D68F260CCc44256F'
 const lockAddress = '0x5ed6a5bb0fda25eac3b5d03fa875cb60a4639d8e'
 const checksumLockAddress = '0x5ED6a5BB0fDA25eaC3B5D03fa875cB60A4639d8E'
+const fakeERC20ContractAddress = '0x1234123456789012345678901234567890567890'
 
 const transaction = {
   status: 'mined',
@@ -398,8 +399,7 @@ describe('Web3Service', () => {
           blockNumber: 123,
           logs: [
             {
-              // fake ERC20 contract address
-              address: '0x1234123456789012345678901234567890567890',
+              address: fakeERC20ContractAddress,
               data: encoder.encode(['uint'], [2]),
               topics: [
                 EventInfo.events['Transfer(address,address,uint256)'].topic,

--- a/unlock-js/src/__tests__/v10/web3Service.test.js
+++ b/unlock-js/src/__tests__/v10/web3Service.test.js
@@ -20,6 +20,7 @@ const requiredConfirmations = 12
 const unlockAddress = '0xc43efE2C7116CB94d563b5A9D68F260CCc44256F'
 const lockAddress = '0x5ed6a5bb0fda25eac3b5d03fa875cb60a4639d8e'
 const checksumLockAddress = '0x5ED6a5BB0fDA25eaC3B5D03fa875cB60A4639d8E'
+const fakeERC20ContractAddress = '0x1234123456789012345678901234567890567890'
 
 const transaction = {
   status: 'mined',
@@ -399,8 +400,7 @@ describe('Web3Service', () => {
         blockNumber: 123,
         logs: [
           {
-            // fake ERC20 contract address
-            address: '0x1234123456789012345678901234567890567890',
+            address: fakeERC20ContractAddress,
             data: encoder.encode(['uint'], [2]),
             topics: [
               EventInfo.events['Transfer(address,address,uint256)'].topic,

--- a/unlock-js/src/__tests__/v10/web3Service.test.js
+++ b/unlock-js/src/__tests__/v10/web3Service.test.js
@@ -11,6 +11,7 @@ import utils from '../../utils'
 import v10 from '../../v10'
 
 import { KEY_ID } from '../../constants'
+import erc20abi from '../../erc20abi'
 
 const account = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
 const blockTime = 3
@@ -224,6 +225,7 @@ describe('Web3Service', () => {
           blockNumber: 123,
           logs: [
             {
+              address: lockAddress,
               data: encoder.encode(
                 ['address', 'address'],
                 [unlockAddress, lockAddress]
@@ -256,7 +258,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.Unlock,
-          receipt
+          receipt,
+          lockAddress
         )
         expect(web3Service.getLock).toHaveBeenCalledWith(checksumLockAddress)
       })
@@ -299,7 +302,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
 
@@ -345,7 +349,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
 
@@ -380,9 +385,42 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
+    })
+
+    it('ignores events from outside our contract', async () => {
+      expect.assertions(1)
+      await versionedNockBeforeEach()
+      const EventInfo = new ethers.utils.Interface(erc20abi)
+      const receipt = {
+        blockNumber: 123,
+        logs: [
+          {
+            // fake ERC20 contract address
+            address: '0x1234123456789012345678901234567890567890',
+            data: encoder.encode(['uint'], [2]),
+            topics: [
+              EventInfo.events['Transfer(address,address,uint256)'].topic,
+              encoder.encode(['address'], [unlockAddress]),
+              encoder.encode(['address'], [lockAddress]),
+              encoder.encode(['uint'], [2]),
+            ],
+          },
+        ],
+      }
+
+      web3Service.emitContractEvent = jest.fn()
+
+      web3Service._parseTransactionLogsFromReceipt(
+        'hash',
+        UnlockVersion.PublicLock,
+        receipt
+      )
+
+      expect(web3Service.emitContractEvent).not.toHaveBeenCalled()
     })
   })
 
@@ -954,7 +992,7 @@ describe('Web3Service', () => {
       })
 
       it('should _parseTransactionLogsFromReceipt with the Unlock abi if the address is one of the Unlock contract', async done => {
-        expect.assertions(5)
+        expect.assertions(6)
         await versionedNockBeforeEach()
         testsSetup()
         const transactionReceipt = {
@@ -976,7 +1014,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt = (
           transactionHash,
           contract,
-          receipt
+          receipt,
+          lockAddress
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
           expect(contract).toEqual(UnlockVersion.Unlock)
@@ -987,6 +1026,7 @@ describe('Web3Service', () => {
             UnlockVersion.Unlock,
             blockTransaction.input
           )
+          expect(lockAddress).toBe(blockTransaction.to)
           done()
         }
         web3Service.unlockContractAddress = blockTransaction.to
@@ -995,7 +1035,7 @@ describe('Web3Service', () => {
       })
 
       it('should _parseTransactionLogsFromReceipt with the Lock abi otherwise', async done => {
-        expect.assertions(5)
+        expect.assertions(6)
         await versionedNockBeforeEach()
         testsSetup()
         const transactionReceipt = {
@@ -1016,7 +1056,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt = (
           transactionHash,
           contract,
-          receipt
+          receipt,
+          lockAddress
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
           expect(contract).toEqual(UnlockVersion.PublicLock)
@@ -1026,6 +1067,7 @@ describe('Web3Service', () => {
             UnlockVersion.PublicLock,
             blockTransaction.input
           )
+          expect(lockAddress).toBe(blockTransaction.to)
           done()
         }
 

--- a/unlock-js/src/__tests__/v11/web3Service.test.js
+++ b/unlock-js/src/__tests__/v11/web3Service.test.js
@@ -20,6 +20,7 @@ const requiredConfirmations = 12
 const unlockAddress = '0xc43efE2C7116CB94d563b5A9D68F260CCc44256F'
 const lockAddress = '0x5ed6a5bb0fda25eac3b5d03fa875cb60a4639d8e'
 const checksumLockAddress = '0x5ED6a5BB0fDA25eaC3B5D03fa875cB60A4639d8E'
+const fakeERC20ContractAddress = '0x1234123456789012345678901234567890567890'
 
 const transaction = {
   status: 'mined',
@@ -400,8 +401,7 @@ describe('Web3Service', () => {
           blockNumber: 123,
           logs: [
             {
-              // fake ERC20 contract address
-              address: '0x1234123456789012345678901234567890567890',
+              address: fakeERC20ContractAddress,
               data: encoder.encode(['uint'], [2]),
               topics: [
                 EventInfo.events['Transfer(address,address,uint256)'].topic,

--- a/unlock-js/src/__tests__/v11/web3Service.test.js
+++ b/unlock-js/src/__tests__/v11/web3Service.test.js
@@ -11,6 +11,7 @@ import utils from '../../utils'
 import v11 from '../../v11'
 
 import { KEY_ID } from '../../constants'
+import erc20abi from '../../erc20abi'
 
 const account = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
 const blockTime = 3
@@ -224,6 +225,7 @@ describe('Web3Service', () => {
           blockNumber: 123,
           logs: [
             {
+              address: lockAddress,
               data: encoder.encode(
                 ['address', 'address'],
                 [unlockAddress, lockAddress]
@@ -256,7 +258,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.Unlock,
-          receipt
+          receipt,
+          lockAddress
         )
         expect(web3Service.getLock).toHaveBeenCalledWith(checksumLockAddress)
       })
@@ -299,7 +302,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
 
@@ -345,7 +349,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
       })
 
@@ -382,8 +387,42 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt(
           'hash',
           UnlockVersion.PublicLock,
-          receipt
+          receipt,
+          lockAddress
         )
+      })
+
+      it('ignores events from outside our contract', async () => {
+        expect.assertions(1)
+        await versionedNockBeforeEach()
+        const EventInfo = new ethers.utils.Interface(erc20abi)
+        const receipt = {
+          blockNumber: 123,
+          logs: [
+            {
+              // fake ERC20 contract address
+              address: '0x1234123456789012345678901234567890567890',
+              data: encoder.encode(['uint'], [2]),
+              topics: [
+                EventInfo.events['Transfer(address,address,uint256)'].topic,
+                encoder.encode(['address'], [unlockAddress]),
+                encoder.encode(['address'], [lockAddress]),
+                encoder.encode(['uint'], [2]),
+              ],
+            },
+          ],
+        }
+
+        web3Service.emitContractEvent = jest.fn()
+
+        web3Service._parseTransactionLogsFromReceipt(
+          'hash',
+          UnlockVersion.PublicLock,
+          receipt,
+          lockAddress
+        )
+
+        expect(web3Service.emitContractEvent).not.toHaveBeenCalled()
       })
     })
   })
@@ -956,7 +995,7 @@ describe('Web3Service', () => {
       })
 
       it('should _parseTransactionLogsFromReceipt with the Unlock abi if the address is one of the Unlock contract', async done => {
-        expect.assertions(5)
+        expect.assertions(6)
         await versionedNockBeforeEach()
         testsSetup()
         const transactionReceipt = {
@@ -978,7 +1017,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt = (
           transactionHash,
           contract,
-          receipt
+          receipt,
+          lockAddress
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
           expect(contract).toEqual(UnlockVersion.Unlock)
@@ -989,6 +1029,7 @@ describe('Web3Service', () => {
             UnlockVersion.Unlock,
             blockTransaction.input
           )
+          expect(lockAddress).toBe(blockTransaction.to)
           done()
         }
         web3Service.unlockContractAddress = blockTransaction.to
@@ -997,7 +1038,7 @@ describe('Web3Service', () => {
       })
 
       it('should _parseTransactionLogsFromReceipt with the Lock abi otherwise', async done => {
-        expect.assertions(5)
+        expect.assertions(6)
         await versionedNockBeforeEach()
         testsSetup()
         const transactionReceipt = {
@@ -1018,7 +1059,8 @@ describe('Web3Service', () => {
         web3Service._parseTransactionLogsFromReceipt = (
           transactionHash,
           contract,
-          receipt
+          receipt,
+          lockAddress
         ) => {
           expect(transactionHash).toEqual(transaction.hash)
           expect(contract).toEqual(UnlockVersion.PublicLock)
@@ -1028,6 +1070,7 @@ describe('Web3Service', () => {
             UnlockVersion.PublicLock,
             blockTransaction.input
           )
+          expect(lockAddress).toBe(blockTransaction.to)
           done()
         }
 

--- a/unlock-js/src/erc20.js
+++ b/unlock-js/src/erc20.js
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers'
 import utils from './utils'
 import FastJsonRpcSigner from './FastJsonRpcSigner'
+import erc20abi from './erc20abi'
 
 // This file provides ways to interact with an ERC20 contract
 export async function getErc20BalanceForAddress(
@@ -8,11 +9,7 @@ export async function getErc20BalanceForAddress(
   lockContractAddress,
   provider
 ) {
-  const contract = new ethers.Contract(
-    erc20ContractAddress,
-    ['function balanceOf(address tokenOwner) public view returns (uint)'],
-    provider
-  )
+  const contract = new ethers.Contract(erc20ContractAddress, erc20abi, provider)
   const balance = await contract.balanceOf(lockContractAddress)
   return utils.hexToNumberString(balance)
 }
@@ -23,11 +20,7 @@ export async function getErc20BalanceForAddress(
  * @param {*} provider
  */
 export async function getErc20Decimals(erc20ContractAddress, provider) {
-  const contract = new ethers.Contract(
-    erc20ContractAddress,
-    ['function decimals() public view returns (uint)'],
-    provider
-  )
+  const contract = new ethers.Contract(erc20ContractAddress, erc20abi, provider)
   const decimals = await contract.decimals()
   return utils.toNumber(decimals)
 }
@@ -43,11 +36,7 @@ export async function approveTransfer(
   // TODO: add test to ensure that this is actually retuning instantly?
   const signer = new FastJsonRpcSigner(provider.getSigner())
 
-  const contract = new ethers.Contract(
-    erc20ContractAddress,
-    ['function approve(address spender, uint256 value) returns (bool value)'],
-    signer
-  )
+  const contract = new ethers.Contract(erc20ContractAddress, erc20abi, signer)
   return contract.approve(lockContractAddress, value)
 }
 

--- a/unlock-js/src/erc20abi.js
+++ b/unlock-js/src/erc20abi.js
@@ -1,0 +1,14 @@
+const erc20abi = [
+  'function totalSupply() public view returns (uint)',
+  'function balanceOf(address tokenOwner) public view returns (uint balance)',
+  'function decimals() public view returns (uint decimals)',
+  'function allowance(address tokenOwner, address spender) public view returns (uint remaining)',
+  'function transfer(address to, uint tokens) public returns (bool success)',
+  'function approve(address spender, uint tokens) public returns (bool success)',
+  'function transferFrom(address from, address to, uint tokens) public returns (bool success)',
+
+  'event Transfer(address indexed from, address indexed to, uint tokens)',
+  'event Approval(address indexed tokenOwner, address indexed spender, uint tokens)',
+]
+
+export default erc20abi

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -273,17 +273,21 @@ export default class Web3Service extends UnlockService {
    * @param {*} transactionHash
    * @param {*} contract
    * @param {*} transactionReceipt
+   * @param {string} contractAddress
    */
   _parseTransactionLogsFromReceipt(
     transactionHash,
     contract,
-    transactionReceipt
+    transactionReceipt,
+    contractAddress
   ) {
-    const metadata = new ethers.utils.Interface(contract.abi)
+    const parser = new ethers.utils.Interface(contract.abi)
 
     transactionReceipt.logs.forEach(log => {
+      // ignore events not from our contract
+      if (log.address !== contractAddress) return
       // For each log, let's find which event it is
-      const logInfo = metadata.parseLog(log)
+      const logInfo = parser.parseLog(log)
 
       this.emitContractEvent(
         transactionHash,
@@ -498,7 +502,8 @@ export default class Web3Service extends UnlockService {
         return this._parseTransactionLogsFromReceipt(
           transactionHash,
           contract,
-          transactionReceipt
+          transactionReceipt,
+          contractAddress
         )
       }
     })


### PR DESCRIPTION
# Description

This PR addresses a couple of erc20 issues. First, is the p-1  bug #4187 which is causing `getTransaction` to fail on erc20 key purchases. The second is just unifying the erc20 abi in a single file to provide a single point of failure for the abi we use.

Note for ease of reviewing:

There are 10 files. Only 2 are really relevant, they're at the bottom of the PR. The rest are the same changes to every `v*/web3Service.test.js`  and the `CHANGELOG`/`package.json` updates.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4187

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
