### PR TITLE
extract the http post helper into its own file in order to share

### DIFF
--- a/tests/helpers/erc20IsUp.js
+++ b/tests/helpers/erc20IsUp.js
@@ -2,61 +2,9 @@
 // balanceOf(0xaaadeed4...) to get the ERC20 token balance.
 // when the standup script has finished, it will return 500 tokens,
 // which is assumed if our call to balanceOf returns a non-zero value.
-const http = require('http')
+const post = require('./http').post
 
-const {
-  erc20ContractAddress,
-  testingAddress,
-  httpProviderHost,
-  httpProviderPort,
-} = require('./vars.js')
-
-function post(payload) {
-  return new Promise((resolve, reject) => {
-    const body = JSON.stringify(payload)
-
-    const options = {
-      hostname: httpProviderHost,
-      port: httpProviderPort,
-      path: '/',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(body),
-      },
-      body: body,
-    }
-
-    const request = new http.ClientRequest(options)
-
-    request.on('response', res => {
-      if (res.statusCode !== 200) {
-        reject(new Error(`failed ${res.statusCode}`))
-      }
-      res.setEncoding('utf8')
-      let result = ''
-      res.on('data', chunk => {
-        result += chunk
-      })
-      res.on('end', () => {
-        try {
-          const response = {
-            data: JSON.parse(result),
-          }
-          resolve(response)
-        } catch (e) {
-          reject(e)
-        }
-      })
-    })
-
-    request.on('error', e => {
-      reject(new Error(`problem with request: ${e.message}`))
-    })
-
-    request.end(body)
-  })
-}
+const { erc20ContractAddress, testingAddress } = require('./vars.js')
 
 const erc20IsUp = ({ delay, maxAttempts }) => {
   let attempts = 0

--- a/tests/helpers/http.js
+++ b/tests/helpers/http.js
@@ -1,0 +1,54 @@
+// This file is a no-extra-dependencies-required way of mimicking the API of axios.post
+// It is used by both erc20IsUp.js and locksAreDeployed.js
+const http = require('http')
+
+const { httpProviderHost, httpProviderPort } = require('./vars.js')
+
+function post(payload) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(payload)
+
+    const options = {
+      hostname: httpProviderHost,
+      port: httpProviderPort,
+      path: '/',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+      body: body,
+    }
+
+    const request = new http.ClientRequest(options)
+
+    request.on('response', res => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`failed ${res.statusCode}`))
+      }
+      res.setEncoding('utf8')
+      let result = ''
+      res.on('data', chunk => {
+        result += chunk
+      })
+      res.on('end', () => {
+        try {
+          const response = {
+            data: JSON.parse(result),
+          }
+          resolve(response)
+        } catch (e) {
+          reject(e)
+        }
+      })
+    })
+
+    request.on('error', e => {
+      reject(new Error(`problem with request: ${e.message}`))
+    })
+
+    request.end(body)
+  })
+}
+
+module.exports = { post }


### PR DESCRIPTION
# Description

The `post` helper will be used to confirm the integration test locks have been deployed. This extracts it into its own file. Functionality is unchanged

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #3848 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
