### PR TITLE
Add getTokenSymbol to Web3Service

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+### Next Version
+- add `getTokenSymbol` method to web3Service to identify arbitrary ERC20 tokens (#4481)
+
 ## 0.3.10
 - Add "for" field for pending/submitted key purchase transactions (#4190)
 - ignore events from other contracts (erc20 for instance) (#4187)

--- a/unlock-js/src/__tests__/integration/web3ServiceIntegration.test.js
+++ b/unlock-js/src/__tests__/integration/web3ServiceIntegration.test.js
@@ -72,4 +72,29 @@ describe('Web3 Service Integration', () => {
       ).toEqual([])
     })
   })
+
+  describe('getTokenSymbol', () => {
+    it('returns a promise that resolves to the ERC20 symbol', async () => {
+      expect.assertions(1)
+      const symbol = await web3Service.getTokenSymbol(
+        '0x591AD9066603f5499d12fF4bC207e2f577448c46'
+      )
+
+      expect(symbol).toBe('TT')
+    })
+
+    it('emits an event mapping the contract address to the ERC20 symbol', async () => {
+      expect.assertions(2)
+      const contractAddress = '0x591AD9066603f5499d12fF4bC207e2f577448c46'
+
+      web3Service.on('token.update', (receivedContractAddress, update) => {
+        expect(receivedContractAddress).toBe(contractAddress)
+        expect(update).toEqual({
+          symbol: 'TT',
+        })
+      })
+
+      await web3Service.getTokenSymbol(contractAddress)
+    })
+  })
 })

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -666,4 +666,32 @@ export default class Web3Service extends UnlockService {
   async recoverAccountFromSignedData(data, signedData) {
     return utils.verifyMessage(data, signedData)
   }
+
+  /**
+   * Given an ERC20 token contract address, resolve with the symbol that identifies that token.
+   * Additionally emits an event that maps the address to the symbol.
+   * @param {string} contractAddress
+   * @returns {Promise<string>}
+   */
+  async getTokenSymbol(contractAddress) {
+    const abi = ['function symbol() view returns (string)']
+    const contract = new ethers.Contract(contractAddress, abi, this.provider)
+    const symbolPromise = contract.symbol()
+
+    this.emitTokenSymbol(contractAddress, symbolPromise)
+    return symbolPromise
+  }
+
+  /**
+   * Given an ERC20 token contract address, and a promise that resolves to the symbol that identifies the token,
+   * emit a event that maps the address to the symbol.
+   * @param {string} contractAddress
+   * @param {Promise<string>} symbolPromise
+   */
+  async emitTokenSymbol(contractAddress, symbolPromise) {
+    const symbol = await symbolPromise
+    this.emit('token.update', contractAddress, {
+      symbol,
+    })
+  }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
The addition of this method to Web3Service should move us close to identifying arbitrary ERC20 tokens on the paywall.

The method returns a promise that resolves to the symbol, and also calls out to a helper that emits an event that can help us map the contract address to the symbol.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4481

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
