### PR TITLE
moving normalizeConfig outside of setupPostOffices so we can use it to determine whether we should load the account iframe

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
@@ -195,7 +195,9 @@ describe('setupPostOffice', () => {
         postMessage: jest.fn(),
       },
     }
+
     setupPostOffices(
+      fakeWindow.unlockProtocolConfig,
       fakeWindow,
       fakeDataIframe,
       fakeUIIframe,
@@ -276,7 +278,7 @@ describe('setupPostOffice', () => {
     expect.assertions(1)
 
     makeFakeWindow()
-    fakeWindow.unlockProtocolConfig = {
+    const config = normalizeConfig({
       type: 'paywall',
       locks: {},
       callToAction: {
@@ -285,10 +287,11 @@ describe('setupPostOffice', () => {
         pending: '',
         confirmed: '',
       },
-    }
+    })
 
     // we will use the normalized config from the beforeEach, this ensures we use our own
     setupPostOffices(
+      config,
       fakeWindow,
       fakeDataIframe,
       fakeUIIframe,
@@ -304,7 +307,7 @@ describe('setupPostOffice', () => {
     expect.assertions(1)
 
     makeFakeWindow()
-    fakeWindow.unlockProtocolConfig = {
+    const config = normalizeConfig({
       type: 'paywall',
       locks: {},
       callToAction: {
@@ -313,10 +316,11 @@ describe('setupPostOffice', () => {
         pending: '',
         confirmed: '',
       },
-    }
+    })
 
     // we will use the normalized config from the beforeEach, this ensures we use our own
     setupPostOffices(
+      config,
       fakeWindow,
       fakeDataIframe,
       fakeUIIframe,

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -46,6 +46,7 @@ export function normalizeConfig(unlockConfig: any) {
  *                                  (created by document.createElement)
  */
 export default function setupPostOffices(
+  normalizedConfig: any,
   window: UnlockWindow,
   dataIframe: IframeType,
   CheckoutUIIframe: IframeType,
@@ -62,7 +63,6 @@ export default function setupPostOffices(
     window,
     CheckoutUIIframe
   )
-  const normalizedConfig = normalizeConfig(window.unlockProtocolConfig)
 
   const dataHandlers: MessageHandlerTemplates<MessageTypes> = {
     [PostMessages.READY]: send => {

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -1,5 +1,5 @@
 import { makeIframe, addIframeToDocument } from './iframeManager'
-import setupPostOffices from './setupPostOffices'
+import setupPostOffices, { normalizeConfig } from './setupPostOffices'
 import dispatchEvent from './dispatchEvent'
 import { UnlockWindow } from '../windowTypes'
 
@@ -23,6 +23,9 @@ export default function startup(window: UnlockWindow) {
     dispatchEvent(window, 'unlocked')
   }
 
+  // Get the config
+  const normalizedConfig = normalizeConfig(window.unlockProtocolConfig)
+
   const origin = '?origin=' + encodeURIComponent(window.origin)
 
   const dataIframe = makeIframe(
@@ -33,6 +36,7 @@ export default function startup(window: UnlockWindow) {
     window,
     process.env.PAYWALL_URL + '/checkout' + origin
   )
+  // TODO: We should not load the iframe for user account is the configuration does not mention it
   const userAccountsIframe = makeIframe(
     window,
     process.env.USER_IFRAME_URL + origin
@@ -41,5 +45,11 @@ export default function startup(window: UnlockWindow) {
   addIframeToDocument(window, userAccountsIframe)
   addIframeToDocument(window, checkoutIframe)
 
-  setupPostOffices(window, dataIframe, checkoutIframe, userAccountsIframe)
+  setupPostOffices(
+    normalizedConfig,
+    window,
+    dataIframe,
+    checkoutIframe,
+    userAccountsIframe
+  )
 }


### PR DESCRIPTION
# Description

This is the first step to make sure that the config is available in the startup script so that we do not load the user accountSettingif we do not need to.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread