### PR TITLE
fix the standup so the default locks have 1 minute expiration

### DIFF
--- a/docker/development/deploy-locks.js
+++ b/docker/development/deploy-locks.js
@@ -147,7 +147,7 @@ async function deployERC20Lock(
   name = 'Lock',
   keyPrice = '1', // 1 ERC20 token
   maxNumberOfKeys = -1, // unlimited
-  expirationDuration = 60 * 5 // 1 minute!
+  expirationDuration = 60 // 1 minute!
 ) {
   return deployLock(wallet, account, {
     expirationDuration,
@@ -244,7 +244,8 @@ async function prepareEnvironment(
       account,
       'paywall lock',
       '0.1', // 0.1 Eth
-      '1000' // 1000 keys maximum
+      '1000', // 1000 keys maximum
+      60 * 5 // expire in 5 minutes
     )
   )
 
@@ -253,7 +254,10 @@ async function prepareEnvironment(
       wallet,
       account,
       testERC20Token.address,
-      'paywall lock'
+      'paywall lock',
+      '1', // 1 ERC20
+      -1, // unlimited keys
+      60 * 5 // expire in 5 minutes
     )
   )
 


### PR DESCRIPTION
# Description

The changes to the dev standup unintentionally changed the default expiry time of the eth and erc20 locks to 5 minutes. This PR changes them back to 1 minute by correcting the default value, and passing in 5 minutes to the integration test locks.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
