### PR TITLE
Don't show the overlay when using a user account

### DIFF
--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -29,6 +29,7 @@ import { WrongNetwork } from '../creator/FatalError'
 import Greyout from '../helpers/Greyout'
 import useListenForPostMessage from '../../hooks/browser/useListenForPostMessage'
 import CheckoutConfirmingModal from '../checkout/CheckoutConfirmingModal'
+import { PostMessages } from '../../messageTypes'
 
 interface networkNames {
   [key: number]: string[]
@@ -100,6 +101,11 @@ export default function CheckoutContent() {
     defaultValue: false,
     getValue: (val: any) => !!val,
   })
+  const usingManagedAccount = useListenForPostMessage({
+    type: PostMessages.USING_MANAGED_ACCOUNT,
+    defaultValue: false,
+    getValue: () => true,
+  })
 
   // This listener is used only for the side effect of closing the overlay when a purchase is rejected.
   useListenForPostMessage({
@@ -139,6 +145,7 @@ export default function CheckoutContent() {
   // One we have something in purchasingLocks, we can assume that the
   // user approved the transaction in their wallet and dismiss the wallet
   //check overlay.
+  // TODO: handle rejected purchase?
   if (purchasingLocks.length && showWalletCheckOverlay) {
     setShowWalletCheckOverlay(false)
   }
@@ -234,7 +241,9 @@ export default function CheckoutContent() {
   // purchasingLocks is an array of locks for which a transaction has
   // been initiated. Once purchasingLocks is non-empty, we know that the
   // user's wallet is enabled and no longer need to show the overlay.
-  if (showWalletCheckOverlay) {
+  // We should only show the wallet check overlay if there is a browser wallet.
+  // It will not appear when using a managed user account.
+  if (showWalletCheckOverlay && !usingManagedAccount) {
     return (
       <Greyout>
         <MessageBox>

--- a/paywall/src/messageTypes.ts
+++ b/paywall/src/messageTypes.ts
@@ -25,6 +25,7 @@ export enum PostMessages {
   WEB3_RESULT = 'web3', // this is the same as WEB3 because the exchange is 1-way
   READY_WEB3 = 'ready/web3',
   WALLET_INFO = 'walletInfo',
+  USING_MANAGED_ACCOUNT = 'info/managedUserAccount',
 
   UPDATE_LOCKS = 'update/locks',
   UPDATE_ACCOUNT = 'update/account',
@@ -153,6 +154,10 @@ export type Message =
   | {
       type: PostMessages.UPDATE_TRANSACTIONS
       payload: Transactions
+    }
+  | {
+      type: PostMessages.USING_MANAGED_ACCOUNT
+      payload: undefined
     }
 
 export type MessageTypes = Message['type']

--- a/paywall/src/unlock.js/Wallet.ts
+++ b/paywall/src/unlock.js/Wallet.ts
@@ -80,6 +80,12 @@ export default class Wallet {
       // if user accounts are explicitly enabled, we use them
       // but only if there is no crypto wallet
       this.setupUserAccountsProxyWallet()
+
+      // We should also tell the checkout iframe that we are in a user account context
+      const { checkout } = this.iframes
+      checkout.once(PostMessages.READY, () => {
+        checkout.postMessage(PostMessages.USING_MANAGED_ACCOUNT, undefined)
+      })
     } else {
       // if we have a wallet, we always use it
       // if we have no wallet, and no use accounts, we use the web3 proxy wallet


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR sends a postMessage to the checkout iframe so that it knows when it's using a user account and when it's using a browser wallet. Using that information, the checkout iframe then decides whether it should show the wallet check overlay on certain interactions. (it should do so only when a browser wallet is in use)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4680 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
