### PR TITLE
new checkout iframe handler

### DIFF
--- a/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
@@ -63,9 +63,6 @@ export default class FakeWindow
   public localStorage: Pick<LocalStorageWindow, 'localStorage'>['localStorage']
   public storage: { [key: string]: string } = {}
   public document: IframeManagingDocument
-  public iframeMap: {
-    [url: string]: IframeType
-  } = {}
 
   constructor() {
     this.fetch = jest.fn((_: string) => {

--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.test.ts
@@ -1,0 +1,203 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PurchaseKeyRequest } from '../../../unlockTypes'
+import CheckoutIframeMessageEmitter from '../../../unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter'
+import { PostMessages } from '../../../messageTypes'
+
+declare const process: {
+  env: any
+}
+process.env.PAYWALL_URL = 'http://paywall'
+
+describe('CheckoutIframeMessageEmitter', () => {
+  let fakeWindow: FakeWindow
+  const checkoutOrigin = process.env.PAYWALL_URL
+
+  function makeEmitter(fakeWindow: FakeWindow) {
+    const emitter = new CheckoutIframeMessageEmitter(
+      fakeWindow,
+      'http://fun.times/fakey'
+    )
+    emitter.setupListeners()
+    return emitter
+  }
+
+  describe('emitter construction', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should create a checkout iframe', () => {
+      expect.assertions(2)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      expect(emitter.iframe.src).toBe('http://fun.times/fakey')
+      expect(emitter.iframe.name).toBe('unlock checkout')
+    })
+
+    it('should add the checkout iframe to the document', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      expect(
+        fakeWindow.document.body.insertAdjacentElement
+      ).toHaveBeenCalledWith('afterbegin', emitter.iframe)
+    })
+
+    it('should set up postMessage', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.postMessage(PostMessages.SCROLL_POSITION, 5)
+
+      fakeWindow.expectPostMessageSentToIframe(
+        PostMessages.SCROLL_POSITION,
+        5,
+        emitter.iframe,
+        process.env.PAYWALL_URL // iframe origin
+      )
+    })
+
+    it('should set up addHandler', () => {
+      expect.assertions(1)
+
+      const fakeReady = jest.fn()
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.addHandler(PostMessages.READY, fakeReady)
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.READY,
+        undefined,
+        emitter.iframe,
+        process.env.PAYWALL_URL
+      )
+
+      expect(fakeReady).toHaveBeenCalled()
+    })
+  })
+
+  describe('iframe visibility', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should show the iframe when showIframe() is called', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.showIframe()
+
+      expect(emitter.iframe.className).toBe('unlock start show')
+    })
+
+    it('should disable scrolling on showing the iframe', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.showIframe()
+
+      expect(fakeWindow.document.body.style.overflow).toBe('hidden')
+    })
+
+    it('should hide the iframe when hideIframe() is called', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.showIframe()
+      emitter.hideIframe()
+
+      expect(emitter.iframe.className).toBe('unlock start')
+    })
+
+    it('should enable scrolling on hiding the iframe', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.showIframe()
+      emitter.hideIframe()
+
+      expect(fakeWindow.document.body.style.overflow).toBe('')
+    })
+  })
+
+  describe('setupListeners', () => {
+    let ready: () => void
+    let dismiss: () => void
+    let purchase: (request: PurchaseKeyRequest) => void
+    const request: PurchaseKeyRequest = {
+      lock: '0x1234567890123456789012345678901234567890',
+      extraTip: '0',
+    }
+
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+      ready = jest.fn()
+      dismiss = jest.fn()
+      purchase = jest.fn()
+    })
+
+    it('should emit PostMessages.READY upon receiving it', () => {
+      expect.assertions(1)
+
+      dismiss()
+      purchase(request)
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.on(PostMessages.READY, ready)
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.READY,
+        undefined,
+        emitter.iframe,
+        checkoutOrigin
+      )
+
+      expect(ready).toHaveBeenCalled()
+    })
+
+    it('should emit PostMessages.DISMISS_CHECKOUT upon receiving it', () => {
+      expect.assertions(1)
+
+      dismiss()
+      purchase(request)
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.on(PostMessages.DISMISS_CHECKOUT, dismiss)
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.DISMISS_CHECKOUT,
+        undefined,
+        emitter.iframe,
+        checkoutOrigin
+      )
+
+      expect(dismiss).toHaveBeenCalled()
+    })
+
+    it('should emit PostMessages.PURCHASE_KEY upon receiving it', () => {
+      expect.assertions(1)
+
+      dismiss()
+      purchase(request)
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.on(PostMessages.PURCHASE_KEY, purchase)
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.PURCHASE_KEY,
+        request,
+        emitter.iframe,
+        checkoutOrigin
+      )
+
+      expect(purchase).toHaveBeenCalledWith(request)
+    })
+  })
+})

