### PR TITLE
Revert "Defer lock authorization (#4030)"

### DIFF
--- a/locksmith/__tests__/controllers/purchaseController.test.ts
+++ b/locksmith/__tests__/controllers/purchaseController.test.ts
@@ -8,6 +8,7 @@ const models = require('../../src/models')
 
 let AuthorizedLock = models.AuthorizedLock
 let participatingLock = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
+let nonParticipatingLock = '0xF4906CE8a8E861339F75611c129b9679EDAe7bBD'
 let recipient = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
 
 let privateKey = ethJsUtil.toBuffer(
@@ -120,6 +121,30 @@ describe('Purchase Controller', () => {
           .set('Authorization', `Bearer ${Base64.encode(sig)}`)
           .send(typedData)
         expect(response.status).toBe(412)
+      })
+    })
+
+    describe('when the Lock has not been authorized for participation in the purchasing program', () => {
+      let message = {
+        purchaseRequest: {
+          recipient: recipient,
+          lock: nonParticipatingLock,
+          expiry: 16733658026,
+        },
+      }
+
+      let typedData = generateTypedData(message)
+      const sig = sigUtil.signTypedData(privateKey, {
+        data: typedData,
+      })
+      it('rejects the purchase', async () => {
+        expect.assertions(1)
+        let response = await request(app)
+          .post('/purchase')
+          .set('Accept', 'json')
+          .set('Authorization', `Bearer ${Base64.encode(sig)}`)
+          .send(typedData)
+        expect(response.status).toBe(451)
       })
     })
   })

--- a/locksmith/src/controllers/purchaseController.ts
+++ b/locksmith/src/controllers/purchaseController.ts
@@ -1,12 +1,11 @@
 import { Response } from 'express-serve-static-core' // eslint-disable-line no-unused-vars, import/no-unresolved
-import { SignedRequest } from '../types' // eslint-disable-line no-unused-vars, import/no-unresolved, import/named
+import { SignedRequest, ethereumAddress } from '../types' // eslint-disable-line no-unused-vars, import/no-unresolved, import/named
+import AuthorizedLockOperations from '../operations/authorizedLockOperations'
 import PaymentProcessor from '../payment/paymentProcessor'
 
 const env = process.env.NODE_ENV || 'development'
 const config = require('../../config/config')[env]
 
-// TODO: re-enable lock authorization pending business decision. See usage prior
-// to #4030.
 namespace PurchaseController {
   //eslint-disable-next-line import/prefer-default-export
   export const purchase = async (
@@ -19,6 +18,8 @@ namespace PurchaseController {
 
     if (expired(expiry)) {
       return res.sendStatus(412)
+    } else if (!(await authorizedLock(lock))) {
+      return res.sendStatus(451)
     } else {
       let paymentProcessor = new PaymentProcessor(
         config.stripeSecret,
@@ -41,6 +42,10 @@ namespace PurchaseController {
   const expired = (expiry: number): Boolean => {
     let currentTime = Math.floor(Date.now() / 1000)
     return expiry < currentTime
+  }
+
+  const authorizedLock = (lock: ethereumAddress): Promise<Boolean> => {
+    return AuthorizedLockOperations.hasAuthorization(lock)
   }
 }
 


### PR DESCRIPTION
# Description

This reverts commit e8a2f822d7f4e1b19dbaab65b3be951dae55c2b9.

It's time to get back to checking whether locks are authorized for a purchase. This PR makes it so that user account purchases against locks that Unlock has not approved get rejected.

We'll follow this up with scripts around lock approval and something to conveniently approve a lock while running in development for testing purposes.

Note: once this is merged, user account key purchases will fail until there are authorized locks, including in development.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4542 

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
