### PR TITLE
Web3ProxyProvider: don't set result.id if it is an error

### DIFF
--- a/paywall/src/providers/Web3ProxyProvider.js
+++ b/paywall/src/providers/Web3ProxyProvider.js
@@ -54,7 +54,11 @@ export default class Web3ProxyProvider {
       }
       const callback = this.requests[id]
       delete this.requests[id]
-      result.id = 42 // ethers needs to not do this...
+
+      if (result) {
+        // only set the id if there isn't an error condition
+        result.id = 42 // ethers needs to not do this...
+      }
       callback(error, result)
     })
 


### PR DESCRIPTION
# Description

This makes sure we don't crash on errors from the wallet by trying to set `result.id = 42` when `result` is `undefined` (always true in an error condition).

It also adds 2 basic tests to ensure the flow of receiving a response (either an error or a result) actually works.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4415

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
