### PR TITLE
Store raw fees for component to use

### DIFF
--- a/unlock-app/src/__tests__/actions/keyPurchase.test.ts
+++ b/unlock-app/src/__tests__/actions/keyPurchase.test.ts
@@ -23,10 +23,18 @@ describe('keyPurchase actions', () => {
 
   it('should create an action to update the cart with the price of a key to the lock', () => {
     expect.assertions(1)
-    expect(updatePrice(5.5)).toEqual(
+
+    const fees = {
+      creditCardProcessing: 450,
+      gasFee: 30,
+      keyPrice: 100,
+      unlockServiceFee: 20,
+    }
+
+    expect(updatePrice(fees)).toEqual(
       expect.objectContaining({
         type: UPDATE_PRICE,
-        price: 5.5,
+        fees,
       })
     )
   })

--- a/unlock-app/src/__tests__/components/interface/user-account/KeyPurchaseConfirmation.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/user-account/KeyPurchaseConfirmation.test.tsx
@@ -5,8 +5,10 @@ import {
   KeyPurchaseConfirmation,
   mapDispatchToProps,
   mapStateToProps,
+  makePriceBreakdown,
 } from '../../../../components/interface/user-account/KeyPurchaseConfirmation'
 import { PurchaseData } from '../../../../actions/user'
+import { Fees } from '../../../../actions/keyPurchase'
 
 const cards: stripe.Card[] = [
   {
@@ -55,7 +57,14 @@ const lock: Lock = {
 }
 const emailAddress = 'gaben@valve.hats'
 const address = '0xe29ec42F0b620b1c9A716f79A02E9DC5A5f5F98a'
-const price = 1212
+const fees: Fees = {
+  creditCardProcessing: 450,
+  gasFee: 30,
+  keyPrice: 100,
+  unlockServiceFee: 20,
+}
+
+const priceBreakdown = makePriceBreakdown(fees)
 
 describe('KeyPurchaseConfirmation', () => {
   describe('component', () => {
@@ -69,7 +78,7 @@ describe('KeyPurchaseConfirmation', () => {
           signPurchaseData={signPurchaseData}
           cards={cards}
           lock={lock}
-          price={price}
+          priceBreakdown={priceBreakdown}
         />
       )
       const submitButton = wrapper.container.getElementsByTagName('button')[0]
@@ -88,7 +97,7 @@ describe('KeyPurchaseConfirmation', () => {
           emailAddress=""
           cards={cards}
           signPurchaseData={signPurchaseData}
-          price={price}
+          priceBreakdown={priceBreakdown}
         />
       )
 
@@ -125,7 +134,7 @@ describe('KeyPurchaseConfirmation', () => {
         },
         cart: {
           lock,
-          price,
+          fees,
         },
       }
 
@@ -134,7 +143,7 @@ describe('KeyPurchaseConfirmation', () => {
         emailAddress,
         address,
         lock,
-        price,
+        priceBreakdown,
       })
     })
 
@@ -149,7 +158,7 @@ describe('KeyPurchaseConfirmation', () => {
         address: '',
         cards: [],
         lock: undefined,
-        price: undefined,
+        priceBreakdown: {},
       })
     })
   })

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -669,13 +669,12 @@ describe('Storage middleware', () => {
         keyPrice: 100,
         unlockServiceFee: 20,
       }
-      const price = 600
 
       mockStorageService.emit(success.getKeyPrice, fees)
 
       expect(store.dispatch).toHaveBeenCalledWith({
         type: UPDATE_PRICE,
-        price,
+        fees,
       })
     })
 

--- a/unlock-app/src/__tests__/reducers/cartReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/cartReducer.test.ts
@@ -12,7 +12,7 @@ describe('cartReducer', () => {
     })
   })
 
-  it('should update existing state with a price when receiving UPDATE_PRICE', () => {
+  it('should update existing state with the fees object when receiving UPDATE_PRICE', () => {
     expect.assertions(1)
     const lock = 'a lock'
     const tip = 'a tip'
@@ -20,11 +20,18 @@ describe('cartReducer', () => {
       lock,
       tip,
     }
-    const price = 5.5
-    expect(reducer(currentState, updatePrice(5.5))).toEqual({
+
+    const fees = {
+      creditCardProcessing: 450,
+      gasFee: 30,
+      keyPrice: 100,
+      unlockServiceFee: 20,
+    }
+
+    expect(reducer(currentState, updatePrice(fees))).toEqual({
       lock,
       tip,
-      price,
+      fees,
     })
   })
 

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -60777,7 +60777,7 @@ Object {
               <span
                 class="c8"
               >
-                $12.15
+                $6.00
               </span>
               <span
                 class="c9"
@@ -60850,7 +60850,7 @@ Object {
             <span
               class="sc-gqjmRU KgwZy"
             >
-              $12.15
+              $6.00
             </span>
             <span
               class="sc-VigVT ieqVAN"

--- a/unlock-app/src/actions/keyPurchase.ts
+++ b/unlock-app/src/actions/keyPurchase.ts
@@ -2,15 +2,19 @@ export const ADD_TO_CART = 'keyPurchase/ADD_TO_CART'
 export const UPDATE_PRICE = 'keyPurchase/UPDATE_PRICE'
 export const DISMISS_PURCHASE_MODAL = 'keyPurchase/DISMISS_MODAL'
 
+interface Fees {
+  [name: string]: number
+}
+
 export const addToCart = ({ lock, tip }: any) => ({
   type: ADD_TO_CART,
   lock,
   tip,
 })
 
-export const updatePrice = (price: number) => ({
+export const updatePrice = (fees: Fees) => ({
   type: UPDATE_PRICE,
-  price,
+  fees,
 })
 
 export const dismissPurchaseModal = () => ({

--- a/unlock-app/src/actions/keyPurchase.ts
+++ b/unlock-app/src/actions/keyPurchase.ts
@@ -2,8 +2,11 @@ export const ADD_TO_CART = 'keyPurchase/ADD_TO_CART'
 export const UPDATE_PRICE = 'keyPurchase/UPDATE_PRICE'
 export const DISMISS_PURCHASE_MODAL = 'keyPurchase/DISMISS_MODAL'
 
-interface Fees {
-  [name: string]: number
+export interface Fees {
+  keyPrice: number
+  gasFee: number
+  creditCardProcessing: number
+  unlockServiceFee: number
 }
 
 export const addToCart = ({ lock, tip }: any) => ({

--- a/unlock-app/src/components/interface/user-account/KeyPurchaseConfirmation.tsx
+++ b/unlock-app/src/components/interface/user-account/KeyPurchaseConfirmation.tsx
@@ -70,8 +70,8 @@ export const KeyPurchaseConfirmation = ({
   )
 }
 
-const presentLock = (price: string, timeRemaining: any) => {
-  let displayedPrice = price || '-'
+const presentLock = (price: string, timeRemaining: any, none: string = '-') => {
+  let displayedPrice = price || none
   return <LockInfo price={displayedPrice} timeRemaining={timeRemaining} />
 }
 

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -179,9 +179,7 @@ const storageMiddleware = config => {
     })
 
     storageService.on(success.getKeyPrice, fees => {
-      // For now just dispatch the sum of these, in the future we may want to be
-      // more granular so we can provide a price breakdown on the checkout page.
-      dispatch(updatePrice(Object.values(fees).reduce((a, b) => a + b)))
+      dispatch(updatePrice(fees))
     })
     storageService.on(failure.getKeyPrice, () => {
       dispatch(

--- a/unlock-app/src/reducers/cartReducer.ts
+++ b/unlock-app/src/reducers/cartReducer.ts
@@ -20,8 +20,8 @@ const cartReducer = (state = initialState, action: Action) => {
     const { lock, tip } = action
     state = { lock, tip }
   } else if (action.type === UPDATE_PRICE) {
-    const { price } = action
-    state = Object.assign({}, state, { price })
+    const { fees } = action
+    state = Object.assign({}, state, { fees })
   }
 
   return state

--- a/unlock-app/src/stories/interface/UserAccount.stories.js
+++ b/unlock-app/src/stories/interface/UserAccount.stories.js
@@ -2,7 +2,10 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { AccountInfo } from '../../components/interface/user-account/AccountInfo'
 import { ChangePassword } from '../../components/interface/user-account/ChangePassword'
-import { KeyPurchaseConfirmation } from '../../components/interface/user-account/KeyPurchaseConfirmation'
+import {
+  KeyPurchaseConfirmation,
+  makePriceBreakdown,
+} from '../../components/interface/user-account/KeyPurchaseConfirmation'
 import { PaymentMethods } from '../../components/interface/user-account/PaymentMethods'
 import { changePassword, signPurchaseData } from '../../actions/user'
 import { Grid } from '../../components/interface/user-account/styles'
@@ -41,7 +44,14 @@ const lock = {
   key,
 }
 
-const price = 1215
+const fees = {
+  creditCardProcessing: 450,
+  gasFee: 30,
+  keyPrice: 100,
+  unlockServiceFee: 20,
+}
+
+const priceBreakdown = makePriceBreakdown(fees)
 
 storiesOf('User Account/Components', module)
   .add('AccountInfo, no info', () => {
@@ -64,6 +74,7 @@ storiesOf('User Account/Components', module)
         emailAddress="jenny@googlemail.com"
         signPurchaseData={signPurchaseData}
         cards={[]}
+        priceBreakdown={{}}
       />
     )
   })
@@ -74,7 +85,7 @@ storiesOf('User Account/Components', module)
         signPurchaseData={signPurchaseData}
         lock={lock}
         cards={cards}
-        price={price}
+        priceBreakdown={priceBreakdown}
       />
     )
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Instead of computing a price in `storageMiddleware` and storing that, now we store the fees object in a raw state and let the component operate on it for display. This puts us well on the way to resolving #4543. This PR does not actually change the outward behavior yet, it just puts the data where it needs to be for us to do so.

There is a small storyshots change, just because I'm using a fees object from elsewhere that added up to $6.00, instead of the arbitrarily chosen hardcoded price of $12.15.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
