### PR TITLE
User account page now dispatches the close action

### DIFF
--- a/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
@@ -6,6 +6,7 @@ import {
   AccountContent,
   mapStateToProps,
   mapDispatchToProps,
+  getStripeHelper,
 } from '../../../components/content/AccountContent'
 import { DISMISS_PURCHASE_MODAL } from '../../../actions/keyPurchase'
 
@@ -142,6 +143,42 @@ describe('AccountContent', () => {
       expect(dispatch).toHaveBeenCalledWith({
         type: DISMISS_PURCHASE_MODAL,
       })
+    })
+  })
+
+  describe('getStripeHelper', () => {
+    it('should do nothing when window does not contain stripe', () => {
+      expect.assertions(2)
+
+      jest.useFakeTimers()
+      const interval = setInterval(() => {}, 15000)
+      const setStripe = jest.fn()
+
+      getStripeHelper({}, interval, setStripe)
+
+      expect(clearInterval).not.toHaveBeenCalled()
+      expect(setStripe).not.toHaveBeenCalled()
+    })
+
+    it('should setStripe and clearInterval when the window does contain stripe', () => {
+      expect.assertions(2)
+
+      jest.useFakeTimers()
+      const interval = setInterval(() => {}, 15000)
+      const setStripe = jest.fn()
+      const Stripe = jest.fn()
+      ;(Stripe as any).version = 16000
+
+      getStripeHelper(
+        {
+          Stripe: Stripe as any,
+        },
+        interval,
+        setStripe
+      )
+
+      expect(clearInterval).toHaveBeenCalledWith(interval)
+      expect(setStripe).toHaveBeenCalledWith(Stripe)
     })
   })
 })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -689,37 +689,7 @@ Object {
 exports[`Storyshots AccountContent (iframe embed for paywall) The embed 1`] = `
 Object {
   "asFragment": [Function],
-  "baseElement": .c3 {
-  background-color: var(--lightgrey);
-  cursor: pointer;
-  border-radius: 50%;
-  height: 24px;
-  width: 24px;
-  display: inline-block;
-  padding: 0;
-  border: 0;
-  line-height: '15px';
-}
-
-.c3 > svg {
-  fill: var(--grey);
-  height: 24px;
-  width: 24px;
-}
-
-.c3:hover {
-  background-color: var(--link);
-}
-
-.c3:hover > svg {
-  fill: white;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-.c1 {
+  "baseElement": .c1 {
   background-color: var(--offwhite);
   max-height: 100%;
   overflow-y: scroll;
@@ -759,11 +729,11 @@ Object {
   align-items: center;
 }
 
-.c4 {
+.c2 {
   width: 100%;
 }
 
-.c5 {
+.c3 {
   font-family: 'IBM Plex Sans',sans-serif;
   font-size: 15px;
   line-height: 19px;
@@ -772,7 +742,7 @@ Object {
   padding: 24px 32px 24px 32px;
 }
 
-.c9 {
+.c7 {
   font-family: 'IBM Plex Serif',serif;
   font-weight: 300;
   font-size: 20px;
@@ -781,7 +751,7 @@ Object {
   padding-top: 24px;
 }
 
-.c8 {
+.c6 {
   height: 60px;
   width: 100%;
   border: none;
@@ -791,7 +761,7 @@ Object {
   font-size: 16px;
 }
 
-.c11 {
+.c9 {
   height: 60px;
   width: 100%;
   border: none;
@@ -802,7 +772,7 @@ Object {
   cursor: pointer;
 }
 
-.c7 {
+.c5 {
   display: block;
   text-transform: uppercase;
   font-size: 10px;
@@ -811,18 +781,12 @@ Object {
   margin-bottom: 5px;
 }
 
-.c10 {
+.c8 {
   cursor: pointer;
 }
 
-.c6 {
+.c4 {
   padding: 0 32px;
-}
-
-.c2 {
-  position: absolute;
-  right: 24px;
-  top: 24px;
 }
 
 <body>
@@ -837,44 +801,26 @@ Object {
         <div
           class="c1"
         >
-          <a
-            class="c2 c3"
-            target="_self"
-          >
-            <svg
-              viewBox="0 0 24 24"
-            >
-              <title>
-                Close
-              </title>
-              <path
-                clip-rule="evenodd"
-                d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            
-          </a>
           <div
-            class="c4"
+            class="c2"
           >
             <h1
-              class="c5"
+              class="c3"
             >
               Log In
             </h1>
             <form>
               <div
-                class="c6"
+                class="c4"
               >
                 <label
-                  class="c7"
+                  class="c5"
                   for="emailInput"
                 >
                   Email
                 </label>
                 <input
-                  class="c8"
+                  class="c6"
                   id="emailInput"
                   name="emailAddress"
                   placeholder="Enter your email"
@@ -882,25 +828,25 @@ Object {
                 />
                 <br />
                 <label
-                  class="c7"
+                  class="c5"
                   for="passwordInput"
                 >
                   Password
                 </label>
                 <input
-                  class="c8"
+                  class="c6"
                   id="passwordInput"
                   name="password"
                   placeholder="Enter your password"
                   type="password"
                 />
                 <p
-                  class="c9"
+                  class="c7"
                 >
                   Don't have an account?
                    
                   <a
-                    class="c10"
+                    class="c8"
                   >
                     Sign up here.
                   </a>
@@ -908,7 +854,7 @@ Object {
               </div>
               <br />
               <input
-                class="c11"
+                class="c9"
                 type="submit"
                 value="Submit"
               />
@@ -929,6 +875,7 @@ Object {
       <div
         class="sc-kAzzGY cBdfch"
       >
+<<<<<<< HEAD
         <a
           class="sc-fAjcbJ glPBrL sc-850ddk-0 bqpIVT"
           target="_self"
@@ -947,6 +894,8 @@ Object {
           </svg>
           
         </a>
+=======
+>>>>>>> Update storyshots
         <div
           class="sc-kpOJdX LsipW"
         >

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -875,27 +875,6 @@ Object {
       <div
         class="sc-kAzzGY cBdfch"
       >
-<<<<<<< HEAD
-        <a
-          class="sc-fAjcbJ glPBrL sc-850ddk-0 bqpIVT"
-          target="_self"
-        >
-          <svg
-            viewBox="0 0 24 24"
-          >
-            <title>
-              Close
-            </title>
-            <path
-              clip-rule="evenodd"
-              d="M8.237 7.177a.75.75 0 1 0-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 1 0 1.06 1.06L12 13.061l3.763 3.762a.75.75 0 1 0 1.06-1.06L13.061 12l3.762-3.763a.75.75 0 0 0-1.06-1.06L12 10.939 8.237 7.177z"
-              fill-rule="evenodd"
-            />
-          </svg>
-          
-        </a>
-=======
->>>>>>> Update storyshots
         <div
           class="sc-kpOJdX LsipW"
         >

--- a/unlock-app/src/components/content/AccountContent.tsx
+++ b/unlock-app/src/components/content/AccountContent.tsx
@@ -94,20 +94,28 @@ export class AccountContent extends React.Component<
     }
   }
 
-  render() {
+  handleClose = () => {
     const { dismissPurchaseModal } = this.props
+    dismissPurchaseModal()
+  }
+
+  render() {
     const mode = this.currentPageMode()
+    const showCloseButton =
+      mode === 'CollectPaymentDetails' || mode === 'ConfirmPurchase'
     return (
       <IframeWrapper>
         <Head>
           <title>{pageTitle('Account')}</title>
           <script src="https://js.stripe.com/v3/" async />
         </Head>
-        <Quit
-          backgroundColor="var(--lightgrey)"
-          fillColor="var(--grey)"
-          action={dismissPurchaseModal}
-        />
+        {showCloseButton && (
+          <Quit
+            backgroundColor="var(--lightgrey)"
+            fillColor="var(--grey)"
+            action={this.handleClose}
+          />
+        )}
         <Errors />
         {this.getComponent(mode)}
       </IframeWrapper>
@@ -141,7 +149,12 @@ export const mapDispatchToProps = (dispatch: any) => ({
   dismissPurchaseModal: () => dispatch(dismissPurchaseModal()),
 })
 
-export default withConfig(connect(mapStateToProps)(AccountContent))
+export default withConfig(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(AccountContent)
+)
 
 const Quit = styled(Close)`
   position: absolute;

--- a/unlock-app/src/components/content/AccountContent.tsx
+++ b/unlock-app/src/components/content/AccountContent.tsx
@@ -12,10 +12,12 @@ import { GridPadding, IframeWrapper } from '../interface/user-account/styles'
 import Close from '../interface/buttons/layout/Close'
 import { dismissPurchaseModal } from '../../actions/keyPurchase'
 
+interface StripeWindow {
+  Stripe?: stripe.StripeStatic
+}
+
 declare global {
-  interface Window {
-    Stripe?: stripe.StripeStatic
-  }
+  interface Window extends StripeWindow {}
 }
 
 interface AccountContentProps {
@@ -80,18 +82,17 @@ export class AccountContent extends React.Component<
     }
   }
 
