### PR TITLE
makeDefaultKeys uses -1 to indicate default key

### DIFF
--- a/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
@@ -13,13 +13,16 @@ import {
   setupTestDefaults,
   MailboxTestDefaults,
 } from '../../test-helpers/setupMailboxHelpers'
-import BlockchainHandler from '../../../data-iframe/blockchainHandler/BlockchainHandler'
+import BlockchainHandler, {
+  makeDefaultKeys,
+} from '../../../data-iframe/blockchainHandler/BlockchainHandler'
 import FakeWindow from '../../test-helpers/fakeWindowHelpers'
 import { PostMessages } from '../../../messageTypes'
 import { waitFor } from '../../../utils/promises'
 import {
   getWalletService,
   getWeb3Service,
+  lockAddresses,
 } from '../../test-helpers/setupBlockchainHelpers'
 
 let mockWalletService: WalletServiceType
@@ -180,23 +183,7 @@ describe('Mailbox - init', () => {
       // Even though we are in a null state (just initialized), there
       // are keys here because of makeDefaultKeys. Somewhat confusing,
       // but at least there's a comment now.
-      keys: {
-        '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8': {
-          expiration: 0,
-          lock: '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8',
-          owner: null,
-        },
-        '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2': {
-          expiration: 0,
-          lock: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-          owner: null,
-        },
-        '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e': {
-          expiration: 0,
-          lock: '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e',
-          owner: null,
-        },
-      },
+      keys: makeDefaultKeys(lockAddresses, null),
       transactions: {},
     })
   })

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/BlockchainHandler.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/BlockchainHandler.test.ts
@@ -7,7 +7,9 @@ import {
   SetTimeoutWindow,
   LocksmithTransactionsResult,
 } from '../../../../data-iframe/blockchainHandler/blockChainTypes'
-import BlockchainHandler from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import BlockchainHandler, {
+  makeDefaultKeys,
+} from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
 import {
   defaultValuesOverride,
   BlockchainTestDefaults,
@@ -92,23 +94,7 @@ describe('BlockchainHandler class setup', () => {
       },
       account: null,
       balance: '0',
-      keys: {
-        [lockAddresses[0]]: {
-          lock: lockAddresses[0],
-          owner: null,
-          expiration: 0,
-        },
-        [lockAddresses[1]]: {
-          lock: lockAddresses[1],
-          owner: null,
-          expiration: 0,
-        },
-        [lockAddresses[2]]: {
-          lock: lockAddresses[2],
-          owner: null,
-          expiration: 0,
-        },
-      }, // default keys for each lock are created
+      keys: makeDefaultKeys(lockAddresses, null),
       locks: {},
       transactions: {},
       network: 1984, // default network is used for network

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/makeDefaultKeys.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/makeDefaultKeys.test.ts
@@ -16,17 +16,17 @@ describe('BlockchainHandler - makeDefaultKeys', () => {
         [lowerAddresses[0].toLowerCase()]: {
           lock: lowerAddresses[0],
           owner: account,
-          expiration: 0,
+          expiration: -1,
         },
         [lowerAddresses[1].toLowerCase()]: {
           lock: lowerAddresses[1],
           owner: account,
-          expiration: 0,
+          expiration: -1,
         },
         [lowerAddresses[2].toLowerCase()]: {
           lock: lowerAddresses[2],
           owner: account,
-          expiration: 0,
+          expiration: -1,
         },
       }
 

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/retrieveCurrentBlockchainData.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/retrieveCurrentBlockchainData.test.ts
@@ -8,7 +8,9 @@ import {
   ConstantsType,
   KeyResult,
 } from '../../../../data-iframe/blockchainHandler/blockChainTypes'
-import BlockchainHandler from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import BlockchainHandler, {
+  makeDefaultKeys,
+} from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
 import {
   TransactionStatus,
   TransactionType,
@@ -112,24 +114,7 @@ describe('BlockchainHandler - retrieveCurrentBlockchainData', () => {
         account: null,
         balance: '0',
         network: 1984,
-        // These keys are from makeDefaultKeys
-        keys: {
-          '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8': {
-            expiration: 0,
-            lock: '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8',
-            owner: null,
-          },
-          '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2': {
-            expiration: 0,
-            lock: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-            owner: null,
-          },
-          '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e': {
-            expiration: 0,
-            lock: '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e',
-            owner: null,
-          },
-        },
+        keys: makeDefaultKeys(lockAddresses, null),
         transactions: {},
       })
     })
@@ -161,23 +146,7 @@ describe('BlockchainHandler - retrieveCurrentBlockchainData', () => {
         account: null,
         balance: '0',
         network: 1984,
-        keys: {
-          '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8': {
-            expiration: 0,
-            lock: '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8',
-            owner: null,
-          },
-          '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2': {
-            expiration: 0,
-            lock: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-            owner: null,
-          },
-          '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e': {
-            expiration: 0,
-            lock: '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e',
-            owner: null,
-          },
-        },
+        keys: makeDefaultKeys(lockAddresses, null),
         transactions: {},
       })
     })
