### PR TITLE
new data iframe handler

### DIFF
--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
@@ -1,0 +1,284 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import DataIframeMessageEmitter from '../../../unlock.js/PostMessageEmitters/DataIframeMessageEmitter'
+import { PostMessages, ExtractPayload } from '../../../messageTypes'
+import { web3MethodCall } from '../../../windowTypes'
+
+declare const process: {
+  env: any
+}
+process.env.PAYWALL_URL = 'http://paywall'
+
+describe('DataIframeMessageEmitter', () => {
+  let fakeWindow: FakeWindow
+  const dataOrigin = process.env.PAYWALL_URL
+
+  function makeEmitter(fakeWindow: FakeWindow) {
+    const emitter = new DataIframeMessageEmitter(
+      fakeWindow,
+      'http://fun.times/fakey'
+    )
+    emitter.setupListeners()
+    return emitter
+  }
+
+  describe('emitter construction', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should create a data iframe', () => {
+      expect.assertions(2)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      expect(emitter.iframe.src).toBe('http://fun.times/fakey')
+      expect(emitter.iframe.name).toBe('unlock data')
+    })
+
+    it('should add the data iframe to the document', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      expect(
+        fakeWindow.document.body.insertAdjacentElement
+      ).toHaveBeenCalledWith('afterbegin', emitter.iframe)
+    })
+
+    it('should set up postMessage', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.postMessage(PostMessages.SCROLL_POSITION, 5)
+
+      fakeWindow.expectPostMessageSentToIframe(
+        PostMessages.SCROLL_POSITION,
+        5,
+        emitter.iframe,
+        process.env.PAYWALL_URL // iframe origin
+      )
+    })
+
+    it('should set up addHandler', () => {
+      expect.assertions(1)
+
+      const fakeReady = jest.fn()
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.addHandler(PostMessages.READY, fakeReady)
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.READY,
+        undefined,
+        emitter.iframe,
+        process.env.PAYWALL_URL
+      )
+
+      expect(fakeReady).toHaveBeenCalled()
+    })
+  })
+
+  describe('setupListeners', () => {
+    let ready: () => void
+
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+      ready = jest.fn()
+    })
+
+    type VoidMessages = [
+      string,
+      PostMessages.READY | PostMessages.READY_WEB3 | PostMessages.LOCKED
+    ][]
+    it.each(<VoidMessages>[
+      ['READY', PostMessages.READY],
+      ['READY_WEB3', PostMessages.READY_WEB3],
+      ['LOCKED', PostMessages.LOCKED],
+    ])('should emit PostMessages.%s upon receiving it', (_, message) => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.on(message, ready)
+
+      fakeWindow.receivePostMessageFromIframe(
+        message,
+        undefined,
+        emitter.iframe,
+        dataOrigin
+      )
+
+      expect(ready).toHaveBeenCalled()
+    })
+
+    interface PayloadMessageTypes {
+      [PostMessages.UNLOCKED]: ExtractPayload<PostMessages.UNLOCKED>
+      [PostMessages.ERROR]: ExtractPayload<PostMessages.ERROR>
+      [PostMessages.UPDATE_WALLET]: ExtractPayload<PostMessages.UPDATE_WALLET>
+      [PostMessages.WEB3]: ExtractPayload<PostMessages.WEB3>
+      [PostMessages.UPDATE_ACCOUNT]: ExtractPayload<PostMessages.UPDATE_ACCOUNT>
+      [PostMessages.UPDATE_ACCOUNT_BALANCE]: ExtractPayload<
+        PostMessages.UPDATE_ACCOUNT_BALANCE
+      >
+      [PostMessages.UPDATE_NETWORK]: ExtractPayload<PostMessages.UPDATE_NETWORK>
+      [PostMessages.UPDATE_LOCKS]: ExtractPayload<PostMessages.UPDATE_LOCKS>
+    }
+    type Messages = keyof PayloadMessageTypes
+    type PayloadMessages<T extends Messages = Messages> = [
+      string,
+      T,
+      PayloadMessageTypes[T]
+    ][]
+    const lockAddresses = ['lock1']
+    const web3Request = {
+      id: 1,
+      jsonrpc: '2.0',
+      params: [],
+      method: 'eth_getAccounts',
+    }
+    const locks: ExtractPayload<PostMessages.UPDATE_LOCKS> = {
+      lock: {
+        address: 'lock',
+        name: 'a lock',
+        currencyContractAddress: null,
+        keyPrice: '123',
+        expirationDuration: 123,
+        key: {
+          lock: 'lock',
+          expiration: 0,
+          status: 'none',
+          transactions: [],
+          confirmations: 0,
+          owner: 'account',
+        },
+      },
+    }
+    it.each(<PayloadMessages>[
+      ['UNLOCKED', PostMessages.UNLOCKED, lockAddresses],
+      ['ERROR', PostMessages.ERROR, 'error message'],
+      ['UPDATE_WALLET', PostMessages.UPDATE_WALLET, true],
+      ['WEB3', PostMessages.WEB3, web3Request],
+      ['UPDATE_ACCOUNT', PostMessages.UPDATE_ACCOUNT, 'account'],
+      ['UPDATE_ACCOUNT_BALANCE', PostMessages.UPDATE_ACCOUNT_BALANCE, '123'],
+      ['UPDATE_NETWORK', PostMessages.UPDATE_NETWORK, 4],
+      ['UPDATE_LOCKS', PostMessages.UPDATE_LOCKS, locks],
+    ])(
+      'should emit PostMessages.%s upon receiving it',
+      (_, message, payload) => {
+        expect.assertions(1)
+
+        const emitter = makeEmitter(fakeWindow)
+        const receive: (p: typeof payload) => void = jest.fn()
+
+        emitter.on(message, receive)
+
+        fakeWindow.receivePostMessageFromIframe(
+          message,
+          payload,
+          emitter.iframe,
+          dataOrigin
+        )
+
+        expect(receive).toHaveBeenCalledWith(payload)
+      }
+    )
+  })
+
+  describe('validateWeb3MethodCall', () => {
+    type FailureStuff = [string, any][]
+    it.each(<FailureStuff>[
+      ['not an object: number', 5],
+      ['not an object: string', 'hi'],
+      ['not an object: array', ['hi']],
+      ['object missing method', {}],
+      ['object, method is a number', { method: 5 }],
+      ['object, method is an array', { method: [] }],
+      ['object, method is an object', { method: {} }],
+      ['object, params is a number', { method: 'eth_call', params: 5 }],
+      ['object, params is a string', { method: 'eth_call', params: 'hi' }],
+      ['object, params is an object', { method: 'eth_call', params: {} }],
+      ['object, id is a string', { method: 'eth_call', params: [], id: 'hi' }],
+      ['object, id is an array', { method: 'eth_call', params: [], id: [] }],
+      ['object, id is an object', { method: 'eth_call', params: [], id: {} }],
+      [
+        'object, id is not an integer',
+        { method: 'eth_call', params: [], id: 4.5 },
+      ],
+    ])('should return false with invalid method call, %s', (_, methodCall) => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+      expect(emitter.validateWeb3MethodCall(methodCall)).toBe(false)
+    })
+
+    it('should return true on valid method call', () => {
+      expect.assertions(1)
+
+      const methodCall: web3MethodCall = {
+        id: 123,
+        jsonrpc: '2.0',
+        method: 'some_function',
+        params: [1, '2'],
+      }
+
+      const emitter = makeEmitter(fakeWindow)
+      expect(emitter.validateWeb3MethodCall(methodCall)).toBe(true)
+    })
+  })
+
+  describe('PostMessages.WEB3 validation', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should not emit a web3 method request that is invalid', () => {
+      expect.assertions(1)
+
+      const invalidMethodCall = {
+        id: 'oops',
+        jsonrpc: '2.0',
+        method: 'some_function',
+        params: [1, '2'],
+      }
+      const checker = jest.fn()
+
+      const emitter = makeEmitter(fakeWindow)
+      emitter.on(PostMessages.WEB3, checker)
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.WEB3,
+        (invalidMethodCall as unknown) as web3MethodCall,
+        emitter.iframe,
+        dataOrigin
+      )
+
+      expect(checker).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('PostMessages.UPDATE_LOCKS validation', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should not emit a locks update that is empty', () => {
+      expect.assertions(1)
+
+      const locks = {}
+      const checker = jest.fn()
+
+      const emitter = makeEmitter(fakeWindow)
+      emitter.on(PostMessages.UPDATE_LOCKS, checker)
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.UPDATE_LOCKS,
+        locks,
+        emitter.iframe,
+        dataOrigin
+      )
+
+      expect(checker).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
@@ -1,0 +1,125 @@
+import { EventEmitter } from 'events'
+import { PostMessages } from '../../messageTypes'
+import {
+  PostMessageResponder,
+  mainWindowPostOffice,
+  PostMessageListener,
+} from '../../utils/postOffice'
+import {
+  IframeType,
+  IframeManagingWindow,
+  PostOfficeWindow,
+} from '../../windowTypes'
+import { makeIframe, addIframeToDocument } from '../iframeManager'
+import { DataIframeEventEmitter, DataIframeEvents } from './EventEmitterTypes'
+
+declare const process: {
+  env: any
+}
+
+interface UnvalidatedPayload {
+  method?: any
+  id?: any
+  params?: any
+}
+
+class FancyEmitter extends (EventEmitter as {
+  new (): DataIframeEventEmitter
+}) {}
+
+/**
+ * This is an abstraction layer around the post office for the data iframe
+ *
+ * It is used both to listen for incoming messages, and to send outgoing messages.
+ * For most, it simply emits what it receives, but in some cases it performs
+ * additional logic, such as validating web3 method calls, or not forwarding
+ * empty locks
+ */
+export default class DataIframeMessageEmitter extends FancyEmitter {
+  public readonly addHandler: (
+    type: keyof DataIframeEvents,
+    listener: PostMessageListener
+  ) => void
+
+  public readonly postMessage: PostMessageResponder<PostMessages>
+  public readonly iframe: IframeType
+
+  constructor(
+    window: IframeManagingWindow & PostOfficeWindow,
+    dataIframeUrl: string
+  ) {
+    super()
+
+    this.iframe = makeIframe(window, dataIframeUrl, 'unlock data')
+    addIframeToDocument(window, this.iframe)
+
+    const { postMessage, addHandler } = mainWindowPostOffice(
+      window,
+      this.iframe,
+      process.env.PAYWALL_URL,
+      'main window',
+      'Data iframe'
+    )
+    this.postMessage = postMessage
+    this.addHandler = addHandler
+  }
+
+  /**
+   * Validate a payload sent from the data iframe to ensure it is in fact a web3 method call
+   */
+  validateWeb3MethodCall(payload: UnvalidatedPayload) {
+    if (!payload || typeof payload !== 'object') return false
+    if (!payload.method || typeof payload.method !== 'string') {
+      return false
+    }
+    if (!payload.params || !Array.isArray(payload.params)) {
+      return false
+    }
+    if (
+      typeof payload.id !== 'number' ||
+      Math.round(payload.id) !== payload.id
+    ) {
+      return false
+    }
+    return true
+  }
+
+  public setupListeners() {
+    this.addHandler(PostMessages.READY, () => this.emit(PostMessages.READY))
+    this.addHandler(PostMessages.READY_WEB3, () =>
+      this.emit(PostMessages.READY_WEB3)
+    )
+    this.addHandler(PostMessages.LOCKED, () => this.emit(PostMessages.LOCKED))
+    this.addHandler(PostMessages.UNLOCKED, locks =>
+      this.emit(PostMessages.UNLOCKED, locks)
+    )
+    this.addHandler(PostMessages.ERROR, error =>
+      this.emit(PostMessages.ERROR, error)
+    )
+    this.addHandler(PostMessages.UPDATE_WALLET, update =>
+      this.emit(PostMessages.UPDATE_WALLET, update)
+    )
+    this.addHandler(PostMessages.WEB3, payload => {
+      // don't pass on anything that is not a valid web3 request
+      if (!this.validateWeb3MethodCall(payload)) return
+      this.emit(PostMessages.WEB3, payload)
+    })
+    this.addHandler(PostMessages.UPDATE_ACCOUNT, account =>
+      this.emit(PostMessages.UPDATE_ACCOUNT, account)
+    )
+    this.addHandler(PostMessages.UPDATE_ACCOUNT_BALANCE, balance =>
+      this.emit(PostMessages.UPDATE_ACCOUNT_BALANCE, balance)
+    )
+    this.addHandler(PostMessages.UPDATE_NETWORK, network =>
+      this.emit(PostMessages.UPDATE_NETWORK, network)
+    )
+    this.addHandler(PostMessages.UPDATE_LOCKS, locks => {
+      if (!Object.keys(locks).length) {
+        // this happens on a fresh start before the blockchain handler retrieves locks
+        // in this case, we ignore the update to simplify downstream
+        return
+      }
+      this.emit(PostMessages.UPDATE_LOCKS, locks)
+    })
+  }
+}

