### PR TITLE
Add loading spinner when logging in

### DIFF
--- a/unlock-app/src/__tests__/components/interface/user-account/LogIn.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/user-account/LogIn.test.tsx
@@ -3,7 +3,7 @@ import * as rtl from 'react-testing-library'
 import { LogIn } from '../../../../components/interface/user-account/LogIn'
 // eslint-disable-next-line no-unused-vars
 import { Credentials } from '../../../../actions/user'
-import { WarningError } from '../../../../utils/Error'
+import Errors, { WarningError } from '../../../../utils/Error'
 
 let loginCredentials: (c: Credentials) => any
 let toggleSignup: () => any
@@ -106,5 +106,30 @@ describe('LogIn', () => {
     )
 
     getByText('Sign Up')
+  })
+
+  it('should show allow for reset and retry when there is an error', () => {
+    expect.assertions(2)
+
+    const errors = [Errors.LogIn.Warning('Failed to decrypt private key.')]
+
+    const { getByText } = rtl.render(
+      <LogIn
+        toggleSignup={toggleSignup}
+        loginCredentials={loginCredentials}
+        errors={errors}
+        close={close}
+      />
+    )
+
+    // There's an error, so the red button should be visible
+    const resetButton = getByText('Retry Login')
+
+    rtl.fireEvent.click(resetButton)
+
+    // After clicking, it should close the errors
+    expect(close).toHaveBeenCalledWith(errors[0])
+    // And then submit the login request
+    expect(loginCredentials).toHaveBeenCalled()
   })
 })

--- a/unlock-app/src/__tests__/components/interface/user-account/LogIn.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/user-account/LogIn.test.tsx
@@ -3,21 +3,31 @@ import * as rtl from 'react-testing-library'
 import { LogIn } from '../../../../components/interface/user-account/LogIn'
 // eslint-disable-next-line no-unused-vars
 import { Credentials } from '../../../../actions/user'
+import { WarningError } from '../../../../utils/Error'
 
 let loginCredentials: (c: Credentials) => any
