### PR TITLE
don't dispatch before we create window.unlockProtocol

### DIFF
--- a/paywall/src/__tests__/unlock.js/startup.test.js
+++ b/paywall/src/__tests__/unlock.js/startup.test.js
@@ -118,6 +118,19 @@ describe('unlock.js startup', () => {
 
       expect(fakeWindow.dispatchEvent).not.toHaveBeenCalled()
     })
+
+    it('should not dispatch before window.unlockProtocol is created', done => {
+      expect.assertions(2)
+
+      fakeWindow.storage['__unlockProtocol.locked'] = 'false'
+      fakeWindow.dispatchEvent = () => {
+        expect(fakeWindow.unlockProtocol).not.toBeUndefined()
+        done()
+      }
+
+      expect(fakeWindow.unlockProtocol).toBeUndefined()
+      startup(fakeWindow)
+    })
   })
 
   describe('iframe creation', () => {

--- a/paywall/src/unlock.js/setupPostOffices.ts
+++ b/paywall/src/unlock.js/setupPostOffices.ts
@@ -64,6 +64,25 @@ export default function setupPostOffices(
     CheckoutUIIframe
   )
 
+  // this is a cache for the time between script startup and the full load
+  // of the data iframe. The data iframe will then send down the current
+  // value, overriding this. A bit later, the blockchain handler will update
+  // with the actual value, so this is only used for a few milliseconds
+  let locked
+  try {
+    locked = JSON.parse(
+      window.localStorage.getItem('__unlockProtocol.locked') || '"ignore"'
+    )
+  } catch (_) {
+    locked = 'ignore'
+  }
+  if (locked === true) {
+    dispatchEvent(window, 'locked')
+  }
+  if (locked === false) {
+    dispatchEvent(window, 'unlocked')
+  }
+
   const dataHandlers: MessageHandlerTemplates<MessageTypes> = {
     [PostMessages.READY]: send => {
       return () => {

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -1,28 +1,8 @@
 import { makeIframe, addIframeToDocument } from './iframeManager'
 import setupPostOffices, { normalizeConfig } from './setupPostOffices'
-import dispatchEvent from './dispatchEvent'
 import { UnlockWindow } from '../windowTypes'
 
 export default function startup(window: UnlockWindow) {
-  // this is a cache for the time between script startup and the full load
-  // of the data iframe. The data iframe will then send down the current
-  // value, overriding this. A bit later, the blockchain handler will update
-  // with the actual value, so this is only used for a few milliseconds
-  let locked
-  try {
-    locked = JSON.parse(
-      window.localStorage.getItem('__unlockProtocol.locked') || '"ignore"'
-    )
-  } catch (_) {
-    locked = 'ignore'
-  }
-  if (locked === true) {
-    dispatchEvent(window, 'locked')
-  }
-  if (locked === false) {
-    dispatchEvent(window, 'unlocked')
-  }
-
   // Get the config
   const normalizedConfig = normalizeConfig(window.unlockProtocolConfig)
 


### PR DESCRIPTION
# Description

This moves the retrieval of locked/unlocked state to after the creation of `window.unlockProtocol`, so that the event listener can use it.

It also adds a crucial regression test

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4404 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
