### PR TITLE
getUnlockedLockAddresses based on keys now

### DIFF
--- a/paywall/src/__tests__/data-iframe/Mailbox/getUnlockedLockAddresses.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/getUnlockedLockAddresses.test.ts
@@ -1,177 +1,128 @@
-import { IframePostOfficeWindow } from '../../../windowTypes'
-import {
-  ConstantsType,
-  FetchWindow,
-  SetTimeoutWindow,
-  WalletServiceType,
-  Web3ServiceType,
-  BlockchainData,
-} from '../../../data-iframe/blockchainHandler/blockChainTypes'
-import { Locks, TransactionType, TransactionStatus } from '../../../unlockTypes'
-import Mailbox from '../../../data-iframe/Mailbox'
-import {
-  setupTestDefaults,
-  MailboxTestDefaults,
-} from '../../test-helpers/setupMailboxHelpers'
-import FakeWindow from '../../test-helpers/fakeWindowHelpers'
-import {
-  addresses,
-  getWalletService,
-  getWeb3Service,
-  lockAddresses,
-  firstLockLocked,
-  firstLockSubmitted,
-  secondLockLocked,
-} from '../../test-helpers/setupBlockchainHelpers'
+import { getUnlockedLockAddresses } from '../../../data-iframe/Mailbox'
+import { lockAddresses } from '../../test-helpers/setupBlockchainHelpers'
+import { currentTimeInSeconds } from '../../../utils/durations'
 