+let toggleSignup: () => any
+let close: (e: any) => void
+let errors: WarningError[]
 
 describe('LogIn', () => {
   beforeEach(() => {
     loginCredentials = jest.fn((c: Credentials) => c)
+    toggleSignup = jest.fn()
+    close = jest.fn()
+    errors = []
   })
 
   it('should call toggleSignup when the link is clicked', () => {
     expect.assertions(1)
 
-    const toggleSignup = jest.fn()
-
     const { getByText } = rtl.render(
-      <LogIn toggleSignup={toggleSignup} loginCredentials={loginCredentials} />
+      <LogIn
+        toggleSignup={toggleSignup}
+        loginCredentials={loginCredentials}
+        errors={errors}
+        close={close}
+      />
     )
 
     const signUp = getByText('Sign up here.')
@@ -32,7 +42,12 @@ describe('LogIn', () => {
     const password = 'guest'
 
     const { getByDisplayValue, getByLabelText } = rtl.render(
-      <LogIn toggleSignup={() => {}} loginCredentials={loginCredentials} />
+      <LogIn
+        toggleSignup={toggleSignup}
+        loginCredentials={loginCredentials}
+        errors={errors}
+        close={close}
+      />
     )
 
     const emailInput = getByLabelText('Email')
@@ -55,7 +70,12 @@ describe('LogIn', () => {
     expect.assertions(1)
 
     const { getByText, getByDisplayValue } = rtl.render(
-      <LogIn toggleSignup={() => {}} loginCredentials={loginCredentials} />
+      <LogIn
+        toggleSignup={toggleSignup}
+        loginCredentials={loginCredentials}
+        errors={errors}
+        close={close}
+      />
     )
 
     // Should not already be in the loading state
@@ -70,8 +90,6 @@ describe('LogIn', () => {
   it('should show SignupSuccess when there is an account in state', () => {
     expect.assertions(0)
 
-    const toggleSignup = jest.fn()
-    const loginCredentials = jest.fn()
     const account = {
       address: '0x123abc',
       balance: '0',
@@ -82,6 +100,8 @@ describe('LogIn', () => {
         toggleSignup={toggleSignup}
         loginCredentials={loginCredentials}
         account={account}
+        errors={errors}
+        close={close}
       />
     )
 

--- a/unlock-app/src/__tests__/components/interface/user-account/LogIn.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/user-account/LogIn.test.tsx
@@ -51,6 +51,22 @@ describe('LogIn', () => {
     )
   })
 
+  it('should transition to a loading state when the form is submitted', () => {
+    expect.assertions(1)
+
+    const { getByText, getByDisplayValue } = rtl.render(
+      <LogIn toggleSignup={() => {}} loginCredentials={loginCredentials} />
+    )
+
+    // Should not already be in the loading state
+    expect(() => getByText('Logging In...')).toThrow()
+
+    const submit = getByDisplayValue('Submit')
+    rtl.fireEvent.click(submit)
+
+    getByText('Logging In...')
+  })
+
   it('should show SignupSuccess when there is an account in state', () => {
     expect.assertions(0)
 

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -949,10 +949,10 @@ Object {
           
         </a>
         <div
-          class="sc-kpOJdX iMWLHm"
+          class="sc-kpOJdX gCFVZh"
         >
           <h1
-            class="sc-dxgOiQ kCvUDj"
+            class="sc-dxgOiQ bjveIj"
           >
             Log In
           </h1>
@@ -961,13 +961,13 @@ Object {
               class="sc-kkGfuU dTGOmL"
             >
               <label
-                class="sc-hMqMXs boiFZQ"
+                class="sc-hMqMXs hMxlwy"
                 for="emailInput"
               >
                 Email
               </label>
               <input
-                class="sc-jKJlTe iiMoSO"
+                class="sc-jKJlTe kQfwwT"
                 id="emailInput"
                 name="emailAddress"
                 placeholder="Enter your email"
@@ -975,20 +975,20 @@ Object {
               />
               <br />
               <label
-                class="sc-hMqMXs boiFZQ"
+                class="sc-hMqMXs hMxlwy"
                 for="passwordInput"
               >
                 Password
               </label>
               <input
-                class="sc-jKJlTe iiMoSO"
+                class="sc-jKJlTe kQfwwT"
                 id="passwordInput"
                 name="password"
                 placeholder="Enter your password"
                 type="password"
               />
               <p
-                class="sc-ckVGcZ gDOexU"
+                class="sc-ckVGcZ fkiXIW"
               >
                 Don't have an account?
                  
@@ -1001,7 +1001,7 @@ Object {
             </div>
             <br />
             <input
-              class="sc-eNQAEJ fdriJu"
+              class="sc-eNQAEJ gnfvLE"
               type="submit"
               value="Submit"
             />

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -797,6 +797,7 @@ Object {
   width: 100%;
   border: none;
   background-color: var(--green);
+  color: var(--white);
   border-radius: 0 0 4px;
   font-size: 16px;
   cursor: pointer;
@@ -948,10 +949,10 @@ Object {
           
         </a>
         <div
-          class="sc-kpOJdX gCFVZh"
+          class="sc-kpOJdX iMWLHm"
         >
           <h1
-            class="sc-dxgOiQ bjveIj"
+            class="sc-dxgOiQ kCvUDj"
           >
             Log In
           </h1>
@@ -960,13 +961,13 @@ Object {
               class="sc-kkGfuU dTGOmL"
             >
               <label
-                class="sc-hMqMXs hMxlwy"
+                class="sc-hMqMXs boiFZQ"
                 for="emailInput"
               >
                 Email
               </label>
               <input
-                class="sc-jKJlTe kQfwwT"
+                class="sc-jKJlTe iiMoSO"
                 id="emailInput"
                 name="emailAddress"
                 placeholder="Enter your email"
@@ -974,20 +975,20 @@ Object {
               />
               <br />
               <label
-                class="sc-hMqMXs hMxlwy"
+                class="sc-hMqMXs boiFZQ"
                 for="passwordInput"
               >
                 Password
               </label>
               <input
-                class="sc-jKJlTe kQfwwT"
+                class="sc-jKJlTe iiMoSO"
                 id="passwordInput"
                 name="password"
                 placeholder="Enter your password"
                 type="password"
               />
               <p
-                class="sc-ckVGcZ fkiXIW"
+                class="sc-ckVGcZ gDOexU"
               >
                 Don't have an account?
                  
@@ -1000,7 +1001,7 @@ Object {
             </div>
             <br />
             <input
-              class="sc-eNQAEJ jWNVir"
+              class="sc-eNQAEJ fdriJu"
               type="submit"
               value="Submit"
             />
@@ -59976,6 +59977,7 @@ Object {
 
 .c6 {
   height: 60px;
+  width: 100%;
   border: none;
   background-color: var(--green);
   border-radius: 4px;
@@ -60158,7 +60160,7 @@ Object {
           class="sc-dnqmqq kkgxkC"
         />
         <button
-          class="sc-iwsKbI sc-esjQYD fGpsQB"
+          class="sc-iwsKbI sc-esjQYD jhFzQE"
         >
           Update Password
         </button>
@@ -60302,6 +60304,7 @@ Object {
 
 .c10 {
   height: 60px;
+  width: 100%;
   border: none;
   background-color: var(--green);
   border-radius: 0 0 4px 4px;
@@ -60517,7 +60520,7 @@ Object {
         </div>
       </div>
       <button
-        class="sc-iwsKbI sc-jzJRlG ixbFAk"
+        class="sc-iwsKbI sc-jzJRlG btXmdY"
       >
         No lock found
       </button>
@@ -60630,6 +60633,7 @@ Object {
 
 .c10 {
   height: 60px;
+  width: 100%;
   border: none;
   background-color: var(--green);
   border-radius: 0 0 4px 4px;
@@ -60873,7 +60877,7 @@ Object {
         </div>
       </div>
       <button
-        class="sc-iwsKbI hqCHWS"
+        class="sc-iwsKbI ekNeOx"
       >
         Confirm Purchase
       </button>
@@ -61309,6 +61313,7 @@ Object {
 
 .c7 {
   height: 60px;
+  width: 100%;
   border: none;
   background-color: var(--green);
   border-radius: 4px;
@@ -61625,7 +61630,7 @@ Object {
             class="sc-dnqmqq kkgxkC"
           />
           <button
-            class="sc-iwsKbI sc-esjQYD fGpsQB"
+            class="sc-iwsKbI sc-esjQYD jhFzQE"
           >
             Update Password
           </button>

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -760,7 +760,6 @@ Object {
 }
 
 .c4 {
-  max-width: 456px;
   width: 100%;
 }
 
@@ -949,7 +948,7 @@ Object {
           
         </a>
         <div
-          class="sc-kpOJdX gCFVZh"
+          class="sc-kpOJdX LsipW"
         >
           <h1
             class="sc-dxgOiQ bjveIj"

--- a/unlock-app/src/components/interface/user-account/LogIn.tsx
+++ b/unlock-app/src/components/interface/user-account/LogIn.tsx
@@ -169,7 +169,6 @@ export default connect(
 )(LogIn)
 
 const LogInWrapper = styled.div`
-  max-width: 456px;
   width: 100%;
 `
 

--- a/unlock-app/src/components/interface/user-account/LogIn.tsx
+++ b/unlock-app/src/components/interface/user-account/LogIn.tsx
@@ -7,6 +7,7 @@ import { Account } from '../../../unlockTypes'
 import SignupSuccess from '../SignupSuccess'
 // eslint-disable-next-line no-unused-vars
 import { loginCredentials, Credentials } from '../../../actions/user'
+import { LoadingButton } from './styles'
 
 interface Props {
   toggleSignup: () => void
@@ -61,6 +62,15 @@ export class LogIn extends React.Component<Props, State> {
     toggleSignup()
   }
 
+  submitButton = () => {
+    const { submitted } = this.state
+    if (submitted) {
+      return <LoadingButton>Logging In...</LoadingButton>
+    }
+
+    return <SubmitButton type="submit" value="Submit" />
+  }
+
   render = () => {
     const { account } = this.props
 
@@ -96,7 +106,7 @@ export class LogIn extends React.Component<Props, State> {
             </Description>
           </Indent>
           <br />
-          <SubmitButton type="submit" value="Submit" />
+          {this.submitButton()}
         </form>
       </LogInWrapper>
     )
@@ -159,6 +169,7 @@ const SubmitButton = styled.input`
   width: 100%;
   border: none;
   background-color: var(--green);
+  color: var(--white);
   border-radius: 0 0 4px;
   font-size: 16px;
   cursor: pointer;

--- a/unlock-app/src/components/interface/user-account/styles.tsx
+++ b/unlock-app/src/components/interface/user-account/styles.tsx
@@ -95,6 +95,7 @@ interface SubmitButtonProps {
 }
 export const SubmitButton = styled.button`
   height: 60px;
+  width: 100%;
   border: none;
   background-color: ${(props: SubmitButtonProps) =>
     props.backgroundColor || 'var(--green)'};

--- a/unlock-app/src/stories/content/AccountContent.stories.js
+++ b/unlock-app/src/stories/content/AccountContent.stories.js
@@ -9,6 +9,17 @@ import AccountContent from '../../components/content/AccountContent'
 const baseState = {
   account: {},
 }
+
+const baseStateWithError = {
+  account: {},
+  errors: [
+    {
+      kind: 'LogIn',
+      level: 'Warning',
+      message: 'An error',
+    },
+  ],
+}
 const loggedInState = {
   account: {
     emailAddress: 'jenny@googlemail.com',
@@ -59,6 +70,7 @@ storiesOf('AccountContent (iframe embed for paywall)', module)
     const label = 'Component State'
     const options = {
       'Not logged in yet': baseState,
+      'Not logged in yet (error)': baseStateWithError,
       'Logged in': loggedInState,
       'Logged in with cards': loggedInWithCards,
     }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Before clicking
<img width="433" alt="image" src="https://user-images.githubusercontent.com/9300702/64064311-af391a00-cbcd-11e9-8f23-7d2143c08aef.png">

After clicking
<img width="430" alt="image" src="https://user-images.githubusercontent.com/9300702/64064314-bb24dc00-cbcd-11e9-9da5-2be063b1c7d9.png">

On error
<img width="608" alt="image" src="https://user-images.githubusercontent.com/9300702/64200452-8e392900-ce5a-11e9-922e-3cc702ec6761.png">

When there's a login-related error, clicking the "Retry Login" button will clear the error and then resubmit the login request

In the interest of education, a potential future enhancement for this component would be to swap out the text with the 2 things we do to log in to an account as we do them, so during the network request we could say "retrieving encrypted private key", and then when the request comes back change it to "decrypting private key".

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4544 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
