### PR TITLE
new utility for normalizing lock addresses

### DIFF
--- a/paywall/src/__tests__/utils/normalizing.test.ts
+++ b/paywall/src/__tests__/utils/normalizing.test.ts
@@ -1,0 +1,43 @@
+import {
+  normalizeLockAddress,
+  normalizeAddressKeys,
+} from '../../utils/normalizeAddresses'
+
+describe('BlockchainHandler - normalizing functionality', () => {
+  describe('normalizeLockAddress', () => {
+    it('should normalize a lock address to all lower case', () => {
+      expect.assertions(2)
+
+      const upperAddress = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+      const lowerAddress = upperAddress.toLowerCase()
+
+      expect(normalizeLockAddress(upperAddress)).toBe(lowerAddress)
+      expect(normalizeLockAddress(lowerAddress)).toBe(lowerAddress)
+    })
+  })
+
+  describe('normalizeAddressKeys', () => {
+    it('should normalize all keys of an object to lower case', () => {
+      expect.assertions(1)
+
+      const addresses = [
+        '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+        '0x15B87bdC4B3ecb783F56f735653332EAD3BCa5F8',
+        '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
+      ]
+      const lowerAddresses = addresses.map(address => address.toLowerCase())
+      const obj = {
+        [addresses[0]]: 0,
+        [addresses[1]]: 1,
+        [addresses[2]]: 2,
+      }
+      const expectedObj = {
+        [lowerAddresses[0]]: 0,
+        [lowerAddresses[1]]: 1,
+        [lowerAddresses[2]]: 2,
+      }
+
+      expect(normalizeAddressKeys(obj)).toEqual(expectedObj)
+    })
+  })
+})

--- a/paywall/src/utils/normalizeAddresses.ts
+++ b/paywall/src/utils/normalizeAddresses.ts
@@ -1,0 +1,29 @@
+/**
+ * convert lock addresses to a normal form.
+ */
+export function normalizeLockAddress(address: string) {
+  // TODO: export checksum lock function from web3Service and use that instead
+  return address.toLowerCase()
+}
+
+type KeyedObject = { [key: string]: any }
+type SpecificObject<T> = { [key: string]: T }
+type InternalType<T> = T extends { [key: string]: infer U } ? U : never
+/**
+ * convert the key indices of an object to normalized form
+ *
+ * Used for normalizing key and lock indices
+ */
+export function normalizeAddressKeys<
+  T extends KeyedObject,
+  U extends InternalType<T> = InternalType<T>
+>(object: SpecificObject<U>): SpecificObject<U> {
+  return Object.keys(object).reduce(
+    (newObject: { [key: string]: any }, key) => {
+      const value = object[key]
+      newObject[normalizeLockAddress(key)] = value
+      return newObject
+    },
+    {}
+  )
+}


### PR DESCRIPTION
# Description

This utility provides some simple functionality to normalize account addresses across the  data iframe. For now, it simply lower-cases them. In the future, we may choose to use checksummed addresses instead.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #4252

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
