### PR TITLE
passing transactions and keys to the checkout iframe

### DIFF
--- a/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
+++ b/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
@@ -1,6 +1,7 @@
 import FakeWindow from '../test-helpers/fakeWindowHelpers'
 import CheckoutUIHandler from '../../unlock.js/CheckoutUIHandler'
-import { PaywallConfig, Locks } from '../../unlockTypes'
+import { PaywallConfig, Locks, Transactions } from '../../unlockTypes'
+import { KeyResults } from '../../data-iframe/blockchainHandler/blockChainTypes'
 import IframeHandler from '../../unlock.js/IframeHandler'
 import { PostMessages, ExtractPayload } from '../../messageTypes'
 
@@ -39,6 +40,11 @@ describe('CheckoutUIHandler', () => {
       },
     },
   }
+
+  const fakeKeys: KeyResults = {}
+
+  const fakeTransactions: Transactions = {}
+
   const config: PaywallConfig = {
     locks: {},
     callToAction: {
@@ -155,6 +161,12 @@ describe('CheckoutUIHandler', () => {
       ['UPDATE_ACCOUNT', PostMessages.UPDATE_ACCOUNT, fakeAccount],
       ['UPDATE_ACCOUNT_BALANCE', PostMessages.UPDATE_ACCOUNT_BALANCE, '123'],
       ['UPDATE_LOCKS', PostMessages.UPDATE_LOCKS, fakeLocks],
+      ['UPDATE_KEYS', PostMessages.UPDATE_KEYS, fakeKeys],
+      [
+        'UPDATE_TRANSACTIONS',
+        PostMessages.UPDATE_TRANSACTIONS,
+        fakeTransactions,
+      ],
       ['UPDATE_NETWORK', PostMessages.UPDATE_NETWORK, 3],
       ['UPDATE_WALLET', PostMessages.UPDATE_WALLET, true],
       ['ERROR', PostMessages.ERROR, 'error message'],

--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
@@ -149,6 +149,11 @@ describe('DataIframeMessageEmitter', () => {
         },
       },
     }
+
+    const keys: ExtractPayload<PostMessages.UPDATE_KEYS> = {}
+
+    const transactions: ExtractPayload<PostMessages.UPDATE_TRANSACTIONS> = {}
+
     it.each(<PayloadMessages>[
       ['UNLOCKED', PostMessages.UNLOCKED, lockAddresses],
       ['ERROR', PostMessages.ERROR, 'error message'],
@@ -158,6 +163,8 @@ describe('DataIframeMessageEmitter', () => {
       ['UPDATE_ACCOUNT_BALANCE', PostMessages.UPDATE_ACCOUNT_BALANCE, '123'],
       ['UPDATE_NETWORK', PostMessages.UPDATE_NETWORK, 4],
       ['UPDATE_LOCKS', PostMessages.UPDATE_LOCKS, locks],
+      ['UPDATE_KEYS', PostMessages.UPDATE_KEYS, keys],
+      ['UPDATE_TRANSACTIONS', PostMessages.UPDATE_TRANSACTIONS, transactions],
     ])(
       'should emit PostMessages.%s upon receiving it',
       (_, message, payload) => {

--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -10,7 +10,13 @@ import useBlockchainData from '../../hooks/useBlockchainData'
 import useWindow from '../../hooks/browser/useWindow'
 import usePaywallConfig from '../../hooks/usePaywallConfig'
 import usePostMessage from '../../hooks/browser/usePostMessage'
-import { Key, Locks, PaywallConfig, Account } from '../../unlockTypes'
+import {
+  Key,
+  Locks,
+  PaywallConfig,
+  Account,
+  Transactions,
+} from '../../unlockTypes'
 import {
   POST_MESSAGE_PURCHASE_KEY,
   POST_MESSAGE_DISMISS_CHECKOUT,
@@ -33,6 +39,7 @@ interface blockchainData {
   account: Account | null
   network: number
   locks: Locks
+  transactions: Transactions
 }
 type useBlockchainDataFunc = (
   window: any,
@@ -57,6 +64,7 @@ export default function CheckoutContent() {
     window,
     paywallConfig
   )
+
   const currentNetwork: string = (ETHEREUM_NETWORKS_NAMES as networkNames)[
     network
   ][0]

--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -244,7 +244,7 @@ export default class Mailbox {
   sendUpdates(updateRequest: unknown) {
     if (!this.blockchainData) return
 
-    const { locks, account, balance, network, keys } = this
+    const { locks, account, balance, network, keys, transactions } = this
       .blockchainData as BlockchainData
     const configLockAddresses: string[] =
       (this.configuration && Object.keys(this.configuration.locks)) || []
@@ -262,11 +262,22 @@ export default class Mailbox {
         break
       }
     }
-
-    const type = updateRequest as 'locks' | 'account' | 'balance' | 'network'
+    const type = updateRequest as
+      | 'locks'
+      | 'account'
+      | 'balance'
+      | 'network'
+      | 'transactions'
+      | 'keys'
     switch (type) {
       case 'locks':
         this.postMessage(PostMessages.UPDATE_LOCKS, locks)
+        break
+      case 'transactions':
+        this.postMessage(PostMessages.UPDATE_TRANSACTIONS, transactions)
+        break
+      case 'keys':
+        this.postMessage(PostMessages.UPDATE_KEYS, keys)
         break
       case 'account':
         this.postMessage(PostMessages.UPDATE_ACCOUNT, account)

--- a/paywall/src/data-iframe/blockchainHandler/blockChainTypes.ts
+++ b/paywall/src/data-iframe/blockchainHandler/blockChainTypes.ts
@@ -47,6 +47,7 @@ export interface TransactionDefaults {
   [key: string]: any
 }
 
+// TODO: move these types to unlockTypes with other ones!
 export interface KeyResult {
   lock: string
   owner: string | null

--- a/paywall/src/hooks/useBlockchainData.js
+++ b/paywall/src/hooks/useBlockchainData.js
@@ -3,12 +3,16 @@ import {
   POST_MESSAGE_UPDATE_ACCOUNT,
   POST_MESSAGE_UPDATE_ACCOUNT_BALANCE,
   POST_MESSAGE_UPDATE_LOCKS,
+  POST_MESSAGE_UPDATE_KEYS,
+  POST_MESSAGE_UPDATE_TRANSACTIONS,
   POST_MESSAGE_UPDATE_NETWORK,
 } from '../paywall-builder/constants'
 import {
   isAccountOrNull,
   isPositiveInteger,
   isValidLocks,
+  isValidKeys,
+  isValidTransactions,
   isPositiveNumber,
 } from '../utils/validators'
 import useConfig from './utils/useConfig'
@@ -56,6 +60,22 @@ export default function useBlockchainData(window, paywallConfig) {
     local: 'useBlockchainData [locks]',
   })
 
+  // retrieve the keys from the data iframe
+  const keys = useListenForPostMessage({
+    type: POST_MESSAGE_UPDATE_KEYS,
+    defaultValue: {},
+    validator: isValidKeys,
+    local: 'useBlockchainData [keys]',
+  })
+
+  // retrieve the transactions from the data iframe
+  const transactions = useListenForPostMessage({
+    type: POST_MESSAGE_UPDATE_TRANSACTIONS,
+    defaultValue: {},
+    validator: isValidTransactions,
+    local: 'useBlockchainData [transactions]',
+  })
+
   // construct the object format expected by the checkout UI
   const account = address ? { address, balance } : null
 
@@ -92,5 +112,7 @@ export default function useBlockchainData(window, paywallConfig) {
     account,
     network,
     locks,
+    transactions,
+    keys,
   }
 }

--- a/paywall/src/messageTypes.ts
+++ b/paywall/src/messageTypes.ts
@@ -10,6 +10,7 @@ import { KeyResults } from './data-iframe/blockchainHandler/blockChainTypes'
 
 // This file written with HEAVY inspiration from https://artsy.github.io/blog/2018/11/21/conditional-types-in-typescript/
 
+// TODO: there is a lot of duplicates from constants.js
 export enum PostMessages {
   LOCKED = 'locked',
   UNLOCKED = 'unlocked',
@@ -149,7 +150,10 @@ export type Message =
       type: PostMessages.UPDATE_KEYS
       payload: KeyResults
     }
-  | { type: PostMessages.UPDATE_TRANSACTIONS; payload: Transactions }
+  | {
+      type: PostMessages.UPDATE_TRANSACTIONS
+      payload: Transactions
+    }
 
 export type MessageTypes = Message['type']
 export type ExtractPayload<TYPE> = Extract<Message, { type: TYPE }>['payload']

--- a/paywall/src/paywall-builder/constants.js
+++ b/paywall/src/paywall-builder/constants.js
@@ -12,6 +12,8 @@ export const POST_MESSAGE_READY_WEB3 = 'ready/web3'
 export const POST_MESSAGE_WALLET_INFO = 'walletInfo'
 
 export const POST_MESSAGE_UPDATE_LOCKS = 'update/locks'
+export const POST_MESSAGE_UPDATE_KEYS = 'update/keys'
+export const POST_MESSAGE_UPDATE_TRANSACTIONS = 'update/transactions'
 export const POST_MESSAGE_UPDATE_ACCOUNT = 'update/account'
 export const POST_MESSAGE_UPDATE_ACCOUNT_BALANCE = 'update/accountBalance'
 export const POST_MESSAGE_UPDATE_NETWORK = 'update/network'

--- a/paywall/src/unlock.js/CheckoutUIHandler.ts
+++ b/paywall/src/unlock.js/CheckoutUIHandler.ts
@@ -32,6 +32,15 @@ export default class CheckoutUIHandler {
     this.iframes.data.on(PostMessages.UPDATE_LOCKS, locks =>
       this.iframes.checkout.postMessage(PostMessages.UPDATE_LOCKS, locks)
     )
+    this.iframes.data.on(PostMessages.UPDATE_KEYS, keys =>
+      this.iframes.checkout.postMessage(PostMessages.UPDATE_KEYS, keys)
+    )
+    this.iframes.data.on(PostMessages.UPDATE_TRANSACTIONS, transactions => {
+      return this.iframes.checkout.postMessage(
+        PostMessages.UPDATE_TRANSACTIONS,
+        transactions
+      )
+    })
     this.iframes.data.on(PostMessages.UPDATE_NETWORK, network =>
       this.iframes.checkout.postMessage(PostMessages.UPDATE_NETWORK, network)
     )
@@ -49,6 +58,8 @@ export default class CheckoutUIHandler {
       this.iframes.data.postMessage(PostMessages.SEND_UPDATES, 'account')
       this.iframes.data.postMessage(PostMessages.SEND_UPDATES, 'balance')
       this.iframes.data.postMessage(PostMessages.SEND_UPDATES, 'network')
+      this.iframes.data.postMessage(PostMessages.SEND_UPDATES, 'keys')
+      this.iframes.data.postMessage(PostMessages.SEND_UPDATES, 'transactions')
     })
 
     // pass on any errors

--- a/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
@@ -118,5 +118,11 @@ export default class DataIframeMessageEmitter extends FancyEmitter {
       }
       this.emit(PostMessages.UPDATE_LOCKS, locks)
     })
+    this.addHandler(PostMessages.UPDATE_TRANSACTIONS, transactions => {
+      this.emit(PostMessages.UPDATE_TRANSACTIONS, transactions)
+    })
+    this.addHandler(PostMessages.UPDATE_KEYS, keys => {
+      this.emit(PostMessages.UPDATE_KEYS, keys)
+    })
   }
 }

--- a/paywall/src/unlock.js/PostMessageEmitters/EventEmitterTypes.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/EventEmitterTypes.ts
@@ -32,6 +32,12 @@ export interface DataIframeEvents {
   [PostMessages.UPDATE_LOCKS]: (
     update: ExtractPayload<PostMessages.UPDATE_LOCKS>
   ) => void
+  [PostMessages.UPDATE_KEYS]: (
+    update: ExtractPayload<PostMessages.UPDATE_KEYS>
+  ) => void
+  [PostMessages.UPDATE_TRANSACTIONS]: (
+    update: ExtractPayload<PostMessages.UPDATE_TRANSACTIONS>
+  ) => void
   [PostMessages.UPDATE_NETWORK]: (
     update: ExtractPayload<PostMessages.UPDATE_NETWORK>
   ) => void

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -250,6 +250,22 @@ export const isValidLocks = locks => {
 }
 
 /**
+ * validate the list of keys returned from the data iframe
+ * TODO: consider if validation is actually required
+ */
+export const isValidKeys = () => {
+  return true
+}
+
+/**
+ * validate the list of transactions returned from the data iframe
+ * TODO: consider if validation is actually required
+ */
+export const isValidTransactions = () => {
+  return true
+}
+
+/**
  * validate a balance as an object of currency: balance
  */
 export const isValidBalance = balance => {


### PR DESCRIPTION
# Description

In an effort to refactor the checkout UI we need tthe transactions and keys to be sent independently of the locks.
This PR does just this.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

