### PR TITLE
Provide ability to persist and recall key specific metadata

### DIFF
--- a/locksmith/migrations/20190821200705-create-key-metadata.js
+++ b/locksmith/migrations/20190821200705-create-key-metadata.js
@@ -1,0 +1,39 @@
+'use strict'
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable(
+      'KeyMetadata',
+      {
+        id: {
+          allowNull: false,
+          type: Sequelize.STRING,
+        },
+        address: {
+          allowNull: false,
+          type: Sequelize.STRING,
+        },
+        data: {
+          type: Sequelize.JSON,
+        },
+        createdAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+        },
+        updatedAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+        },
+      },
+      {
+        uniqueKeys: {
+          id_unique: {
+            fields: ['id', 'address'],
+          },
+        },
+      }
+    )
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('KeyMetadata')
+  },
+}

--- a/locksmith/src/controllers/metadataController.ts
+++ b/locksmith/src/controllers/metadataController.ts
@@ -3,9 +3,9 @@ import { Request, Response } from 'express-serve-static-core' // eslint-disable-
 import Metadata from '../../config/metadata'
 import Normalizer from '../utils/normalizer'
 import { LockMetadata } from '../models/lockMetadata'
+import { KeyMetadata } from '../models/keyMetadata'
 
 namespace MetadataController {
-  // eslint-disable-next-line import/prefer-default-export
   export const data = async (req: Request, res: Response): Promise<any> => {
     let defaultResponse = {
       name: 'Unlock Key',
@@ -13,15 +13,15 @@ namespace MetadataController {
       image: 'https://assets.unlock-protocol.com/unlock-default-key-image.png',
     }
 
-    let lockAddress: string = Normalizer.ethereumAddress(req.params.lockAddress)
+    let address = Normalizer.ethereumAddress(req.params.address)
+    let keyId = req.params.keyId.toLowerCase()
 
     // Custom mappings
     // TODO: move that to a datastore at some point...
     Metadata.forEach(lockMetadata => {
       if (
         req.params &&
-        req.params.lockAddress.toLowerCase() ==
-          lockMetadata.address.toLowerCase()
+        req.params.address.toLowerCase() == lockMetadata.address.toLowerCase()
       ) {
         defaultResponse.name = lockMetadata.name
         defaultResponse.description = lockMetadata.description
@@ -33,27 +33,55 @@ namespace MetadataController {
     defaultResponse.description = `${defaultResponse.description} Unlock is a protocol for memberships. https://unlock-protocol.com/`
 
     let metadata = await LockMetadata.findOne({
-      where: { address: lockAddress },
+      where: { address: address },
     })
 
-    if (metadata) {
-      return res.json(metadata.data)
-    } else {
-      return res.json(defaultResponse)
-    }
+    let keyCentricData: any = await KeyMetadata.findOne({
+      where: {
+        address: address,
+        id: keyId,
+      },
+    })
+
+    let result = keyCentricData ? keyCentricData.data : {}
+    let defaults = metadata ? metadata.data : defaultResponse
+    return res.json(Object.assign(result, defaults))
   }
 
   export const updateDefaults = async (
     req: Request,
     res: Response
   ): Promise<any> => {
-    let lockAddress: string = Normalizer.ethereumAddress(req.params.lockAddress)
+    let address: string = Normalizer.ethereumAddress(req.params.address)
     let metadata = req.body.message
 
     try {
       await LockMetadata.upsert(
         {
-          address: lockAddress,
+          address: address,
+          data: metadata,
+        },
+        { returning: true }
+      )
+      res.sendStatus(202)
+    } catch (e) {
+      res.sendStatus(400)
+    }
+  }
+
+  export const updateKeyMetadata = async (
+    req: Request,
+    res: Response
+  ): Promise<any> => {
+    let address: string = Normalizer.ethereumAddress(req.params.address)
+    let metadata = req.body.message
+    let id = req.params.keyId.toLowerCase()
+
+    try {
+      await KeyMetadata.upsert(
+        {
+          address: address,
+          id: id,
           data: metadata,
         },
         { returning: true }

--- a/locksmith/src/models/index.ts
+++ b/locksmith/src/models/index.ts
@@ -8,6 +8,7 @@ import { Transaction } from './transaction'
 import { AuthorizedLock } from './authorizedLock'
 import { EventLink } from './eventLink'
 import { LockMetadata } from './lockMetadata'
+import { KeyMetadata } from './keyMetadata'
 
 const env = process.env.NODE_ENV || 'development'
 const config = require('../../config/config')[env]
@@ -24,6 +25,7 @@ sequelize.addModels([
   AuthorizedLock,
   EventLink,
   LockMetadata,
+  KeyMetadata,
 ])
 
 User.removeAttribute('id')

--- a/locksmith/src/models/keyMetadata.ts
+++ b/locksmith/src/models/keyMetadata.ts
@@ -1,0 +1,13 @@
+import { Table, Model, Column, DataType } from 'sequelize-typescript'
+@Table({ tableName: 'KeyMetadata', timestamps: true })
+// eslint-disable-next-line import/prefer-default-export
+export class KeyMetadata extends Model<KeyMetadata> {
+  @Column(DataType.JSON)
+  data!: JSON
+
+  @Column({ primaryKey: true })
+  id!: string
+
+  @Column
+  address!: string
+}

--- a/locksmith/src/routes/metadata.ts
+++ b/locksmith/src/routes/metadata.ts
@@ -9,14 +9,26 @@ let metaDataConfiguration = {
   signee: 'owner',
 }
 
+let keyMetaDataConfiguration = {
+  name: 'KeyMetaData',
+  required: ['owner'],
+  signee: 'owner',
+}
+
 router.put(
-  '/:lockAddress',
+  '/:address',
   signatureValidationMiddleware.generateProcessor(metaDataConfiguration)
+)
+
+router.put(
+  '/:address/:keyId',
+  signatureValidationMiddleware.generateProcessor(keyMetaDataConfiguration)
 )
 
 var metaDataController = require('../controllers/metadataController')
 
-router.get('/:lockAddress/:keyId', metaDataController.data)
-router.put('/:lockAddress', metaDataController.updateDefaults)
+router.get('/:address/:keyId', metaDataController.data)
+router.put('/:address/:keyId', metaDataController.updateKeyMetadata)
+router.put('/:address', metaDataController.updateDefaults)
 
 module.exports = router


### PR DESCRIPTION
# Description

Exposes an endpoint allowing the ability to persist key specific data.
Requesting data will now merge key specific data with the Lock provided details when present

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
