### PR TITLE
Stop using hardcoded id in Web3ProxyProvider

### DIFF
--- a/paywall/src/__tests__/providers/Web3ProxyProvider.test.js
+++ b/paywall/src/__tests__/providers/Web3ProxyProvider.test.js
@@ -241,7 +241,7 @@ describe('Web3ProxyProvider', () => {
       })
 
       expect(callback).toHaveBeenCalledWith(null, {
-        id: 42,
+        id: 1,
         jsonrpc: '2.0',
         result: 'foo',
       })
@@ -263,6 +263,17 @@ describe('Web3ProxyProvider', () => {
         },
         undefined
       )
+    })
+
+    it('should do nothing if data is missing', async () => {
+      expect.assertions(1)
+
+      fakeWindow.receivePostMessageFromMainWindow(POST_MESSAGE_WEB3, {
+        id: 1,
+        jsonrpc: '2.0',
+      })
+
+      expect(callback).not.toHaveBeenCalled()
     })
   })
 })

--- a/paywall/src/providers/Web3ProxyProvider.js
+++ b/paywall/src/providers/Web3ProxyProvider.js
@@ -55,10 +55,6 @@ export default class Web3ProxyProvider {
       const callback = this.requests[id]
       delete this.requests[id]
 
-      if (result) {
-        // only set the id if there isn't an error condition
-        result.id = 42 // ethers needs to not do this...
-      }
       callback(error, result)
     })
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR removes the hardcoded id of `42` that was applied to all requests in `Web3ProxyProvider`. Previously this was done for compatibility with `ethers`, but `ethers` doesn't hardcode the id anymore so we shouldn't either.

The change is simple, we just no longer modify the payload to overwrite its id. It's not a critical change, but I figured we should snip it out sooner rather than later.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4112 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
