### PR TITLE
Leveraging Forage in Locksmith around looking up token assets

### DIFF
--- a/locksmith/__tests__/operations/metadataOperations.test.ts
+++ b/locksmith/__tests__/operations/metadataOperations.test.ts
@@ -1,0 +1,51 @@
+const metadataOperations = require('../../src/operations/metadataOperations')
+require('../../src/models')
+
+describe('metadataOperations', () => {
+  describe('updateKeyMetadata', () => {
+    describe('when update is successful', () => {
+      it('returns true', async () => {
+        expect.assertions(1)
+        let updateStatus = await metadataOperations.updateKeyMetadata({
+          address: '0x2335',
+          id: '2',
+        })
+        expect(updateStatus).toBe(true)
+      })
+    })
+    describe('when update fails', () => {
+      it('returns false', async () => {
+        expect.assertions(1)
+        let updateStatus = await metadataOperations.updateKeyMetadata({})
+        expect(updateStatus).toBe(false)
+      })
+    })
+  })
+  describe('updateDefaultLockMetadata', () => {
+    describe('when update is successful', () => {
+      it('returns true', async () => {
+        expect.assertions(1)
+        let updateStatus = await metadataOperations.updateDefaultLockMetadata({
+          address: '0x2335',
+          id: 2,
+          data: {
+            foo: 'bar',
+          },
+        })
+        expect(updateStatus).toBe(true)
+      })
+    })
+    describe('when update fails', () => {
+      it('returns false', async () => {
+        expect.assertions(1)
+        let updateStatus = await metadataOperations.updateDefaultLockMetadata({
+          id: 2,
+          data: {
+            foo: 'bar',
+          },
+        })
+        expect(updateStatus).toBe(false)
+      })
+    })
+  })
+})

--- a/locksmith/__tests__/utils/assets.test.ts
+++ b/locksmith/__tests__/utils/assets.test.ts
@@ -1,0 +1,63 @@
+const Asset = require('../../src/utils/assets')
+
+let returnStatus = { statusCode: 200 }
+
+jest.mock('request-promise-native', () => {
+  return jest.fn(() => {
+    return returnStatus
+  })
+})
+
+describe('Assets', () => {
+  describe('exists', () => {
+    describe('when the asset exists', () => {
+      it('returns true', async () => {
+        expect.assertions(1)
+        expect(await Asset.exists('existing_image')).toBe(true)
+      })
+    })
+
+    describe('when the asset does not exist', () => {
+      it('returns false', async () => {
+        expect.assertions(1)
+        returnStatus = { statusCode: 403 }
+        expect(await Asset.exists('non_existing_image')).toBe(false)
+      })
+    })
+  })
+
+  describe('tokenMetadataDefaultImage', () => {
+    it('returns the relevant image path', () => {
+      expect.assertions(1)
+      expect(
+        Asset.tokenMetadataDefaultImage({
+          base: 'host',
+          address: 'address',
+        })
+      ).toEqual('host/address/metadata/default_image')
+    })
+  })
+  describe('tokenCentricImage', () => {
+    it('returns the relevant image path', () => {
+      expect.assertions(1)
+      expect(
+        Asset.tokenCentricImage({
+          base: 'host',
+          address: 'address',
+          tokenId: 42,
+        })
+      ).toEqual('host/address/metadata/42')
+    })
+  })
+  describe('ticketsBannerImage', () => {
+    it('returns the relevant image path', () => {
+      expect.assertions(1)
+      expect(
+        Asset.ticketsBannerImage({
+          base: 'host',
+          address: 'address',
+        })
+      ).toEqual('host/address/tickets/banner')
+    })
+  })
+})