-  getStripe = () => {
+  setStripe = (s: stripe.StripeStatic) => {
     const {
       config: { stripeApiKey },
     } = this.props
-    if (window.Stripe) {
-      this.setState({
-        stripe: window.Stripe(stripeApiKey),
-      })
-      if (this.interval) {
-        clearInterval(this.interval)
-      }
-    }
+    this.setState({
+      stripe: s(stripeApiKey),
+    })
+  }
+
+  getStripe = () => {
+    getStripeHelper(window, this.interval, this.setStripe)
   }
 
   handleClose = () => {
@@ -148,6 +149,20 @@ export const mapStateToProps = (state: ReduxState) => {
 export const mapDispatchToProps = (dispatch: any) => ({
   dismissPurchaseModal: () => dispatch(dismissPurchaseModal()),
 })
+
+export const getStripeHelper = (
+  window: StripeWindow,
+  interval: number | null,
+  setStripe: (s: stripe.StripeStatic) => void
+) => {
+  const { Stripe } = window
+  if (Stripe) {
+    setStripe(Stripe)
+    if (interval) {
+      clearInterval(interval)
+    }
+  }
+}
 
 export default withConfig(
   connect(

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -7,7 +7,7 @@ import {
 import { setError } from '../actions/error'
 import { KEY_PURCHASE_INITIATED } from '../actions/user'
 import { PostOffice } from '../utils/Error'
-import { addToCart } from '../actions/keyPurchase'
+import { addToCart, DISMISS_PURCHASE_MODAL } from '../actions/keyPurchase'
 import { SET_ACCOUNT } from '../actions/accounts'
 
 const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
@@ -48,6 +48,8 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
           postOfficeService.hideAccountModal()
         } else if (action.type === KEY_PURCHASE_INITIATED) {
           postOfficeService.transactionInitiated()
+          postOfficeService.hideAccountModal()
+        } else if (action.type === DISMISS_PURCHASE_MODAL) {
           postOfficeService.hideAccountModal()
         }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR actually hooks up `mapDispatchToProps` in the account iframe, so now clicking the `X` will close the modal.

For the moment, I'm only allowing the close button _after_ the user has logged in, because there won't be a way to bring it back up without it. A future PR will account for that (probably in tandem with #4452 and #4202 ).

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4545 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
