### PR TITLE
Update NoWallet warning with iOS Opera info

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -9592,12 +9592,12 @@ Object {
             </a>
             <a
               class="c8"
-              href="https://play.google.com/store/apps/details?id=com.opera.browser"
+              href="https://www.opera.com/crypto"
               rel="noopener"
               target="_blank"
             >
               <span>
-                Mobile Android
+                Mobile iOS & Android
               </span>
               <div>
                 <svg
@@ -11152,12 +11152,12 @@ Object {
           </a>
           <a
             class="sc-kpOJdX gNsbNX"
-            href="https://play.google.com/store/apps/details?id=com.opera.browser"
+            href="https://www.opera.com/crypto"
             rel="noopener"
             target="_blank"
           >
             <span>
-              Mobile Android
+              Mobile iOS & Android
             </span>
             <div>
               <svg
@@ -13009,12 +13009,12 @@ Object {
             </a>
             <a
               class="c8"
-              href="https://play.google.com/store/apps/details?id=com.opera.browser"
+              href="https://www.opera.com/crypto"
               rel="noopener"
               target="_blank"
             >
               <span>
-                Mobile Android
+                Mobile iOS & Android
               </span>
               <div>
                 <svg
@@ -14569,12 +14569,12 @@ Object {
           </a>
           <a
             class="sc-kpOJdX gNsbNX"
-            href="https://play.google.com/store/apps/details?id=com.opera.browser"
+            href="https://www.opera.com/crypto"
             rel="noopener"
             target="_blank"
           >
             <span>
-              Mobile Android
+              Mobile iOS & Android
             </span>
             <div>
               <svg
@@ -16426,12 +16426,12 @@ Object {
             </a>
             <a
               class="c8"
-              href="https://play.google.com/store/apps/details?id=com.opera.browser"
+              href="https://www.opera.com/crypto"
               rel="noopener"
               target="_blank"
             >
               <span>
-                Mobile Android
+                Mobile iOS & Android
               </span>
               <div>
                 <svg
@@ -17986,12 +17986,12 @@ Object {
           </a>
           <a
             class="sc-kpOJdX gNsbNX"
-            href="https://play.google.com/store/apps/details?id=com.opera.browser"
+            href="https://www.opera.com/crypto"
             rel="noopener"
             target="_blank"
           >
             <span>
-              Mobile Android
+              Mobile iOS & Android
             </span>
             <div>
               <svg

--- a/paywall/src/components/checkout/NoWallet.tsx
+++ b/paywall/src/components/checkout/NoWallet.tsx
@@ -44,11 +44,11 @@ export const NoWallet = ({ config }: Props) => {
           </div>
         </WalletDescription>
         <WalletDescription
-          href="https://play.google.com/store/apps/details?id=com.opera.browser"
+          href="https://www.opera.com/crypto"
           target="_blank"
           rel="noopener"
         >
-          <span>Mobile Android</span>
+          <span>Mobile iOS &amp; Android</span>
           <div>
             <Opera />
             <Caption>Opera</Caption>


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR updates the `NoWallet` warning with more correct information about Opera Touch, which supports both iOS and Android. Additionally, the link the Opera component points to is updated to the [main landing page for Opera's crypto efforts](https://www.opera.com/crypto) (which links to both apps) instead of going directly to the Google Play store.

<img width="832" alt="image" src="https://user-images.githubusercontent.com/9300702/64962310-2bd22680-d865-11e9-8a68-f00c46b84cdc.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4735 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
