### PR TITLE
use a local transaction cache for web3ServiceHub

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/web3ServiceHub.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/web3ServiceHub.test.js
@@ -1,6 +1,4 @@
-import web3ServiceHub, {
-  __clearCache,
-} from '../../../data-iframe/blockchainHandler/web3ServiceHub'
+import web3ServiceHub from '../../../data-iframe/blockchainHandler/web3ServiceHub'
 import { setAccount } from '../../../data-iframe/cacheHandler'
 import { TRANSACTION_TYPES } from '../../../constants'
 
@@ -8,7 +6,6 @@ describe('web3ServiceHub', () => {
   let fakeWindow
 
   function makeFakeWindow() {
-    __clearCache()
     fakeWindow = {
       storage: {},
       localStorage: {

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/web3ServiceHub.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/web3ServiceHub.test.js
@@ -1,10 +1,14 @@
-import web3ServiceHub from '../../../data-iframe/blockchainHandler/web3ServiceHub'
-import { setTransaction, setAccount } from '../../../data-iframe/cacheHandler'
+import web3ServiceHub, {
+  __clearCache,
+} from '../../../data-iframe/blockchainHandler/web3ServiceHub'
+import { setAccount } from '../../../data-iframe/cacheHandler'
 import { TRANSACTION_TYPES } from '../../../constants'
 
 describe('web3ServiceHub', () => {
   let fakeWindow
+
   function makeFakeWindow() {
+    __clearCache()
     fakeWindow = {
       storage: {},
       localStorage: {
@@ -90,7 +94,7 @@ describe('web3ServiceHub', () => {
     })
 
     it('should use the cached transaction as a base', async () => {
-      expect.assertions(1)
+      expect.assertions(2)
 
       await web3ServiceHub({
         web3Service,
@@ -100,22 +104,29 @@ describe('web3ServiceHub', () => {
 
       const listener = getTransactionListener()
 
-      await setTransaction(fakeWindow, {
+      await await listener('hi', {
         hash: 'hi',
         thing: 'value',
       })
 
       await listener('hi', { another: 'thing' })
 
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          transaction: {
-            hash: 'hi',
-            thing: 'value',
-            another: 'thing',
-          },
-        })
-      )
+      expect(onChange).toHaveBeenNthCalledWith(1, {
+        transaction: {
+          hash: 'hi',
+          thing: 'value',
+          blockNumber: Number.MAX_SAFE_INTEGER,
+        },
+      })
+
+      expect(onChange).toHaveBeenNthCalledWith(2, {
+        transaction: {
+          hash: 'hi',
+          thing: 'value',
+          another: 'thing',
+          blockNumber: Number.MAX_SAFE_INTEGER,
+        },
+      })
     })
 
     it('should use an empty transaction as a base if it is not cached', async () => {

--- a/paywall/src/data-iframe/blockchainHandler/web3ServiceHub.js
+++ b/paywall/src/data-iframe/blockchainHandler/web3ServiceHub.js
@@ -1,13 +1,5 @@
 import { getAccount } from '../cacheHandler'
 
-let transactionCache = {}
-
-/**
- * for unit testing purposes
- */
-export function __clearCache() {
-  transactionCache = {}
-}
 /**
  * Listen for transaction updates, update the transaction and key that it affects
  * if the transaction is for a key purchase.
@@ -22,6 +14,7 @@ export default async function web3ServiceHub({
   web3Service,
   onChange,
   window,
+  transactionCache = {},
 }) {
   web3Service.on('transaction.updated', async (hash, update) => {
     const account = await getAccount(window)

--- a/paywall/src/data-iframe/blockchainHandler/web3ServiceHub.js
+++ b/paywall/src/data-iframe/blockchainHandler/web3ServiceHub.js
@@ -1,5 +1,13 @@
-import { getTransactions, getAccount } from '../cacheHandler'
+import { getAccount } from '../cacheHandler'
 
+let transactionCache = {}
+
+/**
+ * for unit testing purposes
+ */
+export function __clearCache() {
+  transactionCache = {}
+}
 /**
  * Listen for transaction updates, update the transaction and key that it affects
  * if the transaction is for a key purchase.
@@ -17,10 +25,9 @@ export default async function web3ServiceHub({
 }) {
   web3Service.on('transaction.updated', async (hash, update) => {
     const account = await getAccount(window)
-    const transactions = await getTransactions(window)
     // we need to build on the previous transaction because 'transaction.updated'
     // never returns the full transaction, we will rely upon the cache
-    const oldTransaction = transactions[hash] || {
+    const oldTransaction = transactionCache[hash] || {
       hash,
       blockNumber: Number.MAX_SAFE_INTEGER,
     }
@@ -28,6 +35,7 @@ export default async function web3ServiceHub({
       ...oldTransaction,
       ...update,
     }
+    transactionCache[hash] = transaction
     // report the changed transaction to syncToCache
     onChange({
       transaction,


### PR DESCRIPTION
# Description

This removes the possibility of race conditions where prior transactions could be stale by using an in-memory cache local to the `web3ServiceHub`. This is necessary because `'transaction.updated'` events do not contain the full transaction, only the portions that have been changed.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #4191

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
