### PR TITLE
adding unlockUserAccounts to config validation

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -586,6 +586,86 @@ describe('Form field validators', () => {
           ).toBe(false)
         })
       })
+
+      describe('unlockUserAccounts', () => {
+        it('unlockUserAccounts is missing', () => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+            })
+          ).toBe(true)
+        })
+
+        it('unlockUserAccounts is true', () => {
+          expect.assertions(2)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: true,
+            })
+          ).toBe(true)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: 'true',
+            })
+          ).toBe(true)
+        })
+
+        it('unlockUserAccounts is false', () => {
+          expect.assertions(2)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: false,
+            })
+          ).toBe(true)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: 'false',
+            })
+          ).toBe(true)
+        })
+
+        it('unlockUserAccounts is not a boolean', () => {
+          expect.assertions(4)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: 'hello',
+            })
+          ).toBe(false)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: [],
+            })
+          ).toBe(false)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: 7,
+            })
+          ).toBe(false)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: {},
+            })
+          ).toBe(false)
+        })
+      })
     })
 
     describe('valid cases', () => {

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -108,6 +108,17 @@ export const isValidPaywallConfig = config => {
   ) {
     return false
   }
+  if (
+    config.unlockUserAccounts &&
+    !(
+      typeof config.unlockUserAccounts === 'boolean' ||
+      config.unlockUserAccounts === 'true' ||
+      config.unlockUserAccounts === 'false'
+    )
+  ) {
+    return false
+  }
+
   return true
 }
 


### PR DESCRIPTION
# Description

This option will let implementers decide whether they want to use our user accounts... or stay with crypto only!


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread