### PR TITLE
keyStore experiment

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/KeyStore.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/KeyStore.test.ts
@@ -1,0 +1,72 @@
+import KeyStore from '../../../data-iframe/blockchainHandler/KeyStore'
+import { KeyResult } from '../../../data-iframe/blockchainHandler/blockChainTypes'
+
+let store: KeyStore
+let signal = jest.fn()
+
+const lockAddresses = ['0x123abc', '0xabc123']
+
+const aKey: KeyResult = {
+  lock: lockAddresses[0],
+  owner: '0xfeedbeef',
+  expiration: 1234567890,
+}
+
+const anotherKey: KeyResult = {
+  lock: lockAddresses[1],
+  owner: '0xfeedbeef',
+  expiration: 1234567890,
+}
+
+describe('KeyStore', () => {
+  describe('constructor', () => {
+    it('should start out with all null keys in the store', () => {
+      expect.assertions(2)
+      store = new KeyStore(lockAddresses)
+      lockAddresses.forEach(lockAddress => {
+        expect(store.keys[lockAddress]).toBeNull()
+      })
+    })
+  })
+
+  describe('addKey', () => {
+    beforeAll(() => {
+      store = new KeyStore(lockAddresses)
+    })
+
+    it('should add a key', () => {
+      expect.assertions(1)
+
+      store.addKey(aKey)
+      expect(store.keys[aKey.lock]).toEqual(aKey)
+    })
+
+    it('should add another key', () => {
+      expect.assertions(2)
+
+      store.addKey(anotherKey)
+      expect(store.keys[aKey.lock]).toEqual(aKey) // still have it!
+      expect(store.keys[anotherKey.lock]).toEqual(anotherKey)
+    })
+  })
+
+  describe('emitValidKeys', () => {
+    beforeAll(() => {
+      store = new KeyStore(lockAddresses)
+      signal = jest.fn()
+      store.on('keyStore.validKeys', () => {
+        signal()
+      })
+    })
+
+    it('should only emit when the number of keys matches the number of locks', () => {
+      expect.assertions(2)
+
+      store.addKey(aKey)
+      expect(signal).not.toHaveBeenCalled()
+
+      store.addKey(anotherKey)
+      expect(signal).toHaveBeenCalledWith()
+    })
+  })
+})

--- a/paywall/src/data-iframe/blockchainHandler/KeyStore.ts
+++ b/paywall/src/data-iframe/blockchainHandler/KeyStore.ts
@@ -1,0 +1,38 @@
+import { EventEmitter } from 'events'
+import { KeyResult } from './blockChainTypes'
+
+/**
+ * KeyStore holds the keys corresponding to the locks on the
+ * page. When it has been filled up (i.e., `addKey()` has been called
+ * `numLocks` times), it emits an event containing all the currently
+ * valid keys.
+ */
+export default class KeyStore extends EventEmitter {
+  keys: { [lockAddress: string]: KeyResult | null }
+
+  constructor(lockAddresses: string[]) {
+    super()
+    this.keys = {}
+    lockAddresses.forEach(lockAddress => {
+      this.keys[lockAddress] = null
+    })
+  }
+
+  hasAllKeys(): boolean {
+    return Object.values(this.keys).every(value => value !== null)
+  }
+
+  addKey(key: KeyResult) {
+    const lockAddress = key.lock
+    this.keys[lockAddress] = key
+
+    // Once we've received all the keys we expect, we should emit the valid ones.
+    if (this.hasAllKeys()) {
+      this.emitValidKeys()
+    }
+  }
+
+  emitValidKeys() {
+    this.emit('keyStore.validKeys', this.keys)
+  }
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This draft PR is an experiment around a way of ensuring we don't emit the `locked` or `unlocked` messages from the paywall until we have all the necessary information.

https://github.com/unlock-protocol/unlock/blob/df9b8bb745d78aa1785b6a24cceb86ccf77fe5a4/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts#L283

Currently we maintain the list of keys in a bare object that the BlockchainHandler operates on. This PR introduces a `KeyStore` object that will be the source of truth on key validity. The `KeyStore` is instantiated with a list of the lock addresses included in the paywall config, and will only emit an event with the keys when it has received a key for each lock.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
