### PR TITLE
new locksAreDeployed helper

### DIFF
--- a/docker/development/deploy-unlock.js
+++ b/docker/development/deploy-unlock.js
@@ -59,7 +59,7 @@ serverIsUp(1000 /* every second */, 120 /* up to 2 minutes */)
         readOnlyProvider: providerURL,
         unlockAddress: newContractInstance.options.address,
         requiredConfirmations: 1,
-        blockTime: 3,
+        blockTime: 3000, // this is in milliseconds
       })
 
       wallet.on('account.changed', async account => {

--- a/tests/helpers/environment.js
+++ b/tests/helpers/environment.js
@@ -3,6 +3,7 @@
 const PuppeteerEnvironment = require('jest-environment-puppeteer')
 const serverIsUp = require('./serverIsUp')
 const erc20IsUp = require('./erc20IsUp')
+const locksAreDeployed = require('./locksAreDeployed')
 
 const {
   unlockPort,
@@ -50,6 +51,9 @@ class UnlockEnvironment extends PuppeteerEnvironment {
     )
     console.log('Waiting for ERC20 setup')
     await erc20IsUp({ delay: 1000, maxAttempts: 60 })
+
+    console.log('Waiting for Locks to Deploy')
+    await locksAreDeployed({ delay: 1000, maxAttempts: 60 })
     this.global.page.setViewport({ width: 1024, height: 768 })
     console.log('Ready!')
   }

--- a/tests/helpers/locksAreDeployed.js
+++ b/tests/helpers/locksAreDeployed.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // This file is used to probe the ganache server. It attempts to call
 // eth_getCode to ensure each of the locks needed for testing have been deployed
 const post = require('./http').post
@@ -58,6 +59,17 @@ function resolveWhenDeployed(address, delay, maxAttempts) {
 
 const locksAreDeployed = ({ delay, maxAttempts }) => {
   // return a promise that resolves when every lock has been deployed
+  console.log('Will wait for the following lock addresses to deploy:')
+  console.log(paywallETHLockAddress)
+  console.log(paywallERC20LockAddress)
+  adblockETHLockAddresses.forEach(address => console.log(address))
+  adblockERC20LockAddresses.forEach(address => console.log(address))
+  console.log(
+    'If any are incorrect, integration tests will fail. Change to correct values in tests/helpers/vars.js'
+  )
+  console.log(
+    'Get new values by running the dev standup in docker/development (see the README.md in the root directory)'
+  )
   return Promise.all([
     resolveWhenDeployed(paywallETHLockAddress, delay, maxAttempts),
     resolveWhenDeployed(paywallERC20LockAddress, delay, maxAttempts),

--- a/tests/helpers/locksAreDeployed.js
+++ b/tests/helpers/locksAreDeployed.js
@@ -1,0 +1,73 @@
+// This file is used to probe the ganache server. It attempts to call
+// eth_getCode to ensure each of the locks needed for testing have been deployed
+const post = require('./http').post
+
+const {
+  paywallETHLockAddress,
+  paywallERC20LockAddress,
+  adblockETHLockAddresses,
+  adblockERC20LockAddresses,
+} = require('./vars')
+
+let id = 1
+
+function resolveWhenDeployed(address, delay, maxAttempts) {
+  let attempts = 1
+  return new Promise((resolve, reject) => {
+    function retrieveCode() {
+      post(
+        {
+          jsonrpc: '2.0',
+          id: id++,
+          method: 'eth_getCode',
+          params: [address, 'latest'],
+        },
+        {
+          'content-type': 'application/json',
+        }
+      )
+        .then(response => {
+          if (
+            response.data.error ||
+            response.data.result === '0x' // lock is not deployed
+          ) {
+            if (response.data.result) {
+              if (response.data.result === '0x') {
+                console.log(`...Lock ${address} not deployed yet`) // eslint-disable-line
+              }
+            }
+            if (attempts < maxAttempts) {
+              setTimeout(retrieveCode, delay)
+              return
+            }
+          }
+          // any other response shows that the contract has been successfully deployed
+          resolve()
+        })
+        .catch(error => {
+          if (attempts < maxAttempts) {
+            setTimeout(retrieveCode, delay)
+            return
+          }
+          return reject(error)
+        })
+    }
+    retrieveCode()
+  })
+}
+
+const locksAreDeployed = ({ delay, maxAttempts }) => {
+  // return a promise that resolves when every lock has been deployed
+  return Promise.all([
+    resolveWhenDeployed(paywallETHLockAddress, delay, maxAttempts),
+    resolveWhenDeployed(paywallERC20LockAddress, delay, maxAttempts),
+    ...adblockETHLockAddresses.map(address =>
+      resolveWhenDeployed(address, delay, maxAttempts)
+    ),
+    ...adblockERC20LockAddresses.map(address =>
+      resolveWhenDeployed(address, delay, maxAttempts)
+    ),
+  ])
+}
+
+module.exports = locksAreDeployed

--- a/tests/helpers/vars.js
+++ b/tests/helpers/vars.js
@@ -19,6 +19,20 @@ const testingAddress =
 const httpProviderHost = process.env.HTTP_PROVIDER_HOST || '127.0.0.1'
 const httpProviderPort = process.env.HTTP_PROVIDER_PORT || 8545
 
+const paywallETHLockAddress = '0x45DeBF700aB8120aC0665119467EA82BDB45E00b'
+const paywallERC20LockAddress = '0x80bc6d2870bB72CB3E37B648C160dA20733386F7'
+
+const adblockETHLockAddresses = [
+  '0xC11eF3E2cCE6963653C2c9F66b52e5bD2d274564',
+  '0xd9B3865D630941C54B6aA263a4DD4B8e66AB3c5c',
+  '0x1c7ec43575239A482a01Ac8A2A73d0c68887e151',
+]
+const adblockERC20LockAddresses = [
+  '0x1c0E27f7967899578eF138384F8cFC0bf579d063',
+  '0xce341cc78D9774808f0E5b654aF8B57B5126C6BA',
+  '0x0AAF2059Cb2cE8Eeb1a0C60f4e0f2789214350a5',
+]
+
 module.exports = {
   unlockPort,
   locksmithPort,
@@ -33,4 +47,8 @@ module.exports = {
   testingAddress,
   httpProviderHost,
   httpProviderPort,
+  paywallETHLockAddress,
+  paywallERC20LockAddress,
+  adblockETHLockAddresses,
+  adblockERC20LockAddresses,
 }


### PR DESCRIPTION
# Description

This creates and enables a new `locksAreDeployed` helper which is used in the integration tests to ensure that all locks are ready prior to deploying. Because the locks are deployed in parallel, I have not seen the "waiting for" text invoked, but it is useful for the future case where the contract addresses may change.

Questions to resolve:

1) it makes me uncomfortable to hard-code the addresses we are waiting for, it would be great if there were a way to pull that in from docker standup somehow, or to predict it based on the base contract address.
2) If #1 isn't possible, it would be great to get suggestions of good ways to document the dependency and how to update it

# Issues

Refs #3848 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