--- a/locksmith/__tests__/utils/forage.test.ts
+++ b/locksmith/__tests__/utils/forage.test.ts
@@ -1,29 +1,29 @@
-import { Forage, Usage } from '../../src/utils/forage'
+import Forage from '../../src/utils/forage'
 
 describe('Forage', () => {
-  describe("when searching for an event's banner image", () => {
+  describe('ticketsBannerImage', () => {
     it('returns the appropriate image', () => {
       expect.assertions(1)
       let forage = new Forage()
-      let output = forage.locate(Usage.TicketBanner, { address: '0xabc' })
+      let output = forage.ticketsBannerImage({ address: '0xabc' })
       expect(output).toEqual('0xabc/tickets/banner')
     })
   })
 
-  describe("when searching for a token's default image", () => {
+  describe('tokenMetadataDefaultImage', () => {
     it('returns the path of the image', () => {
       expect.assertions(1)
       let forage = new Forage()
-      let output = forage.locate(Usage.TokenDefaultImage, { address: '0xabc' })
+      let output = forage.tokenMetadataDefaultImage({ address: '0xabc' })
       expect(output).toEqual('0xabc/metadata/default_image')
     })
   })
 
-  describe('when searching for a token specific image', () => {
+  describe('tokenCentricImage', () => {
     it('returns the path of the image', () => {
       expect.assertions(1)
       let forage = new Forage()
-      let output = forage.locate(Usage.TokenSpecificImage, {
+      let output = forage.tokenCentricImage({
         address: '0xabc',
         tokenId: 223,
       })

--- a/locksmith/src/operations/metadataOperations.ts
+++ b/locksmith/src/operations/metadataOperations.ts
@@ -5,10 +5,12 @@ import KeyData from '../utils/keyData'
 
 const env = process.env.NODE_ENV || 'development'
 const config = require('../../config/config')[env]
+const Asset = require('../utils/assets')
 
 export const updateKeyMetadata = async (data: any) => {
   try {
-    return !!(await KeyMetadata.upsert(data, { returning: true }))
+    await KeyMetadata.upsert(data, { returning: true })
+    return true
   } catch (e) {
     return false
   }
@@ -16,10 +18,72 @@ export const updateKeyMetadata = async (data: any) => {
 
 export const updateDefaultLockMetadata = async (data: any) => {
   try {
-    return !!(await LockMetadata.upsert(data, { returning: true }))
+    await LockMetadata.upsert(data, { returning: true })
+    return true
   } catch (e) {
     return false
   }
+}
+
+export const generateKeyMetadata = async (address: string, keyId: string) => {
+  let onChainKeyMetadata = await fetchChainData(address, keyId)
+  if (Object.keys(onChainKeyMetadata).length == 0) {
+    return {}
+  }
+  let keyCentricData = await getKeyCentricData(address, keyId)
+  let baseTokenData = await getBaseTokenData(address)
+  return Object.assign(baseTokenData, keyCentricData, onChainKeyMetadata)
+}
+
+const getBaseTokenData = async (address: string) => {
+  let defaultResponse = defaultMappings(address)
+  let persistedBasedMetadata = await LockMetadata.findOne({
+    where: { address: address },
+  })
+
+  let assetLocation = Asset.tokenMetadataDefaultImage({
+    base: 'https://assets.unlock-protocol.com',
+    address: address,
+  })
+
+  let result = persistedBasedMetadata
+    ? persistedBasedMetadata.data
+    : defaultResponse
+
+  if (await Asset.exists(assetLocation)) {
+    ;(result as { image: string }).image = assetLocation
+  }
+
+  return result
+}
+
+const getKeyCentricData = async (address: string, tokenId: string) => {
+  let keyCentricData: any = await KeyMetadata.findOne({
+    where: {
+      address: address,
+      id: tokenId,
+    },
+  })
+
+  let assetLocation = Asset.tokenCentricImage({
+    base: 'https://assets.unlock-protocol.com',
+    address: address,
+    tokenId: tokenId,
+  })
+
+  let result = keyCentricData ? keyCentricData.data : {}
+
+  if (await Asset.exists(assetLocation)) {
+    result.image = assetLocation
+  }
+
+  return result
+}
+
+const fetchChainData = async (address: string, keyId: string) => {
+  let kd = new KeyData(config.web3ProviderHost)
+  let data = await kd.get(address, keyId)
+  return kd.openSeaPresentation(data)
 }
 
 const defaultMappings = (address: string) => {
@@ -42,35 +106,4 @@ const defaultMappings = (address: string) => {
   // Append description
   defaultResponse.description = `${defaultResponse.description} Unlock is a protocol for memberships. https://unlock-protocol.com/`
   return defaultResponse
-}
-
-export const generateKeyMetadata = async (address: string, keyId: string) => {
-  let onChainKeyMetadata = await fetchChainData(address, keyId)
-  if (Object.keys(onChainKeyMetadata).length == 0) {
-    return {}
-  }
-
-  let defaultResponse = defaultMappings(address)
-  let persistedBasedMetadata = await LockMetadata.findOne({
-    where: { address: address },
-  })
-
-  let keyCentricData: any = await KeyMetadata.findOne({
-    where: {
-      address: address,
-      id: keyId,
-    },
-  })
-
-  let result = keyCentricData ? keyCentricData.data : {}
-  let defaults = persistedBasedMetadata
-    ? persistedBasedMetadata.data
-    : defaultResponse
-  return Object.assign(result, defaults, onChainKeyMetadata)
-}
-
-const fetchChainData = async (address: string, keyId: string) => {
-  let kd = new KeyData(config.web3ProviderHost)
-  let data = await kd.get(address, keyId)
-  return kd.openSeaPresentation(data)
 }

--- a/locksmith/src/utils/assets.ts
+++ b/locksmith/src/utils/assets.ts
@@ -1,0 +1,43 @@
+import Forage from './forage'
+
+const request = require('request-promise-native')
+
+interface tokenCentricData {
+  base: string
+  address: string
+  tokenId: string
+}
+
+interface ticketsBannerData {
+  base: string
+  address: string
+}
+
+interface tokenMetadataDefaultData {
+  base: string
+  address: string
+}
+
+export const exists = async (image: string) => {
+  try {
+    let lookup = await request(image, { resolveWithFullResponse: true })
+    return lookup.statusCode == 200
+  } catch (e) {
+    return false
+  }
+}
+
+export const tokenMetadataDefaultImage = (data: tokenMetadataDefaultData) => {
+  let fg = new Forage()
+  return `${data.base}/${fg.tokenMetadataDefaultImage(data)}`
+}
+
+export const tokenCentricImage = (data: tokenCentricData) => {
+  let fg = new Forage()
+  return `${data.base}/${fg.tokenCentricImage(data)}`
+}
+
+export const ticketsBannerImage = (data: ticketsBannerData) => {
+  let fg = new Forage()
+  return `${data.base}/${fg.ticketsBannerImage(data)}`
+}

--- a/locksmith/src/utils/forage.ts
+++ b/locksmith/src/utils/forage.ts
@@ -1,36 +1,19 @@
-/* eslint-disable no-unused-vars */
-export enum Usage {
-  TicketBanner = 'banner',
-  TokenDefaultImage = 'default-image',
-  TokenSpecificImage = 'token-image',
-}
-/* eslint-enable no-unused-vars */
-
-export class Forage {
-  locate(usage: Usage, data: any): string {
-    switch (usage) {
-      case Usage.TicketBanner:
-        return this.ticketsBannerImage(data)
-      case Usage.TokenDefaultImage:
-        return this.tokenMetadataDefaultImage(data)
-      case Usage.TokenSpecificImage:
-        return this.tokenCentricImage(data)
-    }
-  }
-
+class Forage {
   private normalizedAddress(address: string) {
     return address.toLowerCase()
   }
 
-  private tokenMetadataDefaultImage(data: any) {
+  tokenMetadataDefaultImage(data: any) {
     return `${this.normalizedAddress(data.address)}/metadata/default_image`
   }
 
-  private tokenCentricImage(data: any) {
+  tokenCentricImage(data: any) {
     return `${this.normalizedAddress(data.address)}/metadata/${data.tokenId}`
   }
 
-  private ticketsBannerImage(data: any) {
+  ticketsBannerImage(data: any) {
     return `${this.normalizedAddress(data.address)}/tickets/banner`
   }
 }
+
+export = Forage


### PR DESCRIPTION
# Description

As part of standardizing the usage of assets so that we can open uploads to external parties, now using Forage to locate the appropriate location of assets for tokens. 

Some of this is a bit transitional as we currently have assets that exists outside of the paradigm,  but will be merge to confirm and reduce code paths as we setup an ingestion method.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
