### PR TITLE
new account iframe emitter

### DIFF
--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/AccountsIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/AccountsIframeMessageEmitter.test.ts
@@ -1,0 +1,231 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import AccountsIframeMessageEmitter from '../../../unlock.js/PostMessageEmitters/AccountsIframeMessageEmitter'
+import { PostMessages, ExtractPayload } from '../../../messageTypes'
+
+describe('AccountsIframeMessageEmitter', () => {
+  let fakeWindow: FakeWindow
+  const accountsOrigin = 'http://fun.times'
+
+  function makeEmitter(fakeWindow: FakeWindow) {
+    const emitter = new AccountsIframeMessageEmitter(
+      fakeWindow,
+      'http://fun.times/fakey'
+    )
+    return emitter
+  }
+
+  function makeEmitterWithIframe(fakeWindow: FakeWindow) {
+    const emitter = new AccountsIframeMessageEmitter(
+      fakeWindow,
+      'http://fun.times/fakey'
+    )
+    emitter.createIframe()
+    return emitter
+  }
+
+  describe('emitter construction', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should create a dummy user accounts iframe', () => {
+      expect.assertions(2)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      expect(emitter.iframe.src).toBe('http://fun.times/fakey')
+      expect(emitter.iframe.name).toBe('unlock accounts')
+    })
+
+    it('should not add the dummy iframe to the document', () => {
+      expect.assertions(1)
+
+      makeEmitter(fakeWindow)
+
+      expect(
+        fakeWindow.document.body.insertAdjacentElement
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should set up postMessage after the iframe is created', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitterWithIframe(fakeWindow)
+
+      emitter.postMessage(PostMessages.SCROLL_POSITION, 5)
+
+      fakeWindow.expectPostMessageSentToIframe(
+        PostMessages.SCROLL_POSITION,
+        5,
+        emitter.iframe,
+        accountsOrigin // iframe origin
+      )
+    })
+
+    it('should set up addHandler after the iframe is created', () => {
+      expect.assertions(1)
+
+      const fakeReady = jest.fn()
+      const emitter = makeEmitterWithIframe(fakeWindow)
+
+      emitter.addHandler(PostMessages.READY, fakeReady)
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.READY,
+        undefined,
+        emitter.iframe,
+        accountsOrigin
+      )
+
+      expect(fakeReady).toHaveBeenCalled()
+    })
+
+    it('should set up a dummy postMessage if the iframe is not created yet', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+      emitter.iframe.contentWindow.postMessage = jest.fn()
+
+      emitter.postMessage(PostMessages.SCROLL_POSITION, 5)
+
+      expect(emitter.iframe.contentWindow.postMessage).not.toHaveBeenCalled()
+    })
+
+    it('should set up a dummy addHandler if the iframe is not created yet', () => {
+      expect.assertions(1)
+
+      const fakeReady = jest.fn()
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.addHandler(PostMessages.READY, fakeReady)
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.READY,
+        undefined,
+        emitter.iframe,
+        accountsOrigin
+      )
+
+      expect(fakeReady).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('iframe visibility', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should show the iframe when showIframe() is called', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.showIframe()
+
+      expect(emitter.iframe.className).toBe('unlock start show')
+    })
+
+    it('should disable scrolling on showing the iframe', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.showIframe()
+
+      expect(fakeWindow.document.body.style.overflow).toBe('hidden')
+    })
+
+    it('should hide the iframe when hideIframe() is called', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.showIframe()
+      emitter.hideIframe()
+
+      expect(emitter.iframe.className).toBe('unlock start')
+    })
+
+    it('should enable scrolling on hiding the iframe', () => {
+      expect.assertions(1)
+
+      const emitter = makeEmitter(fakeWindow)
+
+      emitter.showIframe()
+      emitter.hideIframe()
+
+      expect(fakeWindow.document.body.style.overflow).toBe('')
+    })
+  })
+
+  describe('setupListeners', () => {
+    let ready: () => void
+
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+      ready = jest.fn()
+    })
+
+    type messageTypes =
+      | PostMessages.READY
+      | PostMessages.INITIATED_TRANSACTION
+      | PostMessages.SHOW_ACCOUNTS_MODAL
+      | PostMessages.HIDE_ACCOUNTS_MODAL
+    type VoidMessages = [string, messageTypes][]
+    it.each(<VoidMessages>[
+      ['READY', PostMessages.READY],
+      ['INITIATED_TRANSACTION', PostMessages.INITIATED_TRANSACTION],
+      ['SHOW_ACCOUNTS_MODAL', PostMessages.SHOW_ACCOUNTS_MODAL],
+      ['HIDE_ACCOUNTS_MODAL', PostMessages.HIDE_ACCOUNTS_MODAL],
+    ])('should emit PostMessages.%s upon receiving it', (_, message) => {
+      expect.assertions(1)
+
+      const emitter = makeEmitterWithIframe(fakeWindow)
+
+      emitter.on(message, ready)
+
+      fakeWindow.receivePostMessageFromIframe(
+        message,
+        undefined,
+        emitter.iframe,
+        accountsOrigin
+      )
+
+      expect(ready).toHaveBeenCalled()
+    })
+
+    interface PayloadMessageTypes {
+      [PostMessages.UPDATE_ACCOUNT]: ExtractPayload<PostMessages.UPDATE_ACCOUNT>
+      [PostMessages.UPDATE_NETWORK]: ExtractPayload<PostMessages.UPDATE_NETWORK>
+    }
+    type Messages = keyof PayloadMessageTypes
+    type PayloadMessages<T extends Messages = Messages> = [
+      string,
+      T,
+      PayloadMessageTypes[T]
+    ][]
+    it.each(<PayloadMessages>[
+      ['UPDATE_ACCOUNT', PostMessages.UPDATE_ACCOUNT, 'account'],
+      ['UPDATE_NETWORK', PostMessages.UPDATE_NETWORK, 4],
+    ])(
+      'should emit PostMessages.%s upon receiving it',
+      (_, message, payload) => {
+        expect.assertions(1)
+
+        const emitter = makeEmitterWithIframe(fakeWindow)
+        const receive: (p: typeof payload) => void = jest.fn()
+
+        emitter.on(message, receive)
+
+        fakeWindow.receivePostMessageFromIframe(
+          message,
+          payload,
+          emitter.iframe,
+          accountsOrigin
+        )
+
+        expect(receive).toHaveBeenCalledWith(payload)
+      }
+    )
+  })
+})