--- a/paywall/src/unlock.js/PostMessageEmitters/EventEmitterTypes.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/EventEmitterTypes.ts
@@ -1,6 +1,43 @@
 import { EventEmitter } from 'events'
 import StrictEventEmitter from 'strict-event-emitter-types'
 import { PostMessages, ExtractPayload } from '../../messageTypes'
+import { web3MethodCall } from '../../windowTypes'
+
+/**
+ * These are the event definitions for the data iframe. They correspond directly with the post message events
+ * These events are the ones received from the data iframe
+ *
+ * for new events, they should have 1 of 2 forms:
+ *
+ * for events with no payload, () => void
+ * for all others, (payload: ExtractPayload<PostMessages.***>) => void
+ */
+export interface DataIframeEvents {
+  [PostMessages.READY]: () => void
+  [PostMessages.READY_WEB3]: () => void
+  [PostMessages.LOCKED]: () => void
+  [PostMessages.UNLOCKED]: (
+    locks: ExtractPayload<PostMessages.UNLOCKED>
+  ) => void
+  [PostMessages.ERROR]: (error: ExtractPayload<PostMessages.ERROR>) => void
+  [PostMessages.UPDATE_WALLET]: (
+    update: ExtractPayload<PostMessages.UPDATE_WALLET>
+  ) => void
+  [PostMessages.UPDATE_ACCOUNT]: (
+    update: ExtractPayload<PostMessages.UPDATE_ACCOUNT>
+  ) => void
+  [PostMessages.UPDATE_ACCOUNT_BALANCE]: (
+    update: ExtractPayload<PostMessages.UPDATE_ACCOUNT_BALANCE>
+  ) => void
+  [PostMessages.UPDATE_LOCKS]: (
+    update: ExtractPayload<PostMessages.UPDATE_LOCKS>
+  ) => void
+  [PostMessages.UPDATE_NETWORK]: (
+    update: ExtractPayload<PostMessages.UPDATE_NETWORK>
+  ) => void
+  // this has to be more specific because WEB3 is overloaded
+  [PostMessages.WEB3]: (request: web3MethodCall) => void
+}
 
 /**
  * These are the event definitions for the checkout iframe. They correspond directly with the post message events
@@ -22,4 +59,9 @@ export interface CheckoutIframeEvents {
 export type CheckoutIframeEventEmitter = StrictEventEmitter<
   EventEmitter,
   CheckoutIframeEvents
+>
+
+export type DataIframeEventEmitter = StrictEventEmitter<
+  EventEmitter,
+  DataIframeEvents
 >


### PR DESCRIPTION
# Description

This is a slice-and-dice of #4382 

The `DataIframeMessageEmitter` provides a thin abstraction between the post office for the data iframe and the `unlock.min.js` script.

Follow-up PRs will include the User Accounts iframe emitter

# Issues

Refs #4385 #4396 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
