### PR TITLE
refactor values passed into the post office in prep for validation

### DIFF
--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -489,6 +489,7 @@ describe('cacheHandler', () => {
         confirmations: 12345,
       },
     }
+    const constants = { requiredConfirmations: 5, defaultNetwork: 4 }
 
     beforeEach(async () => {
       fakeWindow = {
@@ -506,7 +507,7 @@ describe('cacheHandler', () => {
         },
       }
 
-      await setNetwork(fakeWindow, 3)
+      await setNetwork(fakeWindow, 4)
       await setAccount(fakeWindow, 'account')
       await setAccountBalance(fakeWindow, '2')
       await setKeys(fakeWindow, keys)
@@ -517,12 +518,12 @@ describe('cacheHandler', () => {
     it('returns properly formatted values', async () => {
       expect.assertions(1)
 
-      const values = await getFormattedCacheValues(fakeWindow, 5)
+      const values = await getFormattedCacheValues(fakeWindow, constants)
 
       expect(values).toEqual({
         account: 'account',
         balance: '2',
-        networkId: 3,
+        networkId: 4,
         locks: {
           lock1: {
             ...locks.lock1,
@@ -570,12 +571,12 @@ describe('cacheHandler', () => {
         transactions: [],
       }
 
-      const values = await getFormattedCacheValues(fakeWindow, 5)
+      const values = await getFormattedCacheValues(fakeWindow, constants)
 
       expect(values).toEqual({
         account: null,
         balance: '0',
-        networkId: 3,
+        networkId: 4,
         locks: {
           lock1: {
             ...locks.lock1,

--- a/paywall/src/__tests__/data-iframe/postOffice.test.js
+++ b/paywall/src/__tests__/data-iframe/postOffice.test.js
@@ -25,6 +25,10 @@ import { setPaywallConfig } from '../../data-iframe/paywallConfig'
 describe('data iframe postOffice', () => {
   let fakeWindow
   let fakeTarget
+  const constants = {
+    requiredConfirmations: 12,
+    defaultNetwork: 1,
+  }
 
   describe('postOffice', () => {
     function makeWindow() {
@@ -63,7 +67,7 @@ describe('data iframe postOffice', () => {
     it('should return an update listener callback', () => {
       expect.assertions(1)
 
-      const { blockChainUpdater } = postOffice(fakeWindow, 12)
+      const { blockChainUpdater } = postOffice(fakeWindow, constants)
 
       expect(blockChainUpdater).toBeInstanceOf(Function)
     })
@@ -71,7 +75,7 @@ describe('data iframe postOffice', () => {
     it('should return an addHandler callback', () => {
       expect.assertions(1)
 
-      const { addHandler } = postOffice(fakeWindow, 12)
+      const { addHandler } = postOffice(fakeWindow, constants)
 
       expect(addHandler).toBeInstanceOf(Function)
     })
@@ -79,7 +83,7 @@ describe('data iframe postOffice', () => {
     it('should return a postMessage callback', () => {
       expect.assertions(1)
 
-      const { postMessage } = postOffice(fakeWindow, 12)
+      const { postMessage } = postOffice(fakeWindow, constants)
 
       expect(postMessage).toBeInstanceOf(Function)
     })
@@ -89,7 +93,7 @@ describe('data iframe postOffice', () => {
       beforeEach(() => {
         makeWindow()
 
-        const info = postOffice(fakeWindow, 12)
+        const info = postOffice(fakeWindow, constants)
         blockChainUpdater = info.blockChainUpdater
         setPaywallConfig({
           locks: {
@@ -190,7 +194,7 @@ describe('data iframe postOffice', () => {
         expect.assertions(3)
 
         await setAccount(fakeWindow, 'account')
-        await setNetwork(fakeWindow, 2)
+        await setNetwork(fakeWindow, 1)
         await setLocks(fakeWindow, {
           '0x123': {
             address: '0x123',
@@ -278,13 +282,13 @@ describe('data iframe postOffice', () => {
       it('network passes the network id to the main window', async done => {
         expect.assertions(1)
 
-        await setNetwork(fakeWindow, 2)
+        await setNetwork(fakeWindow, 4)
 
         fakeTarget.postMessage = (...args) => {
           expect(args).toEqual([
             {
               type: POST_MESSAGE_UPDATE_NETWORK,
-              payload: 2,
+              payload: 4,
             },
             'http://fun.times',
           ])
@@ -297,7 +301,7 @@ describe('data iframe postOffice', () => {
         expect.assertions(1)
 
         await setAccount(fakeWindow, 'account')
-        await setNetwork(fakeWindow, 2)
+        await setNetwork(fakeWindow, 1)
         await setLocks(fakeWindow, {
           '0x123': {
             address: '0x123',
@@ -390,7 +394,7 @@ describe('data iframe postOffice', () => {
           makeWindow()
 
           await setAccount(fakeWindow, 'account')
-          await setNetwork(fakeWindow, 2)
+          await setNetwork(fakeWindow, 1)
           await setLocks(fakeWindow, {
             '0x123': {
               address: '0x123',
@@ -413,7 +417,7 @@ describe('data iframe postOffice', () => {
               expiration: 0,
             },
           })
-          const info = postOffice(fakeWindow, 12)
+          const info = postOffice(fakeWindow, constants)
           blockChainUpdater = info.blockChainUpdater
           setPaywallConfig({
             locks: {
@@ -566,7 +570,7 @@ describe('data iframe postOffice', () => {
         })
 
         await setAccount(fakeWindow, 'account')
-        await setNetwork(fakeWindow, 2)
+        await setNetwork(fakeWindow, 1)
         await setLocks(fakeWindow, {
           '0x123': {
             address: '0x123',
@@ -623,7 +627,7 @@ describe('data iframe postOffice', () => {
         beforeEach(() => {
           makeWindow()
 
-          const info = postOffice(fakeWindow, 12)
+          const info = postOffice(fakeWindow, constants)
           blockChainUpdater = info.blockChainUpdater
           fakeTarget.postMessage = jest.fn()
         })

--- a/paywall/src/__tests__/data-iframe/start/index.test.js
+++ b/paywall/src/__tests__/data-iframe/start/index.test.js
@@ -41,10 +41,7 @@ describe('data iframe startup index', () => {
 
     await start(window, constants)
 
-    expect(postOffice).toHaveBeenCalledWith(
-      window,
-      constants.requiredConfirmations
-    )
+    expect(postOffice).toHaveBeenCalledWith(window, constants)
   })
 
   it('should add a listener to the cache with the post office updater', async () => {

--- a/paywall/src/data-iframe/cacheHandler.js
+++ b/paywall/src/data-iframe/cacheHandler.js
@@ -165,7 +165,10 @@ export async function setTransaction(window, transaction) {
  * @param {number} requiredConfirmations the number of confirmations needed to consider a key valid
  * @returns {object} returns locks, account, balance, and networkId, all formatted for use in the UI
  */
-export async function getFormattedCacheValues(window, requiredConfirmations) {
+export async function getFormattedCacheValues(
+  window,
+  { requiredConfirmations }
+) {
   const account = await getAccount(window)
   const balance = await getAccountBalance(window)
   const networkId = await getNetwork(window)

--- a/paywall/src/data-iframe/postOffice.js
+++ b/paywall/src/data-iframe/postOffice.js
@@ -66,11 +66,12 @@ export const lockHandler = (window, cachedData, actions) => {
  * The callback also sends "unlocked" and "locked" events to the main window, based on
  * the status of the lock/key pairs.
  * @param {window} window the global context (window, self, global)
- * @param {number} requiredConfirmations the minimum number of confirmations for a key to be valid
+ * @param {number} constants.requiredConfirmations the minimum number of confirmations for a key to be valid
+ * @param {number} constants.defaultNetwork the network we expect to be on
  * @returns {Function} a callback that should be passed one of "locks", "account", "balance",
  *                     "network" or "walletModal" to trigger a post of changed data to the main window
  */
-export default function postOffice(window, requiredConfirmations) {
+export default function postOffice(window, constants) {
   const { postMessage, addHandler } = iframePostOffice(
     window,
     'data iframe',
@@ -109,10 +110,7 @@ export default function postOffice(window, requiredConfirmations) {
 
   return {
     blockChainUpdater: async (update, content) => {
-      const cachedData = await getFormattedCacheValues(
-        window,
-        requiredConfirmations
-      )
+      const cachedData = await getFormattedCacheValues(window, constants)
       switch (update) {
         case 'ready':
           actions.ready()

--- a/paywall/src/data-iframe/start/index.js
+++ b/paywall/src/data-iframe/start/index.js
@@ -20,10 +20,7 @@ export default async function start(window, constants) {
   import(/* webpackPrefetch: true */ '../blockchainHandler/purchaseKey')
   // set up the post office for communicating cache values, errors, and
   // wallet modal notifications to the main window
-  const { blockChainUpdater, addHandler } = postOffice(
-    window,
-    constants.requiredConfirmations
-  )
+  const { blockChainUpdater, addHandler } = postOffice(window, constants)
   // when the cache changes, we send the new information to the main window
   addListener(blockChainUpdater)
   // create the listener setup function for POST_MESSAGE_INITIATED_TRANSACTION


### PR DESCRIPTION
# Description

In preparation for validating and sanitizing the network returns from localStorage, this refactors the postOffice to accept the environment-specific constants. The ones used are `requiredConfirmations` and soon `defaultNetwork`.

`defaultNetwork` will be used as the value to return when there is no cache value present or if it is invalid.

This PR also updates the tests in advance to move all the network values to one of the 3 networks Unlock actually uses.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #4208 

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
