### PR TITLE
Store last logged-in account address in localStorage

### DIFF
--- a/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
@@ -97,10 +97,21 @@ describe('postOfficeMiddleware', () => {
       expect(mockPostOfficeService.setAccount).toHaveBeenLastCalledWith(null)
     })
 
-    it('should set account to the value provided by localStorage', () => {
+    it('should set account to null when localStorage contains a malformed value', () => {
       expect.assertions(1)
 
-      const anAddress = '0x123abc'
+      const anAddress = 'some random garbage'
+      fakeWindow.localStorage.getItem = jest.fn(() => anAddress)
+
+      makeMiddleware()
+
+      expect(mockPostOfficeService.setAccount).toHaveBeenLastCalledWith(null)
+    })
+
+    it('should set account to the value provided by localStorage, if it is a real address', () => {
+      expect.assertions(1)
+
+      const anAddress = '0x0AAF2059Cb2cE8Eeb1a0C60f4e0f2789214350a5'
       fakeWindow.localStorage.getItem = jest.fn(() => anAddress)
 
       makeMiddleware()

--- a/unlock-app/src/__tests__/services/postOfficeService.test.ts
+++ b/unlock-app/src/__tests__/services/postOfficeService.test.ts
@@ -2,7 +2,7 @@ import {
   PostOfficeService,
   PostOfficeEvents,
 } from '../../services/postOfficeService'
-import { IframePostOfficeWindow } from '../../windowTypes'
+import { IframePostOfficeWindow } from '../../utils/postOffice'
 import { PostMessages, ExtractPayload } from '../../messageTypes'
 import { Locks } from '../../unlockTypes'
 
@@ -67,6 +67,8 @@ describe('postOfficeService', () => {
         href: 'http://example.com?origin=http%3a%2f%2ffun.times',
       },
       addEventListener: jest.fn(),
+      // These tests don't rely on localStorage
+      localStorage: {} as any,
     }
   }
 

--- a/unlock-app/src/__tests__/utils/postOffice.test.ts
+++ b/unlock-app/src/__tests__/utils/postOffice.test.ts
@@ -378,6 +378,8 @@ describe('postOffice', () => {
         addEventListener(type, handler) {
           handlers[type] = handler
         },
+        // These tests don't rely on localStorage
+        localStorage: {} as any,
       }
     })
 

--- a/unlock-app/src/constants.ts
+++ b/unlock-app/src/constants.ts
@@ -103,3 +103,5 @@ export const MAX_UINT =
 export const POLLING_INTERVAL = 2000
 
 export const CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL = 10000
+
+export const USER_ACCOUNT_ADDRESS_STORAGE_ID = 'managedUserAccountAddress'

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -11,6 +11,7 @@ import { PostOffice } from '../utils/Error'
 import { addToCart, DISMISS_PURCHASE_MODAL } from '../actions/keyPurchase'
 import { SET_ACCOUNT } from '../actions/accounts'
 import { USER_ACCOUNT_ADDRESS_STORAGE_ID } from '../constants'
+import { isAccount } from '../utils/validators'
 
 const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
   const postOfficeService = new PostOfficeService(
@@ -23,8 +24,14 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
   // purchases, but they will still be able to access any locks they
   // have keys to without logging in. This value should not go into
   // redux within `unlock-app`. Let the sign-in process handle that.
-  const userAccountAddress = getItem(window, USER_ACCOUNT_ADDRESS_STORAGE_ID)
-  const gotAddressFromStorage = !!userAccountAddress
+  let userAccountAddress = getItem(window, USER_ACCOUNT_ADDRESS_STORAGE_ID)
+  let gotAddressFromStorage = !!userAccountAddress
+  if (!isAccount(userAccountAddress)) {
+    // Value retrieved from storage isn't a real account -- garbage crept in somewhere.
+    userAccountAddress = null
+    gotAddressFromStorage = false
+  }
+
   postOfficeService.setAccount(userAccountAddress)
 
   // Locks on the paywall, keys are lower-cased lock addresses

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -21,7 +21,8 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
   // To reduce need to log in, remember the last user account address
   // logged into. User will need to authenticate again to make any
   // purchases, but they will still be able to access any locks they
-  // have keys to without logging in.
+  // have keys to without logging in. This value should not go into
+  // redux within `unlock-app`. Let the sign-in process handle that.
   const userAccountAddress = getItem(window, USER_ACCOUNT_ADDRESS_STORAGE_ID)
   postOfficeService.setAccount(userAccountAddress)
 
@@ -52,6 +53,8 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
       return (action: Action) => {
         if (action.type === SET_ACCOUNT) {
           postOfficeService.setAccount(action.account.address)
+          // Update the localStorage value for the most recent user
+          // account address signed into.
           setItem(
             window,
             USER_ACCOUNT_ADDRESS_STORAGE_ID,

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -24,6 +24,7 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
   // have keys to without logging in. This value should not go into
   // redux within `unlock-app`. Let the sign-in process handle that.
   const userAccountAddress = getItem(window, USER_ACCOUNT_ADDRESS_STORAGE_ID)
+  const gotAddressFromStorage = !!userAccountAddress
   postOfficeService.setAccount(userAccountAddress)
 
   // Locks on the paywall, keys are lower-cased lock addresses
@@ -60,7 +61,22 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
             USER_ACCOUNT_ADDRESS_STORAGE_ID,
             action.account.address
           )
-          postOfficeService.hideAccountModal()
+          // There are two paths for logging in:
+          //
+          // 1. The user had previously logged in, and we pulled their address
+          // from localStorage and "optimistically" browsed the page without
+          // logging in. Then, by attempting to purchase a key, they submitted a
+          // login. In that case, we should not hide the account modal, since
+          // they will need it open for the next step (key purchase
+          // confirmation).
+          //
+          // 2. The user had not previously logged in (address was null in
+          // localStorage). In this case, they were confronted with the login
+          // modal immediately upon visiting the page and will need it to get
+          // out of the way so that they can interact with the checkout.
+          if (!gotAddressFromStorage) {
+            postOfficeService.hideAccountModal()
+          }
         } else if (action.type === KEY_PURCHASE_INITIATED) {
           postOfficeService.transactionInitiated()
           postOfficeService.hideAccountModal()

--- a/unlock-app/src/utils/postOffice.ts
+++ b/unlock-app/src/utils/postOffice.ts
@@ -19,6 +19,7 @@ export interface PostOfficeWindow {
 export interface IframePostOfficeWindow extends PostOfficeWindow {
   parent: PostMessageTarget
   location: location
+  localStorage: Storage
 }
 
 export interface PostMessageTarget {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR mitigates some of the pain of #4202 and #4452 by caching the last account address logged into a user account. This way, on a return visit, a user will not have to log in again unless they wish to purchase a key.

~~We'll consider this blocked until #4706 lands and we can test reliably on the demo page~~

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
