### PR TITLE
Add vendor-prefix for safari button text centering

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -58019,6 +58019,7 @@ Object {
   -ms-flex-direction: column;
   flex-direction: column;
   text-align: center;
+  text-align: -webkit-center;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -58184,7 +58185,7 @@ Object {
           class="sc-dnqmqq kkgxkC"
         />
         <button
-          class="sc-iwsKbI kCRntp"
+          class="sc-iwsKbI brlwMR"
         >
           Update Password
         </button>
@@ -58389,6 +58390,7 @@ Object {
   -ms-flex-direction: column;
   flex-direction: column;
   text-align: center;
+  text-align: -webkit-center;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -58544,7 +58546,7 @@ Object {
         </div>
       </div>
       <button
-        class="sc-iwsKbI sc-fjdhpX sc-eqIVtm ktBbsx"
+        class="sc-iwsKbI sc-fjdhpX sc-eqIVtm bwGNNh"
       >
         No lock found
       </button>
@@ -58748,6 +58750,7 @@ Object {
   -ms-flex-direction: column;
   flex-direction: column;
   text-align: center;
+  text-align: -webkit-center;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -58901,7 +58904,7 @@ Object {
         </div>
       </div>
       <button
-        class="sc-iwsKbI sc-dVhcbM bBsIgi"
+        class="sc-iwsKbI sc-dVhcbM epkeON"
       >
         Confirm Purchase
       </button>
@@ -59352,6 +59355,7 @@ Object {
   -ms-flex-direction: column;
   flex-direction: column;
   text-align: center;
+  text-align: -webkit-center;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -59651,7 +59655,7 @@ Object {
             class="sc-dnqmqq kkgxkC"
           />
           <button
-            class="sc-iwsKbI kCRntp"
+            class="sc-iwsKbI brlwMR"
           >
             Update Password
           </button>

--- a/unlock-app/src/components/interface/user-account/styles.tsx
+++ b/unlock-app/src/components/interface/user-account/styles.tsx
@@ -104,6 +104,7 @@ export const SubmitButton = styled.button`
   display: flex;
   flex-direction: column;
   text-align: center;
+  text-align: -webkit-center; /* Safari fix  */
   justify-content: center;
   color: var(--darkgrey);
 `


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR adds a vendor-prefixed `text-align` to the submit button used on user accounts elements to avoid an issue Safari has with the un-prefixed `center` value in flex containers.

<img width="454" alt="image" src="https://user-images.githubusercontent.com/9300702/62630793-a0788380-b8fd-11e9-8048-2d26529e12b0.png">

<img width="454" alt="image" src="https://user-images.githubusercontent.com/9300702/62630951-e2a1c500-b8fd-11e9-8b26-0696a10832c6.png">


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4367

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
