### PR TITLE
Adding Pagination to blog

### DIFF
--- a/unlock-protocol.com/next.config.js
+++ b/unlock-protocol.com/next.config.js
@@ -76,7 +76,6 @@ module.exports = withTypescript({
       '/jobs': { page: '/jobs' },
       '/terms': { page: '/terms' },
       '/privacy': { page: '/privacy' },
-      '/post': { page: '/post' },
       '/blog': { page: '/blog' },
     }
 

--- a/unlock-protocol.com/src/__tests__/pages/pages.test.js
+++ b/unlock-protocol.com/src/__tests__/pages/pages.test.js
@@ -115,10 +115,15 @@ describe('Pages', () => {
     })
 
     it('should load blog posts as initial props', async () => {
-      expect.assertions(1)
+      expect.assertions(2)
 
-      await Blog.getInitialProps()
+      await Blog.getInitialProps({
+        query: {
+          slug: '2',
+        },
+      })
       expect(prepareBlogProps).toHaveBeenCalledTimes(1)
+      expect(prepareBlogProps).toHaveBeenCalledWith(10, 2)
     })
   })
 
@@ -140,10 +145,15 @@ describe('Pages', () => {
     })
 
     it('should load post details in initial props', async () => {
-      expect.assertions(1)
+      expect.assertions(2)
 
-      await Post.getInitialProps()
+      await Post.getInitialProps({
+        query: {
+          slug: 'a-post',
+        },
+      })
       expect(preparePostProps).toHaveBeenCalledTimes(1)
+      expect(preparePostProps).toHaveBeenCalledWith('a-post')
     })
   })
 })

--- a/unlock-protocol.com/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-protocol.com/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -192,7 +192,7 @@ Object {
   line-height: 0;
 }
 
-.c23 {
+.c26 {
   margin-top: 24px;
   margin-bottom: 24px;
   display: grid;
@@ -205,7 +205,7 @@ Object {
   align-items: center;
 }
 
-.c24 {
+.c27 {
   justify-self: end;
   font-size: 12px;
   font-weight: 200;
@@ -320,6 +320,24 @@ Object {
   font-size: 36px;
 }
 
+.c23 {
+  margin: 0px;
+  padding: 0px;
+}
+
+.c23 li {
+  display: inline-block;
+  padding: 1px;
+}
+
+.c24 {
+  float: left;
+}
+
+.c25 {
+  float: right;
+}
+
 @media only screen and (min-width:0px) and (max-width:736px) {
   .c16 {
     display: none;
@@ -382,7 +400,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c25 {
+  .c28 {
     display: none;
   }
 }
@@ -753,8 +771,48 @@ Look at us! We're posting on our very own blog! How exciting!
               </div>
             </div>
           </div>
-          <footer
+          <ul
             class="c23"
+          >
+            <li
+              class="c24"
+            >
+              <a
+                href="/blog/"
+              >
+                ← First Page
+              </a>
+            </li>
+            <li
+              class="c24"
+            >
+              <a
+                href="/blog/4"
+              >
+                │ Previous
+              </a>
+            </li>
+            <li
+              class="c25"
+            >
+              <a
+                href="/blog/9"
+              >
+                Last Page →
+              </a>
+            </li>
+            <li
+              class="c25"
+            >
+              <a
+                href="/blog/6"
+              >
+                Next │
+              </a>
+            </li>
+          </ul>
+          <footer
+            class="c26"
           >
             <a
               class="c6 c7"
@@ -889,14 +947,14 @@ Look at us! We're posting on our very own blog! How exciting!
               </small>
             </a>
             <span
-              class="c24"
+              class="c27"
             >
               Made with passion in New York
             </span>
           </footer>
         </div>
         <div
-          class="c25"
+          class="c28"
         />
       </div>
     </div>
@@ -1259,6 +1317,46 @@ Look at us! We're posting on our very own blog! How exciting!
             </div>
           </div>
         </div>
+        <ul
+          class="sc-5kpfof-1 iGnITw"
+        >
+          <li
+            class="sc-5kpfof-2 hMEOFM"
+          >
+            <a
+              href="/blog/"
+            >
+              ← First Page
+            </a>
+          </li>
+          <li
+            class="sc-5kpfof-2 hMEOFM"
+          >
+            <a
+              href="/blog/4"
+            >
+              │ Previous
+            </a>
+          </li>
+          <li
+            class="sc-5kpfof-3 cRNTJI"
+          >
+            <a
+              href="/blog/9"
+            >
+              Last Page →
+            </a>
+          </li>
+          <li
+            class="sc-5kpfof-3 cRNTJI"
+          >
+            <a
+              href="/blog/6"
+            >
+              Next │
+            </a>
+          </li>
+        </ul>
         <footer
           class="sc-2ix2yp-0 fmIKjS"
         >

--- a/unlock-protocol.com/src/__tests__/utils/blogLoader.test.js
+++ b/unlock-protocol.com/src/__tests__/utils/blogLoader.test.js
@@ -19,7 +19,7 @@ describe('blogLoader', () => {
           '{"items":[{"title":"This is a second sample post","subTitle":"And some sample metadata","publishDate":"Jan 7, 1979","slug":"test2"},{"title":"This is a sample post","subTitle":"And some sample metadata","publishDate":"Dec 31, 1978","slug":"test1"},{"title":"This is a FUTURE POST","subTitle":"IT IS FROM THE FUTURE","publishDate":"Jan 7, 2037","slug":"future"}]}',
       }
     })
-    let posts = await loadBlogIndexFile(10)
+    let { posts } = await loadBlogIndexFile(10)
     expect(posts[0].slug).toEqual('test2')
     expect(posts[1].slug).toEqual('test1')
   })
@@ -33,7 +33,7 @@ describe('blogLoader', () => {
           '{"items":[{"title":"This is a second sample post","subTitle":"And some sample metadata","publishDate":"Jan 7, 1979","slug":"test2"},{"title":"This is a sample post","subTitle":"And some sample metadata","publishDate":"Dec 31, 1978","slug":"test1"},{"title":"This is a FUTURE POST","subTitle":"IT IS FROM THE FUTURE","publishDate":"Jan 7, 2037","slug":"future"}]}',
       }
     })
-    let posts = await loadBlogIndexFile(1)
+    let { posts } = await loadBlogIndexFile(1)
     expect(posts[0].slug).toEqual('test2')
     expect(posts[1]).toBe(undefined)
   })
