### PR TITLE
fix typescript build for both storybook and checkout scripts

### DIFF
--- a/paywall/tsconfig.json
+++ b/paywall/tsconfig.json
@@ -15,7 +15,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    "outDir": "./tmp/unlockpaywall" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     "removeComments": false /* Do not emit comments to output. */,


### PR DESCRIPTION
# Description

This simple change fixes typescript builds in the paywall for both scripts and storybook. I did some sleuthing to try to understand why this works. screenshots tell a story. It appears that `outDir` is not actually used by the babel plugin (screenshot of me hitting `ls tmp` continuously attached). The docs say it will output javascript files there. I suspect because webpack is doing the compiling that it is putting everything into a temporary directory anyways, which explains why it isn't modifying the source tree. If we were running `tsc` directly, it would obey `outDir` literally.

<img width="1209" alt="Screen Shot 2019-07-15 at 9 02 54 AM" src="https://user-images.githubusercontent.com/98250/61218487-21b66f00-a6e0-11e9-9b2d-ec6d3f65490d.png">
<img width="1560" alt="Screen Shot 2019-07-15 at 9 02 36 AM" src="https://user-images.githubusercontent.com/98250/61218488-21b66f00-a6e0-11e9-8015-0cb8e95f2d40.png">
<img width="1560" alt="Screen Shot 2019-07-15 at 9 02 17 AM" src="https://user-images.githubusercontent.com/98250/61218489-21b66f00-a6e0-11e9-87e4-afea0c156822.png">


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3989 
# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