@@ -194,23 +163,7 @@ describe('BlockchainHandler - retrieveCurrentBlockchainData', () => {
       await handler.retrieveCurrentBlockchainData()
 
       expect(store.transactions).toEqual({})
-      expect(store.keys).toEqual({
-        [lockAddresses[0]]: {
-          lock: lockAddresses[0],
-          owner: null,
-          expiration: 0,
-        },
-        [lockAddresses[1]]: {
-          lock: lockAddresses[1],
-          owner: null,
-          expiration: 0,
-        },
-        [lockAddresses[2]]: {
-          lock: lockAddresses[2],
-          owner: null,
-          expiration: 0,
-        },
-      })
+      expect(store.keys).toEqual(makeDefaultKeys(lockAddresses, null))
       expect(store.balance).toBe('0')
     })
 
@@ -227,23 +180,7 @@ describe('BlockchainHandler - retrieveCurrentBlockchainData', () => {
         account: null,
         balance: '0',
         network: 1984,
-        keys: {
-          '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8': {
-            expiration: 0,
-            lock: '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8',
-            owner: null,
-          },
-          '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2': {
-            expiration: 0,
-            lock: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-            owner: null,
-          },
-          '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e': {
-            expiration: 0,
-            lock: '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e',
-            owner: null,
-          },
-        },
+        keys: makeDefaultKeys(lockAddresses, null),
         transactions: {},
       })
     })
@@ -267,23 +204,7 @@ describe('BlockchainHandler - retrieveCurrentBlockchainData', () => {
         account: addresses[2],
         balance: '0',
         network: 1984,
-        keys: {
-          '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8': {
-            expiration: 0,
-            lock: '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8',
-            owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-          },
-          '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2': {
-            expiration: 0,
-            lock: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-            owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-          },
-          '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e': {
-            expiration: 0,
-            lock: '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e',
-            owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-          },
-        },
+        keys: makeDefaultKeys(lockAddresses, addresses[2]),
         transactions: {},
       })
     })
@@ -314,23 +235,13 @@ describe('BlockchainHandler - retrieveCurrentBlockchainData', () => {
         account: addresses[2],
         balance: '0',
         network: 1984,
-        keys: {
-          '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8': {
-            expiration: 0,
-            lock: '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8',
-            owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-          },
+        keys: expect.objectContaining({
           '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2': {
             expiration: 12345,
             lock: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
             owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
           },
-          '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e': {
-            expiration: 0,
-            lock: '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e',
-            owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-          },
-        },
+        }),
         transactions: {},
       })
     })
@@ -378,23 +289,7 @@ describe('BlockchainHandler - retrieveCurrentBlockchainData', () => {
           account: addresses[2],
           balance: '0',
           network: 1984,
-          keys: {
-            '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8': {
-              expiration: 0,
-              lock: '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8',
-              owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-            },
-            '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2': {
-              expiration: 0,
-              lock: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-              owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-            },
-            '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e': {
-              expiration: 0,
-              lock: '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e',
-              owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-            },
-          },
+          keys: makeDefaultKeys(lockAddresses, addresses[2]),
           transactions: {},
         })
       })
