### PR TITLE
Add getState() to window.unlockProtocol

### DIFF
--- a/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
+++ b/paywall/src/__tests__/unlock.js/setupPostOffices.test.ts
@@ -102,6 +102,7 @@ describe('setupPostOffice', () => {
       setInterval: jest.fn(),
       unlockProtocol: {
         loadCheckoutModal: jest.fn(),
+        getState: jest.fn(),
       },
       document: {
         createEvent: jest.fn(),

--- a/paywall/src/__tests__/unlock.js/setupUnlockProtocolVariable.test.ts
+++ b/paywall/src/__tests__/unlock.js/setupUnlockProtocolVariable.test.ts
@@ -1,10 +1,19 @@
 import setupUnlockProtocolVariable, {
   UnlockAndIframeManagerWindow,
 } from '../../unlock.js/setupUnlockProtocolVariable'
-import { IframeType, IframeManagingWindow } from '../../windowTypes'
+import {
+  IframeType,
+  IframeManagingWindow,
+  AddEventListenerFunc,
+} from '../../windowTypes'
+
+interface IframeManagingWindowWithAddEventListener
+  extends IframeManagingWindow {
+  addEventListener: AddEventListenerFunc
+}
 
 describe('setupUnlockProtocolVariable', () => {
-  let fakeWindow: IframeManagingWindow
+  let fakeWindow: IframeManagingWindowWithAddEventListener
   let fakeCheckoutUIIframe: IframeType
 
   beforeEach(() => {
@@ -20,6 +29,7 @@ describe('setupUnlockProtocolVariable', () => {
         },
       },
       setInterval: jest.fn(),
+      addEventListener: jest.fn(),
     }
     fakeCheckoutUIIframe = {
       contentWindow: {
@@ -38,7 +48,7 @@ describe('setupUnlockProtocolVariable', () => {
       fakeWindow as UnlockAndIframeManagerWindow,
       fakeCheckoutUIIframe
     )
-    const resultWindow: UnlockAndIframeManagerWindow = fakeWindow as UnlockAndIframeManagerWindow
+    const resultWindow = fakeWindow as UnlockAndIframeManagerWindow
 
     expect(resultWindow.unlockProtocol).not.toBeUndefined()
   })
@@ -50,11 +60,24 @@ describe('setupUnlockProtocolVariable', () => {
       fakeWindow as UnlockAndIframeManagerWindow,
       fakeCheckoutUIIframe
     )
-    const resultWindow: UnlockAndIframeManagerWindow = fakeWindow as UnlockAndIframeManagerWindow
+    const resultWindow = fakeWindow as UnlockAndIframeManagerWindow
 
     expect(resultWindow.unlockProtocol.loadCheckoutModal).toBeInstanceOf(
       Function
     )
+  })
+
+  it('should set a getState function on the window.unlockProtocol object, which initially returns undefined', () => {
+    expect.assertions(2)
+
+    setupUnlockProtocolVariable(
+      fakeWindow as UnlockAndIframeManagerWindow,
+      fakeCheckoutUIIframe
+    )
+    const resultWindow = fakeWindow as UnlockAndIframeManagerWindow
+
+    expect(resultWindow.unlockProtocol.getState).toBeInstanceOf(Function)
+    expect(resultWindow.unlockProtocol.getState()).toBeUndefined()
   })
 
   it('should not allow setting new variables on the unlockProtocol object', () => {
@@ -67,10 +90,11 @@ describe('setupUnlockProtocolVariable', () => {
     interface MockWindowWithHi extends UnlockAndIframeManagerWindow {
       unlockProtocol: {
         loadCheckoutModal: () => void
+        getState: () => undefined
         hi: number
       }
     }
-    const resultWindow: MockWindowWithHi = fakeWindow as MockWindowWithHi
+    const resultWindow = fakeWindow as MockWindowWithHi
 
     expect(() => {
       resultWindow.unlockProtocol.hi = 1
@@ -84,7 +108,7 @@ describe('setupUnlockProtocolVariable', () => {
       fakeWindow as UnlockAndIframeManagerWindow,
       fakeCheckoutUIIframe
     )
-    const resultWindow: UnlockAndIframeManagerWindow = fakeWindow as UnlockAndIframeManagerWindow
+    const resultWindow = fakeWindow as UnlockAndIframeManagerWindow
 
     expect(() => {
       resultWindow.unlockProtocol.loadCheckoutModal = () => {}
@@ -99,7 +123,7 @@ describe('setupUnlockProtocolVariable', () => {
       fakeCheckoutUIIframe
     )
 
-    const resultWindow: UnlockAndIframeManagerWindow = fakeWindow as UnlockAndIframeManagerWindow
+    const resultWindow = fakeWindow as UnlockAndIframeManagerWindow
 
     resultWindow.unlockProtocol.loadCheckoutModal()
     expect(fakeCheckoutUIIframe.className).toBe('unlock start show')
@@ -113,7 +137,7 @@ describe('setupUnlockProtocolVariable', () => {
       fakeCheckoutUIIframe
     )
 
-    const resultWindow: UnlockAndIframeManagerWindow = fakeWindow as UnlockAndIframeManagerWindow
+    const resultWindow = fakeWindow as UnlockAndIframeManagerWindow
 
     resultWindow.unlockProtocol.loadCheckoutModal()
     expect(fakeCheckoutUIIframe.className).toBe('unlock start show')

--- a/paywall/src/__tests__/unlock.js/startup.test.js
+++ b/paywall/src/__tests__/unlock.js/startup.test.js
@@ -169,12 +169,14 @@ describe('unlock.js startup', () => {
 
     startup(fakeWindow)
 
-    // this is a simple way to test whether setupPostOffices was called
-    // by checking to see if event listeners for postMessage were set up
-    // The 3 are:
+    // this is a simple way to test whether setupPostOffices was
+    // called by checking to see if event listeners for postMessage
+    // and state were set up
+    // The 4 are:
     // - the data iframe post office (used for web3Proxy as well)
     // - the checkout UI post office
     // - the user accounts UI post office
-    expect(fakeWindow.addEventListener).toHaveBeenCalledTimes(3)
+    // - getState (locked, unlocked, undefined)
+    expect(fakeWindow.addEventListener).toHaveBeenCalledTimes(4)
   })
 })

--- a/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
+++ b/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
@@ -55,6 +55,7 @@ describe('web3Proxy', () => {
       dispatchEvent: jest.fn(),
       unlockProtocol: {
         loadCheckoutModal: jest.fn(),
+        getState: jest.fn(),
       },
       setInterval: jest.fn(),
       localStorage: {

--- a/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
+++ b/paywall/src/__tests__/unlock.js/web3Proxy.test.ts
@@ -18,6 +18,7 @@ describe('web3Proxy', () => {
   let handlers: {
     message: Array<(message: any) => void>
     storage: Array<(message: any) => void>
+    unlockProtocol: Array<(message: any) => void>
   }
   let mapHandlers: MapHandlers
   let fakeCheckoutIframe: IframeType
@@ -43,6 +44,7 @@ describe('web3Proxy', () => {
     handlers = {
       message: [],
       storage: [],
+      unlockProtocol: [],
     }
     process.env.PAYWALL_URL = 'http://fun.times'
     process.env.USER_IFRAME_URL = 'http://fun.times/account'

--- a/paywall/src/unlock.js/setupUnlockProtocolVariable.ts
+++ b/paywall/src/unlock.js/setupUnlockProtocolVariable.ts
@@ -1,8 +1,10 @@
 import { showIframe, hideIframe } from './iframeManager'
 import {
+  EventTypes,
   IframeManagingWindow,
-  UnlockProtocolWindow,
   IframeType,
+  LockStatus,
+  UnlockProtocolWindow,
 } from '../windowTypes'
 
 interface hasPrototype {
@@ -12,6 +14,13 @@ interface hasPrototype {
 export interface UnlockAndIframeManagerWindow
   extends IframeManagingWindow,
     UnlockProtocolWindow {}
+
+// lockStatus holds the current state of the lock. It is undefined when we
+// haven't yet determined whether the paywall is locked or unlocked (typically
+// for a short period right after the page loads).
+// lockStatus is _never_ used to make decisions within the paywall, it is simply
+// a user-facing way to query the current state of the paywall
+let lockStatus: LockStatus = undefined
 
 export default function setupUnlockProtocolVariable(
   window: UnlockAndIframeManagerWindow,
@@ -23,8 +32,14 @@ export default function setupUnlockProtocolVariable(
   const hideCheckoutModal = () => {
     hideIframe(window, CheckoutUIIframe)
   }
+  const getState = () => lockStatus
 
   const unlockProtocol: hasPrototype = {}
+
+  // Update the user-facing status with locked/unlocked updates
+  window.addEventListener(EventTypes.UNLOCK, ({ detail }) => {
+    lockStatus = detail
+  })
 
   Object.defineProperties(unlockProtocol, {
     loadCheckoutModal: {
@@ -32,6 +47,12 @@ export default function setupUnlockProtocolVariable(
       writable: false, // prevent changing loadCheckoutModal by simple `unlockProtocol.loadCheckoutModal = () => {}`
       configurable: false, // prevent re-defining the writable property
       enumerable: false, // prevent finding it exists via `for ... of`
+    },
+    getState: {
+      value: getState,
+      writable: false,
+      configurable: false,
+      enumerable: false,
     },
   })
 

--- a/paywall/src/unlock.js/setupUnlockProtocolVariable.ts
+++ b/paywall/src/unlock.js/setupUnlockProtocolVariable.ts
@@ -15,11 +15,12 @@ export interface UnlockAndIframeManagerWindow
   extends IframeManagingWindow,
     UnlockProtocolWindow {}
 
-// lockStatus holds the current state of the lock. It is undefined when we
-// haven't yet determined whether the paywall is locked or unlocked (typically
-// for a short period right after the page loads).
-// lockStatus is _never_ used to make decisions within the paywall, it is simply
-// a user-facing way to query the current state of the paywall
+// lockStatus holds the current state of the lock, and is only ever updated by
+// the event listener defined in `setupUnlockProtocolVariable`. It is undefined
+// when we haven't yet determined whether the paywall is locked or unlocked
+// (typically for a short period right after the page loads).  lockStatus is
+// _never_ used to make decisions within the paywall, it is simply a user-facing
+// way to query the current state of the paywall
 let lockStatus: LockStatus = undefined
 
 export default function setupUnlockProtocolVariable(

--- a/paywall/src/unlock.js/setupUnlockProtocolVariable.ts
+++ b/paywall/src/unlock.js/setupUnlockProtocolVariable.ts
@@ -15,12 +15,11 @@ export interface UnlockAndIframeManagerWindow
   extends IframeManagingWindow,
     UnlockProtocolWindow {}
 
-// lockStatus holds the current state of the lock, and is only ever updated by
-// the event listener defined in `setupUnlockProtocolVariable`. It is undefined
-// when we haven't yet determined whether the paywall is locked or unlocked
-// (typically for a short period right after the page loads).  lockStatus is
-// _never_ used to make decisions within the paywall, it is simply a user-facing
-// way to query the current state of the paywall
+// lockStatus is a private variable that is only ever set by the event listener
+// defined in setupUnlockProtocolVariable.
+// lockStatus is _never_ used to make decisions withing the paywall, it is simply
+// a convenience that allows users to query to state of the paywall.
+// The undefined state should only occur for a brief period when the page first loads.
 let lockStatus: LockStatus = undefined
 
 export default function setupUnlockProtocolVariable(

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -38,11 +38,13 @@ export interface EventWindow {
 export enum EventTypes {
   STORAGE = 'storage',
   MESSAGE = 'message',
+  UNLOCK = 'unlockProtocol',
 }
 
 export interface MappedEvents {
   [EventTypes.STORAGE]: StorageEvent
   [EventTypes.MESSAGE]: MessageEvent
+  [EventTypes.UNLOCK]: UnlockProtocolEvent
 }
 
 export type ExtractEvent<T extends EventTypes> = MappedEvents[T]
@@ -125,6 +127,13 @@ export interface StorageEvent {
   storageArea: any
 }
 
+export type LockStatus = 'locked' | 'unlocked' | undefined
+
+// used in setupUnlockProtocolVariable
+export interface UnlockProtocolEvent {
+  detail: LockStatus
+}
+
 export type MessageHandler = (event: MessageEvent) => void
 
 export type PostOfficeEventTypes = 'message' // augment later if needed
@@ -167,10 +176,12 @@ export interface IframeManagingWindow {
 
 export interface UnlockProtocolObject {
   loadCheckoutModal: () => void
+  getState: () => LockStatus
 }
 
 export interface UnlockProtocolWindow {
   unlockProtocol: UnlockProtocolObject
+  addEventListener: AddEventListenerFunc
 }
 
 export interface UnlockWindow


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
In response to an issue with using the paywall inside react applications, this PR adds a method that allows end-users to query the current state of the paywall. There are 3 states:

1. `'locked'`
2. `'unlocked'`
3. `undefined` -- this is the value early in the page load when we haven't yet determined the page status

This method and the variable it wraps are not used inside our app, they simply provide a way for users to know what's going on if they remount a react component after a change has already been dispatched.

While I've manually verified that the event listener works and updates the variable that `getState` points to, there is only a unit test for the initial state. Since our unit tests work entirely with mock windows, I think we'll need to have an integration test for `getState` to get total coverage.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
