### PR TITLE
Adding links and HTML to GCal description

### DIFF
--- a/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -9630,7 +9630,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -9806,7 +9806,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -10394,7 +10394,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -10570,7 +10570,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -11052,7 +11052,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -11190,7 +11190,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -11686,7 +11686,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -11845,7 +11845,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -12310,7 +12310,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -12448,7 +12448,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -12892,7 +12892,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -13030,7 +13030,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -13474,7 +13474,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -13612,7 +13612,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -14056,7 +14056,7 @@ Object {
                   class="c16"
                 >
                   <a
-                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                    href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -14194,7 +14194,7 @@ Object {
                 class="sc-1fq9sck-4 gfUnAs"
               >
                 <a
-                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0AFor%20more%20details%2C%20click%20here%3A%20http%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
+                  href="https://calendar.google.com/calendar/r/eventedit?&text=My%20Doctor%20Who%20party&dates=20631123T183000/20631123T193000&details=Unbelievably%2C%20it's%20been%20100%20years%20since%20it%20first%20came%20to%20our%20screens.%0A%0AJoin%20us%20for%20an%20hour%20or%20two%20of%20fine%20entertainment.%0A%0A%3Cstrong%3EEvent%20Website%3C%2Fstrong%3E%0Ahttps%3A%2F%2Fparty.com%2Ffun%0A%0A%3Cstrong%3ETicket%20Details%3C%2Fstrong%3E%0Ahttp%3A%2F%2Flocalhost%2F&location=Totters%20Lane%2C%20London&sf=true&output=xml"
                   rel="noopener noreferrer"
                   target="_blank"
                 >

--- a/tickets/src/components/content/EventContent.js
+++ b/tickets/src/components/content/EventContent.js
@@ -61,16 +61,20 @@ export const EventContent = ({
 
   const convertCurrency = !lock.currencyContractAddress
 
-  const details =
-    description +
-    '\n\n' +
-    `For more details, click here: ${window.location.href}`
-
   // Sanitize user-provided links
   const sanitizedLinks = links.map(link => {
     link.href = encodeURI(link.href)
     return link
   })
+
+  let details = description
+  if (sanitizedLinks.length) {
+    details += '\n\n<strong>Event Website</strong>'
+    sanitizedLinks.forEach(link => {
+      details += '\n' + link.href
+    })
+  }
+  details += `\n\n<strong>Ticket Details</strong>\n${window.location.href}`
 
   // No need to sanitize the GCal link because googleCalendarLinkBuilder does it for us
   let googleCalendarLink = googleCalendarLinkBuilder(


### PR DESCRIPTION
# Description

Google Calendar event descriptions now include the event URL and clearer headings.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4439 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

cc @smombartz 

<img width="858" alt="Screen Shot 2019-08-15 at 1 26 06 PM" src="https://user-images.githubusercontent.com/624104/63124501-46606980-bf60-11e9-9d3f-4af4ea755be7.png">

<img width="1049" alt="Screen Shot 2019-08-15 at 1 19 30 PM" src="https://user-images.githubusercontent.com/624104/63124467-30eb3f80-bf60-11e9-81ac-6b4d2590310d.png">
