### PR TITLE
differentiating further between pending and submitted transactions

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 0.3.12
+- fixed a difference between pending transactions (node knows about them) and submitted transactions (which may be transactions that have been cancelled and will never succeed)
+
 ## 0.3.11
 - add `getTokenSymbol` method to web3Service to identify arbitrary ERC20 tokens (#4481)
 - add `getTokenBalance` method to web3Service to get the user's balance of arbitrary ERC20 tokens (#4431)

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/v0/web3Service.test.js
+++ b/unlock-js/src/__tests__/v0/web3Service.test.js
@@ -473,7 +473,7 @@ describe('Web3Service', () => {
   })
 
   describe('_parseTransactionFromInput', () => {
-    it('should emit transaction.updated with the transaction marked as pending', async done => {
+    it('should emit transaction.updated with the transaction marked with the right status', async done => {
       expect.assertions(2)
       await versionedNockBeforeEach()
       web3Service._getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
@@ -494,7 +494,8 @@ describe('Web3Service', () => {
         transaction.hash,
         UnlockVersion.Unlock,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        'pending'
       )
     })
 

--- a/unlock-js/src/__tests__/v01/web3Service.test.js
+++ b/unlock-js/src/__tests__/v01/web3Service.test.js
@@ -461,7 +461,8 @@ describe('Web3Service', () => {
         transaction.hash,
         UnlockVersion.Unlock,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        'pending'
       )
     })
 

--- a/unlock-js/src/__tests__/v02/web3Service.test.js
+++ b/unlock-js/src/__tests__/v02/web3Service.test.js
@@ -474,7 +474,7 @@ describe('Web3Service', () => {
   })
 
   describe('_parseTransactionFromInput', () => {
-    it('should emit transaction.updated with the transaction marked as pending', async done => {
+    it('should emit transaction.updated with the transaction marked with the right state', async done => {
       expect.assertions(2)
       await versionedNockBeforeEach()
       web3Service._getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
@@ -495,7 +495,8 @@ describe('Web3Service', () => {
         transaction.hash,
         UnlockVersion.Unlock,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        'pending'
       )
     })
 

--- a/unlock-js/src/__tests__/v10/web3Service.test.js
+++ b/unlock-js/src/__tests__/v10/web3Service.test.js
@@ -473,7 +473,7 @@ describe('Web3Service', () => {
   })
 
   describe('_parseTransactionFromInput', () => {
-    it('should emit transaction.updated with the transaction marked as pending', async done => {
+    it('should emit transaction.updated with the transaction marked with the right status', async done => {
       expect.assertions(2)
       await versionedNockBeforeEach()
       web3Service._getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
@@ -494,7 +494,8 @@ describe('Web3Service', () => {
         transaction.hash,
         UnlockVersion.Unlock,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        'pending'
       )
     })
 

--- a/unlock-js/src/__tests__/v11/web3Service.test.js
+++ b/unlock-js/src/__tests__/v11/web3Service.test.js
@@ -497,7 +497,8 @@ describe('Web3Service', () => {
         transaction.hash,
         UnlockVersion.Unlock,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        'pending'
       )
     })
 


### PR DESCRIPTION
# Description

This is the root cause of the paywall never locking back for me: one of my transactions awas cancelled but unlock-js considers is as "pending" and then does the paywall does optimitic unlocking.

A second PR will fix the paywall to take "submitted" transaction with a grain of salt when they're "old".


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread