### PR TITLE
allowing event creators to save links

### DIFF
--- a/locksmith/__tests__/controllers/eventController.test.ts
+++ b/locksmith/__tests__/controllers/eventController.test.ts
@@ -8,31 +8,6 @@ const models = require('../../src/models')
 
 let Event = models.Event
 
-let message = {
-  event: {
-    lockAddress: '0x49158d35259e3264ad2a6abb300cda19294d125e',
-    name: 'A Test Event',
-    description: 'A fun event for everyone',
-    location: 'http://example.com/a_sample_location',
-    date: 1744487946000,
-    logo: 'http://example.com/a_logo',
-    owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-    duration: 42,
-  },
-}
-
-let badOwnerMessage = {
-  event: {
-    lockAddress: '0x49158d35259e3264ad2a6abb300cda19294d125e',
-    name: 'A Test Event',
-    description: 'A fun event for everyone',
-    location: 'http://example.com/a_sample_location',
-    date: 1744487946000,
-    logo: 'http://example.com/a_logo',
-    owner: '0xbbbcdde4c0b861cb36f4ce006a9c90ba2e43abc9',
-  },
-}
-
 let newLinks = {
   eventModification: {
     lockAddress: '0x49158d35259e3264ad2a6abb300cda19294d125e',
@@ -48,6 +23,32 @@ let newLinks = {
       href: 'https://www.msn.com',
     },
   ],
+}
+
+let message = {
+  event: {
+    lockAddress: '0x49158d35259e3264ad2a6abb300cda19294d125e',
+    name: 'A Test Event',
+    description: 'A fun event for everyone',
+    location: 'http://example.com/a_sample_location',
+    date: 1744487946000,
+    logo: 'http://example.com/a_logo',
+    owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+    duration: 42,
+    links: newLinks,
+  },
+}
+
+let badOwnerMessage = {
+  event: {
+    lockAddress: '0x49158d35259e3264ad2a6abb300cda19294d125e',
+    name: 'A Test Event',
+    description: 'A fun event for everyone',
+    location: 'http://example.com/a_sample_location',
+    date: 1744487946000,
+    logo: 'http://example.com/a_logo',
+    owner: '0xbbbcdde4c0b861cb36f4ce006a9c90ba2e43abc9',
+  },
 }
 
 let overWritingLinks = {
@@ -148,6 +149,7 @@ describe('Event Controller', () => {
         expect(await Event.count()).toEqual(0)
       })
     })