--- a/paywall/src/unlock.js/PostMessageEmitters/AccountsIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/AccountsIframeMessageEmitter.ts
@@ -41,7 +41,7 @@ class FancyEmitter extends (EventEmitter as {
  * in the IframeHandler.setupAccountUIHandler() method, which is also
  * called by the Wallet class in Wallet.setupWallet()
  */
-export default class UserAccountsIframeMessageEmitter extends FancyEmitter {
+export default class AccountsIframeMessageEmitter extends FancyEmitter {
   private _addHandler?: (
     type: keyof UserAccountsIframeEvents,
     listener: PostMessageListener

--- a/paywall/src/unlock.js/PostMessageEmitters/AccountsIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/AccountsIframeMessageEmitter.ts
@@ -1,0 +1,147 @@
+import { EventEmitter } from 'events'
+import { PostMessages, MessageTypes, ExtractPayload } from '../../messageTypes'
+import {
+  PostMessageResponder,
+  mainWindowPostOffice,
+  PostMessageListener,
+} from '../../utils/postOffice'
+import {
+  IframeType,
+  IframeManagingWindow,
+  PostOfficeWindow,
+  OriginWindow,
+} from '../../windowTypes'
+import {
+  makeIframe,
+  addIframeToDocument,
+  hideIframe,
+  showIframe,
+} from '../iframeManager'
+import {
+  UserAccountsIframeEventEmitter,
+  UserAccountsIframeEvents,
+} from './EventEmitterTypes'
+
+// eslint is too stupid to parse this if the extends is in the class declaration below, so we extract it
+class FancyEmitter extends (EventEmitter as {
+  new (): UserAccountsIframeEventEmitter
+}) {}
+
+/**
+ * This class loads user accounts on-demand
+ *
+ * As such, it is slightly different from the other emitters.
+ * This one does not create the iframe in the constructor, but instead
+ * makes a fake one so that we can interact with it as if it were there,
+ * but nothing happens unless we actually have an explicit need for user
+ * accounts.
+ *
+ * The Wallet class handles initialization of this, and the
+ * IframeHandler class handles setting up cross-iframe communication
+ * in the IframeHandler.setupAccountUIHandler() method, which is also
+ * called by the Wallet class in Wallet.setupWallet()
+ */
+export default class UserAccountsIframeMessageEmitter extends FancyEmitter {
+  private _addHandler?: (
+    type: keyof UserAccountsIframeEvents,
+    listener: PostMessageListener
+  ) => void
+  private window: IframeManagingWindow & PostOfficeWindow & OriginWindow
+
+  private _postMessage?: PostMessageResponder<PostMessages>
+  public iframe: IframeType
+
+  constructor(
+    window: IframeManagingWindow & PostOfficeWindow & OriginWindow,
+    userIframeUrl: string
+  ) {
+    super()
+
+    this.window = window
+    this.iframe = {
+      contentWindow: {
+        postMessage: () => {},
+      },
+      className: '',
+      name: 'unlock accounts',
+      src: userIframeUrl,
+      setAttribute: () => {},
+    }
+  }
+
+  /**
+   * This is called by the Wallet.setupWallet() method if user accounts
+   * are needed
+   */
+  createIframe() {
+    const url = new URL(this.iframe.src)
+    this.iframe = makeIframe(this.window, this.iframe.src, 'unlock accounts')
+    addIframeToDocument(this.window, this.iframe)
+
+    const { postMessage, addHandler } = mainWindowPostOffice(
+      this.window,
+      this.iframe,
+      url.origin,
+      'main window',
+      'User Accounts iframe'
+    )
+    this._postMessage = postMessage
+    this._addHandler = addHandler
+    this.setupListeners()
+  }
+
+  /**
+   * This method is used by the MainWindowHandler to show the account iframe when needed.
+   * It also hides the checkout iframe if it is visible
+   */
+  showIframe() {
+    // note: if we are using a dummy iframe this will not display anything
+    showIframe(this.window, this.iframe)
+  }
+
+  hideIframe() {
+    // note: if we are using a dummy iframe this will not hide anything
+    hideIframe(this.window, this.iframe)
+  }
+
+  private setupListeners() {
+    this.addHandler(PostMessages.READY, () => this.emit(PostMessages.READY))
+    this.addHandler(PostMessages.UPDATE_ACCOUNT, account =>
+      this.emit(PostMessages.UPDATE_ACCOUNT, account)
+    )
+    this.addHandler(PostMessages.UPDATE_NETWORK, network =>
+      this.emit(PostMessages.UPDATE_NETWORK, network)
+    )
+    this.addHandler(PostMessages.INITIATED_TRANSACTION, () =>
+      this.emit(PostMessages.INITIATED_TRANSACTION)
+    )
+    this.addHandler(PostMessages.SHOW_ACCOUNTS_MODAL, () =>
+      this.emit(PostMessages.SHOW_ACCOUNTS_MODAL)
+    )
+    this.addHandler(PostMessages.HIDE_ACCOUNTS_MODAL, () =>
+      this.emit(PostMessages.HIDE_ACCOUNTS_MODAL)
+    )
+  }
+
+  /**
+   * This is a proxy that ignores requests if the account iframe is not active yet
+   */
+  async addHandler(
+    type: keyof UserAccountsIframeEvents,
+    listener: PostMessageListener
+  ) {
+    if (!this._addHandler) return
+    this._addHandler(type, listener)
+  }
+
+  /**
+   * This is a proxy that ignores requests if the account iframe is not active yet
+   */
+  async postMessage<T extends MessageTypes = MessageTypes>(
+    type: T,
+    payload: ExtractPayload<T>
+  ) {
+    if (!this._postMessage) return
+    this._postMessage(type, payload)
+  }
+}

--- a/paywall/src/unlock.js/PostMessageEmitters/EventEmitterTypes.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/EventEmitterTypes.ts
@@ -19,6 +19,33 @@ export interface CheckoutIframeEvents {
   ) => void
 }
 
+/**
+ * These are the event definitions for the user accounts iframe. They correspond directly with the post message events
+ * These events are the ones received from the user accounts iframe
+ *
+ * for new events, they should have 1 of 2 forms:
+ *
+ * for events with no payload, () => void
+ * for all others, (payload: ExtractPayload<PostMessages.***>) => void
+ */
+export interface UserAccountsIframeEvents {
+  [PostMessages.READY]: () => void
+  [PostMessages.UPDATE_ACCOUNT]: (
+    account: ExtractPayload<PostMessages.UPDATE_ACCOUNT>
+  ) => void
+  [PostMessages.UPDATE_NETWORK]: (
+    account: ExtractPayload<PostMessages.UPDATE_NETWORK>
+  ) => void
+  [PostMessages.INITIATED_TRANSACTION]: () => void
+  [PostMessages.SHOW_ACCOUNTS_MODAL]: () => void
+  [PostMessages.HIDE_ACCOUNTS_MODAL]: () => void
+}
+
+export type UserAccountsIframeEventEmitter = StrictEventEmitter<
+  EventEmitter,
+  UserAccountsIframeEvents
+>
+
 export type CheckoutIframeEventEmitter = StrictEventEmitter<
   EventEmitter,
   CheckoutIframeEvents


### PR DESCRIPTION
# Description

This is a slice-and-dice of #4382 

The `AccountIframeMessageEmitter` provides a thin abstraction between the post office for the account iframe and the `unlock.min.js` script.

Unlike the `DataIframeMessageEmitter` and `CheckoutIframeMessageEmitter`, this does not create the user accounts iframe in the constructor. Instead, this is deferred to `createIframe()` method, which is called in the `Wallet` class when user accounts are needed.

# Issues

Refs #4385 #4396 #4400 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
