### PR TITLE
Prevent checkout from automatically displaying while using a browser wallet

### DIFF
--- a/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
+++ b/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
@@ -1092,6 +1092,26 @@ describe('web3Proxy', () => {
         },
       })
     })
+
+    it('should ignore the HIDE_ACCOUNTS_MODAL postmessage', () => {
+      expect.assertions(2)
+      const startingAccountIframeClassName = fakeAccountIframe.className
+      const startingCheckoutIframeClassName = fakeCheckoutIframe.className
+
+      web3Proxy(fakeWindow, mapHandlers)
+
+      postFromAccountIframe({
+        source: fakeAccountIframe.contentWindow,
+        origin: 'http://fun.times',
+        data: {
+          type: PostMessages.HIDE_ACCOUNTS_MODAL,
+          payload: undefined,
+        },
+      })
+
+      expect(fakeAccountIframe.className).toBe(startingAccountIframeClassName)
+      expect(fakeCheckoutIframe.className).toBe(startingCheckoutIframeClassName)
+    })
   })
 
   describe('enable fails', () => {

--- a/paywall/src/unlock.js/web3Proxy.ts
+++ b/paywall/src/unlock.js/web3Proxy.ts
@@ -183,8 +183,12 @@ export default function web3Proxy(
       accountIframe
     ) => {
       return () => {
-        hideIframe(window, accountIframe)
-        showIframe(window, checkoutIframe)
+        // Need to check for canUseUserAccounts here because otherwise this will
+        // run when using metamask, causing the checkoutIframe to always appear
+        if (canUseUserAccounts) {
+          hideIframe(window, accountIframe)
+          showIframe(window, checkoutIframe)
+        }
       }
     },
   }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR should fix the issue with non-paywall paywalls automatically launching the checkout UI by filtering the `HIDE_ACCOUNTS_MODAL` postMessage to only happen when we're actually using user accounts. Future work (assuming that the account iframe will continue to be present) should include applying this filtering at a higher level, since none of the messages that `web3proxy` handles should apply when we have a browser wallet.

(I'll see if I can write a regression test real quick before we merge this)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4333 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
