### PR TITLE
Moving GA initialization check

### DIFF
--- a/unlock-protocol.com/src/pages/_app.js
+++ b/unlock-protocol.com/src/pages/_app.js
@@ -85,22 +85,23 @@ The Unlock team
       }
 
       window.addEventListener('unlockProtocol', event => {
-        if (!this.state.gaInitialized) return
         if (event.detail === 'unlocked') {
-          ReactGA.event({
-            category: GA_LABELS.MEMBERSHIP,
-            action: GA_ACTIONS.UNLOCKED,
-          })
+          if (this.state.gaInitialized)
+            ReactGA.event({
+              category: GA_LABELS.MEMBERSHIP,
+              action: GA_ACTIONS.UNLOCKED,
+            })
           this.setState(state => ({
             ...state,
             isMember: 'yes',
           }))
         }
         if (event.detail === 'locked') {
-          ReactGA.event({
-            category: GA_LABELS.MEMBERSHIP,
-            action: GA_ACTIONS.LOCKED,
-          })
+          if (this.state.gaInitialized)
+            ReactGA.event({
+              category: GA_LABELS.MEMBERSHIP,
+              action: GA_ACTIONS.LOCKED,
+            })
           this.setState(state => ({
             ...state,
             isMember: 'no',


### PR DESCRIPTION
# Description

In some circumstances (like dev), Google Analytics isn't initialized. We need to check it's been initialized before firing GA events, but we don't want to block memberships.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
