### PR TITLE
Display lock names when available when creating tickets

### DIFF
--- a/tickets/src/__tests__/components/content/CreateContent.test.js
+++ b/tickets/src/__tests__/components/content/CreateContent.test.js
@@ -23,7 +23,7 @@ const account = {
 }
 
 const inputLocks = {
-  abc123: { address: 'abc123', owner: '0x123' },
+  abc123: { address: 'abc123', name: 'This one has a name', owner: '0x123' },
   def459: { address: 'def456', owner: '0x123' },
   ghi789: { address: 'ghi789', owner: '0x567' },
 }
@@ -59,13 +59,13 @@ describe('CreateContent', () => {
       <Provider store={store}>
         <CreateContent
           config={config}
-          locks={['abc123', 'def456']}
+          locks={[inputLocks.abc123, inputLocks.def459]}
           loadEvent={jest.fn()}
         />
       </Provider>
     )
     expect(form.container.querySelector('option[value="abc123"]').text).toEqual(
-      'abc123'
+      'This one has a name'
     )
     expect(form.container.querySelector('option[value="def456"]').text).toEqual(
       'def456'
@@ -104,7 +104,7 @@ describe('CreateContent', () => {
           <CreateContent
             config={config}
             account={{ address: 'ben' }}
-            locks={['abc123', 'def456']}
+            locks={[inputLocks.abc123, inputLocks.def459]}
             addEvent={addEvent}
             now={now}
             loadEvent={jest.fn()}
@@ -178,7 +178,7 @@ describe('CreateContent', () => {
           <CreateContent
             config={config}
             account={{ address: 'ben' }}
-            locks={['abc123', 'def456']}
+            locks={[inputLocks.abc123, inputLocks.def459]}
             addEvent={addEvent}
             loadEvent={loadEvent}
             now={now}
@@ -221,7 +221,7 @@ describe('CreateContent', () => {
         <CreateContent
           config={config}
           account={{ address: 'ben' }}
-          locks={['abc123', 'def456']}
+          locks={[inputLocks.abc123, inputLocks.def459]}
           addEvent={addEvent}
           loadEvent={loadEvent}
           now={now}
@@ -267,7 +267,7 @@ describe('CreateContent', () => {
         <CreateContent
           config={config}
           account={{ address: 'ben' }}
-          locks={['abc123', 'def456']}
+          locks={[inputLocks.abc123, inputLocks.def459]}
           addEvent={addEvent}
           loadEvent={loadEvent}
           now={now}
@@ -288,8 +288,8 @@ describe('mapStateToProps', () => {
     const props = mapStateToProps({ locks: inputLocks, account }, { now: null })
 
     expect(props.locks.length).toEqual(2)
-    expect(props.locks[0]).toEqual('abc123')
-    expect(props.locks[1]).toEqual('def456')
+    expect(props.locks[0]).toEqual(inputLocks.abc123)
+    expect(props.locks[1]).toEqual(inputLocks.def459)
     expect(props.now).toBeInstanceOf(Date)
   })
 

--- a/tickets/src/components/content/CreateContent.js
+++ b/tickets/src/components/content/CreateContent.js
@@ -49,9 +49,12 @@ export class CreateContent extends Component {
       website: '',
     }
 
+    let firstLockAddress
+    if (locks[0]) firstLockAddress = locks[0].address
+
     this.state = {
       lockAddress:
-        locks[0] || event.lockAddress || this.defaultState.lockAddress,
+        firstLockAddress || event.lockAddress || this.defaultState.lockAddress,
       name: event.name || this.defaultState.name,
       description: event.description || this.defaultState.description,
       location: event.location || this.defaultState.location,
@@ -186,8 +189,8 @@ export class CreateContent extends Component {
                       className="select-container"
                       classNamePrefix="select-option"
                       options={locks.map(savedLock => ({
-                        value: savedLock,
-                        label: savedLock,
+                        value: savedLock.address,
+                        label: savedLock.name || savedLock.address,
                       }))}
                       onChange={selectedOption => {
                         if (selectedOption.value)
@@ -274,7 +277,7 @@ CreateContent.propTypes = {
   addEvent: PropTypes.func.isRequired,
   loadEvent: PropTypes.func.isRequired,
   event: UnlockPropTypes.ticketedEvent,
-  locks: PropTypes.arrayOf(PropTypes.string),
+  locks: PropTypes.arrayOf(UnlockPropTypes.lock),
   submitted: PropTypes.bool,
   config: UnlockPropTypes.configuration.isRequired,
 }
@@ -287,9 +290,9 @@ CreateContent.defaultProps = {
 }
 
 export const mapStateToProps = ({ locks, account, event }, { now }) => {
-  let selectLocks = Object.values(locks)
-    .filter(lock => lock.owner === account.address)
-    .map(lock => lock.address)
+  let selectLocks = Object.values(locks).filter(
+    lock => lock.owner === account.address
+  )
 
   return {
     locks: selectLocks,

--- a/tickets/src/stories/content/CreateContent.stories.js
+++ b/tickets/src/stories/content/CreateContent.stories.js
@@ -15,7 +15,7 @@ const config = configure({
 
 const store = createUnlockStore({
   locks: {
-    abc123: { address: 'abc123', owner: '0xuser' },
+    abc123: { address: 'abc123', name: 'Lock with name', owner: '0xuser' },
     def459: { address: 'def456', owner: '0xuser' },
   },
   account: {


### PR DESCRIPTION
# Description

Rather than displaying oblique lock addresses when creating a ticket, display the friendly name if it exists.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4344

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<img width="1129" alt="Screen Shot 2019-08-05 at 5 02 05 PM" src="https://user-images.githubusercontent.com/624104/62502605-2c2acc80-b7a5-11e9-853e-4fbd8ce8d5c3.png">

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
