### PR TITLE
Don't render anything stripe related until we have a stripe object

### DIFF
--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -46,6 +46,10 @@ export class SettingsContent extends React.Component<
     this.interval = setInterval(this.getStripe, 500)
   }
 
+  componentWillUnmount() {
+    this.removeInterval()
+  }
+
   getStripe = () => {
     const {
       config: { stripeApiKey },
@@ -54,15 +58,20 @@ export class SettingsContent extends React.Component<
       this.setState({
         stripe: window.Stripe(stripeApiKey),
       })
-      if (this.interval) {
-        clearInterval(this.interval)
-      }
+      this.removeInterval()
+    }
+  }
+
+  removeInterval() {
+    if (this.interval) {
+      clearInterval(this.interval)
     }
   }
 
   render() {
     const { stripe } = this.state
     const { cards } = this.props
+
     return (
       <Layout title="Account Settings">
         <Head>
@@ -73,7 +82,7 @@ export class SettingsContent extends React.Component<
         <AccountInfo />
         <ChangePassword />
         {cards.length > 0 && <PaymentMethods cards={cards} />}
-        {!cards.length && <PaymentDetails stripe={stripe} />}
+        {stripe && !cards.length && <PaymentDetails stripe={stripe} />}
       </Layout>
     )
   }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

We noticed earlier today that the settings page was broken. Some investigation made it clear that the issue was related to `react-stripe-elements`. I was able to fix this issue by not rendering the credit card form until we absolutely already had a Stripe object instantiated. This is contrary to the Stripe docs which indicate that it is OK for it to be null before the object is ready. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
