### PR TITLE
validate and sanitize the account that returns from localStorage

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/web3ServiceHub.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/web3ServiceHub.test.js
@@ -4,6 +4,7 @@ import { TRANSACTION_TYPES } from '../../../constants'
 
 describe('web3ServiceHub', () => {
   let fakeWindow
+  const fakeAccount = '0x1234567890123456789012345678901234567890'
 
   function makeFakeWindow() {
     fakeWindow = {
@@ -87,7 +88,7 @@ describe('web3ServiceHub', () => {
           owner,
         }),
       }
-      await setAccount(fakeWindow, 'account')
+      await setAccount(fakeWindow, fakeAccount)
     })
 
     it('should use the cached transaction as a base', async () => {
@@ -194,7 +195,7 @@ describe('web3ServiceHub', () => {
           key: {
             expiration: 123,
             lock: 'lock',
-            owner: 'account', // this verifies we pulled it from the cache
+            owner: fakeAccount, // this verifies we pulled it from the cache
           },
         })
       )
@@ -214,7 +215,7 @@ describe('web3ServiceHub', () => {
       web3Service = {
         on: jest.fn(),
       }
-      await setAccount(fakeWindow, 'account')
+      await setAccount(fakeWindow, fakeAccount)
     })
 
     it('should call onChange with the error', async () => {

--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -20,16 +20,18 @@ import { TRANSACTION_TYPES } from '../../constants'
 
 describe('cacheHandler', () => {
   let fakeWindow
+  const fakeAccount = '0x1234567890123456789012345678901234567890'
+  const fakeAccount2 = '0xa234567890123456789012345678901234567890'
   const myKeys = {
     lock: {
       id: 'myKey',
-      owner: 'account',
+      owner: fakeAccount,
       lock: 'lock',
       expirationTimestamp: 0,
     },
     lock2: {
       id: 'myKey',
-      owner: 'account',
+      owner: fakeAccount,
       lock: 'lock2',
       expirationTimestamp: 0,
     },
@@ -52,7 +54,7 @@ describe('cacheHandler', () => {
   }
 
   beforeEach(() => {
-    setup('network', 'account')
+    setup('network', fakeAccount)
     fakeWindow = {
       storage: {},
       localStorage: {
@@ -192,7 +194,7 @@ describe('cacheHandler', () => {
         },
       }
 
-      await setAccount(fakeWindow, 'account')
+      await setAccount(fakeWindow, fakeAccount)
       await setNetwork(fakeWindow, 2)
       await setKeys(fakeWindow, myKeys)
       await setLocks(fakeWindow, myLocks)
@@ -222,9 +224,9 @@ describe('cacheHandler', () => {
         ...myKeys,
         another: {
           expiration: 0,
-          id: 'another-account',
+          id: `another-${fakeAccount}`,
           lock: 'another',
-          owner: 'account',
+          owner: fakeAccount,
         },
       })
     })
@@ -298,13 +300,13 @@ describe('cacheHandler', () => {
         },
       }
 
-      await setAccount(fakeWindow, 'account')
+      await setAccount(fakeWindow, fakeAccount)
       await setNetwork(fakeWindow, 2)
       await setKeys(fakeWindow, myKeys)
       await setLocks(fakeWindow, myLocks)
       await setTransactions(fakeWindow, myTransactions)
 
-      await setAccount(fakeWindow, 'different')
+      await setAccount(fakeWindow, fakeAccount2)
     })
 
     it('should still return cached locks', async () => {
@@ -319,15 +321,15 @@ describe('cacheHandler', () => {
       expect(await getKeys(fakeWindow)).toEqual({
         lock: {
           expiration: 0,
-          id: 'lock-different',
+          id: `lock-${fakeAccount2}`,
           lock: 'lock',
-          owner: 'different',
+          owner: fakeAccount2,
         },
         lock2: {
           expiration: 0,
-          id: 'lock2-different',
+          id: `lock2-${fakeAccount2}`,
           lock: 'lock2',
-          owner: 'different',
+          owner: fakeAccount2,
         },
       })
     })
@@ -345,20 +347,20 @@ describe('cacheHandler', () => {
         // a dummy key created just-in-time
         lock: {
           expiration: 0,
-          id: 'lock-different',
+          id: `lock-${fakeAccount2}`,
           lock: 'lock',
-          owner: 'different',
+          owner: fakeAccount2,
         },
         lock2: {
           lock: 'lock2',
-          owner: 'different',
+          owner: fakeAccount2,
         },
       }
 
       await setKeys(fakeWindow, differentKeys)
       expect(await getKeys(fakeWindow)).toEqual(differentKeys)
 
-      await setAccount(fakeWindow, 'account')
+      await setAccount(fakeWindow, fakeAccount)
       expect(await getKeys(fakeWindow)).toEqual(myKeys)
     })
   })
@@ -380,7 +382,7 @@ describe('cacheHandler', () => {
         },
       }
 
-      await setAccount(fakeWindow, 'account')
+      await setAccount(fakeWindow, fakeAccount)
       await setNetwork(fakeWindow, 2)
       await setKeys(fakeWindow, myKeys)
       await setLocks(fakeWindow, myLocks)
@@ -413,7 +415,7 @@ describe('cacheHandler', () => {
       const differentKeys = {
         lock2: {
           lock: 'lock2',
-          owner: 'different',
+          owner: fakeAccount2,
         },
       }
 
@@ -428,20 +430,20 @@ describe('cacheHandler', () => {
   describe('getFormattedCacheValues', () => {
     const keys = {
       lock1: {
-        id: 'lock1-account',
-        owner: 'account',
+        id: `lock1-${fakeAccount}`,
+        owner: fakeAccount,
         lock: 'lock1',
         expiration: new Date().getTime() / 1000 + 1000,
       },
       lock2: {
-        id: 'lock2-account',
-        owner: 'account',
+        id: `lock2-${fakeAccount}`,
+        owner: fakeAccount,
         lock: 'lock2',
         expiration: 0,
       },
       lock3: {
-        id: 'lock3-account',
-        owner: 'account',
+        id: `lock3-${fakeAccount}`,
+        owner: fakeAccount,
         lock: 'lock3',
         expiration: new Date().getTime() / 1000 - 1000,
       },
@@ -469,8 +471,8 @@ describe('cacheHandler', () => {
         lock: 'lock1',
         key: 'lock1-account',
         to: 'lock1',
-        from: 'account',
-        for: 'account',
+        from: fakeAccount,
+        for: fakeAccount,
         type: TRANSACTION_TYPES.KEY_PURCHASE,
         blockNumber: 1,
         status: 'mined',
@@ -481,8 +483,8 @@ describe('cacheHandler', () => {
         lock: 'lock3',
         key: 'lock3-account',
         to: 'lock3',
-        from: 'account',
-        for: 'account',
+        from: fakeAccount,
+        for: fakeAccount,
         type: TRANSACTION_TYPES.KEY_PURCHASE,
         blockNumber: 2,
         status: 'mined',
@@ -507,7 +509,7 @@ describe('cacheHandler', () => {
       }
 
       await setNetwork(fakeWindow, 3)
-      await setAccount(fakeWindow, 'account')
+      await setAccount(fakeWindow, fakeAccount)
       await setAccountBalance(fakeWindow, '2')
       await setKeys(fakeWindow, keys)
       await setLocks(fakeWindow, locks)
@@ -520,7 +522,7 @@ describe('cacheHandler', () => {
       const values = await getFormattedCacheValues(fakeWindow, 5)
 
       expect(values).toEqual({
-        account: 'account',
+        account: fakeAccount,
         balance: '2',
         networkId: 3,
         locks: {
@@ -779,7 +781,7 @@ describe('cacheHandler', () => {
           const listener = jest.fn()
           addListener(listener)
 
-          await setAccount(fakeWindow, 'account')
+          await setAccount(fakeWindow, fakeAccount)
 
           expect(listener).toHaveBeenCalledWith('account')
         })
@@ -787,7 +789,7 @@ describe('cacheHandler', () => {
         it('sends balance when balance is modified', async () => {
           expect.assertions(1)
 
-          await setAccount(fakeWindow, 'account')
+          await setAccount(fakeWindow, fakeAccount)
 
           const listener = jest.fn()
           addListener(listener)

--- a/paywall/src/__tests__/data-iframe/postOffice.test.js
+++ b/paywall/src/__tests__/data-iframe/postOffice.test.js
@@ -25,6 +25,7 @@ import { setPaywallConfig } from '../../data-iframe/paywallConfig'
 describe('data iframe postOffice', () => {
   let fakeWindow
   let fakeTarget
+  const fakeAccount = '0x1234567890123456789012345678901234567890'
 
   describe('postOffice', () => {
     function makeWindow() {
@@ -173,14 +174,14 @@ describe('data iframe postOffice', () => {
       it('account passes account address to the main window', async () => {
         expect.assertions(1)
 
-        await setAccount(fakeWindow, 'account')
+        await setAccount(fakeWindow, fakeAccount)
 
         fakeTarget.postMessage = jest.fn()
         await blockChainUpdater('account')
         expect(fakeTarget.postMessage).toHaveBeenCalledWith(
           expect.objectContaining({
             type: POST_MESSAGE_UPDATE_ACCOUNT,
-            payload: 'account',
+            payload: fakeAccount,
           }),
           'http://fun.times'
         )
@@ -189,7 +190,7 @@ describe('data iframe postOffice', () => {
       it('should pass locks to the main window on account change', async () => {
         expect.assertions(3)
 
-        await setAccount(fakeWindow, 'account')
+        await setAccount(fakeWindow, fakeAccount)
         await setNetwork(fakeWindow, 2)
         await setLocks(fakeWindow, {
           '0x123': {
@@ -201,14 +202,14 @@ describe('data iframe postOffice', () => {
         })
         await setKeys(fakeWindow, {
           '0x123': {
-            id: '0x123-account',
-            owner: 'account',
+            id: `0x123-${fakeAccount}`,
+            owner: fakeAccount,
             lock: '0x123',
             expiration: 0,
           },
           '0x456': {
-            id: '0x456-account',
-            owner: 'account',
+            id: `0x456-${fakeAccount}`,
+            owner: fakeAccount,
             lock: '0x456',
             expiration: 0,
           },
@@ -224,8 +225,8 @@ describe('data iframe postOffice', () => {
               '0x123': {
                 address: '0x123',
                 key: {
-                  id: '0x123-account',
-                  owner: 'account',
+                  id: `0x123-${fakeAccount}`,
+                  owner: fakeAccount,
                   lock: '0x123',
                   expiration: 0,
                   status: 'none',
@@ -236,8 +237,8 @@ describe('data iframe postOffice', () => {
               '0x456': {
                 address: '0x456',
                 key: {
-                  id: '0x456-account',
-                  owner: 'account',
+                  id: `0x456-${fakeAccount}`,
+                  owner: fakeAccount,
                   lock: '0x456',
                   expiration: 0,
                   status: 'none',
@@ -261,7 +262,7 @@ describe('data iframe postOffice', () => {
       it('balance passes account balance to the main window', async () => {
         expect.assertions(1)
 
-        await setAccount(fakeWindow, 'account')
+        await setAccount(fakeWindow, fakeAccount)
         await setAccountBalance(fakeWindow, '123')
 
         fakeTarget.postMessage = jest.fn()
@@ -296,7 +297,7 @@ describe('data iframe postOffice', () => {
       it('locks passes the lock data to the main window', async done => {
         expect.assertions(1)
 
-        await setAccount(fakeWindow, 'account')
+        await setAccount(fakeWindow, fakeAccount)
         await setNetwork(fakeWindow, 2)
         await setLocks(fakeWindow, {
           '0x123': {
@@ -308,14 +309,14 @@ describe('data iframe postOffice', () => {
         })
         await setKeys(fakeWindow, {
           '0x123': {
-            id: '0x123-account',
-            owner: 'account',
+            id: `0x123-${fakeAccount}`,
+            owner: fakeAccount,
             lock: '0x123',
             expiration: 0,
           },
           '0x456': {
-            id: '0x456-account',
-            owner: 'account',
+            id: `0x456-${fakeAccount}`,
+            owner: fakeAccount,
             lock: '0x456',
             expiration: 0,
           },
@@ -330,8 +331,8 @@ describe('data iframe postOffice', () => {
                 '0x123': {
                   address: '0x123',
                   key: {
-                    id: '0x123-account',
-                    owner: 'account',
+                    id: `0x123-${fakeAccount}`,
+                    owner: fakeAccount,
                     lock: '0x123',
                     expiration: 0,
                     status: 'none',
@@ -342,8 +343,8 @@ describe('data iframe postOffice', () => {
                 '0x456': {
                   address: '0x456',
                   key: {
-                    id: '0x456-account',
-                    owner: 'account',
+                    id: `0x456-${fakeAccount}`,
+                    owner: fakeAccount,
                     lock: '0x456',
                     expiration: 0,
                     status: 'none',
@@ -378,7 +379,7 @@ describe('data iframe postOffice', () => {
             [hash]: {
               hash,
               lock,
-              key: `${lock}-account`,
+              key: `${lock}-${fakeAccount}`,
               status,
               confirmations,
               blockNumber: 5,
@@ -389,7 +390,7 @@ describe('data iframe postOffice', () => {
         beforeEach(async () => {
           makeWindow()
 
-          await setAccount(fakeWindow, 'account')
+          await setAccount(fakeWindow, fakeAccount)
           await setNetwork(fakeWindow, 2)
           await setLocks(fakeWindow, {
             '0x123': {
@@ -401,14 +402,14 @@ describe('data iframe postOffice', () => {
           })
           await setKeys(fakeWindow, {
             '0x123': {
-              id: '0x123-account',
-              owner: 'account',
+              id: `0x123-${fakeAccount}`,
+              owner: fakeAccount,
               lock: '0x123',
               expiration: 0,
             },
             '0x456': {
-              id: '0x456-account',
-              owner: 'account',
+              id: `0x456-${fakeAccount}`,
+              owner: fakeAccount,
               lock: '0x456',
               expiration: 0,
             },
@@ -565,7 +566,7 @@ describe('data iframe postOffice', () => {
           },
         })
 
-        await setAccount(fakeWindow, 'account')
+        await setAccount(fakeWindow, fakeAccount)
         await setNetwork(fakeWindow, 2)
         await setLocks(fakeWindow, {
           '0x123': {
@@ -577,14 +578,14 @@ describe('data iframe postOffice', () => {
         })
         await setKeys(fakeWindow, {
           '0x123': {
-            id: '0x123-account',
-            owner: 'account',
+            id: `0x123-${fakeAccount}`,
+            owner: fakeAccount,
             lock: '0x123',
             expiration: 0,
           },
           '0x456': {
-            id: '0x456-account',
-            owner: 'account',
+            id: `0x456-${fakeAccount}`,
+            owner: fakeAccount,
             lock: '0x456',
             expiration: 0,
           },
@@ -599,8 +600,8 @@ describe('data iframe postOffice', () => {
                 '0x123': {
                   address: '0x123',
                   key: {
-                    id: '0x123-account',
-                    owner: 'account',
+                    id: `0x123-${fakeAccount}`,
+                    owner: fakeAccount,
                     lock: '0x123',
                     expiration: 0,
                     status: 'none',

--- a/paywall/src/__tests__/data-iframe/start/syncToCache.test.js
+++ b/paywall/src/__tests__/data-iframe/start/syncToCache.test.js
@@ -12,6 +12,7 @@ import {
 
 describe('syncToCache', () => {
   let fakeWindow
+  const fakeAccount = '0x1234567890123456789012345678901234567890'
 
   beforeEach(() => {
     fakeWindow = {
@@ -125,7 +126,7 @@ describe('syncToCache', () => {
   it('syncs account to the cache', async () => {
     expect.assertions(1)
 
-    const account = 'account'
+    const account = fakeAccount
     await syncToCache(fakeWindow, { account })
 
     expect(await getAccount(fakeWindow)).toEqual(account)
@@ -152,7 +153,7 @@ describe('syncToCache', () => {
   it('syncs multiple keys to the cache at once', async () => {
     expect.assertions(2)
 
-    const account = 'account'
+    const account = fakeAccount
     const balance = '1'
     await syncToCache(fakeWindow, { account, balance })
 

--- a/paywall/src/data-iframe/cacheHandler.js
+++ b/paywall/src/data-iframe/cacheHandler.js
@@ -1,11 +1,11 @@
 import * as cache from './cache'
 import linkKeysToLocks from './blockchainHandler/linkKeysToLocks'
+import { isAccount } from '../utils/validators'
 
 let currentNetwork
 let currentAccount
 const nullAccount = '0x0000000000000000000000000000000000000000'
 
-export const getAccount = cache.getAccount
 export const getNetwork = cache.getNetwork
 
 export function setup(networkId, account) {
@@ -58,6 +58,15 @@ export async function createMissingKeys(window, locks, keys) {
       })
     }
   }
+}
+
+export async function getAccount(window) {
+  const account = await cache.getAccount(window)
+  if (!isAccount(account)) {
+    // validate the account
+    return null
+  }
+  return account
 }
 
 export async function getKeys(window) {


### PR DESCRIPTION
# Description

Beginning the process of treating localStorage has a hostile external input, this validates the account returned from local storage, and returns null if it is invalid.

Question: should this also clear the cache upon any invalid value? Chances are the rest of it will be corrupt as well. If so, once the validation/sanitization PRs are done, I'll set up a PR that clears the cache, probably centralizing the validation as well.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #4208

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
