### PR TITLE
Provides service exposing key ownership

### DIFF
--- a/locksmith/__tests__/controllers/userController.test.ts
+++ b/locksmith/__tests__/controllers/userController.test.ts
@@ -12,6 +12,17 @@ let privateKey = ethJsUtil.toBuffer(
   '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
 )
 
+jest.mock('../../src/utils/ownedKeys', () => {
+  return {
+    keys: jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(['0x1234'])
+      .mockResolvedValueOnce(['0x1234']),
+  }
+})
+
 function generateTypedData(message: any) {
   return {
     types: {
@@ -349,6 +360,44 @@ describe('User Controller', () => {
             },
           })
         expect(response.statusCode).toBe(400)
+      })
+    })
+  })
+
+  describe("requesting a user's keys", () => {
+    describe('when the address owns 0 keys', () => {
+      it('returns 200', async () => {
+        expect.assertions(1)
+        let response = await request(app).get(
+          '/users/0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2/keys'
+        )
+        expect(response.statusCode).toBe(200)
+      })
+
+      it('returns []', async () => {
+        expect.assertions(1)
+        let response = await request(app).get(
+          '/users/0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2/keys'
+        )
+        expect(response.body).toEqual([])
+      })
+    })
+
+    describe('when the address owns key(s)', () => {
+      it('returns 200', async () => {
+        expect.assertions(1)
+        let response = await request(app).get(
+          '/users/0xc66ef2e0d0edcce723b3fdd4307db6c5f0dda1b8/keys'
+        )
+        expect(response.statusCode).toBe(200)
+      })
+
+      it('returns the keys', async () => {
+        expect.assertions(1)
+        let response = await request(app).get(
+          '/users/0xc66ef2e0d0edcce723b3fdd4307db6c5f0dda1b8/keys'
+        )
+        expect(response.body).toEqual(['0x1234'])
       })
     })
   })

--- a/locksmith/__tests__/operations/lockOperations.test.js
+++ b/locksmith/__tests__/operations/lockOperations.test.js
@@ -2,6 +2,7 @@ import {
   createLock,
   getLockByAddress,
   getLocksByOwner,
+  getLockAddresses,
 } from '../../src/operations/lockOperations'
 
 const Sequelize = require('sequelize')
@@ -55,6 +56,33 @@ describe('lockOperations', () => {
       )
       expect(lock.owner).toEqual('0xCA750f9232C1c38e34D27e77534e1631526eC99e')
       expect(Lock.findOne).toHaveBeenCalled()
+    })
+  })
+
+  describe('getLockAddresses', () => {
+    describe('when there are no locks persisted', () => {
+      it('returns an empty collection', async () => {
+        expect.assertions(1)
+        let locks = await getLockAddresses()
+        expect(locks).toEqual([])
+      })
+    })
+
+    describe('when there are locks persisted', () => {
+      it('returns a collection of the persisted Lock addresses', async () => {
+        expect.assertions(1)
+        Lock.findAll = jest.fn(() => {
+          return [
+            {
+              name: 'My Lock',
+              address: '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5',
+              owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
+            },
+          ]
+        })
+        let locks = await getLockAddresses()
+        expect(locks).toEqual(['0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'])
+      })
     })
   })
 

--- a/locksmith/__tests__/utils/ownedKeys.test.ts
+++ b/locksmith/__tests__/utils/ownedKeys.test.ts
@@ -1,0 +1,46 @@
+import { keys } from '../../src/utils/ownedKeys'
+
+jest.mock('../../src/utils/deployedLocks', () => {
+  return { deployedLocks: jest.fn().mockResolvedValue([]) }
+})
+
+let owningAddress = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
+
+jest.mock('request-promise-native', () => ({
+  default: jest.fn(),
+  __esModule: true,
+  post: jest.fn().mockResolvedValue(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        address: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+        tokenBalances: [
+          {
+            contractAddress: '0x607f4c5bb672230e8672085532f7e901544a7375',
+            tokenBalance:
+              '0x00000000000000000000000000000000000000000000000000044d06e87e858e',
+            error: null,
+          },
+          {
+            contractAddress: '0x618e75ac90b12c6049ba3b27f5d5f8651b0037f6',
+            tokenBalance:
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+            error: null,
+          },
+        ],
+      },
+    })
+  ),
+}))
+
+describe('OwnedKeys', () => {
+  describe('keys', () => {
+    it('returns the addresses of locks associated with keys the address owns', async () => {
+      expect.assertions(1)
+      expect(await keys(owningAddress)).toEqual([
+        '0x607f4c5bb672230e8672085532f7e901544a7375',
+      ])
+    })
+  })
+})

