### PR TITLE
Improve error handling in the data iframe

### DIFF
--- a/paywall/src/__tests__/data-iframe/start/makePurchaseCallback.test.js
+++ b/paywall/src/__tests__/data-iframe/start/makePurchaseCallback.test.js
@@ -111,10 +111,12 @@ describe('makePurchaseCallback', () => {
     it('should pass on any error thrown in keyPurchase', async () => {
       expect.assertions(1)
 
-      walletService.purchaseKey = jest.fn().mockRejectedValue(new Error('fail'))
+      const error = new Error('fail')
+
+      walletService.purchaseKey = jest.fn().mockRejectedValue(error)
 
       await purchase('lock')
-      expect(update).toHaveBeenCalledWith({ error: 'fail' })
+      expect(update).toHaveBeenCalledWith({ error })
     })
 
     it('should initiate monitoring of key purchase transaction', async () => {
@@ -142,14 +144,16 @@ describe('makePurchaseCallback', () => {
     it('should pass on any error thrown in monitoring key purchase transaction', async () => {
       expect.assertions(1)
 
+      const error = new Error('fail')
+
       walletService.on = (type, cb) => {
         if (type === 'error') {
           // trigger an error in the midst of listening for the submitted transaction
-          cb(new Error('fail'))
+          cb(error)
         }
       }
       await purchase('lock')
-      expect(update).toHaveBeenCalledWith({ error: 'fail' })
+      expect(update).toHaveBeenCalledWith({ error })
     })
   })
 })

--- a/paywall/src/data-iframe/postOffice.js
+++ b/paywall/src/data-iframe/postOffice.js
@@ -135,6 +135,10 @@ export default function postOffice(window, requiredConfirmations) {
           actions.walletModal()
           break
         case 'error':
+          if (content.message) {
+            // eslint-disable-next-line no-console
+            console.error(content)
+          }
           actions.error(content.message ? content.message : content)
           break
       }

--- a/paywall/src/data-iframe/postOffice.js
+++ b/paywall/src/data-iframe/postOffice.js
@@ -135,7 +135,7 @@ export default function postOffice(window, requiredConfirmations) {
           actions.walletModal()
           break
         case 'error':
-          if (content.message) {
+          if (process.env.UNLOCK_ENV === 'dev' && content.message) {
             // eslint-disable-next-line no-console
             console.error(content)
           }

--- a/paywall/src/data-iframe/start/makePurchaseCallback.js
+++ b/paywall/src/data-iframe/start/makePurchaseCallback.js
@@ -60,7 +60,7 @@ const makePurchaseCallback = ({
         }),
       ])
     } catch (error) {
-      update({ error: error.message })
+      update({ error })
     }
   }
 


### PR DESCRIPTION
# Description

This improves the error handling of the data iframe. In addition to passing the full error object down, in dev, it logs it to the console so we can more easily access the stack trace

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
