### PR TITLE
Add getTokenBalance to web3service

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Next Version
 - add `getTokenSymbol` method to web3Service to identify arbitrary ERC20 tokens (#4481)
+- add `getTokenBalance` method to web3Service to get the user's balance of arbitrary ERC20 tokens (#4431)
 
 ## 0.3.10
 - Add "for" field for pending/submitted key purchase transactions (#4190)

--- a/unlock-js/src/__tests__/integration/web3ServiceIntegration.test.js
+++ b/unlock-js/src/__tests__/integration/web3ServiceIntegration.test.js
@@ -108,5 +108,19 @@ describe('Web3 Service Integration', () => {
 
       expect(balance).toBe('500.0')
     })
+
+    it('emits an error when balance cannot be retrieved', async () => {
+      expect.assertions(1)
+      web3Service.on('error', e => {
+        expect(e.message).toEqual(
+          expect.stringContaining('contract not deployed')
+        )
+      })
+
+      await web3Service.getTokenBalance(
+        '0xffffffffffffffffffffffffffffffffffffffff',
+        '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a'
+      )
+    })
   })
 })

--- a/unlock-js/src/__tests__/integration/web3ServiceIntegration.test.js
+++ b/unlock-js/src/__tests__/integration/web3ServiceIntegration.test.js
@@ -97,4 +97,16 @@ describe('Web3 Service Integration', () => {
       await web3Service.getTokenSymbol(contractAddress)
     })
   })
+
+  describe('getTokenBalance', () => {
+    it('returns a promise that resolves to the balance', async () => {
+      expect.assertions(1)
+      const balance = await web3Service.getTokenBalance(
+        '0x591AD9066603f5499d12fF4bC207e2f577448c46',
+        '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a'
+      )
+
+      expect(balance).toBe('500.0')
+    })
+  })
 })

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -694,4 +694,21 @@ export default class Web3Service extends UnlockService {
       symbol,
     })
   }
+
+  /**
+   * Given an ERC20 token contract address, resolve with the provided user's balance of that token.
+   * @param {string} contractAddress
+   * @param {string} userWalletAddress
+   * @returns {Promise<string>}
+   */
+  async getTokenBalance(contractAddress, userWalletAddress) {
+    const abi = ['function balanceOf(address owner) view returns (uint)']
+    const contract = new ethers.Contract(contractAddress, abi, this.provider)
+    try {
+      const rawBalance = await contract.balanceOf(userWalletAddress)
+      return ethers.utils.formatEther(rawBalance)
+    } catch (e) {
+      this.emit('error', e)
+    }
+  }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a method that returns the user's balance of a given ERC20 token. It essentially mirrors the interface we provide for getting eth balance.

A future PR could consider unifying these methods into one interface that can get balances for both, but I think for the sake of moving quickly we should keep them separate instead.

#4484 will be rebased when this is merged.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4431 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
