### PR TITLE
Implement a simple localStorage cache around the mailbox

### DIFF
--- a/paywall/src/__tests__/data-iframe/Mailbox/getBlockchainDataFromLocalStorageCache.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/getBlockchainDataFromLocalStorageCache.test.ts
@@ -1,0 +1,239 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+  BlockchainData,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+  addresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+import {
+  PaywallConfig,
+  TransactionStatus,
+  TransactionType,
+} from '../../../unlockTypes'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - getBlockchainDataFromLocalStorageCache', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  const account = addresses[1]
+  // all locks have had their addresses normalized before arriving
+  const blockchainData: BlockchainData = {
+    account: addresses[1],
+    balance: '234',
+    network: 1984,
+    locks: {
+      [lockAddresses[0]]: {
+        address: lockAddresses[0],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'none',
+          confirmations: 0,
+          expiration: 0,
+          transactions: [],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+      [lockAddresses[1]]: {
+        address: lockAddresses[1],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'expired',
+          confirmations: 1678234,
+          expiration: 163984,
+          transactions: [
+            {
+              status: TransactionStatus.MINED,
+              confirmations: 1678234,
+              hash: 'hash',
+              type: TransactionType.KEY_PURCHASE,
+              blockNumber: 123,
+            },
+          ],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+    },
+  }
+
+  function setupDefaults(killLocalStorage = false) {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    if (killLocalStorage) {
+      fakeWindow.throwOnLocalStorageSet()
+    }
+    mailbox = new Mailbox(constants, fakeWindow)
+    ;(testingMailbox().configuration as PaywallConfig) = {
+      locks: {
+        [lockAddresses[1]]: { name: '' },
+        [lockAddresses[2]]: { name: '' },
+      },
+      callToAction: {
+        default: '',
+        pending: '',
+        expired: '',
+        confirmed: '',
+      },
+    }
+  }
+
+  function testingMailbox() {
+    return mailbox as any
+  }
+
+  describe('error conditions', () => {
+    describe('localStorage is not available', () => {
+      beforeEach(() => {
+        setupDefaults(true)
+        fakeWindow.localStorage.getItem = jest.fn()
+      })
+
+      it('should do nothing if localStorage is not available', () => {
+        expect.assertions(1)
+
+        mailbox.getBlockchainDataFromLocalStorageCache()
+
+        expect(fakeWindow.localStorage.getItem).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('configuration not received/not saved because it was invalid', () => {
+      beforeEach(() => {
+        setupDefaults()
+        fakeWindow.localStorage.setItem = jest.fn()
+        testingMailbox().configuration = undefined
+      })
+
+      it('should do nothing if configuration is not set', () => {
+        expect.assertions(1)
+
+        mailbox.saveCacheInLocalStorage()
+
+        expect(fakeWindow.localStorage.setItem).not.toHaveBeenCalled()
+      })
+    })
+
+    type BadDataTest = [string, (cb?: () => void) => any]
+
+    describe.each(<BadDataTest[]>[
+      [
+        'localStorage throws on attempting to getItem',
+        () => {
+          setupDefaults()
+          fakeWindow.localStorage.clear = jest.fn()
+          fakeWindow.throwOnLocalStorageGet()
+        },
+      ],
+      [
+        'JSON.parsing cached value throws',
+        () => {
+          setupDefaults()
+          fakeWindow.localStorage.clear = jest.fn()
+          fakeWindow.localStorage.getItem = () => '{invalid JSON'
+        },
+      ],
+    ])('%s', (_, setup) => {
+      beforeEach(setup)
+
+      afterEach(() => {
+        // reset to avoid affecting other tests
+        process.env.UNLOCK_ENV = 'prod'
+      })
+
+      it('in dev, it should log the error', () => {
+        expect.assertions(1)
+
+        process.env.UNLOCK_ENV = 'dev'
+        mailbox.getBlockchainDataFromLocalStorageCache()
+
+        expect(fakeWindow.console.error).toHaveBeenCalledWith(expect.any(Error))
+      })
+
+      it('in other envs, it should not log the error', () => {
+        expect.assertions(1)
+
+        mailbox.getBlockchainDataFromLocalStorageCache()
+
+        expect(fakeWindow.console.error).not.toHaveBeenCalled()
+      })
+
+      it('should clear the entire localStorage cache to be safe', () => {
+        expect.assertions(1)
+
+        mailbox.getBlockchainDataFromLocalStorageCache()
+
+        expect(fakeWindow.localStorage.clear).toHaveBeenCalled()
+      })
+
+      it('should return default blockchain data', () => {
+        expect.assertions(1)
+
+        expect(mailbox.getBlockchainDataFromLocalStorageCache()).toBe(
+          testingMailbox().defaultBlockchainData
+        )
+      })
+    })
+  })
+
+  describe('normal operation', () => {
+    describe('empty cache', () => {
+      beforeEach(() => {
+        setupDefaults()
+        ;(testingMailbox().blockchainData as BlockchainData) = blockchainData
+      })
+
+      it('should return the default blockchain data', () => {
+        expect.assertions(1)
+
+        expect(mailbox.getBlockchainDataFromLocalStorageCache()).toBe(
+          testingMailbox().defaultBlockchainData
+        )
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/getCacheKey.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/getCacheKey.test.ts
@@ -1,0 +1,133 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+  addresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+import { PaywallConfig } from '../../../unlockTypes'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - getCacheKey', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+  }
+
+  function testingMailbox() {
+    return mailbox as any
+  }
+
+  describe('error state', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should throw if there is no configuration set', () => {
+      expect.assertions(1)
+
+      expect(() => mailbox.getCacheKey()).toThrow(
+        'internal error: cannot retrieve cache without configuration'
+      )
+    })
+  })
+
+  describe('valid state', () => {
+    beforeEach(() => {
+      setupDefaults()
+      ;(testingMailbox().configuration as PaywallConfig) = {
+        locks: {
+          // intentionally out of alphabetical order to verify sorting
+          // the configuration should be normalized by here, but this verifies that toLowerCase() is called
+          [addresses[2]]: { name: '' },
+          [lockAddresses[1]]: { name: '' },
+        },
+        callToAction: {
+          default: '',
+          pending: '',
+          expired: '',
+          confirmed: '',
+        },
+      }
+    })
+
+    it('should return the cache prefix plus a sorted list of lock addresses', () => {
+      expect.assertions(1)
+
+      const lockAddressPortion = JSON.stringify([
+        lockAddresses[1],
+        lockAddresses[2],
+      ])
+
+      expect(mailbox.getCacheKey()).toBe(
+        '__unlockProtocol.cache' + lockAddressPortion
+      )
+    })
+
+    it('should use the same cache for a config in a different order', () => {
+      expect.assertions(1)
+      ;(testingMailbox().configuration as PaywallConfig) = {
+        locks: {
+          // different order of locks
+          [lockAddresses[1]]: { name: '' },
+          [addresses[2]]: { name: '' },
+        },
+        callToAction: {
+          default: '',
+          pending: '',
+          expired: '',
+          confirmed: '',
+        },
+      }
+
+      const lockAddressPortion = JSON.stringify([
+        lockAddresses[1],
+        lockAddresses[2],
+      ])
+
+      expect(mailbox.getCacheKey()).toBe(
+        '__unlockProtocol.cache' + lockAddressPortion
+      )
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
@@ -109,6 +109,36 @@ describe('Mailbox - init', () => {
     await waitFor(() => testingMailbox().handler)
   })
 
+  describe('errors', () => {
+    beforeEach(() => {
+      setupDefaults(false)
+      ;(unlock.WalletService as any).mockImplementationOnce(function() {
+        mockWalletService = getWalletService({})
+        mockWalletService.connect = jest.fn((provider: any) => {
+          mockWalletService.provider = provider
+          return Promise.reject(new Error('fail'))
+        })
+        return mockWalletService
+      })
+    })
+
+    it('should emit an error if connecting to the provider fails', async done => {
+      expect.assertions(1)
+
+      mailbox.emitError = (e: Error) => {
+        expect(e.message).toMatch('fail')
+        done()
+      }
+
+      mailbox.init()
+
+      fakeWindow.receivePostMessageFromMainWindow(
+        PostMessages.CONFIG,
+        configuration
+      )
+    })
+  })
+
   it('should initialize a BlockchainHandler', async () => {
     expect.assertions(1)
 

--- a/paywall/src/__tests__/data-iframe/Mailbox/invalidateLocalStorageCache.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/invalidateLocalStorageCache.test.ts
@@ -1,0 +1,242 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+  BlockchainData,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+  addresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+import {
+  PaywallConfig,
+  TransactionStatus,
+  TransactionType,
+} from '../../../unlockTypes'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - invalidateLocalStorageCache', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  const account = addresses[1]
+  // all locks have had their addresses normalized before arriving
+  const blockchainData: BlockchainData = {
+    account: addresses[1],
+    balance: '234',
+    network: 1984,
+    locks: {
+      [lockAddresses[0]]: {
+        address: lockAddresses[0],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'none',
+          confirmations: 0,
+          expiration: 0,
+          transactions: [],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+      [lockAddresses[1]]: {
+        address: lockAddresses[1],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'expired',
+          confirmations: 1678234,
+          expiration: 163984,
+          transactions: [
+            {
+              status: TransactionStatus.MINED,
+              confirmations: 1678234,
+              hash: 'hash',
+              type: TransactionType.KEY_PURCHASE,
+              blockNumber: 123,
+            },
+          ],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+    },
+  }
+
+  function setupDefaults(killLocalStorage = false) {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    if (killLocalStorage) {
+      fakeWindow.throwOnLocalStorageSet()
+    }
+    mailbox = new Mailbox(constants, fakeWindow)
+    ;(testingMailbox().configuration as PaywallConfig) = {
+      locks: {
+        [lockAddresses[1]]: { name: '' },
+        [lockAddresses[2]]: { name: '' },
+      },
+      callToAction: {
+        default: '',
+        pending: '',
+        expired: '',
+        confirmed: '',
+      },
+    }
+  }
+
+  function testingMailbox() {
+    return mailbox as any
+  }
+
+  describe('error conditions', () => {
+    describe('localStorage is not available', () => {
+      beforeEach(() => {
+        setupDefaults(true)
+        fakeWindow.localStorage.removeItem = jest.fn()
+      })
+
+      it('should do nothing if localStorage is not available', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.localStorage.removeItem).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('configuration not received/not saved because it was invalid', () => {
+      beforeEach(() => {
+        setupDefaults()
+        fakeWindow.localStorage.removeItem = jest.fn()
+        testingMailbox().configuration = undefined
+      })
+
+      it('should do nothing if configuration is not set', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.localStorage.removeItem).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('localStorage throws on attempting to getItem', () => {
+      beforeEach(() => {
+        setupDefaults()
+        fakeWindow.localStorage.clear = jest.fn()
+        fakeWindow.throwOnLocalStorageRemove()
+      })
+
+      afterEach(() => {
+        // reset to avoid affecting other tests
+        process.env.UNLOCK_ENV = 'prod'
+      })
+
+      it('in dev, it should log the error', () => {
+        expect.assertions(1)
+
+        process.env.UNLOCK_ENV = 'dev'
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.console.error).toHaveBeenCalledWith(expect.any(Error))
+      })
+
+      it('in other envs, it should not log the error', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.console.error).not.toHaveBeenCalled()
+      })
+
+      it('should clear the entire localStorage cache to be safe', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.localStorage.clear).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('normal operation', () => {
+    describe('empty cache', () => {
+      beforeEach(() => {
+        setupDefaults()
+        ;(testingMailbox().blockchainData as BlockchainData) = blockchainData
+      })
+
+      it('should not throw if cache is empty', () => {
+        expect.assertions(0)
+
+        mailbox.getBlockchainDataFromLocalStorageCache()
+      })
+    })
+
+    describe('full cache', () => {
+      beforeEach(() => {
+        setupDefaults()
+        ;(testingMailbox().blockchainData as BlockchainData) = blockchainData
+        // used to show we don't nuke other caches
+        fakeWindow.localStorage.setItem('another', 'item')
+        mailbox.saveCacheInLocalStorage()
+      })
+
+      it('should not remove other caches', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.localStorage.getItem('another')).toBe('item')
+      })
+
+      it('should remove the current cache', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(
+          fakeWindow.localStorage.getItem(mailbox.getCacheKey())
+        ).toBeNull()
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/setConfig.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/setConfig.test.ts
@@ -113,5 +113,31 @@ describe('Mailbox - setConfig', () => {
 
       expect(testingMailbox().configuration).toEqual(expectedConfiguration)
     })
+
+    describe('caching', () => {
+      beforeEach(() => {
+        setupDefaults()
+        mailbox.getBlockchainDataFromLocalStorageCache = jest.fn()
+        mailbox.setupStorageListener = jest.fn()
+      })
+
+      it('should retrive the cache', () => {
+        expect.assertions(1)
+
+        mailbox.setConfig(configuration)
+
+        expect(
+          mailbox.getBlockchainDataFromLocalStorageCache
+        ).toHaveBeenCalled()
+      })
+
+      it('should begin listening for storage events', () => {
+        expect.assertions(1)
+
+        mailbox.setConfig(configuration)
+
+        expect(mailbox.setupStorageListener).toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/paywall/src/__tests__/data-iframe/Mailbox/setupStorageListener.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/setupStorageListener.test.ts
@@ -1,0 +1,142 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import { PaywallConfig } from '../../../unlockTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - setupStorageListener', () => {
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    configuration = defaults.configuration
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  beforeEach(() => {
+    setupDefaults()
+    fakeWindow.addEventListener = jest.fn()
+  })
+
+  it('should set up a listener for storage events', () => {
+    expect.assertions(1)
+
+    mailbox.setupStorageListener()
+
+    expect(fakeWindow.addEventListener).toHaveBeenCalledWith(
+      'storage',
+      expect.any(Function)
+    )
+  })
+
+  describe('event listener', () => {
+    describe('error states', () => {
+      beforeEach(() => {
+        setupDefaults()
+        mailbox.setupStorageListener()
+        testingMailbox().configuration = configuration
+      })
+
+      it('should do nothing if there is no configuration', () => {
+        expect.assertions(1)
+
+        const cacheKey = mailbox.getCacheKey()
+        mailbox.getCacheKey = jest.fn()
+        testingMailbox().configuration = undefined
+
+        fakeWindow.receiveStorageEvent(cacheKey, 'old', 'new')
+
+        expect(mailbox.getCacheKey).not.toHaveBeenCalled()
+      })
+
+      it('should do nothing if there is no handler', () => {
+        expect.assertions(1)
+
+        const cacheKey = mailbox.getCacheKey()
+        mailbox.getCacheKey = jest.fn()
+        testingMailbox().configuration = configuration
+        testingMailbox().handler = undefined
+
+        fakeWindow.receiveStorageEvent(cacheKey, 'old', 'new')
+
+        expect(mailbox.getCacheKey).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('valid states', () => {
+      beforeEach(() => {
+        setupDefaults()
+        mailbox.setupStorageListener()
+        testingMailbox().configuration = configuration
+        testingMailbox().handler = {
+          retrieveCurrentBlockchainData: jest.fn(),
+        }
+      })
+
+      it('should not retrieve data for a different cache key', () => {
+        expect.assertions(1)
+
+        fakeWindow.receiveStorageEvent('different cache', 'old', 'new')
+
+        expect(
+          testingMailbox().handler.retrieveCurrentBlockchainData
+        ).not.toHaveBeenCalled()
+      })
+
+      it("should retrieve data for this paywall's cache key", () => {
+        expect.assertions(1)
+
+        fakeWindow.receiveStorageEvent(mailbox.getCacheKey(), 'old', 'new')
+
+        expect(
+          testingMailbox().handler.retrieveCurrentBlockchainData
+        ).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/cache/cache.test.ts
+++ b/paywall/src/__tests__/data-iframe/cache/cache.test.ts
@@ -10,50 +10,12 @@ import {
   getNetwork,
   clear,
 } from '../../../data-iframe/cache/cache'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
 
 describe('cache utility', () => {
-  let storage: any = {}
-  const fakeWindow: LocalStorageWindow = {
-    localStorage: {
-      length: 1,
-      clear: () => {
-        storage = {}
-      },
-      getItem(key: string) {
-        return storage[key] || null
-      },
-      key(_: number) {
-        return '' // unused but required for the interface
-      },
-      removeItem(key: string) {
-        delete storage[key]
-      },
-      setItem(key: string, value: string) {
-        storage[key] = value
-      },
-    },
-  }
-  const fakeWindowNoLocalStorage: LocalStorageWindow = {
-    localStorage: {
-      length: 0,
-      clear: () => {
-        storage = {}
-      },
-      getItem(key: string) {
-        return storage[key] || null
-      },
-      key(_: number) {
-        return '' // unused but required for the interface
-      },
-      removeItem(key: string) {
-        delete storage[key]
-      },
-      setItem(key: string, value: string) {
-        storage[key] = value
-        throw new Error('no local storage available')
-      },
-    },
-  }
+  const fakeWindow: LocalStorageWindow = new FakeWindow()
+  const fakeWindowNoLocalStorage: LocalStorageWindow = new FakeWindow()
+  ;(fakeWindowNoLocalStorage as FakeWindow).throwOnLocalStorageSet()
 
   type eachThing = Array<[string, LocalStorageWindow]>
   const theEach: eachThing = [
@@ -63,7 +25,7 @@ describe('cache utility', () => {
   describe.each(theEach)('%s driver cache', (_, testWindow) => {
     function clearCache() {
       __clearDriver()
-      storage = {}
+      fakeWindow.localStorage.clear()
     }
     beforeEach(() => {
       clearCache()

--- a/paywall/src/__tests__/data-iframe/cache/drivers/allDrivers.test.ts
+++ b/paywall/src/__tests__/data-iframe/cache/drivers/allDrivers.test.ts
@@ -2,29 +2,10 @@ import LocalStorageDriver from '../../../../data-iframe/cache/drivers/localStora
 import InMemoryDriver from '../../../../data-iframe/cache/drivers/memory'
 import CacheDriver from '../../../../data-iframe/cache/drivers/driverInterface'
 import { LocalStorageWindow } from '../../../../windowTypes'
+import FakeWindow from '../../../test-helpers/fakeWindowHelpers'
 
 describe('common functionality between all drivers', () => {
-  let storage: any = {}
-  const fakeWindow: LocalStorageWindow = {
-    localStorage: {
-      length: 1,
-      clear: () => {
-        storage = {}
-      },
-      getItem(key: string) {
-        return storage[key] || null
-      },
-      key(_: number) {
-        return '' // unused but required for the interface
-      },
-      removeItem(key: string) {
-        delete storage[key]
-      },
-      setItem(key: string, value: string) {
-        storage[key] = value
-      },
-    },
-  }
+  const fakeWindow: LocalStorageWindow = new FakeWindow()
 
   type eachThing = Array<[string, CacheDriver]>
   const theEach: eachThing = [
@@ -33,7 +14,7 @@ describe('common functionality between all drivers', () => {
   ]
   describe.each(theEach)('%s driver', (_, driver) => {
     function clearCache() {
-      storage = {}
+      fakeWindow.localStorage.clear()
       if (driver.__clear) driver.__clear()
     }
     describe('getKeyedItem/saveKeyedItem', () => {

--- a/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
@@ -12,7 +12,7 @@ import {
   web3MethodResult,
   ConsoleWindow,
   LocalStorageWindow,
-  AddEventListener,
+  AddEventListenerFunc,
   StorageHandler,
   StorageEvent,
 } from '../../windowTypes'
@@ -43,7 +43,7 @@ export default class FakeWindow
   public location: {
     href: string
   }
-  public addEventListener: AddEventListener
+  public addEventListener: AddEventListenerFunc
   public messageListeners: {
     [key: string]: Map<MessageHandler, MessageHandler>
   } = {}
@@ -68,15 +68,6 @@ export default class FakeWindow
       postMessage: jest.fn(),
     }
     this.addEventListener = jest.fn((type, handler) => {
-      if (type === 'storage') {
-        this.storageListeners[type] =
-          this.storageListeners[type] ||
-          new Map<StorageHandler, StorageHandler>()
-        this.storageListeners[type].set(
-          handler as StorageHandler,
-          handler as StorageHandler
-        )
-      }
       if (type === 'message') {
         this.messageListeners[type] =
           this.messageListeners[type] ||
@@ -84,6 +75,15 @@ export default class FakeWindow
         this.messageListeners[type].set(
           handler as MessageHandler,
           handler as MessageHandler
+        )
+      }
+      if (type === 'storage') {
+        this.storageListeners[type] =
+          this.storageListeners[type] ||
+          new Map<StorageHandler, StorageHandler>()
+        this.storageListeners[type].set(
+          handler as StorageHandler,
+          handler as StorageHandler
         )
       }
     })

--- a/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
@@ -8,10 +8,13 @@ import {
   IframePostOfficeWindow,
   PostMessageTarget,
   MessageHandler,
-  PostOfficeEventTypes,
   MessageEvent,
   web3MethodResult,
   ConsoleWindow,
+  LocalStorageWindow,
+  AddEventListener,
+  StorageHandler,
+  StorageEvent,
 } from '../../windowTypes'
 import { ExtractPayload, PostMessages } from '../../messageTypes'
 import { waitFor } from '../../utils/promises'
@@ -21,7 +24,8 @@ export default class FakeWindow
     FetchWindow,
     SetTimeoutWindow,
     IframePostOfficeWindow,
-    ConsoleWindow {
+    ConsoleWindow,
+    LocalStorageWindow {
   public fetchResult: any = {}
   public fetch: (
     url: string,
@@ -39,12 +43,16 @@ export default class FakeWindow
   public location: {
     href: string
   }
-  public addEventListener: (
-    type: PostOfficeEventTypes,
-    handler: MessageHandler
-  ) => void
-  public listeners: { [key: string]: Map<MessageHandler, MessageHandler> } = {}
+  public addEventListener: AddEventListener
+  public messageListeners: {
+    [key: string]: Map<MessageHandler, MessageHandler>
+  } = {}
+  public storageListeners: {
+    [key: string]: Map<StorageHandler, StorageHandler>
+  } = {}
   public console: Pick<ConsoleWindow, 'console'>['console']
+  public localStorage: Pick<LocalStorageWindow, 'localStorage'>['localStorage']
+  public storage: { [key: string]: string } = {}
 
   constructor() {
     this.fetch = jest.fn((_: string) => {
@@ -60,12 +68,40 @@ export default class FakeWindow
       postMessage: jest.fn(),
     }
     this.addEventListener = jest.fn((type, handler) => {
-      this.listeners[type] = this.listeners[type] || new Map()
-      this.listeners[type].set(handler, handler)
+      if (type === 'storage') {
+        this.storageListeners[type] =
+          this.storageListeners[type] ||
+          new Map<StorageHandler, StorageHandler>()
+        this.storageListeners[type].set(
+          handler as StorageHandler,
+          handler as StorageHandler
+        )
+      }
+      if (type === 'message') {
+        this.messageListeners[type] =
+          this.messageListeners[type] ||
+          new Map<MessageHandler, MessageHandler>()
+        this.messageListeners[type].set(
+          handler as MessageHandler,
+          handler as MessageHandler
+        )
+      }
     })
     this.console = {
       log: jest.fn(),
       error: jest.fn(),
+    }
+    this.localStorage = {
+      length: 0,
+      clear: () => (this.storage = {}),
+      getItem: (key: string) => this.storage[key] || null,
+      setItem: (key: string, value: string) => (this.storage[key] = value),
+      key: (index: number) => {
+        return Object.keys(this.storage)[index]
+      },
+      removeItem: (key: string) => {
+        delete this.storage[key]
+      },
     }
   }
 
@@ -86,8 +122,19 @@ export default class FakeWindow
         payload,
       },
     }
-    this.listeners.message &&
-      this.listeners.message.forEach(handler => handler(event))
+    this.messageListeners.message &&
+      this.messageListeners.message.forEach(handler => handler(event))
+  }
+
+  public receiveStorageEvent(key: string, newValue: string, oldValue: string) {
+    const event: StorageEvent = {
+      key,
+      oldValue,
+      newValue,
+      storageArea: this.localStorage,
+    }
+    this.storageListeners.storage &&
+      this.storageListeners.storage.forEach(handler => handler(event))
   }
 
   public waitForPostMessage() {
@@ -109,6 +156,24 @@ export default class FakeWindow
       },
       'http://example.com' // origin passed in the URL as ?origin=<urlencoded origin>
     )
+  }
+
+  public throwOnLocalStorageGet() {
+    this.localStorage.getItem = () => {
+      throw new Error('failed to get')
+    }
+  }
+
+  public throwOnLocalStorageRemove() {
+    this.localStorage.removeItem = () => {
+      throw new Error('failed to get')
+    }
+  }
+
+  public throwOnLocalStorageSet() {
+    this.localStorage.setItem = () => {
+      throw new Error('failed to set')
+    }
   }
 
   public respondToWeb3(netversion: number, account: string | null) {

--- a/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
+++ b/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
@@ -1,6 +1,6 @@
 import web3Proxy from '../../unlock.js/web3Proxy'
 import { PostMessages } from '../../messageTypes'
-import { IframeType, UnlockWindow, MessageHandler } from '../../windowTypes'
+import { IframeType, UnlockWindow } from '../../windowTypes'
 import setupIframeMailbox, {
   MapHandlers,
 } from '../../unlock.js/setupIframeMailbox'
@@ -17,6 +17,7 @@ describe('web3Proxy', () => {
   let fakeIframe: IframeType
   let handlers: {
     message: Array<(message: any) => void>
+    storage: Array<(message: any) => void>
   }
   let mapHandlers: MapHandlers
   let fakeCheckoutIframe: IframeType
@@ -39,6 +40,7 @@ describe('web3Proxy', () => {
     }
     handlers = {
       message: [],
+      storage: [],
     }
     process.env.PAYWALL_URL = 'http://fun.times'
     process.env.USER_IFRAME_URL = 'http://fun.times/account'
@@ -81,7 +83,7 @@ describe('web3Proxy', () => {
           enable: enableFuncOrUndefined,
         },
       },
-      addEventListener(type: 'message', handler: MessageHandler) {
+      addEventListener(type, handler) {
         handlers[type].push(handler)
       },
     }

--- a/paywall/src/__tests__/utils/postOffice.test.ts
+++ b/paywall/src/__tests__/utils/postOffice.test.ts
@@ -2,13 +2,13 @@ import {
   setupPostOffice,
   iframePostOffice,
   mainWindowPostOffice,
-  PostOfficeWindow,
   PostMessageTarget,
   PostMessageListener,
   IframePostOfficeWindow,
   Iframe,
 } from '../../utils/postOffice'
 import { PostMessages } from '../../messageTypes'
+import { PostOfficeWindow } from '../../windowTypes'
 
 describe('postOffice', () => {
   const fakeResponder = () => {}

--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -11,6 +11,7 @@ import {
   IframePostOfficeWindow,
   ConsoleWindow,
   LocalStorageWindow,
+  EventTypes,
 } from '../windowTypes'
 import { waitFor } from '../utils/promises'
 import { iframePostOffice, PostMessageListener } from '../utils/postOffice'
@@ -94,7 +95,7 @@ export default class Mailbox {
    * We can use this to determine whether the user has purchased a key in another tab
    */
   setupStorageListener() {
-    this.window.addEventListener('storage', event => {
+    this.window.addEventListener(EventTypes.STORAGE, event => {
       if (!this.configuration || !this.handler) return
       if (event.key === this.getCacheKey()) {
         // another tab has done something that affects our data, so

--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -7,7 +7,11 @@ import {
 } from './blockchainHandler/blockChainTypes'
 import { isValidPaywallConfig, isAccount } from '../utils/validators'
 import { PaywallConfig, PurchaseKeyRequest } from '../unlockTypes'
-import { IframePostOfficeWindow, ConsoleWindow } from '../windowTypes'
+import {
+  IframePostOfficeWindow,
+  ConsoleWindow,
+  LocalStorageWindow,
+} from '../windowTypes'
 import { waitFor } from '../utils/promises'
 import { iframePostOffice, PostMessageListener } from '../utils/postOffice'
 import { MessageTypes, PostMessages, ExtractPayload } from '../messageTypes'
@@ -15,15 +19,19 @@ import {
   normalizeAddressKeys,
   normalizeLockAddress,
 } from '../utils/normalizeAddresses'
+import localStorageAvailable from '../utils/localStorage'
 
 export default class Mailbox {
+  private useLocalStorageCache = true
+  private readonly cachePrefix = '__unlockProtocol.cache'
   private handler?: BlockchainHandler
   private constants: ConstantsType
   private configuration?: PaywallConfig
   private window: FetchWindow &
     SetTimeoutWindow &
     IframePostOfficeWindow &
-    ConsoleWindow
+    ConsoleWindow &
+    LocalStorageWindow
   private postMessage: (
     type: MessageTypes,
     payload: ExtractPayload<MessageTypes>
@@ -32,16 +40,20 @@ export default class Mailbox {
     type: T,
     listener: PostMessageListener
   ) => void = () => {}
-  private blockchainData?: BlockchainData
+  private blockchainData: BlockchainData
+  private readonly defaultBlockchainData: BlockchainData
+  private readonly localStorageAvailable: boolean
   constructor(
     constants: ConstantsType,
     window: FetchWindow &
       SetTimeoutWindow &
       IframePostOfficeWindow &
-      ConsoleWindow
+      ConsoleWindow &
+      LocalStorageWindow
   ) {
     this.constants = constants
     this.window = window
+    this.localStorageAvailable = localStorageAvailable(window)
     this.setConfig = this.setConfig.bind(this)
     this.sendUpdates = this.sendUpdates.bind(this)
     this.purchaseKey = this.purchaseKey.bind(this)
@@ -56,6 +68,14 @@ export default class Mailbox {
     )
     this.postMessage = postMessage
     this.addPostMessageListener = addHandler
+    this.defaultBlockchainData = {
+      locks: {},
+      account: null,
+      balance: '0',
+      network: this.constants.defaultNetwork,
+    }
+    // set the defaults
+    this.blockchainData = this.defaultBlockchainData
     this.setupPostMessageListeners()
   }
 
@@ -68,6 +88,20 @@ export default class Mailbox {
       this.refreshBlockchainTransactions
     )
     this.postMessage(PostMessages.READY, undefined)
+  }
+
+  /**
+   * We can use this to determine whether the user has purchased a key in another tab
+   */
+  setupStorageListener() {
+    this.window.addEventListener('storage', event => {
+      if (!this.configuration || !this.handler) return
+      if (event.key === this.getCacheKey()) {
+        // another tab has done something that affects our data, so
+        // let's refetch
+        this.handler.retrieveCurrentBlockchainData()
+      }
+    })
   }
 
   async init() {
@@ -94,6 +128,12 @@ export default class Mailbox {
     // configuration is set by "setConfig" in response to "READY"
     // it is the paywall configuration
     await waitFor(() => this.configuration)
+    // now that we have a valid configuration, we know which locks
+    // are relevant, and can retrieve any cached data.
+    // the cache is retrieved once per process, and thereafter
+    // only changed when new blockchain data comes in.
+    this.blockchainData = this.getBlockchainDataFromLocalStorageCache()
+    this.setupStorageListener()
 
     // we do not need a connected walletService to work
     walletService.connect(provider).catch((e: Error) => {
@@ -117,8 +157,8 @@ export default class Mailbox {
    * Retrieve the addresses of any unlocked locks
    */
   getUnlockedLockAddresses() {
-    if (!this.getBlockchainData()) return []
-    const data = this.getBlockchainData() as BlockchainData
+    if (!this.blockchainData) return []
+    const data = this.blockchainData as BlockchainData
     // lock addresses are normalized by here
     return Object.keys(data.locks).filter(lockAddress => {
       const lock = data.locks[lockAddress]
@@ -134,19 +174,15 @@ export default class Mailbox {
    * send data back to the main window
    */
   sendUpdates(updateRequest: unknown) {
-    if (!this.getBlockchainData()) return
+    if (!this.blockchainData) return
     const unlockedLocks = this.getUnlockedLockAddresses()
     if (unlockedLocks.length) {
       this.postMessage(PostMessages.UNLOCKED, unlockedLocks)
     } else {
       this.postMessage(PostMessages.LOCKED, undefined)
     }
-    const {
-      locks,
-      account,
-      balance,
-      network,
-    } = this.getBlockchainData() as BlockchainData
+    const { locks, account, balance, network } = this
+      .blockchainData as BlockchainData
     const type = updateRequest as 'locks' | 'account' | 'balance' | 'network'
     switch (type) {
       case 'locks':
@@ -196,7 +232,7 @@ export default class Mailbox {
    * do the purchase
    */
   purchaseKey(request: unknown) {
-    if (!this.handler || !this.getBlockchainData()) return
+    if (!this.handler || !this.blockchainData) return
     if (
       !request ||
       !(request as PurchaseKeyRequest).lock ||
@@ -211,7 +247,7 @@ export default class Mailbox {
     // format is validated here
     const details: PurchaseKeyRequest = request as PurchaseKeyRequest
     // lock addresses are normalized
-    const data = this.getBlockchainData() as BlockchainData
+    const data = this.blockchainData as BlockchainData
     if (!data.locks[details.lock]) {
       this.emitError(
         new Error(`Cannot purchase key on unknown lock: "${details.lock}"`)
@@ -246,7 +282,6 @@ export default class Mailbox {
   emitChanges(newData: BlockchainData) {
     this.setBlockchainData(newData)
     // TODO: don't send unchanged values
-    // TODO: cache values
     this.postMessage(PostMessages.UPDATE_ACCOUNT, newData.account)
     this.postMessage(PostMessages.UPDATE_ACCOUNT_BALANCE, newData.balance)
     this.postMessage(PostMessages.UPDATE_NETWORK, newData.network)
@@ -270,11 +305,107 @@ export default class Mailbox {
     this.postMessage(PostMessages.ERROR, error.message)
   }
 
-  getBlockchainData(): BlockchainData | undefined {
-    return this.blockchainData
-  }
-
+  /**
+   * Save the blockchain data in-memory, and also in localStorage if available
+   */
   setBlockchainData(data: BlockchainData) {
     this.blockchainData = data
+    if (this.useLocalStorageCache) {
+      this.saveCacheInLocalStorage()
+    }
+  }
+
+  /**
+   * This either retrieves the cache, or returns a fresh value
+   *
+   * All error conditions result in obliteration of the entire localStorage cache
+   * out of an abundance of caution.
+   *
+   * The cache is indexed by the configuration locks, so that we have separate caches
+   * for every paywall configuration
+   */
+  getBlockchainDataFromLocalStorageCache(): BlockchainData {
+    if (!this.localStorageAvailable) return this.defaultBlockchainData
+
+    try {
+      const blockchainData = this.window.localStorage.getItem(
+        this.getCacheKey()
+      )
+      if (!blockchainData) {
+        return this.defaultBlockchainData
+      }
+      return JSON.parse(blockchainData)
+    } catch (error) {
+      if (process.env.UNLOCK_ENV === 'dev') {
+        // eslint-disable-next-line
+        this.window.console.error(error)
+        // ignore errors from a UI perspective, log for development
+      }
+      // invalidate on any error
+      this.window.localStorage.clear()
+      return this.defaultBlockchainData
+    }
+  }
+
+  /**
+   * The cache is indexed by a sorted list of lock addresses converted to JSON and normalized to lower-case
+   */
+  getCacheKey() {
+    if (!this.configuration) {
+      // this should never happen, and is a guard against crash bugs
+      throw new Error(
+        'internal error: cannot retrieve cache without configuration'
+      )
+    }
+    const configKey = JSON.stringify(
+      Object.keys(this.configuration.locks).sort()
+    ).toLowerCase()
+    return this.cachePrefix + configKey
+  }
+
+  /**
+   * This clears only the current paywall's cache. if there is any error thrown,
+   * the whole cache is cleared out of an abundance of caution.
+   */
+  invalidateLocalStorageCache() {
+    if (!this.localStorageAvailable) return
+    if (!this.configuration) return
+    try {
+      this.window.localStorage.removeItem(this.getCacheKey())
+    } catch (error) {
+      // localStorage can throw, and getCacheKey can throw
+      if (process.env.UNLOCK_ENV === 'dev') {
+        // eslint-disable-next-line
+        this.window.console.error(error)
+        // ignore errors from a UI perspective, log for development
+      }
+      // safety first: clear entire cache on *any* error
+      this.window.localStorage.clear()
+    }
+  }
+
+  /**
+   * This is performed every time we get an update from the BlockchainHandler
+   *
+   * On any errors, the entire localStorage is cleared out of an abundance of caution.
+   */
+  saveCacheInLocalStorage() {
+    if (!this.localStorageAvailable) return
+    if (!this.configuration) return
+
+    const cacheableData = JSON.stringify(this.blockchainData)
+
+    try {
+      this.window.localStorage.setItem(this.getCacheKey(), cacheableData)
+    } catch (error) {
+      // localStorage can throw, and getCacheKey can throw
+      if (process.env.UNLOCK_ENV === 'dev') {
+        // eslint-disable-next-line
+        this.window.console.error(error)
+        // ignore errors from a UI perspective, log for development
+      }
+      // safety first: clear cache on *any* error
+      this.window.localStorage.clear()
+    }
   }
 }

--- a/paywall/src/unlock.js/setupIframeMailbox.ts
+++ b/paywall/src/unlock.js/setupIframeMailbox.ts
@@ -1,9 +1,5 @@
-import { IframeType } from '../windowTypes'
-import {
-  mainWindowPostOffice,
-  PostMessageListener,
-  PostOfficeWindow,
-} from '../utils/postOffice'
+import { IframeType, PostOfficeWindow } from '../windowTypes'
+import { mainWindowPostOffice, PostMessageListener } from '../utils/postOffice'
 import { MessageTypes, ExtractPayload } from '../messageTypes'
 
 export type IframeNames = 'checkout' | 'data' | 'account'

--- a/paywall/src/utils/postOffice.ts
+++ b/paywall/src/utils/postOffice.ts
@@ -1,4 +1,5 @@
 import { MessageTypes, ExtractPayload } from '../messageTypes'
+import { PostOfficeWindow, EventTypes } from '../windowTypes'
 
 export interface MessageEvent {
   source: any
@@ -10,10 +11,6 @@ export type MessageHandler = (event: MessageEvent) => void
 
 interface location {
   href: string
-}
-
-export interface PostOfficeWindow {
-  addEventListener: (type: 'message', handler: MessageHandler) => void
 }
 
 export interface IframePostOfficeWindow extends PostOfficeWindow {
@@ -75,7 +72,7 @@ export function setupPostOffice<T extends MessageTypes = MessageTypes>(
     )
   }
   let handlers: PostMessageHandlers = {}
-  window.addEventListener('message', event => {
+  window.addEventListener(EventTypes.MESSAGE, event => {
     // **SECURITY CHECKS**
     // ignore messages that do not come from our target window
     if (event.source !== target || event.origin !== targetOrigin) return

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -35,20 +35,31 @@ export interface EventWindow {
   dispatchEvent: (event: CustomEvent) => void
 }
 
-export type MessageEventHandler<T> = T extends StorageEventTypes
-  ? StorageHandler
-  : (T extends PostOfficeEventTypes ? MessageHandler : never)
-export type AddEventListener<
-  T extends StorageEventTypes | PostOfficeEventTypes =
-    | StorageEventTypes
-    | PostOfficeEventTypes
-> = (type: T, handler: MessageEventHandler<T>) => void
+export enum EventTypes {
+  STORAGE = 'storage',
+  MESSAGE = 'message',
+}
+
+export interface MappedEvents {
+  [EventTypes.STORAGE]: StorageEvent
+  [EventTypes.MESSAGE]: MessageEvent
+}
+
+export type ExtractEvent<T extends EventTypes> = MappedEvents[T]
+export type EventHandler<T extends EventTypes> = (
+  event: MappedEvents[T]
+) => void
+
+export type AddEventListenerFunc = <T extends EventTypes>(
+  type: T,
+  handler: EventHandler<T>
+) => void
 // used anywhere cache is used
 export type StorageEventTypes = 'storage'
 export type StorageHandler = (event: StorageEvent) => void
 export interface LocalStorageWindow {
   localStorage: Storage
-  addEventListener: AddEventListener<StorageEventTypes>
+  addEventListener: AddEventListenerFunc
 }
 
 // used in web3Proxy.ts
@@ -118,7 +129,7 @@ export type MessageHandler = (event: MessageEvent) => void
 
 export type PostOfficeEventTypes = 'message' // augment later if needed
 export interface PostOfficeWindow {
-  addEventListener: AddEventListener<PostOfficeEventTypes>
+  addEventListener: AddEventListenerFunc
 }
 
 type WindowConsole = Pick<Window, 'console'>['console']

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -35,9 +35,20 @@ export interface EventWindow {
   dispatchEvent: (event: CustomEvent) => void
 }
 
+export type MessageEventHandler<T> = T extends StorageEventTypes
+  ? StorageHandler
+  : (T extends PostOfficeEventTypes ? MessageHandler : never)
+export type AddEventListener<
+  T extends StorageEventTypes | PostOfficeEventTypes =
+    | StorageEventTypes
+    | PostOfficeEventTypes
+> = (type: T, handler: MessageEventHandler<T>) => void
 // used anywhere cache is used
+export type StorageEventTypes = 'storage'
+export type StorageHandler = (event: StorageEvent) => void
 export interface LocalStorageWindow {
   localStorage: Storage
+  addEventListener: AddEventListener<StorageEventTypes>
 }
 
 // used in web3Proxy.ts
@@ -95,14 +106,19 @@ export interface MessageEvent {
   data: any
 }
 
+// used in Mailbox.ts
+export interface StorageEvent {
+  key: string
+  oldValue: string | null
+  newValue: string | null
+  storageArea: any
+}
+
 export type MessageHandler = (event: MessageEvent) => void
 
 export type PostOfficeEventTypes = 'message' // augment later if needed
 export interface PostOfficeWindow {
-  addEventListener: (
-    type: PostOfficeEventTypes,
-    handler: MessageHandler
-  ) => void
+  addEventListener: AddEventListener<PostOfficeEventTypes>
 }
 
 type WindowConsole = Pick<Window, 'console'>['console']


### PR DESCRIPTION
# Description

This adds caching to the `Mailbox`. The principles are extremely simple:

- The cache consists of the entire blockchainData structure, so includes `locks`, `account`, `balance`, and `network`.
- The cache is only used while the `BlockchainHandler` is loading

Here is the state flow:

1. on startup, if localStorage is available, it checks to see if the current paywall has a cache
2. if so, it sets the default value of `Mailbox.blockchainData` to this value. Otherwise, it uses a blank default.
3. Throughout the process, whenever the blockchain sends an update, it saves it to the localStorage cache
4. if the user has the same paywall open in another tab, and purchases a key (say a different article), the BlockchainHandler will refresh the blockchain data, thereby propagating keys between tabs. The refresh *only* happens if the paywall is exactly the same (it ignores updates to other caches)

Thus, the cache is a one-way data flow, and is only used at startup to speed things up. Otherwise, it is a write-only cache.

Each paywall cache is differentiated by the locks in the paywall configuration. Thus, a paywall that uses locks `'0x123...'` and `'0x456...'` is a different cache from paywall that uses '`0x789...'`, and is also different from a paywall that only uses one of the `'0x123'` or `'0x456'` locks.

If there are any errors at all, whether reading or writing from the cache, it clears the entire localStorage cache.

This branch includes a bunch of semi-related changes that can all be split off into their own pre-PRs:

1. updating the type signature for `addEventListener` is most of the semi-related complexity
2. adding LocalStorageWindow to the `FakeWindowHelper.ts`

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
