### PR TITLE
Support double digit params in the deployment script

### DIFF
--- a/locksmith/scripts/deploy-elasticbeanstalk-docker.sh
+++ b/locksmith/scripts/deploy-elasticbeanstalk-docker.sh
@@ -8,8 +8,8 @@ node_env=$7
 is_forked_pr=$8
 build_id=$9
 message="${10}"
-stripe_secret=$11
-purchaser_credentials=$12
+stripe_secret=${11}
+purchaser_credentials=${12}
 
 function check_is_forked_pr()
 {


### PR DESCRIPTION
# Description

We noticed the we had a few environment variable not being passed to the Elastic Beanstalk environment.  Double digit params require {}

https://stackoverflow.com/questions/18318716/why-do-bash-command-line-arguments-after-9-require-curly-brackets


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
