### PR TITLE
Revert "Send 'locked' by default when using user accounts (#4705)"

### DIFF
--- a/paywall/src/__tests__/unlock.js/startup.test.ts
+++ b/paywall/src/__tests__/unlock.js/startup.test.ts
@@ -1,7 +1,4 @@
-import startup, {
-  normalizeConfig,
-  sendDefaultLockedState,
-} from '../../unlock.js/startup'
+import startup, { normalizeConfig } from '../../unlock.js/startup'
 import FakeWindow from '../test-helpers/fakeWindowHelpers'
 import StartupConstants from '../../unlock.js/startupTypes'
 import { PaywallConfig } from '../../unlockTypes'
@@ -48,44 +45,6 @@ describe('unlock.js startup', () => {
       }
 
       expect(normalizeConfig(config)).toEqual(normalizedConfig)
-    })
-  })
-
-  describe('sendDefaultLockedState', () => {
-    it('should call toggleLockState when there is no wallet and we are using managed user accounts', () => {
-      expect.assertions(1)
-
-      const toggleLockState = jest.fn()
-      const useUserAccounts = true
-      const hasWallet = false
-
-      sendDefaultLockedState(useUserAccounts, hasWallet, toggleLockState)
-
-      expect(toggleLockState).toHaveBeenCalledWith('locked')
-    })
-
-    it('should not call toggleLockState when there is a wallet', () => {
-      expect.assertions(1)
-
-      const toggleLockState = jest.fn()
-      const useUserAccounts = true
-      const hasWallet = true
-
-      sendDefaultLockedState(useUserAccounts, hasWallet, toggleLockState)
-
-      expect(toggleLockState).not.toHaveBeenCalled()
-    })
-
-    it('should not call toggleLockState when we cannot use user accounts', () => {
-      expect.assertions(1)
-
-      const toggleLockState = jest.fn()
-      const useUserAccounts = false
-      const hasWallet = false
-
-      sendDefaultLockedState(useUserAccounts, hasWallet, toggleLockState)
-
-      expect(toggleLockState).not.toHaveBeenCalled()
     })
   })
 

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -30,7 +30,6 @@ export default class MainWindowHandler {
   constructor(window: UnlockWindowNoProtocolYet, iframes: IframeHandler) {
     this.window = window
     this.iframes = iframes
-    this.toggleLockState = this.toggleLockState.bind(this)
   }
 
   init() {

--- a/paywall/src/unlock.js/Wallet.ts
+++ b/paywall/src/unlock.js/Wallet.ts
@@ -24,11 +24,11 @@ import StartupConstants from './startupTypes'
 export default class Wallet {
   private readonly iframes: IframeHandler
   private readonly window: Web3Window
-  readonly hasWallet: boolean = true
+  private readonly hasWallet: boolean = true
   private readonly isMetamask: boolean
   private readonly config: PaywallConfig
   private hasWeb3: boolean = false
-  useUserAccounts: boolean = false
+  private useUserAccounts: boolean = false
 
   private userAccountAddress: string | null = null
   private userAccountNetwork: number

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -4,7 +4,6 @@ import Wallet from './Wallet'
 import MainWindowHandler from './MainWindowHandler'
 import CheckoutUIHandler from './CheckoutUIHandler'
 import StartupConstants from './startupTypes'
-import { PostMessages } from '../messageTypes'
 
 /**
  * convert all of the lock addresses to lower-case so they are normalized across the app
@@ -30,16 +29,6 @@ export function normalizeConfig(unlockConfig: any) {
     }, {}),
   }
   return normalizedConfig
-}
-
-export function sendDefaultLockedState(
-  useUserAccounts: boolean,
-  hasWallet: boolean,
-  toggleLockState: (message: PostMessages.LOCKED) => void
-) {
-  if (useUserAccounts && !hasWallet) {
-    toggleLockState(PostMessages.LOCKED)
-  }
 }
 
 /**
@@ -88,12 +77,5 @@ export default function startup(
   mainWindow.init()
   wallet.init()
   checkoutIframeHandler.init()
-
-  const { hasWallet, useUserAccounts } = wallet
-  // After Wallet has initialized, we have enough information to determine if we
-  // are in the managed user account scenario. If we are, the paywall defaults
-  // to 'locked'
-  sendDefaultLockedState(useUserAccounts, hasWallet, mainWindow.toggleLockState)
-
   return iframes // this is only useful in testing, it is ignored in the app
 }


### PR DESCRIPTION
This reverts commit 50bc5512fe946dd449b71ed45782eeee2d557235.

Since we're moving down a different path for user account login for the time being, it's easiest to revert this commit and revisit later if necessary.