### PR TITLE
Send 'locked' when there is no crypto wallet

### DIFF
--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
@@ -197,6 +197,40 @@ describe('MainWindowHandler - init', () => {
 
       expect(handler.dispatchEvent).toHaveBeenCalledWith('unlocked')
     })
+
+    it('should dispatch locked when receiving a no crypto wallet error', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.init()
+      handler.dispatchEvent = jest.fn()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.ERROR,
+        'no ethereum wallet is available',
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      expect(handler.dispatchEvent).toHaveBeenCalledWith('locked')
+    })
+
+    it('should not dispatch anything when receiving other errors', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.init()
+      handler.dispatchEvent = jest.fn()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.ERROR,
+        'angry bees have invaded the datacenter',
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      expect(handler.dispatchEvent).not.toHaveBeenCalled()
+    })
   })
 
   describe('iframe visibility', () => {

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -59,6 +59,11 @@ export default class MainWindowHandler {
     this.iframes.data.on(PostMessages.UNLOCKED, () => {
       this.toggleLockState(PostMessages.UNLOCKED)
     })
+    this.iframes.data.on(PostMessages.ERROR, e => {
+      if (e === 'no ethereum wallet is available') {
+        this.toggleLockState(PostMessages.LOCKED)
+      }
+    })
 
     // handle display of checkout and account UI
     this.iframes.checkout.on(PostMessages.DISMISS_CHECKOUT, () => {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR listens for the error sent by the data iframe when there is no ethereum wallet available. This error is only sent in situations where there is no browser wallet, and we cannot use a managed user account.

When the main window handler receives that error event, it locks the page.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4683 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
