### PR TITLE
add missing await to "ensureWalletReady" for retrieving keys and transactions

### DIFF
--- a/paywall/src/data-iframe/blockchainHandler/index.js
+++ b/paywall/src/data-iframe/blockchainHandler/index.js
@@ -98,7 +98,7 @@ async function getKeysAndTransactions({
   window,
   locksmithHost,
 }) {
-  ensureWalletReady(walletService)
+  await ensureWalletReady(walletService)
   const [keys] = await Promise.all([
     getKeys({ walletService, locks, web3Service }),
     // trigger retrieval of transactions. web3ServiceHub will do the actual


### PR DESCRIPTION
# Description

The issues we have seen with the paywall occasionally requesting transactions from a `null` account. This should not be happening. As it turns out, the reason it is happening is because there was a stray call to `ensureWalletReady` which was not being `await`ed upon.

Incidentally, typescript catches these things at compile-time. The sooner we can move the whole project, the better.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4013 
Refs #

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
