### PR TITLE
ignoring old submitted transactions

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/retrieveTransactions.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/retrieveTransactions.test.ts
@@ -4,7 +4,6 @@ import {
   FetchWindow,
   ConstantsType,
   LocksmithTransactionsResult,
-  TransactionDefaults,
   WalletServiceType,
   SetTimeoutWindow,
 } from '../../../../data-iframe/blockchainHandler/blockChainTypes'
@@ -105,6 +104,7 @@ describe('BlockchainHandler - retrieveTransactions', () => {
       } = {
         transactions: [
           {
+            createdAt: '2019-08-23T17:42:24.476Z',
             transactionHash: 'hash1',
             chain: 1984,
             recipient: addresses[0],
@@ -113,6 +113,7 @@ describe('BlockchainHandler - retrieveTransactions', () => {
             for: addresses[2],
           },
           {
+            createdAt: '2019-08-23T16:42:24.476Z',
             transactionHash: 'hash2',
             chain: 1984,
             recipient: addresses[1],
@@ -141,19 +142,19 @@ describe('BlockchainHandler - retrieveTransactions', () => {
 
         const transaction1 = (returnedTransactions.transactions &&
           returnedTransactions.transactions[0]) as LocksmithTransactionsResult
-        const defaults: TransactionDefaults = {
-          to: transaction1.recipient,
-          from: transaction1.sender,
-          for: transaction1.for,
-          input: transaction1.data,
-          hash: 'hash1',
-          network: 1984,
-        }
 
         expect(web3Service.getTransaction).toHaveBeenNthCalledWith(
           1,
           'hash1',
-          defaults
+          expect.objectContaining({
+            to: transaction1.recipient,
+            from: transaction1.sender,
+            for: transaction1.for,
+            input: transaction1.data,
+            hash: 'hash1',
+            network: 1984,
+            createdAt: expect.any(Date),
+          })
         )
         expect(web3Service.getTransaction).toHaveBeenNthCalledWith(
           2,

--- a/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
+++ b/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
@@ -324,6 +324,7 @@ export default class BlockchainHandler {
       // ensure all references to locks are normalized
       update.to = normalizeLockAddress(update.to)
     }
+
     this._mergeUpdate(
       hash,
       'transactions',
@@ -334,8 +335,23 @@ export default class BlockchainHandler {
       },
       update
     )
+
     const transaction = this.store.transactions[hash]
+    // Submitted transaction are the ones which are not known by the web3 node to which we
+    // asked. So either they are very recent (and have not propagated to all mempools), or
+    // they are old and have been dropped from all mempools.
+    // In that latter case, we want to consider these transactions as STALE (as they are not going
+    // to happen).
+    if (
+      transaction.status === TransactionStatus.SUBMITTED &&
+      transaction.createdAt &&
+      transaction.createdAt.getTime() < Date.now() - 60 * 60 * 1000
+    ) {
+      transaction.status = TransactionStatus.STALE
+    }
+
     const isMined = transaction.status === TransactionStatus.MINED
+    const isStale = transaction.status === TransactionStatus.STALE
     const recipient = transaction.lock || transaction.to
     const isKeyPurchase = transaction.type === TransactionType.KEY_PURCHASE
     const accountAddress = this.store.account as string
@@ -348,7 +364,7 @@ export default class BlockchainHandler {
 
     // If we receive a submitted or pending key purchase we should
     // create and store a temporary key.
-    if (isKeyPurchase && recipient && !isMined) {
+    if (isKeyPurchase && recipient && !isMined && !isStale) {
       const lock = this.store.locks[recipient]
       const temporaryKey = createTemporaryKey(recipient, accountAddress, lock)
       this.store.keys[recipient] = temporaryKey
@@ -463,7 +479,10 @@ export default class BlockchainHandler {
       // TODO: which purchase failed? unlock-js needs to provide this information
       // for now, we will kill all submitted transactions and re-fetch
       this.store.transactions = Object.keys(this.store.transactions)
-        .filter(hash => this.store.transactions[hash].status !== 'submitted')
+        .filter(
+          hash =>
+            this.store.transactions[hash].status !== TransactionStatus.SUBMITTED
+        )
         .reduce(
           (allTransactions: Transactions, hash) => ({
             ...allTransactions,
@@ -522,6 +541,7 @@ export default class BlockchainHandler {
     if (result.transactions) {
       result.transactions
         .map(t => ({
+          createdAt: new Date(t.createdAt),
           hash: t.transactionHash,
           network: t.chain,
           to: t.recipient,
@@ -534,6 +554,16 @@ export default class BlockchainHandler {
           // we pass the transaction as defaults if it has input set, so that we can
           // parse out the transaction type and other details. If input is not set,
           // we can't safely pass the transaction default
+          this._mergeUpdate(
+            transaction.hash,
+            'transactions',
+            {
+              hash: transaction.hash,
+              blockNumber: Number.MAX_SAFE_INTEGER,
+              status: TransactionStatus.SUBMITTED, // This will be updated from web3Service
+            },
+            transaction
+          )
           this.web3Service
             .getTransaction(
               transaction.hash,

--- a/paywall/src/data-iframe/blockchainHandler/blockChainTypes.ts
+++ b/paywall/src/data-iframe/blockchainHandler/blockChainTypes.ts
@@ -77,6 +77,7 @@ export interface BlockchainData {
 }
 
 export interface LocksmithTransactionsResult {
+  createdAt: string
   transactionHash: string
   chain: unlockNetworks
   recipient: string

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -17,6 +17,7 @@ export enum TransactionStatus {
   SUBMITTED = 'submitted',
   PENDING = 'pending',
   MINED = 'mined',
+  STALE = 'stale',
   NONE = '', // for testing purposes
 }
 /* eslint-enable no-unused-vars */
@@ -28,6 +29,7 @@ export interface Transaction {
   type: TransactionType
   blockNumber: number
 
+  createdAt?: Date
   to?: string
   for?: string
   from?: string

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -152,6 +152,7 @@ function isValidKeyStatus(status) {
       'submitted',
       'pending',
       'failed',
+      'stale',
     ].includes(status)
   ) {
     return false


### PR DESCRIPTION
# Description

This should finally put to bed our bug with "canceled" transactions.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread