### PR TITLE
adding the ability for lock owners to fully refund keys

### DIFF
--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -89,7 +89,8 @@ contract MixinLockCore is
    * considering the available balance. Set to 0 or MAX_UINT to withdraw everything.
    *
    * TODO: consider allowing anybody to trigger this as long as it goes to owner anyway?
-   *  -- however be wary of draining funds as it breaks the `cancelAndRefund` use case.
+   *  -- however be wary of draining funds as it breaks the `cancelAndRefund` and `fullRefund`
+   * use cases.
    */
   function withdraw(
     address _tokenAddress,

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -39,23 +39,24 @@ contract MixinRefunds is
   );
 
   /**
-   * @dev Invoked by the lock owner to destroy the user's ket and perform a full refund.
+   * @dev Invoked by the lock owner to destroy the user's ket and perform a refund and cancellation
+   * of the key
    */
-  function fullRefund(address _keyOwner)
+  function fullRefund(address _keyOwner, uint amount)
     external
     onlyOwner
     hasValidKey(_keyOwner)
   {
     Key storage key = _getKeyFor(_keyOwner);
 
-    emit CancelKey(key.tokenId, _keyOwner, msg.sender, keyPrice);
+    emit CancelKey(key.tokenId, _keyOwner, msg.sender, amount);
 
     // expirationTimestamp is a proxy for hasKey, setting this to `block.timestamp` instead
     // of 0 so that we can still differentiate hasKey from hasValidKey.
     key.expirationTimestamp = block.timestamp;
 
     // Security: doing this last to avoid re-entrancy concerns
-    _transfer(tokenAddress, _keyOwner, keyPrice);
+    _transfer(tokenAddress, _keyOwner, amount);
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -39,6 +39,26 @@ contract MixinRefunds is
   );
 
   /**
+   * @dev Invoked by the lock owner to destroy the user's ket and perform a full refund.
+   */
+  function fullRefund(address _keyOwner)
+    external
+    onlyOwner
+    hasValidKey(_keyOwner)
+  {
+    Key storage key = _getKeyFor(_keyOwner);
+
+    emit CancelKey(key.tokenId, _keyOwner, msg.sender, keyPrice);
+
+    // expirationTimestamp is a proxy for hasKey, setting this to `block.timestamp` instead
+    // of 0 so that we can still differentiate hasKey from hasValidKey.
+    key.expirationTimestamp = block.timestamp;
+
+    // Security: doing this last to avoid re-entrancy concerns
+    _transfer(tokenAddress, _keyOwner, keyPrice);
+  }
+
+  /**
    * @dev Destroys the user's key and sends a refund based on the amount of time remaining.
    */
   function cancelAndRefund()

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -55,7 +55,8 @@
     "ganache": "ganache-cli --mnemonic \"hello unlock save the web\"",
     "zos": "zos",
     "flatten": "(truffle-flattener contracts/PublicLock.sol > build/PublicLock-Flattened.sol) && (echo Wrote file: build/PublicLock-Flattened.sol)",
