### PR TITLE
Make dashboard button have white text

### DIFF
--- a/unlock-protocol.com/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-protocol.com/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -11406,6 +11406,7 @@ Object {
   transition: background-color 200ms ease;
   max-width: 400px;
   padding: 20px 50px;
+  color: var(--white);
 }
 
 .c15:hover {
@@ -12325,7 +12326,7 @@ Object {
           class="sc-9upljg-3 kjuFdI"
         >
           <button
-            class="q8p5ah-0 sc-9upljg-0 kSuzMP"
+            class="q8p5ah-0 sc-9upljg-0 bCIeGK"
           >
             Go to Your Dashboard
           </button>
@@ -12847,6 +12848,7 @@ Object {
   transition: background-color 200ms ease;
   max-width: 400px;
   padding: 20px 50px;
+  color: var(--white);
 }
 
 .c1:hover {
@@ -12904,7 +12906,7 @@ Object {
       class="sc-9upljg-3 kjuFdI"
     >
       <button
-        class="q8p5ah-0 sc-9upljg-0 kSuzMP"
+        class="q8p5ah-0 sc-9upljg-0 bCIeGK"
       >
         Go to Your Dashboard
       </button>

--- a/unlock-protocol.com/src/components/interface/buttons/homepage/HomepageButton.js
+++ b/unlock-protocol.com/src/components/interface/buttons/homepage/HomepageButton.js
@@ -67,6 +67,7 @@ export class HomepageButton extends React.Component {
 const DashboardButton = styled(ActionButton)`
   max-width: 400px;
   padding: 20px 50px;
+  color: var(--white);
 `
 
 const TermsButton = styled(ActionButton)`


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This makes all button usage on the homepage consistent

<img width="638" alt="image" src="https://user-images.githubusercontent.com/9300702/62629032-648fef00-b8fa-11e9-9b60-5b23d701917b.png">

(not sure why the blog posts updated -- that happened when I ran the app)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4365 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
