### PR TITLE
disable the localStorage cache, use in-memory cache only

### DIFF
--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -153,7 +153,6 @@ describe('cacheHandler', () => {
       it('overwrites an existing transaction', async () => {
         expect.assertions(1)
 
-        // HERE IS THE FAIL - memory driver mutates its input
         await setTransactions(fakeWindow, myTransactions)
         await setTransaction(fakeWindow, {
           hash: 'myTransaction',

--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -17,6 +17,7 @@ import {
   removeListener,
 } from '../../data-iframe/cacheHandler'
 import { TRANSACTION_TYPES } from '../../constants'
+import { __clearDriver } from '../../data-iframe/cache/cache'
 
 describe('cacheHandler', () => {
   let fakeWindow
@@ -67,6 +68,7 @@ describe('cacheHandler', () => {
         },
       },
     }
+    __clearDriver()
   })
 
   describe('setting values', () => {
@@ -130,6 +132,10 @@ describe('cacheHandler', () => {
     })
 
     describe('setTransaction', () => {
+      beforeEach(() => {
+        __clearDriver()
+      })
+
       it('sets a new transaction without disturbing existing transactions', async () => {
         expect.assertions(1)
 
@@ -147,6 +153,7 @@ describe('cacheHandler', () => {
       it('overwrites an existing transaction', async () => {
         expect.assertions(1)
 
+        // HERE IS THE FAIL - memory driver mutates its input
         await setTransactions(fakeWindow, myTransactions)
         await setTransaction(fakeWindow, {
           hash: 'myTransaction',
@@ -177,6 +184,7 @@ describe('cacheHandler', () => {
 
   describe('getting values', () => {
     beforeEach(async () => {
+      __clearDriver()
       fakeWindow = {
         storage: {},
         localStorage: {
@@ -247,6 +255,7 @@ describe('cacheHandler', () => {
 
     describe('values not set', () => {
       beforeEach(async () => {
+        __clearDriver()
         fakeWindow = {
           storage: {},
           localStorage: {
@@ -283,6 +292,7 @@ describe('cacheHandler', () => {
 
   describe('user account changes', () => {
     beforeEach(async () => {
+      __clearDriver()
       fakeWindow = {
         storage: {},
         localStorage: {
@@ -365,6 +375,7 @@ describe('cacheHandler', () => {
 
   describe('network changes', () => {
     beforeEach(async () => {
+      __clearDriver()
       fakeWindow = {
         storage: {},
         localStorage: {
@@ -491,6 +502,7 @@ describe('cacheHandler', () => {
     }
 
     beforeEach(async () => {
+      __clearDriver()
       fakeWindow = {
         storage: {},
         localStorage: {
@@ -623,6 +635,7 @@ describe('cacheHandler', () => {
     }
     describe('addListener and removeListener', () => {
       beforeEach(() => {
+        __clearDriver()
         fakeWindow.storage = {}
         clearListeners()
       })

--- a/paywall/src/__tests__/data-iframe/postOffice.test.js
+++ b/paywall/src/__tests__/data-iframe/postOffice.test.js
@@ -21,6 +21,7 @@ import {
   getTransactions,
 } from '../../data-iframe/cacheHandler'
 import { setPaywallConfig } from '../../data-iframe/paywallConfig'
+import { __clearDriver } from '../../data-iframe/cache/cache'
 
 describe('data iframe postOffice', () => {
   let fakeWindow
@@ -28,6 +29,7 @@ describe('data iframe postOffice', () => {
 
   describe('postOffice', () => {
     function makeWindow() {
+      __clearDriver()
       fakeTarget = {
         postMessage: jest.fn(),
       }

--- a/paywall/src/data-iframe/cache/cache.ts
+++ b/paywall/src/data-iframe/cache/cache.ts
@@ -1,6 +1,6 @@
 import localStorageAvailable from '../../utils/localStorage'
 import InMemoryDriver from './drivers/memory'
-import LocalStorageDriver from './drivers/localStorage'
+// import LocalStorageDriver from './drivers/localStorage'
 import CacheDriver from './drivers/driverInterface'
 import { LocalStorageWindow } from '../../windowTypes'
 
@@ -12,7 +12,9 @@ export function getDriver(window: LocalStorageWindow) {
   if (!localStorageAvailable(window)) {
     __driver = new InMemoryDriver()
   } else {
-    __driver = new LocalStorageDriver(window)
+    __driver = new InMemoryDriver()
+
+    // __driver = new LocalStorageDriver(window)
   }
   return __driver
 }


### PR DESCRIPTION
# Description

This disables the localStorage cache, using only in-memory cache. In making the transition, an unintended mutation of input in `cache.merge` was discovered and is addressed as well.

This buys us some time to strengthen the localStorage cache.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