--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.test.ts
@@ -146,8 +146,6 @@ describe('CheckoutIframeMessageEmitter', () => {
     it('should emit PostMessages.READY upon receiving it', () => {
       expect.assertions(1)
 
-      dismiss()
-      purchase(request)
       const emitter = makeEmitter(fakeWindow)
 
       emitter.on(PostMessages.READY, ready)
@@ -165,8 +163,6 @@ describe('CheckoutIframeMessageEmitter', () => {
     it('should emit PostMessages.DISMISS_CHECKOUT upon receiving it', () => {
       expect.assertions(1)
 
-      dismiss()
-      purchase(request)
       const emitter = makeEmitter(fakeWindow)
 
       emitter.on(PostMessages.DISMISS_CHECKOUT, dismiss)
@@ -184,8 +180,6 @@ describe('CheckoutIframeMessageEmitter', () => {
     it('should emit PostMessages.PURCHASE_KEY upon receiving it', () => {
       expect.assertions(1)
 
-      dismiss()
-      purchase(request)
       const emitter = makeEmitter(fakeWindow)
 
       emitter.on(PostMessages.PURCHASE_KEY, purchase)

--- a/paywall/src/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.ts
@@ -1,0 +1,88 @@
+import { EventEmitter } from 'events'
+import { PostMessages } from '../../messageTypes'
+import {
+  PostMessageResponder,
+  mainWindowPostOffice,
+  PostMessageListener,
+} from '../../utils/postOffice'
+import {
+  IframeType,
+  IframeManagingWindow,
+  PostOfficeWindow,
+  OriginWindow,
+} from '../../windowTypes'
+import {
+  makeIframe,
+  addIframeToDocument,
+  showIframe,
+  hideIframe,
+} from '../iframeManager'
+import {
+  CheckoutIframeEventEmitter,
+  CheckoutIframeEvents,
+} from './EventEmitterTypes'
+
+declare const process: {
+  env: any
+}
+
+class FancyEmitter extends (EventEmitter as {
+  new (): CheckoutIframeEventEmitter
+}) {}
+
+/**
+ * This is an abstraction layer around the post office for the checkout iframe
+ *
+ * It is used both to listen for incoming messages, and to send outgoing messages.
+ * In addition, it handles showing and hiding the iframe. Those pieces are handled
+ * in the MainWindowHandler for showing the checkout and user accounts iframes
+ */
+export default class CheckoutIframeMessageEmitter extends FancyEmitter {
+  private window: IframeManagingWindow & PostOfficeWindow & OriginWindow
+  public readonly addHandler: (
+    type: keyof CheckoutIframeEvents,
+    listener: PostMessageListener
+  ) => void
+
+  public readonly postMessage: PostMessageResponder<PostMessages>
+  public readonly iframe: IframeType
+
+  constructor(
+    window: IframeManagingWindow & PostOfficeWindow & OriginWindow,
+    checkoutIframeUrl: string
+  ) {
+    super()
+
+    this.window = window
+    this.iframe = makeIframe(window, checkoutIframeUrl, 'unlock checkout')
+    addIframeToDocument(window, this.iframe)
+
+    const { postMessage, addHandler } = mainWindowPostOffice(
+      window,
+      this.iframe,
+      process.env.PAYWALL_URL,
+      'main window',
+      'Checkout UI iframe'
+    )
+    this.postMessage = postMessage
+    this.addHandler = addHandler
+  }
+
+  showIframe() {
+    showIframe(this.window, this.iframe)
+  }
+
+  hideIframe() {
+    hideIframe(this.window, this.iframe)
+  }
+
+  async setupListeners() {
+    this.addHandler(PostMessages.READY, () => this.emit(PostMessages.READY))
+    this.addHandler(PostMessages.DISMISS_CHECKOUT, () =>
+      this.emit(PostMessages.DISMISS_CHECKOUT)
+    )
+    this.addHandler(PostMessages.PURCHASE_KEY, request =>
+      this.emit(PostMessages.PURCHASE_KEY, request)
+    )
+  }
+}

--- a/paywall/src/unlock.js/PostMessageEmitters/EventEmitterTypes.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/EventEmitterTypes.ts
@@ -1,0 +1,25 @@
+import { EventEmitter } from 'events'
+import StrictEventEmitter from 'strict-event-emitter-types'
+import { PostMessages, ExtractPayload } from '../../messageTypes'
+
+/**
+ * These are the event definitions for the checkout iframe. They correspond directly with the post message events
+ * These events are the ones received from the checkout iframe
+ *
+ * for new events, they should have 1 of 2 forms:
+ *
+ * for events with no payload, () => void
+ * for all others, (payload: ExtractPayload<PostMessages.***>) => void
+ */
+export interface CheckoutIframeEvents {
+  [PostMessages.READY]: () => void
+  [PostMessages.DISMISS_CHECKOUT]: () => void
+  [PostMessages.PURCHASE_KEY]: (
+    request: ExtractPayload<PostMessages.PURCHASE_KEY>
+  ) => void
+}
+
+export type CheckoutIframeEventEmitter = StrictEventEmitter<
+  EventEmitter,
+  CheckoutIframeEvents
+>

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -162,6 +162,7 @@ export type IframeAttributeNames = 'src' | 'name'
 export interface IframeType {
   contentWindow: PostMessageTarget
   className: string
+  name?: string
   src: string
   setAttribute: (attr: IframeAttributeNames, value: string) => void
 }


### PR DESCRIPTION
# Description

This is a slice-and-dice of #4382 

The `CheckoutIframeMessageEmitter` provides a thin abstraction between the post office for the checkout UI iframe and the `unlock.min.js` script.

Follow-up PRs will include the Data iframe emitter and User Accounts iframe emitter

# Issues

Refs #4385 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
