### PR TITLE
Fix cards condition in AccountContent, add tests

### DIFF
--- a/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { Provider } from 'react-redux'
+import createUnlockStore from '../../../createUnlockStore'
+import {
+  AccountContent,
+  mapStateToProps,
+} from '../../../components/content/AccountContent'
+
+const config = {
+  stripeApiKey: 'pk_not_a_real_key',
+}
+
+const store = createUnlockStore({
+  account: {
+    emailAddress: 'john@smi.th',
+  },
+})
+
+const mockCard: stripe.Card = {
+  id: 'not_a_real_id',
+  object: 'a string',
+  brand: 'Visa',
+  country: 'United States',
+  dynamic_last4: '4242',
+  exp_month: 12,
+  exp_year: 2021,
+  fingerprint: 'another string',
+  funding: 'credit',
+  last4: '4242',
+  metadata: {},
+}
+
+describe('AccountContent', () => {
+  describe('Possible rendering states', () => {
+    it('Should prompt for login if there is no account', () => {
+      expect.assertions(0)
+      const { getByText } = rtl.render(
+        <Provider store={store}>
+          <AccountContent config={config} />
+        </Provider>
+      )
+      getByText((_, node) => {
+        return !!node.textContent && !!node.textContent.match('Log In')
+      })
+    })
+
+    it('Should collect payment details if there are no cards in account', () => {
+      expect.assertions(0)
+
+      const { getByText } = rtl.render(
+        <Provider store={store}>
+          <AccountContent
+            config={config}
+            emailAddress="john@smi.th"
+            cards={[]}
+          />
+        </Provider>
+      )
+
+      getByText('Card Details')
+    })
+
+    it('Should prompt to confirm purchase if we have an account with cards', () => {
+      expect.assertions(0)
+
+      const { getByText } = rtl.render(
+        <Provider store={store}>
+          <AccountContent
+            config={config}
+            emailAddress="john@smi.th"
+            cards={[mockCard]}
+          />
+        </Provider>
+      )
+
+      getByText('Confirm Purchase')
+    })
+  })
+
+  describe('mapStateToProps', () => {
+    it('should return empty object if no account in state', () => {
+      expect.assertions(2)
+      expect(mapStateToProps({})).toEqual({})
+      // or if state has an account with no contents
+      expect(mapStateToProps({ account: {} })).toEqual({})
+    })
+
+    it('should grab and pass email and cards from account if available', () => {
+      expect.assertions(1)
+      const emailAddress = 'football@sports.gov'
+      const cards: stripe.Card[] = []
+      const state = {
+        account: {
+          emailAddress,
+          cards,
+        },
+      }
+
+      expect(mapStateToProps(state)).toEqual({
+        emailAddress,
+        cards,
+      })
+    })
+  })
+})

--- a/unlock-app/src/components/content/AccountContent.tsx
+++ b/unlock-app/src/components/content/AccountContent.tsx
@@ -65,7 +65,7 @@ export class AccountContent extends React.Component<
     const { emailAddress, cards } = this.props
     if (!emailAddress) {
       return 'LogIn'
-    } else if (!cards) {
+    } else if (!cards || !cards.length) {
       return 'CollectPaymentDetails'
     } else {
       return 'ConfirmPurchase'


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

There was a flawed condition in `AccountContent`: if we had an empty array of cards (which _shouldn't_ happen), then it would proceed to key purchase confirmation despite not having a payment method. This PR fixes that, and also adds much-awaited tests for `AccountContent`.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
