### PR TITLE
Add token to withdraw contract API

### DIFF
--- a/smart-contracts/contracts/mixins/MixinDisableAndDestroy.sol
+++ b/smart-contracts/contracts/mixins/MixinDisableAndDestroy.sol
@@ -63,7 +63,7 @@ contract MixinDisableAndDestroy is
     emit Destroy(address(this).balance, msg.sender);
 
     // this will send any ETH or ERC20 held by the lock to the owner
-    _transfer(msg.sender, getBalance(address(this)));
+    _transfer(tokenAddress, msg.sender, getBalance(tokenAddress, address(this)));
     selfdestruct(msg.sender);
 
     // Note we don't clean up the `locks` data in Unlock.sol as it should not be necessary

--- a/smart-contracts/contracts/mixins/MixinFunds.sol
+++ b/smart-contracts/contracts/mixins/MixinFunds.sol
@@ -30,14 +30,15 @@ contract MixinFunds
    * Gets the current balance of the account provided.
    */
   function getBalance(
+    address _tokenAddress,
     address _account
   ) public view
     returns (uint)
   {
-    if(tokenAddress == address(0)) {
+    if(_tokenAddress == address(0)) {
       return _account.balance;
     } else {
-      return IERC20(tokenAddress).balanceOf(_account);
+      return IERC20(_tokenAddress).balanceOf(_account);
     }
   }
 
@@ -75,15 +76,16 @@ contract MixinFunds
    * Security: be wary of re-entrancy when calling this function.
    */
   function _transfer(
+    address _tokenAddress,
     address _to,
     uint _amount
   ) internal
   {
     if(_amount > 0) {
-      if(tokenAddress == address(0)) {
+      if(_tokenAddress == address(0)) {
         address(uint160(_to)).transfer(_amount);
       } else {
-        IERC20 token = IERC20(tokenAddress);
+        IERC20 token = IERC20(_tokenAddress);
         uint balanceBefore = token.balanceOf(_to);
         token.transfer(_to, _amount);
 

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -24,6 +24,7 @@ contract MixinLockCore is
 
   event Withdrawal(
     address indexed sender,
+    address indexed tokenAddress,
     address indexed beneficiary,
     uint amount
   );
@@ -82,6 +83,8 @@ contract MixinLockCore is
 
   /**
    * @dev Called by owner to withdraw all funds from the lock and send them to the `beneficiary`.
+   * @param _tokenAddress specifies the token address to withdraw or 0 for ETH. This is usually 
+   * the same as `tokenAddress` in MixinFunds.
    * @param _amount specifies the max amount to withdraw, which may be reduced when
    * considering the available balance. Set to 0 or MAX_UINT to withdraw everything.
    *
@@ -89,11 +92,12 @@ contract MixinLockCore is
    *  -- however be wary of draining funds as it breaks the `cancelAndRefund` use case.
    */
   function withdraw(
+    address _tokenAddress,
     uint _amount
   ) external
     onlyOwnerOrBeneficiary
   {
-    uint balance = getBalance(address(this));
+    uint balance = getBalance(_tokenAddress, address(this));
     uint amount;
     if(_amount == 0 || _amount > balance)
     {
@@ -105,9 +109,9 @@ contract MixinLockCore is
       amount = _amount;
     }
 
-    emit Withdrawal(msg.sender, beneficiary, amount);
+    emit Withdrawal(msg.sender, _tokenAddress, beneficiary, amount);
     // Security: re-entrancy not a risk as this is the last line of an external function
-    _transfer(beneficiary, amount);
+    _transfer(_tokenAddress, beneficiary, amount);
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -156,7 +156,7 @@ contract MixinRefunds is
 
     if (refund > 0) {
       // Security: doing this last to avoid re-entrancy concerns
-      _transfer(msg.sender, refund);
+      _transfer(tokenAddress, msg.sender, refund);
     }
   }
 

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -186,7 +186,7 @@ contract('Lock / cancelAndRefund', accounts => {
 
   describe('should fail when', () => {
     it('should fail if the Lock owner withdraws too much funds', async () => {
-      await lock.withdraw(0, {
+      await lock.withdraw(await lock.tokenAddress.call(), 0, {
         from: lockOwner,
       })
       await shouldFail(

--- a/smart-contracts/test/Lock/cancelAndRefundFor.js
+++ b/smart-contracts/test/Lock/cancelAndRefundFor.js
@@ -177,7 +177,7 @@ contract('Lock / cancelAndRefundFor', accounts => {
      * This is a risk: we refund via CC but can't cancel the key because the Lock is broke
      */
     it('should fail if the Lock owner withdraws too much funds', async () => {
-      await lock.withdraw(0, {
+      await lock.withdraw(await lock.tokenAddress.call(), 0, {
         from: lockOwner,
       })
 

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -99,7 +99,7 @@ contract('Lock / disableLock', accounts => {
     })
 
     it('Lock owner can still withdraw', async () => {
-      await lock.withdraw(0)
+      await lock.withdraw(await lock.tokenAddress.call(), 0)
     })
 
     it('Lock owner can still expireKeyFor', async () => {

--- a/smart-contracts/test/Lock/erc20.js
+++ b/smart-contracts/test/Lock/erc20.js
@@ -71,7 +71,7 @@ contract('Lock / erc20', accounts => {
         const lockBalance = new BigNumber(await token.balanceOf(lock.address))
         const ownerBalance = new BigNumber(await token.balanceOf(accounts[0]))
 
-        await lockApi.withdraw(0, accounts[0])
+        await lockApi.withdraw(await lock.tokenAddress.call(), 0, accounts[0])
 
         assert.equal(await token.balanceOf(lock.address), 0)
         assert.equal(

--- a/smart-contracts/test/Lock/getBalance.js
+++ b/smart-contracts/test/Lock/getBalance.js
@@ -14,6 +14,8 @@ const keyPrice = Units.convert('0.01', 'eth', 'wei')
 
 contract('Lock / getBalance', accounts => {
   scenarios.forEach(isErc20 => {
+    let tokenAddress
+
     describe(`Test ${isErc20 ? 'ERC20' : 'ETH'}`, () => {
       before(async () => {
         testToken = await TestErc20Token.new()
@@ -24,9 +26,7 @@ contract('Lock / getBalance', accounts => {
           })
         }
 
-        const tokenAddress = isErc20
-          ? testToken.address
-          : Web3Utils.padLeft(0, 40)
+        tokenAddress = isErc20 ? testToken.address : Web3Utils.padLeft(0, 40)
 
         unlock = await getUnlockProxy(unlockContract)
         locks = await deployLocks(unlock, accounts[0], tokenAddress)
@@ -45,12 +45,18 @@ contract('Lock / getBalance', accounts => {
       })
 
       it('get balance of contract', async () => {
-        const balance = await locks['FIRST'].getBalance(locks['FIRST'].address)
+        const balance = await locks['FIRST'].getBalance(
+          tokenAddress,
+          locks['FIRST'].address
+        )
         assert.equal(balance.toString(), keyPrice.toString())
       })
 
       it('get balance of account', async () => {
-        const balance = await locks['FIRST'].getBalance(accounts[1])
+        const balance = await locks['FIRST'].getBalance(
+          tokenAddress,
+          accounts[1]
+        )
         assert(balance.gt(0))
       })
     })

--- a/smart-contracts/test/Lock/withdraw.js
+++ b/smart-contracts/test/Lock/withdraw.js
@@ -7,14 +7,18 @@ const shouldFail = require('../helpers/shouldFail')
 const unlockContract = artifacts.require('../Unlock.sol')
 const getUnlockProxy = require('../helpers/proxy')
 
-let unlock, locks
-let owner
+let unlock, lock
+let tokenAddress
 const price = Units.convert('0.01', 'eth', 'wei')
 
 contract('Lock / withdraw', accounts => {
+  let owner = accounts[0]
+
   before(async () => {
     unlock = await getUnlockProxy(unlockContract)
-    locks = await deployLocks(unlock, accounts[0])
+    const locks = await deployLocks(unlock, owner)
+    lock = locks['OWNED']
+    tokenAddress = await lock.tokenAddress.call()
 
     await purchaseKeys(accounts)
   })
@@ -22,7 +26,7 @@ contract('Lock / withdraw', accounts => {
   it('should only allow the owner to withdraw', async () => {
     assert.notEqual(owner, accounts[1]) // Making sure
     await shouldFail(
-      locks['OWNED'].withdraw(0, {
+      lock.withdraw(tokenAddress, 0, {
         from: accounts[1],
       }),
       ''
@@ -35,16 +39,14 @@ contract('Lock / withdraw', accounts => {
     let contractBalance
     before(async () => {
       ownerBalance = new BigNumber(await web3.eth.getBalance(owner))
-      contractBalance = new BigNumber(
-        await web3.eth.getBalance(locks['OWNED'].address)
-      )
-      tx = await locks['OWNED'].withdraw(0, {
+      contractBalance = new BigNumber(await web3.eth.getBalance(lock.address))
+      tx = await lock.withdraw(tokenAddress, 0, {
         from: owner,
       })
     })
 
     it("should set the lock's balance to 0", async () => {
-      assert.equal(await web3.eth.getBalance(locks['OWNED'].address), 0)
+      assert.equal(await web3.eth.getBalance(lock.address), 0)
     })
 
     it("should increase the owner's balance with the funds from the lock", async () => {
@@ -64,7 +66,7 @@ contract('Lock / withdraw', accounts => {
 
     it('should fail if there is nothing left to withdraw', async () => {
       await shouldFail(
-        locks['OWNED'].withdraw(0, {
+        lock.withdraw(tokenAddress, 0, {
           from: owner,
         }),
         'NOT_ENOUGH_FUNDS'
@@ -81,17 +83,15 @@ contract('Lock / withdraw', accounts => {
       await purchaseKeys(accounts)
 
       ownerBalance = new BigNumber(await web3.eth.getBalance(owner))
-      contractBalance = new BigNumber(
-        await web3.eth.getBalance(locks['OWNED'].address)
-      )
-      tx = await locks['OWNED'].withdraw(42, {
+      contractBalance = new BigNumber(await web3.eth.getBalance(lock.address))
+      tx = await lock.withdraw(tokenAddress, 42, {
         from: owner,
       })
     })
 
     it("should reduce the lock's balance by 42", async () => {
       assert.equal(
-        (await web3.eth.getBalance(locks['OWNED'].address)).toString(),
+        (await web3.eth.getBalance(lock.address)).toString(),
         contractBalance.minus(42).toString()
       )
     })
@@ -113,14 +113,14 @@ contract('Lock / withdraw', accounts => {
 
     describe('when there is nothing left to withdraw', () => {
       before(async () => {
-        await locks['OWNED'].withdraw(0, {
+        await lock.withdraw(tokenAddress, 0, {
           from: owner,
         })
       })
 
       it('withdraw should fail', async () => {
         await shouldFail(
-          locks['OWNED'].withdraw(42, {
+          lock.withdraw(tokenAddress, 42, {
             from: owner,
           }),
           'NOT_ENOUGH_FUNDS'
@@ -135,24 +135,24 @@ contract('Lock / withdraw', accounts => {
     before(async () => {
       await purchaseKeys(accounts)
 
-      await locks['OWNED'].updateBeneficiary(beneficiary, { from: owner })
+      await lock.updateBeneficiary(beneficiary, { from: owner })
     })
 
     it('can withdraw from beneficiary account', async () => {
-      await locks['OWNED'].withdraw(42, {
+      await lock.withdraw(tokenAddress, 42, {
         from: beneficiary,
       })
     })
 
     it('can withdraw from owner account', async () => {
-      await locks['OWNED'].withdraw(42, {
+      await lock.withdraw(tokenAddress, 42, {
         from: owner,
       })
     })
 
     it('should fail to withdraw as non-owner or beneficiary', async () => {
       await shouldFail(
-        locks['OWNED'].withdraw(42, {
+        lock.withdraw(tokenAddress, 42, {
           from: accounts[4],
         }),
         'ONLY_LOCK_OWNER_OR_BENEFICIARY'
@@ -163,16 +163,12 @@ contract('Lock / withdraw', accounts => {
 
 async function purchaseKeys(accounts) {
   const purchases = [accounts[1], accounts[2]].map(account => {
-    return locks['OWNED'].purchase(account, web3.utils.padLeft(0, 40), {
+    return lock.purchase(account, web3.utils.padLeft(0, 40), {
       value: price,
       from: account,
     })
   })
-  await Promise.all(purchases)
-    .then(() => {
-      return locks['OWNED'].owner.call()
-    })
-    .then(_owner => {
-      owner = _owner
-    })
+  await Promise.all(purchases).then(() => {
+    return lock.owner.call()
+  })
 }

--- a/smart-contracts/test/Lock/withdrawByAddress.js
+++ b/smart-contracts/test/Lock/withdrawByAddress.js
@@ -5,7 +5,7 @@ const shouldFail = require('../helpers/shouldFail')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const TestErc20Token = artifacts.require('TestErc20Token.sol')
-const getUnlockProxy = require('../helpers/proxy')
+const getProxy = require('../helpers/proxy')
 
 let unlock, lock
 let token
@@ -14,7 +14,7 @@ contract('Lock / withdrawByAddress', accounts => {
   let owner = accounts[0]
 
   before(async () => {
-    unlock = await getUnlockProxy(unlockContract)
+    unlock = await getProxy(unlockContract)
     const locks = await deployLocks(unlock, owner)
     lock = locks['OWNED']
 

--- a/smart-contracts/test/Lock/withdrawByAddress.js
+++ b/smart-contracts/test/Lock/withdrawByAddress.js
@@ -1,0 +1,61 @@
+const BigNumber = require('bignumber.js')
+
+const deployLocks = require('../helpers/deployLocks')
+const shouldFail = require('../helpers/shouldFail')
+
+const unlockContract = artifacts.require('../Unlock.sol')
+const TestErc20Token = artifacts.require('TestErc20Token.sol')
+const getUnlockProxy = require('../helpers/proxy')
+
+let unlock, lock
+let token
+
+contract('Lock / withdrawByAddress', accounts => {
+  let owner = accounts[0]
+
+  before(async () => {
+    unlock = await getUnlockProxy(unlockContract)
+    const locks = await deployLocks(unlock, owner)
+    lock = locks['OWNED']
+
+    // Put some ERC-20 tokens into the contract
+    token = await TestErc20Token.new({ from: owner })
+    // TODO: mint or transfer to a contract throws an error in Truffle
+    // however the tx does mine.  Not sure what's causing this yet..
+    //await token.mint(lock.address, 42000)
+  })
+
+  describe.skip('when the owner withdraws funds for a specific token', () => {
+    let ownerBalance
+    let contractBalance
+
+    before(async () => {
+      ownerBalance = new BigNumber(await token.balanceOf(owner))
+      contractBalance = new BigNumber(await token.balanceOf(lock.address))
+      await lock.withdraw(token.address, 0, {
+        from: owner,
+      })
+    })
+
+    it("should set the lock's balance to 0", async () => {
+      assert.equal(await token.balanceOf(lock.address), 0)
+    })
+
+    it("should increase the owner's balance with the funds from the lock", async () => {
+      const balance = new BigNumber(await token.balanceOf(owner))
+      assert.equal(
+        balance.toString(),
+        ownerBalance.plus(contractBalance).toString()
+      )
+    })
+
+    it('should fail if there is nothing left to withdraw', async () => {
+      await shouldFail(
+        lock.withdraw(token.address, 0, {
+          from: owner,
+        }),
+        'NOT_ENOUGH_FUNDS'
+      )
+    })
+  })
+})

--- a/smart-contracts/test/helpers/lockApi.js
+++ b/smart-contracts/test/helpers/lockApi.js
@@ -81,10 +81,10 @@ module.exports = function lockApi(lockContract) {
       })
     },
 
-    async withdraw(amount, from) {
+    async withdraw(tokenAddress, amount, from) {
       const call = web3.eth.abi.encodeFunctionCall(
         lockContract.abi.find(e => e.name === 'withdraw'),
-        [amount]
+        [tokenAddress, amount]
       )
       return web3.eth.sendTransaction({
         to: lockContract.address,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This offers Lock owners a new feature just in case some unexpected funds enter the contract.  e.g. maybe intended to send a tip or maybe the Lock contract was awarded some funds via an airdrop.

Most of the time, this value would simply be set to the tokenAddress used by the lock (e.g. DAI or 0 for ETH)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
