### PR TITLE
Support free trials

### DIFF
--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -34,8 +34,7 @@ contract MixinRefunds is
   );
 
   event RefundPenaltyChanged(
-    uint oldRefundPenaltyNumerator,
-    uint oldRefundPenaltyDenominator,
+    uint freeTrialLength,
     uint refundPenaltyNumerator,
     uint refundPenaltyDenominator
   );
@@ -102,6 +101,7 @@ contract MixinRefunds is
    * Allow the owner to change the refund penalty.
    */
   function updateRefundPenalty(
+    uint _freeTrialLength,
     uint _refundPenaltyNumerator,
     uint _refundPenaltyDenominator
   )
@@ -111,11 +111,12 @@ contract MixinRefunds is
     require(_refundPenaltyDenominator != 0, 'INVALID_RATE');
 
     emit RefundPenaltyChanged(
-      refundPenaltyNumerator,
-      refundPenaltyDenominator,
+      _freeTrialLength,
       _refundPenaltyNumerator,
       _refundPenaltyDenominator
     );
+
+    freeTrialLength = _freeTrialLength;
     refundPenaltyNumerator = _refundPenaltyNumerator;
     refundPenaltyDenominator = _refundPenaltyDenominator;
   }
@@ -192,18 +193,23 @@ contract MixinRefunds is
     Key storage key = _getKeyFor(_owner);
     // Math: safeSub is not required since `hasValidKey` confirms timeRemaining is positive
     uint timeRemaining = key.expirationTimestamp - block.timestamp;
-    if(timeRemaining >= expirationDuration) {
+    if(timeRemaining + freeTrialLength >= expirationDuration) {
       refund = keyPrice;
     } else {
       // Math: using safeMul in case keyPrice or timeRemaining is very large
       refund = keyPrice.mul(timeRemaining) / expirationDuration;
     }
-    uint penalty = keyPrice.mul(refundPenaltyNumerator) / refundPenaltyDenominator;
-    if (refund > penalty) {
-      // Math: safeSub is not required since the if confirms this won't underflow
-      refund -= penalty;
-    } else {
-      refund = 0;
+
+    // Apply the penalty if this is not a free trial
+    if(freeTrialLength > 0 && timeRemaining + freeTrialLength < expirationDuration)
+    {
+      uint penalty = keyPrice.mul(refundPenaltyNumerator) / refundPenaltyDenominator;
+      if (refund > penalty) {
+        // Math: safeSub is not required since the if confirms this won't underflow
+        refund -= penalty;
+      } else {
+        refund = 0;
+      }
     }
   }
 }

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -21,6 +21,8 @@ contract MixinRefunds is
   uint public refundPenaltyNumerator = 1;
   uint public refundPenaltyDenominator = 10;
 
