### PR TITLE
don't call walletService.once('ready') if we are ready already

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/ensureWalletReady.test.js
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/ensureWalletReady.test.js
@@ -15,8 +15,12 @@ describe('blockchain handler waitForReady', () => {
   })
 
   it('succeeds immediately if walletService is ready', async () => {
-    expect.assertions(0)
-    await ensureWalletReady({ ready: true })
+    expect.assertions(1)
+    const once = jest.fn()
+
+    await ensureWalletReady({ ready: true, once })
+
+    expect(once).not.toHaveBeenCalled()
   })
 
   it('succeed eventually when walletService emits ready', done => {

--- a/paywall/src/data-iframe/blockchainHandler/ensureWalletReady.js
+++ b/paywall/src/data-iframe/blockchainHandler/ensureWalletReady.js
@@ -8,10 +8,11 @@ export default async function ensureWalletReady(walletService) {
       )
     }
     if (walletService.ready) {
-      return resolve()
-    }
-    walletService.once('ready', () => {
       resolve()
-    })
+    } else {
+      walletService.once('ready', () => {
+        resolve()
+      })
+    }
   })
 }


### PR DESCRIPTION
# Description

This adds an important condition inside `ensureWalletReady`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #4256

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
