### PR TITLE
A grey background for the account iframe

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -923,10 +923,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-kAzzGY eXxQeO"
+      class="sc-kAzzGY guDuMp"
     >
       <div
-        class="sc-cSHVUG jIhLkm"
+        class="sc-cSHVUG bCBeAO"
       >
         <a
           class="sc-fAjcbJ glPBrL sc-850ddk-0 eZjxtV"

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -736,6 +736,7 @@ Object {
 }
 
 .c0 {
+  background: rgba(0,0,0,0.4) none repeat scroll 0% 0%;
   position: fixed;
   height: 100%;
   width: 100%;
@@ -922,10 +923,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-kAzzGY cxOjox"
+      class="sc-kAzzGY eXxQeO"
     >
       <div
-        class="sc-cSHVUG bCBeAO"
+        class="sc-cSHVUG jIhLkm"
       >
         <a
           class="sc-fAjcbJ glPBrL sc-850ddk-0 eZjxtV"

--- a/unlock-app/src/components/interface/user-account/styles.tsx
+++ b/unlock-app/src/components/interface/user-account/styles.tsx
@@ -190,6 +190,7 @@ export const IframeLayout = styled.div`
 `
 
 export const XYCenter = styled.div`
+  background: rgba(0, 0, 0, 0.4) none repeat scroll 0% 0%;
   position: fixed;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
Now that the checkout iframe gets out of the way, the account iframe needs its own grey background. This PR adds it.

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/9300702/62160580-4ca8e180-b2e2-11e9-8bca-cdb75fe96b62.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
