### PR TITLE
Show and hide checkout iframe based on account iframe visibility

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
@@ -74,6 +74,7 @@ describe('setupPostOffice', () => {
   let fakeDataIframe: MockIframe
   let fakeUIIframe: MockIframe
   let fakeAccountIframe: MockIframe
+  let visibleFakeAccountIframe: MockIframe
 
   function sendMessage(
     source: MockIframe,
@@ -176,6 +177,16 @@ describe('setupPostOffice', () => {
     }
     fakeAccountIframe = {
       className: 'unlock start',
+      setAttribute: jest.fn(),
+      src: 'http://unlock-app.com/account',
+      origin: unlockOrigin,
+      contentWindow: {
+        Iam: 'account',
+        postMessage: jest.fn(),
+      },
+    }
+    visibleFakeAccountIframe = {
+      className: 'unlock start show',
       setAttribute: jest.fn(),
       src: 'http://unlock-app.com/account',
       origin: unlockOrigin,
@@ -287,6 +298,34 @@ describe('setupPostOffice', () => {
     sendMessage(fakeUIIframe, PostMessages.READY)
 
     expect(fakeUIIframe.className).toBe('unlock start show')
+  })
+
+  it('does not show the checkout UI on PostMessages.READY if the account iframe is visible', () => {
+    expect.assertions(1)
+
+    makeFakeWindow()
+    fakeWindow.unlockProtocolConfig = {
+      type: 'paywall',
+      locks: {},
+      callToAction: {
+        default: '',
+        expired: '',
+        pending: '',
+        confirmed: '',
+      },
+    }
+
+    // we will use the normalized config from the beforeEach, this ensures we use our own
+    setupPostOffices(
+      fakeWindow,
+      fakeDataIframe,
+      fakeUIIframe,
+      visibleFakeAccountIframe
+    )
+
+    sendMessage(fakeUIIframe, PostMessages.READY)
+
+    expect(fakeUIIframe.className).toBe('unlock start')
   })
 
   it('responds to PostMessages.UNLOCKED by sending unlocked to the UI iframe', () => {

--- a/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
+++ b/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
@@ -250,7 +250,7 @@ describe('web3Proxy', () => {
       })
 
       it('should hide the accounts iframe', async () => {
-        expect.assertions(1)
+        expect.assertions(2)
 
         postFromAccountIframe({
           source: fakeAccountIframe.contentWindow,
@@ -262,6 +262,7 @@ describe('web3Proxy', () => {
         })
 
         expect(fakeAccountIframe.className).toBe('unlock start')
+        expect(fakeCheckoutIframe.className).toBe('unlock start show')
       })
     })
 
@@ -295,8 +296,8 @@ describe('web3Proxy', () => {
         })
       })
 
-      it('should show the iframe if there are any erc20 locks', async () => {
-        expect.assertions(1)
+      it('should show the account iframe and hide the checkout iframe if there are any erc20 locks', async () => {
+        expect.assertions(2)
 
         postFromDataIframe({
           source: fakeIframe.contentWindow,
@@ -317,6 +318,7 @@ describe('web3Proxy', () => {
         })
 
         expect(fakeAccountIframe.className).toBe('unlock start show')
+        expect(fakeCheckoutIframe.className).toBe('unlock start')
       })
 
       it('should not show the iframe if there are no erc20 locks', async () => {
@@ -423,9 +425,9 @@ describe('web3Proxy', () => {
         })
       })
 
-      it('should show the account iframe if there are erc20 locks', async () => {
+      it('should show the account iframe and hide the checkout iframe if there are erc20 locks', async () => {
         // if this test fails due to "too many assertions", uncomment the debug line in web3Proxy.ts
-        expect.assertions(1)
+        expect.assertions(2)
 
         delete fakeWindow.web3
 
@@ -452,6 +454,7 @@ describe('web3Proxy', () => {
         // wait for the iframe to be shown
         await waitFor(() => fakeAccountIframe.className)
         expect(fakeAccountIframe.className).toBe('unlock start show')
+        expect(fakeCheckoutIframe.className).toBe('unlock start')
       })
 
       it('if the account iframe loads before locks, it should show the account iframe if there are erc20 locks', async () => {

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -167,8 +167,16 @@ export default function setupPostOffices(
           send('data', PostMessages.SEND_UPDATES, 'balance')
           send('data', PostMessages.SEND_UPDATES, 'locks')
           if (normalizedConfig && normalizedConfig.type === 'paywall') {
-            // always show the checkout modal on start for the paywall app
-            showIframe(window, CheckoutUIIframe)
+            // This is a temporary hack to check if the account iframe is
+            // visible. Sometimes it's ready before the checkout iframe is, so
+            // the UI can end up in a state where both iframes are visible. This
+            // condition makes sure we only show the checkout iframe when the
+            // account iframe is not there.
+            const accountIsVisible =
+              AccountUIIframe.className === 'unlock start show'
+            if (!accountIsVisible) {
+              showIframe(window, CheckoutUIIframe)
+            }
           }
         }
       }

--- a/paywall/src/unlock.js/web3Proxy.ts
+++ b/paywall/src/unlock.js/web3Proxy.ts
@@ -158,7 +158,7 @@ export default function web3Proxy(
     [PostMessages.SHOW_ACCOUNTS_MODAL]: (
       _postMessage,
       _dataIframe,
-      _checkoutIframe,
+      checkoutIframe,
       accountIframe
     ) => {
       return () => {
@@ -172,23 +172,26 @@ export default function web3Proxy(
         }
         if (canUseUserAccounts) {
           showIframe(window, accountIframe)
+          hideIframe(window, checkoutIframe)
         }
       }
     },
     [PostMessages.HIDE_ACCOUNTS_MODAL]: (
       _postMessage,
       _dataIframe,
-      _checkoutIframe,
+      checkoutIframe,
       accountIframe
     ) => {
       return () => {
         hideIframe(window, accountIframe)
+        showIframe(window, checkoutIframe)
       }
     },
   }
 
   const checkForUserAccountWallet = async (
     accountIframe: IframeType,
+    checkoutIframe: IframeType,
     postMessage: PostMessageToIframe<MessageTypes>
   ) => {
     // we don't have web3
@@ -225,6 +228,7 @@ export default function web3Proxy(
     } else if (canUseUserAccounts && !proxyAccount) {
       // show the login form if the user is not logged in
       showIframe(window, accountIframe)
+      hideIframe(window, checkoutIframe)
     }
     hasWeb3 = true
     postMessage('data', PostMessages.WALLET_INFO, {
@@ -238,7 +242,7 @@ export default function web3Proxy(
     [PostMessages.UPDATE_LOCKS]: (
       _postMessage,
       _dataIframe,
-      _checkoutIframe,
+      checkoutIframe,
       accountIframe
     ) => {
       return locks => {
@@ -254,6 +258,7 @@ export default function web3Proxy(
         if (canUseUserAccounts && locks && Object.keys(locks).length) {
           if (showIframeWhenReady) {
             showIframe(window, accountIframe)
+            hideIframe(window, checkoutIframe)
             // turn the flag off, we don't want to re-open the user accounts iframe
             // every time the locks change
             showIframeWhenReady = false
@@ -264,7 +269,7 @@ export default function web3Proxy(
     [PostMessages.READY_WEB3]: (
       postMessage,
       _dataIframe,
-      _checkoutIframe,
+      checkoutIframe,
       accountIframe
     ) => {
       return async () => {
@@ -279,7 +284,11 @@ export default function web3Proxy(
         try {
           const result = await enable(window)
           if (result === NO_WEB3) {
-            checkForUserAccountWallet(accountIframe, postMessage)
+            checkForUserAccountWallet(
+              accountIframe,
+              checkoutIframe,
+              postMessage
+            )
             return
           }
           hasWeb3 = true


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR is an attempt to fix the clash between the checkout iframe and account iframe on the paywall.


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
