### PR TITLE
on key expiration, re-send the data to re-lock the paywall

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/sendDataWhenKeyExpires.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/sendDataWhenKeyExpires.test.ts
@@ -86,9 +86,10 @@ describe('BlockchainHandler - setupListeners', () => {
     const validTimestampInSeconds = validTimestamp / 1000
     handler.sendDataWhenKeyExpires(validTimestampInSeconds)
 
+    const rightNow = new Date().getTime()
     expect(fakeWindow.setTimeout).toHaveBeenCalledWith(
       expect.any(Function),
-      validTimestamp + 1000
+      validTimestamp - rightNow + 1000
     )
   })
 

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/sendDataWhenKeyExpires.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/sendDataWhenKeyExpires.test.ts
@@ -1,0 +1,108 @@
+import {
+  WalletServiceType,
+  Web3ServiceType,
+  PaywallState,
+  SetTimeoutWindow,
+  FetchWindow,
+  LocksmithTransactionsResult,
+  ConstantsType,
+} from '../../../../data-iframe/blockchainHandler/blockChainTypes'
+import BlockchainHandler from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import { PaywallConfig } from '../../../../unlockTypes'
+import {
+  defaultValuesOverride,
+  BlockchainTestDefaults,
+  setupTestDefaults,
+} from '../../../test-helpers/setupBlockchainHelpers'
+
+describe('BlockchainHandler - setupListeners', () => {
+  let walletService: WalletServiceType
+  let web3Service: Web3ServiceType
+  let emitError: (error: Error) => void
+  let emitChanges: () => void
+  let store: PaywallState
+  let constants: ConstantsType
+  let configuration: PaywallConfig
+  let fakeWindow: FetchWindow & SetTimeoutWindow
+  let handler: BlockchainHandler
+  let defaults: BlockchainTestDefaults
+
+  type OptionalBlockchainValues = Partial<PaywallState>
+
+  function setupDefaults(
+    valuesOverride: OptionalBlockchainValues = defaultValuesOverride,
+    jsonToFetch: { transactions?: LocksmithTransactionsResult[] } = {}
+  ) {
+    defaults = setupTestDefaults(valuesOverride, jsonToFetch)
+    walletService = defaults.walletService
+    web3Service = defaults.web3Service
+    emitError = defaults.emitError
+    emitChanges = defaults.emitChanges
+    store = defaults.store
+    constants = defaults.constants
+    configuration = defaults.configuration
+    fakeWindow = defaults.fakeWindow
+    handler = new BlockchainHandler({
+      walletService,
+      web3Service,
+      constants,
+      configuration,
+      emitChanges,
+      emitError,
+      window: fakeWindow,
+      store,
+    })
+    handler.init()
+
+    handler.dispatchChangesToPostOffice = jest.fn()
+    fakeWindow.setTimeout = jest.fn()
+  }
+
+  beforeEach(() => {
+    setupDefaults()
+  })
+
+  it('should not set a timeout if there is no key for the lock yet', () => {
+    expect.assertions(1)
+
+    handler.sendDataWhenKeyExpires(0)
+
+    expect(fakeWindow.setTimeout).not.toHaveBeenCalled()
+  })
+
+  it('should not set a timeout if the key is already expired', () => {
+    expect.assertions(1)
+
+    const expiredTimestamp = new Date().getTime() / 1000 - 100
+    handler.sendDataWhenKeyExpires(expiredTimestamp)
+
+    expect(fakeWindow.setTimeout).not.toHaveBeenCalled()
+  })
+
+  it('should set a timeout if the key valid', () => {
+    expect.assertions(1)
+
+    const validTimestamp = new Date().getTime() + 100 * 1000
+    const validTimestampInSeconds = validTimestamp / 1000
+    handler.sendDataWhenKeyExpires(validTimestampInSeconds)
+
+    expect(fakeWindow.setTimeout).toHaveBeenCalledWith(
+      expect.any(Function),
+      validTimestamp + 1000
+    )
+  })
+
+  it('should pass a callback that when triggered dispatches current data to the post office', () => {
+    expect.assertions(1)
+
+    const validTimestamp = new Date().getTime() + 100 * 1000
+    const validTimestampInSeconds = validTimestamp / 1000
+    handler.sendDataWhenKeyExpires(validTimestampInSeconds)
+
+    const dispatch = (fakeWindow.setTimeout as any).mock.calls[0][0]
+
+    dispatch()
+
+    expect(handler.dispatchChangesToPostOffice).toHaveBeenCalled()
+  })
+})

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setupListeners.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setupListeners.test.ts
@@ -211,6 +211,20 @@ describe('BlockchainHandler - setupListeners', () => {
         },
       })
     })
+
+    it("should call sendDataWhenKeyExpires with the key's expiration", () => {
+      expect.assertions(1)
+
+      handler.sendDataWhenKeyExpires = jest.fn()
+      walletService.emit('key.updated', 'id', {
+        lock: addresses[0], // non-normalized on purpose
+        owner: store.account,
+        expiration: 5,
+      })
+
+      // it is called with the key's expiration
+      expect(handler.sendDataWhenKeyExpires).toHaveBeenCalledWith(5)
+    })
   })
 
   describe('transaction.updated', () => {

--- a/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
+++ b/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
@@ -222,8 +222,10 @@ export default class BlockchainHandler {
     // a key with no expiry yet does not need an expiration trigger
     if (!expiry) return
     const now = new Date().getTime() / 1000
+    const timeToExpirationInSeconds = expiry - now
+    const timeToExpirationInMilliseconds = timeToExpirationInSeconds * 1000
 
-    if (expiry - now <= 0) {
+    if (timeToExpirationInSeconds <= 0) {
       // key is expired already
       // as this is called by the key.updated listener, it will
       // dispatch changes.  If that ever changes, we need to
@@ -234,7 +236,7 @@ export default class BlockchainHandler {
     // 1 second after the key expires, re-send data to lock the paywall
     this.window.setTimeout(
       () => this.dispatchChangesToPostOffice(),
-      expiry * 1000 + 1000
+      timeToExpirationInMilliseconds + 1000
     )
   }
 


### PR DESCRIPTION
# Description

This PR adds missing behavior when a key expires. Currently, the paywall remains unlocked until a refresh. This PR adds a simple setTimeout call that re-dispatches the blockchain data when the key is expired. Because the "locked" state is re-calculated every time the data is sent, this will trigger a state change.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4295 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