+
     describe('when the event could be created', () => {
       it('creates the event and returns 200', async () => {
         expect.assertions(1)

--- a/locksmith/__tests__/operations/eventOperations.test.ts
+++ b/locksmith/__tests__/operations/eventOperations.test.ts
@@ -16,6 +16,10 @@ let eventData = {
   owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
 }
 
+// let eventLinks = {
+
+// }
+
 describe('EventOperations', () => {
   describe('create', () => {
     it('dispatches to the event model with normalized addresses', () => {
@@ -32,7 +36,21 @@ describe('EventOperations', () => {
         owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
       })
     })
+
+    // it('saves links if there are any', () => {
+    //   expect.assertions(1)
+    //   Event.create = jest.fn(() => {})
+    //   EventOperations.addLinks = jest.fn()
+    //   const eventDataWithLinks = {
+    //     ...eventData,
+    //     links: eventLinks
+    //   }
+    //   EventOperations.create(eventDataWithLinks)
+    //   expect(EventOperations.addLinks).toHaveBeenCalledWith({
+    //   })
+    // })
   })
+
   describe('update', () => {
     it('dispatches to the event model with a normalized address', () => {
       expect.assertions(1)
@@ -61,7 +79,16 @@ describe('EventOperations', () => {
         }
       )
     })
+    // it.only('should add links if there are any', () => {
+    //   expect.assertions(1)
+    //   Event.update = jest.fn(() => {})
+    //   EventOperations.addLinks = jest.fn()
+    //   EventOperations.update(eventData)
+    //   expect(EventOperations.addLinks).toHaveBeenCalledWith({
+    //   })
+    // })
   })
+
   describe('find', () => {
     it('dispatches to the event model with a normalized address', () => {
       expect.assertions(1)

--- a/locksmith/src/operations/eventOperations.ts
+++ b/locksmith/src/operations/eventOperations.ts
@@ -9,16 +9,20 @@ const { Event } = models
 const Op = Sequelize.Op
 
 namespace EventOperations {
-  export const create = (event: EventCreation): Promise<any> => {
+  export const create = async (event: EventCreation): Promise<any> => {
     event.owner = Normalizer.ethereumAddress(event.owner)
     event.lockAddress = Normalizer.ethereumAddress(event.lockAddress)
-    return Event.create(event)
+    const result = await Event.create(event)
+    if (event.links) {
+      await addLinks(event.lockAddress, event.links)
+    }
+    return result
   }
 
   export const update = async (event: EventCreation): Promise<any> => {
     event.owner = Normalizer.ethereumAddress(event.owner)
     event.lockAddress = Normalizer.ethereumAddress(event.lockAddress)
-    return await Event.update(event, {
+    const result = await Event.update(event, {
       where: {
         lockAddress: {
           [Op.eq]: Normalizer.ethereumAddress(event.lockAddress),
@@ -29,6 +33,10 @@ namespace EventOperations {
       },
       raw: true,
     })
+    if (event.links) {
+      await addLinks(event.lockAddress, event.links)
+    }
+    return result
   }
 
   export const find = async (lockAddress: string): Promise<any> => {

--- a/locksmith/src/types.ts
+++ b/locksmith/src/types.ts
@@ -27,6 +27,7 @@ export interface EventCreation {
   logo: string
   owner: string
   duration?: number
+  links?: any
 }
 
 export interface ItemizedKeyPrice {

--- a/tickets/src/__tests__/components/content/CreateContent.test.js
+++ b/tickets/src/__tests__/components/content/CreateContent.test.js
@@ -125,6 +125,17 @@ describe('CreateContent', () => {
     rtl.fireEvent.change(form.getByTestId('Pick a day'), {
       target: { value: '23' },
     })
+    rtl.fireEvent.change(form.getByPlaceholderText('Give it a nice name'), {
+      target: { value: 'Party!' },
+    })
+    rtl.fireEvent.change(
+      form.getByPlaceholderText(
+        '(Optional) A web page where your visitors can learn more about the event'
+      ),
+      {
+        target: { value: 'https://party.com/fun' },
+      }
+    )
 
     const submit = form.getByText('Save Event')
     expect(submit).not.toBeNull()
@@ -133,12 +144,18 @@ describe('CreateContent', () => {
     let date = new Date('2020-11-23T00:00:00.000')
     expect(addEvent).toHaveBeenCalledWith({
       lockAddress: 'abc123',
-      name: '',
+      name: 'Party!',
       description: '',
       location: '',
       owner: 'ben',
       logo: '',
       date,
+      links: [
+        {
+          href: 'https://party.com/fun',
+          text: 'Event Website',
+        },
+      ],
     })
   })
 

--- a/tickets/src/__tests__/services/eventService.test.js
+++ b/tickets/src/__tests__/services/eventService.test.js
@@ -124,16 +124,51 @@ describe('EventService', () => {
   describe('getEvent', () => {
     describe('when an event can be retrieved', () => {
       it('returns a successful promise', async () => {
-        expect.assertions(1)
+        expect.assertions(2)
         const eventAddress = 'abc123'
-        axios.get.mockReturnValue({})
-        await eventService.getEvent(eventAddress)
+        const date = new Date(2019, 7, 4, 6, 11, 30)
+        const name = 'My Party'
+        const description = 'The fancy party'
+        const location = 'The block'
+        const duration = 60 * 60 * 3
+        const links = {
+          href: 'https://party.com',
+          text: 'Event website',
+        }
+        const logo = 'mylogo'
+        const image = 'myimage'
+
+        axios.get.mockReturnValue({
+          data: {
+            name,
+            date,
+            description,
+            location,
+            duration,
+            logo,
+            image,
+            eventLinks: links,
+          },
+        })
+        const event = await eventService.getEvent(eventAddress)
 
         expect(axios.get).toHaveBeenCalledWith(
           `${serviceHost}/events/${eventAddress}`
         )
+        expect(event).toEqual({
+          date,
+          name,
+          description,
+          location,
+          links,
+          duration,
+          image,
+          lockAddress: eventAddress,
+          logo,
+        })
       })
     })
+
     describe('when an event cannot be retrieved', () => {
       it('returns a rejected promise', async () => {
         expect.assertions(2)

--- a/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2397,6 +2397,26 @@ Object {
                       </div>
                     </div>
                   </div>
+                  <div
+                    class="c12"
+                  >
+                     
+                  </div>
+                  <div
+                    class="c12"
+                  >
+                    <label
+                      class="c9"
+                    >
+                      Event website
+                    </label>
+                    <input
+                      class="c13"
+                      placeholder="(Optional) A web page where your visitors can learn more about the event"
+                      type="url"
+                      value=""
+                    />
+                  </div>
                 </div>
               </li>
               <li
@@ -2981,6 +3001,26 @@ Object {
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  class="sc-1xgodx9-5 hKuMTX"
+                >
+                   
+                </div>
+                <div
+                  class="sc-1xgodx9-5 hKuMTX"
+                >
+                  <label
+                    class="sc-1xgodx9-6 loqXYl"
+                  >
+                    Event website
+                  </label>
+                  <input
+                    class="sc-1xgodx9-1 gaAqRD"
+                    placeholder="(Optional) A web page where your visitors can learn more about the event"
+                    type="url"
+                    value=""
+                  />
                 </div>
               </div>
             </li>
@@ -3931,6 +3971,26 @@ Object {
                       </div>
                     </div>
                   </div>
+                  <div
+                    class="c12"
+                  >
+                     
+                  </div>
+                  <div
+                    class="c12"
+                  >
+                    <label
+                      class="c9"
+                    >
+                      Event website
+                    </label>
+                    <input
+                      class="c13"
+                      placeholder="(Optional) A web page where your visitors can learn more about the event"
+                      type="url"
+                      value=""
+                    />
+                  </div>
                 </div>
               </li>
               <li
@@ -4527,6 +4587,26 @@ Object {
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  class="sc-1xgodx9-5 hKuMTX"
+                >
+                   
+                </div>
+                <div
+                  class="sc-1xgodx9-5 hKuMTX"
+                >
+                  <label
+                    class="sc-1xgodx9-6 loqXYl"
+                  >
+                    Event website
+                  </label>
+                  <input
+                    class="sc-1xgodx9-1 gaAqRD"
+                    placeholder="(Optional) A web page where your visitors can learn more about the event"
+                    type="url"
+                    value=""
+                  />
                 </div>
               </div>
             </li>

--- a/tickets/src/components/content/CreateContent.js
+++ b/tickets/src/components/content/CreateContent.js
@@ -18,13 +18,19 @@ import withConfig from '../../utils/withConfig'
 import TimePicker from '../interface/TimePicker'
 
 export const formValuesToEvent = formValues => {
-  const { lockAddress, name, description, location, date } = formValues
+  const { lockAddress, name, description, location, date, website } = formValues
   return {
     lockAddress,
     name,
     description,
     location,
     date,
+    links: [
+      {
+        text: 'Event Website',
+        href: website,
+      },
+    ],
   }
 }
 
@@ -40,6 +46,7 @@ export class CreateContent extends Component {
       location: '',
       date: now,
       submitted: false,
+      website: '',
     }
 
     this.state = {
@@ -50,6 +57,7 @@ export class CreateContent extends Component {
       location: event.location || this.defaultState.location,
       date: event.date || this.defaultState.date,
       submitted: submitted || this.defaultState.submitted,
+      website: '',
     }
 
     this.onChange = this.onChange.bind(this)
@@ -88,6 +96,7 @@ export class CreateContent extends Component {
         description: event.description,
         date: event.date,
         location: event.location,
+        website: event.links[0].href, // TODO: support multiple links
       }
     })
   }
@@ -133,7 +142,9 @@ export class CreateContent extends Component {
 
   saveEvent() {
     const { account, addEvent } = this.props
-    const newEvent = formValuesToEvent(this.state)
+    const newEvent = formValuesToEvent({
+      ...this.state,
+    })
     addEvent({
       ...newEvent,
       logo: '', // TODO add logo support
@@ -151,6 +162,7 @@ export class CreateContent extends Component {
       location,
       lockAddress,
       submitted,
+      website,
     } = this.state
 
     return (
@@ -228,6 +240,16 @@ export class CreateContent extends Component {
                         now={now}
                         date={date}
                         onChange={this.timeChanged}
+                      />
+                    </Field>
+                    <Field>&nbsp;</Field>
+                    <Field>
+                      <Label>Event website</Label>
+                      <Input
+                        type="url"
+                        placeholder="(Optional) A web page where your visitors can learn more about the event"
+                        onChange={this.onChange('website')}
+                        value={website}
                       />
                     </Field>
                   </Fieldset>

--- a/tickets/src/components/content/EventContent.js
+++ b/tickets/src/components/content/EventContent.js
@@ -62,11 +62,11 @@ export const EventContent = ({
 
   const convertCurrency = !lock.currencyContractAddress
 
-  const externalLinks = links.map(({ href, title }) => {
+  const externalLinks = links.map(({ href, text }) => {
     return (
       <li key={href}>
         <a target="_blank" rel="noopener noreferrer" href={href}>
-          {title}
+          {text}
         </a>
       </li>
     )
@@ -207,7 +207,7 @@ export const mapStateToProps = (
   }
 
   if (event) {
-    event.date = new Date(event.date)
+    event.date = new Date(event.date) // TODO: What is this for?
     // TEMPORARY: HARD CODE VALUES FOR NFT EVENT
     if (lockAddress === '0x5865Ff2CBd045Ef1cfE19739df19E83B32b783b4') {
       event.name = 'NFT Dev Meetup - NYC Blockchain Week 2019'
@@ -227,7 +227,7 @@ Meet us at 6:30PM on May 16th, at the Bushwick Generator.
         'https://s3.amazonaws.com/assets.unlock-protocol.com/NFTEventLogos.png'
       event.links = [
         {
-          title: '💬 Telegram Group',
+          text: '💬 Telegram Group',
           href: 'https://t.me/joinchat/GzMTuRZfLMHZ1n2EMmF0UQ',
         },
         // {

--- a/tickets/src/middlewares/eventMiddleware.js
+++ b/tickets/src/middlewares/eventMiddleware.js
@@ -26,31 +26,11 @@ const eventMiddleware = config => {
     return next => {
       setTimeout(() => {
         if (lockAddress) {
-          eventService.getEvent(lockAddress).then(res => {
-            const {
-              name,
-              date,
-              lockAddress,
-              description,
-              location,
-              duration,
-              logo,
-              image,
-            } = res.data
-            const event = {
-              name,
-              date: new Date(date),
-              lockAddress,
-              description,
-              location,
-              duration,
-              logo,
-              image,
-            }
+          eventService.getEvent(lockAddress).then(event => {
             dispatch(updateEvent(event))
           })
         }
-      }, 0)
+      }, 0) // WEIRD HACK?
 
       return action => {
         // Initial event to add a new ticketed event: here we process data and send for signing
@@ -65,6 +45,7 @@ const eventMiddleware = config => {
             duration,
             logo,
             image,
+            links,
           } = action.event
           const data = UnlockEvent.build({
             lockAddress,
@@ -76,6 +57,7 @@ const eventMiddleware = config => {
             duration,
             logo,
             image,
+            links,
           })
           // We need to sign the data before we can store it
           dispatch(signData(data))
@@ -94,27 +76,7 @@ const eventMiddleware = config => {
 
         // Load an event from locksmith
         if (action.type === LOAD_EVENT) {
-          eventService.getEvent(action.address).then(res => {
-            const {
-              name,
-              date,
-              lockAddress,
-              description,
-              location,
-              duration,
-              logo,
-              image,
-            } = res.data
-            const event = {
-              name,
-              date: new Date(date),
-              lockAddress,
-              description,
-              location,
-              duration,
-              logo,
-              image,
-            }
+          eventService.getEvent(action.address).then(event => {
             dispatch(updateEvent(event))
           })
         }

--- a/tickets/src/services/eventService.js
+++ b/tickets/src/services/eventService.js
@@ -16,7 +16,7 @@ export default class EventService {
    * @returns {Promise<*>}
    */
   async saveEvent(
-    { lockAddress, name, description, location, date, owner, logo },
+    { lockAddress, name, description, location, date, owner, logo, links },
     token
   ) {
     const opts = {}
@@ -31,6 +31,7 @@ export default class EventService {
       date,
       owner,
       logo,
+      links,
     })
 
     // First check if the event exists
@@ -65,7 +66,29 @@ export default class EventService {
    */
   async getEvent(lockAddress) {
     try {
-      return await axios.get(`${this.host}/events/${lockAddress}`)
+      const response = await axios.get(`${this.host}/events/${lockAddress}`)
+      const {
+        name,
+        date,
+        description,
+        location,
+        duration,
+        logo,
+        image,
+        eventLinks,
+      } = response.data
+
+      return {
+        name,
+        date: new Date(date),
+        lockAddress,
+        description,
+        location,
+        duration,
+        logo,
+        image,
+        links: eventLinks,
+      }
     } catch (error) {
       return Promise.reject(error)
     }

--- a/tickets/src/structured_data/unlockEvent.js
+++ b/tickets/src/structured_data/unlockEvent.js
@@ -18,6 +18,7 @@ export default class UnlockEvent {
       { name: 'logo', type: 'string' },
       { name: 'image', type: 'string' },
       { name: 'duration', type: 'uint64' },
+      { name: 'links', type: 'string' },
     ]
 
     let domainData = {
@@ -36,6 +37,7 @@ export default class UnlockEvent {
         logo: input.logo,
         image: input.image,
         duration: input.duration,
+        links: input.links,
       },
     }
 


### PR DESCRIPTION
# Description

The organizers of BOSS, which are using Unlock to sell tickets for their conference https://twitter.com/bmann/status/1152649548658950144 have asked for the ability to add links to their events.
We had some of that work in place, this PR adds the missing parts.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread