### PR TITLE
Make expiry text more human-logical

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -8453,7 +8453,7 @@ Object {
               <footer
                 class="c23 c24"
               >
-                Expires in 1 Hour
+                Expires in 2 Hours
               </footer>
               <footer
                 class="c25 c26"
@@ -8714,7 +8714,7 @@ Object {
             <footer
               class="sc-1549ebs-2 ik5149-0 ik5149-2 epNQgy"
             >
-              Expires in 1 Hour
+              Expires in 2 Hours
             </footer>
             <footer
               class="sc-1549ebs-2 ik5149-0 ik5149-1 ocNib"

--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5779,7 +5779,7 @@ Object {
 }
 `;
 
-exports[`Storyshots Checkout Checkout with 3 locks and one valid key purchase 1`] = `
+exports[`Storyshots Checkout Checkout with 3 locks and two valid key purchases 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -6354,7 +6354,7 @@ Object {
               <footer
                 class="c23 c24"
               >
-                Expires in 1 hour
+                Expires in &lt; 1 Minute
               </footer>
               <footer
                 class="c25 c26"
@@ -6364,9 +6364,8 @@ Object {
             </div>
           </li>
           <li
-            class="lock c27"
+            class="lock c8"
             data-address="0x456"
-            disabled=""
           >
             <header
               class="c9"
@@ -6374,36 +6373,68 @@ Object {
               One Month
             </header>
             <div
-              class="c28"
-              disabled=""
+              class="c10"
             >
               <div
-                class="price c29"
+                class="c11 price c12"
               >
                 0.3
                  
                 Eth
               </div>
-              <div>
+              <div
+                class="c13 "
+              >
                 <span
-                  class="c30"
+                  class="c14 c15"
                 >
                   $
                   ---
                 </span>
                 <span
-                  class="c31"
+                  class="c16"
                 >
                   <span>
                     30 days
                   </span>
                 </span>
               </div>
-              <footer
-                class="c32 c33"
-                disabled=""
+              <a
+                class="c17 c18 c19"
               >
-                Purchase
+                <svg
+                  class="c20 "
+                  viewBox="0 0 24 24"
+                >
+                  <title />
+                  <path
+                    clip-rule="evenodd"
+                    d="M16.857 7.6a.5.5 0 0 1 .099.7l-5.32 7.07a.5.5 0 0 1-.704.096l-3.236-2.482a.5.5 0 1 1 .608-.794l2.836 2.175L16.157 7.7a.5.5 0 0 1 .7-.098z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+                <svg
+                  class="c21 c22"
+                  viewBox="0 0 24 24"
+                >
+                  <title />
+                  <path
+                    clip-rule="evenodd"
+                    d="M17.5 12a.5.5 0 0 1-.175.38l-3.5 3a.5.5 0 1 1-.65-.76l2.473-2.12H7a.5.5 0 0 1 0-1h8.648l-2.473-2.12a.5.5 0 1 1 .65-.76l3.5 3a.5.5 0 0 1 .175.38z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+                
+              </a>
+              <footer
+                class="c23 c24"
+              >
+                Expires in 20 Minutes
+              </footer>
+              <footer
+                class="c25 c26"
+              >
+                Go to Content
               </footer>
             </div>
           </li>
@@ -6586,7 +6617,7 @@ Object {
             <footer
               class="sc-1549ebs-2 ik5149-0 ik5149-2 epNQgy"
             >
-              Expires in 1 hour
+              Expires in &lt; 1 Minute
             </footer>
             <footer
               class="sc-1549ebs-2 ik5149-0 ik5149-1 ocNib"
@@ -6596,9 +6627,8 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 lock cGsVZV"
+          class="sc-1549ebs-0 lock gxqdDg"
           data-address="0x456"
-          disabled=""
         >
           <header
             class="sc-1549ebs-1 kSQjXI"
@@ -6606,36 +6636,68 @@ Object {
             One Month
           </header>
           <div
-            class="sc-1549ebs-3 sc-5sgq84-2 ddHjJt"
-            disabled=""
+            class="sc-1549ebs-3 azpr18-5 fsNpLg"
           >
             <div
-              class="sc-5sgq84-3 price bIZSQm"
+              class="azpr18-1 price gXKeU"
             >
               0.3
                
               Eth
             </div>
-            <div>
+            <div
+              class="azpr18-0 hGLUUF"
+            >
               <span
-                class="sc-5sgq84-4 sc-5sgq84-5 bjYoJT"
+                class="azpr18-2 azpr18-3 jHnszm"
               >
                 $
                 ---
               </span>
               <span
-                class="sc-5sgq84-4 sc-5sgq84-6 ickXrh"
+                class="azpr18-2 azpr18-4 kvkGQn"
               >
                 <span>
                   30 days
                 </span>
               </span>
             </div>
-            <footer
-              class="sc-1549ebs-2 sc-5sgq84-1 IxeZt"
-              disabled=""
+            <a
+              class="sc-1hzn3pu-2 jZYYLs is925m-0 kmZaWo"
             >
-              Purchase
+              <svg
+                class="sc-1hzn3pu-0 dozNUb"
+                viewBox="0 0 24 24"
+              >
+                <title />
+                <path
+                  clip-rule="evenodd"
+                  d="M16.857 7.6a.5.5 0 0 1 .099.7l-5.32 7.07a.5.5 0 0 1-.704.096l-3.236-2.482a.5.5 0 1 1 .608-.794l2.836 2.175L16.157 7.7a.5.5 0 0 1 .7-.098z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              <svg
+                class="sc-1hzn3pu-1 gckVYZ"
+                viewBox="0 0 24 24"
+              >
+                <title />
+                <path
+                  clip-rule="evenodd"
+                  d="M17.5 12a.5.5 0 0 1-.175.38l-3.5 3a.5.5 0 1 1-.65-.76l2.473-2.12H7a.5.5 0 0 1 0-1h8.648l-2.473-2.12a.5.5 0 1 1 .65-.76l3.5 3a.5.5 0 0 1 .175.38z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              
+            </a>
+            <footer
+              class="sc-1549ebs-2 ik5149-0 ik5149-2 epNQgy"
+            >
+              Expires in 20 Minutes
+            </footer>
+            <footer
+              class="sc-1549ebs-2 ik5149-0 ik5149-1 ocNib"
+            >
+              Go to Content
             </footer>
           </div>
         </li>
@@ -7340,7 +7402,7 @@ Object {
               <footer
                 class="c23 c24"
               >
-                Expires in 1 hour
+                Expires in 8 Days
               </footer>
               <footer
                 class="c25 c26"
@@ -7568,7 +7630,7 @@ Object {
             <footer
               class="sc-1549ebs-2 ik5149-0 ik5149-2 epNQgy"
             >
-              Expires in 1 hour
+              Expires in 8 Days
             </footer>
             <footer
               class="sc-1549ebs-2 ik5149-0 ik5149-1 ocNib"
@@ -8318,7 +8380,7 @@ Object {
               <footer
                 class="c23 c24"
               >
-                Expires in 1 hour
+                Expires in 1 Hour
               </footer>
               <footer
                 class="c25 c26"
@@ -8328,44 +8390,75 @@ Object {
             </div>
           </li>
           <li
-            class="lock c27"
+            class="lock c8"
             data-address="0x456"
-            disabled=""
           >
             <header
               class="c9"
             />
             <div
-              class="c28"
-              disabled=""
+              class="c10"
             >
               <div
-                class="price c29"
+                class="c11 price c12"
               >
                 0.3
                  
                 Eth
               </div>
-              <div>
+              <div
+                class="c13 "
+              >
                 <span
-                  class="c30"
+                  class="c14 c15"
                 >
                   $
                   ---
                 </span>
                 <span
-                  class="c31"
+                  class="c16"
                 >
                   <span>
                     30 days
                   </span>
                 </span>
               </div>
-              <footer
-                class="c32 c33"
-                disabled=""
+              <a
+                class="c17 c18 c19"
               >
-                Purchase
+                <svg
+                  class="c20 "
+                  viewBox="0 0 24 24"
+                >
+                  <title />
+                  <path
+                    clip-rule="evenodd"
+                    d="M16.857 7.6a.5.5 0 0 1 .099.7l-5.32 7.07a.5.5 0 0 1-.704.096l-3.236-2.482a.5.5 0 1 1 .608-.794l2.836 2.175L16.157 7.7a.5.5 0 0 1 .7-.098z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+                <svg
+                  class="c21 c22"
+                  viewBox="0 0 24 24"
+                >
+                  <title />
+                  <path
+                    clip-rule="evenodd"
+                    d="M17.5 12a.5.5 0 0 1-.175.38l-3.5 3a.5.5 0 1 1-.65-.76l2.473-2.12H7a.5.5 0 0 1 0-1h8.648l-2.473-2.12a.5.5 0 1 1 .65-.76l3.5 3a.5.5 0 0 1 .175.38z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+                
+              </a>
+              <footer
+                class="c23 c24"
+              >
+                Expires in 1 Hour
+              </footer>
+              <footer
+                class="c25 c26"
+              >
+                Go to Content
               </footer>
             </div>
           </li>
@@ -8548,7 +8641,7 @@ Object {
             <footer
               class="sc-1549ebs-2 ik5149-0 ik5149-2 epNQgy"
             >
-              Expires in 1 hour
+              Expires in 1 Hour
             </footer>
             <footer
               class="sc-1549ebs-2 ik5149-0 ik5149-1 ocNib"
@@ -8558,44 +8651,75 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 lock cGsVZV"
+          class="sc-1549ebs-0 lock gxqdDg"
           data-address="0x456"
-          disabled=""
         >
           <header
             class="sc-1549ebs-1 kSQjXI"
           />
           <div
-            class="sc-1549ebs-3 sc-5sgq84-2 ddHjJt"
-            disabled=""
+            class="sc-1549ebs-3 azpr18-5 fsNpLg"
           >
             <div
-              class="sc-5sgq84-3 price bIZSQm"
+              class="azpr18-1 price gXKeU"
             >
               0.3
                
               Eth
             </div>
-            <div>
+            <div
+              class="azpr18-0 hGLUUF"
+            >
               <span
-                class="sc-5sgq84-4 sc-5sgq84-5 bjYoJT"
+                class="azpr18-2 azpr18-3 jHnszm"
               >
                 $
                 ---
               </span>
               <span
-                class="sc-5sgq84-4 sc-5sgq84-6 ickXrh"
+                class="azpr18-2 azpr18-4 kvkGQn"
               >
                 <span>
                   30 days
                 </span>
               </span>
             </div>
-            <footer
-              class="sc-1549ebs-2 sc-5sgq84-1 IxeZt"
-              disabled=""
+            <a
+              class="sc-1hzn3pu-2 jZYYLs is925m-0 kmZaWo"
             >
-              Purchase
+              <svg
+                class="sc-1hzn3pu-0 dozNUb"
+                viewBox="0 0 24 24"
+              >
+                <title />
+                <path
+                  clip-rule="evenodd"
+                  d="M16.857 7.6a.5.5 0 0 1 .099.7l-5.32 7.07a.5.5 0 0 1-.704.096l-3.236-2.482a.5.5 0 1 1 .608-.794l2.836 2.175L16.157 7.7a.5.5 0 0 1 .7-.098z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              <svg
+                class="sc-1hzn3pu-1 gckVYZ"
+                viewBox="0 0 24 24"
+              >
+                <title />
+                <path
+                  clip-rule="evenodd"
+                  d="M17.5 12a.5.5 0 0 1-.175.38l-3.5 3a.5.5 0 1 1-.65-.76l2.473-2.12H7a.5.5 0 0 1 0-1h8.648l-2.473-2.12a.5.5 0 1 1 .65-.76l3.5 3a.5.5 0 0 1 .175.38z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              
+            </a>
+            <footer
+              class="sc-1549ebs-2 ik5149-0 ik5149-2 epNQgy"
+            >
+              Expires in 1 Hour
+            </footer>
+            <footer
+              class="sc-1549ebs-2 ik5149-0 ik5149-1 ocNib"
+            >
+              Go to Content
             </footer>
           </div>
         </li>

--- a/paywall/src/__tests__/utils/durations.test.js
+++ b/paywall/src/__tests__/utils/durations.test.js
@@ -2,9 +2,66 @@ import {
   durationsAsTextFromSeconds,
   durationsAsArrayFromSeconds,
   expirationAsText,
+  durations,
 } from '../../utils/durations'
 
 describe('duration utilities', () => {
+  describe('durations', () => {
+    it('should return an object with seconds set for < 1 minute', () => {
+      expect.assertions(3)
+
+      expect(durations(0.5, {})).toEqual({
+        seconds: 0.5,
+      })
+      expect(durations(59, {})).toEqual({
+        seconds: 59,
+      })
+      expect(durations(59.9, {})).toEqual({
+        seconds: 59.9,
+      })
+    })
+
+    it('should return an object with minutes set for > 1 minute, < 1 hour', () => {
+      expect.assertions(3)
+
+      expect(durations(60, {})).toEqual({
+        minutes: 1,
+      })
+      expect(durations(61, {})).toEqual({
+        seconds: 1,
+        minutes: 1,
+      })
+      expect(durations(3599, {})).toEqual({
+        minutes: 59,
+        seconds: 59,
+      })
+    })
+
+    it('should return an object with hours set for > 1 hour, < 1 day', () => {
+      expect.assertions(3)
+
+      expect(durations(3600, {})).toEqual({
+        hours: 1,
+      })
+      expect(durations(3601, {})).toEqual({
+        seconds: 1,
+        hours: 1,
+      })
+      expect(durations(60 * 60 * 24 - 1, {})).toEqual({
+        minutes: 59,
+        seconds: 59,
+        hours: 23,
+      })
+    })
+
+    it('should return an object with days set for > 1 day', () => {
+      expect.assertions(1)
+
+      expect(durations(60 * 60 * 24 * 5, {})).toEqual({
+        days: 5,
+      })
+    })
+  })
   describe('durationsAsTextFromSeconds', () => {
     it('should return the right durations', () => {
       expect.assertions(3)
@@ -47,32 +104,136 @@ describe('duration utilities', () => {
   })
 
   describe('expirationAsText', () => {
-    it('should return "Expires in ..." for small values', () => {
+    function addMinutes(timestamp, minutes) {
+      return timestamp + 60 * minutes
+    }
+    function addHours(timestamp, hours) {
+      return timestamp + 3600 * hours
+    }
+    function addDays(timestamp, days) {
+      return timestamp + 3600 * 24 * days
+    }
+    function getTimestamp({ minutes = 0, hours = 0, days = 0 }) {
+      return addDays(
+        addHours(addMinutes(new Date().getTime() / 1000, minutes), hours),
+        days
+      )
+    }
+
+    it('should return "never" for 0 timestamp', () => {
+      expect.assertions(1)
+
+      expect(expirationAsText(0)).toBe('Never Expires')
+    })
+
+    it('should return "Expired" for old timestamps', () => {
+      expect.assertions(1)
+
+      expect(expirationAsText(getTimestamp({ minutes: -1 }))).toBe('Expired')
+    })
+
+    it('should return "< 1 Minute" for expiration in seconds', () => {
+      expect.assertions(1)
+
+      expect(expirationAsText(getTimestamp({ seconds: 30 }))).toBe(
+        'Expires in < 1 Minute'
+      )
+    })
+
+    it('should return "1 Minute" for expiration between 1 minute and 2 minutes', () => {
+      expect.assertions(2)
+
+      expect(expirationAsText(getTimestamp({ minutes: 1, seconds: 0.5 }))).toBe(
+        'Expires in 1 Minute'
+      )
+
+      expect(
+        expirationAsText(getTimestamp({ minutes: 1, seconds: 59.9 }))
+      ).toBe('Expires in 1 Minute')
+    })
+
+    it('should return "X Minutes" for expiration between 2 minutes and 30 minutes', () => {
+      expect.assertions(2)
+
+      expect(expirationAsText(getTimestamp({ minutes: 2, seconds: 0.5 }))).toBe(
+        'Expires in 2 Minutes'
+      )
+
+      expect(
+        expirationAsText(getTimestamp({ minutes: 29, seconds: 59.9 }))
+      ).toBe('Expires in 29 Minutes')
+    })
+
+    it('should return "1 Hour" for expiration between 30 minutes and 1 hour, 30 minutes', () => {
+      expect.assertions(2)
+
+      expect(expirationAsText(getTimestamp({ minutes: 31 }))).toBe(
+        'Expires in 1 Hour'
+      )
+
+      expect(expirationAsText(getTimestamp({ hours: 1, minutes: 29 }))).toBe(
+        'Expires in 1 Hour'
+      )
+    })
+
+    it('should round up if there are more than 30 minutes', () => {
       expect.assertions(2)
 
       expect(
-        expirationAsText(new Date().getTime() / 1000 + 60 * 60 * 12)
-      ).toEqual('Expires in 12 hours')
-      expect(
-        expirationAsText(new Date().getTime() / 1000 + 60 * 60 * 12 + 60)
-      ).toEqual('Expires in 12 hours and 1 minute')
+        expirationAsText(getTimestamp({ minutes: 31, seconds: 0.5 }))
+      ).toBe('Expires in 1 Hour')
+
+      expect(expirationAsText(getTimestamp({ hours: 1, minutes: 31 }))).toBe(
+        'Expires in 2 Hours'
+      )
     })
 
-    it('should return "Expires ..." for large values', () => {
-      expect.assertions(1)
+    it('should return "X Hours" for expiration between 2 hours and 23 hours, 30 minutes', () => {
+      expect.assertions(2)
 
-      const now = new Date()
-      const then = new Date(
-        now.getFullYear(),
-        now.getMonth(),
-        now.getDate(),
-        0,
-        0,
-        0
+      expect(expirationAsText(getTimestamp({ hours: 2, seconds: 0.5 }))).toBe(
+        'Expires in 2 Hours'
       )
-      const seconds = (now.getTime() - then.getTime()) / 1000
-      const future = new Date('2100-01-01 00:00:00').getTime() / 1000 + seconds
-      expect(expirationAsText(future)).toEqual('Expires Jan 1, 2100')
+
+      expect(expirationAsText(getTimestamp({ hours: 23, minutes: 30 }))).toBe(
+        'Expires in 23 Hours'
+      )
+    })
+
+    it('should return "1 Day" for expiration between 23 hours, 31 minutes and 1 day, 23 hours, 30 minutes', () => {
+      expect.assertions(2)
+
+      expect(expirationAsText(getTimestamp({ hours: 23, minutes: 31 }))).toBe(
+        'Expires in 1 Day'
+      )
+
+      expect(
+        expirationAsText(getTimestamp({ days: 1, hours: 23, minutes: 29 }))
+      ).toBe('Expires in 1 Day')
+    })
+
+    it('should return "X Days" for expiration between 1 day, 23 hours, 31 minutes and 29 days, 23 hours, 30 minutes', () => {
+      expect.assertions(2)
+
+      expect(
+        expirationAsText(getTimestamp({ days: 1, hours: 23, minutes: 31 }))
+      ).toBe('Expires in 2 Days')
+
+      expect(
+        expirationAsText(getTimestamp({ days: 30, hours: 23, minutes: 29 }))
+      ).toBe('Expires in 30 Days')
+    })
+
+    it('should return "Blah 3, 1234" format for expiration between 29 days, 23 hours, 31 minutes and beyond', () => {
+      expect.assertions(2)
+
+      expect(
+        expirationAsText(getTimestamp({ days: 30, hours: 23, minutes: 31 }))
+      ).toMatch(/^Expires [a-zA-Z]+ \d+, \d{4}$/)
+
+      expect(
+        expirationAsText(getTimestamp({ days: 123, hours: 23, minutes: 31 }))
+      ).toMatch(/^Expires [a-zA-Z]+ \d+, \d{4}$/)
     })
   })
 })

--- a/paywall/src/stories/checkout/Checkout.stories.js
+++ b/paywall/src/stories/checkout/Checkout.stories.js
@@ -362,7 +362,7 @@ storiesOf('Checkout', module)
           status: 'valid',
           transactions: [],
           // expiration in rounded up hours
-          expiration: new Date().getTime() / 1000 + 60 * 91,
+          expiration: new Date().getTime() / 1000 + 60 * 101,
         },
       },
       '0x789': {

--- a/paywall/src/stories/checkout/Checkout.stories.js
+++ b/paywall/src/stories/checkout/Checkout.stories.js
@@ -289,7 +289,7 @@ storiesOf('Checkout', module)
       />
     )
   })
-  .add('Checkout with 3 locks and one valid key purchase', () => {
+  .add('Checkout with 3 locks and two valid key purchases', () => {
     const locks = {
       '0x123': {
         name: 'Weekly',
@@ -299,7 +299,8 @@ storiesOf('Checkout', module)
         key: {
           status: 'valid',
           transactions: [{}],
-          expiration: new Date().getTime() / 1000 + 60 * 60,
+          // expiration < 1 minute
+          expiration: new Date().getTime() / 1000 + 30,
         },
       },
       '0x456': {
@@ -308,9 +309,10 @@ storiesOf('Checkout', module)
         keyPrice: '0.3',
         expirationDuration: 60 * 60 * 24 * 30,
         key: {
-          status: 'none',
+          status: 'valid',
           transactions: [],
-          expiration: 0,
+          // expiration in minutes
+          expiration: new Date().getTime() / 1000 + 60 * 20 + 4,
         },
       },
       '0x789': {
@@ -347,7 +349,8 @@ storiesOf('Checkout', module)
         key: {
           status: 'valid',
           transactions: [{}],
-          expiration: new Date().getTime() / 1000 + 60 * 60,
+          // expiration in hours
+          expiration: new Date().getTime() / 1000 + 60 * 60 + 300,
         },
       },
       '0x456': {
@@ -356,9 +359,10 @@ storiesOf('Checkout', module)
         keyPrice: '0.3',
         expirationDuration: 60 * 60 * 24 * 30,
         key: {
-          status: 'none',
+          status: 'valid',
           transactions: [],
-          expiration: 0,
+          // expiration in rounded up hours
+          expiration: new Date().getTime() / 1000 + 60 * 90 + 1,
         },
       },
       '0x789': {
@@ -395,7 +399,7 @@ storiesOf('Checkout', module)
         key: {
           status: 'valid',
           transactions: [{}],
-          expiration: new Date().getTime() / 1000 + 60 * 60,
+          expiration: new Date().getTime() / 1000 + 60 * 60 * 24 * 8,
         },
       },
       '0x456': {

--- a/paywall/src/stories/checkout/Checkout.stories.js
+++ b/paywall/src/stories/checkout/Checkout.stories.js
@@ -362,7 +362,7 @@ storiesOf('Checkout', module)
           status: 'valid',
           transactions: [],
           // expiration in rounded up hours
-          expiration: new Date().getTime() / 1000 + 60 * 90 + 1,
+          expiration: new Date().getTime() / 1000 + 60 * 91,
         },
       },
       '0x789': {


### PR DESCRIPTION
# Description

In response to massive, specific descriptions down to the second of key expiry overflowing the bounds of the lock, this PR simplifies the output. It follows some basic breakpoints:

59 seconds or less:
`Expires in < 1 Minute`
60 seconds to 1 minute, 30 seconds:
`Expires in 1 Minute`
... to 59 minutes 30 seconds:
`Expires in X Minutes` (where `X` is the number)
... to 23 hours, 30 minutes:
`Expires in X Hours` (where `X` is the number)
... to 30 days, 23 hours, 30 minutes:
`Expires in X Days` (where `X` is the number)
... beyond:
`Expires Xxx Y, ZZZZ` (where `Xxx` is the month name, `Y` is the day, and `ZZZZ` is the year)

<img width="883" alt="Screen Shot 2019-07-18 at 2 05 36 PM" src="https://user-images.githubusercontent.com/98250/61481244-c4cbea80-a965-11e9-9097-1cb516adbd81.png">
<img width="883" alt="Screen Shot 2019-07-18 at 2 05 32 PM" src="https://user-images.githubusercontent.com/98250/61481245-c5648100-a965-11e9-9213-d16323604d8c.png">
<img width="883" alt="Screen Shot 2019-07-18 at 2 04 39 PM" src="https://user-images.githubusercontent.com/98250/61481246-c5648100-a965-11e9-95ce-80209f88c4d6.png">

This *should* have the side effect of fixing the flaky test as well, because it will still say `Expires in 1 Hour` even for 59:59.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4239

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
