### PR TITLE
disable localStorage cache, add TODOs

### DIFF
--- a/paywall/src/__tests__/data-iframe/Mailbox/invalidateLocalStorageCache.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/invalidateLocalStorageCache.test.ts
@@ -108,6 +108,7 @@ describe('Mailbox - invalidateLocalStorageCache', () => {
       fakeWindow.throwOnLocalStorageSet()
     }
     mailbox = new Mailbox(constants, fakeWindow)
+    testingMailbox().useLocalStorageCache = true
     ;(testingMailbox().configuration as PaywallConfig) = {
       locks: {
         [lockAddresses[1]]: { name: '' },
@@ -237,6 +238,27 @@ describe('Mailbox - invalidateLocalStorageCache', () => {
           fakeWindow.localStorage.getItem(mailbox.getCacheKey())
         ).toBeNull()
       })
+    })
+  })
+
+  describe('localStorage cache disabled', () => {
+    beforeEach(() => {
+      setupDefaults()
+      ;(testingMailbox().blockchainData as BlockchainData) = blockchainData
+      // used to show we don't nuke other caches
+      fakeWindow.localStorage.setItem('another', 'item')
+      mailbox.saveCacheInLocalStorage()
+      testingMailbox().useLocalStorageCache = false
+    })
+
+    it('should not remove any cache', () => {
+      expect.assertions(1)
+
+      mailbox.invalidateLocalStorageCache()
+
+      expect(fakeWindow.localStorage.getItem(mailbox.getCacheKey())).toEqual(
+        JSON.stringify(blockchainData)
+      )
     })
   })
 })

--- a/paywall/src/__tests__/data-iframe/Mailbox/saveCacheInLocalStorage.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/saveCacheInLocalStorage.test.ts
@@ -108,6 +108,7 @@ describe('Mailbox - saveCacheInLocalStorage', () => {
       fakeWindow.throwOnLocalStorageSet()
     }
     mailbox = new Mailbox(constants, fakeWindow)
+    testingMailbox().useLocalStorageCache = true
     ;(testingMailbox().configuration as PaywallConfig) = {
       locks: {
         [lockAddresses[1]]: { name: '' },
@@ -218,6 +219,22 @@ describe('Mailbox - saveCacheInLocalStorage', () => {
       mailbox.saveCacheInLocalStorage()
 
       expectCacheToContain(blockchainData)
+    })
+  })
+
+  describe('localStorage cache disabled', () => {
+    beforeEach(() => {
+      setupDefaults()
+      testingMailbox().useLocalStorageCache = false
+      ;(testingMailbox().blockchainData as BlockchainData) = blockchainData
+    })
+
+    it('should not save a serialized representation of current data to the cache', () => {
+      expect.assertions(1)
+
+      mailbox.saveCacheInLocalStorage()
+
+      expect(fakeWindow.storage).toEqual({})
     })
   })
 })