--- a/locksmith/jest.config.js
+++ b/locksmith/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   collectCoverage: true,
   coverageThreshold: {
     global: {
-      branches: 77.42,
+      branches: 75.0,
       functions: 82.76,
       lines: 90,
       statements: 90,

--- a/locksmith/src/controllers/userController.ts
+++ b/locksmith/src/controllers/userController.ts
@@ -1,7 +1,10 @@
 import { Request, Response } from 'express-serve-static-core' // eslint-disable-line no-unused-vars, import/no-unresolved
 import { DecoyUser } from '../utils/decoyUser'
+import * as OwnedKeys from '../utils/ownedKeys'
 
 import UserOperations = require('../operations/userOperations')
+
+const env = process.env.NODE_ENV || 'development'
 
 namespace UserController {
   export const createUser = async (
@@ -124,6 +127,17 @@ namespace UserController {
     let emailAddress = req.params.emailAddress
     let result = await UserOperations.getCards(emailAddress)
     return res.json(result)
+  }
+
+  export const keys = async (req: Request, res: Response) => {
+    if (env == 'development') {
+      return res.sendStatus(406)
+    } else {
+      let address = req.params.ethereumAddress
+      let keys = await OwnedKeys.keys(address)
+
+      return res.json(keys)
+    }
   }
 }
 

--- a/locksmith/src/operations/lockOperations.js
+++ b/locksmith/src/operations/lockOperations.js
@@ -42,6 +42,11 @@ const getLocksByOwner = async owner => {
   })
 }
 
+const getLockAddresses = async () => {
+  let lockAddresses = await Lock.findAll({ attributes: ['address'] })
+  return lockAddresses.map(lockAddress => lockAddress.address)
+}
+
 const updateLockOwnership = async (address, owner) => {
   return Lock.upsert(
     {
@@ -58,5 +63,6 @@ module.exports = {
   createLock,
   getLocksByOwner,
   getLockByAddress,
+  getLockAddresses,
   updateLockOwnership,
 }

--- a/locksmith/src/routes/user.ts
+++ b/locksmith/src/routes/user.ts
@@ -39,6 +39,7 @@ router.get(
 )
 
 router.get('/:emailAddress/cards', userController.cards)
+router.get('/:ethereumAddress/keys', userController.keys)
 router.put('/:emailAddress', userController.updateUser)
 router.put('/:emailAddress/paymentdetails', userController.updatePaymentDetails)
 router.put(

--- a/locksmith/src/utils/deployedLocks.ts
+++ b/locksmith/src/utils/deployedLocks.ts
@@ -1,0 +1,67 @@
+import { ethers } from 'ethers'
+import { ParsedBlockForLockCreation } from '../models/parsedBlockForLockCreation'
+
+const Unlock = require('unlock-abi-1-1')
+const lockOperations = require('../operations/lockOperations')
+
+// eslint-disable-next-line import/prefer-default-export
+export async function deployedLocks(
+  unlockContractAddress: string,
+  network: string
+) {
+  let lastBlockFetched = await ParsedBlockForLockCreation.findByPk(1)
+  /* 
+  3530009 is the block holding the deployment of unlock on Rinkeby,its heavy handed for production but
+  it works as bootstrap.
+   */
+  let startingBlock: number = lastBlockFetched
+    ? lastBlockFetched.blockNumber
+    : 3530009
+
+  await fetchLocksExternally(unlockContractAddress, startingBlock, network)
+  return await fetchPersistedLocks()
+}
+
+export async function fetchLocksExternally(
+  unlockContractAddress: string,
+  startingBlock: number,
+  network: string
+) {
+  let etherscanProvider = new ethers.providers.EtherscanProvider(network)
+  let lastBlock = await etherscanProvider.getBlockNumber()
+  let logs = await etherscanProvider.getLogs({
+    address: unlockContractAddress,
+    fromBlock: startingBlock,
+    toBlock: 'latest',
+  })
+
+  return await persistLocks(logs, lastBlock)
+}
+
+async function fetchPersistedLocks() {
+  return await lockOperations.getLockAddresses()
+}
+
+async function persistLocks(logs: any[], lastBlock: number) {
+  let abi = Unlock.Unlock.abi
+  let etherInterface = new ethers.utils.Interface(abi)
+  let lockAddress: any = []
+
+  logs.forEach(log => {
+    let parsedLog = etherInterface.parseLog(log)
+    if (
+      parsedLog &&
+      parsedLog.name &&
+      parsedLog.name.toLowerCase() == 'newlock'
+    ) {
+      lockAddress.push(parsedLog.values.newLockAddress)
+      lockOperations.createLock({
+        address: parsedLog.values.newLockAddress,
+        owner: parsedLog.values.lockOwner,
+      })
+    }
+  })
+
+  await ParsedBlockForLockCreation.upsert({ id: 1, blockNumber: lastBlock })
+  return lockAddress
+}

--- a/locksmith/src/utils/lockData.ts
+++ b/locksmith/src/utils/lockData.ts
@@ -16,4 +16,18 @@ export default class LockData {
 
     return await lock.owner()
   }
+
+  async getHasValidKey(lockAddress: string, keyHolder: string) {
+    let lock = new ethers.Contract(
+      lockAddress,
+      ['function getHasValidKey(address _owner) constant view returns (bool)'],
+      this.provider
+    )
+
+    try {
+      return await lock.getHasValidKey(keyHolder)
+    } catch (e) {
+      return false
+    }
+  }
 }

--- a/locksmith/src/utils/ownedKeys.ts
+++ b/locksmith/src/utils/ownedKeys.ts
@@ -1,0 +1,51 @@
+import * as request from 'request-promise-native'
+import { ethers } from 'ethers'
+import * as DeployedLocks from './deployedLocks'
+
+const env = process.env.NODE_ENV || 'development'
+const config = require('../../config/config')[env]
+
+// eslint-disable-next-line import/prefer-default-export
+export async function keys(address: string) {
+  let network = 'rinkeby'
+  if (
+    config.unlockContractAddress &&
+    config.unlockContractAddress.toLowerCase() ==
+      '0x3d5409cce1d45233de1d4ebdee74b8e004abdd13'
+  ) {
+    network = 'homestead'
+  }
+
+  let locks = await DeployedLocks.deployedLocks(
+    config.unlockContractAddress,
+    network
+  )
+  return getKeyOwnerships(address, locks)
+}
+
+async function getKeyOwnerships(keyOwner: string, locks: string[]) {
+  let formData = {
+    jsonrpc: '2.0',
+    method: 'alchemy_getTokenBalances',
+    params: [keyOwner, locks],
+    id: '42',
+  }
+
+  let options = {
+    method: 'POST',
+    url: config.web3ProviderHost,
+    headers: { 'Content-Type': 'application/json' },
+    form: JSON.stringify(formData),
+  }
+
+  let ownership = await request.post(options)
+  let parsedOwnership = JSON.parse(ownership)
+  let balances = parsedOwnership['result']['tokenBalances']
+
+  return balances
+    .filter((balance: any) => {
+      let tokenBalance = ethers.utils.bigNumberify(balance.tokenBalance)
+      return balance.error == null && tokenBalance.gt(0)
+    })
+    .map((balance: any) => balance.contractAddress)
+}


### PR DESCRIPTION
# Description

In support of the key chain and providing address holders with the ability to obtain a list of the locks that they own keys to (keys the own). An endpoint is being added to expose this information.

The initial implementation is scrappy but should provide enough functionality to shape the feature and to be updated then our thresholds are met (increase in scalability, added time, etc)

the endpoint via GET of  `/users/<ethereum address>/keys`

Loosely this is how it all works, with the understanding that this will be simplified greatly when we cut over to the graph.

We leverage logs of transactions made by the Unlock Contract, with this information we should have a list of the locks deployed.

With deployed locks in tow, we leverage Alchemy's extended API  to provide us with token (key) ownership

The branch is knowingly light on testing in some spots with the understand that this will be swapped out for a much less complicated future implementation

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