+  uint public freeTrialLength;
+
   // Stores a nonce per user to use for signed messages
   mapping(address => uint) public keyOwnerToNonce;
 

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -144,21 +144,13 @@ contract('Lock / cancelAndRefund', accounts => {
     let tx
 
     before(async () => {
-      tx = await lock.updateRefundPenalty(2, 10) // 20%
+      tx = await lock.updateRefundPenalty(0, 2, 10) // 20%
     })
 
     it('should trigger an event', async () => {
       const event = tx.logs.find(log => {
         return log.event === 'RefundPenaltyChanged'
       })
-      assert.equal(
-        new BigNumber(event.args.oldRefundPenaltyNumerator).toFixed(),
-        1
-      )
-      assert.equal(
-        new BigNumber(event.args.oldRefundPenaltyDenominator).toFixed(),
-        10
-      )
       assert.equal(
         new BigNumber(event.args.refundPenaltyNumerator).toFixed(),
         2
@@ -219,7 +211,7 @@ contract('Lock / cancelAndRefund', accounts => {
     })
 
     it('attempt to set the denominator to 0', async () => {
-      await shouldFail(lock.updateRefundPenalty(1, 0), 'INVALID_RATE')
+      await shouldFail(lock.updateRefundPenalty(0, 1, 0), 'INVALID_RATE')
     })
   })
 })

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -2,7 +2,6 @@ const Units = require('ethereumjs-units')
 const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
-const shouldFail = require('../helpers/shouldFail')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const getProxy = require('../helpers/proxy')

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -2,6 +2,7 @@ const Units = require('ethereumjs-units')
 const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
+const shouldFail = require('../helpers/shouldFail')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const getProxy = require('../helpers/proxy')

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -122,7 +122,7 @@ contract('Lock / disableLock', accounts => {
     })
 
     it('Lock owner can still updateRefundPenaltyDenominator', async () => {
-      await lock.updateRefundPenalty(5, 100)
+      await lock.updateRefundPenalty(0, 5, 100)
     })
 
     it('should fail to setApprovalForAll', async () => {

--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -1,0 +1,81 @@
+const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
+
+const deployLocks = require('../helpers/deployLocks')
+const shouldFail = require('../helpers/shouldFail')
+
+const unlockContract = artifacts.require('Unlock.sol')
+const getProxy = require('../helpers/proxy')
+
+let unlock, locks
+
+contract('Lock / freeTrial', accounts => {
+  let lock
+  const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
+  const keyPrice = new BigNumber(Units.convert(0.01, 'eth', 'wei'))
+
+  beforeEach(async () => {
+    unlock = await getProxy(unlockContract)
+    locks = await deployLocks(unlock, accounts[0])
+    lock = locks['SECOND']
+    const purchases = keyOwners.map(account => {
+      return lock.purchase(account, web3.utils.padLeft(0, 40), [], {
+        value: keyPrice.toFixed(),
+        from: account,
+      })
+    })
+    await Promise.all(purchases)
+  })
+
+  it('No free trial by default', async () => {
+    const freeTrialLength = new BigNumber(await lock.freeTrialLength.call())
+    assert.equal(freeTrialLength.toFixed(), 0)
+  })
+
+  describe('with a free trial defined', () => {
+    let initialLockBalance
+
+    beforeEach(async () => {
+      await lock.updateRefundPenalty(5, 2, 10)
+      initialLockBalance = new BigNumber(
+        await web3.eth.getBalance(lock.address)
+      )
+    })
+
+    describe('should cancel and provide a full refund when enough time remains', () => {
+      beforeEach(async () => {
+        await lock.cancelAndRefund({
+          from: keyOwners[0],
+        })
+      })
+
+      it('should provide a full refund', async () => {
+        const refundAmount = initialLockBalance.minus(
+          await web3.eth.getBalance(lock.address)
+        )
+        assert.equal(refundAmount.toFixed(), keyPrice.toFixed())
+      })
+    })
+
+    describe('should cancel and provide a partial refund after the trial expires', () => {
+      beforeEach(async () => {
+        await sleep(6000)
+        await lock.cancelAndRefund({
+          from: keyOwners[0],
+        })
+      })
+
+      it('should provide less than a full refund', async () => {
+        const refundAmount = initialLockBalance.minus(
+          await web3.eth.getBalance(lock.address)
+        )
+        assert.notEqual(refundAmount.toFixed(), keyPrice.toFixed())
+        assert(refundAmount.lt(keyPrice))
+      })
+    })
+  })
+})
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -2,7 +2,6 @@ const Units = require('ethereumjs-units')
 const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
-const shouldFail = require('../helpers/shouldFail')
 
 const unlockContract = artifacts.require('Unlock.sol')
 const getProxy = require('../helpers/proxy')


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Adds a `freeTrialLength` to the PublicLock.  This defaults to 0.  When set to a non-zero value by the lock owner, this is the number of seconds where `cancelAndRefund` will provide a full refund.

The `getCancelAndRefundValueFor` function will reflect the trial as well.

Note that the time is based on when the transaction is mined, not when it's issued.  So it's possible that a user attempts to cancel during the free trial but it does not actually mine until after the trial has passed (resulting in a partial refund instead).

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4762
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