@@ -44,7 +44,7 @@ describe('blogLoader', () => {
     jest.mock('../../../blog/blog.index', () => {
       return { default: '{"foo":"bar"}' }
     })
-    let posts = await loadBlogIndexFile(10)
+    let { posts } = await loadBlogIndexFile(10)
     expect(posts.length).toEqual(0)
   })
 
@@ -67,7 +67,7 @@ Here is some markdown
     expect(post.__content).toContain('Here is some markdown')
   })
 
-  it('given a context object, returns a blog post and slug for the post page', async () => {
+  it('given a slug, returns a blog post and slug for the post page', async () => {
     expect.assertions(2)
 
     jest.mock('../../../blog/what-is-unlock.md', () => {
@@ -81,9 +81,7 @@ Here is some markdown
 `,
       }
     })
-    let { slug, post } = await preparePostProps({
-      query: { slug: 'what-is-unlock' },
-    })
+    let { slug, post } = await preparePostProps('what-is-unlock')
     expect(slug).toEqual('what-is-unlock')
     expect(post.title).toEqual('This is a sample post')
   })
@@ -97,7 +95,7 @@ Here is some markdown
           '{"items":[{"title":"This is a second sample post","subTitle":"And some sample metadata","publishDate":"Jan 7, 1979","slug":"test2"},{"title":"This is a sample post","subTitle":"And some sample metadata","publishDate":"Dec 31, 1978","slug":"test1"},{"title":"This is a FUTURE POST","subTitle":"IT IS FROM THE FUTURE","publishDate":"Jan 7, 2037","slug":"future"}]}',
       }
     })
-    let { posts } = await prepareBlogProps(10)
+    let { posts } = await prepareBlogProps(10, 1)
     expect(posts[0].slug).toEqual('test2')
     expect(posts[1].slug).toEqual('test1')
   })
@@ -110,7 +108,7 @@ Here is some markdown
         default: '<arbitrary-tag>Hello, I am not JSON</arbitrary-tag>',
       }
     })
-    let posts = await loadBlogIndexFile(10)
+    let { posts } = await loadBlogIndexFile(10)
     expect(posts.length).toEqual(0)
   })
 
@@ -123,7 +121,7 @@ Here is some markdown
           '{"items":[{"title":"This is a second sample post","subTitle":"And some sample metadata","publishDate":"Jan 7, 1979","slug":"test2"},{"title":"This is a sample post","subTitle":"And some sample metadata","publishDate":"Dec 31, 1978","slug":"test1"},{"title":"This is a FUTURE POST","subTitle":"IT IS FROM THE FUTURE","publishDate":"Jan 7, 2037","slug":"future"}]}',
       }
     })
-    let posts = await loadBlogIndexFile(10)
+    let { posts } = await loadBlogIndexFile(10)
     expect(posts.length).toEqual(2) // Ignores the future post
     expect(posts[0].slug).toEqual('test2')
     expect(posts[1].slug).toEqual('test1')

--- a/unlock-protocol.com/src/_server.js
+++ b/unlock-protocol.com/src/_server.js
@@ -26,7 +26,11 @@ function _server(port, dev) {
         } else if (path === 'blog') {
           const params = route('/blog/:slug')(pathname)
           if (params.slug) {
-            app.render(req, res, '/post', Object.assign(params, query))
+            if (isNaN(params.slug)) {
+              app.render(req, res, '/post', Object.assign(params, query))
+            } else {
+              app.render(req, res, '/blog', Object.assign(params, query))
+            }
           } else {
             app.render(req, res, '/blog', Object.assign(params, query))
           }

--- a/unlock-protocol.com/src/pages/about.js
+++ b/unlock-protocol.com/src/pages/about.js
@@ -11,7 +11,7 @@ About.propTypes = {
 
 About.getInitialProps = async () => {
   // Showing 10 posts on the blog page
-  return await prepareBlogProps(10)
+  return await prepareBlogProps(10, 1)
 }
 
 export default About

--- a/unlock-protocol.com/src/pages/blog.js
+++ b/unlock-protocol.com/src/pages/blog.js
@@ -1,6 +1,8 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Head from 'next/head'
 import styled from 'styled-components'
+import Link from 'next/link'
 
 import UnlockPropTypes from '../propTypes'
 import Layout from '../components/interface/Layout'
@@ -11,9 +13,12 @@ import BlogIndex from '../components/content/BlogIndex'
 import { prepareBlogProps } from '../utils/blogLoader'
 
 // TODO move to BlogContent
-const Blog = ({ posts }) => {
-  const title = 'Blog'
-  const description = 'News and updates from the Unlock Protocol team.'
+const Blog = ({ posts, page, totalPages }) => {
+  let title = 'Blog'
+  if (page > 1) {
+    title += ` - Page ${page}`
+  }
+  let description = 'News and updates from the Unlock Protocol team.'
 
   return (
     <Layout forContent>
@@ -33,17 +38,50 @@ const Blog = ({ posts }) => {
       </Head>
       <Title>Unlock Blog</Title>
       <BlogIndex posts={posts} />
+      <Pagination>
+        {page > 1 && (
+          <Left>
+            <Link href="/blog/">
+              <a>← First Page</a>
+            </Link>
+          </Left>
+        )}
+        {page > 2 && (
+          <Left>
+            <Link href={`/blog/${page - 1}`}>
+              <a>│ Previous</a>
+            </Link>
+          </Left>
+        )}
+        {page != totalPages && (
+          <Right>
+            <Link href={`/blog/${totalPages}`}>
+              <a>Last Page →</a>
+            </Link>
+          </Right>
+        )}
+        {totalPages > page + 1 && (
+          <Right>
+            <Link href={`/blog/${page + 1}`}>
+              <a>Next │</a>
+            </Link>
+          </Right>
+        )}
+      </Pagination>
     </Layout>
   )
 }
 
 Blog.propTypes = {
   posts: UnlockPropTypes.postFeed.isRequired,
+  page: PropTypes.number.isRequired,
+  totalPages: PropTypes.number.isRequired,
 }
 
-Blog.getInitialProps = async () => {
-  // Showing 10 posts on the blog page
-  return await prepareBlogProps(10)
+Blog.getInitialProps = async context => {
+  const { slug } = context.query // The slug is the page number
+  const page = parseInt(slug)
+  return await prepareBlogProps(10, page)
 }
 
 export default Blog
@@ -54,4 +92,20 @@ const Title = styled.h1`
   font-weight: 700;
   font-family: 'IBM Plex Sans', Helvetica, sans-serif;
   font-size: 36px;
+`
+
+const Pagination = styled.ul`
+  margin: 0px;
+  padding: 0px;
+  li {
+    display: inline-block;
+    padding: 1px;
+  }
+`
+const Left = styled.li`
+  float: left;
+`
+
+const Right = styled.li`
+  float: right;
 `

--- a/unlock-protocol.com/src/pages/post.js
+++ b/unlock-protocol.com/src/pages/post.js
@@ -60,7 +60,8 @@ Post.propTypes = {
 }
 
 Post.getInitialProps = async context => {
-  return await preparePostProps(context)
+  const { slug } = context.query
+  return await preparePostProps(slug)
 }
 
 export default Post

--- a/unlock-protocol.com/src/stories/blog.stories.js
+++ b/unlock-protocol.com/src/stories/blog.stories.js
@@ -61,5 +61,5 @@ Look at us! We're posting on our very own blog! How exciting!`,
         slug: 'post1',
       },
     ]
-    return <Blog posts={posts} />
+    return <Blog posts={posts} page={5} totalPages={9} />
   })


### PR DESCRIPTION
# Description

I was looking for old posts and could not find them, so I added pagination ;)
Since we only have 20 posts in the current setup that's just 2 pages. I changed locally to 3 posts per page to make sure pagination worked as expected. (shows first only when on any other page, last on another page, and previous/next when applicable)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread