### PR TITLE
Send 'locked' by default when using user accounts

### DIFF
--- a/paywall/src/__tests__/unlock.js/startup.test.ts
+++ b/paywall/src/__tests__/unlock.js/startup.test.ts
@@ -1,4 +1,7 @@
-import startup, { normalizeConfig } from '../../unlock.js/startup'
+import startup, {
+  normalizeConfig,
+  sendDefaultLockedState,
+} from '../../unlock.js/startup'
 import FakeWindow from '../test-helpers/fakeWindowHelpers'
 import StartupConstants from '../../unlock.js/startupTypes'
 import { PaywallConfig } from '../../unlockTypes'
@@ -45,6 +48,44 @@ describe('unlock.js startup', () => {
       }
 
       expect(normalizeConfig(config)).toEqual(normalizedConfig)
+    })
+  })
+
+  describe('sendDefaultLockedState', () => {
+    it('should call toggleLockState when there is no wallet and we are using managed user accounts', () => {
+      expect.assertions(1)
+
+      const toggleLockState = jest.fn()
+      const useUserAccounts = true
+      const hasWallet = false
+
+      sendDefaultLockedState(useUserAccounts, hasWallet, toggleLockState)
+
+      expect(toggleLockState).toHaveBeenCalledWith('locked')
+    })
+
+    it('should not call toggleLockState when there is a wallet', () => {
+      expect.assertions(1)
+
+      const toggleLockState = jest.fn()
+      const useUserAccounts = true
+      const hasWallet = true
+
+      sendDefaultLockedState(useUserAccounts, hasWallet, toggleLockState)
+
+      expect(toggleLockState).not.toHaveBeenCalled()
+    })
+
+    it('should not call toggleLockState when we cannot use user accounts', () => {
+      expect.assertions(1)
+
+      const toggleLockState = jest.fn()
+      const useUserAccounts = false
+      const hasWallet = false
+
+      sendDefaultLockedState(useUserAccounts, hasWallet, toggleLockState)
+
+      expect(toggleLockState).not.toHaveBeenCalled()
     })
   })
 

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -30,6 +30,7 @@ export default class MainWindowHandler {
   constructor(window: UnlockWindowNoProtocolYet, iframes: IframeHandler) {
     this.window = window
     this.iframes = iframes
+    this.toggleLockState = this.toggleLockState.bind(this)
   }
 
   init() {

--- a/paywall/src/unlock.js/Wallet.ts
+++ b/paywall/src/unlock.js/Wallet.ts
@@ -24,11 +24,11 @@ import StartupConstants from './startupTypes'
 export default class Wallet {
   private readonly iframes: IframeHandler
   private readonly window: Web3Window
-  private readonly hasWallet: boolean = true
+  readonly hasWallet: boolean = true
   private readonly isMetamask: boolean
   private readonly config: PaywallConfig
   private hasWeb3: boolean = false
-  private useUserAccounts: boolean = false
+  useUserAccounts: boolean = false
 
   private userAccountAddress: string | null = null
   private userAccountNetwork: number

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -4,6 +4,7 @@ import Wallet from './Wallet'
 import MainWindowHandler from './MainWindowHandler'
 import CheckoutUIHandler from './CheckoutUIHandler'
 import StartupConstants from './startupTypes'
+import { PostMessages } from '../messageTypes'
 
 /**
  * convert all of the lock addresses to lower-case so they are normalized across the app
@@ -29,6 +30,16 @@ export function normalizeConfig(unlockConfig: any) {
     }, {}),
   }
   return normalizedConfig
+}
+
+export function sendDefaultLockedState(
+  useUserAccounts: boolean,
+  hasWallet: boolean,
+  toggleLockState: (message: PostMessages.LOCKED) => void
+) {
+  if (useUserAccounts && !hasWallet) {
+    toggleLockState(PostMessages.LOCKED)
+  }
 }
 
 /**
@@ -77,5 +88,12 @@ export default function startup(
   mainWindow.init()
   wallet.init()
   checkoutIframeHandler.init()
+
+  const { hasWallet, useUserAccounts } = wallet
+  // After Wallet has initialized, we have enough information to determine if we
+  // are in the managed user account scenario. If we are, the paywall defaults
+  // to 'locked'
+  sendDefaultLockedState(useUserAccounts, hasWallet, mainWindow.toggleLockState)
+
   return iframes // this is only useful in testing, it is ignored in the app
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Part one of handling user account login better on the paywall, this PR sends the `locked` event by default when we are using user accounts.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4202, #4452 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