-    "verify": "truffle run verify"
+    "verify": "truffle run verify",
+    "debug": "truffle debug"
   },
   "author": "",
   "license": "ISC"

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -13,15 +13,19 @@ contract('Lock / disableLock', accounts => {
   let lock
   let keyOwner = accounts[1]
   let keyOwner2 = accounts[2]
-
+  let keyOwner3 = accounts[3]
+  let lockOwner = accounts[0]
   before(async () => {
     unlock = await getProxy(unlockContract)
-    locks = await deployLocks(unlock, accounts[0])
+    locks = await deployLocks(unlock, lockOwner)
     lock = locks['FIRST']
     await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
       value: Units.convert('0.01', 'eth', 'wei'),
     })
     await lock.purchase(keyOwner2, web3.utils.padLeft(0, 40), [], {
+      value: Units.convert('0.01', 'eth', 'wei'),
+    })
+    await lock.purchase(keyOwner3, web3.utils.padLeft(0, 40), [], {
       value: Units.convert('0.01', 'eth', 'wei'),
     })
     ID = new BigNumber(await lock.getTokenIdFor(keyOwner)).toFixed()
@@ -38,7 +42,7 @@ contract('Lock / disableLock', accounts => {
   describe('when the lock has been disabled', () => {
     let txObj, event
     before(async () => {
-      txObj = await lock.disableLock({ from: accounts[0] })
+      txObj = await lock.disableLock({ from: lockOwner })
       event = txObj.logs[0]
     })
 
@@ -95,6 +99,12 @@ contract('Lock / disableLock', accounts => {
     it('Key owners can still cancel for a partial refund', async () => {
       await lock.cancelAndRefund({
         from: keyOwner,
+      })
+    })
+
+    it('Lock owners can still fully refund keys', async () => {
+      await lock.fullRefund(keyOwner3, {
+        from: lockOwner,
       })
     })
 

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -103,7 +103,8 @@ contract('Lock / disableLock', accounts => {
     })
 
     it('Lock owners can still fully refund keys', async () => {
-      await lock.fullRefund(keyOwner3, {
+      const refundAmount = Units.convert('0.01', 'eth', 'wei')
+      await lock.fullRefund(keyOwner3, refundAmount, {
         from: lockOwner,
       })
     })

--- a/smart-contracts/test/Lock/erc20.js
+++ b/smart-contracts/test/Lock/erc20.js
@@ -22,7 +22,7 @@ contract('Lock / erc20', accounts => {
   })
 
   describe('creating ERC20 priced locks', () => {
-    let keyPrice
+    let keyPrice, refundAmount
     const keyOwner = accounts[1]
     const keyOwner2 = accounts[2]
     const keyOwner3 = accounts[3]
@@ -44,6 +44,7 @@ contract('Lock / erc20', accounts => {
       await token.approve(lock.address, -1, { from: keyOwner3 })
 
       keyPrice = new BigNumber(await lock.keyPrice.call())
+      refundAmount = keyPrice.toFixed()
     })
 
     describe('users can purchase keys', () => {
@@ -74,7 +75,7 @@ contract('Lock / erc20', accounts => {
           await token.balanceOf(lock.address)
         )
 
-        await lockApi.fullRefund(keyOwner3, accounts[0])
+        await lockApi.fullRefund(keyOwner3, refundAmount, accounts[0])
         const balanceOwnerAfter = new BigNumber(
           await token.balanceOf(keyOwner3)
         )

--- a/smart-contracts/test/Lock/erc20.js
+++ b/smart-contracts/test/Lock/erc20.js
@@ -25,6 +25,7 @@ contract('Lock / erc20', accounts => {
     let keyPrice
     const keyOwner = accounts[1]
     const keyOwner2 = accounts[2]
+    const keyOwner3 = accounts[3]
     const defaultBalance = new BigNumber(100000000000000000)
 
     before(async () => {
@@ -35,10 +36,12 @@ contract('Lock / erc20', accounts => {
       // Mint some tokens for testing
       await token.mint(keyOwner, defaultBalance)
       await token.mint(keyOwner2, defaultBalance)
+      await token.mint(keyOwner3, defaultBalance)
 
       // Approve the lock to make transfers
       await token.approve(lock.address, -1, { from: keyOwner })
       await token.approve(lock.address, -1, { from: keyOwner2 })
+      await token.approve(lock.address, -1, { from: keyOwner3 })
 
       keyPrice = new BigNumber(await lock.keyPrice.call())
     })
@@ -59,6 +62,35 @@ contract('Lock / erc20', accounts => {
       it('transfered the tokens to the contract', async () => {
         const balance = new BigNumber(await token.balanceOf(lock.address))
         assert.equal(balance.toFixed(), keyPrice.toFixed())
+      })
+
+      it('when a lock owner refunds a key, tokens are fully refunded', async () => {
+        await lockApi.purchase(keyOwner3, web3.utils.padLeft(0, 40))
+
+        const balanceOwnerBefore = new BigNumber(
+          await token.balanceOf(keyOwner3)
+        )
+        const balanceLockBefore = new BigNumber(
+          await token.balanceOf(lock.address)
+        )
+
+        await lockApi.fullRefund(keyOwner3, accounts[0])
+        const balanceOwnerAfter = new BigNumber(
+          await token.balanceOf(keyOwner3)
+        )
+        const balanceLockAfter = new BigNumber(
+          await token.balanceOf(lock.address)
+        )
+
+        assert.equal(
+          balanceLockBefore.minus(keyPrice).toFixed(),
+          balanceLockAfter.toFixed()
+        )
+
+        assert.equal(
+          balanceOwnerBefore.plus(keyPrice).toFixed(),
+          balanceOwnerAfter.toFixed()
+        )
       })
 
       it('when a key owner cancels a key, they are refunded in tokens', async () => {
@@ -104,7 +136,7 @@ contract('Lock / erc20', accounts => {
     })
 
     it('purchaseKey fails when the user does not have enough funds', async () => {
-      const account = accounts[3]
+      const account = accounts[4]
       await token.approve(lock.address, -1)
       await token.mint(account, keyPrice.minus(1))
       await shouldFail(

--- a/smart-contracts/test/Lock/fullRefund.js
+++ b/smart-contracts/test/Lock/fullRefund.js
@@ -18,6 +18,7 @@ contract('Lock / fullRefund', accounts => {
   let lock
   const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
   const keyPrice = new BigNumber(Units.convert(0.01, 'eth', 'wei'))
+  const refundAmount = new BigNumber(Units.convert(0.01, 'eth', 'wei'))
   let lockOwner
 
   before(async () => {
@@ -42,7 +43,7 @@ contract('Lock / fullRefund', accounts => {
       initialKeyOwnerBalance = new BigNumber(
         await web3.eth.getBalance(keyOwners[0])
       )
-      txObj = await lock.fullRefund(keyOwners[0], {
+      txObj = await lock.fullRefund(keyOwners[0], refundAmount, {
         from: lockOwner,
       })
     })
@@ -90,20 +91,10 @@ contract('Lock / fullRefund', accounts => {
     })
   })
 
-  it('can cancel a free key', async () => {
-    await locks['FREE'].grantKeys([accounts[1]], [999999999999], {
-      from: lockOwner,
-    })
-    const txObj = await locks['FREE'].fullRefund(accounts[1], {
-      from: lockOwner,
-    })
-    assert.equal(txObj.logs[0].event, 'CancelKey')
-  })
-
   describe('should fail when', () => {
     it('should fail if invoked by the key owner', async () => {
       await shouldFail(
-        lock.fullRefund(keyOwners[3], {
+        lock.fullRefund(keyOwners[3], refundAmount, {
           from: keyOwners[3],
         }),
         ''
@@ -112,7 +103,7 @@ contract('Lock / fullRefund', accounts => {
 
     it('should fail if invoked by another user', async () => {
       await shouldFail(
-        lock.fullRefund(accounts[7], {
+        lock.fullRefund(accounts[7], refundAmount, {
           from: keyOwners[3],
         }),
         ''
@@ -124,7 +115,7 @@ contract('Lock / fullRefund', accounts => {
         from: lockOwner,
       })
       await shouldFail(
-        lock.fullRefund(keyOwners[3], {
+        lock.fullRefund(keyOwners[3], refundAmount, {
           from: lockOwner,
         }),
         ''
@@ -136,7 +127,7 @@ contract('Lock / fullRefund', accounts => {
         from: lockOwner,
       })
       await shouldFail(
-        lock.fullRefund(keyOwners[3], {
+        lock.fullRefund(keyOwners[3], refundAmount, {
           from: lockOwner,
         }),
         'KEY_NOT_VALID'
@@ -145,7 +136,7 @@ contract('Lock / fullRefund', accounts => {
 
     it('the owner does not have a key', async () => {
       await shouldFail(
-        lock.fullRefund(accounts[7], {
+        lock.fullRefund(accounts[7], refundAmount, {
           from: lockOwner,
         }),
         'KEY_NOT_VALID'

--- a/smart-contracts/test/Lock/fullRefund.js
+++ b/smart-contracts/test/Lock/fullRefund.js
@@ -1,0 +1,155 @@
+const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
+
+const deployLocks = require('../helpers/deployLocks')
+const shouldFail = require('../helpers/shouldFail')
+
+const unlockContract = artifacts.require('../Unlock.sol')
+const getProxy = require('../helpers/proxy')
+
+let unlock, locks
+
+contract('Lock / fullRefund', accounts => {
+  before(async () => {
+    unlock = await getProxy(unlockContract)
+    locks = await deployLocks(unlock, accounts[0])
+  })
+
+  let lock
+  const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
+  const keyPrice = new BigNumber(Units.convert(0.01, 'eth', 'wei'))
+  let lockOwner
+
+  before(async () => {
+    lock = locks['SECOND']
+    const purchases = keyOwners.map(account => {
+      return lock.purchase(account, web3.utils.padLeft(0, 40), [], {
+        value: keyPrice.toFixed(),
+        from: account,
+      })
+    })
+    await Promise.all(purchases)
+    lockOwner = await lock.owner.call()
+  })
+
+  describe('should cancel and refund when enough time remains', () => {
+    let initialLockBalance, initialKeyOwnerBalance, txObj
+
+    before(async () => {
+      initialLockBalance = new BigNumber(
+        await web3.eth.getBalance(lock.address)
+      )
+      initialKeyOwnerBalance = new BigNumber(
+        await web3.eth.getBalance(keyOwners[0])
+      )
+      txObj = await lock.fullRefund(keyOwners[0], {
+        from: lockOwner,
+      })
+    })
+
+    it('should emit a CancelKey event', async () => {
+      assert.equal(txObj.logs[0].event, 'CancelKey')
+    })
+
+    it('the amount of refund should be the key price', async () => {
+      const refund = new BigNumber(txObj.logs[0].args.refund)
+      assert.equal(refund.toFixed(), keyPrice.toFixed())
+    })
+
+    it('should make the key no longer valid (i.e. expired)', async () => {
+      const isValid = await lock.getHasValidKey.call(keyOwners[0])
+      assert.equal(isValid, false)
+    })
+
+    it("should increase the owner's balance with the amount of funds refunded from the lock", async () => {
+      const txHash = await web3.eth.getTransaction(txObj.tx)
+      const gasUsed = new BigNumber(txObj.receipt.gasUsed)
+      const gasPrice = new BigNumber(txHash.gasPrice)
+      const txFee = gasPrice.times(gasUsed)
+      const finalOwnerBalance = new BigNumber(
+        await web3.eth.getBalance(keyOwners[0])
+      )
+      assert(
+        finalOwnerBalance.toFixed(),
+        initialKeyOwnerBalance
+          .plus(keyPrice)
+          .minus(txFee)
+          .toFixed()
+      )
+    })
+
+    it("should increase the locks's balance by the keyPrice", async () => {
+      const finalLockBalance = new BigNumber(
+        await web3.eth.getBalance(lock.address)
+      ).minus(initialLockBalance)
+
+      assert(
+        finalLockBalance.toFixed(),
+        initialLockBalance.minus(keyPrice).toFixed()
+      )
+    })
+  })
+
+  it('can cancel a free key', async () => {
+    await locks['FREE'].grantKeys([accounts[1]], [999999999999], {
+      from: lockOwner,
+    })
+    const txObj = await locks['FREE'].fullRefund(accounts[1], {
+      from: lockOwner,
+    })
+    assert.equal(txObj.logs[0].event, 'CancelKey')
+  })
+
+  describe('should fail when', () => {
+    it('should fail if invoked by the key owner', async () => {
+      await shouldFail(
+        lock.fullRefund(keyOwners[3], {
+          from: keyOwners[3],
+        }),
+        ''
+      )
+    })
+
+    it('should fail if invoked by another user', async () => {
+      await shouldFail(
+        lock.fullRefund(accounts[7], {
+          from: keyOwners[3],
+        }),
+        ''
+      )
+    })
+
+    it('should fail if the Lock owner withdraws too much funds', async () => {
+      await lock.withdraw(await lock.tokenAddress.call(), 0, {
+        from: lockOwner,
+      })
+      await shouldFail(
+        lock.fullRefund(keyOwners[3], {
+          from: lockOwner,
+        }),
+        ''
+      )
+    })
+
+    it('the key is expired', async () => {
+      await lock.expireKeyFor(keyOwners[3], {
+        from: lockOwner,
+      })
+      await shouldFail(
+        lock.fullRefund(keyOwners[3], {
+          from: lockOwner,
+        }),
+        'KEY_NOT_VALID'
+      )
+    })
+
+    it('the owner does not have a key', async () => {
+      await shouldFail(
+        lock.fullRefund(accounts[7], {
+          from: lockOwner,
+        }),
+        'KEY_NOT_VALID'
+      )
+    })
+  })
+})

--- a/smart-contracts/test/helpers/lockApi.js
+++ b/smart-contracts/test/helpers/lockApi.js
@@ -22,10 +22,10 @@ module.exports = function lockApi(lockContract) {
       })
     },
 
-    async fullRefund(keyOwner, lockOwner) {
+    async fullRefund(keyOwner, amount, lockOwner) {
       const call = web3.eth.abi.encodeFunctionCall(
         lockContract.abi.find(e => e.name === 'fullRefund'),
-        [keyOwner]
+        [keyOwner, amount]
       )
       return web3.eth.sendTransaction({
         to: lockContract.address,

--- a/smart-contracts/test/helpers/lockApi.js
+++ b/smart-contracts/test/helpers/lockApi.js
@@ -22,6 +22,19 @@ module.exports = function lockApi(lockContract) {
       })
     },
 
+    async fullRefund(keyOwner, lockOwner) {
+      const call = web3.eth.abi.encodeFunctionCall(
+        lockContract.abi.find(e => e.name === 'fullRefund'),
+        [keyOwner]
+      )
+      return web3.eth.sendTransaction({
+        to: lockContract.address,
+        data: call,
+        from: lockOwner,
+        gas: walletService.gasAmountConstants().fullRefund,
+      })
+    },
+
     async cancelAndRefund(from) {
       const call = web3.eth.abi.encodeFunctionCall(
         lockContract.abi.find(e => e.name === 'cancelAndRefund'),

--- a/smart-contracts/test/helpers/walletServiceMock.js
+++ b/smart-contracts/test/helpers/walletServiceMock.js
@@ -10,6 +10,7 @@ module.exports = class WalletService {
       createLock: 4500000,
       updateKeyPrice: 1000000,
       purchaseKey: 1000000,
+      fullRefund: 1000000,
       cancelAndRefund: 1000000,
       withdrawFromLock: 1000000,
     }


### PR DESCRIPTION
# Description

Lock owner can proceed to a full refund of individual keys at their discretion.
This feature is added as part of our work for EthGlobal tickets.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread