### PR TITLE
Remove _redirects copy as it doesn't exist anymore

### DIFF
--- a/unlock-protocol.com/next.config.js
+++ b/unlock-protocol.com/next.config.js
@@ -61,12 +61,6 @@ module.exports = withTypescript({
         join(dir, 'static', 'humans.txt'),
         join(outDir, 'humans.txt')
       )
-
-      // Export _redirects which is used by netlify for URL rewrites
-      await copyFile(
-        join(dir, 'static', '_redirects'),
-        join(outDir, '_redirects')
-      )
     }
 
     // Our statically-defined pages to export


### PR DESCRIPTION
# Description

We no longer have a _redirects file, so let's not try to copy it.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
