### PR TITLE
Uniswap token value to track GDP in ETH

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -163,24 +163,27 @@ contract Unlock is
     public
     onlyFromDeployedLock()
   {
-    uint valueInETH;
-    if(_value > 0 && PublicLock(msg.sender).tokenAddress() != address(0)) {
-      // If priced in an ERC-20 token, find the supported uniswap exchange
-      IUniswap exchange = uniswapExchanges[PublicLock(msg.sender).tokenAddress()];
-      if(address(exchange) != address(0)) {
-        valueInETH = exchange.getTokenToEthInputPrice(_value);
-      } else {
-        // If the token type is not supported, assume 0 value
-        valueInETH = 0;
+    if(_value > 0) {
+      uint valueInETH;
+      address tokenAddress = PublicLock(msg.sender).tokenAddress();
+      if(tokenAddress != address(0)) {
+        // If priced in an ERC-20 token, find the supported uniswap exchange
+        IUniswap exchange = uniswapExchanges[tokenAddress];
+        if(address(exchange) != address(0)) {
+          valueInETH = exchange.getTokenToEthInputPrice(_value);
+        } else {
+          // If the token type is not supported, assume 0 value
+          valueInETH = 0;
+        }
       }
-    }
-    else {
-      // If priced in ETH (or value is 0), no conversion is required
-      valueInETH = _value;
-    }
+      else {
+        // If priced in ETH (or value is 0), no conversion is required
+        valueInETH = _value;
+      }
 
-    grossNetworkProduct += valueInETH;
-    locks[msg.sender].totalSales += valueInETH;
+      grossNetworkProduct += valueInETH;
+      locks[msg.sender].totalSales += valueInETH;
+    }
   }
 
   /**

--- a/smart-contracts/contracts/interfaces/IUniswap.sol
+++ b/smart-contracts/contracts/interfaces/IUniswap.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.11;
 
 /// @title Functions from the uniswap contract interface
 

--- a/smart-contracts/contracts/interfaces/IUniswap.sol
+++ b/smart-contracts/contracts/interfaces/IUniswap.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.5.10;
+
+/// @title Functions from the uniswap contract interface
+
+interface IUniswap {
+  function getTokenToEthInputPrice(uint tokens_sold) external returns (uint256);
+}

--- a/smart-contracts/contracts/interfaces/IUniswap.sol
+++ b/smart-contracts/contracts/interfaces/IUniswap.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity 0.5.12;
 
 /// @title Functions from the uniswap contract interface
 

--- a/smart-contracts/test/Unlock/uniswapValue.js
+++ b/smart-contracts/test/Unlock/uniswapValue.js
@@ -1,0 +1,142 @@
+const BigNumber = require('bignumber.js')
+
+const { protocols } = require('hardlydifficult-test-helpers')
+const deployLocks = require('../helpers/deployLocks')
+
+const TestErc20Token = artifacts.require('TestErc20Token.sol')
+
+const unlockContract = artifacts.require('../Unlock.sol')
+const getProxy = require('../helpers/proxy')
+
+let unlock, locks, lock, token, exchange
+
+contract('Unlock / uniswapValue', accounts => {
+  const price = '10000000000000000'
+  const ethValue = '9969999900' // an arbitrary goal based on the liquidity provided for this test
+
+  beforeEach(async () => {
+    unlock = await getProxy(unlockContract)
+  })
+
+  describe('A supported token', () => {
+    beforeEach(async () => {
+      token = await TestErc20Token.new()
+      // Mint some tokens so that the totalSupply is greater than 0
+      await token.mint(accounts[0], '1000000000000000000000000')
+
+      locks = await deployLocks(unlock, accounts[0], token.address)
+      lock = locks['FIRST']
+
+      // Deploy the exchange
+      const uniswapFactory = await protocols.uniswap.deploy(web3, accounts[0])
+      const tx = await uniswapFactory.createExchange(token.address, {
+        from: accounts[0],
+      })
+      exchange = await protocols.uniswap.getExchange(
+        web3,
+        tx.logs[0].args.exchange
+      )
+
+      // Approve transfering tokens to the exchange
+      await token.approve(exchange.address, -1, { from: accounts[0] })
+
+      // And seed it
+      await exchange.addLiquidity(
+        '1',
+        '1000000000000000000000000',
+        Math.round(Date.now() / 1000) + 60,
+        {
+          from: accounts[0],
+          value: web3.utils.toWei('1', 'ether'),
+        }
+      )
+
+      // Config in Unlock
+      await unlock.setExchange(token.address, exchange.address)
+    })
+
+    it('Uniswap reports a non-zero value', async () => {
+      const value = await exchange.getTokenToEthInputPrice(price)
+      assert.equal(value.toString(), ethValue)
+    })
+
+    describe('Purchase key', () => {
+      const keyOwner = accounts[1]
+      let gdpBefore
+
+      beforeEach(async () => {
+        gdpBefore = new BigNumber(await unlock.grossNetworkProduct())
+
+        await token.mint(keyOwner, price, { from: accounts[0] })
+        await token.approve(lock.address, -1, { from: keyOwner })
+
+        await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
+          from: keyOwner,
+        })
+      })
+
+      it('GDP went up by the expected ETH value', async () => {
+        const gdp = new BigNumber(await unlock.grossNetworkProduct())
+        assert.equal(gdp.toFixed(), gdpBefore.plus(ethValue).toFixed())
+      })
+    })
+  })
+
+  describe('A unsupported token', () => {
+    beforeEach(async () => {
+      token = await TestErc20Token.new()
+      // Mint some tokens so that the totalSupply is greater than 0
+      await token.mint(accounts[0], '1000000000000000000000000')
+
+      locks = await deployLocks(unlock, accounts[0], token.address)
+      lock = locks['FIRST']
+    })
+
+    describe('Purchase key', () => {
+      const keyOwner = accounts[1]
+      let gdpBefore
+
+      beforeEach(async () => {
+        gdpBefore = new BigNumber(await unlock.grossNetworkProduct())
+
+        await token.mint(keyOwner, price, { from: accounts[0] })
+        await token.approve(lock.address, -1, { from: keyOwner })
+
+        await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
+          from: keyOwner,
+        })
+      })
+
+      it('GDP did not change', async () => {
+        const gdp = new BigNumber(await unlock.grossNetworkProduct())
+        assert.equal(gdp.toFixed(), gdpBefore.toFixed())
+      })
+    })
+  })
+
+  describe('ETH', () => {
+    beforeEach(async () => {
+      locks = await deployLocks(unlock, accounts[0])
+      lock = locks['FIRST']
+    })
+
+    describe('Purchase key', () => {
+      const keyOwner = accounts[1]
+      let gdpBefore
+
+      beforeEach(async () => {
+        gdpBefore = new BigNumber(await unlock.grossNetworkProduct())
+
+        await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
+          from: keyOwner,
+          value: price,
+        })
+      })
+
+      it('GDP went up by the keyPrice', async () => {
+        const gdp = new BigNumber(await unlock.grossNetworkProduct())
+        assert.equal(gdp.toFixed(), gdpBefore.plus(price).toFixed())
+      })
+    })
+  })
+})

--- a/smart-contracts/test/Unlock/upgrades/v0ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v0ToLatest.js
@@ -14,7 +14,7 @@ const { LatestUnlockVersion, LatestLockVersion } = require('./latestVersion.js')
 
 let project, proxy, unlock
 
-contract('Unlock / upgrades', accounts => {
+contract('Unlock / upgrades v0', accounts => {
   const unlockOwner = accounts[9]
   const lockOwner = accounts[1]
   const keyOwner = accounts[2]
@@ -100,7 +100,13 @@ contract('Unlock / upgrades', accounts => {
         assert.equal(Web3Utils.toChecksumAddress(Web3Utils.toHex(id)), keyOwner)
       })
 
-      it('New keys may still be purchased', async () => {
+      /**
+       * v0 Locks are NO LONGER SUPPORTED.
+       * Attempting to purchase a key will fail.
+       * This is due to Unlock.sol calling PublicLock before the version was available.
+       * Other functions, such as withdraw, should be fine.
+       */
+      it.skip('New keys may still be purchased', async () => {
         const tx = await lockV0.methods
           .purchaseFor(accounts[6], Web3Utils.toHex('Julien'))
           .send({
@@ -111,7 +117,7 @@ contract('Unlock / upgrades', accounts => {
         assert.equal(tx.events.Transfer.event, 'Transfer')
       })
 
-      it('Keys may still be transfered', async () => {
+      it.skip('Keys may still be transfered', async () => {
         await lockV0.methods
           .purchaseFor(accounts[7], Web3Utils.toHex('Julien'))
           .send({
@@ -138,7 +144,7 @@ contract('Unlock / upgrades', accounts => {
         )
         assert.equal(
           grossNetworkProduct.toFixed(),
-          new BigNumber(keyPrice).times(3).toFixed()
+          new BigNumber(keyPrice).times(1).toFixed()
         )
       })
 
@@ -189,7 +195,7 @@ contract('Unlock / upgrades', accounts => {
         )
         assert.equal(
           grossNetworkProduct.toFixed(),
-          new BigNumber(keyPrice).times(4).toFixed()
+          new BigNumber(keyPrice).times(2).toFixed()
         )
       })
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Allows us to register support for certain ERC-20 tokens.  If the token is supported, we use the registered Uniswap exchange to convert the value paid into the ETH equivalent.

If the token is not supported, the value is assumed to be 0.
If the lock is priced in ETH, no conversion is applied.

!! This breaks v0 Locks !!
Any Lock created with v0 will no longer support purchasing new keys.  Other functions should be fine.

We could workaround this by using assembly, but as discussed is Slack previously it should be okay to retire v0 at this point.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #3711
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
