### PR TITLE
Prevent GA from being initialized multiple times

### DIFF
--- a/unlock-protocol.com/src/pages/_app.js
+++ b/unlock-protocol.com/src/pages/_app.js
@@ -56,6 +56,7 @@ The Unlock team
 
     this.state = {
       isMember: 'pending',
+      gaInitialized: false,
     }
 
     // Listen to Unlock events
@@ -70,7 +71,21 @@ The Unlock team
         )
       }
 
+      // Initialize Google Analytics on the client side only, and only once
+      if (
+        !this.state.gaInitialized &&
+        config.googleAnalyticsId &&
+        config.googleAnalyticsId !== '0'
+      ) {
+        ReactGA.initialize(config.googleAnalyticsId)
+        this.setState(state => ({
+          ...state,
+          gaInitialized: true,
+        }))
+      }
+
       window.addEventListener('unlockProtocol', event => {
+        if (!this.state.gaInitialized) return
         if (event.detail === 'unlocked') {
           ReactGA.event({
             category: GA_LABELS.MEMBERSHIP,
@@ -97,14 +112,6 @@ The Unlock team
 
   render() {
     const { Component, pageProps } = this.props
-    // Register pageview with Google Analytics on the client side only
-    if (
-      process.browser &&
-      config.googleAnalyticsId &&
-      config.googleAnalyticsId !== '0'
-    ) {
-      ReactGA.initialize(config.googleAnalyticsId)
-    }
 
     return (
       <Container>


### PR DESCRIPTION
# Description

GA events were being fired when GA wasn't initialized, and GA was being initialized multiple times.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
