### PR TITLE
Make loading an optional property in CreatorLog

### DIFF
--- a/unlock-app/src/components/creator/CreatorLog.tsx
+++ b/unlock-app/src/components/creator/CreatorLog.tsx
@@ -8,7 +8,7 @@ import Loading from '../interface/Loading'
 interface Props {
   transactionFeed: UnlockTypes.Transaction[]
   explorerLinks: { [key: string]: string }
-  loading: boolean
+  loading?: boolean
 }
 
 export const CreatorLog = ({


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

The issue in the renovate TS update was presumably caused by stricter enforcement of types. In tests, we use the unconnected forms of components and weren't passing all required props for the CreatorLog component (which is difficult to do, since it's nested inside other components). Making this property optional is essentially the same as making it false unless overridden, which is a reasonable default and should have no impact on production code.

I verified this change against a locally-installed version of TypeScript 3.6.2, so this should solve the `unlock-app` portion of the renovate PR failure.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4640 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
