### PR TITLE
allowing users to set a default ERC20 based on query string

### DIFF
--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -117,6 +117,14 @@ export class CreatorLockForm extends React.Component {
     const { validityState: valid, errors } = this.formValidity(this.state)
     this.state.valid = valid
     this.state.errors = errors
+
+    // Set up the ERC20 address, based on query string or defaults to config.
+    const url = new window.URL(document.location)
+    this.ERC20Contract = props.config.ERC20Contract
+    if (url.searchParams.get('erc20')) {
+      this.ERC20Contract.address = url.searchParams.get('erc20')
+      this.ERC20Contract.name = url.searchParams.get('ticker') || 'ERC20'
+    }
   }
 
   /**
@@ -225,12 +233,9 @@ export class CreatorLockForm extends React.Component {
   }
 
   toggleCurrency() {
-    const {
-      config: { ERC20Contract },
-    } = this.props
     this.setState(state => ({
       ...state,
-      currency: !state.currency ? ERC20Contract.address : null,
+      currency: !state.currency ? this.ERC20Contract.address : null,
     }))
   }
 
@@ -257,10 +262,7 @@ export class CreatorLockForm extends React.Component {
   }
 
   render() {
-    const {
-      lock,
-      config: { ERC20Contract },
-    } = this.props
+    const { lock } = this.props
     const isNew = !lock || !lock.address
     const {
       expirationDuration,
@@ -319,7 +321,7 @@ export class CreatorLockForm extends React.Component {
         </FormLockKeys>
         <FormBalanceWithUnit>
           {!currency && <Eth />}
-          {!!currency && <ERC20 name={ERC20Contract.name} />}
+          {!!currency && <ERC20 name={this.ERC20Contract.name} />}
           <input
             type="number"
             step="0.00001"
@@ -332,7 +334,7 @@ export class CreatorLockForm extends React.Component {
           />
           {isNew && !currency && (
             <LockLabelCurrency onClick={this.toggleCurrency}>
-              {`Use ${ERC20Contract.name}`}
+              {`Use ${this.ERC20Contract.name}`}
             </LockLabelCurrency>
           )}
           {isNew && !!currency && (


### PR DESCRIPTION
# Description

Since I have had 2 people asking for an easy way to create a lock with a custom ERC20, I added this quick hack to let users configure the one used by default.

I tried to write tests but it's not possible to mock the `window` object :/

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread