### PR TITLE
Purchaser should not pass a value of a key(spend eth)

### DIFF
--- a/locksmith/__tests__/fulfillment/dispatcher.test.ts
+++ b/locksmith/__tests__/fulfillment/dispatcher.test.ts
@@ -84,7 +84,7 @@ describe('Dispatcher', () => {
         expect(mockWalletService.purchaseKey).toHaveBeenCalledWith(
           lockAddress,
           recipient,
-          '0.01',
+          '0',
           buyer
         )
       })

--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -65,11 +65,6 @@ export default class Dispatcher {
     )
 
     await walletService.connect(this.provider)
-    await walletService.purchaseKey(
-      lockAddress,
-      recipient,
-      lock.keyPrice,
-      this.buyer
-    )
+    await walletService.purchaseKey(lockAddress, recipient, '0', this.buyer)
   }
 }


### PR DESCRIPTION
# Description

A fix to a bug found while live testing the integration on staging. Our purchaser should not send eth for ERC20 Key purchases

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
