### PR TITLE
Fixing account header to not push mobile width beyond 100%

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -58,7 +58,7 @@ Object {
   .c0 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
-    grid-template-columns: 45px 145px repeat(2,80px);
+    grid-template-columns: 45px 145px repeat(2,0px);
   }
 }
 
@@ -184,7 +184,7 @@ Object {
       class="sc-ksYbfQ jHwjmi"
     >
       <div
-        class="sc-frDJqD dFqKry"
+        class="sc-frDJqD geJjYR"
       >
         <div
           class="sc-kvZOFW bNXwYv"
@@ -401,7 +401,7 @@ Object {
   .c0 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
-    grid-template-columns: 45px 145px repeat(2,80px);
+    grid-template-columns: 45px 145px repeat(2,0px);
   }
 }
 
@@ -527,7 +527,7 @@ Object {
       class="sc-ksYbfQ jHwjmi"
     >
       <div
-        class="sc-frDJqD dFqKry"
+        class="sc-frDJqD geJjYR"
       >
         <div
           class="sc-kvZOFW bNXwYv"
@@ -26496,7 +26496,7 @@ Object {
   .c19 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
-    grid-template-columns: 45px 145px repeat(2,80px);
+    grid-template-columns: 45px 145px repeat(2,0px);
   }
 }
 
@@ -27975,7 +27975,7 @@ Object {
             class="sc-ksYbfQ jHwjmi"
           >
             <div
-              class="sc-frDJqD dFqKry"
+              class="sc-frDJqD geJjYR"
             >
               <div
                 class="sc-kvZOFW bNXwYv"
@@ -29828,7 +29828,7 @@ Object {
   .c22 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
-    grid-template-columns: 45px 145px repeat(2,80px);
+    grid-template-columns: 45px 145px repeat(2,0px);
   }
 }
 
@@ -31339,7 +31339,7 @@ Object {
             class="sc-ksYbfQ jHwjmi"
           >
             <div
-              class="sc-frDJqD dFqKry"
+              class="sc-frDJqD geJjYR"
             >
               <div
                 class="sc-kvZOFW bNXwYv"
@@ -39615,7 +39615,7 @@ Object {
   .c16 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
-    grid-template-columns: 45px 145px repeat(2,80px);
+    grid-template-columns: 45px 145px repeat(2,0px);
   }
 }
 
@@ -40122,7 +40122,7 @@ Object {
           class="sc-ksYbfQ jHwjmi"
         >
           <div
-            class="sc-frDJqD dFqKry"
+            class="sc-frDJqD geJjYR"
           >
             <div
               class="sc-kvZOFW bNXwYv"
@@ -56529,7 +56529,7 @@ Object {
   .c19 {
     -webkit-column-gap: 2px;
     column-gap: 2px;
-    grid-template-columns: 45px 145px repeat(2,80px);
+    grid-template-columns: 45px 145px repeat(2,0px);
   }
 }
 
@@ -57218,7 +57218,7 @@ Object {
             class="sc-ksYbfQ jHwjmi"
           >
             <div
-              class="sc-frDJqD dFqKry"
+              class="sc-frDJqD geJjYR"
             >
               <div
                 class="sc-kvZOFW bNXwYv"

--- a/unlock-app/src/components/interface/Account.tsx
+++ b/unlock-app/src/components/interface/Account.tsx
@@ -64,7 +64,7 @@ const AccountDetails = styled.div`
   grid-template-columns: 40px 200px repeat(2, 100px) repeat(3, 24px) 1fr;
   ${Media.phone`
     column-gap: 2px;
-    grid-template-columns: 45px 145px repeat(2, 80px);
+    grid-template-columns: 45px 145px repeat(2, 0px);
   `};
 `
 


### PR DESCRIPTION
# Description

The account header was making the dashboard scroll horizontally on mobile. I noticed this while testing with Metamask iOS. This PR brings down the size of some empty grid items to achieve this.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

Before:

<img width="302" alt="Screen Shot 2019-07-25 at 3 21 11 PM" src="https://user-images.githubusercontent.com/624104/61915693-910b3a80-aefa-11e9-9baf-7428184d9a58.png">

After:

<img width="413" alt="Screen Shot 2019-07-25 at 3 51 54 PM" src="https://user-images.githubusercontent.com/624104/61915696-96688500-aefa-11e9-87f7-71d650dd9fad.png">
