### PR TITLE
remove use of PAYWALL_URL in the unlock.js iframe emitters

### DIFF
--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.test.ts
@@ -3,14 +3,9 @@ import { PurchaseKeyRequest } from '../../../unlockTypes'
 import CheckoutIframeMessageEmitter from '../../../unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter'
 import { PostMessages } from '../../../messageTypes'
 
-declare const process: {
-  env: any
-}
-process.env.PAYWALL_URL = 'http://paywall'
-
 describe('CheckoutIframeMessageEmitter', () => {
   let fakeWindow: FakeWindow
-  const checkoutOrigin = process.env.PAYWALL_URL
+  const checkoutOrigin = 'http://fun.times'
 
   function makeEmitter(fakeWindow: FakeWindow) {
     const emitter = new CheckoutIframeMessageEmitter(
@@ -56,7 +51,7 @@ describe('CheckoutIframeMessageEmitter', () => {
         PostMessages.SCROLL_POSITION,
         5,
         emitter.iframe,
-        process.env.PAYWALL_URL // iframe origin
+        checkoutOrigin // iframe origin
       )
     })
 
@@ -72,7 +67,7 @@ describe('CheckoutIframeMessageEmitter', () => {
         PostMessages.READY,
         undefined,
         emitter.iframe,
-        process.env.PAYWALL_URL
+        checkoutOrigin
       )
 
       expect(fakeReady).toHaveBeenCalled()

--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
@@ -3,14 +3,9 @@ import DataIframeMessageEmitter from '../../../unlock.js/PostMessageEmitters/Dat
 import { PostMessages, ExtractPayload } from '../../../messageTypes'
 import { web3MethodCall } from '../../../windowTypes'
 
-declare const process: {
-  env: any
-}
-process.env.PAYWALL_URL = 'http://paywall'
-
 describe('DataIframeMessageEmitter', () => {
   let fakeWindow: FakeWindow
-  const dataOrigin = process.env.PAYWALL_URL
+  const dataOrigin = 'http://fun.times'
 
   function makeEmitter(fakeWindow: FakeWindow) {
     const emitter = new DataIframeMessageEmitter(
@@ -56,7 +51,7 @@ describe('DataIframeMessageEmitter', () => {
         PostMessages.SCROLL_POSITION,
         5,
         emitter.iframe,
-        process.env.PAYWALL_URL // iframe origin
+        dataOrigin // iframe origin
       )
     })
 
@@ -72,7 +67,7 @@ describe('DataIframeMessageEmitter', () => {
         PostMessages.READY,
         undefined,
         emitter.iframe,
-        process.env.PAYWALL_URL
+        dataOrigin
       )
 
       expect(fakeReady).toHaveBeenCalled()

--- a/paywall/src/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/CheckoutIframeMessageEmitter.ts
@@ -22,10 +22,6 @@ import {
   CheckoutIframeEvents,
 } from './EventEmitterTypes'
 
-declare const process: {
-  env: any
-}
-
 class FancyEmitter extends (EventEmitter as {
   new (): CheckoutIframeEventEmitter
 }) {}
@@ -55,12 +51,13 @@ export default class CheckoutIframeMessageEmitter extends FancyEmitter {
 
     this.window = window
     this.iframe = makeIframe(window, checkoutIframeUrl, 'unlock checkout')
+    const url = new URL(this.iframe.src)
     addIframeToDocument(window, this.iframe)
 
     const { postMessage, addHandler } = mainWindowPostOffice(
       window,
       this.iframe,
-      process.env.PAYWALL_URL,
+      url.origin,
       'main window',
       'Checkout UI iframe'
     )

--- a/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
@@ -13,10 +13,6 @@ import {
 import { makeIframe, addIframeToDocument } from '../iframeManager'
 import { DataIframeEventEmitter, DataIframeEvents } from './EventEmitterTypes'
 
-declare const process: {
-  env: any
-}
-
 interface UnvalidatedPayload {
   method?: any
   id?: any
@@ -51,12 +47,13 @@ export default class DataIframeMessageEmitter extends FancyEmitter {
     super()
 
     this.iframe = makeIframe(window, dataIframeUrl, 'unlock data')
+    const url = new URL(this.iframe.src)
     addIframeToDocument(window, this.iframe)
 
     const { postMessage, addHandler } = mainWindowPostOffice(
       window,
       this.iframe,
-      process.env.PAYWALL_URL,
+      url.origin,
       'main window',
       'Data iframe'
     )


### PR DESCRIPTION
# Description

As noted by @julien51, we should not use `process.env` directly anywhere in the code. Although configuration is one option, this approach is more correct, as we extract the origin of the URL passed in to create the iframe, and use that as the origin, just as `window.postMessage` will.

# Issues

Refs #4385 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
