### PR TITLE
add name to iframes so we can refer to them in integration tests by name

### DIFF
--- a/paywall/src/__tests__/unlock.js/iframeManager.test.js
+++ b/paywall/src/__tests__/unlock.js/iframeManager.test.js
@@ -9,12 +9,13 @@ describe('iframeManager', () => {
   jest.useFakeTimers()
 
   it('creates an iframe element', () => {
-    expect.assertions(3)
+    expect.assertions(4)
 
-    const iframe = makeIframe(window, 'http://example.com')
+    const iframe = makeIframe(window, 'http://example.com', 'iframe name')
 
     expect(iframe).toBeInstanceOf(Element)
     expect(iframe.src).toBe('http://example.com/')
+    expect(iframe.name).toBe('iframe name')
     expect(iframe.className).toBe('unlock start')
   })
 

--- a/paywall/src/__tests__/unlock.js/startup.test.js
+++ b/paywall/src/__tests__/unlock.js/startup.test.js
@@ -122,7 +122,7 @@ describe('unlock.js startup', () => {
 
   describe('iframe creation', () => {
     it('should create a data iframe with the correct URL', () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       startup(fakeWindow)
 
@@ -130,13 +130,18 @@ describe('unlock.js startup', () => {
         'src',
         'http://paywall/static/data-iframe.1.0.html?origin=http%3A%2F%2Ffun.times'
       )
+
+      expect(fakeDataIframe.setAttribute).toHaveBeenCalledWith(
+        'name',
+        'unlock data'
+      )
       expect(
         fakeWindow.document.body.insertAdjacentElement
       ).toHaveBeenNthCalledWith(1, 'afterbegin', fakeDataIframe)
     })
 
     it('should create a Checkout UI iframe with the correct URL', () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       startup(fakeWindow)
 
@@ -144,19 +149,27 @@ describe('unlock.js startup', () => {
         'src',
         'http://paywall/checkout?origin=http%3A%2F%2Ffun.times'
       )
+      expect(fakeCheckoutIframe.setAttribute).toHaveBeenCalledWith(
+        'name',
+        'unlock checkout'
+      )
       expect(
         fakeWindow.document.body.insertAdjacentElement
       ).toHaveBeenNthCalledWith(3, 'afterbegin', fakeCheckoutIframe)
     })
 
     it('should create a User Accounts UI iframe with the correct URL', () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       startup(fakeWindow)
 
       expect(fakeUserAccountsIframe.setAttribute).toHaveBeenCalledWith(
         'src',
         `${process.env.USER_IFRAME_URL}?origin=http%3A%2F%2Ffun.times`
+      )
+      expect(fakeUserAccountsIframe.setAttribute).toHaveBeenCalledWith(
+        'name',
+        'unlock accounts'
       )
       expect(
         fakeWindow.document.body.insertAdjacentElement

--- a/paywall/src/unlock.js/iframeManager.ts
+++ b/paywall/src/unlock.js/iframeManager.ts
@@ -1,9 +1,14 @@
 import { IframeManagingWindow, IframeType } from '../windowTypes'
 
-export function makeIframe(window: IframeManagingWindow, src: string) {
+export function makeIframe(
+  window: IframeManagingWindow,
+  src: string,
+  iframeName: string
+) {
   const iframe = window.document.createElement('iframe')
   iframe.className = 'unlock start'
   iframe.setAttribute('src', src)
+  iframe.setAttribute('name', iframeName)
 
   return iframe
 }

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -30,16 +30,19 @@ export default function startup(window: UnlockWindow) {
 
   const dataIframe = makeIframe(
     window,
-    process.env.PAYWALL_URL + '/static/data-iframe.1.0.html' + origin
+    process.env.PAYWALL_URL + '/static/data-iframe.1.0.html' + origin,
+    'unlock data'
   )
   const checkoutIframe = makeIframe(
     window,
-    process.env.PAYWALL_URL + '/checkout' + origin
+    process.env.PAYWALL_URL + '/checkout' + origin,
+    'unlock checkout'
   )
   // TODO: We should not load the iframe for user account is the configuration does not mention it
   const userAccountsIframe = makeIframe(
     window,
-    process.env.USER_IFRAME_URL + origin
+    process.env.USER_IFRAME_URL + origin,
+    'unlock accounts'
   )
   addIframeToDocument(window, dataIframe)
   addIframeToDocument(window, userAccountsIframe)

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -158,7 +158,7 @@ export interface PostMessageTarget {
 }
 
 // the attributes we expect will be modified by setAttribute
-export type IframeAttributeNames = 'src'
+export type IframeAttributeNames = 'src' | 'name'
 export interface IframeType {
   contentWindow: PostMessageTarget
   className: string
@@ -184,14 +184,20 @@ export interface UnlockProtocolWindow {
   addEventListener: AddEventListenerFunc
 }
 
+export interface OriginWindow extends Pick<Window, 'origin'> {}
+
+export interface ConfigWindow {
+  unlockProtocolConfig?: PaywallConfig
+}
+
 export interface UnlockWindow
   extends PostOfficeWindow,
     EventWindow,
     UnlockProtocolWindow,
     LocalStorageWindow,
     IframeManagingWindow,
-    Web3Window {
-  unlockProtocolConfig?: PaywallConfig
+    Web3Window,
+    OriginWindow,
+    ConfigWindow {
   document: FullDocument
-  origin: string
 }

--- a/tests/helpers/iframes.js
+++ b/tests/helpers/iframes.js
@@ -2,6 +2,8 @@
 // so that any re-ordering of frames is controlled in a single location
 
 module.exports = {
-  checkoutIframe: page => page.mainFrame().childFrames()[2],
-  accountsIframe: page => page.mainFrame().childFrames()[1],
+  checkoutIframe: page =>
+    page.frames().find(frame => frame.name() === 'unlock checkout'),
+  accountsIframe: page =>
+    page.frames().find(frame => frame.name() === 'unlock accounts'),
 }


### PR DESCRIPTION
# Description

This adds a `name` attribute to the iframes created by the `unlock.min.js` script, so that it is more robust in integration tests.

This is a pre-requisite for a smooth transition to the new refactored unlock.js that is to come soon.


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #4385 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
