### PR TITLE
Show wallet check message when enabling provider on the paywall

### DIFF
--- a/paywall/src/__tests__/middlewares/providerMiddleware.test.ts
+++ b/paywall/src/__tests__/middlewares/providerMiddleware.test.ts
@@ -1,7 +1,12 @@
-import providerMiddleware from '../../middlewares/providerMiddleware'
-import { SET_PROVIDER } from '../../actions/provider'
+import providerMiddleware, {
+  initializeProvider,
+  delayedDispatch,
+  enableProvider,
+} from '../../middlewares/providerMiddleware'
+import { SET_PROVIDER, providerReady } from '../../actions/provider'
 import { setError } from '../../actions/error'
 import { FATAL_MISSING_PROVIDER } from '../../errors'
+import { dismissWalletCheck } from '../../actions/walletStatus'
 
 const config = {
   providers: {
@@ -98,6 +103,104 @@ describe('provider middleware', () => {
       }
 
       providerMiddleware(config)({ getState, dispatch })(next)(sameAction)
+    })
+  })
+  describe('delayedDispatch', () => {
+    it('should dispatch after the set time passes', () => {
+      expect.assertions(3)
+      jest.useFakeTimers()
+      const dispatch = jest.fn()
+      const time = 750
+      const action = () => ({ type: 'neato' })
+
+      delayedDispatch(dispatch, action, time)
+
+      // Most of the way through the timeout, it still hasn't been called
+      jest.advanceTimersByTime(749)
+      expect(dispatch).not.toHaveBeenCalled()
+
+      // But now it has
+      jest.advanceTimersByTime(10)
+      expect(dispatch).toHaveBeenCalledWith(action())
+
+      expect(setTimeout).toHaveBeenCalledTimes(1)
+    })
+  })
+  describe('enableProvider', () => {
+    it('should return true if the provider can be enabled', async () => {
+      expect.assertions(1)
+      const provider = {
+        enable: () => {
+          return
+        },
+      }
+
+      const result = await enableProvider(provider)
+      expect(result).toBeTruthy()
+    })
+
+    it('should return false if the provider cannot be enabled', async () => {
+      expect.assertions(1)
+      const provider = {
+        enable: async () => {
+          throw new Error('My providing days are over')
+        },
+      }
+
+      const result = await enableProvider(provider)
+      expect(result).toBeFalsy()
+    })
+
+    it('should return true if provider does not have enable property', async () => {
+      expect.assertions(1)
+      const provider = {}
+
+      const result = await enableProvider(provider)
+      expect(result).toBeTruthy()
+    })
+  })
+  describe('initializeProvider', () => {
+    it('should clear the timeout and dismiss the wallet overlay when done', async () => {
+      expect.assertions(3)
+      jest.useFakeTimers()
+      const provider = {}
+      const dispatch = jest.fn()
+
+      await initializeProvider(provider, dispatch)
+
+      // The timeout to open the wallet overlay
+      expect(setTimeout).toHaveBeenCalledTimes(1)
+      // clearing that timeout at the end of the function
+      expect(clearTimeout).toHaveBeenCalledTimes(1)
+      // done checking for wallet, hide the overlay
+      expect(dispatch).toHaveBeenCalledWith(dismissWalletCheck())
+    })
+
+    it('should dispatch providerReady when the provider can be enabled', async () => {
+      expect.assertions(1)
+      const provider = {}
+      const dispatch = jest.fn()
+
+      await initializeProvider(provider, dispatch)
+
+      expect(dispatch).toHaveBeenCalledWith(providerReady())
+    })
+
+    it('should set an error when the provider can not be enabled', async () => {
+      expect.assertions(1)
+      const provider = {
+        enable: () => {
+          throw new Error('go back to bed, garfield')
+        },
+      }
+      const dispatch = jest.fn()
+
+      await initializeProvider(provider, dispatch)
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error/SET_ERROR',
+        })
+      )
     })
   })
 })

--- a/paywall/src/middlewares/providerMiddleware.ts
+++ b/paywall/src/middlewares/providerMiddleware.ts
@@ -33,7 +33,7 @@ export async function enableProvider(provider: { enable?: () => any }) {
       return false
     }
   }
-  // provider.enable doesn't exist, so provider is de facto enabled
+  // provider.enable doesn't exist, which means it doesn't support EIP1102. The provider is already in a state we can work with, and thus counts as "enabled."
   return true
 }
 

--- a/paywall/src/middlewares/providerMiddleware.ts
+++ b/paywall/src/middlewares/providerMiddleware.ts
@@ -48,7 +48,7 @@ export async function initializeProvider(
 
   // To avoid flickering when wallet enables without user interaction, delay for a bit
   // before showing the overlay
-  const timeout = delayedDispatch(dispatch, waitForWallet, 750)
+  const walletCheckTimeout = delayedDispatch(dispatch, waitForWallet, 750)
   const enabled = await enableProvider(provider)
 
   if (enabled) {
@@ -58,7 +58,7 @@ export async function initializeProvider(
   }
 
   // The timeout should be cleared no matter what
-  clearTimeout(timeout)
+  clearTimeout(walletCheckTimeout)
   // Always safe to dismiss the overlay, even if it hasn't come up yet.
   dispatch(dismissWalletCheck())
 }

--- a/paywall/src/middlewares/providerMiddleware.ts
+++ b/paywall/src/middlewares/providerMiddleware.ts
@@ -4,6 +4,7 @@ import {
   FATAL_MISSING_PROVIDER,
   FATAL_NOT_ENABLED_IN_PROVIDER,
 } from '../errors'
+import { waitForWallet, dismissWalletCheck } from '../actions/walletStatus'
 
 interface Action {
   type: string
@@ -12,7 +13,29 @@ interface Action {
 
 type dispatcher = (action: Action) => void
 
-function initializeProvider(
+export function delayedDispatch(
+  dispatch: dispatcher,
+  action: () => { type: string },
+  time: number
+) {
+  return setTimeout(() => dispatch(action()), time)
+}
+
+// Returns true if provider was successfully enabled, false otherwise
+export async function enableProvider(provider: { enable?: () => any }) {
+  if (provider.enable) {
+    try {
+      await provider.enable()
+      return true
+    } catch (_) {
+      return false
+    }
+  }
+  // provider.enable doesn't exist, so provider is de facto enabled
+  return true
+}
+
+export async function initializeProvider(
   provider: { enable?: () => any },
   dispatch: dispatcher
 ) {
@@ -23,15 +46,17 @@ function initializeProvider(
 
   // provider.enable exists for metamask and other modern dapp wallets and must be called, see:
   // https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8
-  if (provider.enable) {
-    provider
-      .enable()
-      .then(() => dispatch(providerReady()))
-      .catch(() => dispatch(setError(FATAL_NOT_ENABLED_IN_PROVIDER)))
-  } else {
-    // Default case, provider doesn't have an enable method, so it must already be ready
+  const timeout = delayedDispatch(dispatch, waitForWallet, 750)
+  const couldEnable = await enableProvider(provider)
+
+  if (couldEnable) {
     dispatch(providerReady())
+  } else {
+    dispatch(setError(FATAL_NOT_ENABLED_IN_PROVIDER))
   }
+
+  clearTimeout(timeout)
+  dispatch(dismissWalletCheck())
 }
 
 const providerMiddleware = (config: any) => {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR shows the wallet check overlay when we wait for the user to authorize the app to access their browser wallet.

It includes a delay to avoid flickering in the case where no user interaction is necessary (user authorized access on a previous visit).

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4383 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
