### PR TITLE
not skipping tests if the the root level package.json file has been changed

### DIFF
--- a/scripts/monorepo.sh
+++ b/scripts/monorepo.sh
@@ -8,7 +8,7 @@ BRANCH=$3
 # current git changes are not relevant to the folder being tested (and not on master)
 
 if [ ! "$BRANCH" = "master" ]; then
-  HAS_CHANGES=$(git show --name-only $COMMIT -- $SERVICE)
+  HAS_CHANGES=$(git show --name-only $COMMIT -- package.json $SERVICE)
   if [ ! -n "$HAS_CHANGES" ]; then
     echo "No change in $SERVICE, skipping job."
     circleci step halt


### PR DESCRIPTION
# Description

If we only check for changes in the subfolder to decide whether we should run tests for a given pull-request then we are missing root level configuration tests which would have an effect on the tests.

This pull request also check for changes in the package.json file.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->