@@ -466,23 +361,7 @@ describe('BlockchainHandler - retrieveCurrentBlockchainData', () => {
           account: addresses[2],
           balance: '0',
           network: 1984,
-          keys: {
-            '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8': {
-              expiration: 0,
-              lock: '0x15b87bdc4b3ecb783f56f735653332ead3bca5f8',
-              owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-            },
-            '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2': {
-              expiration: 0,
-              lock: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
-              owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-            },
-            '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e': {
-              expiration: 0,
-              lock: '0xbf7f1bdb3a2d6c318603ffc8f39974e597b6af5e',
-              owner: '0xBF7F1bdB3a2D6c318603FFc8f39974e597b6af5e',
-            },
-          },
+          keys: makeDefaultKeys(lockAddresses, addresses[2]),
           transactions: {
             hash: {
               blockNumber: 9007199254740991,

--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setupListeners.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setupListeners.test.ts
@@ -202,12 +202,12 @@ describe('BlockchainHandler - setupListeners', () => {
         [lockAddresses[1]]: {
           lock: lockAddresses[1],
           owner: store.account,
-          expiration: 0,
+          expiration: -1,
         },
         [lockAddresses[2]]: {
           lock: lockAddresses[2],
           owner: store.account,
-          expiration: 0,
+          expiration: -1,
         },
       })
     })

--- a/paywall/src/__tests__/test-helpers/setupBlockchainHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/setupBlockchainHelpers.ts
@@ -218,7 +218,7 @@ export function getDefaultFullLocks(
       address: lockAddresses[0],
       key: {
         confirmations: 0,
-        expiration: keyExpirations[lockAddresses[0]] || 0,
+        expiration: keyExpirations[lockAddresses[0]] || -1,
         lock: lockAddresses[0],
         owner: store.account,
         status: 'none',
@@ -233,7 +233,7 @@ export function getDefaultFullLocks(
       address: lockAddresses[1],
       key: {
         confirmations: 0,
-        expiration: keyExpirations[lockAddresses[1]] || 0,
+        expiration: keyExpirations[lockAddresses[1]] || -1,
         lock: lockAddresses[1],
         owner: store.account,
         status: 'none',
@@ -248,7 +248,7 @@ export function getDefaultFullLocks(
       address: lockAddresses[2],
       key: {
         confirmations: 0,
-        expiration: keyExpirations[lockAddresses[2]] || 0,
+        expiration: keyExpirations[lockAddresses[2]] || -1,
         lock: lockAddresses[2],
         owner: store.account,
         status: 'none',

--- a/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
+++ b/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
@@ -36,7 +36,11 @@ export function makeDefaultKeys(
     allKeys[address] = {
       lock: address,
       owner: account,
-      expiration: 0,
+      // Negative expiration is not valid. This is a hack to distinguish
+      // "default" keys from keys returned from Web3Service. In the long term we
+      // will remove the idea of "default" keys because they cause a lot of
+      // problems.
+      expiration: -1,
     }
     return allKeys
   }, {})


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR is split off from #4517. A big chunk of the PR was this change, so it makes sense to review this separately.

The only change it makes is to use `-1` as the `expiration` for the default keys. This lets us know which keys are defaults and which have come from Web3Service (`expiration` from Web3Service is always >= 0). With that knowledge, we know when we can set the paywall state, since doing it before we have complete information is not correct.

Additionally, in every place I saw that used literal values for the results of `makeDefaultKeys`, I replaced it with a call to `makeDefaultKeys` to make the intent clear. The only exception is for the test of `makeDefaultKeys` itself.

I made an honest effort to get rid of the idea of "default keys", but the current code relies way too heavily on them for that to be a quick change. We'll fix it moving forward.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
