### PR TITLE
Actually remove the walletCheck overlay when a purchase happens

### DIFF
--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -150,16 +150,7 @@ export default function CheckoutContent() {
     if (activeLocks.length && !userInitiatedPurchase) {
       hideCheckout()
     }
-
-    if (activeLocks.length && showWalletCheckOverlay) {
-      setShowWalletCheckOverlay(false)
-    }
-  }, [
-    activeLocks.length,
-    hideCheckout,
-    showWalletCheckOverlay,
-    userInitiatedPurchase,
-  ])
+  }, [activeLocks.length, hideCheckout, userInitiatedPurchase])
 
   let child: React.ReactNode
   let bgColor = 'var(--offwhite)'

--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -129,6 +129,14 @@ export default function CheckoutContent() {
         locks[lockAddress].key.status
       )
   )
+
+  // One we have something in purchasingLocks, we can assume that the
+  // user approved the transaction in their wallet and dismiss the wallet
+  //check overlay.
+  if (purchasingLocks.length && showWalletCheckOverlay) {
+    setShowWalletCheckOverlay(false)
+  }
+
   const [userDismissedConfirmingModal, dismissConfirmingModal] = useState(false)
   const hideConfirmingModal = useCallback(() => {
     hideCheckout()
@@ -142,7 +150,16 @@ export default function CheckoutContent() {
     if (activeLocks.length && !userInitiatedPurchase) {
       hideCheckout()
     }
-  }, [activeLocks.length, hideCheckout, userInitiatedPurchase])
+
+    if (activeLocks.length && showWalletCheckOverlay) {
+      setShowWalletCheckOverlay(false)
+    }
+  }, [
+    activeLocks.length,
+    hideCheckout,
+    showWalletCheckOverlay,
+    userInitiatedPurchase,
+  ])
 
   let child: React.ReactNode
   let bgColor = 'var(--offwhite)'
@@ -220,7 +237,7 @@ export default function CheckoutContent() {
   // purchasingLocks is an array of locks for which a transaction has
   // been initiated. Once purchasingLocks is non-empty, we know that the
   // user's wallet is enabled and no longer need to show the overlay.
-  if (showWalletCheckOverlay && !purchasingLocks.length) {
+  if (showWalletCheckOverlay) {
     return (
       <Greyout>
         <MessageBox>


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR updates CheckoutContent to set the state variable that controls whether the wallet overlay is visible to fix a case where the wallet overlay would pop up again after a purchase finished confirming, which would happen if you kept the checkout window open and watch all the confirmations.

I'm unsure what the best way to test this is, without a large effort in mocking the various components and simulating a key purchase.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