--- a/paywall/src/__tests__/data-iframe/Mailbox/setupStorageListener.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/setupStorageListener.test.ts
@@ -68,10 +68,17 @@ describe('Mailbox - setupStorageListener', () => {
 
     mailbox.setupStorageListener()
 
-    expect(fakeWindow.addEventListener).toHaveBeenCalledWith(
-      'storage',
-      expect.any(Function)
-    )
+    if (testingMailbox().useLocalStorageCache) {
+      expect(fakeWindow.addEventListener).toHaveBeenCalledWith(
+        'storage',
+        expect.any(Function)
+      )
+    } else {
+      expect(fakeWindow.addEventListener).not.toHaveBeenCalledWith(
+        'storage',
+        expect.any(Function)
+      )
+    }
   })
 
   describe('event listener', () => {
@@ -80,6 +87,8 @@ describe('Mailbox - setupStorageListener', () => {
         setupDefaults()
         mailbox.setupStorageListener()
         testingMailbox().configuration = configuration
+        // enable caching to test functionality
+        testingMailbox().useLocalStorageCache = true
       })
 
       it('should do nothing if there is no configuration', () => {
@@ -111,6 +120,8 @@ describe('Mailbox - setupStorageListener', () => {
     describe('valid states', () => {
       beforeEach(() => {
         setupDefaults()
+        // enable caching to test functionality
+        testingMailbox().useLocalStorageCache = true
         mailbox.setupStorageListener()
         testingMailbox().configuration = configuration
         testingMailbox().handler = {

--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -427,7 +427,7 @@ export default class Mailbox {
    * the whole cache is cleared out of an abundance of caution.
    */
   invalidateLocalStorageCache() {
-    if (!this.localStorageAvailable) return
+    if (!this.localStorageAvailable || !this.useLocalStorageCache) return
     if (!this.configuration) return
     try {
       this.window.localStorage.removeItem(this.getCacheKey())
@@ -448,7 +448,7 @@ export default class Mailbox {
    * On any errors, the entire localStorage is cleared out of an abundance of caution.
    */
   saveCacheInLocalStorage() {
-    if (!this.localStorageAvailable) return
+    if (!this.localStorageAvailable || !this.useLocalStorageCache) return
     if (!this.configuration) return
 
     const cacheableData = JSON.stringify(this.blockchainData)

--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -29,7 +29,7 @@ import {
 import localStorageAvailable from '../utils/localStorage'
 
 export default class Mailbox {
-  private useLocalStorageCache = true
+  private readonly useLocalStorageCache = false
   private readonly cachePrefix = '__unlockProtocol.cache'
   private handler?: BlockchainHandler
   private constants: ConstantsType
@@ -101,6 +101,8 @@ export default class Mailbox {
    * We can use this to determine whether the user has purchased a key in another tab
    */
   setupStorageListener() {
+    if (!this.useLocalStorageCache) return
+    // TODO: check to see if there are any changes to the keys and don't retrieve if not
     this.window.addEventListener(EventTypes.STORAGE, event => {
       if (!this.configuration || !this.handler) return
       if (event.key === this.getCacheKey()) {

--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -103,6 +103,7 @@ export default class Mailbox {
   setupStorageListener() {
     if (!this.useLocalStorageCache) return
     // TODO: check to see if there are any changes to the keys and don't retrieve if not
+    // Issues that reference this: #4381 #4410
     this.window.addEventListener(EventTypes.STORAGE, event => {
       if (!this.configuration || !this.handler) return
       if (event.key === this.getCacheKey()) {

--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -103,7 +103,7 @@ export default class Mailbox {
   setupStorageListener() {
     if (!this.useLocalStorageCache) return
     // TODO: check to see if there are any changes to the keys and don't retrieve if not
-    // Issues that reference this: #4381 #4410
+    // Issues that reference this: #4381 #4411
     this.window.addEventListener(EventTypes.STORAGE, event => {
       if (!this.configuration || !this.handler) return
       if (event.key === this.getCacheKey()) {


### PR DESCRIPTION
# Description

This PR is a temporary fix for #4381.

It works by simply disabling the localStorage cache.

## Background of the bug's root cause

This bug is caused when 2 paywalls with the same locks are loaded. The bug occurs when this loop occurs:

paywall 1 retrieves blockchain data.
paywall 2 retrieves blockchain data.
paywall 1 stores the updated data in localStorage
paywall 2 receives a notification "hey, localStorage changed for your locks"
paywall 2 requests updated blockchain data download
paywall 2 retrieves blockchain data
paywall 2 stores the updated data in localStorage
paywall 1 receives a notification "hey, localStorage changed for your locks"
paywall 1 requests updated blockchain data download
paywall 1 stores the updated data in localStorage
...etc.

Under some conditions, the loop does not occur, but in the right combo, it spawns a race condition of the localStorage notifications looping and causing chain retrievals in multiple async execution threads.

## Long-term solution

Over the long term, the solution is to be granular. We should validate the incoming localStorage value, and then check to see if any keys have been purchased, and only retrieve new data if a key has become valid/confirming/pending/submitted.

I added a TODO in this PR

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #4381

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
