### PR TITLE
Only display card form when there are no cards

### DIFF
--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import Head from 'next/head'
 import withConfig from '../../utils/withConfig'
 import Layout from '../interface/Layout'
@@ -72,7 +73,7 @@ export class SettingsContent extends React.Component<
         <AccountInfo />
         <ChangePassword />
         {cards.length > 0 && <PaymentMethods cards={cards} />}
-        {!!cards.length && <PaymentDetails stripe={stripe} />}
+        {!cards.length && <PaymentDetails stripe={stripe} />}
       </Layout>
     )
   }
@@ -95,4 +96,4 @@ export const mapStateToProps = ({ account }: ReduxState) => {
   }
 }
 
-export default withConfig(SettingsContent)
+export default connect(mapStateToProps)(withConfig(SettingsContent))

--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -80,14 +80,14 @@ export class SettingsContent extends React.Component<
 }
 
 interface ReduxState {
-  account: {
+  account?: {
     cards?: stripe.Card[]
   }
 }
 
 export const mapStateToProps = ({ account }: ReduxState) => {
   let cards: stripe.Card[] = []
-  if (account.cards) {
+  if (account && account.cards) {
     cards = account.cards
   }
 

--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -7,6 +7,7 @@ import Errors from '../interface/Errors'
 import AccountInfo from '../interface/user-account/AccountInfo'
 import ChangePassword from '../interface/user-account/ChangePassword'
 import PaymentDetails from '../interface/user-account/PaymentDetails'
+import PaymentMethods from '../interface/user-account/PaymentMethods'
 
 // TODO: tighten up this type
 declare global {
@@ -19,6 +20,7 @@ interface SettingsContentProps {
   config: {
     stripeApiKey: string
   }
+  cards: stripe.Card[]
 }
 interface SettingsContentState {
   stripe: stripe.Stripe | null
@@ -59,6 +61,7 @@ export class SettingsContent extends React.Component<
 
   render() {
     const { stripe } = this.state
+    const { cards } = this.props
     return (
       <Layout title="Account Settings">
         <Head>
@@ -68,9 +71,27 @@ export class SettingsContent extends React.Component<
         <Errors />
         <AccountInfo />
         <ChangePassword />
-        <PaymentDetails stripe={stripe} />
+        {cards.length > 0 && <PaymentMethods cards={cards} />}
+        {!!cards.length && <PaymentDetails stripe={stripe} />}
       </Layout>
     )
+  }
+}
+
+interface ReduxState {
+  account: {
+    cards?: stripe.Card[]
+  }
+}
+
+export const mapStateToProps = ({ account }: ReduxState) => {
+  let cards: stripe.Card[] = []
+  if (account.cards) {
+    cards = account.cards
+  }
+
+  return {
+    cards,
   }
 }
 

--- a/unlock-app/src/components/interface/user-account/PaymentMethods.tsx
+++ b/unlock-app/src/components/interface/user-account/PaymentMethods.tsx
@@ -1,20 +1,10 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import { Grid, SectionHeader, Item, ItemValue } from './styles'
 
-interface StripeCard {
-  id: string
-  brand: string
-  exp_month: number
-  exp_year: number
-  last4: string
-}
-
 interface PaymentMethodProps {
-  cards: StripeCard[]
+  cards: stripe.Card[]
 }
 
-// TODO: Swap between this component and the add payment method component
 // TODO: Make this prettier
 export const PaymentMethods = ({ cards }: PaymentMethodProps) => (
   <Grid>
@@ -29,21 +19,4 @@ export const PaymentMethods = ({ cards }: PaymentMethodProps) => (
   </Grid>
 )
 
-interface ReduxState {
-  account: {
-    cards?: StripeCard[]
-  }
-}
-
-export const mapStateToProps = ({ account }: ReduxState) => {
-  let cards: StripeCard[] = []
-  if (account.cards) {
-    cards = account.cards
-  }
-
-  return {
-    cards,
-  }
-}
-
-export default connect(mapStateToProps)(PaymentMethods)
+export default PaymentMethods


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR makes the settings page only show the card form when there are no cards.

Without cards:
<img width="1792" alt="Screen Shot 2019-07-24 at 2 47 52 PM" src="https://user-images.githubusercontent.com/9300702/61820079-5209b600-ae22-11e9-82e5-cf655aa7c07a.png">

With a card:
<img width="1792" alt="Screen Shot 2019-07-24 at 2 48 08 PM" src="https://user-images.githubusercontent.com/9300702/61820090-56ce6a00-ae22-11e9-97fc-6dd1c8aeb975.png">

This will receive more enhancement in future PRs.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
