### PR TITLE
Properly load time and date of event

### DIFF
--- a/tickets/src/__tests__/components/interface/DatePicker.test.js
+++ b/tickets/src/__tests__/components/interface/DatePicker.test.js
@@ -44,6 +44,19 @@ describe('DatePicker', () => {
     expect(wrapper.queryByText('2')).not.toBeNull()
   })
 
+  it('should show a date in the future if it has been initialized with this', () => {
+    expect.assertions(3)
+    const now = new Date('2019-03-02T00:00:00.000Z') // March 2nd, 2019
+    const date = new Date('2020-03-02T00:00:00.000Z') // March 2nd, 2020
+    let wrapper = rtl.render(
+      <DatePicker now={now} date={date} onChange={jest.fn()} />
+    )
+    wrapper.debug()
+    expect(wrapper.queryByText('2020')).not.toBeNull()
+    expect(wrapper.queryByText('Mar')).not.toBeNull()
+    expect(wrapper.queryByText('2')).not.toBeNull()
+  })
+
   it('should let the user pick a year and trigger onChange', () => {
     expect.assertions(1)
     const onChange = jest.fn()

--- a/tickets/src/components/content/CreateContent.js
+++ b/tickets/src/components/content/CreateContent.js
@@ -238,11 +238,7 @@ export class CreateContent extends Component {
                     </Field>
                     <Field>
                       <Label>Start Time</Label>
-                      <TimePicker
-                        now={now}
-                        date={date}
-                        onChange={this.timeChanged}
-                      />
+                      <TimePicker now={date} onChange={this.timeChanged} />
                     </Field>
                     <Field>&nbsp;</Field>
                     <Field>

--- a/tickets/src/components/interface/DatePicker.js
+++ b/tickets/src/components/interface/DatePicker.js
@@ -27,10 +27,10 @@ export const getDaysMonthsAndYearsForSelect = (now, year, month) => {
 export default class DatePicker extends Component {
   constructor(props) {
     super(props)
-    const { now } = props
+    const { now, date } = props
     this.state = {
       ...getDaysMonthsAndYearsForSelect(now),
-      date: now, // defaults to now
+      date: date < now ? date : now,
     }
     this.onChange = this.onChange.bind(this)
   }
@@ -110,11 +110,13 @@ export default class DatePicker extends Component {
 
 DatePicker.propTypes = {
   now: PropTypes.instanceOf(Date),
+  date: PropTypes.instanceOf(Date),
   onChange: PropTypes.func.isRequired,
 }
 
 DatePicker.defaultProps = {
   now: new Date(),
+  date: new Date(),
 }
 
 export const EventDate = styled.div`


### PR DESCRIPTION
# Description

The time and date of an event are now properly loaded.

# Issues

Fixes #4345

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
