### PR TITLE
Improve signup messaging

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -40947,11 +40947,16 @@ Object {
             <p
               class="c18"
             >
-              If you want to know more about Unlock's decentralized payment protocol, check out our
+              If you want to know more about Unlock's decentralized payment protocol, check out
                
-              <span>
-                blog
-              </span>
+              <a
+                href="https://unlock-protocol.com/blog"
+                target="_blank"
+              >
+                <span>
+                  our blog
+                </span>
+              </a>
               .
             </p>
             <form
@@ -40971,13 +40976,13 @@ Object {
               <p
                 class="c18"
               >
-                Already have an account?
-                 
+                Already have an account? 
                 <a
                   class="c22"
                 >
-                  Log in here.
+                  Log in here
                 </a>
+                .
               </p>
             </form>
           </div>
@@ -41200,11 +41205,16 @@ Object {
           <p
             class="sc-brqgnP kLeLPN"
           >
-            If you want to know more about Unlock's decentralized payment protocol, check out our
+            If you want to know more about Unlock's decentralized payment protocol, check out
              
-            <span>
-              blog
-            </span>
+            <a
+              href="https://unlock-protocol.com/blog"
+              target="_blank"
+            >
+              <span>
+                our blog
+              </span>
+            </a>
             .
           </p>
           <form
@@ -41224,13 +41234,13 @@ Object {
             <p
               class="sc-brqgnP kLeLPN"
             >
-              Already have an account?
-               
+              Already have an account? 
               <a
                 class="sc-iRbamj bpwFyB"
               >
-                Log in here.
+                Log in here
               </a>
+              .
             </p>
           </form>
         </div>
@@ -50086,11 +50096,16 @@ Object {
         <p
           class="c2"
         >
-          If you want to know more about Unlock's decentralized payment protocol, check out our
+          If you want to know more about Unlock's decentralized payment protocol, check out
            
-          <span>
-            blog
-          </span>
+          <a
+            href="https://unlock-protocol.com/blog"
+            target="_blank"
+          >
+            <span>
+              our blog
+            </span>
+          </a>
           .
         </p>
         <form
@@ -50110,13 +50125,13 @@ Object {
           <p
             class="c2"
           >
-            Already have an account?
-             
+            Already have an account? 
             <a
               class="c6"
             >
-              Log in here.
+              Log in here
             </a>
+            .
           </p>
         </form>
       </div>
@@ -50146,11 +50161,16 @@ Object {
       <p
         class="sc-brqgnP kLeLPN"
       >
-        If you want to know more about Unlock's decentralized payment protocol, check out our
+        If you want to know more about Unlock's decentralized payment protocol, check out
          
-        <span>
-          blog
-        </span>
+        <a
+          href="https://unlock-protocol.com/blog"
+          target="_blank"
+        >
+          <span>
+            our blog
+          </span>
+        </a>
         .
       </p>
       <form
@@ -50170,13 +50190,13 @@ Object {
         <p
           class="sc-brqgnP kLeLPN"
         >
-          Already have an account?
-           
+          Already have an account? 
           <a
             class="sc-iRbamj bpwFyB"
           >
-            Log in here.
+            Log in here
           </a>
+          .
         </p>
       </form>
     </div>
@@ -50957,11 +50977,16 @@ Object {
         <p
           class="c2"
         >
-          If you want to know more about Unlock's decentralized payment protocol, check out our
+          If you want to know more about Unlock's decentralized payment protocol, check out
            
-          <span>
-            blog
-          </span>
+          <a
+            href="https://unlock-protocol.com/blog"
+            target="_blank"
+          >
+            <span>
+              our blog
+            </span>
+          </a>
           .
         </p>
         <form
@@ -50981,13 +51006,13 @@ Object {
           <p
             class="c2"
           >
-            Already have an account?
-             
+            Already have an account? 
             <a
               class="c6"
             >
-              Log in here.
+              Log in here
             </a>
+            .
           </p>
         </form>
       </div>
@@ -51017,11 +51042,16 @@ Object {
       <p
         class="sc-brqgnP kLeLPN"
       >
-        If you want to know more about Unlock's decentralized payment protocol, check out our
+        If you want to know more about Unlock's decentralized payment protocol, check out
          
-        <span>
-          blog
-        </span>
+        <a
+          href="https://unlock-protocol.com/blog"
+          target="_blank"
+        >
+          <span>
+            our blog
+          </span>
+        </a>
         .
       </p>
       <form
@@ -51041,13 +51071,13 @@ Object {
         <p
           class="sc-brqgnP kLeLPN"
         >
-          Already have an account?
-           
+          Already have an account? 
           <a
             class="sc-iRbamj bpwFyB"
           >
-            Log in here.
+            Log in here
           </a>
+          .
         </p>
       </form>
     </div>
@@ -55897,11 +55927,16 @@ Object {
         <p
           class="c2"
         >
-          If you want to know more about Unlock's decentralized payment protocol, check out our
+          If you want to know more about Unlock's decentralized payment protocol, check out
            
-          <span>
-            blog
-          </span>
+          <a
+            href="https://unlock-protocol.com/blog"
+            target="_blank"
+          >
+            <span>
+              our blog
+            </span>
+          </a>
           .
         </p>
         <form
@@ -55921,13 +55956,13 @@ Object {
           <p
             class="c2"
           >
-            Already have an account?
-             
+            Already have an account? 
             <a
               class="c6"
             >
-              Log in here.
+              Log in here
             </a>
+            .
           </p>
         </form>
       </div>
@@ -55957,11 +55992,16 @@ Object {
       <p
         class="sc-brqgnP kLeLPN"
       >
-        If you want to know more about Unlock's decentralized payment protocol, check out our
+        If you want to know more about Unlock's decentralized payment protocol, check out
          
-        <span>
-          blog
-        </span>
+        <a
+          href="https://unlock-protocol.com/blog"
+          target="_blank"
+        >
+          <span>
+            our blog
+          </span>
+        </a>
         .
       </p>
       <form
@@ -55981,13 +56021,13 @@ Object {
         <p
           class="sc-brqgnP kLeLPN"
         >
-          Already have an account?
-           
+          Already have an account? 
           <a
             class="sc-iRbamj bpwFyB"
           >
-            Log in here.
+            Log in here
           </a>
+          .
         </p>
       </form>
     </div>

--- a/unlock-app/src/components/interface/SignUp.tsx
+++ b/unlock-app/src/components/interface/SignUp.tsx
@@ -62,6 +62,10 @@ export class SignUp extends React.Component<Props, State> {
       return <SignupSuccess />
     }
 
+    const LogInLink = (callToAction: string) => (
+      <LinkButton onClick={this.handleClick}>{callToAction}</LinkButton>
+    )
+
     if (!emailAddress) {
       return (
         <div>
@@ -78,7 +82,7 @@ export class SignUp extends React.Component<Props, State> {
           <Description>
             If you want to know more about Unlock&#39;s decentralized payment
             protocol, check out{' '}
-            <Link href="/blog">
+            <Link href="https://unlock-protocol.com/blog">
               <a target="_blank">
                 <span>our blog</span>
               </a>
@@ -95,8 +99,7 @@ export class SignUp extends React.Component<Props, State> {
               />
               <SubmitButton type="submit" value="Sign Up" />
               <Description>
-                Already have an account?{' '}
-                <LinkButton onClick={this.handleClick}>Log in here.</LinkButton>
+                Already have an account? {LogInLink('Log in here')}.
               </Description>
             </Form>
           )}
@@ -104,6 +107,10 @@ export class SignUp extends React.Component<Props, State> {
             <Confirmation>
               <div>Please check your email</div>
               <div>We need to confirm your email before proceeding.</div>
+              <div>
+                Once you&#39;ve created your account you can{' '}
+                {LogInLink('log in here')}.
+              </div>
             </Confirmation>
           )}
         </div>

--- a/unlock-app/src/components/interface/SignUp.tsx
+++ b/unlock-app/src/components/interface/SignUp.tsx
@@ -77,9 +77,11 @@ export class SignUp extends React.Component<Props, State> {
           </Description>
           <Description>
             If you want to know more about Unlock&#39;s decentralized payment
-            protocol, check out our{' '}
+            protocol, check out{' '}
             <Link href="/blog">
-              <span>blog</span>
+              <a target="_blank">
+                <span>our blog</span>
+              </a>
             </Link>
             .
           </Description>


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR fixes two issues with the messaging on the signup component.

1. The blog link didn't look like a link, and pointed to an incorrect URL.
2. There was no way to go back and log in after signing up, which is an important use-case for creating an account from the paywall. Now there is a link that toggles so a user can continue.

<img width="802" alt="image" src="https://user-images.githubusercontent.com/9300702/61226111-d99f4880-a6ef-11e9-9831-5219a46d55d6.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4164 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
