### PR TITLE
Add a basic format-agnostic QR code to paywall ticket purchase

### DIFF
--- a/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/tickets/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -16648,10 +16648,10 @@ Object {
           </p>
         </div>
         <section
-          class="sc-ifAKCX buhloV"
+          class="sc-EHOje cSOQLT"
         >
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           >
             <div
               class="sc-1yqikln-17 kqTvmk"
@@ -16695,7 +16695,7 @@ Object {
             </ul>
           </div>
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           />
         </section>
         <div
@@ -17165,10 +17165,10 @@ Object {
           </p>
         </div>
         <section
-          class="sc-ifAKCX buhloV"
+          class="sc-EHOje cSOQLT"
         >
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           >
             <div
               class="sc-1yqikln-17 kqTvmk"
@@ -17212,7 +17212,7 @@ Object {
             </ul>
           </div>
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           />
         </section>
         <div
@@ -17682,10 +17682,10 @@ Object {
           </p>
         </div>
         <section
-          class="sc-ifAKCX buhloV"
+          class="sc-EHOje cSOQLT"
         >
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           >
             <div
               class="sc-1yqikln-17 kqTvmk"
@@ -17729,7 +17729,7 @@ Object {
             </ul>
           </div>
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           />
         </section>
         <div
@@ -18199,10 +18199,10 @@ Object {
           </p>
         </div>
         <section
-          class="sc-ifAKCX buhloV"
+          class="sc-EHOje cSOQLT"
         >
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           >
             <div
               class="sc-1yqikln-17 kqTvmk"
@@ -18246,7 +18246,7 @@ Object {
             </ul>
           </div>
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           />
         </section>
         <div
@@ -18716,10 +18716,10 @@ Object {
           </p>
         </div>
         <section
-          class="sc-ifAKCX buhloV"
+          class="sc-EHOje cSOQLT"
         >
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           >
             <div
               class="sc-1yqikln-17 kqTvmk"
@@ -18763,7 +18763,7 @@ Object {
             </ul>
           </div>
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           />
         </section>
         <div
@@ -19233,10 +19233,10 @@ Object {
           </p>
         </div>
         <section
-          class="sc-ifAKCX buhloV"
+          class="sc-EHOje cSOQLT"
         >
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           >
             <div
               class="sc-1yqikln-17 kqTvmk"
@@ -19280,7 +19280,7 @@ Object {
             </ul>
           </div>
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           />
         </section>
         <div
@@ -19750,10 +19750,10 @@ Object {
           </p>
         </div>
         <section
-          class="sc-ifAKCX buhloV"
+          class="sc-EHOje cSOQLT"
         >
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           >
             <div
               class="sc-1yqikln-17 kqTvmk"
@@ -19797,7 +19797,7 @@ Object {
             </ul>
           </div>
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           />
         </section>
         <div
@@ -20267,10 +20267,10 @@ Object {
           </p>
         </div>
         <section
-          class="sc-ifAKCX buhloV"
+          class="sc-EHOje cSOQLT"
         >
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           >
             <div
               class="sc-1yqikln-17 kqTvmk"
@@ -20314,7 +20314,7 @@ Object {
             </ul>
           </div>
           <div
-            class="sc-EHOje kXPRgG"
+            class="sc-bZQynM fbijPR"
           />
         </section>
         <div

--- a/tickets/src/components/content/NewEventContent.tsx
+++ b/tickets/src/components/content/NewEventContent.tsx
@@ -102,7 +102,7 @@ export class EventContent extends Component<
 
   render() {
     const { paywallStatus } = this.state
-    const { event } = this.props
+    const { event, lockAddress } = this.props
 
     // TODO: make this better (get event faster? SSR?)
     if (Object.keys(event).length === 0) {
@@ -133,7 +133,7 @@ export class EventContent extends Component<
                 keyPrice="0.01"
               />
             )}
-            {paywallStatus === PaywallStatus.Unlocked && <EventTicket />}
+            {paywallStatus === PaywallStatus.Unlocked && <EventTicket lockAddress={lockAddress} />}
           </Column>
         </Columns>
       </Layout>

--- a/tickets/src/components/content/NewEventContent.tsx
+++ b/tickets/src/components/content/NewEventContent.tsx
@@ -133,7 +133,9 @@ export class EventContent extends Component<
                 keyPrice="0.01"
               />
             )}
-            {paywallStatus === PaywallStatus.Unlocked && <EventTicket lockAddress={lockAddress} />}
+            {paywallStatus === PaywallStatus.Unlocked && (
+              <EventTicket lockAddress={lockAddress} />
+            )}
           </Column>
         </Columns>
       </Layout>

--- a/tickets/src/components/interface/EventQRCode.tsx
+++ b/tickets/src/components/interface/EventQRCode.tsx
@@ -6,7 +6,7 @@ interface Props {
   // For now we'll just JSON.Stringify arbitrary objects as the payload
   payload: { [key: string]: string }
 }
-export const EventQRCode = ({ payload }) => {
+export const EventQRCode = ({ payload }: Props) => {
   return (
     <QR
       value={JSON.stringify(payload)}

--- a/tickets/src/components/interface/EventQRCode.tsx
+++ b/tickets/src/components/interface/EventQRCode.tsx
@@ -7,14 +7,7 @@ interface Props {
   payload: { [key: string]: string }
 }
 export const EventQRCode = ({ payload }: Props) => {
-  return (
-    <QR
-      value={JSON.stringify(payload)}
-      size={200}
-      renderAs="canvas"
-      includeMargin
-    />
-  )
+  return <QR value={JSON.stringify(payload)} size={200} renderAs="canvas" />
 }
 
 export default EventQRCode

--- a/tickets/src/components/interface/EventQRCode.tsx
+++ b/tickets/src/components/interface/EventQRCode.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import QRCode from 'qrcode.react'
+import styled from 'styled-components'
+
+interface Props {
+  // For now we'll just JSON.Stringify arbitrary objects as the payload
+  payload: { [key: string]: string }
+}
+export const EventQRCode = ({ payload }) => {
+  return (
+    <QR
+      value={JSON.stringify(payload)}
+      size={200}
+      renderAs="canvas"
+      includeMargin
+    />
+  )
+}
+
+export default EventQRCode
+
+const QR = styled(QRCode)`
+  width: 200px;
+  height: 200px;
+  border: 1px solid black;
+`

--- a/tickets/src/components/interface/EventTicket.tsx
+++ b/tickets/src/components/interface/EventTicket.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { sendConfirmation } from '../../actions/email'
 import { TicketInfo, Form, Input, SendButton } from './EventStyles'
+import EventQRCode from './EventQRCode'
 
 interface Props {
   sendConfirmation: typeof sendConfirmation
+  lockAddress: string
 }
 interface State {
   email: string
@@ -52,11 +54,17 @@ export class EventTicket extends React.Component<Props, State> {
   }
 
   render = () => {
+    const { lockAddress } = this.props
     const { email, sent } = this.state
     return (
       <TicketInfo>
         <Form onSubmit={this.handleSubmit}>
-          <h2>A QR Code</h2>
+          <h2>Your Ticket</h2>
+          <EventQRCode
+            payload={{
+              lockAddress,
+            }}
+          />
           <Input
             disabled={sent}
             placeholder="Enter your email address"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a basic QR code to `NewEventContent`. Right now it just JSON stringifies a payload containing the lock address. Once we have firmed up what we want to go into the QR code we can extend it.

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/9300702/65275058-c98e5580-daf2-11e9-8b0b-91f4e2c9f8f2.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
