### PR TITLE
passing Membership as props instead of context on stateless component:

### DIFF
--- a/unlock-protocol.com/src/components/interface/Membership.js
+++ b/unlock-protocol.com/src/components/interface/Membership.js
@@ -27,7 +27,7 @@ MembershipLocked.propTypes = {
   becomeMember: PropTypes.func.isRequired,
 }
 
-export const Membership = (_, { isMember, becomeMember }) => {
+export const Membership = ({ isMember, becomeMember }) => {
   if (isMember === 'yes') {
     return <MembershipUnlocked />
   }
@@ -37,6 +37,14 @@ export const Membership = (_, { isMember, becomeMember }) => {
   return null
 }
 
+Membership.propTypes = {
+  isMember: PropTypes.string,
+  becomeMember: PropTypes.func.isRequired,
+}
+
+Membership.defaultProps = {
+  isMember: 'pending',
+}
 export default Membership
 
 const MembersBar = styled.div`

--- a/unlock-protocol.com/src/pages/_app.js
+++ b/unlock-protocol.com/src/pages/_app.js
@@ -113,11 +113,11 @@ The Unlock team
 
   render() {
     const { Component, pageProps } = this.props
-
+    const { isMember, becomeMember } = this.state
     return (
       <Container>
         <MembershipContext.Provider value={this.state}>
-          <Membership />
+          <Membership isMember={isMember} becomeMember={becomeMember} />
           <GlobalStyle />
           <Component {...pageProps} />
           <Intercom appID={config.intercomAppId} />

--- a/unlock-protocol.com/src/stories/interface/Membership.stories.js
+++ b/unlock-protocol.com/src/stories/interface/Membership.stories.js
@@ -1,18 +1,16 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import {
-  Membership,
-  MembershipUnlocked,
-  MembershipLocked,
-} from '../../components/interface/Membership'
+import Membership from '../../components/interface/Membership'
+
+const becomeMember = () => {}
 
 storiesOf('Membership', module)
   .add('unknown state', () => {
-    return <Membership />
+    return <Membership becomeMember={becomeMember} />
   })
   .add('unlocked state', () => {
-    return <MembershipUnlocked />
+    return <Membership isMember="yes" becomeMember={becomeMember} />
   })
   .add('locked state', () => {
-    return <MembershipLocked becomeMember={() => {}} />
+    return <Membership isMember="no" becomeMember={becomeMember} />
   })


### PR DESCRIPTION
# Description

This restores the bar ;)


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread