### PR TITLE
enable cache in user accounts (new data iframe base)

### DIFF
--- a/paywall/data-iframe.1.0.webpack.config.js
+++ b/paywall/data-iframe.1.0.webpack.config.js
@@ -35,7 +35,7 @@ module.exports = () => {
     cache: false,
     mode: 'production',
     devtool: 'source-map',
-    entry: path.resolve(__dirname, 'src', 'data-iframe', 'index.js'),
+    entry: path.resolve(__dirname, 'src', 'data-iframe', 'index.ts'),
     output: {
       path: path.resolve(__dirname, 'src', 'static'),
       filename: 'data-iframe.1.0.min.js',

--- a/paywall/src/__tests__/data-iframe/Mailbox/Mailbox.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/Mailbox.test.ts
@@ -1,0 +1,123 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PostMessages } from '../../../messageTypes'
+import { waitFor } from '../../../utils/promises'
+import {
+  getWalletService,
+  getWeb3Service,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - constructor', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+  defaults = setupTestDefaults()
+
+  function setupDefaults() {
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  beforeEach(() => {
+    setupDefaults()
+  })
+
+  it('should set up postMessage functions', () => {
+    expect.assertions(1)
+
+    testingMailbox().postMessage(PostMessages.SCROLL_POSITION, 5)
+    fakeWindow.expectPostMessageSent(PostMessages.SCROLL_POSITION, 5)
+  })
+
+  it('should set up addPostMessageListener function', async () => {
+    expect.assertions(1)
+
+    const handler = jest.fn()
+    const payload = undefined
+
+    testingMailbox().addPostMessageListener(PostMessages.REDIRECT, handler)
+
+    fakeWindow.receivePostMessageFromMainWindow(PostMessages.REDIRECT, payload)
+
+    await waitFor(() => handler.mock.calls.length)
+
+    expect(handler).toHaveBeenCalledWith(payload, expect.any(Function)) // the 2nd argument is the "respond" function
+  })
+
+  it('should call setupPostMessageListeners', async () => {
+    expect.assertions(1)
+
+    // this is the last line of "setupPostMessageListeners"
+    await fakeWindow.expectPostMessageSent(PostMessages.READY, undefined)
+  })
+
+  describe('setting values', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+    type TestValues = [string, any]
+
+    it.each(<TestValues[]>[
+      ['constants', defaults.constants],
+      ['window', defaults.fakeWindow],
+    ])('should initialize %s', (member, value) => {
+      expect.assertions(1)
+
+      expect(testingMailbox()[member]).toBe(value)
+    })
+
+    it.each([
+      'setConfig',
+      'sendUpdates',
+      'purchaseKey',
+      'refreshBlockchainTransactions',
+      'emitChanges',
+      'emitError',
+    ])('this.%s should be bound to the current instance', func => {
+      expect.assertions(1)
+
+      // based on https://stackoverflow.com/a/35687230
+
+      expect(testingMailbox()[func].hasOwnProperty('prototype')).toBeFalsy()
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/emitChanges.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/emitChanges.test.ts
@@ -1,0 +1,181 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+  BlockchainData,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+  addresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+import { PostMessages, ExtractPayload } from '../../../messageTypes'
+import { TransactionType, TransactionStatus } from '../../../unlockTypes'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - emitChanges', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  const account = addresses[1]
+  // all locks have had their addresses normalized before arriving
+  const lockedLocks: BlockchainData = {
+    account: addresses[1],
+    balance: '234',
+    network: 1984,
+    locks: {
+      [lockAddresses[0]]: {
+        address: lockAddresses[0],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'none',
+          confirmations: 0,
+          expiration: 0,
+          transactions: [],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+      [lockAddresses[1]]: {
+        address: lockAddresses[1],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'expired',
+          confirmations: 1678234,
+          expiration: 163984,
+          transactions: [
+            {
+              status: TransactionStatus.MINED,
+              confirmations: 1678234,
+              hash: 'hash',
+              type: TransactionType.KEY_PURCHASE,
+              blockNumber: 123,
+            },
+          ],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+    },
+  }
+
+  const submittedLocks: BlockchainData = {
+    ...lockedLocks,
+    locks: {
+      ...lockedLocks.locks,
+      [lockAddresses[0]]: {
+        ...lockedLocks.locks[lockAddresses[0]],
+        key: {
+          ...lockedLocks.locks[lockAddresses[0]].key,
+          status: 'submitted',
+          confirmations: 0,
+          expiration: 0,
+          transactions: [
+            {
+              status: TransactionStatus.SUBMITTED,
+              confirmations: 0,
+              hash: 'hash',
+              type: TransactionType.KEY_PURCHASE,
+              blockNumber: Number.MAX_SAFE_INTEGER,
+            },
+          ],
+        },
+      },
+    },
+  }
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+
+    fakeWindow.clearPostMessageMock()
+  }
+
+  type TestSent = [string, PostMessages, ExtractPayload<PostMessages>]
+
+  describe('with locked locks', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it.each(<TestSent[]>[
+      ['account', PostMessages.UPDATE_ACCOUNT, lockedLocks.account],
+      ['network', PostMessages.UPDATE_NETWORK, lockedLocks.network],
+      ['locks', PostMessages.UPDATE_LOCKS, lockedLocks.locks],
+      ['balance', PostMessages.UPDATE_ACCOUNT_BALANCE, lockedLocks.balance],
+      ['locked', PostMessages.LOCKED, undefined],
+    ])(
+      'should send the %s to the main window',
+      async (_, type: PostMessages, payload: any) => {
+        expect.assertions(1)
+
+        mailbox.emitChanges(lockedLocks)
+
+        await fakeWindow.expectPostMessageSent(type, payload)
+      }
+    )
+  })
+
+  describe('with unlocked locks', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it.each(<TestSent[]>[
+      ['account', PostMessages.UPDATE_ACCOUNT, submittedLocks.account],
+      ['network', PostMessages.UPDATE_NETWORK, submittedLocks.network],
+      ['locks', PostMessages.UPDATE_LOCKS, submittedLocks.locks],
+      ['balance', PostMessages.UPDATE_ACCOUNT_BALANCE, submittedLocks.balance],
+      ['unlocked', PostMessages.UNLOCKED, [lockAddresses[0]]],
+    ])(
+      'should send the %s to the main window',
+      async (_, type: PostMessages, payload: any) => {
+        expect.assertions(1)
+
+        mailbox.emitChanges(submittedLocks)
+
+        await fakeWindow.expectPostMessageSent(type, payload)
+      }
+    )
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/emitError.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/emitError.test.ts
@@ -1,0 +1,93 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+} from '../../test-helpers/setupBlockchainHelpers'
+import { PostMessages } from '../../../messageTypes'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - emitError', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  const error = new Error('fail')
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+
+    fakeWindow.clearPostMessageMock()
+  }
+
+  async function expectErrorsEmitted(error: string) {
+    await fakeWindow.waitForPostMessage()
+    return fakeWindow.expectPostMessageSent(PostMessages.ERROR, error)
+  }
+
+  beforeEach(() => {
+    setupDefaults()
+    process.env.UNLOCK_ENV = 'prod'
+  })
+
+  it('should log the error to console in development', () => {
+    expect.assertions(1)
+
+    process.env.UNLOCK_ENV = 'dev'
+    mailbox.emitError(error)
+
+    expect(fakeWindow.console.error).toHaveBeenCalledWith(error)
+  })
+
+  it('should not log the error to console in development', () => {
+    expect.assertions(1)
+
+    mailbox.emitError(error)
+
+    expect(fakeWindow.console.error).not.toHaveBeenCalled()
+  })
+
+  it('should postMessage the error message to the main window', async () => {
+    expect.assertions(1)
+
+    mailbox.emitError(error)
+
+    await expectErrorsEmitted('fail')
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/getBlockchainDataFromLocalStorageCache.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/getBlockchainDataFromLocalStorageCache.test.ts
@@ -1,0 +1,239 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+  BlockchainData,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+  addresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+import {
+  PaywallConfig,
+  TransactionStatus,
+  TransactionType,
+} from '../../../unlockTypes'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - getBlockchainDataFromLocalStorageCache', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  const account = addresses[1]
+  // all locks have had their addresses normalized before arriving
+  const blockchainData: BlockchainData = {
+    account: addresses[1],
+    balance: '234',
+    network: 1984,
+    locks: {
+      [lockAddresses[0]]: {
+        address: lockAddresses[0],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'none',
+          confirmations: 0,
+          expiration: 0,
+          transactions: [],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+      [lockAddresses[1]]: {
+        address: lockAddresses[1],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'expired',
+          confirmations: 1678234,
+          expiration: 163984,
+          transactions: [
+            {
+              status: TransactionStatus.MINED,
+              confirmations: 1678234,
+              hash: 'hash',
+              type: TransactionType.KEY_PURCHASE,
+              blockNumber: 123,
+            },
+          ],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+    },
+  }
+
+  function setupDefaults(killLocalStorage = false) {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    if (killLocalStorage) {
+      fakeWindow.throwOnLocalStorageSet()
+    }
+    mailbox = new Mailbox(constants, fakeWindow)
+    ;(testingMailbox().configuration as PaywallConfig) = {
+      locks: {
+        [lockAddresses[1]]: { name: '' },
+        [lockAddresses[2]]: { name: '' },
+      },
+      callToAction: {
+        default: '',
+        pending: '',
+        expired: '',
+        confirmed: '',
+      },
+    }
+  }
+
+  function testingMailbox() {
+    return mailbox as any
+  }
+
+  describe('error conditions', () => {
+    describe('localStorage is not available', () => {
+      beforeEach(() => {
+        setupDefaults(true)
+        fakeWindow.localStorage.getItem = jest.fn()
+      })
+
+      it('should do nothing if localStorage is not available', () => {
+        expect.assertions(1)
+
+        mailbox.getBlockchainDataFromLocalStorageCache()
+
+        expect(fakeWindow.localStorage.getItem).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('configuration not received/not saved because it was invalid', () => {
+      beforeEach(() => {
+        setupDefaults()
+        fakeWindow.localStorage.setItem = jest.fn()
+        testingMailbox().configuration = undefined
+      })
+
+      it('should do nothing if configuration is not set', () => {
+        expect.assertions(1)
+
+        mailbox.saveCacheInLocalStorage()
+
+        expect(fakeWindow.localStorage.setItem).not.toHaveBeenCalled()
+      })
+    })
+
+    type BadDataTest = [string, (cb?: () => void) => any]
+
+    describe.each(<BadDataTest[]>[
+      [
+        'localStorage throws on attempting to getItem',
+        () => {
+          setupDefaults()
+          fakeWindow.localStorage.clear = jest.fn()
+          fakeWindow.throwOnLocalStorageGet()
+        },
+      ],
+      [
+        'JSON.parsing cached value throws',
+        () => {
+          setupDefaults()
+          fakeWindow.localStorage.clear = jest.fn()
+          fakeWindow.localStorage.getItem = () => '{invalid JSON'
+        },
+      ],
+    ])('%s', (_, setup) => {
+      beforeEach(setup)
+
+      afterEach(() => {
+        // reset to avoid affecting other tests
+        process.env.UNLOCK_ENV = 'prod'
+      })
+
+      it('in dev, it should log the error', () => {
+        expect.assertions(1)
+
+        process.env.UNLOCK_ENV = 'dev'
+        mailbox.getBlockchainDataFromLocalStorageCache()
+
+        expect(fakeWindow.console.error).toHaveBeenCalledWith(expect.any(Error))
+      })
+
+      it('in other envs, it should not log the error', () => {
+        expect.assertions(1)
+
+        mailbox.getBlockchainDataFromLocalStorageCache()
+
+        expect(fakeWindow.console.error).not.toHaveBeenCalled()
+      })
+
+      it('should clear the entire localStorage cache to be safe', () => {
+        expect.assertions(1)
+
+        mailbox.getBlockchainDataFromLocalStorageCache()
+
+        expect(fakeWindow.localStorage.clear).toHaveBeenCalled()
+      })
+
+      it('should return default blockchain data', () => {
+        expect.assertions(1)
+
+        expect(mailbox.getBlockchainDataFromLocalStorageCache()).toBe(
+          testingMailbox().defaultBlockchainData
+        )
+      })
+    })
+  })
+
+  describe('normal operation', () => {
+    describe('empty cache', () => {
+      beforeEach(() => {
+        setupDefaults()
+        ;(testingMailbox().blockchainData as BlockchainData) = blockchainData
+      })
+
+      it('should return the default blockchain data', () => {
+        expect.assertions(1)
+
+        expect(mailbox.getBlockchainDataFromLocalStorageCache()).toBe(
+          testingMailbox().defaultBlockchainData
+        )
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/getCacheKey.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/getCacheKey.test.ts
@@ -1,0 +1,133 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+  addresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+import { PaywallConfig } from '../../../unlockTypes'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - getCacheKey', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+  }
+
+  function testingMailbox() {
+    return mailbox as any
+  }
+
+  describe('error state', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should throw if there is no configuration set', () => {
+      expect.assertions(1)
+
+      expect(() => mailbox.getCacheKey()).toThrow(
+        'internal error: cannot retrieve cache without configuration'
+      )
+    })
+  })
+
+  describe('valid state', () => {
+    beforeEach(() => {
+      setupDefaults()
+      ;(testingMailbox().configuration as PaywallConfig) = {
+        locks: {
+          // intentionally out of alphabetical order to verify sorting
+          // the configuration should be normalized by here, but this verifies that toLowerCase() is called
+          [addresses[2]]: { name: '' },
+          [lockAddresses[1]]: { name: '' },
+        },
+        callToAction: {
+          default: '',
+          pending: '',
+          expired: '',
+          confirmed: '',
+        },
+      }
+    })
+
+    it('should return the cache prefix plus a sorted list of lock addresses', () => {
+      expect.assertions(1)
+
+      const lockAddressPortion = JSON.stringify([
+        lockAddresses[1],
+        lockAddresses[2],
+      ])
+
+      expect(mailbox.getCacheKey()).toBe(
+        '__unlockProtocol.cache' + lockAddressPortion
+      )
+    })
+
+    it('should use the same cache for a config in a different order', () => {
+      expect.assertions(1)
+      ;(testingMailbox().configuration as PaywallConfig) = {
+        locks: {
+          // different order of locks
+          [lockAddresses[1]]: { name: '' },
+          [addresses[2]]: { name: '' },
+        },
+        callToAction: {
+          default: '',
+          pending: '',
+          expired: '',
+          confirmed: '',
+        },
+      }
+
+      const lockAddressPortion = JSON.stringify([
+        lockAddresses[1],
+        lockAddresses[2],
+      ])
+
+      expect(mailbox.getCacheKey()).toBe(
+        '__unlockProtocol.cache' + lockAddressPortion
+      )
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/getUnlockedLockAddresses.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/getUnlockedLockAddresses.test.ts
@@ -1,0 +1,223 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+  BlockchainData,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import { Locks, TransactionType, TransactionStatus } from '../../../unlockTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  addresses,
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - getUnlockedLockAddresses', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  const account = addresses[1]
+
+  // all locks have had their addresses normalized before arriving
+  const lockedLocks = {
+    [lockAddresses[0]]: {
+      address: lockAddresses[0],
+      name: '1',
+      expirationDuration: 5,
+      currencyContractAddress: addresses[2],
+      keyPrice: '1',
+      key: {
+        status: 'none',
+        confirmations: 0,
+        expiration: 0,
+        transactions: [],
+        owner: account,
+        lock: lockAddresses[0],
+      },
+    },
+    [lockAddresses[1]]: {
+      address: lockAddresses[1],
+      name: '1',
+      expirationDuration: 5,
+      currencyContractAddress: addresses[2],
+      keyPrice: '1',
+      key: {
+        status: 'expired',
+        confirmations: 1678234,
+        expiration: 163984,
+        transactions: [
+          {
+            status: TransactionStatus.MINED,
+            confirmations: 1678234,
+            hash: 'hash',
+            type: TransactionType.KEY_PURCHASE,
+            blockNumber: 123,
+          },
+        ],
+        owner: account,
+        lock: lockAddresses[0],
+      },
+    },
+  }
+
+  const submittedLocks: Locks = {
+    [lockAddresses[0]]: {
+      ...lockedLocks[lockAddresses[0]],
+      key: {
+        ...lockedLocks[lockAddresses[0]].key,
+        status: 'submitted',
+        confirmations: 0,
+        expiration: 0,
+        transactions: [
+          {
+            status: TransactionStatus.SUBMITTED,
+            confirmations: 0,
+            hash: 'hash',
+            type: TransactionType.KEY_PURCHASE,
+            blockNumber: Number.MAX_SAFE_INTEGER,
+          },
+        ],
+      },
+    },
+  }
+
+  const pendingLocks: Locks = {
+    [lockAddresses[0]]: {
+      ...lockedLocks[lockAddresses[0]],
+      key: {
+        ...lockedLocks[lockAddresses[0]].key,
+        status: 'pending',
+        transactions: [
+          {
+            status: TransactionStatus.PENDING,
+            confirmations: 0,
+            hash: 'hash',
+            type: TransactionType.KEY_PURCHASE,
+            blockNumber: Number.MAX_SAFE_INTEGER,
+          },
+        ],
+      },
+    },
+  }
+
+  const validLocks: Locks = {
+    [lockAddresses[0]]: {
+      ...lockedLocks[lockAddresses[0]],
+      key: {
+        ...lockedLocks[lockAddresses[0]].key,
+        status: 'valid',
+        expiration: 12345,
+        transactions: [
+          {
+            status: TransactionStatus.PENDING,
+            confirmations: 617234,
+            hash: 'hash',
+            type: TransactionType.KEY_PURCHASE,
+            blockNumber: 123,
+          },
+        ],
+      },
+    },
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  function setupDefaults(locks: Locks = {}) {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+
+    const testingData: BlockchainData = {
+      locks,
+      account,
+      balance: '0',
+      network: 1,
+    }
+    testingMailbox().data = testingData
+  }
+
+  it('should return [] if the BlockchainHandler has not yet sent any data', () => {
+    expect.assertions(1)
+
+    setupDefaults()
+
+    delete testingMailbox().data
+
+    expect(mailbox.getUnlockedLockAddresses()).toEqual([])
+  })
+
+  it('should return [] if the blockchain data does not yet have any locks', () => {
+    expect.assertions(1)
+
+    setupDefaults()
+
+    expect(mailbox.getUnlockedLockAddresses()).toEqual([])
+  })
+
+  it('should return [] if none of the lock keys returned are valid or in process of key purchase', () => {
+    expect.assertions(1)
+
+    setupDefaults(lockedLocks)
+
+    expect(mailbox.getUnlockedLockAddresses()).toEqual([])
+  })
+
+  it('should return an array containing the unlocked lock addresses for submitted purchases', () => {
+    expect.assertions(1)
+
+    setupDefaults(submittedLocks)
+
+    expect(mailbox.getUnlockedLockAddresses()).toEqual([lockAddresses[0]])
+  })
+
+  it('should return an array containing the unlocked lock addresses for pending purchases', () => {
+    expect.assertions(1)
+
+    setupDefaults(pendingLocks)
+
+    expect(mailbox.getUnlockedLockAddresses()).toEqual([lockAddresses[0]])
+  })
+
+  it('should return an array containing the unlocked lock addresses for valid purchases', () => {
+    expect.assertions(1)
+
+    setupDefaults(validLocks)
+
+    expect(mailbox.getUnlockedLockAddresses()).toEqual([lockAddresses[0]])
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/getUnlockedLockAddresses.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/getUnlockedLockAddresses.test.ts
@@ -168,7 +168,7 @@ describe('Mailbox - getUnlockedLockAddresses', () => {
       balance: '0',
       network: 1,
     }
-    testingMailbox().data = testingData
+    testingMailbox().blockchainData = testingData
   }
 
   it('should return [] if the BlockchainHandler has not yet sent any data', () => {
@@ -176,7 +176,7 @@ describe('Mailbox - getUnlockedLockAddresses', () => {
 
     setupDefaults()
 
-    delete testingMailbox().data
+    delete testingMailbox().blockchainData
 
     expect(mailbox.getUnlockedLockAddresses()).toEqual([])
   })

--- a/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
@@ -109,6 +109,36 @@ describe('Mailbox - init', () => {
     await waitFor(() => testingMailbox().handler)
   })
 
+  describe('errors', () => {
+    beforeEach(() => {
+      setupDefaults(false)
+      ;(unlock.WalletService as any).mockImplementationOnce(function() {
+        mockWalletService = getWalletService({})
+        mockWalletService.connect = jest.fn((provider: any) => {
+          mockWalletService.provider = provider
+          return Promise.reject(new Error('fail'))
+        })
+        return mockWalletService
+      })
+    })
+
+    it('should emit an error if connecting to the provider fails', async done => {
+      expect.assertions(1)
+
+      mailbox.emitError = (e: Error) => {
+        expect(e.message).toMatch('fail')
+        done()
+      }
+
+      mailbox.init()
+
+      fakeWindow.receivePostMessageFromMainWindow(
+        PostMessages.CONFIG,
+        configuration
+      )
+    })
+  })
+
   it('should initialize a BlockchainHandler', async () => {
     expect.assertions(1)
 

--- a/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
@@ -25,7 +25,7 @@ let mockWalletService: WalletServiceType
 let mockWeb3Service: Web3ServiceType
 jest.mock('@unlock-protocol/unlock-js', () => {
   return {
-    WalletService: () => {
+    WalletService: function() {
       mockWalletService = getWalletService({})
       mockWalletService.connect = jest.fn((provider: any) => {
         mockWalletService.provider = provider
@@ -33,7 +33,7 @@ jest.mock('@unlock-protocol/unlock-js', () => {
       })
       return mockWalletService
     },
-    Web3Service: () => {
+    Web3Service: function() {
       mockWeb3Service = getWeb3Service({})
       return mockWeb3Service
     },

--- a/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
@@ -1,0 +1,89 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import { PaywallConfig } from '../../../unlockTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import BlockchainHandler from '../../../data-iframe/blockchainHandler/BlockchainHandler'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PostMessages } from '../../../messageTypes'
+import { waitFor } from '../../../utils/promises'
+import {
+  getWalletService,
+  getWeb3Service,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - init', () => {
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    configuration = defaults.configuration
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+
+    fakeWindow.receivePostMessageFromMainWindow(
+      PostMessages.CONFIG,
+      configuration
+    )
+    ;(fakeWindow.parent as any).postMessage.mockClear()
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  beforeEach(() => {
+    setupDefaults()
+  })
+
+  it('should initialize a BlockchainHandler', async () => {
+    expect.assertions(1)
+
+    mailbox.init().then(() => {
+      expect(testingMailbox().handler).toBeInstanceOf(BlockchainHandler)
+    })
+
+    fakeWindow.receivePostMessageFromMainWindow(PostMessages.WALLET_INFO, {
+      noWallet: false,
+      notEnabled: false,
+      isMetamask: false,
+    })
+
+    await waitFor(() => testingMailbox().handler)
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/invalidateLocalStorageCache.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/invalidateLocalStorageCache.test.ts
@@ -1,0 +1,242 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+  BlockchainData,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+  addresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+import {
+  PaywallConfig,
+  TransactionStatus,
+  TransactionType,
+} from '../../../unlockTypes'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - invalidateLocalStorageCache', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  const account = addresses[1]
+  // all locks have had their addresses normalized before arriving
+  const blockchainData: BlockchainData = {
+    account: addresses[1],
+    balance: '234',
+    network: 1984,
+    locks: {
+      [lockAddresses[0]]: {
+        address: lockAddresses[0],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'none',
+          confirmations: 0,
+          expiration: 0,
+          transactions: [],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+      [lockAddresses[1]]: {
+        address: lockAddresses[1],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'expired',
+          confirmations: 1678234,
+          expiration: 163984,
+          transactions: [
+            {
+              status: TransactionStatus.MINED,
+              confirmations: 1678234,
+              hash: 'hash',
+              type: TransactionType.KEY_PURCHASE,
+              blockNumber: 123,
+            },
+          ],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+    },
+  }
+
+  function setupDefaults(killLocalStorage = false) {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    if (killLocalStorage) {
+      fakeWindow.throwOnLocalStorageSet()
+    }
+    mailbox = new Mailbox(constants, fakeWindow)
+    ;(testingMailbox().configuration as PaywallConfig) = {
+      locks: {
+        [lockAddresses[1]]: { name: '' },
+        [lockAddresses[2]]: { name: '' },
+      },
+      callToAction: {
+        default: '',
+        pending: '',
+        expired: '',
+        confirmed: '',
+      },
+    }
+  }
+
+  function testingMailbox() {
+    return mailbox as any
+  }
+
+  describe('error conditions', () => {
+    describe('localStorage is not available', () => {
+      beforeEach(() => {
+        setupDefaults(true)
+        fakeWindow.localStorage.removeItem = jest.fn()
+      })
+
+      it('should do nothing if localStorage is not available', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.localStorage.removeItem).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('configuration not received/not saved because it was invalid', () => {
+      beforeEach(() => {
+        setupDefaults()
+        fakeWindow.localStorage.removeItem = jest.fn()
+        testingMailbox().configuration = undefined
+      })
+
+      it('should do nothing if configuration is not set', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.localStorage.removeItem).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('localStorage throws on attempting to getItem', () => {
+      beforeEach(() => {
+        setupDefaults()
+        fakeWindow.localStorage.clear = jest.fn()
+        fakeWindow.throwOnLocalStorageRemove()
+      })
+
+      afterEach(() => {
+        // reset to avoid affecting other tests
+        process.env.UNLOCK_ENV = 'prod'
+      })
+
+      it('in dev, it should log the error', () => {
+        expect.assertions(1)
+
+        process.env.UNLOCK_ENV = 'dev'
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.console.error).toHaveBeenCalledWith(expect.any(Error))
+      })
+
+      it('in other envs, it should not log the error', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.console.error).not.toHaveBeenCalled()
+      })
+
+      it('should clear the entire localStorage cache to be safe', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.localStorage.clear).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('normal operation', () => {
+    describe('empty cache', () => {
+      beforeEach(() => {
+        setupDefaults()
+        ;(testingMailbox().blockchainData as BlockchainData) = blockchainData
+      })
+
+      it('should not throw if cache is empty', () => {
+        expect.assertions(0)
+
+        mailbox.getBlockchainDataFromLocalStorageCache()
+      })
+    })
+
+    describe('full cache', () => {
+      beforeEach(() => {
+        setupDefaults()
+        ;(testingMailbox().blockchainData as BlockchainData) = blockchainData
+        // used to show we don't nuke other caches
+        fakeWindow.localStorage.setItem('another', 'item')
+        mailbox.saveCacheInLocalStorage()
+      })
+
+      it('should not remove other caches', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(fakeWindow.localStorage.getItem('another')).toBe('item')
+      })
+
+      it('should remove the current cache', () => {
+        expect.assertions(1)
+
+        mailbox.invalidateLocalStorageCache()
+
+        expect(
+          fakeWindow.localStorage.getItem(mailbox.getCacheKey())
+        ).toBeNull()
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/purchaseKey.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/purchaseKey.test.ts
@@ -1,0 +1,226 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+  BlockchainData,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import { PurchaseKeyRequest } from '../../../unlockTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PostMessages } from '../../../messageTypes'
+import {
+  addresses,
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+import BlockchainHandler from '../../../data-iframe/blockchainHandler/BlockchainHandler'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - purchaseKey', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+  const testingData: BlockchainData = {
+    locks: {
+      [lockAddresses[0]]: {
+        name: 'lock 1',
+        address: lockAddresses[0],
+        keyPrice: '1',
+        expirationDuration: 5,
+        currencyContractAddress: null,
+        key: {
+          expiration: 0,
+          status: 'none',
+          confirmations: 0,
+          owner: addresses[1],
+          transactions: [],
+          lock: lockAddresses[0],
+        },
+      },
+    },
+    account: addresses[1],
+    balance: '123',
+    network: 1,
+  }
+
+  const purchaseRequest: PurchaseKeyRequest = {
+    lock: lockAddresses[0],
+    extraTip: '0',
+  }
+
+  // lock addresses must be normalized
+  const malFormedPurchaseRequest_normalized = {
+    lock: addresses[0],
+    extraTip: '0',
+  }
+
+  const fakeHandler: Pick<BlockchainHandler, 'purchaseKey'> = {
+    purchaseKey: jest.fn(),
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  function setupDefaults(receiveData: boolean = false) {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+
+    fakeWindow.clearPostMessageMock()
+    if (!receiveData) return
+
+    testingMailbox().data = testingData
+  }
+
+  function expectPurchaseKey() {
+    if (!testingMailbox().handler) {
+      return expect(jest.fn()) // it has not been called, so return a dummy mock function
+    }
+    return expect(testingMailbox().handler.purchaseKey)
+  }
+
+  async function expectErrorsEmitted(error: string) {
+    await fakeWindow.waitForPostMessage()
+    return fakeWindow.expectPostMessageSent(PostMessages.ERROR, error)
+  }
+
+  function expectNoErrors() {
+    expect(fakeWindow.parent.postMessage).not.toHaveBeenCalled()
+  }
+
+  describe('loading state', () => {
+    beforeEach(() => {
+      setupDefaults(true)
+    })
+
+    it('should not do anything when the BlockchainHandler is not ready', async () => {
+      expect.assertions(2)
+
+      delete testingMailbox().handler
+      await mailbox.purchaseKey(purchaseRequest)
+
+      expectPurchaseKey().not.toHaveBeenCalled()
+      expectNoErrors()
+    })
+
+    it('should not do anything when the BlockchainHandler has not sent data yet', async () => {
+      expect.assertions(2)
+
+      testingMailbox().handler = fakeHandler
+      delete testingMailbox().data
+      await mailbox.purchaseKey(purchaseRequest)
+
+      expectPurchaseKey().not.toHaveBeenCalled()
+      expectNoErrors()
+    })
+  })
+
+  describe('chain data fully loaded and ready', () => {
+    beforeEach(() => {
+      setupDefaults()
+      testingMailbox().handler = fakeHandler
+    })
+
+    describe('errors', () => {
+      beforeEach(() => {
+        setupDefaults()
+        testingMailbox().handler = fakeHandler
+        testingMailbox().data = testingData
+      })
+
+      describe('malformed purchase request', () => {
+        type TestingRequest = [string, any]
+        type Requests = TestingRequest[]
+        it.each(<Requests>[
+          ['5', 5],
+          ['request is falsy', false],
+          ['null', null],
+          ['no lock field', { extraTip: '0' }],
+          ['no extraTip field', { lock: lockAddresses[1] }],
+          ['lock is invalid format', { lock: 5, extraTip: '0' }],
+          ["''", ''],
+          ['lock not normalized', malFormedPurchaseRequest_normalized],
+        ])(
+          'should error if the request is invalid "%s"',
+          async (_, request) => {
+            expect.assertions(2)
+
+            await mailbox.purchaseKey(request)
+
+            await expectErrorsEmitted('Cannot purchase, malformed request')
+            expectPurchaseKey().not.toHaveBeenCalled()
+          }
+        )
+      })
+
+      it('should error on unknown lock', async () => {
+        expect.assertions(2)
+
+        await mailbox.purchaseKey({
+          lock: lockAddresses[2], // this address is not stored in "data"
+          extraTip: '0',
+        })
+
+        await expectErrorsEmitted(
+          `Cannot purchase key on unknown lock: "${lockAddresses[2]}"`
+        )
+        expectPurchaseKey().not.toHaveBeenCalled()
+      })
+    })
+
+    describe('valid purchase requests', () => {
+      beforeEach(() => {
+        setupDefaults()
+        testingMailbox().handler = fakeHandler
+        testingMailbox().data = testingData
+      })
+
+      it('should pass the correct values to handler.purchaseKey', async () => {
+        expect.assertions(1)
+
+        const lock = testingData.locks[lockAddresses[0]]
+        await mailbox.purchaseKey({
+          lock: lockAddresses[0],
+          extraTip: '0',
+        })
+
+        expectPurchaseKey().toHaveBeenCalledWith({
+          lockAddress: lock.address,
+          amountToSend: lock.keyPrice,
+          erc20Address: lock.currencyContractAddress,
+        })
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/purchaseKey.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/purchaseKey.test.ts
@@ -100,7 +100,7 @@ describe('Mailbox - purchaseKey', () => {
     fakeWindow.clearPostMessageMock()
     if (!receiveData) return
 
-    testingMailbox().data = testingData
+    testingMailbox().blockchainData = testingData
   }
 
   function expectPurchaseKey() {
@@ -138,7 +138,7 @@ describe('Mailbox - purchaseKey', () => {
       expect.assertions(2)
 
       testingMailbox().handler = fakeHandler
-      delete testingMailbox().data
+      delete testingMailbox().blockchainData
       await mailbox.purchaseKey(purchaseRequest)
 
       expectPurchaseKey().not.toHaveBeenCalled()
@@ -156,7 +156,7 @@ describe('Mailbox - purchaseKey', () => {
       beforeEach(() => {
         setupDefaults()
         testingMailbox().handler = fakeHandler
-        testingMailbox().data = testingData
+        testingMailbox().blockchainData = testingData
       })
 
       describe('malformed purchase request', () => {
@@ -203,7 +203,7 @@ describe('Mailbox - purchaseKey', () => {
       beforeEach(() => {
         setupDefaults()
         testingMailbox().handler = fakeHandler
-        testingMailbox().data = testingData
+        testingMailbox().blockchainData = testingData
       })
 
       it('should pass the correct values to handler.purchaseKey', async () => {

--- a/paywall/src/__tests__/data-iframe/Mailbox/refreshBlockchainTransactions.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/refreshBlockchainTransactions.test.ts
@@ -1,0 +1,94 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import { PaywallConfig } from '../../../unlockTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PostMessages } from '../../../messageTypes'
+import {
+  getWalletService,
+  getWeb3Service,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - refreshBlockchainTransactions', () => {
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    configuration = defaults.configuration
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+
+    fakeWindow.receivePostMessageFromMainWindow(
+      PostMessages.CONFIG,
+      configuration
+    )
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  beforeEach(() => {
+    setupDefaults()
+  })
+
+  it('should not crash if the BlockchainHandler has not been set yet', () => {
+    expect.assertions(0)
+
+    testingMailbox().handler = undefined
+    fakeWindow.receivePostMessageFromMainWindow(
+      PostMessages.INITIATED_TRANSACTION,
+      undefined
+    )
+  })
+
+  it('should call retrieveTransactions on the BlockchainHandler', () => {
+    expect.assertions(1)
+
+    testingMailbox().handler = {
+      retrieveTransactions: jest.fn(),
+    }
+    fakeWindow.receivePostMessageFromMainWindow(
+      PostMessages.INITIATED_TRANSACTION,
+      undefined
+    )
+
+    expect(testingMailbox().handler.retrieveTransactions).toHaveBeenCalled()
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/saveCacheInLocalStorage.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/saveCacheInLocalStorage.test.ts
@@ -1,0 +1,223 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+  BlockchainData,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+  addresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+import {
+  PaywallConfig,
+  TransactionStatus,
+  TransactionType,
+} from '../../../unlockTypes'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - saveCacheInLocalStorage', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  const account = addresses[1]
+  // all locks have had their addresses normalized before arriving
+  const blockchainData: BlockchainData = {
+    account: addresses[1],
+    balance: '234',
+    network: 1984,
+    locks: {
+      [lockAddresses[0]]: {
+        address: lockAddresses[0],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'none',
+          confirmations: 0,
+          expiration: 0,
+          transactions: [],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+      [lockAddresses[1]]: {
+        address: lockAddresses[1],
+        name: '1',
+        expirationDuration: 5,
+        currencyContractAddress: addresses[2],
+        keyPrice: '1',
+        key: {
+          status: 'expired',
+          confirmations: 1678234,
+          expiration: 163984,
+          transactions: [
+            {
+              status: TransactionStatus.MINED,
+              confirmations: 1678234,
+              hash: 'hash',
+              type: TransactionType.KEY_PURCHASE,
+              blockNumber: 123,
+            },
+          ],
+          owner: account,
+          lock: lockAddresses[0],
+        },
+      },
+    },
+  }
+
+  function setupDefaults(killLocalStorage = false) {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    if (killLocalStorage) {
+      fakeWindow.throwOnLocalStorageSet()
+    }
+    mailbox = new Mailbox(constants, fakeWindow)
+    ;(testingMailbox().configuration as PaywallConfig) = {
+      locks: {
+        [lockAddresses[1]]: { name: '' },
+        [lockAddresses[2]]: { name: '' },
+      },
+      callToAction: {
+        default: '',
+        pending: '',
+        expired: '',
+        confirmed: '',
+      },
+    }
+  }
+
+  function testingMailbox() {
+    return mailbox as any
+  }
+
+  function expectCacheToContain(value: BlockchainData) {
+    const key = mailbox.getCacheKey()
+    const cache = JSON.stringify(value)
+
+    expect(fakeWindow.storage).toEqual({
+      [key]: cache,
+    })
+  }
+
+  describe('error conditions', () => {
+    describe('localStorage is not available', () => {
+      beforeEach(() => {
+        setupDefaults(true)
+        fakeWindow.localStorage.setItem = jest.fn()
+      })
+
+      it('should do nothing if localStorage is not available', () => {
+        expect.assertions(1)
+
+        mailbox.saveCacheInLocalStorage()
+
+        expect(fakeWindow.localStorage.setItem).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('configuration not received/not saved because it was invalid', () => {
+      beforeEach(() => {
+        setupDefaults()
+        fakeWindow.localStorage.setItem = jest.fn()
+        testingMailbox().configuration = undefined
+      })
+
+      it('should do nothing if configuration is not set', () => {
+        expect.assertions(1)
+
+        mailbox.saveCacheInLocalStorage()
+
+        expect(fakeWindow.localStorage.setItem).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('localStorage throws on attempting to setItem', () => {
+      beforeEach(() => {
+        setupDefaults()
+        fakeWindow.localStorage.clear = jest.fn()
+        fakeWindow.throwOnLocalStorageSet()
+      })
+
+      afterEach(() => {
+        // reset to avoid affecting other tests
+        process.env.UNLOCK_ENV = 'prod'
+      })
+
+      it('in dev, it should log the error', () => {
+        expect.assertions(1)
+
+        process.env.UNLOCK_ENV = 'dev'
+        mailbox.saveCacheInLocalStorage()
+
+        expect(fakeWindow.console.error).toHaveBeenCalledWith(expect.any(Error))
+      })
+
+      it('in other envs, it should not log the error', () => {
+        expect.assertions(1)
+
+        mailbox.saveCacheInLocalStorage()
+
+        expect(fakeWindow.console.error).not.toHaveBeenCalled()
+      })
+
+      it('should clear the entire localStorage cache to be safe', () => {
+        expect.assertions(1)
+
+        mailbox.saveCacheInLocalStorage()
+
+        expect(fakeWindow.localStorage.clear).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('normal operation', () => {
+    beforeEach(() => {
+      setupDefaults()
+      ;(testingMailbox().blockchainData as BlockchainData) = blockchainData
+    })
+
+    it('should save a serialized representation of current data to the cache', () => {
+      expect.assertions(1)
+
+      mailbox.saveCacheInLocalStorage()
+
+      expectCacheToContain(blockchainData)
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/sendUpdates.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/sendUpdates.test.ts
@@ -110,7 +110,7 @@ describe('Mailbox - sendUpdates', () => {
   describe('blockchain has sent data down', () => {
     beforeEach(() => {
       setupDefaults()
-      testingMailbox().data = testingData
+      testingMailbox().blockchainData = testingData
     })
 
     it('should send account when requested', async () => {
@@ -152,7 +152,7 @@ describe('Mailbox - sendUpdates', () => {
     describe('locks', () => {
       beforeEach(() => {
         setupDefaults()
-        testingMailbox().data = testingData
+        testingMailbox().blockchainData = testingData
       })
 
       it('should send locks when requested', async () => {
@@ -179,7 +179,7 @@ describe('Mailbox - sendUpdates', () => {
 
       it('should send "unlocked" when there are valid keys', async () => {
         expect.assertions(1)
-        ;(testingMailbox().data as BlockchainData).locks[
+        ;(testingMailbox().blockchainData as BlockchainData).locks[
           lockAddresses[0]
         ].key.status = 'valid'
 

--- a/paywall/src/__tests__/data-iframe/Mailbox/sendUpdates.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/sendUpdates.test.ts
@@ -1,0 +1,220 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+  BlockchainData,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import { PaywallConfig } from '../../../unlockTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PostMessages } from '../../../messageTypes'
+import {
+  addresses,
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - sendUpdates', () => {
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+  const testingData: BlockchainData = {
+    locks: {
+      [lockAddresses[0]]: {
+        name: 'lock 1',
+        address: lockAddresses[0],
+        keyPrice: '1',
+        expirationDuration: 5,
+        currencyContractAddress: null,
+        key: {
+          expiration: 0,
+          status: 'none',
+          confirmations: 0,
+          owner: addresses[1],
+          transactions: [],
+          lock: lockAddresses[0],
+        },
+      },
+    },
+    account: addresses[1],
+    balance: '123',
+    network: 1,
+  }
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    configuration = defaults.configuration
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+
+    fakeWindow.receivePostMessageFromMainWindow(
+      PostMessages.CONFIG,
+      configuration
+    )
+    ;(fakeWindow.parent as any).postMessage.mockClear()
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  describe('blockchain is not ready yet', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should do nothing', () => {
+      expect.assertions(1)
+
+      expect(() => {
+        // this function only accepts "locks", "account", "network" and "balance"
+        // so the following request will throw if the function executes.
+        // Because of strict typing, we have to use "as any" to pass in the invalid value
+        ;(mailbox.sendUpdates as any)('oops')
+      }).not.toThrow()
+    })
+  })
+
+  describe('blockchain has sent data down', () => {
+    beforeEach(() => {
+      setupDefaults()
+      testingMailbox().data = testingData
+    })
+
+    it('should send account when requested', async () => {
+      expect.assertions(1)
+
+      mailbox.sendUpdates('account')
+      await fakeWindow.waitForPostMessage()
+
+      fakeWindow.expectPostMessageSent(
+        PostMessages.UPDATE_ACCOUNT,
+        testingData.account
+      )
+    })
+
+    it('should send account balance when requested', async () => {
+      expect.assertions(1)
+
+      mailbox.sendUpdates('balance')
+      await fakeWindow.waitForPostMessage()
+
+      fakeWindow.expectPostMessageSent(
+        PostMessages.UPDATE_ACCOUNT_BALANCE,
+        testingData.balance
+      )
+    })
+
+    it('should send network when requested', async () => {
+      expect.assertions(1)
+
+      mailbox.sendUpdates('network')
+      await fakeWindow.waitForPostMessage()
+
+      fakeWindow.expectPostMessageSent(
+        PostMessages.UPDATE_NETWORK,
+        testingData.network
+      )
+    })
+
+    describe('locks', () => {
+      beforeEach(() => {
+        setupDefaults()
+        testingMailbox().data = testingData
+      })
+
+      it('should send locks when requested', async () => {
+        expect.assertions(1)
+
+        mailbox.sendUpdates('locks')
+        await fakeWindow.waitForPostMessage()
+
+        fakeWindow.expectPostMessageSent(
+          PostMessages.UPDATE_LOCKS,
+          testingData.locks
+        )
+      })
+
+      it('should send "locked" when there are no valid keys', async () => {
+        expect.assertions(1)
+
+        const payload = undefined
+        mailbox.sendUpdates('locks')
+        await fakeWindow.waitForPostMessage()
+
+        fakeWindow.expectPostMessageSent(PostMessages.LOCKED, payload)
+      })
+
+      it('should send "unlocked" when there are valid keys', async () => {
+        expect.assertions(1)
+        ;(testingMailbox().data as BlockchainData).locks[
+          lockAddresses[0]
+        ].key.status = 'valid'
+
+        const payload = [lockAddresses[0]]
+        mailbox.sendUpdates('locks')
+        await fakeWindow.waitForPostMessage()
+
+        fakeWindow.expectPostMessageSent(PostMessages.UNLOCKED, payload)
+      })
+
+      it('should emit an error when the update requested is an unknown string', async () => {
+        expect.assertions(1)
+
+        const a: any = mailbox.sendUpdates as any
+        a('oops')
+        await fakeWindow.waitForPostMessage()
+
+        fakeWindow.expectPostMessageSent(
+          PostMessages.ERROR,
+          'Unknown update requested: "oops"'
+        )
+      })
+
+      it('should emit an error when the update requested is an unknown something else', async () => {
+        expect.assertions(1)
+
+        const a: any = mailbox.sendUpdates as any
+        a({ double: 'oops' })
+        await fakeWindow.waitForPostMessage()
+
+        fakeWindow.expectPostMessageSent(
+          PostMessages.ERROR,
+          'Unknown update requested: <invalid value>'
+        )
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/setConfig.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/setConfig.test.ts
@@ -1,0 +1,117 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import { PaywallConfig } from '../../../unlockTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PostMessages } from '../../../messageTypes'
+import {
+  addresses,
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - setConfig', () => {
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    configuration = defaults.configuration
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  describe('invalid configuration', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should emit an error', async () => {
+      expect.assertions(1)
+
+      mailbox.setConfig('not a valid config')
+      await fakeWindow.waitForPostMessage()
+
+      fakeWindow.expectPostMessageSent(
+        PostMessages.ERROR,
+        'Invalid paywall configuration, cannot continue'
+      )
+    })
+
+    it('should not save the configuration', async () => {
+      expect.assertions(1)
+
+      mailbox.setConfig('not a valid config')
+      await fakeWindow.waitForPostMessage()
+      expect(testingMailbox().configuration).toBe(undefined)
+    })
+  })
+
+  describe('valid configuration', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should normalize the lock addresses and save the configuration', () => {
+      expect.assertions(1)
+
+      const info1 = configuration.locks[addresses[0]]
+      const info2 = configuration.locks[addresses[1]]
+      const info3 = configuration.locks[addresses[2]]
+
+      const expectedConfiguration = {
+        ...configuration,
+      }
+      delete expectedConfiguration.locks
+      expectedConfiguration.locks = {
+        [lockAddresses[0]]: info1,
+        [lockAddresses[1]]: info2,
+        [lockAddresses[2]]: info3,
+      }
+
+      mailbox.setConfig(configuration)
+
+      expect(testingMailbox().configuration).toEqual(expectedConfiguration)
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/setConfig.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/setConfig.test.ts
@@ -113,5 +113,31 @@ describe('Mailbox - setConfig', () => {
 
       expect(testingMailbox().configuration).toEqual(expectedConfiguration)
     })
+
+    describe('caching', () => {
+      beforeEach(() => {
+        setupDefaults()
+        mailbox.getBlockchainDataFromLocalStorageCache = jest.fn()
+        mailbox.setupStorageListener = jest.fn()
+      })
+
+      it('should retrive the cache', () => {
+        expect.assertions(1)
+
+        mailbox.setConfig(configuration)
+
+        expect(
+          mailbox.getBlockchainDataFromLocalStorageCache
+        ).toHaveBeenCalled()
+      })
+
+      it('should begin listening for storage events', () => {
+        expect.assertions(1)
+
+        mailbox.setConfig(configuration)
+
+        expect(mailbox.setupStorageListener).toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/paywall/src/__tests__/data-iframe/Mailbox/setupPostMessageListeners.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/setupPostMessageListeners.test.ts
@@ -1,0 +1,150 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import { PaywallConfig, PurchaseKeyRequest } from '../../../unlockTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PostMessages } from '../../../messageTypes'
+import {
+  getWalletService,
+  getWeb3Service,
+  lockAddresses,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - setupPostMessageListeners', () => {
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    configuration = defaults.configuration
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+
+    testingMailbox().setConfig = jest.fn()
+    testingMailbox().sendUpdates = jest.fn()
+    testingMailbox().purchaseKey = jest.fn()
+    testingMailbox().refreshBlockchainTransactions = jest.fn()
+    mailbox.setupPostMessageListeners()
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  describe('setupPostMessageListeners', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should listen for the paywall configuration', () => {
+      expect.assertions(1)
+
+      fakeWindow.receivePostMessageFromMainWindow(
+        PostMessages.CONFIG,
+        configuration
+      )
+
+      // called with the payload, and a function that can be used to respond
+      expect(testingMailbox().setConfig).toHaveBeenCalledWith(
+        configuration,
+        expect.any(Function)
+      )
+    })
+
+    it('should listen for requests to send data updates to the main window', () => {
+      expect.assertions(1)
+
+      fakeWindow.receivePostMessageFromMainWindow(
+        PostMessages.SEND_UPDATES,
+        'account'
+      )
+
+      // called with the payload, and a function that can be used to respond
+      expect(testingMailbox().sendUpdates).toHaveBeenCalledWith(
+        'account',
+        expect.any(Function)
+      )
+    })
+
+    it('should listen for requests to purchase a key on a lock', () => {
+      expect.assertions(1)
+
+      const purchaseRequest: PurchaseKeyRequest = {
+        lock: lockAddresses[0],
+        extraTip: '0',
+      }
+      fakeWindow.receivePostMessageFromMainWindow(
+        PostMessages.PURCHASE_KEY,
+        purchaseRequest
+      )
+
+      // called with the payload, and a function that can be used to respond
+      expect(testingMailbox().purchaseKey).toHaveBeenCalledWith(
+        purchaseRequest,
+        expect.any(Function)
+      )
+    })
+
+    it('should listen for notifications that a key purchase has been initiated elsewhere', () => {
+      expect.assertions(1)
+
+      const payload = undefined
+      fakeWindow.receivePostMessageFromMainWindow(
+        PostMessages.INITIATED_TRANSACTION,
+        payload
+      )
+
+      // called with the payload, and a function that can be used to respond
+      expect(
+        testingMailbox().refreshBlockchainTransactions
+      ).toHaveBeenCalledWith(payload, expect.any(Function))
+    })
+
+    it('should send PostMessages.READY to the main window', () => {
+      expect.assertions(1)
+
+      expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith(
+        {
+          type: PostMessages.READY,
+          payload: undefined,
+        },
+        'http://example.com'
+      )
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/Mailbox/setupStorageListener.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/setupStorageListener.test.ts
@@ -1,0 +1,142 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import { PaywallConfig } from '../../../unlockTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import {
+  getWalletService,
+  getWeb3Service,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - setupStorageListener', () => {
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    configuration = defaults.configuration
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  beforeEach(() => {
+    setupDefaults()
+    fakeWindow.addEventListener = jest.fn()
+  })
+
+  it('should set up a listener for storage events', () => {
+    expect.assertions(1)
+
+    mailbox.setupStorageListener()
+
+    expect(fakeWindow.addEventListener).toHaveBeenCalledWith(
+      'storage',
+      expect.any(Function)
+    )
+  })
+
+  describe('event listener', () => {
+    describe('error states', () => {
+      beforeEach(() => {
+        setupDefaults()
+        mailbox.setupStorageListener()
+        testingMailbox().configuration = configuration
+      })
+
+      it('should do nothing if there is no configuration', () => {
+        expect.assertions(1)
+
+        const cacheKey = mailbox.getCacheKey()
+        mailbox.getCacheKey = jest.fn()
+        testingMailbox().configuration = undefined
+
+        fakeWindow.receiveStorageEvent(cacheKey, 'old', 'new')
+
+        expect(mailbox.getCacheKey).not.toHaveBeenCalled()
+      })
+
+      it('should do nothing if there is no handler', () => {
+        expect.assertions(1)
+
+        const cacheKey = mailbox.getCacheKey()
+        mailbox.getCacheKey = jest.fn()
+        testingMailbox().configuration = configuration
+        testingMailbox().handler = undefined
+
+        fakeWindow.receiveStorageEvent(cacheKey, 'old', 'new')
+
+        expect(mailbox.getCacheKey).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('valid states', () => {
+      beforeEach(() => {
+        setupDefaults()
+        mailbox.setupStorageListener()
+        testingMailbox().configuration = configuration
+        testingMailbox().handler = {
+          retrieveCurrentBlockchainData: jest.fn(),
+        }
+      })
+
+      it('should not retrieve data for a different cache key', () => {
+        expect.assertions(1)
+
+        fakeWindow.receiveStorageEvent('different cache', 'old', 'new')
+
+        expect(
+          testingMailbox().handler.retrieveCurrentBlockchainData
+        ).not.toHaveBeenCalled()
+      })
+
+      it("should retrieve data for this paywall's cache key", () => {
+        expect.assertions(1)
+
+        fakeWindow.receiveStorageEvent(mailbox.getCacheKey(), 'old', 'new')
+
+        expect(
+          testingMailbox().handler.retrieveCurrentBlockchainData
+        ).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/BlockchainHandler.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/BlockchainHandler.test.ts
@@ -1,0 +1,212 @@
+import {
+  WalletServiceType,
+  Web3ServiceType,
+  PaywallState,
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  LocksmithTransactionsResult,
+} from '../../../../data-iframe/blockchainHandler/blockChainTypes'
+import BlockchainHandler from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import {
+  defaultValuesOverride,
+  BlockchainTestDefaults,
+  lockAddresses,
+  setupTestDefaults,
+} from '../../../test-helpers/setupBlockchainHelpers'
+import { PaywallConfig } from '../../../../unlockTypes'
+import { POLLING_INTERVAL } from '../../../../constants'
+
+describe('BlockchainHandler class setup', () => {
+  let walletService: WalletServiceType
+  let web3Service: Web3ServiceType
+  let emitError: (error: Error) => void
+  let emitChanges: () => void
+  let listeners: { [key: string]: Function }
+  let store: PaywallState
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let fakeWindow: FetchWindow & SetTimeoutWindow
+  let defaults: BlockchainTestDefaults
+
+  type OptionalBlockchainValues = Partial<PaywallState>
+
+  function setupDefaults(
+    valuesOverride: OptionalBlockchainValues = defaultValuesOverride,
+    jsonToFetch: { transactions?: LocksmithTransactionsResult[] } = {}
+  ) {
+    defaults = setupTestDefaults(valuesOverride, jsonToFetch)
+    walletService = defaults.walletService
+    web3Service = defaults.web3Service
+    emitError = defaults.emitError
+    emitChanges = defaults.emitChanges
+    listeners = defaults.listeners
+    store = defaults.store
+    constants = defaults.constants
+    configuration = defaults.configuration
+    fakeWindow = defaults.fakeWindow
+  }
+
+  async function callSetupBlockchainHandler() {
+    const handler = new BlockchainHandler({
+      walletService,
+      web3Service,
+      constants,
+      configuration,
+      emitChanges,
+      emitError,
+      window: fakeWindow,
+      store,
+    })
+    handler.init()
+    return handler
+  }
+
+  function getAccountPollingFunction() {
+    const mock: any = fakeWindow.setTimeout
+    return mock.mock.calls[0][0]
+  }
+
+  beforeEach(() => {
+    setupDefaults()
+    return callSetupBlockchainHandler()
+  })
+
+  it('should set up initial default store', () => {
+    expect.assertions(1)
+
+    expect(store).toEqual({
+      config: {
+        locks: {
+          // addresses are now normalized
+          [lockAddresses[0]]: { name: '1' },
+          [lockAddresses[1]]: { name: '2' },
+          [lockAddresses[2]]: { name: '3' },
+        },
+        callToAction: {
+          default: '',
+          expired: '',
+          pending: '',
+          confirmed: '',
+        },
+      },
+      account: null,
+      balance: '0',
+      keys: {
+        [lockAddresses[0]]: {
+          lock: lockAddresses[0],
+          owner: null,
+          expiration: 0,
+        },
+        [lockAddresses[1]]: {
+          lock: lockAddresses[1],
+          owner: null,
+          expiration: 0,
+        },
+        [lockAddresses[2]]: {
+          lock: lockAddresses[2],
+          owner: null,
+          expiration: 0,
+        },
+      }, // default keys for each lock are created
+      locks: {},
+      transactions: {},
+      network: 1984, // default network is used for network
+    })
+  })
+
+  it('should set up event listeners', () => {
+    expect.assertions(1)
+
+    expect(Object.keys(listeners)).toEqual([
+      'account.changed',
+      'network.changed',
+      'account.updated',
+      'key.updated',
+      'transaction.updated',
+      'lock.updated',
+      'transaction.new',
+      'error',
+    ])
+  })
+
+  describe('account polling', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should retrieve the current account if walletService has a provider', async () => {
+      expect.assertions(1)
+
+      // for the purposes of this test, we only need the provider to exist
+      walletService.provider = true
+      await callSetupBlockchainHandler()
+
+      expect(walletService.getAccount).toHaveBeenCalled()
+    })
+
+    it('should not retrieve the current account if walletService is not ready', async () => {
+      expect.assertions(1)
+
+      walletService.ready = false
+      await callSetupBlockchainHandler()
+
+      expect(walletService.getAccount).not.toHaveBeenCalled()
+    })
+
+    it('should poll for account changes', async () => {
+      expect.assertions(1)
+
+      await callSetupBlockchainHandler()
+
+      expect(fakeWindow.setTimeout).toHaveBeenCalledWith(
+        expect.any(Function),
+        POLLING_INTERVAL
+      )
+    })
+
+    describe('account polling function', () => {
+      beforeEach(() => {
+        setupDefaults()
+      })
+
+      it('should retrieve current account if walletService is ready', async () => {
+        expect.assertions(1)
+
+        // for the purposes of this test, we only need the provider to exist
+        walletService.provider = true
+        await callSetupBlockchainHandler()
+
+        const pollForAccounts = getAccountPollingFunction()
+        pollForAccounts()
+
+        expect(walletService.getAccount).toHaveBeenCalled()
+      })
+
+      it('should not retrieve current account if walletService is not ready', async () => {
+        expect.assertions(1)
+
+        await callSetupBlockchainHandler()
+
+        const pollForAccounts = getAccountPollingFunction()
+        pollForAccounts()
+
+        expect(walletService.getAccount).not.toHaveBeenCalled()
+      })
+
+      it('should poll for account changes', async () => {
+        expect.assertions(1)
+
+        await callSetupBlockchainHandler()
+
+        const pollForAccounts = getAccountPollingFunction()
+        pollForAccounts()
+
+        expect(fakeWindow.setTimeout).toHaveBeenCalledWith(
+          expect.any(Function),
+          POLLING_INTERVAL
+        )
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/makeDefaultKeys.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/makeDefaultKeys.test.ts
@@ -1,0 +1,36 @@
+import { makeDefaultKeys } from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+
+describe('BlockchainHandler - makeDefaultKeys', () => {
+  it.each([null, '0x1234567890123456789012345678901234567890'])(
+    'should set up default keys for %s account',
+    (account: string | null) => {
+      expect.assertions(1)
+
+      const addresses = [
+        '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+        '0x15B87bdC4B3ecb783F56f735653332EAD3BCa5F8',
+        '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
+      ]
+      const lowerAddresses = addresses.map(address => address.toLowerCase())
+      const expectedKeys = {
+        [lowerAddresses[0].toLowerCase()]: {
+          lock: lowerAddresses[0],
+          owner: account,
+          expiration: 0,
+        },
+        [lowerAddresses[1].toLowerCase()]: {
+          lock: lowerAddresses[1],
+          owner: account,
+          expiration: 0,
+        },
+        [lowerAddresses[2].toLowerCase()]: {
+          lock: lowerAddresses[2],
+          owner: account,
+          expiration: 0,
+        },
+      }
+
+      expect(makeDefaultKeys(lowerAddresses, account)).toEqual(expectedKeys)
+    }
+  )
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/purchaseKey.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/purchaseKey.test.ts
@@ -1,0 +1,114 @@
+import {
+  WalletServiceType,
+  Web3ServiceType,
+  PaywallState,
+  SetTimeoutWindow,
+  FetchWindow,
+  LocksmithTransactionsResult,
+  ConstantsType,
+} from '../../../../data-iframe/blockchainHandler/blockChainTypes'
+import BlockchainHandler from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import { PaywallConfig } from '../../../../unlockTypes'
+import {
+  defaultValuesOverride,
+  BlockchainTestDefaults,
+  setupTestDefaults,
+  lockAddresses,
+  addresses,
+} from '../../../test-helpers/setupBlockchainHelpers'
+
+describe('BlockchainHandler - purchaseKey', () => {
+  let walletService: WalletServiceType
+  let web3Service: Web3ServiceType
+  let emitError: (error: Error) => void
+  let emitChanges: () => void
+  let store: PaywallState
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let fakeWindow: FetchWindow & SetTimeoutWindow
+  let handler: BlockchainHandler
+  let defaults: BlockchainTestDefaults
+
+  type OptionalBlockchainValues = Partial<PaywallState>
+
+  function setupDefaults(
+    valuesOverride: OptionalBlockchainValues = defaultValuesOverride,
+    jsonToFetch: { transactions?: LocksmithTransactionsResult[] } = {}
+  ) {
+    defaults = setupTestDefaults(valuesOverride, jsonToFetch)
+    walletService = defaults.walletService
+    web3Service = defaults.web3Service
+    emitError = defaults.emitError
+    emitChanges = defaults.emitChanges
+    store = defaults.store
+    constants = defaults.constants
+    configuration = defaults.configuration
+    fakeWindow = defaults.fakeWindow
+    handler = new BlockchainHandler({
+      walletService,
+      web3Service,
+      constants,
+      configuration,
+      emitChanges,
+      emitError,
+      window: fakeWindow,
+      store,
+    })
+    const mock: any = web3Service.getLock
+    mock.mockImplementation((address: string) => {
+      web3Service.emit('lock.updated', address, {
+        address,
+        name: '',
+        keyPrice: '0',
+        expirationDuration: 1,
+        currencyContractAddress: null,
+      })
+      return Promise.resolve()
+    })
+    handler.init()
+    walletService.purchaseKey = jest.fn()
+  }
+
+  describe('no account yet', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should not attempt purchase', async () => {
+      expect.assertions(1)
+
+      await handler.purchaseKey({
+        lockAddress: lockAddresses[0],
+        amountToSend: '123',
+        erc20Address: lockAddresses[2], // verify we pass this in too
+      })
+
+      expect(walletService.purchaseKey).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('account is available', () => {
+    beforeEach(() => {
+      setupDefaults({ account: addresses[1] })
+    })
+
+    it('should attempt a key purchase', async () => {
+      expect.assertions(1)
+
+      await handler.purchaseKey({
+        lockAddress: lockAddresses[0],
+        amountToSend: '123',
+        erc20Address: addresses[2], // verify we pass this in too
+      })
+
+      expect(walletService.purchaseKey).toHaveBeenCalledWith(
+        lockAddresses[0],
+        addresses[1],
+        '123',
+        null,
+        null,
+        addresses[2]
+      )
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/retrieveCurrentBlockchainData.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/retrieveCurrentBlockchainData.test.ts
@@ -1,0 +1,366 @@
+import {
+  WalletServiceType,
+  Web3ServiceType,
+  PaywallState,
+  SetTimeoutWindow,
+  FetchWindow,
+  LocksmithTransactionsResult,
+  ConstantsType,
+  KeyResult,
+} from '../../../../data-iframe/blockchainHandler/blockChainTypes'
+import BlockchainHandler from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import {
+  TransactionStatus,
+  TransactionType,
+  PaywallConfig,
+  Transaction,
+  Locks,
+} from '../../../../unlockTypes'
+import {
+  defaultValuesOverride,
+  BlockchainTestDefaults,
+  addresses,
+  setupTestDefaults,
+  lockAddresses,
+  getDefaultFullLocks,
+} from '../../../test-helpers/setupBlockchainHelpers'
+import { waitFor } from '../../../../utils/promises'
+
+describe('BlockchainHandler - retrieveCurrentBlockchainData', () => {
+  let walletService: WalletServiceType
+  let web3Service: Web3ServiceType
+  let emitError: (error: Error) => void
+  let emitChanges: () => void
+  let store: PaywallState
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let fakeWindow: FetchWindow & SetTimeoutWindow
+  let handler: BlockchainHandler
+  let defaults: BlockchainTestDefaults
+
+  type OptionalBlockchainValues = Partial<PaywallState>
+
+  function setupDefaults(
+    valuesOverride: OptionalBlockchainValues = defaultValuesOverride,
+    jsonToFetch: { transactions?: LocksmithTransactionsResult[] } = {}
+  ) {
+    defaults = setupTestDefaults(valuesOverride, jsonToFetch)
+    walletService = defaults.walletService
+    web3Service = defaults.web3Service
+    emitError = defaults.emitError
+    emitChanges = defaults.emitChanges
+    store = defaults.store
+    constants = defaults.constants
+    configuration = defaults.configuration
+    fakeWindow = defaults.fakeWindow
+    handler = new BlockchainHandler({
+      walletService,
+      web3Service,
+      constants,
+      configuration,
+      emitChanges,
+      emitError,
+      window: fakeWindow,
+      store,
+    })
+    const mock: any = web3Service.getLock
+    // emit a unique name for each lock
+    const lockNames = {
+      [lockAddresses[0]]: 'one',
+      [lockAddresses[1]]: 'two',
+      [lockAddresses[2]]: 'three',
+    }
+    mock.mockImplementation((address: string) => {
+      web3Service.emit('lock.updated', address, {
+        address,
+        name: lockNames[address],
+        keyPrice: '0',
+        expirationDuration: 1,
+        currencyContractAddress: null,
+      })
+      return Promise.resolve()
+    })
+    handler.init()
+  }
+
+  describe('lock names', () => {
+    beforeEach(() => {
+      setupDefaults({ account: null })
+    })
+
+    it('should use configuration names if present', async () => {
+      expect.assertions(1)
+
+      handler = new BlockchainHandler({
+        walletService,
+        web3Service,
+        constants,
+        configuration,
+        emitChanges,
+        emitError,
+        window: fakeWindow,
+        store,
+      })
+
+      handler.init()
+
+      // locks get populated when web3Service.getLock emits 'lock.updated'
+      // see the setupListeners function for implementation
+      // the end of "setupDefaults" mocks the emit in this test file
+      expect(emitChanges).toHaveBeenCalledWith({
+        locks: getDefaultFullLocks(store, configuration),
+        account: null,
+        balance: '0',
+        network: 1984,
+      })
+    })
+
+    it('should use lock names if configuration names are not present', async () => {
+      expect.assertions(1)
+
+      configuration.locks[lockAddresses[0]].name = ''
+      handler = new BlockchainHandler({
+        walletService,
+        web3Service,
+        constants,
+        configuration,
+        emitChanges,
+        emitError,
+        window: fakeWindow,
+        store,
+      })
+
+      handler.init()
+
+      await handler.retrieveCurrentBlockchainData()
+
+      // locks get populated when web3Service.getLock emits 'lock.updated'
+      // see the setupListeners function for implementation
+      // the end of "setupDefaults" mocks the emit in this test file
+      expect(emitChanges).toHaveBeenCalledWith({
+        locks: getDefaultFullLocks(store, configuration),
+        account: null,
+        balance: '0',
+        network: 1984,
+      })
+    })
+  })
+
+  describe('user is not logged in', () => {
+    beforeEach(() => {
+      setupDefaults({ account: null })
+    })
+
+    it('should clear transactions, set up default keys, and set balance to "0"', async () => {
+      expect.assertions(3)
+
+      await handler.retrieveCurrentBlockchainData()
+
+      expect(store.transactions).toEqual({})
+      expect(store.keys).toEqual({
+        [lockAddresses[0]]: {
+          lock: lockAddresses[0],
+          owner: null,
+          expiration: 0,
+        },
+        [lockAddresses[1]]: {
+          lock: lockAddresses[1],
+          owner: null,
+          expiration: 0,
+        },
+        [lockAddresses[2]]: {
+          lock: lockAddresses[2],
+          owner: null,
+          expiration: 0,
+        },
+      })
+      expect(store.balance).toBe('0')
+    })
+
+    it('should call emitChanges with the default store', async () => {
+      expect.assertions(1)
+
+      await handler.retrieveCurrentBlockchainData()
+
+      // locks get populated when web3Service.getLock emits 'lock.updated'
+      // see the setupListeners function for implementation
+      // the end of "setupDefaults" mocks the emit in this test file
+      expect(emitChanges).toHaveBeenCalledWith({
+        locks: getDefaultFullLocks(store, configuration),
+        account: null,
+        balance: '0',
+        network: 1984,
+      })
+    })
+  })
+
+  describe('user is logged in', () => {
+    beforeEach(() => {
+      setupDefaults({ account: addresses[2] })
+    })
+
+    it('should call emitChanges with the right store', async () => {
+      expect.assertions(1)
+
+      await handler.retrieveCurrentBlockchainData()
+
+      // locks get populated when web3Service.getLock emits 'lock.updated'
+      // see the setupListeners function for implementation
+      // the end of "setupDefaults" mocks the emit in this test file
+      expect(emitChanges).toHaveBeenCalledWith({
+        locks: getDefaultFullLocks(store, configuration),
+        account: addresses[2],
+        balance: '0',
+        network: 1984,
+      })
+    })
+
+    it('should retrieve keys', async () => {
+      expect.assertions(1)
+
+      const mock: any = web3Service.getKeyByLockForOwner
+      mock.mockImplementationOnce((lock: string, owner: string) => {
+        const key: KeyResult = {
+          lock,
+          owner,
+          expiration: 12345,
+        }
+        web3Service.emit('key.updated', 'id', key)
+        return Promise.resolve(key)
+      })
+
+      await handler.retrieveCurrentBlockchainData()
+
+      // locks get populated when web3Service.getLock emits 'lock.updated'
+      // see the setupListeners function for implementation
+      // the end of "setupDefaults" mocks the emit in this test file
+      expect(emitChanges).toHaveBeenCalledWith({
+        locks: getDefaultFullLocks(store, configuration, {
+          [lockAddresses[0]]: 12345, // override key expiration for key on lock 0
+        }),
+        account: addresses[2],
+        balance: '0',
+        network: 1984,
+      })
+    })
+
+    it('should pass any errors in key retrieval to emitError', async () => {
+      expect.assertions(1)
+
+      const error = new Error('fail')
+      const mock: any = web3Service.getKeyByLockForOwner
+      mock.mockImplementationOnce(() => {
+        return Promise.reject(error)
+      })
+
+      await handler.retrieveCurrentBlockchainData()
+
+      expect(emitError).toHaveBeenCalledWith(error)
+    })
+
+    describe('default keys', () => {
+      beforeEach(() => {
+        setupDefaults({
+          account: addresses[2],
+          keys: {
+            [lockAddresses[0]]: {
+              lock: lockAddresses[0],
+              owner: addresses[2],
+              expiration: 3,
+            },
+          },
+        })
+      })
+
+      it('should fill in the missing keys with defaults', async () => {
+        expect.assertions(1)
+
+        // remove some keys manually
+
+        delete store.keys[lockAddresses[1]]
+        delete store.keys[lockAddresses[2]]
+        await handler.retrieveCurrentBlockchainData()
+
+        // this proves that 3 keys still exist
+        expect(emitChanges).toHaveBeenCalledWith({
+          locks: getDefaultFullLocks(store, configuration, {}),
+          account: addresses[2],
+          balance: '0',
+          network: 1984,
+        })
+      })
+    })
+
+    describe('transactions', () => {
+      beforeEach(() => {
+        setupDefaults(
+          { account: addresses[2] },
+          {
+            transactions: [
+              {
+                transactionHash: 'hash',
+                chain: constants.defaultNetwork,
+                recipient: addresses[1], // locksmith returns checksummed addresses
+                sender: store.account as string,
+                for: store.account as string,
+                data: 'data',
+              },
+            ],
+          }
+        )
+
+        // return a fake transaction
+        const mock: any = web3Service.getTransaction
+        mock.mockImplementationOnce((hash: string) => {
+          const transaction: Transaction = {
+            hash,
+            status: TransactionStatus.PENDING,
+            confirmations: 0,
+            type: TransactionType.KEY_PURCHASE,
+            blockNumber: Number.MAX_SAFE_INTEGER,
+            lock: addresses[1], // chain returns checksummed addresses
+            to: addresses[1], // chain returns checksummed addresses
+            for: store.account as string,
+          }
+          web3Service.emit('transaction.updated', hash, transaction)
+          return Promise.resolve()
+        })
+      })
+
+      it('should retrieve transactions', async () => {
+        expect.assertions(2)
+
+        const locks: Locks = getDefaultFullLocks(store, configuration)
+        locks[lockAddresses[1]].key.status = 'pending'
+        locks[lockAddresses[1]].key.transactions = [
+          {
+            blockNumber: Number.MAX_SAFE_INTEGER,
+            confirmations: 0,
+            for: store.account as string,
+            hash: 'hash',
+            lock: lockAddresses[1], // normalized lock value
+            status: TransactionStatus.PENDING,
+            to: lockAddresses[1], // normalized lock value
+            type: TransactionType.KEY_PURCHASE,
+          },
+        ]
+
+        await handler.retrieveCurrentBlockchainData()
+
+        await waitFor(() => Object.keys(store.transactions).length)
+
+        // locks get populated when web3Service.getLock emits 'lock.updated'
+        // see the setupListeners function for implementation
+        // the end of "setupDefaults" mocks the emit in this test file
+        expect(emitChanges).toHaveBeenCalledWith({
+          locks,
+          account: addresses[2],
+          balance: '0',
+          network: 1984,
+        })
+        // once for each lock (3), once for the transaction
+        expect(emitChanges).toHaveBeenCalledTimes(4)
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/retrieveTransactions.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/retrieveTransactions.test.ts
@@ -1,0 +1,180 @@
+import {
+  Web3ServiceType,
+  PaywallState,
+  FetchWindow,
+  ConstantsType,
+  LocksmithTransactionsResult,
+  TransactionDefaults,
+  WalletServiceType,
+  SetTimeoutWindow,
+} from '../../../../data-iframe/blockchainHandler/blockChainTypes'
+import {
+  BlockchainTestDefaults,
+  defaultValuesOverride,
+  setupTestDefaults,
+  addresses,
+  lockAddresses,
+} from '../../../test-helpers/setupBlockchainHelpers'
+import BlockchainHandler from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import { PaywallConfig } from '../../../../unlockTypes'
+
+describe('BlockchainHandler - retrieveTransactions', () => {
+  let walletService: WalletServiceType
+  let web3Service: Web3ServiceType
+  let emitError: (error: Error) => void
+  let emitChanges: () => void
+  let store: PaywallState
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let fakeWindow: FetchWindow & SetTimeoutWindow
+  let handler: BlockchainHandler
+  let defaults: BlockchainTestDefaults
+
+  type OptionalBlockchainValues = Partial<PaywallState>
+
+  function setupDefaults(
+    valuesOverride: OptionalBlockchainValues = defaultValuesOverride,
+    jsonToFetch: { transactions?: LocksmithTransactionsResult[] } = {}
+  ) {
+    defaults = setupTestDefaults(valuesOverride, jsonToFetch)
+    walletService = defaults.walletService
+    web3Service = defaults.web3Service
+    emitError = defaults.emitError
+    emitChanges = defaults.emitChanges
+    store = defaults.store
+    constants = defaults.constants
+    configuration = defaults.configuration
+    fakeWindow = defaults.fakeWindow
+    handler = new BlockchainHandler({
+      walletService,
+      web3Service,
+      constants,
+      configuration,
+      emitChanges,
+      emitError,
+      window: fakeWindow,
+      store,
+    })
+    handler.init()
+    handler.setupListeners()
+
+    handler.retrieveCurrentBlockchainData = jest.fn()
+    handler.dispatchChangesToPostOffice = jest.fn()
+  }
+
+  function callRetrieveTransactions() {
+    return handler.retrieveTransactions()
+  }
+
+  it('should not fetch transactions if there is no user account', async () => {
+    expect.assertions(1)
+
+    setupDefaults()
+
+    await callRetrieveTransactions()
+
+    expect(fakeWindow.fetch).not.toHaveBeenCalled()
+  })
+
+  describe('has user account', () => {
+    beforeEach(() => {
+      setupDefaults({ account: addresses[2] })
+    })
+
+    it('should call fetch with the correct url', async () => {
+      expect.assertions(1)
+
+      await callRetrieveTransactions()
+
+      expect(fakeWindow.fetch).toHaveBeenCalledWith(
+        `http://fun.times/transactions?for=${addresses[2]}&recipient[]=${lockAddresses[0]}&recipient[]=${lockAddresses[1]}&recipient[]=${lockAddresses[2]}`
+      )
+    })
+
+    it('should not call getTransaction if no results are returned', async () => {
+      expect.assertions(1)
+
+      await callRetrieveTransactions()
+
+      expect(web3Service.getTransaction).not.toHaveBeenCalled()
+    })
+
+    describe('individual transactions', () => {
+      let returnedTransactions: {
+        transactions?: LocksmithTransactionsResult[]
+      } = {
+        transactions: [
+          {
+            transactionHash: 'hash1',
+            chain: 1984,
+            recipient: addresses[0],
+            data: 'hi',
+            sender: addresses[1],
+            for: addresses[2],
+          },
+          {
+            transactionHash: 'hash2',
+            chain: 1984,
+            recipient: addresses[1],
+            data: null,
+            sender: addresses[2],
+            for: addresses[2],
+          },
+        ],
+      }
+      beforeEach(() => {
+        setupDefaults({ account: addresses[2] }, returnedTransactions)
+      })
+
+      it('should call getTransaction for each transaction', async () => {
+        expect.assertions(1)
+
+        await callRetrieveTransactions()
+
+        expect(web3Service.getTransaction).toHaveBeenCalledTimes(2)
+      })
+
+      it('should pass the transaction as defaults if input is present', async () => {
+        expect.assertions(2)
+
+        await callRetrieveTransactions()
+
+        const transaction1 = (returnedTransactions.transactions &&
+          returnedTransactions.transactions[0]) as LocksmithTransactionsResult
+        const defaults: TransactionDefaults = {
+          to: transaction1.recipient,
+          from: transaction1.sender,
+          for: transaction1.for,
+          input: transaction1.data,
+          hash: 'hash1',
+          network: 1984,
+        }
+
+        expect(web3Service.getTransaction).toHaveBeenNthCalledWith(
+          1,
+          'hash1',
+          defaults
+        )
+        expect(web3Service.getTransaction).toHaveBeenNthCalledWith(
+          2,
+          'hash2',
+          undefined
+        )
+      })
+
+      it('should pass on errors to emitError', async () => {
+        expect.assertions(1)
+
+        const error = new Error('fail')
+
+        const mock: any = web3Service.getTransaction as any
+
+        mock.mockImplementationOnce(() => Promise.reject(error))
+
+        await callRetrieveTransactions()
+
+        expect(emitError).toHaveBeenCalledWith(error)
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setupListeners.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setupListeners.test.ts
@@ -1,0 +1,653 @@
+import {
+  WalletServiceType,
+  Web3ServiceType,
+  PaywallState,
+  SetTimeoutWindow,
+  FetchWindow,
+  LocksmithTransactionsResult,
+  ConstantsType,
+  TransactionDefaults,
+} from '../../../../data-iframe/blockchainHandler/blockChainTypes'
+import BlockchainHandler, {
+  makeDefaultKeys,
+} from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import {
+  TransactionStatus,
+  TransactionType,
+  PaywallConfig,
+} from '../../../../unlockTypes'
+import {
+  defaultValuesOverride,
+  BlockchainTestDefaults,
+  addresses,
+  setupTestDefaults,
+  lockAddresses,
+} from '../../../test-helpers/setupBlockchainHelpers'
+
+describe('BlockchainHandler - setupListeners', () => {
+  let walletService: WalletServiceType
+  let web3Service: Web3ServiceType
+  let emitError: (error: Error) => void
+  let emitChanges: () => void
+  let store: PaywallState
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let fakeWindow: FetchWindow & SetTimeoutWindow
+  let handler: BlockchainHandler
+  let defaults: BlockchainTestDefaults
+
+  type OptionalBlockchainValues = Partial<PaywallState>
+
+  function setupDefaults(
+    valuesOverride: OptionalBlockchainValues = defaultValuesOverride,
+    jsonToFetch: { transactions?: LocksmithTransactionsResult[] } = {}
+  ) {
+    defaults = setupTestDefaults(valuesOverride, jsonToFetch)
+    walletService = defaults.walletService
+    web3Service = defaults.web3Service
+    emitError = defaults.emitError
+    emitChanges = defaults.emitChanges
+    store = defaults.store
+    constants = defaults.constants
+    configuration = defaults.configuration
+    fakeWindow = defaults.fakeWindow
+    handler = new BlockchainHandler({
+      walletService,
+      web3Service,
+      constants,
+      configuration,
+      emitChanges,
+      emitError,
+      window: fakeWindow,
+      store,
+    })
+    handler.init()
+    handler.setupListeners()
+
+    handler.retrieveCurrentBlockchainData = jest.fn()
+    handler.dispatchChangesToPostOffice = jest.fn()
+  }
+
+  beforeEach(() => {
+    setupDefaults()
+  })
+
+  describe('account.changed', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should call retrieveCurrentBlockchainData on account.changed', () => {
+      expect.assertions(4)
+
+      walletService.emit('account.changed', addresses[1])
+
+      expect(handler.retrieveCurrentBlockchainData).toHaveBeenCalled()
+
+      expect(store.transactions).toEqual({})
+      expect(store.keys).toEqual(makeDefaultKeys(lockAddresses, addresses[1]))
+      expect(store.account).toBe(addresses[1])
+    })
+
+    it('should not call retrieveCurrentBlockchainData on account.changed if account is the same', () => {
+      expect.assertions(4)
+
+      walletService.emit('account.changed', null)
+
+      expect(handler.retrieveCurrentBlockchainData).not.toHaveBeenCalled()
+
+      expect(store.transactions).toEqual({})
+      expect(store.keys).toEqual(makeDefaultKeys(lockAddresses, null))
+      expect(store.account).toBeNull()
+    })
+  })
+
+  describe('network.changed', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should call retrieveCurrentBlockchainData on network.changed', () => {
+      expect.assertions(4)
+
+      walletService.emit('network.changed', 1)
+
+      expect(handler.retrieveCurrentBlockchainData).toHaveBeenCalled()
+
+      expect(store.transactions).toEqual({})
+      expect(store.keys).toEqual(makeDefaultKeys(lockAddresses, store.account))
+      expect(store.network).toBe(1)
+    })
+
+    it('should not call retrieveCurrentBlockchainData on network.changed if network is the same', () => {
+      expect.assertions(4)
+
+      walletService.emit('network.changed', 1984)
+
+      expect(handler.retrieveCurrentBlockchainData).not.toHaveBeenCalled()
+
+      expect(store.transactions).toEqual({})
+      expect(store.keys).toEqual(makeDefaultKeys(lockAddresses, null))
+      expect(store.network).toBe(1984)
+    })
+  })
+
+  describe('account.updated', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should call dispatchChangesToPostOffice on account.updated for our account', () => {
+      expect.assertions(2)
+
+      walletService.emit(
+        'account.updated',
+        { address: store.account },
+        { balance: '123' }
+      )
+
+      expect(handler.dispatchChangesToPostOffice).toHaveBeenCalled()
+      expect(store.balance).toBe('123')
+    })
+
+    it('should not call dispatchChangesToPostOffice on account.updated for another account', () => {
+      expect.assertions(2)
+
+      walletService.emit(
+        'account.updated',
+        { address: 'oops' },
+        { balance: '123' }
+      )
+
+      expect(handler.dispatchChangesToPostOffice).not.toHaveBeenCalled()
+      expect(store.balance).toBe('0')
+    })
+
+    it('should not call dispatchChangesToPostOffice on account.updated if account is not the user account', () => {
+      expect.assertions(2)
+
+      walletService.emit('account.updated', 'not user account', {
+        balance: '0',
+      })
+
+      expect(handler.dispatchChangesToPostOffice).not.toHaveBeenCalled()
+      expect(store.balance).toBe('0')
+    })
+  })
+
+  describe('key.updated', () => {
+    beforeEach(() => {
+      setupDefaults({
+        account: addresses[1],
+      })
+    })
+
+    it('should set up the normalized key and call dispatchChangesToPostOffice', () => {
+      expect.assertions(2)
+
+      walletService.emit('key.updated', 'id', {
+        lock: addresses[0], // non-normalized on purpose
+        owner: store.account,
+        expiration: 5,
+      })
+
+      expect(handler.dispatchChangesToPostOffice).toHaveBeenCalled()
+      expect(store.keys).toEqual({
+        // normalized lock values
+        [lockAddresses[0]]: {
+          lock: lockAddresses[0],
+          owner: store.account,
+          expiration: 5,
+        },
+        [lockAddresses[1]]: {
+          lock: lockAddresses[1],
+          owner: store.account,
+          expiration: 0,
+        },
+        [lockAddresses[2]]: {
+          lock: lockAddresses[2],
+          owner: store.account,
+          expiration: 0,
+        },
+      })
+    })
+  })
+
+  describe('transaction.updated', () => {
+    beforeEach(() => {
+      setupDefaults({
+        account: addresses[1],
+      })
+    })
+
+    it('should call dispatchChangesToPostOffice', () => {
+      expect.assertions(1)
+
+      walletService.emit('transaction.updated', 'hash', { thing: 1 })
+
+      expect(handler.dispatchChangesToPostOffice).toHaveBeenCalled()
+    })
+
+    it('should use defaults if the transaction does not exist yet', () => {
+      expect.assertions(1)
+
+      walletService.emit('transaction.updated', 'hash', { thing: 1 })
+
+      expect(store.transactions).toEqual({
+        hash: {
+          hash: 'hash',
+          blockNumber: Number.MAX_SAFE_INTEGER,
+          thing: 1,
+          status: 'submitted',
+        },
+      })
+    })
+
+    it('should use the existing transaction if the transaction exists', () => {
+      expect.assertions(1)
+
+      store.transactions = {
+        hash: {
+          hash: 'hash',
+          blockNumber: 5,
+          status: TransactionStatus.MINED,
+          confirmations: 1,
+          type: TransactionType.KEY_PURCHASE,
+        },
+      }
+      walletService.emit('transaction.updated', 'hash', {
+        thing: 1,
+        lock: addresses[0],
+        to: addresses[1],
+      })
+
+      expect(store.transactions).toEqual({
+        hash: {
+          hash: 'hash',
+          blockNumber: 5,
+          status: TransactionStatus.MINED,
+          confirmations: 1,
+          type: TransactionType.KEY_PURCHASE,
+          lock: lockAddresses[0], // verify normalized lock address is used
+          to: lockAddresses[1], // verify normalized lock address is used
+          thing: 1,
+        },
+      })
+    })
+
+    describe('retrieving key', () => {
+      beforeEach(() => {
+        setupDefaults({
+          account: addresses[1],
+        })
+      })
+
+      it('should not retrieve a key for a non-key purchase transaction', () => {
+        expect.assertions(1)
+
+        store.transactions = {
+          hash: {
+            hash: 'hash',
+            blockNumber: 5,
+            status: TransactionStatus.MINED,
+            confirmations: 1,
+            type: TransactionType.LOCK_CREATION,
+          },
+        }
+        walletService.emit('transaction.updated', 'hash', {
+          thing: 1,
+          lock: addresses[0],
+          to: addresses[1],
+        })
+
+        expect(web3Service.getKeyByLockForOwner).not.toHaveBeenCalled()
+      })
+
+      it('should retrieve the key expiry for a key purchase transaction defined by the stored transaction', () => {
+        expect.assertions(1)
+
+        store.transactions = {
+          hash: {
+            hash: 'hash',
+            blockNumber: 5,
+            status: TransactionStatus.MINED,
+            confirmations: 1,
+            lock: lockAddresses[0], // this address has already been normalized
+            type: TransactionType.KEY_PURCHASE,
+          },
+        }
+        walletService.emit('transaction.updated', 'hash', {
+          thing: 1,
+          to: addresses[1],
+        })
+
+        expect(web3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
+          lockAddresses[0],
+          addresses[1]
+        )
+      })
+
+      it('should retrieve the key expiry for a key purchase transaction defined by the update', () => {
+        expect.assertions(1)
+
+        store.transactions = {
+          hash: {
+            hash: 'hash',
+            blockNumber: 5,
+            status: TransactionStatus.MINED,
+            confirmations: 1,
+            type: TransactionType.KEY_PURCHASE,
+          },
+        }
+        walletService.emit('transaction.updated', 'hash', {
+          thing: 1,
+          lock: addresses[0], // this address is normalized in the listener
+          to: addresses[1],
+        })
+
+        expect(web3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
+          lockAddresses[0],
+          addresses[1]
+        )
+      })
+
+      it('should retrieve the key expiry and use transaction.lock if present', () => {
+        expect.assertions(1)
+
+        store.transactions = {
+          hash: {
+            hash: 'hash',
+            blockNumber: 5,
+            status: TransactionStatus.MINED,
+            confirmations: 1,
+            lock: lockAddresses[0], // this address has already been normalized
+            type: TransactionType.KEY_PURCHASE,
+          },
+        }
+        walletService.emit('transaction.updated', 'hash', {
+          thing: 1,
+        })
+
+        expect(web3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
+          lockAddresses[0],
+          addresses[1]
+        )
+      })
+
+      it('should retrieve the key expiry and use transaction.to if lock is not present', () => {
+        expect.assertions(1)
+
+        store.transactions = {
+          hash: {
+            hash: 'hash',
+            blockNumber: 5,
+            status: TransactionStatus.MINED,
+            confirmations: 1,
+            to: lockAddresses[0], // this address has already been normalized
+            type: TransactionType.KEY_PURCHASE,
+          },
+        }
+        walletService.emit('transaction.updated', 'hash', {
+          thing: 1,
+        })
+
+        expect(web3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
+          lockAddresses[0],
+          addresses[1]
+        )
+      })
+
+      it('should retrieve the key expiry and use transaction.lock from the update if present', () => {
+        expect.assertions(1)
+
+        store.transactions = {
+          hash: {
+            hash: 'hash',
+            blockNumber: 5,
+            status: TransactionStatus.MINED,
+            confirmations: 1,
+            type: TransactionType.KEY_PURCHASE,
+          },
+        }
+        walletService.emit('transaction.updated', 'hash', {
+          thing: 1,
+          lock: addresses[0], // this address is normalized in the listener
+        })
+
+        expect(web3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
+          lockAddresses[0],
+          addresses[1]
+        )
+      })
+
+      it('should retrieve the key expiry and use transaction.to from the update if lock is not present', () => {
+        expect.assertions(1)
+
+        store.transactions = {
+          hash: {
+            hash: 'hash',
+            blockNumber: 5,
+            status: TransactionStatus.MINED,
+            confirmations: 1,
+            type: TransactionType.KEY_PURCHASE,
+          },
+        }
+        walletService.emit('transaction.updated', 'hash', {
+          thing: 1,
+          to: addresses[0], // this address is normalized in the listener
+        })
+
+        expect(web3Service.getKeyByLockForOwner).toHaveBeenCalledWith(
+          lockAddresses[0],
+          addresses[1]
+        )
+      })
+    })
+  })
+
+  describe('lock.updated', () => {
+    beforeEach(() => {
+      setupDefaults({
+        account: addresses[1],
+      })
+    })
+
+    it('should call dispatchChangesToPostOffice', () => {
+      expect.assertions(1)
+
+      walletService.emit('lock.updated', addresses[0], { thing: 1 })
+
+      expect(handler.dispatchChangesToPostOffice).toHaveBeenCalled()
+    })
+
+    it('should use defaults if the lock does not exist yet', () => {
+      expect.assertions(1)
+
+      walletService.emit('lock.updated', addresses[0], { thing: 1 })
+
+      expect(store.locks).toEqual({
+        // verify lock addresses are normalized
+        [lockAddresses[0]]: {
+          address: lockAddresses[0],
+          name: '1',
+          thing: 1,
+        },
+      })
+    })
+
+    it('should use the existing transaction if the transaction exists', () => {
+      expect.assertions(1)
+
+      store.locks = {
+        [lockAddresses[0]]: {
+          address: lockAddresses[0],
+          name: 'hi',
+          keyPrice: '1',
+          expirationDuration: 1,
+          currencyContractAddress: null,
+        },
+      }
+      walletService.emit('lock.updated', addresses[0], { thing: 1 })
+
+      expect(store.locks).toEqual({
+        [lockAddresses[0]]: {
+          address: lockAddresses[0],
+          name: '1', // it uses the configuration name if present
+          keyPrice: '1',
+          expirationDuration: 1,
+          currencyContractAddress: null,
+          thing: 1,
+        },
+      })
+    })
+  })
+
+  describe('transaction.new', () => {
+    beforeEach(() => {
+      setupDefaults()
+      handler.storeTransaction = jest.fn()
+    })
+
+    it('should call dispatchChangesToPostOffice', () => {
+      expect.assertions(1)
+
+      walletService.emit(
+        'transaction.new',
+        'hash',
+        'from',
+        addresses[0] /* to */,
+        'input',
+        'type',
+        'status'
+      )
+
+      expect(handler.dispatchChangesToPostOffice).toHaveBeenCalled()
+    })
+
+    it('should add a new submitted transaction with values passed in', () => {
+      expect.assertions(1)
+
+      walletService.emit(
+        'transaction.new',
+        'hash',
+        'from',
+        addresses[0] /* to */,
+        'input',
+        TransactionType.KEY_PURCHASE,
+        'submitted'
+      )
+
+      expect(store.transactions).toEqual({
+        hash: {
+          hash: 'hash',
+          to: lockAddresses[0], // verify lock address is normalized
+          from: 'from',
+          for: 'from',
+          input: 'input',
+          type: TransactionType.KEY_PURCHASE,
+          status: 'submitted',
+          key: `${addresses[0]}-from`, // key is non-normalized
+          lock: lockAddresses[0], // verify lock address is normalized
+          confirmations: 0,
+          network: store.network,
+          blockNumber: Number.MAX_SAFE_INTEGER,
+        },
+      })
+    })
+
+    it('should store the transaction in locksmith', () => {
+      expect.assertions(1)
+
+      walletService.emit(
+        'transaction.new',
+        'hash',
+        'from',
+        addresses[0] /* to */,
+        'input',
+        TransactionType.KEY_PURCHASE,
+        'submitted'
+      )
+
+      const newTransaction: TransactionDefaults = {
+        hash: 'hash',
+        for: 'from',
+        from: 'from',
+        to: lockAddresses[0], // lock address is normalized
+        input: 'input',
+        type: TransactionType.KEY_PURCHASE,
+        status: TransactionStatus.SUBMITTED,
+        blockNumber: Number.MAX_SAFE_INTEGER,
+      }
+
+      expect(handler.storeTransaction).toHaveBeenCalledWith(newTransaction)
+    })
+  })
+
+  describe('error', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should ignore errors that are not from key purchase', () => {
+      expect.assertions(1)
+
+      walletService.emit('error', new Error('this is ignored'))
+
+      expect(emitError).not.toHaveBeenCalled()
+    })
+
+    it('should pass key purchase errors to emitError', () => {
+      expect.assertions(1)
+
+      const keyPurchaseError = new Error('FAILED_TO_PURCHASE_KEY')
+
+      walletService.emit('error', keyPurchaseError)
+
+      expect(emitError).toHaveBeenCalledWith(new Error('purchase failed'))
+    })
+
+    it('should fetch new data on key purchase failure', () => {
+      expect.assertions(1)
+
+      const keyPurchaseError = new Error('FAILED_TO_PURCHASE_KEY')
+
+      walletService.emit('error', keyPurchaseError)
+
+      expect(handler.retrieveCurrentBlockchainData).toHaveBeenCalled()
+    })
+
+    it('should remove submitted transactions from values on key purchase failure', () => {
+      expect.assertions(1)
+
+      const keyPurchaseError = new Error('FAILED_TO_PURCHASE_KEY')
+      store.transactions = {
+        hash: {
+          hash: 'hash',
+          status: TransactionStatus.SUBMITTED,
+          confirmations: 0,
+          type: TransactionType.KEY_PURCHASE,
+          blockNumber: Number.MAX_SAFE_INTEGER,
+        },
+        hash1: {
+          hash: 'hash1',
+          status: TransactionStatus.MINED,
+          confirmations: 2,
+          type: TransactionType.KEY_PURCHASE,
+          blockNumber: 5,
+        },
+      }
+
+      walletService.emit('error', keyPurchaseError)
+
+      expect(store.transactions).toEqual({
+        hash1: {
+          hash: 'hash1',
+          status: TransactionStatus.MINED,
+          confirmations: 2,
+          type: TransactionType.KEY_PURCHASE,
+          blockNumber: 5,
+        },
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/storeTransaction.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/storeTransaction.test.ts
@@ -1,0 +1,122 @@
+import {
+  Web3ServiceType,
+  PaywallState,
+  FetchWindow,
+  ConstantsType,
+  LocksmithTransactionsResult,
+  TransactionDefaults,
+  WalletServiceType,
+  SetTimeoutWindow,
+} from '../../../../data-iframe/blockchainHandler/blockChainTypes'
+import {
+  BlockchainTestDefaults,
+  defaultValuesOverride,
+  setupTestDefaults,
+  addresses,
+} from '../../../test-helpers/setupBlockchainHelpers'
+import BlockchainHandler from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import { PaywallConfig } from '../../../../unlockTypes'
+
+describe('BlockchainHandler - storeTransaction', () => {
+  let walletService: WalletServiceType
+  let web3Service: Web3ServiceType
+  let emitError: (error: Error) => void
+  let emitChanges: () => void
+  let store: PaywallState
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let fakeWindow: FetchWindow & SetTimeoutWindow
+  let handler: BlockchainHandler
+  let defaults: BlockchainTestDefaults
+  let defaultTransaction: TransactionDefaults
+
+  type OptionalBlockchainValues = Partial<PaywallState>
+
+  function setupDefaults(
+    valuesOverride: OptionalBlockchainValues = defaultValuesOverride,
+    jsonToFetch: { transactions?: LocksmithTransactionsResult[] } = {}
+  ) {
+    defaults = setupTestDefaults(valuesOverride, jsonToFetch)
+    walletService = defaults.walletService
+    web3Service = defaults.web3Service
+    emitError = defaults.emitError
+    emitChanges = defaults.emitChanges
+    store = defaults.store
+    constants = defaults.constants
+    configuration = defaults.configuration
+    fakeWindow = defaults.fakeWindow
+    handler = new BlockchainHandler({
+      walletService,
+      web3Service,
+      constants,
+      configuration,
+      emitChanges,
+      emitError,
+      window: fakeWindow,
+      store,
+    })
+    handler.init()
+    handler.setupListeners()
+
+    handler.retrieveCurrentBlockchainData = jest.fn()
+    handler.dispatchChangesToPostOffice = jest.fn()
+
+    defaultTransaction = {
+      to: addresses[1],
+      from: addresses[2],
+      for: addresses[2],
+      input: 'input',
+      hash: 'hash',
+      lock: addresses[1],
+    }
+  }
+
+  function callStoreTransaction(
+    transaction: TransactionDefaults = defaultTransaction
+  ) {
+    return handler.storeTransaction(transaction)
+  }
+
+  it('should not store transactions if there is no user account', async () => {
+    expect.assertions(1)
+
+    setupDefaults()
+
+    await callStoreTransaction()
+
+    expect(fakeWindow.fetch).not.toHaveBeenCalled()
+  })
+
+  describe('has user account', () => {
+    beforeEach(() => {
+      setupDefaults({ account: addresses[2] })
+    })
+
+    it('should call fetch with the correct url', async () => {
+      expect.assertions(1)
+
+      await callStoreTransaction()
+
+      expect(fakeWindow.fetch).toHaveBeenCalledWith(
+        `http://fun.times/transaction`,
+        {
+          method: 'POST',
+          mode: 'cors',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            transactionHash: 'hash',
+            sender: addresses[2],
+            // when purchasing directly, who we purchase the key "for" is
+            // also the "sender" whose wallet the funds came from
+            for: addresses[2],
+            recipient: addresses[1],
+            data: 'input',
+            chain: 1984,
+          }),
+        }
+      )
+    })
+  })
+})

--- a/paywall/src/__tests__/data-iframe/cache/cache.test.ts
+++ b/paywall/src/__tests__/data-iframe/cache/cache.test.ts
@@ -10,50 +10,12 @@ import {
   getNetwork,
   clear,
 } from '../../../data-iframe/cache/cache'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
 
 describe('cache utility', () => {
-  let storage: any = {}
-  const fakeWindow: LocalStorageWindow = {
-    localStorage: {
-      length: 1,
-      clear: () => {
-        storage = {}
-      },
-      getItem(key: string) {
-        return storage[key] || null
-      },
-      key(_: number) {
-        return '' // unused but required for the interface
-      },
-      removeItem(key: string) {
-        delete storage[key]
-      },
-      setItem(key: string, value: string) {
-        storage[key] = value
-      },
-    },
-  }
-  const fakeWindowNoLocalStorage: LocalStorageWindow = {
-    localStorage: {
-      length: 0,
-      clear: () => {
-        storage = {}
-      },
-      getItem(key: string) {
-        return storage[key] || null
-      },
-      key(_: number) {
-        return '' // unused but required for the interface
-      },
-      removeItem(key: string) {
-        delete storage[key]
-      },
-      setItem(key: string, value: string) {
-        storage[key] = value
-        throw new Error('no local storage available')
-      },
-    },
-  }
+  const fakeWindow: LocalStorageWindow = new FakeWindow()
+  const fakeWindowNoLocalStorage: LocalStorageWindow = new FakeWindow()
+  ;(fakeWindowNoLocalStorage as FakeWindow).throwOnLocalStorageSet()
 
   type eachThing = Array<[string, LocalStorageWindow]>
   const theEach: eachThing = [
@@ -63,7 +25,7 @@ describe('cache utility', () => {
   describe.each(theEach)('%s driver cache', (_, testWindow) => {
     function clearCache() {
       __clearDriver()
-      storage = {}
+      fakeWindow.localStorage.clear()
     }
     beforeEach(() => {
       clearCache()

--- a/paywall/src/__tests__/data-iframe/cache/drivers/allDrivers.test.ts
+++ b/paywall/src/__tests__/data-iframe/cache/drivers/allDrivers.test.ts
@@ -2,29 +2,10 @@ import LocalStorageDriver from '../../../../data-iframe/cache/drivers/localStora
 import InMemoryDriver from '../../../../data-iframe/cache/drivers/memory'
 import CacheDriver from '../../../../data-iframe/cache/drivers/driverInterface'
 import { LocalStorageWindow } from '../../../../windowTypes'
+import FakeWindow from '../../../test-helpers/fakeWindowHelpers'
 
 describe('common functionality between all drivers', () => {
-  let storage: any = {}
-  const fakeWindow: LocalStorageWindow = {
-    localStorage: {
-      length: 1,
-      clear: () => {
-        storage = {}
-      },
-      getItem(key: string) {
-        return storage[key] || null
-      },
-      key(_: number) {
-        return '' // unused but required for the interface
-      },
-      removeItem(key: string) {
-        delete storage[key]
-      },
-      setItem(key: string, value: string) {
-        storage[key] = value
-      },
-    },
-  }
+  const fakeWindow: LocalStorageWindow = new FakeWindow()
 
   type eachThing = Array<[string, CacheDriver]>
   const theEach: eachThing = [
@@ -33,7 +14,7 @@ describe('common functionality between all drivers', () => {
   ]
   describe.each(theEach)('%s driver', (_, driver) => {
     function clearCache() {
-      storage = {}
+      fakeWindow.localStorage.clear()
       if (driver.__clear) driver.__clear()
     }
     describe('getKeyedItem/saveKeyedItem', () => {

--- a/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
@@ -1,0 +1,150 @@
+import {
+  FetchWindow,
+  SetTimeoutWindow,
+  LocksmithTransactionsResult,
+  FetchResult,
+} from '../../data-iframe/blockchainHandler/blockChainTypes'
+import {
+  IframePostOfficeWindow,
+  PostMessageTarget,
+  MessageHandler,
+  PostOfficeEventTypes,
+  MessageEvent,
+  web3MethodResult,
+  ConsoleWindow,
+} from '../../windowTypes'
+import { ExtractPayload, PostMessages } from '../../messageTypes'
+import { waitFor } from '../../utils/promises'
+
+export default class FakeWindow
+  implements
+    FetchWindow,
+    SetTimeoutWindow,
+    IframePostOfficeWindow,
+    ConsoleWindow {
+  public fetchResult: any = {}
+  public fetch: (
+    url: string,
+    options?: {
+      method: 'POST'
+      mode: 'cors'
+      headers: {
+        'Content-Type': 'application/json'
+      }
+      body: string
+    }
+  ) => Promise<FetchResult>
+  public setTimeout: (cb: Function, delay?: number) => number
+  public parent: PostMessageTarget
+  public location: {
+    href: string
+  }
+  public addEventListener: (
+    type: PostOfficeEventTypes,
+    handler: MessageHandler
+  ) => void
+  public listeners: { [key: string]: Map<MessageHandler, MessageHandler> } = {}
+  public console: Pick<ConsoleWindow, 'console'>['console']
+
+  constructor() {
+    this.fetch = jest.fn((_: string) => {
+      return Promise.resolve({
+        json: () => Promise.resolve(this.fetchResult),
+      })
+    })
+    this.setTimeout = jest.fn()
+    this.location = {
+      href: 'http://fun.times?origin=http%3a%2f%2fexample.com',
+    }
+    this.parent = {
+      postMessage: jest.fn(),
+    }
+    this.addEventListener = jest.fn((type, handler) => {
+      this.listeners[type] = this.listeners[type] || new Map()
+      this.listeners[type].set(handler, handler)
+    })
+    this.console = {
+      log: jest.fn(),
+      error: jest.fn(),
+    }
+  }
+
+  public setupTransactionsResult(result: {
+    transactions?: LocksmithTransactionsResult[]
+  }) {
+    this.fetchResult = result
+  }
+
+  public receivePostMessageFromMainWindow<
+    T extends PostMessages = PostMessages
+  >(type: T, payload: ExtractPayload<T>) {
+    const event: MessageEvent = {
+      origin: 'http://example.com',
+      source: this.parent,
+      data: {
+        type,
+        payload,
+      },
+    }
+    this.listeners.message &&
+      this.listeners.message.forEach(handler => handler(event))
+  }
+
+  public waitForPostMessage() {
+    return waitFor(() => (this.parent as any).postMessage.mock.calls.length)
+  }
+
+  public clearPostMessageMock() {
+    ;(this.parent as any).postMessage.mockClear()
+  }
+
+  public expectPostMessageSent<T extends PostMessages = PostMessages>(
+    type: T,
+    payload: ExtractPayload<T>
+  ) {
+    expect(this.parent.postMessage).toHaveBeenCalledWith(
+      {
+        type,
+        payload,
+      },
+      'http://example.com' // origin passed in the URL as ?origin=<urlencoded origin>
+    )
+  }
+
+  public respondToWeb3(netversion: number, account: string | null) {
+    const accountResponse = account ? [account] : []
+
+    this.parent.postMessage = jest.fn(message => {
+      const constructResult = (result: any): web3MethodResult => {
+        return {
+          id: message.payload.id,
+          jsonrpc: '2.0',
+          result: {
+            id: message.payload.id,
+            jsonrpc: '2.0',
+            result,
+          },
+        }
+      }
+
+      if (message.type === PostMessages.WEB3) {
+        switch (message.payload.method) {
+          case 'eth_accounts':
+            this.receivePostMessageFromMainWindow(
+              PostMessages.WEB3_RESULT,
+              constructResult(accountResponse)
+            )
+            break
+          case 'net_version':
+            this.receivePostMessageFromMainWindow(
+              PostMessages.WEB3_RESULT,
+              constructResult(netversion)
+            )
+            break
+          default:
+            throw new Error(`unhandled web3 call ${message.payload.method}`)
+        }
+      }
+    })
+  }
+}

--- a/paywall/src/__tests__/test-helpers/setupBlockchainHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/setupBlockchainHelpers.ts
@@ -1,0 +1,252 @@
+import {
+  WalletServiceType,
+  Web3ServiceType,
+  PaywallState,
+  LocksmithTransactionsResult,
+  FetchWindow,
+  SetTimeoutWindow,
+  ConstantsType,
+} from '../../data-iframe/blockchainHandler/blockChainTypes'
+import { PaywallConfig, Locks } from '../../unlockTypes'
+import FakeWindow from './fakeWindowHelpers'
+
+export function getWalletService(listeners: { [key: string]: Function }) {
+  const walletService: WalletServiceType = {
+    ready: true,
+    connect: jest.fn().mockResolvedValue({}),
+    getAccount: jest.fn().mockResolvedValue(false),
+    purchaseKey: jest.fn().mockResolvedValue({}),
+
+    addListener: jest.fn(),
+    on: (type, listener) => {
+      listeners[type as string] = listener
+      return walletService
+    },
+    once: jest.fn(),
+    prependListener: jest.fn(),
+    prependOnceListener: jest.fn(),
+    removeAllListeners: jest.fn(),
+    off: jest.fn(),
+    removeListener: jest.fn(),
+    setMaxListeners: jest.fn(),
+    getMaxListeners: jest.fn(),
+    listeners: jest.fn(),
+    rawListeners: jest.fn(),
+    emit: (type, ...args) => {
+      listeners[type as string](...args)
+      return true
+    },
+    eventNames: jest.fn(),
+    listenerCount: jest.fn(),
+  }
+  return walletService
+}
+
+export function getWeb3Service(listeners: { [key: string]: Function }) {
+  const web3Service: Web3ServiceType = {
+    refreshAccountBalance: jest.fn().mockResolvedValue('123'),
+    getTransaction: jest.fn().mockResolvedValue({}),
+    getLock: jest.fn().mockResolvedValue({}),
+    getKeyByLockForOwner: jest.fn().mockResolvedValue({}),
+
+    addListener: jest.fn(),
+    on: (type, listener) => {
+      listeners[type as string] = listener
+      return web3Service
+    },
+    once: jest.fn(),
+    prependListener: jest.fn(),
+    prependOnceListener: jest.fn(),
+    removeAllListeners: jest.fn(),
+    off: jest.fn(),
+    removeListener: jest.fn(),
+    setMaxListeners: jest.fn(),
+    getMaxListeners: jest.fn(),
+    listeners: jest.fn(),
+    rawListeners: jest.fn(),
+    emit: (type, ...args) => {
+      listeners[type as string](...args)
+      return true
+    },
+    eventNames: jest.fn(),
+    listenerCount: jest.fn(),
+  }
+  return web3Service
+}
+
+export const addresses = [
+  '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+  '0x15B87bdC4B3ecb783F56f735653332EAD3BCa5F8',
+  '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
+]
+export const lockAddresses = addresses.map(address => address.toLowerCase())
+
+export type OptionalBlockchainValues = Partial<PaywallState>
+
+export interface BlockchainTestDefaults {
+  fakeWindow: FetchWindow & SetTimeoutWindow
+  walletService: WalletServiceType
+  web3Service: Web3ServiceType
+  emitError: (error: Error) => void
+  emitChanges: () => void
+  listeners: { [key: string]: Function }
+  store: PaywallState
+  constants: ConstantsType
+  configuration: PaywallConfig
+}
+
+export type PartialBlockchainTestDefaults = Partial<BlockchainTestDefaults>
+
+export const defaultValuesOverride: OptionalBlockchainValues = {
+  config: {
+    locks: {
+      // addresses are normalized by the time they reach the listeners
+      [lockAddresses[0]]: { name: '1' },
+      [lockAddresses[1]]: { name: '2' },
+      [lockAddresses[2]]: { name: '3' },
+    },
+    callToAction: {
+      default: '',
+      expired: '',
+      pending: '',
+      confirmed: '',
+    },
+  },
+  account: null,
+  balance: '0',
+  keys: {},
+  locks: {},
+  transactions: {},
+  network: 1,
+}
+
+export function setupTestDefaults(
+  valuesOverride: OptionalBlockchainValues = {
+    config: {
+      locks: {
+        // addresses are normalized by the time they reach the listeners
+        [lockAddresses[0]]: { name: '1' },
+        [lockAddresses[1]]: { name: '2' },
+        [lockAddresses[2]]: { name: '3' },
+      },
+      callToAction: {
+        default: '',
+        expired: '',
+        pending: '',
+        confirmed: '',
+      },
+    },
+    account: null,
+    balance: '0',
+    keys: {},
+    locks: {},
+    transactions: {},
+    network: 1,
+  },
+  jsonToFetch: { transactions?: LocksmithTransactionsResult[] } = {}
+): BlockchainTestDefaults {
+  const result: PartialBlockchainTestDefaults = {}
+  result.fakeWindow = new FakeWindow()
+  ;(result.fakeWindow as FakeWindow).setupTransactionsResult(jsonToFetch)
+  result.listeners = {}
+  result.constants = {
+    requiredConfirmations: 12,
+    locksmithHost: 'http://fun.times',
+    unlockAddress: '0x123',
+    blockTime: 5000,
+    readOnlyProvider: 'http://readonly',
+    defaultNetwork: 1984,
+  }
+  result.emitChanges = jest.fn()
+  result.emitError = jest.fn()
+  result.walletService = getWalletService(result.listeners)
+  result.web3Service = getWeb3Service(result.listeners)
+  const thisStore: PaywallState = {
+    config: {
+      locks: {
+        // addresses are not normalized yet
+        [addresses[0]]: { name: '1' },
+        [addresses[1]]: { name: '2' },
+        [addresses[2]]: { name: '3' },
+      },
+      callToAction: {
+        default: '',
+        expired: '',
+        pending: '',
+        confirmed: '',
+      },
+    },
+    account: null,
+    balance: '0',
+    keys: {},
+    locks: {},
+    transactions: {},
+    network: 1,
+    ...valuesOverride,
+  }
+
+  result.store = { ...thisStore }
+  result.store.transactions = {}
+  result.store.locks = {}
+  result.store.keys = {}
+  result.configuration = result.store.config
+  return result as BlockchainTestDefaults
+}
+
+type KeyExpirationOverrides = {
+  [key: string]: number
+}
+
+export function getDefaultFullLocks(
+  store: PaywallState,
+  config: PaywallConfig,
+  keyExpirations: KeyExpirationOverrides = {}
+): Locks {
+  return {
+    [lockAddresses[0]]: {
+      address: lockAddresses[0],
+      key: {
+        confirmations: 0,
+        expiration: keyExpirations[lockAddresses[0]] || 0,
+        lock: lockAddresses[0],
+        owner: store.account,
+        status: 'none',
+        transactions: [],
+      },
+      name: config.locks[lockAddresses[0]].name || 'one',
+      keyPrice: '0',
+      expirationDuration: 1,
+      currencyContractAddress: null,
+    },
+    [lockAddresses[1]]: {
+      address: lockAddresses[1],
+      key: {
+        confirmations: 0,
+        expiration: keyExpirations[lockAddresses[1]] || 0,
+        lock: lockAddresses[1],
+        owner: store.account,
+        status: 'none',
+        transactions: [],
+      },
+      name: config.locks[lockAddresses[1]].name || 'two',
+      keyPrice: '0',
+      expirationDuration: 1,
+      currencyContractAddress: null,
+    },
+    [lockAddresses[2]]: {
+      address: lockAddresses[2],
+      key: {
+        confirmations: 0,
+        expiration: keyExpirations[lockAddresses[2]] || 0,
+        lock: lockAddresses[2],
+        owner: store.account,
+        status: 'none',
+        transactions: [],
+      },
+      name: config.locks[lockAddresses[2]].name || 'three',
+      keyPrice: '0',
+      expirationDuration: 1,
+      currencyContractAddress: null,
+    },
+  }
+}

--- a/paywall/src/__tests__/test-helpers/setupMailboxHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/setupMailboxHelpers.ts
@@ -1,0 +1,45 @@
+import FakeWindow from './fakeWindowHelpers'
+import { IframePostOfficeWindow } from '../../windowTypes'
+import {
+  SetTimeoutWindow,
+  FetchWindow,
+  ConstantsType,
+} from '../../data-iframe/blockchainHandler/blockChainTypes'
+import { PaywallConfig } from '../../unlockTypes'
+import { addresses } from './setupBlockchainHelpers'
+
+export interface MailboxTestDefaults {
+  fakeWindow: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  constants: ConstantsType
+  configuration: PaywallConfig
+}
+
+export type PartialMailboxTestDefaults = Partial<MailboxTestDefaults>
+export function setupTestDefaults() {
+  const result: PartialMailboxTestDefaults = {}
+  result.fakeWindow = new FakeWindow()
+  result.constants = {
+    requiredConfirmations: 12,
+    locksmithHost: 'http://fun.times',
+    unlockAddress: '0x123',
+    blockTime: 5000,
+    readOnlyProvider: 'http://readonly',
+    defaultNetwork: 1984,
+  }
+
+  result.configuration = {
+    locks: {
+      // addresses are not normalized yet
+      [addresses[0]]: { name: '1' },
+      [addresses[1]]: { name: '2' },
+      [addresses[2]]: { name: '3' },
+    },
+    callToAction: {
+      default: '',
+      expired: '',
+      pending: '',
+      confirmed: '',
+    },
+  }
+  return result as MailboxTestDefaults
+}

--- a/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
+++ b/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
@@ -396,6 +396,16 @@ describe('web3Proxy', () => {
           data: {
             type: PostMessages.UPDATE_LOCKS,
             id: 1,
+            payload: {}, // simulate empty cache
+          },
+        })
+
+        postFromDataIframe({
+          source: fakeIframe.contentWindow,
+          origin: 'http://fun.times',
+          data: {
+            type: PostMessages.UPDATE_LOCKS,
+            id: 1,
             payload: YesERC20Locks,
           },
         })

--- a/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
+++ b/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
@@ -1,5 +1,5 @@
 import web3Proxy, { hasERC20Lock } from '../../unlock.js/web3Proxy'
-import { IframeType, UnlockWindow, MessageHandler } from '../../windowTypes'
+import { IframeType, UnlockWindow } from '../../windowTypes'
 import setupIframeMailbox, {
   MapHandlers,
 } from '../../unlock.js/setupIframeMailbox'
@@ -17,6 +17,7 @@ describe('web3Proxy', () => {
   let fakeIframe: IframeType
   let handlers: {
     message: Array<(message: any) => void>
+    storage: Array<(message: any) => void>
   }
   let mapHandlers: MapHandlers
   let fakeCheckoutIframe: IframeType
@@ -41,6 +42,7 @@ describe('web3Proxy', () => {
     }
     handlers = {
       message: [],
+      storage: [],
     }
     process.env.PAYWALL_URL = 'http://fun.times'
     process.env.USER_IFRAME_URL = 'http://fun.times/account'
@@ -83,7 +85,7 @@ describe('web3Proxy', () => {
           enable: enableFuncOrUndefined,
         },
       },
-      addEventListener(type: 'message', handler: MessageHandler) {
+      addEventListener(type, handler) {
         handlers[type].push(handler)
       },
     }

--- a/paywall/src/__tests__/utils/postOffice.test.ts
+++ b/paywall/src/__tests__/utils/postOffice.test.ts
@@ -2,13 +2,13 @@ import {
   setupPostOffice,
   iframePostOffice,
   mainWindowPostOffice,
-  PostOfficeWindow,
   PostMessageTarget,
   PostMessageListener,
   IframePostOfficeWindow,
   Iframe,
 } from '../../utils/postOffice'
 import { PostMessages } from '../../messageTypes'
+import { PostOfficeWindow } from '../../windowTypes'
 
 describe('postOffice', () => {
   const fakeResponder = () => {}

--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -1,0 +1,262 @@
+import BlockchainHandler from './blockchainHandler/BlockchainHandler'
+import {
+  ConstantsType,
+  BlockchainData,
+  FetchWindow,
+  SetTimeoutWindow,
+} from './blockchainHandler/blockChainTypes'
+import { isValidPaywallConfig, isAccount } from '../utils/validators'
+import { PaywallConfig, PurchaseKeyRequest } from '../unlockTypes'
+import { IframePostOfficeWindow, ConsoleWindow } from '../windowTypes'
+import { waitFor } from '../utils/promises'
+import { iframePostOffice, PostMessageListener } from '../utils/postOffice'
+import { MessageTypes, PostMessages, ExtractPayload } from '../messageTypes'
+import {
+  normalizeAddressKeys,
+  normalizeLockAddress,
+} from '../utils/normalizeAddresses'
+
+export default class Mailbox {
+  private handler?: BlockchainHandler
+  private constants: ConstantsType
+  private configuration?: PaywallConfig
+  private window: FetchWindow &
+    SetTimeoutWindow &
+    IframePostOfficeWindow &
+    ConsoleWindow
+  private postMessage: (
+    type: MessageTypes,
+    payload: ExtractPayload<MessageTypes>
+  ) => void = () => {}
+  private addPostMessageListener: <T extends PostMessages = PostMessages>(
+    type: T,
+    listener: PostMessageListener
+  ) => void = () => {}
+  private data?: BlockchainData
+  constructor(
+    constants: ConstantsType,
+    window: FetchWindow &
+      SetTimeoutWindow &
+      IframePostOfficeWindow &
+      ConsoleWindow
+  ) {
+    this.constants = constants
+    this.window = window
+    this.setConfig = this.setConfig.bind(this)
+    this.sendUpdates = this.sendUpdates.bind(this)
+    this.purchaseKey = this.purchaseKey.bind(this)
+    this.refreshBlockchainTransactions = this.refreshBlockchainTransactions.bind(
+      this
+    )
+    this.emitChanges = this.emitChanges.bind(this)
+    this.emitError = this.emitError.bind(this)
+    const { postMessage, addHandler } = iframePostOffice(
+      this.window,
+      'data iframe'
+    )
+    this.postMessage = postMessage
+    this.addPostMessageListener = addHandler
+    this.setupPostMessageListeners()
+  }
+
+  setupPostMessageListeners() {
+    this.addPostMessageListener(PostMessages.CONFIG, this.setConfig)
+    this.addPostMessageListener(PostMessages.SEND_UPDATES, this.sendUpdates)
+    this.addPostMessageListener(PostMessages.PURCHASE_KEY, this.purchaseKey)
+    this.addPostMessageListener(
+      PostMessages.INITIATED_TRANSACTION,
+      this.refreshBlockchainTransactions
+    )
+    this.postMessage(PostMessages.READY, undefined)
+  }
+
+  async init() {
+    // lazy-loading the blockchain handler, this is essential to implement
+    // code splitting
+    const [
+      {
+        default: Web3ProxyProvider,
+      } /* import('../../providers/Web3ProxyProvider') */,
+      {
+        default: BlockchainHandler,
+        WalletService,
+        Web3Service,
+      } /* './blockchainHandler/BlockchainHandler' */,
+    ] = await Promise.all([
+      import('../providers/Web3ProxyProvider'),
+      import('./blockchainHandler/BlockchainHandler'),
+    ])
+
+    const web3Service = new Web3Service(this.constants)
+    const walletService = new WalletService(this.constants)
+    const provider = new Web3ProxyProvider(this.window)
+    await walletService.connect(provider)
+
+    // configuration is set by "setConfig" in response to "READY"
+    // it is the paywall configuration
+    await waitFor(() => this.configuration)
+
+    this.handler = new BlockchainHandler({
+      web3Service,
+      walletService,
+      constants: this.constants,
+      configuration: this.configuration as PaywallConfig,
+      emitChanges: this.emitChanges,
+      emitError: this.emitError,
+      window: this.window,
+    })
+    this.handler.init()
+    this.handler.retrieveCurrentBlockchainData()
+  }
+
+  /**
+   * Retrieve the addresses of any unlocked locks
+   */
+  getUnlockedLockAddresses() {
+    if (!this.data) return []
+    const data = this.data as BlockchainData
+    // lock addresses are normalized by here
+    return Object.keys(this.data.locks).filter(lockAddress => {
+      const lock = data.locks[lockAddress]
+      // locked states are "none", and "expired"
+      return ['valid', 'pending', 'submitted', 'confirming'].includes(
+        lock.key.status
+      )
+    })
+  }
+
+  /**
+   * When we receive PostMessages.SEND_UPDATES, it is sent here to
+   * send data back to the main window
+   */
+  sendUpdates(updateRequest: unknown) {
+    if (!this.data) return
+    const unlockedLocks = this.getUnlockedLockAddresses()
+    if (unlockedLocks.length) {
+      this.postMessage(PostMessages.UNLOCKED, unlockedLocks)
+    } else {
+      this.postMessage(PostMessages.LOCKED, undefined)
+    }
+    const { locks, account, balance, network } = this.data
+    const type = updateRequest as 'locks' | 'account' | 'balance' | 'network'
+    switch (type) {
+      case 'locks':
+        this.postMessage(PostMessages.UPDATE_LOCKS, locks)
+        break
+      case 'account':
+        this.postMessage(PostMessages.UPDATE_ACCOUNT, account)
+        break
+      case 'balance':
+        this.postMessage(PostMessages.UPDATE_ACCOUNT_BALANCE, balance)
+        break
+      case 'network':
+        this.postMessage(PostMessages.UPDATE_NETWORK, network)
+        break
+      default:
+        this.emitError(
+          new Error(
+            `Unknown update requested: ${
+              typeof type === 'string' ? '"' + type + '"' : '<invalid value>'
+            }`
+          )
+        )
+    }
+  }
+
+  /**
+   * When we receive PostMessages.CONFIG, it is sent here to
+   * validate and then set configuration
+   */
+  setConfig(config: unknown) {
+    if (!isValidPaywallConfig(config)) {
+      this.emitError(
+        new Error('Invalid paywall configuration, cannot continue')
+      )
+      return
+    }
+
+    // ensure the lock addresses are normalized before setting it
+    ;(config as PaywallConfig).locks = normalizeAddressKeys(
+      (config as PaywallConfig).locks
+    )
+    this.configuration = config as PaywallConfig
+  }
+
+  /**
+   * When we receive PostMessages.PURCHASE_KEY, it is sent here to
+   * do the purchase
+   */
+  purchaseKey(request: unknown) {
+    if (!this.handler || !this.data) return
+    if (
+      !request ||
+      !(request as PurchaseKeyRequest).lock ||
+      !(request as PurchaseKeyRequest).extraTip ||
+      !isAccount((request as PurchaseKeyRequest).lock) ||
+      normalizeLockAddress((request as PurchaseKeyRequest).lock) !==
+        (request as PurchaseKeyRequest).lock
+    ) {
+      this.emitError(new Error('Cannot purchase, malformed request'))
+      return
+    }
+    // format is validated here
+    const details: PurchaseKeyRequest = request as PurchaseKeyRequest
+    // lock addresses are normalized
+    if (!this.data.locks[details.lock]) {
+      this.emitError(
+        new Error(`Cannot purchase key on unknown lock: "${details.lock}"`)
+      )
+      return
+    }
+    const lock = this.data.locks[details.lock]
+
+    // this catches its errors internally and emits them with "emitError" (below)
+    this.handler.purchaseKey({
+      lockAddress: details.lock,
+      amountToSend: lock.keyPrice,
+      erc20Address: lock.currencyContractAddress,
+    })
+  }
+
+  /**
+   * When we receive PostMessages.INITIATED_TRANSACTION, it is sent here
+   * to request a new set of transactions
+   */
+  refreshBlockchainTransactions() {
+    // this next condition is unlikely, but technically possible
+    if (!this.handler) return
+    // a key purchase was triggered elsewhere,
+    // so retrieve the pending purchase's transaction
+    this.handler.retrieveTransactions()
+  }
+
+  /**
+   * This is called by the BlockchainHandler when there is an update to chain data
+   */
+  emitChanges(data: BlockchainData) {
+    this.data = data
+    // TODO: don't send unchanged values
+    // TODO: cache values
+    this.postMessage(PostMessages.UPDATE_ACCOUNT, this.data.account)
+    this.postMessage(PostMessages.UPDATE_ACCOUNT_BALANCE, this.data.balance)
+    this.postMessage(PostMessages.UPDATE_NETWORK, this.data.network)
+    this.postMessage(PostMessages.UPDATE_LOCKS, this.data.locks)
+    const unlockedLocks = this.getUnlockedLockAddresses()
+    if (unlockedLocks.length) {
+      this.postMessage(PostMessages.UNLOCKED, unlockedLocks)
+    } else {
+      this.postMessage(PostMessages.LOCKED, undefined)
+    }
+  }
+
+  /**
+   * This is called whenever an error occurs in the data iframe
+   */
+  emitError(error: Error) {
+    if (process.env.UNLOCK_ENV === 'dev') {
+      // eslint-disable-next-line
+      this.window.console.error(error)
+    }
+    this.postMessage(PostMessages.ERROR, error.message)
+  }
+}

--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -90,11 +90,15 @@ export default class Mailbox {
     const web3Service = new Web3Service(this.constants)
     const walletService = new WalletService(this.constants)
     const provider = new Web3ProxyProvider(this.window)
-    await walletService.connect(provider)
 
     // configuration is set by "setConfig" in response to "READY"
     // it is the paywall configuration
     await waitFor(() => this.configuration)
+
+    // we do not need a connected walletService to work
+    walletService.connect(provider).catch((e: Error) => {
+      this.emitError(e)
+    })
 
     this.handler = new BlockchainHandler({
       web3Service,

--- a/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
+++ b/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
@@ -1,0 +1,464 @@
+import { Web3Service, WalletService } from '@unlock-protocol/unlock-js'
+import {
+  PaywallConfig,
+  Transactions,
+  Locks,
+  TransactionType,
+} from '../../unlockTypes'
+import linkKeysToLocks from './linkKeysToLocks'
+import { POLLING_INTERVAL } from '../../constants'
+import {
+  KeyResults,
+  KeyResult,
+  WalletServiceType,
+  Web3ServiceType,
+  ConstantsType,
+  BlockchainData,
+  LocksmithTransactionsResult,
+  TransactionDefaults,
+  FetchWindow,
+  PaywallState,
+  SetTimeoutWindow,
+} from './blockChainTypes'
+import {
+  normalizeAddressKeys,
+  normalizeLockAddress,
+} from '../../utils/normalizeAddresses'
+
+/**
+ * Make empty keys for the current account
+ */
+export function makeDefaultKeys(
+  lockAddresses: string[],
+  account: string | null
+): KeyResults {
+  return lockAddresses.reduce((allKeys: KeyResults, address: string) => {
+    allKeys[address] = {
+      lock: address,
+      owner: account,
+      expiration: 0,
+    }
+    return allKeys
+  }, {})
+}
+
+interface BlockchainHandlerParams {
+  walletService: WalletServiceType
+  web3Service: Web3ServiceType
+  constants: ConstantsType
+  configuration: PaywallConfig
+  emitChanges: (data: BlockchainData) => void
+  emitError: (error: Error) => void
+  window: FetchWindow & SetTimeoutWindow
+  store?: PaywallState
+}
+
+export { Web3Service, WalletService }
+
+// assumptions:
+// 1. walletService has been "connected" to the Web3ProxyProvider
+// 2. config has been validated already
+// 3. emitChanges will pass along the updates to the main window
+// 3. emitError will pass along the error to the main window
+export default class BlockchainHandler {
+  private walletService: WalletServiceType
+  private web3Service: Web3ServiceType
+  private constants: ConstantsType
+  private emitChanges: (data: BlockchainData) => void
+  private emitError: (error: Error) => void
+  private window: FetchWindow & SetTimeoutWindow
+  private store: PaywallState
+  private lockAddresses: string[]
+
+  constructor({
+    walletService,
+    web3Service,
+    constants,
+    configuration,
+    emitChanges,
+    emitError,
+    window,
+    store = {
+      config: {
+        locks: {},
+        callToAction: { default: '', expired: '', pending: '', confirmed: '' },
+      },
+      account: null,
+      balance: '0',
+      keys: {},
+      locks: {},
+      transactions: {},
+      network: 1,
+    },
+  }: BlockchainHandlerParams) {
+    this.walletService = walletService
+    this.web3Service = web3Service
+    this.constants = constants
+    this.emitChanges = emitChanges
+    this.emitError = emitError
+    this.window = window
+
+    // set the actual defaults
+    store.config = configuration
+    store.network = constants.defaultNetwork
+    // take the paywall config, normalize all the locks (this is redundant for safety)
+    store.config.locks = normalizeAddressKeys(store.config.locks)
+    // this will be used to filter the keys and transactions we return
+    this.lockAddresses = Object.keys(store.config.locks)
+    // set the default keys now
+    store.keys = makeDefaultKeys(this.lockAddresses, store.account)
+    this.store = store
+  }
+
+  /**
+   * Initialize non-constant work
+   *
+   * Polling for accounts, setting up listeners, fetching locks happen here
+   */
+  init() {
+    // set up event listeners
+    this.setupListeners()
+
+    // retrieve the locks
+    this.lockAddresses.forEach(address =>
+      this.web3Service.getLock(address).catch(error => this.emitError(error))
+    )
+
+    // poll for account changes
+    const retrieveAccount = () => {
+      if (!this.walletService.provider) return
+      this.walletService.getAccount().catch(error => this.emitError(error))
+    }
+    const pollForAccountChanges = () => {
+      retrieveAccount()
+      this.window.setTimeout(pollForAccountChanges, POLLING_INTERVAL)
+    }
+    pollForAccountChanges()
+  }
+
+  /**
+   * This is the callback used to purchase a key
+   */
+  async purchaseKey({
+    lockAddress,
+    amountToSend,
+    erc20Address,
+  }: {
+    lockAddress: string
+    amountToSend: string
+    erc20Address: string | null
+  }) {
+    if (!this.store.account) return
+    const account = this.store.account as string
+
+    // Support the currency!
+    return this.walletService.purchaseKey(
+      lockAddress,
+      account,
+      amountToSend,
+      null /* account */, // THIS FIELD HAS BEEN DEPRECATED AND WILL BE IGNORED
+      null /* data */, // THIS FIELD HAS BEEN DEPRECATED AND WILL BE IGNORED
+      erc20Address
+    )
+  }
+
+  /**
+   * used to retrieve new values from the chain
+   *
+   * Values retrieved are dispatched back to the main window in event listeners
+   */
+  async retrieveCurrentBlockchainData() {
+    // set up any missing keys prior to retrieval
+    const defaultKeys = makeDefaultKeys(this.lockAddresses, this.store.account)
+    this.lockAddresses.forEach(address => {
+      if (!this.store.keys[address]) {
+        this.store.keys[address] = defaultKeys[address]
+      }
+    })
+
+    if (this.store.account === null) {
+      // no account, we need to obliterate all existing keys and transactions and balance
+      this.store.keys = makeDefaultKeys(this.lockAddresses, this.store.account)
+      this.store.transactions = {}
+      this.store.balance = '0'
+      this.dispatchChangesToPostOffice()
+      return
+    }
+    // first get keys
+    this.lockAddresses.map(address => {
+      return this.web3Service
+        .getKeyByLockForOwner(address, this.store.account as string)
+        .catch(error => this.emitError(error))
+    })
+
+    // no locks, no transactions can exist
+    if (!this.lockAddresses.length) return
+    // then transactions
+    this.retrieveTransactions()
+  }
+
+  /**
+   * Dispatch values back to the post office
+   */
+  async dispatchChangesToPostOffice() {
+    const fullLocks: Locks = await linkKeysToLocks({
+      locks: this.store.locks,
+      keys: this.store.keys,
+      transactions: this.store.transactions,
+      requiredConfirmations: this.constants.requiredConfirmations,
+    })
+    this.emitChanges({
+      locks: fullLocks,
+      account: this.store.account,
+      balance: this.store.balance,
+      network: this.store.network,
+    })
+  }
+
+  /**
+   * Set up the event listeners on walletService and web3Service
+   */
+  setupListeners() {
+    const reset = () => {
+      // we must have keys for every lock at all times
+      this.store.keys = makeDefaultKeys(this.lockAddresses, this.store.account)
+      this.store.transactions = {}
+      if (this.store.account) {
+        this.web3Service.refreshAccountBalance({ address: this.store.account })
+      }
+      this.retrieveCurrentBlockchainData()
+      this.dispatchChangesToPostOffice()
+    }
+    // the event listeners propagate changes to the main window
+    // or fetch new data when network or account changes
+    this.walletService.on('account.changed', newAccount => {
+      if (newAccount === this.store.account) return
+      this.store.account = newAccount
+      reset()
+    })
+
+    this.walletService.on('network.changed', networkId => {
+      if (networkId === this.store.network) return
+      this.store.network = networkId
+      reset()
+    })
+
+    this.web3Service.on(
+      'account.updated',
+      (account: { address: string } | null, { balance }) => {
+        // this can be called for locks also
+        const address = account && account.address
+        if (address !== this.store.account) return
+        if (balance === this.store.balance) return
+        this.store.balance = balance
+        this.dispatchChangesToPostOffice()
+      }
+    )
+
+    this.web3Service.on('key.updated', (_: any, key: KeyResult) => {
+      key.lock = normalizeLockAddress(key.lock)
+      this.store.keys[key.lock] = key
+      this.dispatchChangesToPostOffice()
+    })
+
+    const mergeUpdate = (
+      key: string,
+      type: 'transactions' | 'locks',
+      defaults: Object,
+      update: Object = {}
+    ) => {
+      const initialValue = this.store[type][key] || defaults
+
+      this.store[type][key] = {
+        ...initialValue,
+        ...update,
+      }
+      this.dispatchChangesToPostOffice()
+    }
+
+    this.web3Service.on('transaction.updated', (hash, update) => {
+      if (update.lock) {
+        // ensure all references to locks are normalized
+        update.lock = normalizeLockAddress(update.lock)
+      }
+      if (update.to) {
+        // ensure all references to locks are normalized
+        update.to = normalizeLockAddress(update.to)
+      }
+      mergeUpdate(
+        hash,
+        'transactions',
+        {
+          hash,
+          blockNumber: Number.MAX_SAFE_INTEGER,
+          status: 'submitted',
+        },
+        update
+      )
+      const transaction = this.store.transactions[hash]
+      const recipient = transaction.lock || transaction.to
+      const isKeyPurchase = transaction.type === TransactionType.KEY_PURCHASE
+      if (isKeyPurchase && recipient) {
+        this.web3Service.getKeyByLockForOwner(recipient, this.store
+          .account as string)
+      }
+    })
+
+    this.web3Service.on('lock.updated', (lockAddress, update) => {
+      const address = normalizeLockAddress(lockAddress)
+      if (update.address) {
+        update.address = normalizeLockAddress(update.address)
+      }
+      if (this.store.config.locks[address].name) {
+        // use the configuration lock name if present
+        update.name = this.store.config.locks[address].name
+      }
+      mergeUpdate(
+        address,
+        'locks',
+        {
+          address,
+        },
+        update
+      )
+    })
+
+    // for purchases
+    this.walletService.on(
+      'transaction.new',
+      (
+        hash: string,
+        from: string,
+        to: string,
+        input: string,
+        type: string,
+        status: string
+      ) => {
+        // when purchasing directly, who we purchase the key "for" is
+        // also whose wallet the funds came "from"
+        //TODO normalize *all* addresses
+        const normalizedTo = normalizeLockAddress(to)
+        const newTransaction: TransactionDefaults = {
+          hash,
+          from,
+          for: from,
+          to: normalizedTo,
+          input,
+          type,
+          status,
+          blockNumber: Number.MAX_SAFE_INTEGER,
+        }
+        this.storeTransaction(newTransaction)
+        mergeUpdate(hash, 'transactions', newTransaction, {
+          key: `${to}-${from}`,
+          lock: newTransaction.to,
+          confirmations: 0,
+          network: this.store.network,
+        })
+        // start polling
+        this.web3Service.getTransaction(hash)
+      }
+    )
+
+    this.walletService.on('error', error => {
+      if (error.message === 'FAILED_TO_PURCHASE_KEY') {
+        this.emitError(new Error('purchase failed'))
+        // TODO: which purchase failed? unlock-js needs to provide this information
+        // for now, we will kill all submitted transactions and re-fetch
+        this.store.transactions = Object.keys(this.store.transactions)
+          .filter(hash => this.store.transactions[hash].status !== 'submitted')
+          .reduce(
+            (allTransactions: Transactions, hash) => ({
+              ...allTransactions,
+              [hash]: this.store.transactions[hash],
+            }),
+            {}
+          )
+        this.retrieveCurrentBlockchainData()
+      }
+    })
+  }
+
+  /**
+   * Get relevant transactions to retrieve from Locksmith and pull their details off chain
+   */
+  async retrieveTransactions() {
+    if (!this.store.account) return
+    // filter the transactions we request to only include the
+    // transactions relevant to locks. In most cases this will be
+    // key purchases
+    const filterLocks = this.lockAddresses
+      .map(lockAddress => `recipient[]=${encodeURIComponent(lockAddress)}`)
+      .join('&')
+
+    const url = `${this.constants.locksmithHost}/transactions?for=${this.store.account}&${filterLocks}`
+
+    const response = await this.window.fetch(url)
+    const result: {
+      transactions?: LocksmithTransactionsResult[]
+    } = await response.json()
+    if (result.transactions) {
+      result.transactions
+        .map(t => ({
+          hash: t.transactionHash,
+          network: t.chain,
+          to: t.recipient,
+          input: t.data,
+          from: t.sender,
+          for: t.for,
+        }))
+        .filter(transaction => transaction.network === this.store.network)
+        .map((transaction: TransactionDefaults) => {
+          // we pass the transaction as defaults if it has input set, so that we can
+          // parse out the transaction type and other details. If input is not set,
+          // we can't safely pass the transaction default
+          this.web3Service
+            .getTransaction(
+              transaction.hash,
+              transaction.input ? transaction : undefined
+            )
+            .catch(error => this.emitError(error))
+        })
+    }
+  }
+
+  /**
+   * Store a new key purchase transaction in locksmith
+   */
+  async storeTransaction(transaction: TransactionDefaults) {
+    if (!this.store.account) return
+    const account = this.store.account
+    const network = this.store.network
+    // we use the transaction lock as the recipient
+    const recipient = transaction.lock || transaction.to
+
+    const url = `${this.constants.locksmithHost}/transaction`
+
+    const payload = {
+      transactionHash: transaction.hash,
+      sender: account,
+      // when purchasing directly, who we purchase the key "for" is
+      // also the "sender" whose wallet the funds came from
+      for: account,
+      recipient,
+      data: transaction.input,
+      chain: network,
+    }
+    try {
+      await this.window.fetch(url, {
+        method: 'POST',
+        mode: 'cors',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      })
+    } catch (e) {
+      // we don't pass this error along because it is a non-essential feature
+      // eslint-disable-next-line no-console
+      console.log('unable to save key purchase transaction')
+      // eslint-disable-next-line no-console
+      console.error(e)
+    }
+  }
+}

--- a/paywall/src/data-iframe/blockchainHandler/blockChainTypes.ts
+++ b/paywall/src/data-iframe/blockchainHandler/blockChainTypes.ts
@@ -1,0 +1,110 @@
+import { EventEmitter } from 'events'
+import {
+  RawLock,
+  PaywallConfig,
+  Transactions,
+  RawLocks,
+  Locks,
+} from '../../unlockTypes'
+
+type Web3ProviderType = string | Object
+
+export interface WalletServiceType extends EventEmitter {
+  ready: boolean
+  provider?: any
+  connect: (provider: Web3ProviderType) => Promise<void>
+  getAccount: () => Promise<string | false>
+  purchaseKey: (
+    lock: string,
+    owner: string,
+    keyPrice: string,
+    account: any,
+    data: any,
+    erc20Address: string | null
+  ) => Promise<string>
+}
+
+export interface Web3ServiceType extends EventEmitter {
+  refreshAccountBalance: ({ address }: { address: string }) => Promise<string>
+  getTransaction: (
+    transactionHash: string,
+    defaults?: TransactionDefaults
+  ) => Promise<void>
+  getLock: (address: string) => Promise<RawLock>
+  getKeyByLockForOwner: (lock: string, owner: string) => Promise<KeyResult>
+}
+
+export interface TransactionDefaults {
+  hash: string
+  to: string
+  from: string
+  input: string | null
+  [key: string]: any
+}
+
+export interface KeyResult {
+  lock: string
+  owner: string | null
+  expiration: number
+}
+
+export type KeyResults = { [key: string]: KeyResult }
+
+export type unlockNetworks = 1 | 4 | 1984
+
+export interface ConstantsType {
+  unlockAddress: string
+  blockTime: number
+  requiredConfirmations: number
+  locksmithHost: string
+  readOnlyProvider: string
+  defaultNetwork: unlockNetworks
+}
+
+export interface BlockchainData {
+  locks: Locks
+  account: string | null
+  balance: string
+  network: unlockNetworks
+}
+
+export interface LocksmithTransactionsResult {
+  transactionHash: string
+  chain: unlockNetworks
+  recipient: string
+  data: string | null
+  sender: string
+  for: string
+}
+
+export interface FetchResult {
+  json: () => Promise<any>
+}
+
+export interface FetchWindow {
+  fetch: (
+    url: string,
+    options?: {
+      method: 'POST'
+      mode: 'cors'
+      headers: {
+        'Content-Type': 'application/json'
+      }
+      body: string
+    }
+  ) => Promise<FetchResult>
+}
+
+export interface SetTimeoutWindow {
+  setTimeout: (cb: Function, delay?: number) => number
+}
+
+export interface PaywallState {
+  config: PaywallConfig
+  keys: KeyResults
+  locks: RawLocks
+  transactions: Transactions
+  account: string | null
+  network: unlockNetworks
+  balance: string
+}

--- a/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
+++ b/paywall/src/data-iframe/blockchainHandler/locksmithTransactions.js
@@ -84,24 +84,26 @@ export default async function locksmithTransactions({
   const response = await window.fetch(url)
   const result = await response.json()
   if (result.transactions) {
-    const transactions = Object.values(result.transactions)
-    // take advantage of the order locksmith returns transactions
-    // the last one is the newest
-    for (let i = transactions.length - 1; i >= 0; i--) {
-      const t = transactions[i]
-      const transaction = {
-        hash: t.transactionHash,
-        network, // locksmith always uses the right network now
-        to: t.recipient,
-        input: t.data,
-        from: t.sender,
-        for: t.for,
-      }
-      const defaults = t.data ? transaction : undefined
-      web3Service.getTransaction(transaction.hash, defaults).catch(error => {
-        // eslint-disable-next-line no-console
-        console.error(error)
-      })
-    }
+    await Promise.all(
+      result.transactions
+        .map(t => ({
+          hash: t.transactionHash,
+          network: t.chain,
+          to: t.recipient,
+          input: t.data,
+          from: t.sender,
+          for: t.for,
+        }))
+        .filter(transaction => transaction.network === network)
+        .map(transaction => {
+          // we pass the transaction as defaults if it has input set, so that we can
+          // parse out the transaction type and other details. If input is not set,
+          // we can't safely pass the transaction default
+          web3Service.getTransaction(
+            transaction.hash,
+            transaction.input ? transaction : undefined
+          )
+        })
+    )
   }
 }

--- a/paywall/src/data-iframe/index.ts
+++ b/paywall/src/data-iframe/index.ts
@@ -1,0 +1,51 @@
+import Mailbox from './Mailbox'
+import { ConstantsType } from './blockchainHandler/blockChainTypes'
+
+declare const process: {
+  env: {
+    UNLOCK_ENV: string
+    LOCKSMITH_URI: string
+    READ_ONLY_PROVIDER: string
+  }
+}
+
+const constants: { [key: string]: ConstantsType } = {
+  dev: {
+    unlockAddress: '0x885EF47c3439ADE0CB9b33a4D3c534C99964Db93',
+    blockTime: 3000,
+    requiredConfirmations: 6,
+    locksmithHost: process.env.LOCKSMITH_URI || 'http://localhost:8080',
+    readOnlyProvider: process.env.READ_ONLY_PROVIDER || 'http://localhost:8545',
+    defaultNetwork: 1984,
+  },
+  test: {
+    unlockAddress: '0x885EF47c3439ADE0CB9b33a4D3c534C99964Db93',
+    blockTime: 3000,
+    requiredConfirmations: 6,
+    locksmithHost: process.env.LOCKSMITH_URI || 'http://locksmith:8080',
+    readOnlyProvider:
+      process.env.READ_ONLY_PROVIDER || 'http://ganache-integration:8545',
+    defaultNetwork: 1984,
+  },
+  staging: {
+    unlockAddress: '0xD8C88BE5e8EB88E38E6ff5cE186d764676012B0b',
+    blockTime: 8000,
+    requiredConfirmations: 12,
+    locksmithHost: process.env.LOCKSMITH_URI,
+    readOnlyProvider: process.env.READ_ONLY_PROVIDER,
+    defaultNetwork: 4,
+  },
+  prod: {
+    unlockAddress: '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13',
+    blockTime: 8000,
+    requiredConfirmations: 12,
+    locksmithHost: process.env.LOCKSMITH_URI,
+    readOnlyProvider: process.env.READ_ONLY_PROVIDER,
+    defaultNetwork: 1,
+  },
+}
+
+const mailbox = new Mailbox(constants[process.env.UNLOCK_ENV], window)
+mailbox.init().catch(e => {
+  console.error('startup error', e) // eslint-disable-line
+})

--- a/paywall/src/unlock.js/setupIframeMailbox.ts
+++ b/paywall/src/unlock.js/setupIframeMailbox.ts
@@ -1,9 +1,5 @@
-import { IframeType } from '../windowTypes'
-import {
-  mainWindowPostOffice,
-  PostMessageListener,
-  PostOfficeWindow,
-} from '../utils/postOffice'
+import { IframeType, PostOfficeWindow } from '../windowTypes'
+import { mainWindowPostOffice, PostMessageListener } from '../utils/postOffice'
 import { MessageTypes, ExtractPayload } from '../messageTypes'
 
 export type IframeNames = 'checkout' | 'data' | 'account'

--- a/paywall/src/unlock.js/web3Proxy.ts
+++ b/paywall/src/unlock.js/web3Proxy.ts
@@ -1,4 +1,9 @@
-import { Web3Window, web3MethodCall, IframeType } from '../windowTypes'
+import {
+  Web3Window,
+  web3MethodCall,
+  IframeType,
+  IframeManagingWindow,
+} from '../windowTypes'
 import {
   MapHandlers,
   MessageHandlerTemplates,
@@ -107,7 +112,7 @@ export function handleWeb3Call({
  * @param {string} origin the iframe element's URL origin
  */
 export default function web3Proxy(
-  window: Web3Window,
+  window: Web3Window & IframeManagingWindow,
   mapHandlers: MapHandlers
 ) {
   // use sendAsync if available, otherwise we will use send
@@ -191,10 +196,23 @@ export default function web3Proxy(
     await waitFor(() => currentLocks)
     // wait for locks to be populated
     await waitFor(() => Object.keys(currentLocks).length)
+    if (process.env.DEBUG) {
+      // eslint-disable-next-line
+      console.log('[USER ACCOUNTS] got locks')
+    }
     // wait for the account iframe, then respond
     await waitFor(() => accountIframeReady)
+    if (process.env.DEBUG) {
+      // eslint-disable-next-line
+      console.log('[USER ACCOUNTS] got account from user accounts iframe')
+    }
     // we will use the proxy account!
     if (!canUseUserAccounts) {
+      if (process.env.DEBUG) {
+        // eslint-disable-next-line
+        console.log('[USER ACCOUNTS] cannot use user accounts')
+      }
+
       // if we don't have any locks that can be purchased with a user
       // account, we have no wallet
       hasWeb3 = false
@@ -225,6 +243,13 @@ export default function web3Proxy(
     ) => {
       return locks => {
         canUseUserAccounts = !hasNativeWeb3Wallet && hasERC20Lock(locks)
+        if (process.env.DEBUG) {
+          // eslint-disable-next-line
+          console.log('[USER ACCOUNTS] hasERC20Locks?', hasERC20Lock(locks))
+          // eslint-disable-next-line
+          console.log('[USER ACCOUNTS] no wallet?', !hasNativeWeb3Wallet)
+        }
+
         currentLocks = locks
         if (canUseUserAccounts && locks && Object.keys(locks).length) {
           if (showIframeWhenReady) {

--- a/paywall/src/unlock.js/web3Proxy.ts
+++ b/paywall/src/unlock.js/web3Proxy.ts
@@ -189,6 +189,8 @@ export default function web3Proxy(
     // we don't have web3
     // wait for locks to be retrieved
     await waitFor(() => currentLocks)
+    // wait for locks to be populated
+    await waitFor(() => Object.keys(currentLocks).length)
     // wait for the account iframe, then respond
     await waitFor(() => accountIframeReady)
     // we will use the proxy account!

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -28,6 +28,9 @@ export interface Transaction {
   type: TransactionType
   blockNumber: number
 
+  to?: string
+  for?: string
+  from?: string
   lock?: string
   name?: string
   key?: string // TODO: tighten up our types, hopefully we won't have too many
@@ -88,6 +91,19 @@ export enum KeyStatus {
   FAILED = 'failed',
 }
 
+export interface RawLock {
+  name: string
+  address: string
+  keyPrice: string
+  expirationDuration: number
+  currencyContractAddress: string | null
+  asOf?: number
+  maxNumberOfKeys?: number
+  outstandingKeys?: number
+  balance?: string
+  owner?: string
+}
+
 export interface Lock {
   name: string
   address: string
@@ -104,6 +120,10 @@ export interface Lock {
 
 export interface Locks {
   [address: string]: Lock
+}
+
+export interface RawLocks {
+  [address: string]: RawLock
 }
 
 export interface Key {

--- a/paywall/src/utils/postOffice.ts
+++ b/paywall/src/utils/postOffice.ts
@@ -1,4 +1,5 @@
 import { MessageTypes, ExtractPayload } from '../messageTypes'
+import { PostOfficeWindow, EventTypes } from '../windowTypes'
 
 export interface MessageEvent {
   source: any
@@ -10,10 +11,6 @@ export type MessageHandler = (event: MessageEvent) => void
 
 interface location {
   href: string
-}
-
-export interface PostOfficeWindow {
-  addEventListener: (type: 'message', handler: MessageHandler) => void
 }
 
 export interface IframePostOfficeWindow extends PostOfficeWindow {
@@ -75,7 +72,7 @@ export function setupPostOffice<T extends MessageTypes = MessageTypes>(
     )
   }
   let handlers: PostMessageHandlers = {}
-  window.addEventListener('message', event => {
+  window.addEventListener(EventTypes.MESSAGE, event => {
     // **SECURITY CHECKS**
     // ignore messages that do not come from our target window
     if (event.source !== target || event.origin !== targetOrigin) return

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -105,6 +105,11 @@ export interface PostOfficeWindow {
   ) => void
 }
 
+type WindowConsole = Pick<Window, 'console'>['console']
+export interface ConsoleWindow {
+  console: Pick<WindowConsole, 'log' | 'error'>
+}
+
 export interface IframePostOfficeWindow extends PostOfficeWindow {
   parent: PostMessageTarget
   location: {

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -35,9 +35,31 @@ export interface EventWindow {
   dispatchEvent: (event: CustomEvent) => void
 }
 
+export enum EventTypes {
+  STORAGE = 'storage',
+  MESSAGE = 'message',
+}
+
+export interface MappedEvents {
+  [EventTypes.STORAGE]: StorageEvent
+  [EventTypes.MESSAGE]: MessageEvent
+}
+
+export type ExtractEvent<T extends EventTypes> = MappedEvents[T]
+export type EventHandler<T extends EventTypes> = (
+  event: MappedEvents[T]
+) => void
+
+export type AddEventListenerFunc = <T extends EventTypes>(
+  type: T,
+  handler: EventHandler<T>
+) => void
 // used anywhere cache is used
+export type StorageEventTypes = 'storage'
+export type StorageHandler = (event: StorageEvent) => void
 export interface LocalStorageWindow {
   localStorage: Storage
+  addEventListener: AddEventListenerFunc
 }
 
 // used in web3Proxy.ts
@@ -76,7 +98,7 @@ export type web3Send = (
   callback: web3Callback
 ) => void
 
-export interface Web3Window extends PostOfficeWindow, IframeManagingWindow {
+export interface Web3Window extends PostOfficeWindow {
   Promise: PromiseConstructor
   web3?: {
     currentProvider: {
@@ -95,14 +117,19 @@ export interface MessageEvent {
   data: any
 }
 
+// used in Mailbox.ts
+export interface StorageEvent {
+  key: string
+  oldValue: string | null
+  newValue: string | null
+  storageArea: any
+}
+
 export type MessageHandler = (event: MessageEvent) => void
 
 export type PostOfficeEventTypes = 'message' // augment later if needed
 export interface PostOfficeWindow {
-  addEventListener: (
-    type: PostOfficeEventTypes,
-    handler: MessageHandler
-  ) => void
+  addEventListener: AddEventListenerFunc
 }
 
 type WindowConsole = Pick<Window, 'console'>['console']

--- a/paywall/tsconfig.json
+++ b/paywall/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": [
       "dom",
@@ -42,8 +42,10 @@
 
     /* Module Resolution Options */
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
+    "paths": {
+      "*": ["*", "types/*"]
+    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/paywall/types/@unlock-protocol/unlock-js/index.d.ts
+++ b/paywall/types/@unlock-protocol/unlock-js/index.d.ts
@@ -1,0 +1,12 @@
+import {
+  Web3ServiceType,
+  WalletServiceType,
+} from '../../../src/data-iframe/blockchainHandler/blockChainTypes'
+
+export const Web3Service = Web3ServiceType
+export const WalletService = WalletServiceType
+export const createAccountAndPasswordEncryptKey: any
+export const deploy: any
+export const getAccountFromPrivateKey: any
+export const getCurrentProvider: any
+export const getWeb3Provider: any


### PR DESCRIPTION
# Description

This working branch is based upon the user accounts branch `unlock_provider_base`. It is an extension of the new data iframe branch that adds caching. Because the design is so simple, it literally worked on the first try.

As with the PR against master, there are several things that can be extracted (especially the types surrounding `addEventListener`) which will cut down on the size significantly.

See #4265 for a description of the contents. The code is unchanged, the only difference from #4265 is that this is based upon the user accounts branch.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
