### PR TITLE
Don't show keychain button until we have a keychain

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -6406,7 +6406,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c10 {
@@ -7162,7 +7162,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+            class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
           />
           <div
             class="sc-1glv5oz-2 bwZQqD"
@@ -25097,7 +25097,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c13 {
@@ -25540,7 +25540,7 @@ Object {
             Creator Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+            class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
           />
           <div
             class="sc-1glv5oz-2 bwZQqD"
@@ -26164,7 +26164,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c15 {
@@ -26616,29 +26616,6 @@ Object {
                   class="c11"
                 >
                   Log
-                </small>
-              </a>
-              <a
-                class="c9 c12"
-                href="/keychain"
-                title="Keychain"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                >
-                  <title>
-                    Keychain
-                  </title>
-                  <path
-                    clip-rule="evenodd"
-                    d="M9.5 7.667C9.5 6.524 10.562 5.5 12 5.5s2.5 1.024 2.5 2.167V9h-5V7.667zM8.5 9H7a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-8a1 1 0 0 0-1-1h-1.5V7.667C15.5 5.864 13.876 4.5 12 4.5S8.5 5.864 8.5 7.667V9zM7 18h10v-8H7v8zm3-4c0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2-2 .9-2 2z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-                <small
-                  class="c11"
-                >
-                  Keychain
                 </small>
               </a>
             </div>
@@ -27813,7 +27790,7 @@ Object {
             Creator Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+            class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
           >
             <a
               class="sc-850ddk-0 kmwKuX"
@@ -27857,29 +27834,6 @@ Object {
                 class="sc-850ddk-1 fnqGzL"
               >
                 Log
-              </small>
-            </a>
-            <a
-              class="sc-850ddk-0 eZjxtV"
-              href="/keychain"
-              title="Keychain"
-            >
-              <svg
-                viewBox="0 0 24 24"
-              >
-                <title>
-                  Keychain
-                </title>
-                <path
-                  clip-rule="evenodd"
-                  d="M9.5 7.667C9.5 6.524 10.562 5.5 12 5.5s2.5 1.024 2.5 2.167V9h-5V7.667zM8.5 9H7a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-8a1 1 0 0 0-1-1h-1.5V7.667C15.5 5.864 13.876 4.5 12 4.5S8.5 5.864 8.5 7.667V9zM7 18h10v-8H7v8zm3-4c0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2-2 .9-2 2z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="sc-850ddk-1 fnqGzL"
-              >
-                Keychain
               </small>
             </a>
           </div>
@@ -29478,7 +29432,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c18 {
@@ -30010,29 +29964,6 @@ Object {
                   class="c14"
                 >
                   Log
-                </small>
-              </a>
-              <a
-                class="c12 c15"
-                href="/keychain"
-                title="Keychain"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                >
-                  <title>
-                    Keychain
-                  </title>
-                  <path
-                    clip-rule="evenodd"
-                    d="M9.5 7.667C9.5 6.524 10.562 5.5 12 5.5s2.5 1.024 2.5 2.167V9h-5V7.667zM8.5 9H7a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-8a1 1 0 0 0-1-1h-1.5V7.667C15.5 5.864 13.876 4.5 12 4.5S8.5 5.864 8.5 7.667V9zM7 18h10v-8H7v8zm3-4c0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2-2 .9-2 2z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-                <small
-                  class="c14"
-                >
-                  Keychain
                 </small>
               </a>
             </div>
@@ -31223,7 +31154,7 @@ Object {
             Creator Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+            class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
           >
             <a
               class="sc-850ddk-0 kmwKuX"
@@ -31267,29 +31198,6 @@ Object {
                 class="sc-850ddk-1 fnqGzL"
               >
                 Log
-              </small>
-            </a>
-            <a
-              class="sc-850ddk-0 eZjxtV"
-              href="/keychain"
-              title="Keychain"
-            >
-              <svg
-                viewBox="0 0 24 24"
-              >
-                <title>
-                  Keychain
-                </title>
-                <path
-                  clip-rule="evenodd"
-                  d="M9.5 7.667C9.5 6.524 10.562 5.5 12 5.5s2.5 1.024 2.5 2.167V9h-5V7.667zM8.5 9H7a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-8a1 1 0 0 0-1-1h-1.5V7.667C15.5 5.864 13.876 4.5 12 4.5S8.5 5.864 8.5 7.667V9zM7 18h10v-8H7v8zm3-4c0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2-2 .9-2 2z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="sc-850ddk-1 fnqGzL"
-              >
-                Keychain
               </small>
             </a>
           </div>
@@ -36499,7 +36407,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c7 {
@@ -36803,7 +36711,7 @@ Object {
         </svg>
       </a>
       <div
-        class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+        class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
       />
       <div
         class="sc-1glv5oz-2 bwZQqD"
@@ -37133,7 +37041,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c9 {
@@ -37475,7 +37383,7 @@ Object {
         Roses are red
       </h1>
       <div
-        class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+        class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
       />
       <div
         class="sc-1glv5oz-2 bwZQqD"
@@ -37805,7 +37713,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c9 {
@@ -38147,7 +38055,7 @@ Object {
         Unlock
       </h1>
       <div
-        class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+        class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
       />
       <div
         class="sc-1glv5oz-2 bwZQqD"
@@ -39329,67 +39237,7 @@ exports[`Storyshots KeyChainContent the key chain 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c10 {
-  background-color: var(--lightgrey);
-  cursor: pointer;
-  border-radius: 50%;
-  height: 24px;
-  width: 24px;
-  display: inline-block;
-  padding: 0;
-  border: 0;
-  line-height: 15px;
-}
-
-.c10 > svg {
-  fill: var(--grey);
-  height: 24px;
-  width: 24px;
-}
-
-.c10:hover {
-  background-color: var(--link);
-}
-
-.c10:hover > svg {
-  fill: white;
-}
-
-.c10:focus {
-  outline: none;
-}
-
-.c12 {
-  background-color: var(--link);
-  cursor: pointer;
-  border-radius: 50%;
-  height: 24px;
-  width: 24px;
-  display: inline-block;
-  padding: 0;
-  border: 0;
-  line-height: 15px;
-}
-
-.c12 > svg {
-  fill: var(--white);
-  height: 24px;
-  width: 24px;
-}
-
-.c12:hover {
-  background-color: var(--link);
-}
-
-.c12:hover > svg {
-  fill: white;
-}
-
-.c12:focus {
-  outline: none;
-}
-
-.c14 {
+    .c11 {
   background-color: var(--grey);
   cursor: pointer;
   border-radius: 50%;
@@ -39401,10 +39249,40 @@ Object {
   line-height: 15px;
 }
 
-.c14 > svg {
+.c11 > svg {
   fill: white;
   height: 24px;
   width: 24px;
+}
+
+.c11:hover {
+  background-color: var(--link);
+}
+
+.c11:hover > svg {
+  fill: white;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c14 {
+  background-color: var(--grey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 48px;
+  width: 48px;
+  display: inline-block;
+  padding: 0;
+  border: 0;
+  line-height: 48px;
+}
+
+.c14 > svg {
+  fill: white;
+  height: 48px;
+  width: 48px;
 }
 
 .c14:hover {
@@ -39419,37 +39297,7 @@ Object {
   outline: none;
 }
 
-.c16 {
-  background-color: var(--grey);
-  cursor: pointer;
-  border-radius: 50%;
-  height: 48px;
-  width: 48px;
-  display: inline-block;
-  padding: 0;
-  border: 0;
-  line-height: 48px;
-}
-
-.c16 > svg {
-  fill: white;
-  height: 48px;
-  width: 48px;
-}
-
-.c16:hover {
-  background-color: var(--link);
-}
-
-.c16:hover > svg {
-  fill: white;
-}
-
-.c16:focus {
-  outline: none;
-}
-
-.c11 {
+.c12 {
   display: none;
   position: relative;
   z-index: var(--alwaysontop);
@@ -39464,7 +39312,7 @@ Object {
   color: var(--link);
 }
 
-.c9:hover .c11 {
+.c10:hover .c12 {
   display: inline-block;
 }
 
@@ -39508,7 +39356,7 @@ Object {
   color: var(--grey);
 }
 
-.c13 {
+.c9 {
   display: grid;
   grid-gap: 16px;
   grid-template-columns: repeat(4,24px);
@@ -39530,16 +39378,16 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
-.c15 {
+.c13 {
   display: none;
   height: auto;
   grid-column: second;
 }
 
-.c15 .c9 {
+.c13 .c10 {
   background-color: var(--white);
   -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
   transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
@@ -39550,24 +39398,24 @@ Object {
   align-self: center;
 }
 
-.c15 .c9:nth-child(1) {
+.c13 .c10:nth-child(1) {
   pointer-events: none;
 }
 
-.c15 .c9:nth-child(2) {
+.c13 .c10:nth-child(2) {
   pointer-events: none;
   display: none;
 }
 
-.c15 .c9 > svg {
+.c13 .c10 > svg {
   fill: var(--grey);
 }
 
-.c15 .c9:hover > svg {
+.c13 .c10:hover > svg {
   fill: var(--grey);
 }
 
-.c17 {
+.c15 {
   background-color: var(--white);
   width: 100%;
   height: auto;
@@ -39594,11 +39442,11 @@ Object {
   top: 50px;
 }
 
-.c17 .c9 {
+.c15 .c10 {
   margin: 24px;
 }
 
-.c17 .c9 small {
+.c15 .c10 small {
   display: block;
   color: var(--grey);
   text-align: center;
@@ -39632,7 +39480,7 @@ Object {
   width: 100%;
 }
 
-.c21 {
+.c19 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   font-weight: 500;
@@ -39641,7 +39489,7 @@ Object {
   text-transform: none;
 }
 
-.c18 {
+.c16 {
   font-family: 'IBM Plex Mono',monospace;
   display: grid;
   row-gap: 8px;
@@ -39650,7 +39498,7 @@ Object {
   grid-template-columns: 40px 200px repeat(2,100px) repeat(3,24px) 1fr;
 }
 
-.c19 {
+.c17 {
   display: grid;
   height: 40px;
   grid-row: span 2;
@@ -39663,7 +39511,7 @@ Object {
   align-content: start;
 }
 
-.c20 {
+.c18 {
   font-weight: 100;
   text-transform: uppercase;
   -webkit-letter-spacing: 1px;
@@ -39673,7 +39521,7 @@ Object {
   font-size: 8px;
 }
 
-.c22 {
+.c20 {
   font-family: 'IBM Plex Mono',monospace;
   font-size: 10px;
   width: 128px;
@@ -39699,7 +39547,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c13 {
+  .c9 {
     display: none;
   }
 }
@@ -39711,25 +39559,25 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c15 {
+  .c13 {
     display: grid;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c15 {
+  .c13 {
     display: none;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c17 {
+  .c15 {
     display: grid;
   }
 }
 
 @media only screen and (min-width:736px) {
-  .c17 {
+  .c15 {
     display: none;
   }
 }
@@ -39758,13 +39606,13 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c23 {
+  .c21 {
     display: none;
   }
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c18 {
+  .c16 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
     grid-template-columns: 45px 145px repeat(2,80px);
@@ -39772,7 +39620,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c19 {
+  .c17 {
     height: 0px;
   }
 }
@@ -39838,80 +39686,12 @@ Object {
             </h1>
             <div
               class="c8"
-            >
-              <a
-                class="c9 c10"
-                href="/dashboard"
-                title="Dashboard"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                >
-                  <title>
-                    Dashboard
-                  </title>
-                  <path
-                    d="M12.5 5.5c-.195-.192-.805-.192-1 0l-6.351 6.567a.5.5 0 0 0 .351.856h1.214V17.5a.5.5 0 0 0 .5.5h2.572a.5.5 0 0 0 .5-.5v-2.885h3.428V17.5a.5.5 0 0 0 .5.5h2.572a.5.5 0 0 0 .5-.5v-4.577H18.5a.5.5 0 0 0 .351-.856L12.5 5.5z"
-                  />
-                </svg>
-                <small
-                  class="c11"
-                >
-                  Dashboard
-                </small>
-              </a>
-              <a
-                class="c9 c10"
-                href="/log"
-                title="Log"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                >
-                  <title>
-                    Log
-                  </title>
-                  <path
-                    clip-rule="evenodd"
-                    d="M10.5 8a.5.5 0 0 1 0-1h6a.5.5 0 0 1 0 1h-6zm6.5 2.5a.5.5 0 0 1-.5.5h-6a.5.5 0 0 1 0-1h6a.5.5 0 0 1 .5.5zm-7 3a.5.5 0 0 0 .5.5h6a.5.5 0 0 0 0-1h-6a.5.5 0 0 0-.5.5zm7 3a.5.5 0 0 1-.5.5h-6a.5.5 0 0 1 0-1h6a.5.5 0 0 1 .5.5zm-10-6a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 0-1h-1a.5.5 0 0 0-.5.5zM7.5 8a.5.5 0 0 1 0-1h1a.5.5 0 0 1 0 1h-1zM7 13.5a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 0-1h-1a.5.5 0 0 0-.5.5zm2 3a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1 0-1h1a.5.5 0 0 1 .5.5z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-                <small
-                  class="c11"
-                >
-                  Log
-                </small>
-              </a>
-              <a
-                class="c9 c12"
-                href="/keychain"
-                title="Keychain"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                >
-                  <title>
-                    Keychain
-                  </title>
-                  <path
-                    clip-rule="evenodd"
-                    d="M9.5 7.667C9.5 6.524 10.562 5.5 12 5.5s2.5 1.024 2.5 2.167V9h-5V7.667zM8.5 9H7a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-8a1 1 0 0 0-1-1h-1.5V7.667C15.5 5.864 13.876 4.5 12 4.5S8.5 5.864 8.5 7.667V9zM7 18h10v-8H7v8zm3-4c0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2-2 .9-2 2z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-                <small
-                  class="c11"
-                >
-                  Keychain
-                </small>
-              </a>
-            </div>
+            />
             <div
-              class="c13"
+              class="c9"
             >
               <a
-                class="c9 c14"
+                class="c10 c11"
                 href="http://localhost:3002/about"
                 title="About"
               >
@@ -39928,13 +39708,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c11"
+                  class="c12"
                 >
                   About
                 </small>
               </a>
               <a
-                class="c9 c14"
+                class="c10 c11"
                 href="http://localhost:3002/jobs"
                 title="Join us"
               >
@@ -39950,13 +39730,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c11"
+                  class="c12"
                 >
                   Join us
                 </small>
               </a>
               <a
-                class="c9 c14"
+                class="c10 c11"
                 href="https://github.com/unlock-protocol/unlock"
                 title="Source Code"
               >
@@ -39970,13 +39750,13 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c11"
+                  class="c12"
                 >
                   Source Code
                 </small>
               </a>
               <a
-                class="c9 c14"
+                class="c10 c11"
                 href="https://t.me/unlockprotocol"
                 title="Telegram"
               >
@@ -39992,17 +39772,17 @@ Object {
                   />
                 </svg>
                 <small
-                  class="c11"
+                  class="c12"
                 >
                   Telegram
                 </small>
               </a>
             </div>
             <div
-              class="c15"
+              class="c13"
             >
               <a
-                class="c9 c16"
+                class="c10 c14"
               >
                 <svg
                   viewBox="0 0 56 42"
@@ -40017,7 +39797,7 @@ Object {
                 
               </a>
               <a
-                class="c9 c16"
+                class="c10 c14"
               >
                 <svg
                   viewBox="0 0 58 32"
@@ -40035,17 +39815,17 @@ Object {
               </a>
             </div>
             <div
-              class="c17"
+              class="c15"
             />
           </header>
           <section
             class=""
           >
             <div
-              class="c18"
+              class="c16"
             >
               <div
-                class="c19"
+                class="c17"
               >
                 <div
                   class="paper"
@@ -40102,36 +39882,36 @@ Object {
                 </div>
               </div>
               <div
-                class="c20"
+                class="c18"
               >
                 Address
                 <span
-                  class="c21"
+                  class="c19"
                   id="NetworkName"
                 >
                   Winston
                 </span>
               </div>
               <div
-                class="c19"
+                class="c17"
               />
               <div
-                class="c19"
+                class="c17"
               />
               <div
-                class="c19"
+                class="c17"
               />
               <div
-                class="c19"
+                class="c17"
               />
               <div
-                class="c19"
+                class="c17"
               />
               <div
-                class="c19"
+                class="c17"
               />
               <div
-                class="c22"
+                class="c20"
                 id="UserAddress"
               >
                 0x3ca206264762caf81a8f0a843bbb850987b41e16
@@ -40140,7 +39920,7 @@ Object {
           </section>
         </div>
         <div
-          class="c23"
+          class="c21"
         />
       </div>
     </div>
@@ -40205,76 +39985,8 @@ Object {
             Key Chain
           </h1>
           <div
-            class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
-          >
-            <a
-              class="sc-850ddk-0 eZjxtV"
-              href="/dashboard"
-              title="Dashboard"
-            >
-              <svg
-                viewBox="0 0 24 24"
-              >
-                <title>
-                  Dashboard
-                </title>
-                <path
-                  d="M12.5 5.5c-.195-.192-.805-.192-1 0l-6.351 6.567a.5.5 0 0 0 .351.856h1.214V17.5a.5.5 0 0 0 .5.5h2.572a.5.5 0 0 0 .5-.5v-2.885h3.428V17.5a.5.5 0 0 0 .5.5h2.572a.5.5 0 0 0 .5-.5v-4.577H18.5a.5.5 0 0 0 .351-.856L12.5 5.5z"
-                />
-              </svg>
-              <small
-                class="sc-850ddk-1 fnqGzL"
-              >
-                Dashboard
-              </small>
-            </a>
-            <a
-              class="sc-850ddk-0 eZjxtV"
-              href="/log"
-              title="Log"
-            >
-              <svg
-                viewBox="0 0 24 24"
-              >
-                <title>
-                  Log
-                </title>
-                <path
-                  clip-rule="evenodd"
-                  d="M10.5 8a.5.5 0 0 1 0-1h6a.5.5 0 0 1 0 1h-6zm6.5 2.5a.5.5 0 0 1-.5.5h-6a.5.5 0 0 1 0-1h6a.5.5 0 0 1 .5.5zm-7 3a.5.5 0 0 0 .5.5h6a.5.5 0 0 0 0-1h-6a.5.5 0 0 0-.5.5zm7 3a.5.5 0 0 1-.5.5h-6a.5.5 0 0 1 0-1h6a.5.5 0 0 1 .5.5zm-10-6a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 0-1h-1a.5.5 0 0 0-.5.5zM7.5 8a.5.5 0 0 1 0-1h1a.5.5 0 0 1 0 1h-1zM7 13.5a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 0-1h-1a.5.5 0 0 0-.5.5zm2 3a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1 0-1h1a.5.5 0 0 1 .5.5z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="sc-850ddk-1 fnqGzL"
-              >
-                Log
-              </small>
-            </a>
-            <a
-              class="sc-850ddk-0 kmwKuX"
-              href="/keychain"
-              title="Keychain"
-            >
-              <svg
-                viewBox="0 0 24 24"
-              >
-                <title>
-                  Keychain
-                </title>
-                <path
-                  clip-rule="evenodd"
-                  d="M9.5 7.667C9.5 6.524 10.562 5.5 12 5.5s2.5 1.024 2.5 2.167V9h-5V7.667zM8.5 9H7a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-8a1 1 0 0 0-1-1h-1.5V7.667C15.5 5.864 13.876 4.5 12 4.5S8.5 5.864 8.5 7.667V9zM7 18h10v-8H7v8zm3-4c0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2-2 .9-2 2z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="sc-850ddk-1 fnqGzL"
-              >
-                Keychain
-              </small>
-            </a>
-          </div>
+            class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
+          />
           <div
             class="sc-1glv5oz-2 bwZQqD"
           >
@@ -40719,7 +40431,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c13 {
@@ -41272,7 +40984,7 @@ Object {
             Key Chain
           </h1>
           <div
-            class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+            class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
           />
           <div
             class="sc-1glv5oz-2 bwZQqD"
@@ -44349,7 +44061,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c10 {
@@ -44837,7 +44549,7 @@ Object {
             </svg>
           </a>
           <div
-            class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+            class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
           />
           <div
             class="sc-1glv5oz-2 bwZQqD"
@@ -45279,7 +44991,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c13 {
@@ -45722,7 +45434,7 @@ Object {
             Unlock Dashboard
           </h1>
           <div
-            class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+            class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
           />
           <div
             class="sc-1glv5oz-2 bwZQqD"
@@ -56500,7 +56212,7 @@ Object {
   -ms-flex-align: center;
   align-items: center;
   height: 100%;
-  grid-template-columns: repeat(4,24px);
+  grid-template-columns: repeat(3,24px);
 }
 
 .c15 {
@@ -56939,29 +56651,6 @@ Object {
                   Log
                 </small>
               </a>
-              <a
-                class="c9 c10"
-                href="/keychain"
-                title="Keychain"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                >
-                  <title>
-                    Keychain
-                  </title>
-                  <path
-                    clip-rule="evenodd"
-                    d="M9.5 7.667C9.5 6.524 10.562 5.5 12 5.5s2.5 1.024 2.5 2.167V9h-5V7.667zM8.5 9H7a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-8a1 1 0 0 0-1-1h-1.5V7.667C15.5 5.864 13.876 4.5 12 4.5S8.5 5.864 8.5 7.667V9zM7 18h10v-8H7v8zm3-4c0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2-2 .9-2 2z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-                <small
-                  class="c11"
-                >
-                  Keychain
-                </small>
-              </a>
             </div>
             <div
               class="c13"
@@ -57344,7 +57033,7 @@ Object {
             Creator Log
           </h1>
           <div
-            class="sc-1glv5oz-2 sc-1glv5oz-3 joPXDX"
+            class="sc-1glv5oz-2 sc-1glv5oz-3 kcmgLk"
           >
             <a
               class="sc-850ddk-0 eZjxtV"
@@ -57388,29 +57077,6 @@ Object {
                 class="sc-850ddk-1 fnqGzL"
               >
                 Log
-              </small>
-            </a>
-            <a
-              class="sc-850ddk-0 eZjxtV"
-              href="/keychain"
-              title="Keychain"
-            >
-              <svg
-                viewBox="0 0 24 24"
-              >
-                <title>
-                  Keychain
-                </title>
-                <path
-                  clip-rule="evenodd"
-                  d="M9.5 7.667C9.5 6.524 10.562 5.5 12 5.5s2.5 1.024 2.5 2.167V9h-5V7.667zM8.5 9H7a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-8a1 1 0 0 0-1-1h-1.5V7.667C15.5 5.864 13.876 4.5 12 4.5S8.5 5.864 8.5 7.667V9zM7 18h10v-8H7v8zm3-4c0 1.1.9 2 2 2s2-.9 2-2-.9-2-2-2-2 .9-2 2z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <small
-                class="sc-850ddk-1 fnqGzL"
-              >
-                Keychain
               </small>
             </a>
           </div>

--- a/unlock-app/src/components/interface/Header.js
+++ b/unlock-app/src/components/interface/Header.js
@@ -61,11 +61,6 @@ const appButtons = [
     page: '/settings',
     allowedUsers: [accountTypes.managed],
   },
-  {
-    Button: PageNavButtons.KeyChain,
-    page: '/keychain',
-    allowedUsers: [accountTypes.crypto, accountTypes.managed],
-  },
 ]
 
 export const mapStateToProps = ({


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Until we have some page content on the keychain, we shouldn't make it navigable. Making the keychain nice is on the tasklist, but we shouldn't hold up releasing V1 for it. This PR simply removes it from the header for now.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