-let mockWalletService: WalletServiceType
-let mockWeb3Service: Web3ServiceType
-jest.mock('@unlock-protocol/unlock-js', () => {
-  return {
-    WalletService: () => {
-      mockWalletService = getWalletService({})
-      mockWalletService.connect = jest.fn((provider: any) => {
-        mockWalletService.provider = provider
-        return Promise.resolve()
-      })
-      return mockWalletService
-    },
-    Web3Service: () => {
-      mockWeb3Service = getWeb3Service({})
-      return mockWeb3Service
-    },
-  }
-})
+const theFuture = currentTimeInSeconds() + 2000
+const account = '0xC0FFEE'
+
+const notEnoughKeysData = {}
+
+// The case when we have received one key, even though we don't have
+// the rest of the blockchainData.
+const oneValidKeyData = {
+  [lockAddresses[1]]: {
+    expiration: theFuture,
+    lock: lockAddresses[1],
+    owner: account,
+  },
+}
+
+// The case where we still have a "default key"
+const fakeKeysData = {
+  [lockAddresses[0]]: {
+    expiration: -1,
+    lock: lockAddresses[0],
+    owner: account,
+  },
+  [lockAddresses[1]]: {
+    expiration: 0,
+    lock: lockAddresses[1],
+    owner: account,
+  },
+  [lockAddresses[2]]: {
+    expiration: 0,
+    lock: lockAddresses[2],
+    owner: account,
+  },
+}
+
+const allKeysExpiredData = {
+  [lockAddresses[0]]: {
+    expiration: 0,
+    lock: lockAddresses[0],
+    owner: account,
+  },
+  [lockAddresses[1]]: {
+    expiration: 0,
+    lock: lockAddresses[1],
+    owner: account,
+  },
+  [lockAddresses[2]]: {
+    expiration: 0,
+    lock: lockAddresses[2],
+    owner: account,
+  },
+}
+
+const unexpiredKeysData = {
+  [lockAddresses[0]]: {
+    expiration: 1,
+    lock: lockAddresses[0],
+    owner: account,
+  },
+  [lockAddresses[1]]: {
+    expiration: theFuture,
+    lock: lockAddresses[1],
+    owner: account,
+  },
+  [lockAddresses[2]]: {
+    expiration: 0,
+    lock: lockAddresses[2],
+    owner: account,
+  },
+}
+
+const multipleValidKeyData = {
+  ...unexpiredKeysData,
+  [lockAddresses[0]]: {
+    // arbitrarily different time in the future from the other valid key
+    expiration: theFuture + 500,
+    lock: lockAddresses[0],
+    owner: account,
+  },
+}
 
 describe('Mailbox - getUnlockedLockAddresses', () => {
-  let constants: ConstantsType
-  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
-  let fakeWindow: FakeWindow
-  let mailbox: Mailbox
-  let defaults: MailboxTestDefaults
-
-  const account = addresses[1]
-
-  // all locks have had their addresses normalized before arriving
-  const lockedLocks: Locks = {
-    [lockAddresses[0]]: firstLockLocked,
-    [lockAddresses[1]]: secondLockLocked,
-  }
-
-  const submittedLocks: Locks = {
-    [lockAddresses[0]]: firstLockSubmitted,
-  }
-
-  const pendingLocks: Locks = {
-    [lockAddresses[0]]: {
-      ...lockedLocks[lockAddresses[0]],
-      key: {
-        ...lockedLocks[lockAddresses[0]].key,
-        status: 'pending',
-        transactions: [
-          {
-            status: TransactionStatus.PENDING,
-            confirmations: 0,
-            hash: 'hash',
-            type: TransactionType.KEY_PURCHASE,
-            blockNumber: Number.MAX_SAFE_INTEGER,
-          },
-        ],
-      },
-    },
-  }
-
-  const validLocks: Locks = {
-    [lockAddresses[0]]: {
-      ...lockedLocks[lockAddresses[0]],
-      key: {
-        ...lockedLocks[lockAddresses[0]].key,
-        status: 'valid',
-        expiration: 12345,
-        transactions: [
-          {
-            status: TransactionStatus.PENDING,
-            confirmations: 617234,
-            hash: 'hash',
-            type: TransactionType.KEY_PURCHASE,
-            blockNumber: 123,
-          },
-        ],
-      },
-    },
-  }
-
-  function testingMailbox(): any {
-    return mailbox as any
-  }
-
-  function setupDefaults(locks: Locks = {}) {
-    defaults = setupTestDefaults()
-    constants = defaults.constants
-    win = defaults.fakeWindow
-    fakeWindow = win as FakeWindow
-    mailbox = new Mailbox(constants, fakeWindow)
-
-    const testingData: BlockchainData = {
-      locks,
-      account,
-      balance: {
-        eth: '0',
-      },
-      network: 1,
-      keys: {},
-      transactions: {},
-    }
-    testingMailbox().blockchainData = testingData
-  }
-
-  it('should return [] if the BlockchainHandler has not yet sent any data', () => {
+  it('should return [] if there are no keys', () => {
     expect.assertions(1)
 
-    setupDefaults()
-
-    delete testingMailbox().blockchainData
-
-    expect(mailbox.getUnlockedLockAddresses()).toEqual([])
+    expect(getUnlockedLockAddresses(notEnoughKeysData)).toEqual([])
   })
 
-  it('should return [] if the blockchain data does not yet have any locks', () => {
+  it('should return [] if all keys are expired (including a "default" key)', () => {
     expect.assertions(1)
 
-    setupDefaults()
-
-    expect(mailbox.getUnlockedLockAddresses()).toEqual([])
+    expect(getUnlockedLockAddresses(fakeKeysData)).toEqual([])
   })
 
-  it('should return [] if none of the lock keys returned are valid or in process of key purchase', () => {
+  it('should return [] if all keys are expired (all "real" keys)', () => {
     expect.assertions(1)
 
-    setupDefaults(lockedLocks)
-
-    expect(mailbox.getUnlockedLockAddresses()).toEqual([])
+    expect(getUnlockedLockAddresses(allKeysExpiredData)).toEqual([])
   })
 
-  it('should return an array containing the unlocked lock addresses for submitted purchases', () => {
+  it('should return an array containing the address of an unlocked lock (not all data from chain)', () => {
     expect.assertions(1)
 
-    setupDefaults(submittedLocks)
-
-    expect(mailbox.getUnlockedLockAddresses()).toEqual([lockAddresses[0]])
+    expect(getUnlockedLockAddresses(oneValidKeyData)).toEqual([
+      lockAddresses[1],
+    ])
   })
 
-  it('should return an array containing the unlocked lock addresses for pending purchases', () => {
+  it('should return an array containing the unlocked lock addresses when there is a single valid key', () => {
     expect.assertions(1)
 
-    setupDefaults(pendingLocks)
-
-    expect(mailbox.getUnlockedLockAddresses()).toEqual([lockAddresses[0]])
+    expect(getUnlockedLockAddresses(unexpiredKeysData)).toEqual([
+      lockAddresses[1],
+    ])
   })
 
-  it('should return an array containing the unlocked lock addresses for valid purchases', () => {
+  it('should return an array containing the unlocked lock addresses when there are multiple valid keys', () => {
     expect.assertions(1)
 
-    setupDefaults(validLocks)
-
-    expect(mailbox.getUnlockedLockAddresses()).toEqual([lockAddresses[0]])
+    expect(getUnlockedLockAddresses(multipleValidKeyData)).toEqual([
+      lockAddresses[0],
+      lockAddresses[1],
+    ])
   })
 })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Following on #4536, this PR updates `getUnlockedLockAddresses` to be consistent with the new key-based paywall status. Instead of probing the transactions associated with keys, this function just gets the addresses of unexpired keys.

A helpful side-effect of this change is in the future we can clean up some of the tests that use this syntax: https://github.com/unlock-protocol/unlock/pull/4536#discussion_r318770555 at least in the cases where a key's status was set.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
