### PR TITLE
Show wallet check message when purchasing on paywall

### DIFF
--- a/paywall/src/__tests__/components/content/CheckoutContent.test.tsx
+++ b/paywall/src/__tests__/components/content/CheckoutContent.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import * as rtl from 'react-testing-library'
+import CheckoutContent from '../../../components/content/CheckoutContent'
+import { createUnlockStore } from '../../../createUnlockStore'
+import { ConfigContext } from '../../../utils/withConfig'
+
+jest.mock('../../../hooks/utils/useConfig', () => {
+  return () => ({
+    requiredNetworkId: 1984,
+  })
+})
+
+jest.mock('../../../hooks/useBlockchainData', () => {
+  return () => ({
+    account: {
+      balance: '200',
+      address: '0x123cdc',
+    },
+    network: 1984,
+    locks: {
+      '0x123abc': {
+        name: 'My Lock',
+        address: '0x123abc',
+        keyPrice: '0.005',
+        expirationDuration: 123456,
+        key: {
+          expiration: new Date().getMilliseconds(),
+          transactions: [],
+          status: 'whatever',
+          confirmations: 0,
+          lock: '0x123abc',
+        },
+      },
+    },
+  })
+})
+
+jest.mock('../../../hooks/usePaywallConfig', () => {
+  return () => ({
+    locks: {
+      '0x123abc': {
+        name: 'My Lock',
+      },
+    },
+    callToAction: {
+      default: 'This is a call to action',
+    },
+  })
+})
+
+const store = createUnlockStore()
+const config = {
+  erc20Contract: {
+    address: '0xfeedbeef',
+  },
+}
+
+describe('CheckoutContent', () => {
+  it('shows the wallet check after the purchase button is clicked', () => {
+    expect.assertions(1)
+    const walletCheckMessage =
+      'Please check your browser wallet to complete the transaction.'
+    const { getByText } = rtl.render(
+      <Provider store={store}>
+        <ConfigContext.Provider value={config}>
+          <CheckoutContent />
+        </ConfigContext.Provider>
+      </Provider>
+    )
+
+    // The message isn't there at first...
+    expect(() => {
+      getByText(walletCheckMessage)
+    }).toThrow()
+    const purchaseButton = getByText('Purchase')
+    rtl.fireEvent.click(purchaseButton)
+
+    // ...but then it is
+    getByText(walletCheckMessage)
+  })
+})

--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -219,7 +219,7 @@ export default function CheckoutContent() {
     </CheckoutWrapper>
   )
 
-  if (showWalletCheckOverlay) {
+  if (showWalletCheckOverlay && !purchasingLocks.length) {
     return (
       <Greyout>
         <MessageBox>

--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -97,12 +97,10 @@ export default function CheckoutContent() {
   useListenForPostMessage({
     type: POST_MESSAGE_ERROR,
     defaultValue: undefined,
-    getValue: (payload: any) => {
-      if (payload === 'purchase failed') {
-        // Purchase failed (likely because transaction was rejected in MetaMask)
-        // remove the wallet check overlay.
-        setShowWalletCheckOverlay(false)
-      }
+    getValue: () => {
+      // Purchase failed (likely because transaction was rejected in MetaMask),
+      // remove the wallet check overlay.
+      setShowWalletCheckOverlay(false)
     },
   })
 
@@ -219,6 +217,9 @@ export default function CheckoutContent() {
     </CheckoutWrapper>
   )
 
+  // purchasingLocks is an array of locks for which a transaction has
+  // been initiated. Once purchasingLocks is non-empty, we know that the
+  // user's wallet is enabled and no longer need to show the overlay.
   if (showWalletCheckOverlay && !purchasingLocks.length) {
     return (
       <Greyout>

--- a/paywall/src/unlock.js/Wallet.ts
+++ b/paywall/src/unlock.js/Wallet.ts
@@ -119,6 +119,10 @@ export default class Wallet {
         // the natural behavior would be passing nothing as the 2nd argument
         undefined
       )
+      this.iframes.checkout.postMessage(
+        PostMessages.INITIATED_TRANSACTION,
+        undefined
+      )
     })
 
     // then create the iframe and ready its post office

--- a/paywall/src/unlock.js/Wallet.ts
+++ b/paywall/src/unlock.js/Wallet.ts
@@ -119,10 +119,6 @@ export default class Wallet {
         // the natural behavior would be passing nothing as the 2nd argument
         undefined
       )
-      this.iframes.checkout.postMessage(
-        PostMessages.INITIATED_TRANSACTION,
-        undefined
-      )
     })
 
     // then create the iframe and ready its post office


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR is a partial fix to #4383 

<img width="1126" alt="image" src="https://user-images.githubusercontent.com/9300702/63285546-f5b07f80-c283-11e9-86b1-052808676152.png">

It behaves as follows:

- When the purchase button is clicked, the checkout UI swaps over to the wallet check overlay ("Please check your browser wallet...") to make sure the user authorizes the transaction
- The overlay swaps back to the checkout UI in the following cases:
  - User clicks the dismiss button
  - User rejects the transaction in their browser wallet
  - User approves the transaction in their browser wallet

Now including a test, with more to come

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4383 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
