### PR TITLE
Provide an ERC20 balance representation for managed accounts

### DIFF
--- a/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
+++ b/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
@@ -1,5 +1,8 @@
 import FakeWindow from '../test-helpers/fakeWindowHelpers'
-import CheckoutUIHandler from '../../unlock.js/CheckoutUIHandler'
+import CheckoutUIHandler, {
+  injectDefaultBalance,
+  defaultBalance,
+} from '../../unlock.js/CheckoutUIHandler'
 import { PaywallConfig, Locks, Transactions } from '../../unlockTypes'
 import { KeyResults } from '../../data-iframe/blockchainHandler/blockChainTypes'
 import IframeHandler from '../../unlock.js/IframeHandler'
@@ -74,7 +77,7 @@ describe('CheckoutUIHandler', () => {
     function makeReadyCheckout() {
       fakeWindow = new FakeWindow()
       const handler = makeCheckoutUIHandler(fakeWindow)
-      handler.init()
+      handler.init(false)
 
       fakeWindow.receivePostMessageFromIframe(
         PostMessages.READY,
@@ -184,7 +187,7 @@ describe('CheckoutUIHandler', () => {
         expect.assertions(1)
 
         const handler = makeCheckoutUIHandler(fakeWindow)
-        handler.init()
+        handler.init(false)
 
         fakeWindow.receivePostMessageFromIframe(
           type,
@@ -201,5 +204,34 @@ describe('CheckoutUIHandler', () => {
         )
       }
     )
+  })
+})
+
+describe('CheckoutUIHandler - injectDefaultBalance helper', () => {
+  it('should return empty object given an empty object', () => {
+    expect.assertions(1)
+    expect(injectDefaultBalance({})).toEqual({})
+  })
+
+  it('should leave eth alone', () => {
+    expect.assertions(1)
+    const balance = {
+      eth: '123.4',
+    }
+    expect(injectDefaultBalance(balance)).toEqual(balance)
+  })
+
+  it('should update any non-eth balances with the default', () => {
+    expect.assertions(1)
+    const balance = {
+      eth: '123.4',
+      '0x123abc': '0',
+      '0xdeadbeef': '0',
+    }
+    expect(injectDefaultBalance(balance)).toEqual({
+      eth: '123.4',
+      '0x123abc': defaultBalance,
+      '0xdeadbeef': defaultBalance,
+    })
   })
 })

--- a/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
+++ b/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
@@ -1,12 +1,12 @@
 import FakeWindow from '../test-helpers/fakeWindowHelpers'
 import CheckoutUIHandler, {
   injectDefaultBalance,
-  defaultBalance,
 } from '../../unlock.js/CheckoutUIHandler'
 import { PaywallConfig, Locks, Transactions } from '../../unlockTypes'
 import { KeyResults } from '../../data-iframe/blockchainHandler/blockChainTypes'
 import IframeHandler from '../../unlock.js/IframeHandler'
 import { PostMessages, ExtractPayload } from '../../messageTypes'
+import { DEFAULT_STABLECOIN_BALANCE } from '../../constants'
 
 declare const process: {
   env: {
@@ -230,7 +230,7 @@ describe('CheckoutUIHandler', () => {
 
       const expectedPayload = {
         eth: '123.4',
-        '0xdeadbeef': defaultBalance,
+        '0xdeadbeef': DEFAULT_STABLECOIN_BALANCE,
       }
 
       fakeWindow.receivePostMessageFromIframe(
@@ -273,8 +273,8 @@ describe('CheckoutUIHandler - injectDefaultBalance helper', () => {
     }
     expect(injectDefaultBalance(balance)).toEqual({
       eth: '123.4',
-      '0x123abc': defaultBalance,
-      '0xdeadbeef': defaultBalance,
+      '0x123abc': DEFAULT_STABLECOIN_BALANCE,
+      '0xdeadbeef': DEFAULT_STABLECOIN_BALANCE,
     })
   })
 })

--- a/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
+++ b/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
@@ -211,6 +211,43 @@ describe('CheckoutUIHandler', () => {
       }
     )
   })
+
+  describe('relayed messages - managed user account', () => {
+    beforeEach(() => {
+      fakeWindow = new FakeWindow()
+    })
+
+    it('should intercept balance update with injected balances for managed user account', () => {
+      expect.assertions(1)
+
+      const handler = makeCheckoutUIHandler(fakeWindow)
+      handler.init(true)
+
+      const initialPayload = {
+        eth: '123.4',
+        '0xdeadbeef': '0',
+      }
+
+      const expectedPayload = {
+        eth: '123.4',
+        '0xdeadbeef': defaultBalance,
+      }
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.UPDATE_ACCOUNT_BALANCE,
+        initialPayload,
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      fakeWindow.expectPostMessageSentToIframe(
+        PostMessages.UPDATE_ACCOUNT_BALANCE,
+        expectedPayload,
+        iframes.checkout.iframe,
+        checkoutOrigin
+      )
+    })
+  })
 })
 
 describe('CheckoutUIHandler - injectDefaultBalance helper', () => {

--- a/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
+++ b/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
@@ -77,7 +77,9 @@ describe('CheckoutUIHandler', () => {
     function makeReadyCheckout() {
       fakeWindow = new FakeWindow()
       const handler = makeCheckoutUIHandler(fakeWindow)
-      handler.init(false)
+      handler.init({
+        usingManagedAccount: false,
+      })
 
       fakeWindow.receivePostMessageFromIframe(
         PostMessages.READY,
@@ -193,7 +195,9 @@ describe('CheckoutUIHandler', () => {
         expect.assertions(1)
 
         const handler = makeCheckoutUIHandler(fakeWindow)
-        handler.init(false)
+        handler.init({
+          usingManagedAccount: false,
+        })
 
         fakeWindow.receivePostMessageFromIframe(
           type,
@@ -221,7 +225,9 @@ describe('CheckoutUIHandler', () => {
       expect.assertions(1)
 
       const handler = makeCheckoutUIHandler(fakeWindow)
-      handler.init(true)
+      handler.init({
+        usingManagedAccount: true,
+      })
 
       const initialPayload = {
         eth: '123.4',

--- a/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
+++ b/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
@@ -162,7 +162,13 @@ describe('CheckoutUIHandler', () => {
 
     const data: RelayedMessageTestType = [
       ['UPDATE_ACCOUNT', PostMessages.UPDATE_ACCOUNT, fakeAccount],
-      ['UPDATE_ACCOUNT_BALANCE', PostMessages.UPDATE_ACCOUNT_BALANCE, '123'],
+      [
+        'UPDATE_ACCOUNT_BALANCE',
+        PostMessages.UPDATE_ACCOUNT_BALANCE,
+        {
+          eth: '123',
+        },
+      ],
       ['UPDATE_LOCKS', PostMessages.UPDATE_LOCKS, fakeLocks],
       ['UPDATE_KEYS', PostMessages.UPDATE_KEYS, fakeKeys],
       [

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -118,3 +118,7 @@ export const MAX_UINT =
 export const POLLING_INTERVAL = 2000
 // the length of time to consider an optimistic key purchase to have become pessimistic
 export const OPTIMISM_POLLING_INTERVAL = 15000
+
+// used to provide a default balance for stablecoins so that the paywall does
+// not show "insufficient funds" for managed user accounts
+export const DEFAULT_STABLECOIN_BALANCE = '35'

--- a/paywall/src/unlock.js/CheckoutUIHandler.ts
+++ b/paywall/src/unlock.js/CheckoutUIHandler.ts
@@ -18,17 +18,18 @@ export default class CheckoutUIHandler {
     this.config = config
   }
 
-  init() {
+  init(usingUserAccounts: boolean) {
     // listen for updates to state from the data iframe, and forward them to the checkout UI
     this.iframes.data.on(PostMessages.UPDATE_ACCOUNT, account =>
       this.iframes.checkout.postMessage(PostMessages.UPDATE_ACCOUNT, account)
     )
-    this.iframes.data.on(PostMessages.UPDATE_ACCOUNT_BALANCE, balance =>
+    this.iframes.data.on(PostMessages.UPDATE_ACCOUNT_BALANCE, balance => {
+      console.log(usingUserAccounts)
       this.iframes.checkout.postMessage(
         PostMessages.UPDATE_ACCOUNT_BALANCE,
         balance
       )
-    )
+    })
     this.iframes.data.on(PostMessages.UPDATE_LOCKS, locks =>
       this.iframes.checkout.postMessage(PostMessages.UPDATE_LOCKS, locks)
     )

--- a/paywall/src/unlock.js/CheckoutUIHandler.ts
+++ b/paywall/src/unlock.js/CheckoutUIHandler.ts
@@ -1,6 +1,24 @@
 import IframeHandler from './IframeHandler'
 import { PostMessages } from '../messageTypes'
-import { PaywallConfig } from '../unlockTypes'
+import { PaywallConfig, Balance } from '../unlockTypes'
+
+// Arbitrarily defined number of tokens to assume a managed user
+// account holds for any given stablecoin
+export const defaultBalance = '35'
+
+export const injectDefaultBalance = (oldBalance: Balance): Balance => {
+  const newBalance: Balance = {}
+  const tokens = Object.keys(oldBalance)
+  tokens.forEach(token => {
+    if (token.startsWith('0x')) {
+      newBalance[token] = defaultBalance
+    } else {
+      newBalance[token] = oldBalance[token]
+    }
+  })
+
+  return newBalance
+}
 
 /**
  * This class handles inter-iframe communication between the checkout iframe and data iframe
@@ -18,13 +36,12 @@ export default class CheckoutUIHandler {
     this.config = config
   }
 
-  init(usingUserAccounts: boolean) {
+  init(_: boolean) {
     // listen for updates to state from the data iframe, and forward them to the checkout UI
     this.iframes.data.on(PostMessages.UPDATE_ACCOUNT, account =>
       this.iframes.checkout.postMessage(PostMessages.UPDATE_ACCOUNT, account)
     )
     this.iframes.data.on(PostMessages.UPDATE_ACCOUNT_BALANCE, balance => {
-      console.log(usingUserAccounts)
       this.iframes.checkout.postMessage(
         PostMessages.UPDATE_ACCOUNT_BALANCE,
         balance

--- a/paywall/src/unlock.js/CheckoutUIHandler.ts
+++ b/paywall/src/unlock.js/CheckoutUIHandler.ts
@@ -36,15 +36,19 @@ export default class CheckoutUIHandler {
     this.config = config
   }
 
-  init(_: boolean) {
+  init(usingManagedAccount: boolean) {
     // listen for updates to state from the data iframe, and forward them to the checkout UI
     this.iframes.data.on(PostMessages.UPDATE_ACCOUNT, account =>
       this.iframes.checkout.postMessage(PostMessages.UPDATE_ACCOUNT, account)
     )
     this.iframes.data.on(PostMessages.UPDATE_ACCOUNT_BALANCE, balance => {
+      let balanceUpdate = balance
+      if (usingManagedAccount) {
+        balanceUpdate = injectDefaultBalance(balance)
+      }
       this.iframes.checkout.postMessage(
         PostMessages.UPDATE_ACCOUNT_BALANCE,
-        balance
+        balanceUpdate
       )
     })
     this.iframes.data.on(PostMessages.UPDATE_LOCKS, locks =>

--- a/paywall/src/unlock.js/CheckoutUIHandler.ts
+++ b/paywall/src/unlock.js/CheckoutUIHandler.ts
@@ -33,7 +33,7 @@ export default class CheckoutUIHandler {
     this.config = config
   }
 
-  init(usingManagedAccount: boolean) {
+  init({ usingManagedAccount }: { usingManagedAccount: boolean }) {
     // listen for updates to state from the data iframe, and forward them to the checkout UI
     this.iframes.data.on(PostMessages.UPDATE_ACCOUNT, account =>
       this.iframes.checkout.postMessage(PostMessages.UPDATE_ACCOUNT, account)

--- a/paywall/src/unlock.js/CheckoutUIHandler.ts
+++ b/paywall/src/unlock.js/CheckoutUIHandler.ts
@@ -1,17 +1,14 @@
 import IframeHandler from './IframeHandler'
 import { PostMessages } from '../messageTypes'
 import { PaywallConfig, Balance } from '../unlockTypes'
-
-// Arbitrarily defined number of tokens to assume a managed user
-// account holds for any given stablecoin
-export const defaultBalance = '35'
+import { DEFAULT_STABLECOIN_BALANCE } from '../constants'
 
 export const injectDefaultBalance = (oldBalance: Balance): Balance => {
   const newBalance: Balance = {}
   const tokens = Object.keys(oldBalance)
   tokens.forEach(token => {
     if (token.startsWith('0x')) {
-      newBalance[token] = defaultBalance
+      newBalance[token] = DEFAULT_STABLECOIN_BALANCE
     } else {
       newBalance[token] = oldBalance[token]
     }

--- a/paywall/src/unlock.js/Wallet.ts
+++ b/paywall/src/unlock.js/Wallet.ts
@@ -28,7 +28,7 @@ export default class Wallet {
   private readonly isMetamask: boolean
   private readonly config: PaywallConfig
   private hasWeb3: boolean = false
-  private useUserAccounts: boolean = false
+  useUserAccounts: boolean = false
 
   private userAccountAddress: string | null = null
   private userAccountNetwork: number

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -76,6 +76,6 @@ export default function startup(
   // go!
   mainWindow.init()
   wallet.init()
-  checkoutIframeHandler.init()
+  checkoutIframeHandler.init(wallet.useUserAccounts)
   return iframes // this is only useful in testing, it is ignored in the app
 }

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -76,6 +76,8 @@ export default function startup(
   // go!
   mainWindow.init()
   wallet.init()
-  checkoutIframeHandler.init(wallet.useUserAccounts)
+  checkoutIframeHandler.init({
+    usingManagedAccount: wallet.useUserAccounts,
+  })
   return iframes // this is only useful in testing, it is ignored in the app
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR injects a default balance for ERC20 tokens when we use a managed user account. The balance is arbitrary, but assumed to be high enough to cover likely approved locks for the time being. This change allows the checkout to work with user accounts without needing to be aware that it is.

<img width="825" alt="image" src="https://user-images.githubusercontent.com/9300702/64709690-b17c5d80-d484-11e9-8630-a921354e319b.png">


Fixes #4720 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
