### PR TITLE
treat locks as unconnected to networks in the cache

### DIFF
--- a/paywall/src/__tests__/data-iframe/cache/cache.test.ts
+++ b/paywall/src/__tests__/data-iframe/cache/cache.test.ts
@@ -9,6 +9,8 @@ import {
   setNetwork,
   getNetwork,
   clear,
+  setLocks,
+  getLocks,
 } from '../../../data-iframe/cache/cache'
 
 describe('cache utility', () => {
@@ -448,6 +450,24 @@ describe('cache utility', () => {
       const network = await getNetwork(testWindow)
 
       expect(network).toBe(2)
+    })
+
+    it('should save and retrieve locks', async () => {
+      expect.assertions(1)
+
+      const locks = {
+        '0x123': {
+          name: 'Big ol lock',
+          address: '0x123',
+          keyPrice: '1',
+          expirationDuration: 123,
+          currencyContractAddress: '0x345',
+        },
+      }
+      await setLocks(testWindow, locks)
+      const network = await getLocks(testWindow)
+
+      expect(network).toBe(locks)
     })
   })
 })

--- a/paywall/src/__tests__/data-iframe/cacheHandler.test.js
+++ b/paywall/src/__tests__/data-iframe/cacheHandler.test.js
@@ -399,16 +399,23 @@ describe('cacheHandler', () => {
       await setNetwork(fakeWindow, 4)
     })
 
-    it('cached locks from a different network do not return', async () => {
+    it('should return new, dummy keys', async () => {
       expect.assertions(1)
 
-      expect(await getLocks(fakeWindow)).toEqual({})
-    })
-
-    it('should not return cached keys', async () => {
-      expect.assertions(1)
-
-      expect(await getKeys(fakeWindow)).toEqual({})
+      expect(await getKeys(fakeWindow)).toEqual({
+        lock: {
+          expiration: 0,
+          id: 'lock-account',
+          lock: 'lock',
+          owner: 'account',
+        },
+        lock2: {
+          expiration: 0,
+          id: 'lock2-account',
+          lock: 'lock2',
+          owner: 'account',
+        },
+      })
     })
 
     it('should not return cached transactions', async () => {
@@ -428,7 +435,16 @@ describe('cacheHandler', () => {
       }
 
       await setKeys(fakeWindow, differentKeys)
-      expect(await getKeys(fakeWindow)).toEqual(differentKeys)
+      expect(await getKeys(fakeWindow)).toEqual({
+        ...differentKeys,
+        lock: {
+          // dummy key
+          expiration: 0,
+          id: 'lock-account',
+          lock: 'lock',
+          owner: 'account',
+        },
+      })
 
       await setNetwork(fakeWindow, 2)
       expect(await getKeys(fakeWindow)).toEqual(myKeys)

--- a/paywall/src/data-iframe/cache/cache.ts
+++ b/paywall/src/data-iframe/cache/cache.ts
@@ -167,6 +167,29 @@ export async function merge({
 }
 
 /**
+ * Retrieve the current cached locks
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @returns {Locks}
+ */
+export async function getLocks(window: LocalStorageWindow) {
+  const driver = getDriver(window)
+  return driver.getUnkeyedItem('locks')
+}
+
+/**
+ * Set the current cached account
+ *
+ * @param {object} window this is the global context, either global, window, or self
+ * @param {string} account the ethereum account address of the current user
+ */
+// TODO: use RawLocks once merged instead of any
+export async function setLocks(window: LocalStorageWindow, locks: any) {
+  const driver = getDriver(window)
+  return driver.saveUnkeyedItem('locks', locks)
+}
+
+/**
  * Retrieve the current cached account
  *
  * @param {object} window this is the global context, either global, window, or self

--- a/paywall/src/data-iframe/cache/drivers/driverInterface.ts
+++ b/paywall/src/data-iframe/cache/drivers/driverInterface.ts
@@ -1,16 +1,14 @@
+export type UnkeyedItems = 'account' | 'balance' | 'network' | 'locks'
 export default interface CacheDriver {
   getKeyedItem(networkId: number, accountAddress: string): Promise<any>
   available(): boolean
-  getUnkeyedItem(key: 'account' | 'balance' | 'network'): Promise<any>
+  getUnkeyedItem(key: UnkeyedItems): Promise<any>
   saveKeyedItem(
     networkId: number,
     accountAddress: string,
     value: any
   ): Promise<void>
-  saveUnkeyedItem(
-    key: 'account' | 'balance' | 'network',
-    value: any
-  ): Promise<void>
+  saveUnkeyedItem(key: UnkeyedItems, value: any): Promise<void>
   clearKeyedCache(networkId: number, accountAddress: string): Promise<void>
   __clear?: () => void
 }

--- a/paywall/src/data-iframe/cache/drivers/memory.ts
+++ b/paywall/src/data-iframe/cache/drivers/memory.ts
@@ -1,9 +1,11 @@
-import CacheDriver from './driverInterface'
+import CacheDriver, { UnkeyedItems } from './driverInterface'
+import { Locks } from '../../../unlockTypes'
 
 interface InMemoryCache {
   account?: string
   network?: number
   balance?: number
+  locks?: Locks
   [network: number]: {
     [account: string]: {
       [key: string]: any
@@ -25,7 +27,7 @@ export default class InMemoryDriver implements CacheDriver {
     return true
   }
 
-  async getUnkeyedItem(key: 'account' | 'balance' | 'network') {
+  async getUnkeyedItem(key: UnkeyedItems) {
     const item = this.cache[key]
     if (!item) return null
     return item
@@ -36,7 +38,7 @@ export default class InMemoryDriver implements CacheDriver {
     this.cache[networkId][accountAddress] = value
   }
 
-  async saveUnkeyedItem(key: 'account' | 'balance' | 'network', value: any) {
+  async saveUnkeyedItem(key: UnkeyedItems, value: any) {
     this.cache[key] = value
   }
 

--- a/paywall/src/data-iframe/cache/index.ts
+++ b/paywall/src/data-iframe/cache/index.ts
@@ -10,4 +10,6 @@ export {
   getNetwork,
   setAccount,
   setNetwork,
+  getLocks,
+  setLocks,
 } from './cache'

--- a/paywall/src/data-iframe/cacheHandler.js
+++ b/paywall/src/data-iframe/cacheHandler.js
@@ -74,9 +74,7 @@ export async function getKeys(window) {
  * So we retrieve from the non-account-specific cache
  */
 export async function getLocks(window) {
-  const locks =
-    (await cache.get({ window, networkId: currentNetwork, type: 'locks' })) ||
-    {}
+  const locks = (await cache.getLocks(window)) || {}
   return locks
 }
 
@@ -132,14 +130,9 @@ export async function setKey(window, key) {
  * So we save in the non-account-specific cache
  */
 export async function setLocks(window, locks) {
-  await cache.put({
-    window,
-    networkId: currentNetwork,
-    type: 'locks',
-    value: locks,
-  })
+  await cache.setLocks(window, locks)
+
   notifyListeners('locks')
-  return
 }
 
 export async function setTransactions(window, transactions) {


### PR DESCRIPTION
# Description

As stated in the issue this resolves, the cache was written with an incorrect assumption: that lock contents would change if the user changed the network of their wallet. Locks are immutable in the sense that in each environment (dev, staging, prod), locks can only come from one source.

This changes locks to be an unkeyed cache item.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4258

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
