### PR TITLE
data-iframe test helpers

### DIFF
--- a/paywall/src/__tests__/data-iframe/Mailbox/emitChanges.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/emitChanges.test.ts
@@ -5,7 +5,6 @@ import {
   SetTimeoutWindow,
   WalletServiceType,
   Web3ServiceType,
-  BlockchainData,
 } from '../../../data-iframe/blockchainHandler/blockChainTypes'
 import Mailbox from '../../../data-iframe/Mailbox'
 import {
@@ -17,10 +16,11 @@ import {
   getWalletService,
   getWeb3Service,
   lockAddresses,
-  addresses,
+  blockchainDataNoLocks,
+  blockchainDataLocked,
+  blockchainDataUnlocked,
 } from '../../test-helpers/setupBlockchainHelpers'
 import { PostMessages, ExtractPayload } from '../../../messageTypes'
-import { TransactionType, TransactionStatus } from '../../../unlockTypes'
 
 let mockWalletService: WalletServiceType
 let mockWeb3Service: Web3ServiceType
@@ -48,83 +48,12 @@ describe('Mailbox - emitChanges', () => {
   let mailbox: Mailbox
   let defaults: MailboxTestDefaults
 
-  const account = addresses[1]
   // all locks have had their addresses normalized before arriving
-  const lockedLocks: BlockchainData = {
-    account: addresses[1],
-    balance: '234',
-    network: 1984,
-    locks: {
-      [lockAddresses[0]]: {
-        address: lockAddresses[0],
-        name: '1',
-        expirationDuration: 5,
-        currencyContractAddress: addresses[2],
-        keyPrice: '1',
-        key: {
-          status: 'none',
-          confirmations: 0,
-          expiration: 0,
-          transactions: [],
-          owner: account,
-          lock: lockAddresses[0],
-        },
-      },
-      [lockAddresses[1]]: {
-        address: lockAddresses[1],
-        name: '1',
-        expirationDuration: 5,
-        currencyContractAddress: addresses[2],
-        keyPrice: '1',
-        key: {
-          status: 'expired',
-          confirmations: 1678234,
-          expiration: 163984,
-          transactions: [
-            {
-              status: TransactionStatus.MINED,
-              confirmations: 1678234,
-              hash: 'hash',
-              type: TransactionType.KEY_PURCHASE,
-              blockNumber: 123,
-            },
-          ],
-          owner: account,
-          lock: lockAddresses[0],
-        },
-      },
-    },
-  }
+  const lockedLocks = blockchainDataLocked
 
-  const submittedLocks: BlockchainData = {
-    ...lockedLocks,
-    locks: {
-      ...lockedLocks.locks,
-      [lockAddresses[0]]: {
-        ...lockedLocks.locks[lockAddresses[0]],
-        key: {
-          ...lockedLocks.locks[lockAddresses[0]].key,
-          status: 'submitted',
-          confirmations: 0,
-          expiration: 0,
-          transactions: [
-            {
-              status: TransactionStatus.SUBMITTED,
-              confirmations: 0,
-              hash: 'hash',
-              type: TransactionType.KEY_PURCHASE,
-              blockNumber: Number.MAX_SAFE_INTEGER,
-            },
-          ],
-        },
-      },
-    },
-  }
+  const submittedLocks = blockchainDataUnlocked
 
-  const noLocks: BlockchainData = {
-    ...lockedLocks,
-    locks: {},
-  }
+  const noLocks = blockchainDataNoLocks
 
   function setupDefaults() {
     defaults = setupTestDefaults()

--- a/paywall/src/__tests__/test-helpers/setupBlockchainHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/setupBlockchainHelpers.ts
@@ -6,6 +6,7 @@ import {
   FetchWindow,
   SetTimeoutWindow,
   ConstantsType,
+  BlockchainData,
 } from '../../data-iframe/blockchainHandler/blockChainTypes'
 import { PaywallConfig, Locks } from '../../unlockTypes'
 import FakeWindow from './fakeWindowHelpers'
@@ -73,6 +74,8 @@ export function getWeb3Service(listeners: { [key: string]: Function }) {
   }
   return web3Service
 }
+
+export const accountAddress = '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a'
 
 export const addresses = [
   '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
@@ -248,5 +251,14 @@ export function getDefaultFullLocks(
       expirationDuration: 1,
       currencyContractAddress: null,
     },
+  }
+}
+
+export function makeBlockchainData(): BlockchainData {
+  return {
+    account: accountAddress,
+    balance: '234',
+    network: 1984,
+    locks: {},
   }
 }

--- a/paywall/src/__tests__/test-helpers/setupBlockchainHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/setupBlockchainHelpers.ts
@@ -8,7 +8,13 @@ import {
   ConstantsType,
   BlockchainData,
 } from '../../data-iframe/blockchainHandler/blockChainTypes'
-import { PaywallConfig, Locks } from '../../unlockTypes'
+import {
+  PaywallConfig,
+  Locks,
+  Lock,
+  TransactionStatus,
+  TransactionType,
+} from '../../unlockTypes'
 import FakeWindow from './fakeWindowHelpers'
 
 export function getWalletService(listeners: { [key: string]: Function }) {
@@ -254,11 +260,83 @@ export function getDefaultFullLocks(
   }
 }
 
-export function makeBlockchainData(): BlockchainData {
-  return {
-    account: accountAddress,
-    balance: '234',
-    network: 1984,
-    locks: {},
-  }
+const firstLockAddress = lockAddresses[0]
+const firstLockLocked: Lock = {
+  address: firstLockAddress,
+  name: 'The First Lock',
+  expirationDuration: 5,
+  keyPrice: '1',
+  key: {
+    status: 'none',
+    confirmations: 0,
+    expiration: 0,
+    transactions: [],
+    owner: accountAddress,
+    lock: firstLockAddress,
+  },
+  currencyContractAddress: addresses[2],
+}
+
+const firstLockSubmitted: Lock = {
+  ...firstLockLocked,
+  key: {
+    ...firstLockLocked.key,
+    status: 'submitted',
+    transactions: [
+      {
+        status: TransactionStatus.SUBMITTED,
+        confirmations: 0,
+        hash: 'hash',
+        type: TransactionType.KEY_PURCHASE,
+        blockNumber: Number.MAX_SAFE_INTEGER,
+      },
+    ],
+  },
+}
+
+const secondLockAddress = lockAddresses[1]
+const secondLockLocked: Lock = {
+  address: secondLockAddress,
+  name: 'The Second Lock',
+  expirationDuration: 5,
+  keyPrice: '1',
+  key: {
+    status: 'expired',
+    confirmations: 1678234,
+    expiration: 163984,
+    transactions: [
+      {
+        status: TransactionStatus.MINED,
+        confirmations: 1678234,
+        hash: 'hash',
+        type: TransactionType.KEY_PURCHASE,
+        blockNumber: 123,
+      },
+    ],
+    owner: accountAddress,
+    lock: secondLockAddress,
+  },
+  currencyContractAddress: addresses[2],
+}
+
+export const blockchainDataNoLocks: BlockchainData = {
+  account: accountAddress,
+  balance: '234',
+  network: 1984,
+  locks: {},
+}
+
+export const blockchainDataLocked: BlockchainData = {
+  ...blockchainDataNoLocks,
+  locks: {
+    [firstLockAddress]: firstLockLocked,
+    [secondLockAddress]: secondLockLocked,
+  },
+}
+
+export const blockchainDataUnlocked: BlockchainData = {
+  ...blockchainDataNoLocks,
+  locks: {
+    [firstLockAddress]: firstLockSubmitted,
+  },
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR introduces some standardized test blockchain data for the data-iframe tests to use. It also moves one test to use this data as a proof of concept. This same block of data is copy/pasted in various places throughout the tests.

This change will greatly ease the transition to emitting rawer data from the data-iframe. Once I add the `keys` and `transactions` properties to the `BlockchainData` type, all tests that rely on that type of data will start to fail (because they don't typecheck) and I will be able to replace every usage of that copy/pasted block with these helpers, shrinking the code size considerably.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4497 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
