### PR TITLE
Sanitize Google Calendar links while not double-encoding them

### DIFF
--- a/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -8031,7 +8031,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -8207,7 +8207,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -8795,7 +8795,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -8971,7 +8971,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -9453,7 +9453,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -9591,7 +9591,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -10087,7 +10087,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -10246,7 +10246,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -10711,7 +10711,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -10849,7 +10849,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -11293,7 +11293,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -11431,7 +11431,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -11875,7 +11875,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -12013,7 +12013,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -12457,7 +12457,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -12595,7 +12595,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably,%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details,%20click%20here:%20http://localhost/&location=Totters%20Lane,%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >

--- a/tickets/src/__tests__/utils/links.test.js
+++ b/tickets/src/__tests__/utils/links.test.js
@@ -11,7 +11,7 @@ describe('googleCalendarLinkBuilder', () => {
       'The office'
     )
     expect(link).toEqual(
-      'https://calendar.google.com/calendar/r/eventedit?&text=The party&dates=20200126T233000/20200127T003000&details=This is going to be a very cool party that you should attend&location=The office&sf=true&output=xml'
+      'https://calendar.google.com/calendar/r/eventedit?&text=The%20party&dates=20200126T233000/20200127T003000&details=This%20is%20going%20to%20be%20a%20very%20cool%20party%20that%20you%20should%20attend&location=The%20office&sf=true&output=xml'
     )
   })
 
@@ -25,7 +25,21 @@ describe('googleCalendarLinkBuilder', () => {
       'The office'
     )
     expect(link).toEqual(
-      'https://calendar.google.com/calendar/r/eventedit?&text=The party&dates=20190516T103000/20190516T133000&details=This is going to be a very cool party that you should attend&location=The office&sf=true&output=xml'
+      'https://calendar.google.com/calendar/r/eventedit?&text=The%20party&dates=20190516T103000/20190516T133000&details=This%20is%20going%20to%20be%20a%20very%20cool%20party%20that%20you%20should%20attend&location=The%20office&sf=true&output=xml'
+    )
+  })
+
+  it('should correctly encode special characters', () => {
+    expect.assertions(1)
+    const link = googleCalendarLinkBuilder(
+      "Ben & Julien's party",
+      'This is going to be a very cool party that you should attend',
+      new Date(2019, 4, 16, 10, 30, 0),
+      60 * 60 * 3,
+      'Contact Ben & Julien'
+    )
+    expect(link).toEqual(
+      "https://calendar.google.com/calendar/r/eventedit?&text=Ben%20%26%20Julien's%20party&dates=20190516T103000/20190516T133000&details=This%20is%20going%20to%20be%20a%20very%20cool%20party%20that%20you%20should%20attend&location=Contact%20Ben%20%26%20Julien&sf=true&output=xml"
     )
   })
 })

--- a/tickets/src/components/content/EventContent.js
+++ b/tickets/src/components/content/EventContent.js
@@ -66,6 +66,13 @@ export const EventContent = ({
     '\n\n' +
     `For more details, click here: ${window.location.href}`
 
+  // Sanitize user-provided links
+  const sanitizedLinks = links.map(link => {
+    link.href = encodeURI(link.href)
+    return link
+  })
+
+  // No need to sanitize the GCal link because googleCalendarLinkBuilder does it for us
   let googleCalendarLink = googleCalendarLinkBuilder(
     name,
     details,
@@ -75,7 +82,7 @@ export const EventContent = ({
   )
 
   const eventLinks = [
-    ...links,
+    ...sanitizedLinks,
     {
       href: googleCalendarLink,
       text: 'Add to your Calendar!',
@@ -85,10 +92,9 @@ export const EventContent = ({
 
   const externalLinks = eventLinks.map(
     ({ href, text, icon = '/static/images/illustrations/link.svg' }) => {
-      const encodedHref = encodeURI(href)
       return (
-        <Link key={encodedHref} icon={icon}>
-          <a target="_blank" rel="noopener noreferrer" href={encodedHref}>
+        <Link key={href} icon={icon}>
+          <a target="_blank" rel="noopener noreferrer" href={href}>
             {text}
           </a>
         </Link>

--- a/tickets/src/utils/links.ts
+++ b/tickets/src/utils/links.ts
@@ -33,10 +33,10 @@ export function googleCalendarLinkBuilder(
   }
 
   let googleCalendarLink = `https://calendar.google.com/calendar/r/eventedit?`
-  googleCalendarLink += `&text=${name}`
+  googleCalendarLink += `&text=${encodeURIComponent(name)}`
   googleCalendarLink += `&dates=${start}/${end}`
-  googleCalendarLink += `&details=${details}`
-  googleCalendarLink += `&location=${location}`
+  googleCalendarLink += `&details=${encodeURIComponent(details)}`
+  googleCalendarLink += `&location=${encodeURIComponent(location)}`
   googleCalendarLink += `&sf=true&output=xml`
   return googleCalendarLink
 }


### PR DESCRIPTION
# Description

Content in GCal links is now properly sanitized (allowing for ampersands etc in descriptions). To achieve this I've changed the way links on event pages are sanitized, to avoid double-sanitizing Google Calendar content.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
cc @smombartz 