### PR TITLE
new MainWindowHandler for the refactored unlock.min.js

### DIFF
--- a/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
@@ -17,9 +17,11 @@ import {
   StorageEvent,
   OriginWindow,
   IframeManagingWindow,
-  IframeManagingDocument,
   IframeType,
   IframeAttributeNames,
+  EventWindow,
+  FullDocument,
+  UnlockWindowNoProtocolYet,
 } from '../../windowTypes'
 import { ExtractPayload, PostMessages } from '../../messageTypes'
 import { waitFor } from '../../utils/promises'
@@ -29,10 +31,12 @@ export default class FakeWindow
     FetchWindow,
     SetTimeoutWindow,
     IframePostOfficeWindow,
+    UnlockWindowNoProtocolYet,
     IframeManagingWindow,
     ConsoleWindow,
     LocalStorageWindow,
-    OriginWindow {
+    OriginWindow,
+    EventWindow {
   public origin = 'http://example.com'
   public fetchResult: any = {}
   public fetch: (
@@ -62,7 +66,10 @@ export default class FakeWindow
   public console: Pick<ConsoleWindow, 'console'>['console']
   public localStorage: Pick<LocalStorageWindow, 'localStorage'>['localStorage']
   public storage: { [key: string]: string } = {}
-  public document: IframeManagingDocument
+  public document: FullDocument
+  public CustomEvent = CustomEvent
+  public Promise = Promise
+  public dispatchEvent: (event: Event) => void
 
   constructor() {
     this.fetch = jest.fn((_: string) => {
@@ -89,6 +96,10 @@ export default class FakeWindow
           },
         }
         return iframe
+      },
+      createEvent: (type: string) => {
+        const event = new this.CustomEvent<any>(type)
+        return event
       },
       querySelector: () => false,
       body: {
@@ -125,6 +136,7 @@ export default class FakeWindow
       log: jest.fn(),
       error: jest.fn(),
     }
+    this.dispatchEvent = jest.fn()
     this.localStorage = {
       length: 0,
       clear: () => (this.storage = {}),

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/CachedLockState.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/CachedLockState.test.ts
@@ -1,5 +1,7 @@
 import FakeWindow from '../../test-helpers/fakeWindowHelpers'
-import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+import MainWindowHandler, {
+  IGNORE_CACHE,
+} from '../../../unlock.js/MainWindowHandler'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import { PaywallConfig } from '../../../unlockTypes'
 
@@ -30,11 +32,11 @@ describe('MainWindowHandler - locked/unlocked cache', () => {
       fakeWindow = new FakeWindow()
     })
 
-    it('should return "ignore" if there is no cache', () => {
+    it('should return IGNORE_CACHE if there is no cache', () => {
       expect.assertions(1)
 
       const handler = getMainWindowHandler()
-      expect(handler.getCachedLockState()).toBe('ignore')
+      expect(handler.getCachedLockState()).toBe(IGNORE_CACHE)
     })
 
     it('should return true if cache is true', () => {
@@ -54,22 +56,22 @@ describe('MainWindowHandler - locked/unlocked cache', () => {
       expect(handler.getCachedLockState()).toBe(false)
     })
 
-    it('should return "ignore" if cache is not valid', () => {
+    it('should return IGNORE_CACHE if cache is not valid', () => {
       expect.assertions(1)
 
       fakeWindow.storage['__unlockProtocol.locked'] = '1'
       const handler = getMainWindowHandler()
-      expect(handler.getCachedLockState()).toBe('ignore')
+      expect(handler.getCachedLockState()).toBe(IGNORE_CACHE)
     })
 
-    it('should return "ignore" if localStorage.getItem() throws', () => {
+    it('should return IGNORE_CACHE if localStorage.getItem() throws', () => {
       expect.assertions(1)
 
       fakeWindow.localStorage.getItem = () => {
         throw new Error('fail')
       }
       const handler = getMainWindowHandler()
-      expect(handler.getCachedLockState()).toBe('ignore')
+      expect(handler.getCachedLockState()).toBe(IGNORE_CACHE)
     })
   })
 

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/CachedLockState.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/CachedLockState.test.ts
@@ -1,0 +1,97 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+import IframeHandler from '../../../unlock.js/IframeHandler'
+import { PaywallConfig } from '../../../unlockTypes'
+
+describe('MainWindowHandler - locked/unlocked cache', () => {
+  let fakeWindow: FakeWindow
+  const config: PaywallConfig = {
+    locks: {},
+    callToAction: {
+      default: '',
+      pending: '',
+      expired: '',
+      confirmed: '',
+    },
+  }
+
+  function getMainWindowHandler() {
+    const iframes = new IframeHandler(fakeWindow, '', '', '')
+    return new MainWindowHandler(fakeWindow, iframes, config)
+  }
+
+  describe('getCachedLockState', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should return "ignore" if there is no cache', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      expect(handler.getCachedLockState()).toBe('ignore')
+    })
+
+    it('should return true if cache is true', () => {
+      expect.assertions(1)
+
+      fakeWindow.storage['__unlockProtocol.locked'] = 'true'
+      const handler = getMainWindowHandler()
+
+      expect(handler.getCachedLockState()).toBe(true)
+    })
+
+    it('should return false if cache is false', () => {
+      expect.assertions(1)
+
+      fakeWindow.storage['__unlockProtocol.locked'] = 'false'
+      const handler = getMainWindowHandler()
+      expect(handler.getCachedLockState()).toBe(false)
+    })
+
+    it('should return "ignore" if cache is not valid', () => {
+      expect.assertions(1)
+
+      fakeWindow.storage['__unlockProtocol.locked'] = '1'
+      const handler = getMainWindowHandler()
+      expect(handler.getCachedLockState()).toBe('ignore')
+    })
+
+    it('should return "ignore" if localStorage.getItem() throws', () => {
+      expect.assertions(1)
+
+      fakeWindow.localStorage.getItem = () => {
+        throw new Error('fail')
+      }
+      const handler = getMainWindowHandler()
+      expect(handler.getCachedLockState()).toBe('ignore')
+    })
+  })
+
+  describe('setCachedLockedState', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should save the cached state', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.setCachedLockedState(true)
+
+      expect(fakeWindow.storage['__unlockProtocol.locked']).toBe('true')
+    })
+
+    it('should not save cache if localStorage throws', () => {
+      expect.assertions(1)
+
+      fakeWindow.localStorage.setItem = () => {
+        throw new Error('fail')
+      }
+      const handler = getMainWindowHandler()
+      handler.setCachedLockedState(true)
+
+      expect(fakeWindow.storage).toEqual({})
+    })
+  })
+})

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/CachedLockState.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/CachedLockState.test.ts
@@ -3,16 +3,7 @@ import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import { PaywallConfig } from '../../../unlockTypes'
 
-declare const process: {
-  env: {
-    PAYWALL_URL: string
-    USER_IFRAME_URL: string
-  }
-}
-
 describe('MainWindowHandler - locked/unlocked cache', () => {
-  process.env.PAYWALL_URL = 'http://paywall'
-  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   const config: PaywallConfig = {
     locks: {},
@@ -25,7 +16,12 @@ describe('MainWindowHandler - locked/unlocked cache', () => {
   }
 
   function getMainWindowHandler() {
-    const iframes = new IframeHandler(fakeWindow, '', '', '')
+    const iframes = new IframeHandler(
+      fakeWindow,
+      'http://t', // these values are unused in this test
+      'http://u',
+      'http://v'
+    )
     return new MainWindowHandler(fakeWindow, iframes, config)
   }
 

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/CachedLockState.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/CachedLockState.test.ts
@@ -3,7 +3,16 @@ import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import { PaywallConfig } from '../../../unlockTypes'
 
+declare const process: {
+  env: {
+    PAYWALL_URL: string
+    USER_IFRAME_URL: string
+  }
+}
+
 describe('MainWindowHandler - locked/unlocked cache', () => {
+  process.env.PAYWALL_URL = 'http://paywall'
+  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   const config: PaywallConfig = {
     locks: {},

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/dispatchEvent.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/dispatchEvent.test.ts
@@ -1,0 +1,60 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PaywallConfig } from '../../../unlockTypes'
+import IframeHandler from '../../../unlock.js/IframeHandler'
+import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+
+describe('MainWindowHandler - dispatchEvent', () => {
+  let fakeWindow: FakeWindow
+  const config: PaywallConfig = {
+    locks: {},
+    callToAction: {
+      default: '',
+      pending: '',
+      expired: '',
+      confirmed: '',
+    },
+  }
+
+  function getMainWindowHandler() {
+    const iframes = new IframeHandler(fakeWindow, '', '', '')
+    return new MainWindowHandler(fakeWindow, iframes, config)
+  }
+
+  beforeEach(() => {
+    fakeWindow = new FakeWindow()
+  })
+
+  it('should create an event with provided detail and dispatch it', () => {
+    expect.assertions(2)
+
+    const handler = getMainWindowHandler()
+    handler.dispatchEvent('hi')
+
+    const eventDetail = (fakeWindow.dispatchEvent as any).mock.calls[0][0]
+      .detail
+    expect(fakeWindow.dispatchEvent).toHaveBeenCalledWith(
+      expect.any(CustomEvent)
+    )
+    expect(eventDetail).toBe('hi')
+  })
+
+  it('should create an event the old way if the new way is unsupported', () => {
+    expect.assertions(2)
+    ;(fakeWindow as any).CustomEvent = function() {
+      throw new Error('unsupported')
+    }
+    fakeWindow.document.createEvent = (type: string) => {
+      return new CustomEvent(type)
+    }
+
+    const handler = getMainWindowHandler()
+    handler.dispatchEvent('hi')
+
+    const eventDetail = (fakeWindow.dispatchEvent as any).mock.calls[0][0]
+      .detail
+    expect(fakeWindow.dispatchEvent).toHaveBeenCalledWith(
+      expect.any(CustomEvent)
+    )
+    expect(eventDetail).toBe('hi')
+  })
+})

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/dispatchEvent.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/dispatchEvent.test.ts
@@ -3,7 +3,16 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
+declare const process: {
+  env: {
+    PAYWALL_URL: string
+    USER_IFRAME_URL: string
+  }
+}
+
 describe('MainWindowHandler - dispatchEvent', () => {
+  process.env.PAYWALL_URL = 'http://paywall'
+  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   const config: PaywallConfig = {
     locks: {},

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/dispatchEvent.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/dispatchEvent.test.ts
@@ -3,16 +3,7 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
-declare const process: {
-  env: {
-    PAYWALL_URL: string
-    USER_IFRAME_URL: string
-  }
-}
-
 describe('MainWindowHandler - dispatchEvent', () => {
-  process.env.PAYWALL_URL = 'http://paywall'
-  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   const config: PaywallConfig = {
     locks: {},
@@ -25,7 +16,12 @@ describe('MainWindowHandler - dispatchEvent', () => {
   }
 
   function getMainWindowHandler() {
-    const iframes = new IframeHandler(fakeWindow, '', '', '')
+    const iframes = new IframeHandler(
+      fakeWindow,
+      'http://t', // these values are unused in this test
+      'http://u',
+      'http://v'
+    )
     return new MainWindowHandler(fakeWindow, iframes, config)
   }
 

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/hideAccountIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/hideAccountIframe.test.ts
@@ -3,16 +3,7 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
-declare const process: {
-  env: {
-    PAYWALL_URL: string
-    USER_IFRAME_URL: string
-  }
-}
-
 describe('MainWindowHandler - hideAccountIframe', () => {
-  process.env.PAYWALL_URL = 'http://paywall'
-  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   let iframes: IframeHandler
   const config: PaywallConfig = {
@@ -26,7 +17,8 @@ describe('MainWindowHandler - hideAccountIframe', () => {
   }
 
   function getMainWindowHandler() {
-    iframes = new IframeHandler(fakeWindow, '', '', '')
+    // iframe URLs are unused in this test
+    iframes = new IframeHandler(fakeWindow, 'http://t', 'http://u', 'http://v')
     return new MainWindowHandler(fakeWindow, iframes, config)
   }
 

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/hideAccountIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/hideAccountIframe.test.ts
@@ -3,7 +3,16 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
+declare const process: {
+  env: {
+    PAYWALL_URL: string
+    USER_IFRAME_URL: string
+  }
+}
+
 describe('MainWindowHandler - hideAccountIframe', () => {
+  process.env.PAYWALL_URL = 'http://paywall'
+  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   let iframes: IframeHandler
   const config: PaywallConfig = {

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/hideAccountIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/hideAccountIframe.test.ts
@@ -1,0 +1,62 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PaywallConfig } from '../../../unlockTypes'
+import IframeHandler from '../../../unlock.js/IframeHandler'
+import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+
+describe('MainWindowHandler - hideAccountIframe', () => {
+  let fakeWindow: FakeWindow
+  let iframes: IframeHandler
+  const config: PaywallConfig = {
+    locks: {},
+    callToAction: {
+      default: '',
+      pending: '',
+      expired: '',
+      confirmed: '',
+    },
+  }
+
+  function getMainWindowHandler() {
+    iframes = new IframeHandler(fakeWindow, '', '', '')
+    return new MainWindowHandler(fakeWindow, iframes, config)
+  }
+
+  beforeEach(() => {
+    fakeWindow = new FakeWindow()
+  })
+
+  it('should hide the account iframe', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    iframes.accounts.hideIframe = jest.fn()
+
+    handler.hideAccountIframe()
+
+    expect(iframes.accounts.hideIframe).toHaveBeenCalled()
+  })
+
+  it('should show the checkout if it used to be visible', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    handler.showCheckoutIframe()
+    handler.showAccountIframe()
+    iframes.checkout.showIframe = jest.fn()
+
+    handler.hideAccountIframe()
+
+    expect(iframes.checkout.showIframe).toHaveBeenCalled()
+  })
+
+  it('should not show the checkout if it used to be invisible', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    iframes.checkout.showIframe = jest.fn()
+
+    handler.hideAccountIframe()
+
+    expect(iframes.checkout.showIframe).not.toHaveBeenCalled()
+  })
+})

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/hideCheckoutIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/hideCheckoutIframe.test.ts
@@ -3,16 +3,7 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
-declare const process: {
-  env: {
-    PAYWALL_URL: string
-    USER_IFRAME_URL: string
-  }
-}
-
 describe('MainWindowHandler - hideCheckoutIframe', () => {
-  process.env.PAYWALL_URL = 'http://paywall'
-  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   let iframes: IframeHandler
   const config: PaywallConfig = {
@@ -26,7 +17,8 @@ describe('MainWindowHandler - hideCheckoutIframe', () => {
   }
 
   function getMainWindowHandler() {
-    iframes = new IframeHandler(fakeWindow, '', '', '')
+    // iframe URLs are unused in this test
+    iframes = new IframeHandler(fakeWindow, 'http://t', 'http://u', 'http://v')
     return new MainWindowHandler(fakeWindow, iframes, config)
   }
 

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/hideCheckoutIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/hideCheckoutIframe.test.ts
@@ -1,0 +1,38 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PaywallConfig } from '../../../unlockTypes'
+import IframeHandler from '../../../unlock.js/IframeHandler'
+import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+
+describe('MainWindowHandler - hideCheckoutIframe', () => {
+  let fakeWindow: FakeWindow
+  let iframes: IframeHandler
+  const config: PaywallConfig = {
+    locks: {},
+    callToAction: {
+      default: '',
+      pending: '',
+      expired: '',
+      confirmed: '',
+    },
+  }
+
+  function getMainWindowHandler() {
+    iframes = new IframeHandler(fakeWindow, '', '', '')
+    return new MainWindowHandler(fakeWindow, iframes, config)
+  }
+
+  beforeEach(() => {
+    fakeWindow = new FakeWindow()
+  })
+
+  it('should call hideIframe() on the checkout iframe', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    iframes.checkout.hideIframe = jest.fn()
+
+    handler.hideCheckoutIframe()
+
+    expect(iframes.checkout.hideIframe).toHaveBeenCalled()
+  })
+})

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/hideCheckoutIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/hideCheckoutIframe.test.ts
@@ -3,7 +3,16 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
+declare const process: {
+  env: {
+    PAYWALL_URL: string
+    USER_IFRAME_URL: string
+  }
+}
+
 describe('MainWindowHandler - hideCheckoutIframe', () => {
+  process.env.PAYWALL_URL = 'http://paywall'
+  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   let iframes: IframeHandler
   const config: PaywallConfig = {

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
@@ -1,0 +1,304 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PaywallConfig } from '../../../unlockTypes'
+import IframeHandler from '../../../unlock.js/IframeHandler'
+import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+import { PostMessages } from '../../../messageTypes'
+import { UnlockWindow } from '../../../windowTypes'
+
+declare const process: {
+  env: {
+    PAYWALL_URL: string
+  }
+}
+
+describe('MainWindowHandler - init', () => {
+  let fakeWindow: FakeWindow
+  let iframes: IframeHandler
+  const dataOrigin = 'http://paywall'
+  const checkoutOrigin = 'http://paywall'
+  const accountOrigin = 'http://app'
+  const dataIframeUrl = 'http://paywall/data'
+  const checkoutIframeUrl = 'http://paywall/checkout'
+  const accountIframeUrl = 'http://app/account'
+  const config: PaywallConfig = {
+    locks: {},
+    callToAction: {
+      default: '',
+      pending: '',
+      expired: '',
+      confirmed: '',
+    },
+  }
+  process.env.PAYWALL_URL = 'http://paywall'
+
+  function getMainWindowHandler(configuration = config) {
+    iframes = new IframeHandler(
+      fakeWindow,
+      dataIframeUrl,
+      checkoutIframeUrl,
+      accountIframeUrl
+    )
+    iframes.init(configuration)
+    return new MainWindowHandler(fakeWindow, iframes, configuration)
+  }
+
+  function fullWindow() {
+    return (fakeWindow as unknown) as UnlockWindow
+  }
+
+  beforeEach(() => {
+    fakeWindow = new FakeWindow()
+  })
+
+  it('should call setupUnlockProtocolVariable before getting cache', () => {
+    expect.assertions(2)
+
+    const handler = getMainWindowHandler()
+    handler.setupUnlockProtocolVariable = () => {
+      throw new Error('abort')
+    }
+    handler.getCachedLockState = jest.fn()
+
+    expect(() => handler.init()).toThrow()
+    expect(handler.getCachedLockState).not.toHaveBeenCalled()
+  })
+
+  describe('cache', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should dispatch "locked" if the cached state is true', () => {
+      expect.assertions(2)
+
+      const handler = getMainWindowHandler()
+      fakeWindow.storage['__unlockProtocol.locked'] = 'true'
+
+      handler.init()
+      const eventDetail = (fakeWindow.dispatchEvent as any).mock.calls[0][0]
+        .detail
+
+      expect(fakeWindow.dispatchEvent).toHaveBeenCalled()
+      expect(eventDetail).toBe('locked')
+    })
+
+    it('should dispatch "unlocked" if the cached state is false', () => {
+      expect.assertions(2)
+
+      const handler = getMainWindowHandler()
+      fakeWindow.storage['__unlockProtocol.locked'] = 'false'
+
+      handler.init()
+      const eventDetail = (fakeWindow.dispatchEvent as any).mock.calls[0][0]
+        .detail
+
+      expect(fakeWindow.dispatchEvent).toHaveBeenCalled()
+      expect(eventDetail).toBe('unlocked')
+    })
+
+    it('should return default locked state as "undefined"', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.init()
+
+      expect(fullWindow().unlockProtocol.getState()).toBeUndefined()
+    })
+
+    it('should set locked state for react apps', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.init()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.LOCKED,
+        undefined,
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      expect(fullWindow().unlockProtocol.getState()).toBe('locked')
+    })
+
+    it('should cache locked state', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.init()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.LOCKED,
+        undefined,
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      expect(handler.getCachedLockState()).toBe(true)
+    })
+
+    it('should dispatch unlockProtocol event, locked', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.init()
+      handler.dispatchEvent = jest.fn()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.LOCKED,
+        undefined,
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      expect(handler.dispatchEvent).toHaveBeenCalledWith('locked')
+    })
+
+    it('should set unlocked state for react apps', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.init()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.UNLOCKED,
+        ['address'],
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      expect(fullWindow().unlockProtocol.getState()).toBe('unlocked')
+    })
+
+    it('should cache unlocked state', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.init()
+
+      const unlockedLockAddresses = ['address']
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.UNLOCKED,
+        unlockedLockAddresses,
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      expect(handler.getCachedLockState()).toBe(false)
+    })
+
+    it('should dispatch unlockProtocol event, unlocked', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.init()
+      handler.dispatchEvent = jest.fn()
+
+      const unlockedLockAddresses = ['address']
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.UNLOCKED,
+        unlockedLockAddresses,
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      expect(handler.dispatchEvent).toHaveBeenCalledWith('unlocked')
+    })
+  })
+
+  describe('iframe visibility', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should show the checkout iframe when it is ready on a paywall', () => {
+      expect.assertions(1)
+
+      const paywallConfig: PaywallConfig = {
+        ...config,
+        type: 'paywall',
+      }
+
+      const handler = getMainWindowHandler(paywallConfig)
+      handler.init()
+      handler.showCheckoutIframe = jest.fn()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.READY,
+        undefined,
+        iframes.checkout.iframe,
+        checkoutOrigin
+      )
+
+      expect(handler.showCheckoutIframe).toHaveBeenCalled()
+    })
+
+    it('should hide the checkout iframe on DISMISS_CHECKOUT message', () => {
+      expect.assertions(1)
+
+      const paywallConfig: PaywallConfig = {
+        ...config,
+        type: 'paywall',
+      }
+
+      const handler = getMainWindowHandler(paywallConfig)
+      handler.init()
+      handler.hideCheckoutIframe = jest.fn()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.DISMISS_CHECKOUT,
+        undefined,
+        iframes.checkout.iframe,
+        checkoutOrigin
+      )
+
+      expect(handler.hideCheckoutIframe).toHaveBeenCalled()
+    })
+
+    it('should show the accounts iframe on SHOW_ACCOUNTS_MODAL message', () => {
+      expect.assertions(1)
+
+      const paywallConfig: PaywallConfig = {
+        ...config,
+        type: 'paywall',
+      }
+
+      const handler = getMainWindowHandler(paywallConfig)
+      iframes.accounts.createIframe()
+      handler.init()
+      handler.showAccountIframe = jest.fn()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.SHOW_ACCOUNTS_MODAL,
+        undefined,
+        iframes.accounts.iframe,
+        accountOrigin
+      )
+
+      expect(handler.showAccountIframe).toHaveBeenCalled()
+    })
+
+    it('should hide the accounts iframe on HIDE_ACCOUNTS_MODAL message', () => {
+      expect.assertions(1)
+
+      const paywallConfig: PaywallConfig = {
+        ...config,
+        type: 'paywall',
+      }
+
+      const handler = getMainWindowHandler(paywallConfig)
+      iframes.accounts.createIframe()
+      handler.init()
+      handler.hideAccountIframe = jest.fn()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.HIDE_ACCOUNTS_MODAL,
+        undefined,
+        iframes.accounts.iframe,
+        accountOrigin
+      )
+
+      expect(handler.hideAccountIframe).toHaveBeenCalled()
+    })
+  })
+})

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
@@ -5,12 +5,6 @@ import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 import { PostMessages } from '../../../messageTypes'
 import { UnlockWindow } from '../../../windowTypes'
 
-declare const process: {
-  env: {
-    PAYWALL_URL: string
-  }
-}
-
 describe('MainWindowHandler - init', () => {
   let fakeWindow: FakeWindow
   let iframes: IframeHandler
@@ -29,7 +23,6 @@ describe('MainWindowHandler - init', () => {
       confirmed: '',
     },
   }
-  process.env.PAYWALL_URL = 'http://paywall'
 
   function getMainWindowHandler(configuration = config) {
     iframes = new IframeHandler(

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/setupUnlockProtocolVariable.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/setupUnlockProtocolVariable.test.ts
@@ -1,0 +1,104 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PaywallConfig } from '../../../unlockTypes'
+import IframeHandler from '../../../unlock.js/IframeHandler'
+import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+import { UnlockWindow } from '../../../windowTypes'
+import { UnlockAndIframeManagerWindow } from '../../../unlock.js/setupUnlockProtocolVariable'
+
+describe('MainWindowHandler - setupUnlockProtocolVariable', () => {
+  let fakeWindow: FakeWindow
+  const config: PaywallConfig = {
+    locks: {},
+    callToAction: {
+      default: '',
+      pending: '',
+      expired: '',
+      confirmed: '',
+    },
+  }
+
+  function getMainWindowHandler() {
+    const iframes = new IframeHandler(fakeWindow, '', '', '')
+    return new MainWindowHandler(fakeWindow, iframes, config)
+  }
+
+  function fullWindow() {
+    return (fakeWindow as unknown) as UnlockWindow
+  }
+
+  beforeEach(() => {
+    fakeWindow = new FakeWindow()
+  })
+
+  it('should set an unlockProtocol variable on the window object', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    handler.setupUnlockProtocolVariable()
+
+    expect(fullWindow().unlockProtocol).not.toBeUndefined()
+  })
+
+  it('should set a loadCheckoutModal function on the window.unlockProtocol object', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    handler.setupUnlockProtocolVariable()
+
+    expect(fullWindow().unlockProtocol.loadCheckoutModal).toBeInstanceOf(
+      Function
+    )
+  })
+
+  it('should set a getState function on the window.unlockProtocol object, which initially returns undefined', () => {
+    expect.assertions(2)
+
+    const handler = getMainWindowHandler()
+    handler.setupUnlockProtocolVariable()
+
+    expect(fullWindow().unlockProtocol.getState).toBeInstanceOf(Function)
+    expect(fullWindow().unlockProtocol.getState()).toBeUndefined()
+  })
+
+  it('should not allow setting new variables on the unlockProtocol object', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    handler.setupUnlockProtocolVariable()
+
+    interface MockWindowWithHi extends UnlockAndIframeManagerWindow {
+      unlockProtocol: {
+        loadCheckoutModal: () => void
+        getState: () => undefined
+        hi: number
+      }
+    }
+    const resultWindow = (fakeWindow as unknown) as MockWindowWithHi
+
+    expect(() => {
+      resultWindow.unlockProtocol.hi = 1
+    }).toThrow()
+  })
+
+  it('should not allow changing loadCheckoutModal on the unlockProtocol object', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    handler.setupUnlockProtocolVariable()
+
+    expect(() => {
+      fullWindow().unlockProtocol.loadCheckoutModal = () => {}
+    }).toThrow()
+  })
+
+  it('should show the iframe when unlockProtocol.loadCheckoutModal is called', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    handler.showCheckoutIframe = jest.fn()
+    handler.setupUnlockProtocolVariable()
+
+    fullWindow().unlockProtocol.loadCheckoutModal()
+    expect(handler.showCheckoutIframe).toHaveBeenCalled()
+  })
+})

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/setupUnlockProtocolVariable.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/setupUnlockProtocolVariable.test.ts
@@ -5,16 +5,7 @@ import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 import { UnlockWindow } from '../../../windowTypes'
 import { UnlockAndIframeManagerWindow } from '../../../unlock.js/setupUnlockProtocolVariable'
 
-declare const process: {
-  env: {
-    PAYWALL_URL: string
-    USER_IFRAME_URL: string
-  }
-}
-
 describe('MainWindowHandler - setupUnlockProtocolVariable', () => {
-  process.env.PAYWALL_URL = 'http://paywall'
-  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   const config: PaywallConfig = {
     locks: {},
@@ -27,7 +18,13 @@ describe('MainWindowHandler - setupUnlockProtocolVariable', () => {
   }
 
   function getMainWindowHandler() {
-    const iframes = new IframeHandler(fakeWindow, '', '', '')
+    // iframe URLs are unused in this test
+    const iframes = new IframeHandler(
+      fakeWindow,
+      'http://t',
+      'http://u',
+      'http://v'
+    )
     return new MainWindowHandler(fakeWindow, iframes, config)
   }
 

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/setupUnlockProtocolVariable.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/setupUnlockProtocolVariable.test.ts
@@ -5,7 +5,16 @@ import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 import { UnlockWindow } from '../../../windowTypes'
 import { UnlockAndIframeManagerWindow } from '../../../unlock.js/setupUnlockProtocolVariable'
 
+declare const process: {
+  env: {
+    PAYWALL_URL: string
+    USER_IFRAME_URL: string
+  }
+}
+
 describe('MainWindowHandler - setupUnlockProtocolVariable', () => {
+  process.env.PAYWALL_URL = 'http://paywall'
+  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   const config: PaywallConfig = {
     locks: {},

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/showAccountIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/showAccountIframe.test.ts
@@ -3,7 +3,16 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
+declare const process: {
+  env: {
+    PAYWALL_URL: string
+    USER_IFRAME_URL: string
+  }
+}
+
 describe('MainWindowHandler - showAccountIframe', () => {
+  process.env.PAYWALL_URL = 'http://paywall'
+  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   let iframes: IframeHandler
   const config: PaywallConfig = {

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/showAccountIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/showAccountIframe.test.ts
@@ -3,16 +3,7 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
-declare const process: {
-  env: {
-    PAYWALL_URL: string
-    USER_IFRAME_URL: string
-  }
-}
-
 describe('MainWindowHandler - showAccountIframe', () => {
-  process.env.PAYWALL_URL = 'http://paywall'
-  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   let iframes: IframeHandler
   const config: PaywallConfig = {
@@ -26,7 +17,8 @@ describe('MainWindowHandler - showAccountIframe', () => {
   }
 
   function getMainWindowHandler() {
-    iframes = new IframeHandler(fakeWindow, '', '', '')
+    // iframe URLs are unused in this test
+    iframes = new IframeHandler(fakeWindow, 'http://t', 'http://u', 'http://v')
     return new MainWindowHandler(fakeWindow, iframes, config)
   }
 

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/showAccountIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/showAccountIframe.test.ts
@@ -1,0 +1,60 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PaywallConfig } from '../../../unlockTypes'
+import IframeHandler from '../../../unlock.js/IframeHandler'
+import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+
+describe('MainWindowHandler - showAccountIframe', () => {
+  let fakeWindow: FakeWindow
+  let iframes: IframeHandler
+  const config: PaywallConfig = {
+    locks: {},
+    callToAction: {
+      default: '',
+      pending: '',
+      expired: '',
+      confirmed: '',
+    },
+  }
+
+  function getMainWindowHandler() {
+    iframes = new IframeHandler(fakeWindow, '', '', '')
+    return new MainWindowHandler(fakeWindow, iframes, config)
+  }
+
+  beforeEach(() => {
+    fakeWindow = new FakeWindow()
+  })
+
+  it('should show the account iframe', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    iframes.accounts.showIframe = jest.fn()
+
+    handler.showAccountIframe()
+
+    expect(iframes.accounts.showIframe).toHaveBeenCalled()
+  })
+
+  it('should hide the checkout if it used to be visible', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    handler.showCheckoutIframe()
+    iframes.checkout.hideIframe = jest.fn()
+    handler.showAccountIframe()
+
+    expect(iframes.checkout.hideIframe).toHaveBeenCalled()
+  })
+
+  it('should not hide the checkout if it was not visible', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    iframes.checkout.hideIframe = jest.fn()
+
+    handler.showAccountIframe()
+
+    expect(iframes.checkout.hideIframe).not.toHaveBeenCalled()
+  })
+})

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/showCheckoutIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/showCheckoutIframe.test.ts
@@ -3,7 +3,16 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
+declare const process: {
+  env: {
+    PAYWALL_URL: string
+    USER_IFRAME_URL: string
+  }
+}
+
 describe('MainWindowHandler - showCheckoutIframe', () => {
+  process.env.PAYWALL_URL = 'http://paywall'
+  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   let iframes: IframeHandler
   const config: PaywallConfig = {

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/showCheckoutIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/showCheckoutIframe.test.ts
@@ -1,0 +1,62 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PaywallConfig } from '../../../unlockTypes'
+import IframeHandler from '../../../unlock.js/IframeHandler'
+import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+
+describe('MainWindowHandler - showCheckoutIframe', () => {
+  let fakeWindow: FakeWindow
+  let iframes: IframeHandler
+  const config: PaywallConfig = {
+    locks: {},
+    callToAction: {
+      default: '',
+      pending: '',
+      expired: '',
+      confirmed: '',
+    },
+  }
+
+  function getMainWindowHandler() {
+    iframes = new IframeHandler(fakeWindow, '', '', '')
+    return new MainWindowHandler(fakeWindow, iframes, config)
+  }
+
+  beforeEach(() => {
+    fakeWindow = new FakeWindow()
+  })
+
+  it('should show the checkout iframe', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    iframes.checkout.showIframe = jest.fn()
+
+    handler.showCheckoutIframe()
+
+    expect(iframes.checkout.showIframe).toHaveBeenCalled()
+  })
+
+  it('should not show the checkout iframe if the accounts iframe is visible', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    handler.showAccountIframe()
+    handler.showCheckoutIframe()
+    iframes.checkout.showIframe = jest.fn()
+
+    expect(iframes.checkout.showIframe).not.toHaveBeenCalled()
+  })
+
+  it('should show the checkout iframe after the accounts iframe hides', () => {
+    expect.assertions(1)
+
+    const handler = getMainWindowHandler()
+    handler.showAccountIframe()
+    handler.showCheckoutIframe()
+    iframes.checkout.showIframe = jest.fn()
+
+    handler.hideAccountIframe()
+
+    expect(iframes.checkout.showIframe).toHaveBeenCalled()
+  })
+})

--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/showCheckoutIframe.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/showCheckoutIframe.test.ts
@@ -3,16 +3,7 @@ import { PaywallConfig } from '../../../unlockTypes'
 import IframeHandler from '../../../unlock.js/IframeHandler'
 import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
 
-declare const process: {
-  env: {
-    PAYWALL_URL: string
-    USER_IFRAME_URL: string
-  }
-}
-
 describe('MainWindowHandler - showCheckoutIframe', () => {
-  process.env.PAYWALL_URL = 'http://paywall'
-  process.env.USER_IFRAME_URL = 'http://app/account'
   let fakeWindow: FakeWindow
   let iframes: IframeHandler
   const config: PaywallConfig = {
@@ -26,7 +17,8 @@ describe('MainWindowHandler - showCheckoutIframe', () => {
   }
 
   function getMainWindowHandler() {
-    iframes = new IframeHandler(fakeWindow, '', '', '')
+    // iframe URLs are unused in this test
+    iframes = new IframeHandler(fakeWindow, 'http://t', 'http://u', 'http://v')
     return new MainWindowHandler(fakeWindow, iframes, config)
   }
 

--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.test.ts
@@ -3,14 +3,9 @@ import { PurchaseKeyRequest } from '../../../unlockTypes'
 import CheckoutIframeMessageEmitter from '../../../unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter'
 import { PostMessages } from '../../../messageTypes'
 
-declare const process: {
-  env: any
-}
-process.env.PAYWALL_URL = 'http://paywall'
-
 describe('CheckoutIframeMessageEmitter', () => {
   let fakeWindow: FakeWindow
-  const checkoutOrigin = process.env.PAYWALL_URL
+  const checkoutOrigin = 'http://fun.times'
 
   function makeEmitter(fakeWindow: FakeWindow) {
     const emitter = new CheckoutIframeMessageEmitter(
@@ -56,7 +51,7 @@ describe('CheckoutIframeMessageEmitter', () => {
         PostMessages.SCROLL_POSITION,
         5,
         emitter.iframe,
-        process.env.PAYWALL_URL // iframe origin
+        checkoutOrigin // iframe origin
       )
     })
 
@@ -72,7 +67,7 @@ describe('CheckoutIframeMessageEmitter', () => {
         PostMessages.READY,
         undefined,
         emitter.iframe,
-        process.env.PAYWALL_URL
+        checkoutOrigin
       )
 
       expect(fakeReady).toHaveBeenCalled()

--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
@@ -3,14 +3,9 @@ import DataIframeMessageEmitter from '../../../unlock.js/PostMessageEmitters/Dat
 import { PostMessages, ExtractPayload } from '../../../messageTypes'
 import { web3MethodCall } from '../../../windowTypes'
 
-declare const process: {
-  env: any
-}
-process.env.PAYWALL_URL = 'http://paywall'
-
 describe('DataIframeMessageEmitter', () => {
   let fakeWindow: FakeWindow
-  const dataOrigin = process.env.PAYWALL_URL
+  const dataOrigin = 'http://fun.times'
 
   function makeEmitter(fakeWindow: FakeWindow) {
     const emitter = new DataIframeMessageEmitter(
@@ -56,7 +51,7 @@ describe('DataIframeMessageEmitter', () => {
         PostMessages.SCROLL_POSITION,
         5,
         emitter.iframe,
-        process.env.PAYWALL_URL // iframe origin
+        dataOrigin // iframe origin
       )
     })
 
@@ -72,7 +67,7 @@ describe('DataIframeMessageEmitter', () => {
         PostMessages.READY,
         undefined,
         emitter.iframe,
-        process.env.PAYWALL_URL
+        dataOrigin
       )
 
       expect(fakeReady).toHaveBeenCalled()

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -1,0 +1,266 @@
+import {
+  LockStatus,
+  UnlockWindowNoProtocolYet,
+  UnlockWindow,
+} from '../windowTypes'
+import IframeHandler from './IframeHandler'
+import { PostMessages } from '../messageTypes'
+import { PaywallConfig } from '../unlockTypes'
+
+interface hasPrototype {
+  prototype?: any
+}
+
+/**
+ * This class handles all of the messaging to the window object
+ *
+ * Specifically, sending the "unlockProtocol" event, creating the
+ * "unlockProtocol" object on window, and also all of the showing
+ * and hiding of checkout and account iframes
+ */
+export default class MainWindowHandler {
+  private window: UnlockWindowNoProtocolYet
+  private iframes: IframeHandler
+  private showCheckoutWhenAccountsHides: boolean = false
+  private showingCheckout: boolean = false
+  private showingAccountsIframe: boolean = false
+  private lockStatus: LockStatus = undefined
+  private config: PaywallConfig
+
+  constructor(
+    window: UnlockWindowNoProtocolYet,
+    iframes: IframeHandler,
+    config: PaywallConfig
+  ) {
+    this.window = window
+    this.iframes = iframes
+    this.config = config
+  }
+
+  init() {
+    // create window.unlockProtocol
+    this.setupUnlockProtocolVariable()
+
+    // this is a cache for the time between script startup and the full load
+    // of the data iframe. The data iframe will then send down the current
+    // value, overriding this. A bit later, the blockchain handler will update
+    // with the actual value, so this is only used for a few milliseconds
+    const locked = this.getCachedLockState()
+    if (locked === true) {
+      this.dispatchEvent('locked')
+    }
+    if (locked === false) {
+      this.dispatchEvent('unlocked')
+    }
+
+    // respond to "unlocked" and "locked" events by
+    // dispatching "unlockProtocol" on the main window
+    // and
+    this.iframes.data.on(PostMessages.LOCKED, () => {
+      this.dispatchEvent('locked')
+      this.setCachedLockedState(true)
+      // Update the user-facing status with locked/unlocked updates
+      this.lockStatus = 'locked'
+    })
+    this.iframes.data.on(PostMessages.UNLOCKED, () => {
+      this.dispatchEvent('unlocked')
+      this.setCachedLockedState(false)
+      // Update the user-facing status with locked/unlocked updates
+      this.lockStatus = 'unlocked'
+    })
+
+    // handle display of checkout and account UI
+    this.iframes.checkout.on(PostMessages.DISMISS_CHECKOUT, () => {
+      this.hideCheckoutIframe()
+    })
+
+    this.iframes.checkout.on(PostMessages.READY, () => {
+      if (this.config && this.config.type === 'paywall') {
+        // show the checkout UI
+        this.showCheckoutIframe()
+      }
+    })
+
+    this.iframes.accounts.on(PostMessages.SHOW_ACCOUNTS_MODAL, () => {
+      this.showAccountIframe()
+    })
+
+    this.iframes.accounts.on(PostMessages.HIDE_ACCOUNTS_MODAL, () => {
+      this.hideAccountIframe()
+    })
+  }
+
+  getCachedLockState() {
+    try {
+      const cache = this.window.localStorage.getItem('__unlockProtocol.locked')
+      if (!cache) return 'ignore'
+      if (cache !== 'true' && cache !== 'false') return 'ignore'
+
+      return JSON.parse(cache)
+    } catch (_) {
+      return 'ignore'
+    }
+  }
+
+  setCachedLockedState(newState: boolean) {
+    try {
+      // this is a fast cache. The value will only be used
+      // to prevent a flash of ads on startup. If a cheeky
+      // user attempts to prevent display of ads by setting
+      // the localStorage cache, it will only work for a
+      // few milliseconds
+      this.window.localStorage.setItem(
+        '__unlockProtocol.locked',
+        JSON.stringify(newState)
+      )
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  /**
+   * Create window.unlockProtocol
+   */
+  setupUnlockProtocolVariable() {
+    const loadCheckoutModal = () => {
+      this.showCheckoutIframe()
+    }
+    const getState = () => this.lockStatus
+
+    const unlockProtocol: hasPrototype = {}
+
+    const immutable = {
+      writable: false, // prevent changing loadCheckoutModal by simple `unlockProtocol.loadCheckoutModal = () => {}`
+      configurable: false, // prevent re-defining the writable property
+      enumerable: false, // prevent finding it exists via `for ... of`
+    }
+
+    Object.defineProperties(unlockProtocol, {
+      loadCheckoutModal: {
+        value: loadCheckoutModal,
+        ...immutable,
+      },
+      getState: {
+        value: getState,
+        ...immutable,
+      },
+    })
+
+    const freeze: (obj: any) => void = Object.freeze || Object
+
+    // if freeze is available, prevents adding or
+    // removing the object prototype properties
+    // (value, get, set, enumerable, writable, configurable)
+    freeze(unlockProtocol.prototype)
+    freeze(unlockProtocol)
+
+    // set up the unlockProtocol object on the main window
+    // it will be 100% read-only, unchangeable and un-deleteable
+    try {
+      if (
+        !(this.window as UnlockWindow).unlockProtocol ||
+        (this.window as UnlockWindow).unlockProtocol.loadCheckoutModal !==
+          loadCheckoutModal
+      ) {
+        Object.defineProperties(this.window, {
+          unlockProtocol: {
+            value: unlockProtocol,
+            ...immutable,
+          },
+        })
+      }
+    } catch (e) {
+      // TODO: decide whether to be more nuclear here
+      // eslint-disable-next-line no-console
+      console.error(
+        'WARNING: unlockProtocol already defined, cannot re-define it'
+      )
+    }
+  }
+
+  /**
+   * Dispatch the unlockProtocol event
+   */
+  dispatchEvent(detail: any) {
+    let event
+    try {
+      event = new this.window.CustomEvent('unlockProtocol', { detail })
+    } catch (e) {
+      // older browsers do events this clunky way.
+      // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events#The_old-fashioned_way
+      // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent#Parameters
+      event = this.window.document.createEvent('customevent')
+      event.initCustomEvent(
+        'unlockProtocol',
+        true /* canBubble */,
+        true /* cancelable */,
+        detail
+      )
+    }
+    this.window.dispatchEvent(event)
+  }
+
+  /**
+   * hide the checkout iframe
+   */
+  hideCheckoutIframe() {
+    this.showCheckoutWhenAccountsHides = false
+    this.showingCheckout = false
+    this.iframes.checkout.hideIframe()
+  }
+
+  /**
+   * show the checkout iframe, unless the account iframe is visible,
+   * then mark it for showing when the account iframe is hidden
+   */
+  showCheckoutIframe() {
+    if (this.showingAccountsIframe) {
+      // if the accounts iframe is active, we will
+      // wait to show the checkout iframe
+      // until it is hidden
+      this.showCheckoutWhenAccountsHides = true
+      this.showingCheckout = false
+    } else {
+      // otherwise we will show the checkout iframe immediately
+      this.showingCheckout = true
+      this.showCheckoutWhenAccountsHides = false
+      this.iframes.checkout.showIframe()
+    }
+  }
+
+  /**
+   * show the account iframe
+   *
+   * If the checkout iframe is visible, hide it and mark it for
+   * showing after the account iframe hides
+   */
+  showAccountIframe() {
+    if (this.showingCheckout) {
+      // hide the checkout iframe, but mark it as needing
+      // to be shown when the accounts iframe hides
+      this.showCheckoutWhenAccountsHides = true
+      this.showingCheckout = false
+      this.iframes.checkout.hideIframe()
+    }
+    // note: if user accounts are disabled, this is a no-op
+    this.showingAccountsIframe = true
+    this.iframes.accounts.showIframe()
+  }
+
+  /**
+   * hide the account iframe
+   *
+   * If the checkout iframe was visible, show it again
+   */
+  hideAccountIframe() {
+    this.showingAccountsIframe = false
+    // note: if user accounts are disabled, this is a no-op
+    this.iframes.accounts.hideIframe()
+    if (this.showCheckoutWhenAccountsHides) {
+      // now that the accounts iframe is hidden, show the checkout iframe
+      this.showingCheckout = true
+      this.showCheckoutWhenAccountsHides = false
+      this.iframes.checkout.showIframe()
+    }
+  }
+}

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -11,6 +11,8 @@ interface hasPrototype {
   prototype?: any
 }
 
+export const IGNORE_CACHE = 'ignore'
+
 /**
  * This class handles all of the messaging to the window object
  *
@@ -46,6 +48,8 @@ export default class MainWindowHandler {
     // value, overriding this. A bit later, the blockchain handler will update
     // with the actual value, so this is only used for a few milliseconds
     const locked = this.getCachedLockState()
+    // note: locked can also be value IGNORE_CACHE in addition to true/false
+    // IGNORE_CACHE is used to ignore the cache and not respond to it
     if (locked === true) {
       this.dispatchEvent('locked')
     }
@@ -75,6 +79,8 @@ export default class MainWindowHandler {
     })
 
     this.iframes.checkout.on(PostMessages.READY, () => {
+      // TODO: "type" is going to be removed. Instead, we will respond to specific config directives
+      // so this code will be removed
       if (this.config && this.config.type === 'paywall') {
         // show the checkout UI
         this.showCheckoutIframe()
@@ -93,12 +99,12 @@ export default class MainWindowHandler {
   getCachedLockState() {
     try {
       const cache = this.window.localStorage.getItem('__unlockProtocol.locked')
-      if (!cache) return 'ignore'
-      if (cache !== 'true' && cache !== 'false') return 'ignore'
+      if (!cache) return IGNORE_CACHE
+      if (cache !== 'true' && cache !== 'false') return IGNORE_CACHE
 
       return JSON.parse(cache)
     } catch (_) {
-      return 'ignore'
+      return IGNORE_CACHE
     }
   }
 

--- a/paywall/src/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.ts
@@ -22,10 +22,6 @@ import {
   CheckoutIframeEvents,
 } from './EventEmitterTypes'
 
-declare const process: {
-  env: any
-}
-
 class FancyEmitter extends (EventEmitter as {
   new (): CheckoutIframeEventEmitter
 }) {}
@@ -55,12 +51,13 @@ export default class CheckoutIframeMessageEmitter extends FancyEmitter {
 
     this.window = window
     this.iframe = makeIframe(window, checkoutIframeUrl, 'unlock checkout')
+    const url = new URL(this.iframe.src)
     addIframeToDocument(window, this.iframe)
 
     const { postMessage, addHandler } = mainWindowPostOffice(
       window,
       this.iframe,
-      process.env.PAYWALL_URL,
+      url.origin,
       'main window',
       'Checkout UI iframe'
     )

--- a/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
@@ -13,10 +13,6 @@ import {
 import { makeIframe, addIframeToDocument } from '../iframeManager'
 import { DataIframeEventEmitter, DataIframeEvents } from './EventEmitterTypes'
 
-declare const process: {
-  env: any
-}
-
 interface UnvalidatedPayload {
   method?: any
   id?: any
@@ -51,12 +47,13 @@ export default class DataIframeMessageEmitter extends FancyEmitter {
     super()
 
     this.iframe = makeIframe(window, dataIframeUrl, 'unlock data')
+    const url = new URL(this.iframe.src)
     addIframeToDocument(window, this.iframe)
 
     const { postMessage, addHandler } = mainWindowPostOffice(
       window,
       this.iframe,
-      process.env.PAYWALL_URL,
+      url.origin,
       'main window',
       'Data iframe'
     )

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -191,6 +191,18 @@ export interface ConfigWindow {
   unlockProtocolConfig?: PaywallConfig
 }
 
+export interface UnlockWindowNoProtocolYet
+  extends PostOfficeWindow,
+    EventWindow,
+    LocalStorageWindow,
+    IframeManagingWindow,
+    Web3Window,
+    OriginWindow,
+    ConfigWindow {
+  document: FullDocument
+  addEventListener: AddEventListenerFunc
+}
+
 export interface UnlockWindow
   extends PostOfficeWindow,
     EventWindow,


### PR DESCRIPTION
# Description

This class handles all of the interaction in the main window of the publisher using our paywall.  It manages:

1. dispatching the `unlockProtocol` event
2. setting up `window.unlockProtocol` variable
3. showing and hiding of checkout/account iframes
4. the dumb caching of previous locked/unlocked state

As seen on line 53 of `MainWindowHandler/init.test.ts`, the bug unearthed last week of the `unlockProtocol` event being dispatched before `window.unlockProtocol` exists is both fixed and there is a regression test for the fix.

The creation of the account iframe is done in the upcoming `Wallet` class. If we don't have user accounts, the accounts iframe has a dummy fake iframe.

A note on how the tests are organized: the directory `MainWindowHandler/` contains a separate file for each method tested, similar to how the `Mailbox` and `BlockchainHandler` are tested.

Also, to make testing easier, you'll see I augmented the fake window helper to add event dispatching, as well as a couple small type tweaks.

When made live, this will remedy both #4250 and #4378

# Issues

Refs #4385

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
