### PR TITLE
Add a tip to ERC-20 lock purchases

### DIFF
--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -27,11 +27,13 @@ contract MixinPurchase is
   * @dev Purchase function
   * @param _recipient address of the recipient of the purchased key
   * @param _referrer address of the user making the referral
+  * @param _value the price to pay for this purchase >=keyPrice
   * @param _data arbitrary data populated by the front-end which initiated the sale
   */
   function purchase(
     address _recipient,
     address _referrer,
+    uint256 _value,
     bytes calldata _data
   ) external payable
     onlyIfAlive
@@ -86,6 +88,7 @@ contract MixinPurchase is
     // We explicitly allow for greater amounts of ETH to allow 'donations'
     // Security: after state changes to minimize risk of re-entrancy
     uint pricePaid = _chargeAtLeast(inMemoryKeyPrice);
+    require(_value >= inMemoryKeyPrice, 'INSUFFICIENT_VALUE');
 
     // Security: last line to minimize risk of re-entrancy
     _onKeySold(_recipient, _referrer, pricePaid, _data);

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -27,7 +27,7 @@ contract MixinPurchase is
   * @dev Purchase function
   * @param _recipient address of the recipient of the purchased key
   * @param _referrer address of the user making the referral
-  * @param _value the price to pay for this purchase >=keyPrice
+  * @param _value the price to pay for this purchase >=keyPrice (or 0 to ignore this check)
   * @param _data arbitrary data populated by the front-end which initiated the sale
   */
   function purchase(
@@ -85,10 +85,13 @@ contract MixinPurchase is
       toKey.tokenId
     );
 
-    // We explicitly allow for greater amounts of ETH to allow 'donations'
+    // We explicitly allow for greater amounts of ETH or tokens to allow 'donations'
+    if(_value > 0) {
+      require(_value >= inMemoryKeyPrice, 'INSUFFICIENT_VALUE');
+      inMemoryKeyPrice = _value;
+    }
     // Security: after state changes to minimize risk of re-entrancy
     uint pricePaid = _chargeAtLeast(inMemoryKeyPrice);
-    require(_value >= inMemoryKeyPrice, 'INSUFFICIENT_VALUE');
 
     // Security: last line to minimize risk of re-entrancy
     _onKeySold(_recipient, _referrer, pricePaid, _data);

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -29,6 +29,9 @@ contract MixinPurchase is
   * @param _recipient address of the recipient of the purchased key
   * @param _referrer address of the user making the referral
   * @param _data arbitrary data populated by the front-end which initiated the sale
+  * @dev Setting _value to keyPrice exactly doubles as a security feature. That way if the lock owner increases the
+  * price while my transaction is pending I can't be charged more than I expected (only applicable to ERC-20 when more
+  * than keyPrice is approved for spending).
   */
   function purchase(
     uint256 _value,

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -25,15 +25,15 @@ contract MixinPurchase is
 
   /**
   * @dev Purchase function
+  * @param _value the price to pay for this purchase >=keyPrice (or 0 to ignore this check)
   * @param _recipient address of the recipient of the purchased key
   * @param _referrer address of the user making the referral
-  * @param _value the price to pay for this purchase >=keyPrice (or 0 to ignore this check)
   * @param _data arbitrary data populated by the front-end which initiated the sale
   */
   function purchase(
+    uint256 _value,
     address _recipient,
     address _referrer,
-    uint256 _value,
     bytes calldata _data
   ) external payable
     onlyIfAlive

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -25,7 +25,7 @@ contract MixinPurchase is
 
   /**
   * @dev Purchase function
-  * @param _value the price to pay for this purchase >=keyPrice (or 0 to ignore this check)
+  * @param _value the price to pay for this purchase >=keyPrice (ignored when using ETH)
   * @param _recipient address of the recipient of the purchased key
   * @param _referrer address of the user making the referral
   * @param _data arbitrary data populated by the front-end which initiated the sale
@@ -89,7 +89,7 @@ contract MixinPurchase is
     );
 
     // We explicitly allow for greater amounts of ETH or tokens to allow 'donations'
-    if(_value > 0) {
+    if(tokenAddress != address(0)) {
       require(_value >= inMemoryKeyPrice, 'INSUFFICIENT_VALUE');
       inMemoryKeyPrice = _value;
     }

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -25,7 +25,8 @@ contract MixinPurchase is
 
   /**
   * @dev Purchase function
-  * @param _value the price to pay for this purchase >=keyPrice (ignored when using ETH)
+  * @param _value the number of tokens to pay for this purchase >= the current keyPrice - any applicable discount
+  * (_value is ignored when using ETH)
   * @param _recipient address of the recipient of the purchased key
   * @param _referrer address of the user making the referral
   * @param _data arbitrary data populated by the front-end which initiated the sale

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -23,7 +23,7 @@ contract('Lock / cancelAndRefund', accounts => {
   before(async () => {
     lock = locks['SECOND']
     const purchases = keyOwners.map(account => {
-      return lock.purchase(account, web3.utils.padLeft(0, 40), keyPrice.toFixed(), [], {
+      return lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
         value: keyPrice.toFixed(),
         from: account,
       })

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -23,7 +23,7 @@ contract('Lock / cancelAndRefund', accounts => {
   before(async () => {
     lock = locks['SECOND']
     const purchases = keyOwners.map(account => {
-      return lock.purchase(account, web3.utils.padLeft(0, 40), [], {
+      return lock.purchase(account, web3.utils.padLeft(0, 40), keyPrice.toFixed(), [], {
         value: keyPrice.toFixed(),
         from: account,
       })

--- a/smart-contracts/test/Lock/cancelAndRefundFor.js
+++ b/smart-contracts/test/Lock/cancelAndRefundFor.js
@@ -41,7 +41,7 @@ contract('Lock / cancelAndRefundFor', accounts => {
   before(async () => {
     lock = locks['SECOND']
     const purchases = keyOwners.map(account => {
-      return lock.purchase(account, web3.utils.padLeft(0, 40), [], {
+      return lock.purchase(account, web3.utils.padLeft(0, 40), keyPrice.toFixed(), [], {
         value: keyPrice.toFixed(),
         from: account,
       })
@@ -144,7 +144,7 @@ contract('Lock / cancelAndRefundFor', accounts => {
       await lock.cancelAndRefundFor(keyOwners[2], signature, {
         from: txSender,
       })
-      await lock.purchase(keyOwners[2], web3.utils.padLeft(0, 40), [], {
+      await lock.purchase(keyOwners[2], web3.utils.padLeft(0, 40), keyPrice.toFixed(), [], {
         from: keyOwners[2],
         value: keyPrice.toFixed(),
       })

--- a/smart-contracts/test/Lock/cancelAndRefundFor.js
+++ b/smart-contracts/test/Lock/cancelAndRefundFor.js
@@ -41,7 +41,7 @@ contract('Lock / cancelAndRefundFor', accounts => {
   before(async () => {
     lock = locks['SECOND']
     const purchases = keyOwners.map(account => {
-      return lock.purchase(account, web3.utils.padLeft(0, 40), keyPrice.toFixed(), [], {
+      return lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
         value: keyPrice.toFixed(),
         from: account,
       })
@@ -144,7 +144,7 @@ contract('Lock / cancelAndRefundFor', accounts => {
       await lock.cancelAndRefundFor(keyOwners[2], signature, {
         from: txSender,
       })
-      await lock.purchase(keyOwners[2], web3.utils.padLeft(0, 40), keyPrice.toFixed(), [], {
+      await lock.purchase(0, keyOwners[2], web3.utils.padLeft(0, 40), [], {
         from: keyOwners[2],
         value: keyPrice.toFixed(),
       })

--- a/smart-contracts/test/Lock/destroyLock.js
+++ b/smart-contracts/test/Lock/destroyLock.js
@@ -43,7 +43,7 @@ contract('Lock / destroyLock', accounts => {
 
         // Add ETH to the lock, even if it's priced in ERC20
         // TODO: should we block this from happening instead?
-        await lock.purchase(accounts[9], web3.utils.padLeft(0, 40), [], {
+        await lock.purchase(0, accounts[9], web3.utils.padLeft(0, 40), [], {
           from: accounts[9],
           value: Units.convert('0.01', 'eth', 'wei'),
         })
@@ -62,7 +62,7 @@ contract('Lock / destroyLock', accounts => {
               ? Units.convert('0.01', 'eth', 'wei')
               : 0
 
-          await lock.purchase(accounts[1], web3.utils.padLeft(0, 40), [], {
+          await lock.purchase(0, accounts[1], web3.utils.padLeft(0, 40), [], {
             from: accounts[1],
             value,
           })
@@ -144,7 +144,7 @@ contract('Lock / destroyLock', accounts => {
                 : 0
 
             // This line does not fail, but instead calls the fallback function and sends msg.value to the destroyed contract.
-            await lock.purchase(accounts[1], web3.utils.padLeft(0, 40), [], {
+            await lock.purchase(0, accounts[1], web3.utils.padLeft(0, 40), [], {
               from: accounts[1],
               value,
             })
@@ -163,9 +163,15 @@ contract('Lock / destroyLock', accounts => {
             // assert.equal(await lock.getHasValidKey.call(accounts[1]), false)
           } else {
             try {
-              await lock.purchase(accounts[1], web3.utils.padLeft(0, 40), [], {
-                value: Units.convert('0.01', 'eth', 'wei'),
-              })
+              await lock.purchase(
+                0,
+                accounts[1],
+                web3.utils.padLeft(0, 40),
+                [],
+                {
+                  value: Units.convert('0.01', 'eth', 'wei'),
+                }
+              )
             } catch (e) {
               assert(e.message.endsWith('is not a contract address'))
               return

--- a/smart-contracts/test/Lock/destroyLock.js
+++ b/smart-contracts/test/Lock/destroyLock.js
@@ -10,7 +10,7 @@ const unlockContract = artifacts.require('../Unlock.sol')
 const getProxy = require('../helpers/proxy')
 
 const TestErc20Token = artifacts.require('TestErc20Token.sol')
-
+const keyPrice = Units.convert('0.01', 'eth', 'wei')
 let unlock, locks
 
 contract('Lock / destroyLock', accounts => {
@@ -43,10 +43,16 @@ contract('Lock / destroyLock', accounts => {
 
         // Add ETH to the lock, even if it's priced in ERC20
         // TODO: should we block this from happening instead?
-        await lock.purchase(0, accounts[9], web3.utils.padLeft(0, 40), [], {
-          from: accounts[9],
-          value: Units.convert('0.01', 'eth', 'wei'),
-        })
+        await lock.purchase(
+          keyPrice,
+          accounts[9],
+          web3.utils.padLeft(0, 40),
+          [],
+          {
+            from: accounts[9],
+            value: keyPrice,
+          }
+        )
       })
 
       it('should fail if called by the wrong account', async () => {
@@ -62,10 +68,16 @@ contract('Lock / destroyLock', accounts => {
               ? Units.convert('0.01', 'eth', 'wei')
               : 0
 
-          await lock.purchase(0, accounts[1], web3.utils.padLeft(0, 40), [], {
-            from: accounts[1],
-            value,
-          })
+          await lock.purchase(
+            keyPrice,
+            accounts[1],
+            web3.utils.padLeft(0, 40),
+            [],
+            {
+              from: accounts[1],
+              value,
+            }
+          )
           assert.equal(await lock.getHasValidKey.call(accounts[1]), true) // pre-req
 
           initialLockBalance = await getTokenBalance(lock.address, tokenAddress)
@@ -144,10 +156,16 @@ contract('Lock / destroyLock', accounts => {
                 : 0
 
             // This line does not fail, but instead calls the fallback function and sends msg.value to the destroyed contract.
-            await lock.purchase(0, accounts[1], web3.utils.padLeft(0, 40), [], {
-              from: accounts[1],
-              value,
-            })
+            await lock.purchase(
+              keyPrice,
+              accounts[1],
+              web3.utils.padLeft(0, 40),
+              [],
+              {
+                from: accounts[1],
+                value,
+              }
+            )
 
             let finalLockBalance = await getTokenBalance(
               lock.address,
@@ -164,7 +182,7 @@ contract('Lock / destroyLock', accounts => {
           } else {
             try {
               await lock.purchase(
-                0,
+                keyPrice,
                 accounts[1],
                 web3.utils.padLeft(0, 40),
                 [],

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -9,6 +9,8 @@ const getProxy = require('../helpers/proxy')
 
 let unlock, locks, ID
 
+const keyPrice = Units.convert('0.01', 'eth', 'wei')
+
 contract('Lock / disableLock', accounts => {
   let lock
   let keyOwner = accounts[1]
@@ -19,14 +21,14 @@ contract('Lock / disableLock', accounts => {
     unlock = await getProxy(unlockContract)
     locks = await deployLocks(unlock, lockOwner)
     lock = locks['FIRST']
-    await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
+    await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), keyPrice, [], {
+      value: keyPrice,
     })
-    await lock.purchase(keyOwner2, web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
+    await lock.purchase(keyOwner2, web3.utils.padLeft(0, 40), keyPrice, [], {
+      value: keyPrice,
     })
-    await lock.purchase(keyOwner3, web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
+    await lock.purchase(keyOwner3, web3.utils.padLeft(0, 40), keyPrice, [], {
+      value: keyPrice,
     })
     ID = new BigNumber(await lock.getTokenIdFor(keyOwner)).toFixed()
   })
@@ -56,8 +58,8 @@ contract('Lock / disableLock', accounts => {
 
     it('should fail if a user tries to purchase a key', async () => {
       await shouldFail(
-        lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
-          value: Units.convert('0.01', 'eth', 'wei'),
+        lock.purchase(keyOwner, web3.utils.padLeft(0, 40), keyPrice, [], {
+          value: keyPrice,
         }),
         'LOCK_DEPRECATED'
       )
@@ -65,8 +67,8 @@ contract('Lock / disableLock', accounts => {
 
     it('should fail if a user tries to purchase a key with a referral', async () => {
       await shouldFail(
-        lock.purchase(keyOwner, accounts[3], [], {
-          value: Units.convert('0.01', 'eth', 'wei'),
+        lock.purchase(keyOwner, accounts[3], keyPrice, [], {
+          value: keyPrice,
         }),
         'LOCK_DEPRECATED'
       )

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -21,13 +21,13 @@ contract('Lock / disableLock', accounts => {
     unlock = await getProxy(unlockContract)
     locks = await deployLocks(unlock, lockOwner)
     lock = locks['FIRST']
-    await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), keyPrice, [], {
+    await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
       value: keyPrice,
     })
-    await lock.purchase(keyOwner2, web3.utils.padLeft(0, 40), keyPrice, [], {
+    await lock.purchase(0, keyOwner2, web3.utils.padLeft(0, 40), [], {
       value: keyPrice,
     })
-    await lock.purchase(keyOwner3, web3.utils.padLeft(0, 40), keyPrice, [], {
+    await lock.purchase(0, keyOwner3, web3.utils.padLeft(0, 40), [], {
       value: keyPrice,
     })
     ID = new BigNumber(await lock.getTokenIdFor(keyOwner)).toFixed()
@@ -58,7 +58,7 @@ contract('Lock / disableLock', accounts => {
 
     it('should fail if a user tries to purchase a key', async () => {
       await shouldFail(
-        lock.purchase(keyOwner, web3.utils.padLeft(0, 40), keyPrice, [], {
+        lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
           value: keyPrice,
         }),
         'LOCK_DEPRECATED'
@@ -67,7 +67,7 @@ contract('Lock / disableLock', accounts => {
 
     it('should fail if a user tries to purchase a key with a referral', async () => {
       await shouldFail(
-        lock.purchase(keyOwner, accounts[3], keyPrice, [], {
+        lock.purchase(0, keyOwner, accounts[3], [], {
           value: keyPrice,
         }),
         'LOCK_DEPRECATED'

--- a/smart-contracts/test/Lock/erc20.js
+++ b/smart-contracts/test/Lock/erc20.js
@@ -47,7 +47,7 @@ contract('Lock / erc20', accounts => {
 
     describe('users can purchase keys', () => {
       it('can purchase', async () => {
-        await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
+        await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
           from: keyOwner,
         })
       })
@@ -66,7 +66,7 @@ contract('Lock / erc20', accounts => {
       })
 
       it('when a lock owner refunds a key, tokens are fully refunded', async () => {
-        await lock.purchase(keyOwner3, web3.utils.padLeft(0, 40), [], {
+        await lock.purchase(0, keyOwner3, web3.utils.padLeft(0, 40), [], {
           from: keyOwner3,
         })
 
@@ -119,12 +119,12 @@ contract('Lock / erc20', accounts => {
 
       it('purchaseForFrom works as well', async () => {
         // The referrer needs a valid key for this test
-        await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
+        await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
           from: keyOwner,
         })
         const balanceBefore = new BigNumber(await token.balanceOf(keyOwner2))
 
-        await lock.purchase(keyOwner2, keyOwner, [], { from: keyOwner2 })
+        await lock.purchase(0, keyOwner2, keyOwner, [], { from: keyOwner2 })
 
         const balance = new BigNumber(await token.balanceOf(keyOwner2))
         assert.equal(balance.toFixed(), balanceBefore.minus(keyPrice).toFixed())
@@ -147,7 +147,9 @@ contract('Lock / erc20', accounts => {
       await token.approve(lock.address, -1)
       await token.mint(account, keyPrice.minus(1))
       await shouldFail(
-        lock.purchase(account, web3.utils.padLeft(0, 40), [], { from: account })
+        lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
+          from: account,
+        })
       )
     })
 
@@ -156,7 +158,9 @@ contract('Lock / erc20', accounts => {
       await token.approve(lock.address, -1)
       await token.mint(account, keyPrice)
       await shouldFail(
-        lock.purchase(account, web3.utils.padLeft(0, 40), [], { from: account })
+        lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
+          from: account,
+        })
       )
     })
   })

--- a/smart-contracts/test/Lock/erc20.js
+++ b/smart-contracts/test/Lock/erc20.js
@@ -47,9 +47,15 @@ contract('Lock / erc20', accounts => {
 
     describe('users can purchase keys', () => {
       it('can purchase', async () => {
-        await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
-          from: keyOwner,
-        })
+        await lock.purchase(
+          keyPrice.toFixed(),
+          keyOwner,
+          web3.utils.padLeft(0, 40),
+          [],
+          {
+            from: keyOwner,
+          }
+        )
       })
 
       it('charges correct amount on purchaseKey', async () => {
@@ -66,9 +72,15 @@ contract('Lock / erc20', accounts => {
       })
 
       it('when a lock owner refunds a key, tokens are fully refunded', async () => {
-        await lock.purchase(0, keyOwner3, web3.utils.padLeft(0, 40), [], {
-          from: keyOwner3,
-        })
+        await lock.purchase(
+          keyPrice.toFixed(),
+          keyOwner3,
+          web3.utils.padLeft(0, 40),
+          [],
+          {
+            from: keyOwner3,
+          }
+        )
 
         const balanceOwnerBefore = new BigNumber(
           await token.balanceOf(keyOwner3)
@@ -119,12 +131,20 @@ contract('Lock / erc20', accounts => {
 
       it('purchaseForFrom works as well', async () => {
         // The referrer needs a valid key for this test
-        await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
-          from: keyOwner,
-        })
+        await lock.purchase(
+          keyPrice.toFixed(),
+          keyOwner,
+          web3.utils.padLeft(0, 40),
+          [],
+          {
+            from: keyOwner,
+          }
+        )
         const balanceBefore = new BigNumber(await token.balanceOf(keyOwner2))
 
-        await lock.purchase(0, keyOwner2, keyOwner, [], { from: keyOwner2 })
+        await lock.purchase(keyPrice.toFixed(), keyOwner2, keyOwner, [], {
+          from: keyOwner2,
+        })
 
         const balance = new BigNumber(await token.balanceOf(keyOwner2))
         assert.equal(balance.toFixed(), balanceBefore.minus(keyPrice).toFixed())
@@ -147,9 +167,15 @@ contract('Lock / erc20', accounts => {
       await token.approve(lock.address, -1)
       await token.mint(account, keyPrice.minus(1))
       await shouldFail(
-        lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
-          from: account,
-        })
+        lock.purchase(
+          keyPrice.toFixed(),
+          account,
+          web3.utils.padLeft(0, 40),
+          [],
+          {
+            from: account,
+          }
+        )
       )
     })
 
@@ -158,9 +184,15 @@ contract('Lock / erc20', accounts => {
       await token.approve(lock.address, -1)
       await token.mint(account, keyPrice)
       await shouldFail(
-        lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
-          from: account,
-        })
+        lock.purchase(
+          keyPrice.toFixed(),
+          account,
+          web3.utils.padLeft(0, 40),
+          [],
+          {
+            from: account,
+          }
+        )
       )
     })
   })

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -28,6 +28,7 @@ contract('Lock / erc721 / approve', accounts => {
   describe('when the key exists', () => {
     before(() => {
       return locks['FIRST'].purchase(
+        0,
         accounts[1],
         web3.utils.padLeft(0, 40),
         [],

--- a/smart-contracts/test/Lock/erc721/approveForAll.js
+++ b/smart-contracts/test/Lock/erc721/approveForAll.js
@@ -20,7 +20,7 @@ contract('Lock / erc721 / approveForAll', accounts => {
 
   describe('when the key exists', () => {
     before(async () => {
-      await lock.purchase(owner, web3.utils.padLeft(0, 40), [], {
+      await lock.purchase(0, owner, web3.utils.padLeft(0, 40), [], {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: owner,
       })

--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -31,10 +31,16 @@ contract('Lock / erc721 / balanceOf', accounts => {
   })
 
   it('should return 1 if the user has a non expired key', async () => {
-    await locks['FIRST'].purchase(accounts[1], web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
-      from: accounts[1],
-    })
+    await locks['FIRST'].purchase(
+      0,
+      accounts[1],
+      web3.utils.padLeft(0, 40),
+      [],
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[1],
+      }
+    )
     const balance = new BigNumber(
       await locks['FIRST'].balanceOf.call(accounts[1])
     )
@@ -42,10 +48,16 @@ contract('Lock / erc721 / balanceOf', accounts => {
   })
 
   it('should return 0 if the user has an expired key', async () => {
-    await locks['FIRST'].purchase(accounts[5], web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
-      from: accounts[5],
-    })
+    await locks['FIRST'].purchase(
+      0,
+      accounts[5],
+      web3.utils.padLeft(0, 40),
+      [],
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[5],
+      }
+    )
     await locks['FIRST'].expireKeyFor(accounts[5], {
       from: accounts[0],
     })
@@ -56,10 +68,16 @@ contract('Lock / erc721 / balanceOf', accounts => {
   })
 
   it('should return 0 after a user transfers their key', async () => {
-    await locks['FIRST'].purchase(accounts[6], web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
-      from: accounts[6],
-    })
+    await locks['FIRST'].purchase(
+      0,
+      accounts[6],
+      web3.utils.padLeft(0, 40),
+      [],
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[6],
+      }
+    )
     let ID = await locks['FIRST'].getTokenIdFor.call(accounts[6])
     await locks['FIRST'].transferFrom(accounts[6], accounts[5], ID, {
       from: accounts[6],

--- a/smart-contracts/test/Lock/erc721/enumerable.js
+++ b/smart-contracts/test/Lock/erc721/enumerable.js
@@ -15,7 +15,7 @@ contract('Lock / erc721 / approve', accounts => {
     // Buy test keys for each account
     const keyPrice = await lock.keyPrice()
     for (let i = 0; i < 5; i++) {
-      await lock.purchase(accounts[i], web3.utils.padLeft(0, 40), [], {
+      await lock.purchase(0, accounts[i], web3.utils.padLeft(0, 40), [], {
         value: keyPrice.toString(),
         from: accounts[i],
       })

--- a/smart-contracts/test/Lock/erc721/getApproved.js
+++ b/smart-contracts/test/Lock/erc721/getApproved.js
@@ -16,10 +16,16 @@ contract('Lock / erc721 / getApproved', accounts => {
   })
 
   before(async function() {
-    await locks['FIRST'].purchase(keyPurchaser, web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
-      from: keyPurchaser,
-    })
+    await locks['FIRST'].purchase(
+      0,
+      keyPurchaser,
+      web3.utils.padLeft(0, 40),
+      [],
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: keyPurchaser,
+      }
+    )
     ID = await locks['FIRST'].getTokenIdFor.call(keyPurchaser)
   })
 

--- a/smart-contracts/test/Lock/erc721/getTokenIdFor.js
+++ b/smart-contracts/test/Lock/erc721/getTokenIdFor.js
@@ -23,10 +23,16 @@ contract('Lock / erc721 / getTokenIdFor', accounts => {
   })
 
   it("should return the tokenId for the owner's key", async () => {
-    await locks['FIRST'].purchase(accounts[1], web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
-      from: accounts[1],
-    })
+    await locks['FIRST'].purchase(
+      0,
+      accounts[1],
+      web3.utils.padLeft(0, 40),
+      [],
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[1],
+      }
+    )
     let ID = new BigNumber(await locks['FIRST'].getTokenIdFor.call(accounts[1]))
     // Note that as we implement ERC721 support, the tokenId will no longer
     // be the same as the user's address

--- a/smart-contracts/test/Lock/erc721/ownerOf.js
+++ b/smart-contracts/test/Lock/erc721/ownerOf.js
@@ -19,10 +19,16 @@ contract('Lock / erc721 / ownerOf', accounts => {
   })
 
   it('should return the owner of the key', async () => {
-    await locks['FIRST'].purchase(accounts[1], web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
-      from: accounts[1],
-    })
+    await locks['FIRST'].purchase(
+      0,
+      accounts[1],
+      web3.utils.padLeft(0, 40),
+      [],
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+        from: accounts[1],
+      }
+    )
     let ID = await locks['FIRST'].getTokenIdFor.call(accounts[1])
     let address = await locks['FIRST'].ownerOf.call(ID)
     assert.equal(address, accounts[1])

--- a/smart-contracts/test/Lock/erc721/safeTransferFrom.js
+++ b/smart-contracts/test/Lock/erc721/safeTransferFrom.js
@@ -23,7 +23,7 @@ contract('Lock / erc721 / safeTransferFrom', accounts => {
 
   before(async () => {
     // first, let's purchase a brand new key that we can transfer
-    await lock.purchase(from, web3.utils.padLeft(0, 40), [], {
+    await lock.purchase(0, from, web3.utils.padLeft(0, 40), [], {
       value: Units.convert('0.01', 'eth', 'wei'),
       from,
     })
@@ -39,7 +39,7 @@ contract('Lock / erc721 / safeTransferFrom', accounts => {
   })
 
   it('should work if some data is passed in', async () => {
-    await lock.purchase(accounts[7], web3.utils.padLeft(0, 40), [], {
+    await lock.purchase(0, accounts[7], web3.utils.padLeft(0, 40), [], {
       value: Units.convert('0.01', 'eth', 'wei'),
       from: accounts[7],
     })
@@ -60,7 +60,7 @@ contract('Lock / erc721 / safeTransferFrom', accounts => {
   })
 
   it('should fail if trying to transfer a key to a contract which does not implement onERC721Received', async () => {
-    await lock.purchase(accounts[5], web3.utils.padLeft(0, 40), [], {
+    await lock.purchase(0, accounts[5], web3.utils.padLeft(0, 40), [], {
       value: Units.convert('0.01', 'eth', 'wei'),
       from: accounts[5],
     })

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -76,7 +76,7 @@ contract('Lock / erc721 / tokenURI', accounts => {
       })
       event = txObj.logs[0]
 
-      await lock.purchase(accounts[0], web3.utils.padLeft(0, 40), [], {
+      await lock.purchase(0, accounts[0], web3.utils.padLeft(0, 40), [], {
         value: Units.convert('0.01', 'eth', 'wei'),
       })
       const uri = await lock.tokenURI.call(1)

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -31,15 +31,22 @@ contract('Lock / erc721 / transferFrom', accounts => {
 
   before(() => {
     return Promise.all([
-      locks['FIRST'].purchase(accountWithKey, web3.utils.padLeft(0, 40), [], {
-        value: Units.convert('0.01', 'eth', 'wei'),
-        from: accountWithKey,
-      }),
-      locks['FIRST'].purchase(from, web3.utils.padLeft(0, 40), [], {
+      locks['FIRST'].purchase(
+        0,
+        accountWithKey,
+        web3.utils.padLeft(0, 40),
+        [],
+        {
+          value: Units.convert('0.01', 'eth', 'wei'),
+          from: accountWithKey,
+        }
+      ),
+      locks['FIRST'].purchase(0, from, web3.utils.padLeft(0, 40), [], {
         value: Units.convert('0.01', 'eth', 'wei'),
         from,
       }),
       locks['FIRST'].purchase(
+        0,
         accountWithExpiredKey,
         web3.utils.padLeft(0, 40),
         [],
@@ -49,6 +56,7 @@ contract('Lock / erc721 / transferFrom', accounts => {
         }
       ),
       locks['FIRST'].purchase(
+        0,
         accountWithKeyApproved,
         web3.utils.padLeft(0, 40),
         [],
@@ -100,7 +108,7 @@ contract('Lock / erc721 / transferFrom', accounts => {
       it('should transfer the key validity without extending it', async () => {
         // First let's make sure from has a key!
         let fromExpirationTimestamp, ID
-        await locks['FIRST'].purchase(from, web3.utils.padLeft(0, 40), [], {
+        await locks['FIRST'].purchase(0, from, web3.utils.padLeft(0, 40), [], {
           value: Units.convert('0.01', 'eth', 'wei'),
           from,
         })
@@ -132,7 +140,7 @@ contract('Lock / erc721 / transferFrom', accounts => {
       let previousExpirationTimestamp
 
       before(async () => {
-        await locks['FIRST'].purchase(from, web3.utils.padLeft(0, 40), [], {
+        await locks['FIRST'].purchase(0, from, web3.utils.padLeft(0, 40), [], {
           value: Units.convert('0.01', 'eth', 'wei'),
           from,
         })
@@ -226,7 +234,7 @@ contract('Lock / erc721 / transferFrom', accounts => {
     describe('when the key owner is the sender', () => {
       before(async () => {
         // first, let's purchase a brand new key that we can transfer
-        await locks['FIRST'].purchase(from, web3.utils.padLeft(0, 40), [], {
+        await locks['FIRST'].purchase(0, from, web3.utils.padLeft(0, 40), [], {
           value: Units.convert('0.01', 'eth', 'wei'),
           from,
         })
@@ -267,6 +275,7 @@ contract('Lock / erc721 / transferFrom', accounts => {
       before(async () => {
         // first we create a lock with only 1 key
         await locks['SINGLE KEY'].purchase(
+          0,
           from,
           web3.utils.padLeft(0, 40),
           [],
@@ -278,6 +287,7 @@ contract('Lock / erc721 / transferFrom', accounts => {
         // confirm that the lock is sold out
         await shouldFail(
           locks['SINGLE KEY'].purchase(
+            0,
             accounts[8],
             web3.utils.padLeft(0, 40),
             [],
@@ -303,9 +313,15 @@ contract('Lock / erc721 / transferFrom', accounts => {
   })
 
   it('can transfer a FREE key', async () => {
-    await locks['FREE'].purchase(accounts[1], web3.utils.padLeft(0, 40), [], {
-      from: accounts[1],
-    })
+    await locks['FREE'].purchase(
+      0,
+      accounts[1],
+      web3.utils.padLeft(0, 40),
+      [],
+      {
+        from: accounts[1],
+      }
+    )
     let ID = await locks['FREE'].getTokenIdFor.call(accounts[1])
     await locks['FREE'].transferFrom(accounts[1], accounts[2], ID, {
       from: accounts[1],

--- a/smart-contracts/test/Lock/expireKeyFor.js
+++ b/smart-contracts/test/Lock/expireKeyFor.js
@@ -33,10 +33,16 @@ contract('Lock / expireKeyFor', accounts => {
   })
 
   it('should fail if the key has already expired', async () => {
-    await locks['FIRST'].purchase(accounts[2], web3.utils.padLeft(0, 40), [], {
-      value: locks['FIRST'].params.keyPrice.toFixed(),
-      from: accounts[0],
-    })
+    await locks['FIRST'].purchase(
+      0,
+      accounts[2],
+      web3.utils.padLeft(0, 40),
+      [],
+      {
+        value: locks['FIRST'].params.keyPrice.toFixed(),
+        from: accounts[0],
+      }
+    )
     const expirationTimestamp = new BigNumber(
       await locks['FIRST'].keyExpirationTimestampFor.call(accounts[2])
     )
@@ -59,6 +65,7 @@ contract('Lock / expireKeyFor', accounts => {
 
     before(async () => {
       await locks['FIRST'].purchase(
+        0,
         accounts[1],
         web3.utils.padLeft(0, 40),
         [],

--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -18,7 +18,7 @@ contract('Lock / freeTrial', accounts => {
     locks = await deployLocks(unlock, accounts[0])
     lock = locks['SECOND']
     const purchases = keyOwners.map(account => {
-      return lock.purchase(account, web3.utils.padLeft(0, 40), [], {
+      return lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
         value: keyPrice.toFixed(),
         from: account,
       })

--- a/smart-contracts/test/Lock/fullRefund.js
+++ b/smart-contracts/test/Lock/fullRefund.js
@@ -24,7 +24,7 @@ contract('Lock / fullRefund', accounts => {
   before(async () => {
     lock = locks['SECOND']
     const purchases = keyOwners.map(account => {
-      return lock.purchase(account, web3.utils.padLeft(0, 40), [], {
+      return lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
         value: keyPrice.toFixed(),
         from: account,
       })

--- a/smart-contracts/test/Lock/gas.js
+++ b/smart-contracts/test/Lock/gas.js
@@ -16,9 +16,15 @@ contract('Lock / gas', accounts => {
   })
 
   it('gas used to purchaseFor is less than wallet service limit', async () => {
-    let tx = await lock.purchase(accounts[0], web3.utils.padLeft(0, 40), [], {
-      value: Units.convert('0.01', 'eth', 'wei'),
-    })
+    let tx = await lock.purchase(
+      0,
+      accounts[0],
+      web3.utils.padLeft(0, 40),
+      [],
+      {
+        value: Units.convert('0.01', 'eth', 'wei'),
+      }
+    )
     const gasUsed = new BigNumber(tx.receipt.gasUsed)
     if (!process.env.TEST_COVERAGE) {
       assert(gasUsed.lte(WalletService.gasAmountConstants().purchaseKey))

--- a/smart-contracts/test/Lock/getBalance.js
+++ b/smart-contracts/test/Lock/getBalance.js
@@ -35,7 +35,7 @@ contract('Lock / getBalance', accounts => {
         await testToken.approve(lock.address, '1000000000000000000', {
           from: accounts[2],
         })
-        await lock.purchase(accounts[2], web3.utils.padLeft(0, 40), [], {
+        await lock.purchase(0, accounts[2], web3.utils.padLeft(0, 40), [], {
           from: accounts[2],
           value: isErc20 ? 0 : keyPrice.toString(),
         })

--- a/smart-contracts/test/Lock/getBalance.js
+++ b/smart-contracts/test/Lock/getBalance.js
@@ -35,10 +35,16 @@ contract('Lock / getBalance', accounts => {
         await testToken.approve(lock.address, '1000000000000000000', {
           from: accounts[2],
         })
-        await lock.purchase(0, accounts[2], web3.utils.padLeft(0, 40), [], {
-          from: accounts[2],
-          value: isErc20 ? 0 : keyPrice.toString(),
-        })
+        await lock.purchase(
+          keyPrice,
+          accounts[2],
+          web3.utils.padLeft(0, 40),
+          [],
+          {
+            from: accounts[2],
+            value: isErc20 ? 0 : keyPrice.toString(),
+          }
+        )
       })
 
       it('get balance of contract', async () => {

--- a/smart-contracts/test/Lock/getHasValidKey.js
+++ b/smart-contracts/test/Lock/getHasValidKey.js
@@ -25,7 +25,7 @@ contract('Lock / getHasValidKey', accounts => {
 
   describe('after purchase', () => {
     before(async () => {
-      await lock.purchase(account, web3.utils.padLeft(0, 40), [], {
+      await lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
         value: Units.convert('0.01', 'eth', 'wei'),
       })
     })

--- a/smart-contracts/test/Lock/getOwnersByPage.js
+++ b/smart-contracts/test/Lock/getOwnersByPage.js
@@ -26,6 +26,7 @@ contract('Lock / getOwnersByPage', accounts => {
   describe('when there are less owners than the page size', () => {
     it('should return all of the key owners', async () => {
       await locks['FIRST'].purchase(
+        0,
         accounts[1],
         web3.utils.padLeft(0, 40),
         [],
@@ -44,6 +45,7 @@ contract('Lock / getOwnersByPage', accounts => {
   describe('when there are more owners than the page size', () => {
     it('return page size number of key owners', async () => {
       await locks['FIRST'].purchase(
+        0,
         accounts[1],
         web3.utils.padLeft(0, 40),
         [],
@@ -53,6 +55,7 @@ contract('Lock / getOwnersByPage', accounts => {
       )
 
       await locks['FIRST'].purchase(
+        0,
         accounts[2],
         web3.utils.padLeft(0, 40),
         [],
@@ -62,6 +65,7 @@ contract('Lock / getOwnersByPage', accounts => {
       )
 
       await locks['FIRST'].purchase(
+        0,
         accounts[3],
         web3.utils.padLeft(0, 40),
         [],
@@ -82,6 +86,7 @@ contract('Lock / getOwnersByPage', accounts => {
   describe('when requesting a secondary page', () => {
     it('return page size number of key owners', async () => {
       await locks['FIRST'].purchase(
+        0,
         accounts[1],
         web3.utils.padLeft(0, 40),
         [],
@@ -91,6 +96,7 @@ contract('Lock / getOwnersByPage', accounts => {
       )
 
       await locks['FIRST'].purchase(
+        0,
         accounts[2],
         web3.utils.padLeft(0, 40),
         [],
@@ -100,6 +106,7 @@ contract('Lock / getOwnersByPage', accounts => {
       )
 
       await locks['FIRST'].purchase(
+        0,
         accounts[3],
         web3.utils.padLeft(0, 40),
         [],

--- a/smart-contracts/test/Lock/onKeyCancelHook.js
+++ b/smart-contracts/test/Lock/onKeyCancelHook.js
@@ -18,7 +18,7 @@ contract('Lock / onKeyCancelHook', accounts => {
     testKeySoldHook = await testKeySoldHookContract.new()
     await lock.updateBeneficiary(testKeySoldHook.address)
     keyPrice = await lock.keyPrice()
-    await lock.purchase(to, web3.utils.padLeft(0, 40), [], {
+    await lock.purchase(0, to, web3.utils.padLeft(0, 40), [], {
       from,
       value: keyPrice,
     })

--- a/smart-contracts/test/Lock/onKeySoldHook.js
+++ b/smart-contracts/test/Lock/onKeySoldHook.js
@@ -19,7 +19,7 @@ contract('Lock / onKeySoldHook', accounts => {
     testKeySoldHook = await testKeySoldHookContract.new()
     await lock.updateBeneficiary(testKeySoldHook.address)
     keyPrice = await lock.keyPrice()
-    await lock.purchase(to, web3.utils.padLeft(0, 40), dataField, {
+    await lock.purchase(0, to, web3.utils.padLeft(0, 40), dataField, {
       from,
       value: keyPrice,
     })

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -20,19 +20,19 @@ contract('Lock / owners', accounts => {
   before(() => {
     // Purchase keys!
     return Promise.all([
-      lock.purchase(accounts[1], web3.utils.padLeft(0, 40), [], {
+      lock.purchase(0, accounts[1], web3.utils.padLeft(0, 40), [], {
         value: lock.params.keyPrice.toFixed(),
         from: accounts[0],
       }),
-      lock.purchase(accounts[2], web3.utils.padLeft(0, 40), [], {
+      lock.purchase(0, accounts[2], web3.utils.padLeft(0, 40), [], {
         value: lock.params.keyPrice.toFixed(),
         from: accounts[0],
       }),
-      lock.purchase(accounts[3], web3.utils.padLeft(0, 40), [], {
+      lock.purchase(0, accounts[3], web3.utils.padLeft(0, 40), [], {
         value: lock.params.keyPrice.toFixed(),
         from: accounts[0],
       }),
-      lock.purchase(accounts[4], web3.utils.padLeft(0, 40), [], {
+      lock.purchase(0, accounts[4], web3.utils.padLeft(0, 40), [], {
         value: lock.params.keyPrice.toFixed(),
         from: accounts[0],
       }),

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -18,7 +18,7 @@ contract('Lock / purchaseFor', accounts => {
   describe('when the contract has a public key release', () => {
     it('should fail if the price is not enough', async () => {
       await shouldFail(
-        locks['FIRST'].purchase(accounts[0], web3.utils.padLeft(0, 40), [], {
+        locks['FIRST'].purchase(0, accounts[0], web3.utils.padLeft(0, 40), [], {
           value: Units.convert('0.0001', 'eth', 'wei'),
         }),
         'NOT_ENOUGH_FUNDS'
@@ -32,6 +32,7 @@ contract('Lock / purchaseFor', accounts => {
 
     it('should fail if we reached the max number of keys', async () => {
       await locks['SINGLE KEY'].purchase(
+        0,
         accounts[0],
         web3.utils.padLeft(0, 40),
         [],
@@ -41,6 +42,7 @@ contract('Lock / purchaseFor', accounts => {
       )
       await shouldFail(
         locks['SINGLE KEY'].purchase(
+          0,
           accounts[1],
           web3.utils.padLeft(0, 40),
           [],
@@ -55,6 +57,7 @@ contract('Lock / purchaseFor', accounts => {
 
     it('should trigger an event when successful', async () => {
       const tx = await locks['FIRST'].purchase(
+        0,
         accounts[2],
         web3.utils.padLeft(0, 40),
         [],
@@ -70,6 +73,7 @@ contract('Lock / purchaseFor', accounts => {
     describe('when the user already owns an expired key', () => {
       it('should expand the validity by the default key duration', async () => {
         await locks['SECOND'].purchase(
+          0,
           accounts[4],
           web3.utils.padLeft(0, 40),
           [],
@@ -81,6 +85,7 @@ contract('Lock / purchaseFor', accounts => {
         await locks['SECOND'].expireKeyFor(accounts[4])
         // Purchase a new one
         await locks['SECOND'].purchase(
+          0,
           accounts[4],
           web3.utils.padLeft(0, 40),
           [],
@@ -110,6 +115,7 @@ contract('Lock / purchaseFor', accounts => {
     describe('when the user already owns a non expired key', () => {
       it('should expand the validity by the default key duration', async () => {
         await locks['FIRST'].purchase(
+          0,
           accounts[1],
           web3.utils.padLeft(0, 40),
           [],
@@ -122,6 +128,7 @@ contract('Lock / purchaseFor', accounts => {
         )
         assert(firstExpiration.gt(0))
         await locks['FIRST'].purchase(
+          0,
           accounts[1],
           web3.utils.padLeft(0, 40),
           [],
@@ -154,6 +161,7 @@ contract('Lock / purchaseFor', accounts => {
           await locks['FIRST'].numberOfOwners.call()
         )
         return locks['FIRST'].purchase(
+          0,
           accounts[0],
           web3.utils.padLeft(0, 40),
           [],
@@ -203,6 +211,7 @@ contract('Lock / purchaseFor', accounts => {
 
     it('can purchase a free key', async () => {
       const tx = await locks['FREE'].purchase(
+        0,
         accounts[2],
         web3.utils.padLeft(0, 40),
         []
@@ -215,6 +224,7 @@ contract('Lock / purchaseFor', accounts => {
     describe('can re-purchase an expired key', () => {
       before(async () => {
         await locks['SHORT'].purchase(
+          0,
           accounts[4],
           web3.utils.padLeft(0, 40),
           [],
@@ -231,6 +241,7 @@ contract('Lock / purchaseFor', accounts => {
       it('should expand the validity by the default key duration', async () => {
         // Purchase a new one
         await locks['SHORT'].purchase(
+          0,
           accounts[4],
           web3.utils.padLeft(0, 40),
           [],

--- a/smart-contracts/test/Lock/purchaseForFrom.js
+++ b/smart-contracts/test/Lock/purchaseForFrom.js
@@ -19,7 +19,7 @@ contract('Lock / purchaseForFrom', accounts => {
       // TODO this now falls back to no referral, but allow the purchase
       const lock = locks['FIRST']
       await shouldFail(
-        lock.purchase(accounts[0], accounts[1], []),
+        lock.purchase(0, accounts[0], accounts[1], []),
         'KEY_NOT_VALID'
       )
       // Making sure we do not have a key set!
@@ -34,19 +34,24 @@ contract('Lock / purchaseForFrom', accounts => {
     it('should succeed', () => {
       const lock = locks['FIRST']
       return lock
-        .purchase(accounts[0], web3.utils.padLeft(0, 40), [], {
+        .purchase(0, accounts[0], web3.utils.padLeft(0, 40), [], {
           value: Units.convert('0.01', 'eth', 'wei'),
         })
         .then(() => {
-          return lock.purchase(accounts[1], accounts[0], [], {
+          return lock.purchase(0, accounts[1], accounts[0], [], {
             value: Units.convert('0.01', 'eth', 'wei'),
           })
         })
     })
 
     it('can purchaseForFrom a free key', async () => {
-      await locks['FREE'].purchase(accounts[0], web3.utils.padLeft(0, 40), [])
-      const tx = await locks['FREE'].purchase(accounts[2], accounts[0], [])
+      await locks['FREE'].purchase(
+        0,
+        accounts[0],
+        web3.utils.padLeft(0, 40),
+        []
+      )
+      const tx = await locks['FREE'].purchase(0, accounts[2], accounts[0], [])
       assert.equal(tx.logs[0].event, 'Transfer')
       assert.equal(tx.logs[0].args._from, 0)
       assert.equal(tx.logs[0].args._to, accounts[2])

--- a/smart-contracts/test/Lock/purchaseTip.js
+++ b/smart-contracts/test/Lock/purchaseTip.js
@@ -1,0 +1,135 @@
+const Units = require('ethereumjs-units')
+const Web3Utils = require('web3-utils')
+const truffleAssert = require('truffle-assertions')
+const BigNumber = require('bignumber.js')
+const deployLocks = require('../helpers/deployLocks')
+
+const TestErc20Token = artifacts.require('TestErc20Token.sol')
+
+const unlockContract = artifacts.require('Unlock.sol')
+const getProxy = require('../helpers/proxy')
+
+const scenarios = [false, true]
+let unlock, locks, testToken
+const keyPrice = Units.convert('0.01', 'eth', 'wei')
+const tip = new BigNumber(keyPrice).plus(Units.convert('1', 'eth', 'wei'))
+
+contract('Lock / purchaseTip', accounts => {
+  scenarios.forEach(isErc20 => {
+    let lock
+    let tokenAddress
+
+    describe(`Test ${isErc20 ? 'ERC20' : 'ETH'}`, () => {
+      beforeEach(async () => {
+        testToken = await TestErc20Token.new()
+        // Mint some tokens for testing
+        await testToken.mint(accounts[2], '100000000000000000000')
+
+        tokenAddress = isErc20 ? testToken.address : Web3Utils.padLeft(0, 40)
+
+        unlock = await getProxy(unlockContract)
+        locks = await deployLocks(unlock, accounts[0], tokenAddress)
+        lock = locks['FIRST']
+
+        // Approve spending
+        await testToken.approve(lock.address, -1, {
+          from: accounts[2],
+        })
+      })
+
+      describe('purchase with exact value specified', () => {
+        beforeEach(async () => {
+          await lock.purchase(
+            keyPrice.toString(),
+            accounts[2],
+            web3.utils.padLeft(0, 40),
+            [],
+            {
+              from: accounts[2],
+              value: isErc20 ? 0 : keyPrice.toString(),
+            }
+          )
+        })
+
+        it('user sent keyPrice to the contract', async () => {
+          const balance = await lock.getBalance(tokenAddress, lock.address)
+          assert.equal(balance.toString(), keyPrice.toString())
+        })
+      })
+
+      describe('purchase with tip', () => {
+        beforeEach(async () => {
+          await lock.purchase(
+            tip.toString(),
+            accounts[2],
+            web3.utils.padLeft(0, 40),
+            [],
+            {
+              from: accounts[2],
+              value: isErc20 ? 0 : tip.toString(),
+            }
+          )
+        })
+
+        it('user sent the tip to the contract', async () => {
+          const balance = await lock.getBalance(tokenAddress, lock.address)
+          assert.notEqual(balance.toString(), keyPrice.toString())
+          assert.equal(balance.toString(), tip.toString())
+        })
+      })
+
+      describe('purchase with ETH tip > value specified', () => {
+        beforeEach(async () => {
+          await lock.purchase(
+            keyPrice.toString(),
+            accounts[2],
+            web3.utils.padLeft(0, 40),
+            [],
+            {
+              from: accounts[2],
+              value: isErc20 ? 0 : tip.toString(),
+            }
+          )
+        })
+
+        it('user sent tip to the contract if ETH (else send keyPrice)', async () => {
+          const balance = await lock.getBalance(tokenAddress, lock.address)
+          if (!isErc20) {
+            assert.equal(balance.toString(), tip.toString())
+          } else {
+            assert.equal(balance.toString(), keyPrice.toString())
+          }
+        })
+      })
+
+      describe('purchase with unspecified ETH tip', () => {
+        beforeEach(async () => {
+          await lock.purchase(0, accounts[2], web3.utils.padLeft(0, 40), [], {
+            from: accounts[2],
+            value: isErc20 ? 0 : tip.toString(),
+          })
+        })
+
+        it('user sent tip to the contract if ETH (else send keyPrice)', async () => {
+          const balance = await lock.getBalance(tokenAddress, lock.address)
+          if (!isErc20) {
+            assert.equal(balance.toString(), tip.toString())
+          } else {
+            assert.equal(balance.toString(), keyPrice.toString())
+          }
+        })
+      })
+
+      it('should fail if value is less than keyPrice', async () => {
+        await truffleAssert.fails(
+          lock.purchase(1, accounts[2], web3.utils.padLeft(0, 40), [], {
+            from: accounts[2],
+            value: isErc20 ? 0 : keyPrice.toString(),
+          }),
+          'revert',
+          'INSUFFICIENT_VALUE'
+        )
+      })
+    })
+  })
+})

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -19,7 +19,7 @@ contract('Lock / transferFee', accounts => {
     // TODO test using an ERC20 priced lock as well
     locks = await deployLocks(unlock, accounts[0])
     lock = locks['FIRST']
-    await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
+    await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
       value: keyPrice.toFixed(),
     })
   })

--- a/smart-contracts/test/Lock/withdraw.js
+++ b/smart-contracts/test/Lock/withdraw.js
@@ -163,7 +163,7 @@ contract('Lock / withdraw', accounts => {
 
 async function purchaseKeys(accounts) {
   const purchases = [accounts[1], accounts[2]].map(account => {
-    return lock.purchase(account, web3.utils.padLeft(0, 40), [], {
+    return lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
       value: price,
       from: account,
     })

--- a/smart-contracts/test/Unlock/lockTotalSales.js
+++ b/smart-contracts/test/Unlock/lockTotalSales.js
@@ -27,7 +27,7 @@ contract('Unlock / lockTotalSales', accounts => {
 
   describe('buy 1 key', () => {
     before(async () => {
-      await lock.purchase(accounts[0], web3.utils.padLeft(0, 40), [], {
+      await lock.purchase(0, accounts[0], web3.utils.padLeft(0, 40), [], {
         value: price,
         from: accounts[0],
       })
@@ -44,7 +44,7 @@ contract('Unlock / lockTotalSales', accounts => {
   describe('buy multiple keys', () => {
     before(async () => {
       for (let i = 1; i < 5; i++) {
-        await lock.purchase(accounts[i], web3.utils.padLeft(0, 40), [], {
+        await lock.purchase(0, accounts[i], web3.utils.padLeft(0, 40), [], {
           value: price,
           from: accounts[i],
         })

--- a/smart-contracts/test/Unlock/uniswapValue.js
+++ b/smart-contracts/test/Unlock/uniswapValue.js
@@ -1,3 +1,4 @@
+const Units = require('ethereumjs-units')
 const BigNumber = require('bignumber.js')
 
 const { protocols } = require('hardlydifficult-test-helpers')
@@ -7,6 +8,8 @@ const TestErc20Token = artifacts.require('TestErc20Token.sol')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const getProxy = require('../helpers/proxy')
+
+const keyPrice = Units.convert('0.01', 'eth', 'wei')
 
 let unlock, locks, lock, token, exchange
 
@@ -70,7 +73,7 @@ contract('Unlock / uniswapValue', accounts => {
         await token.mint(keyOwner, price, { from: accounts[0] })
         await token.approve(lock.address, -1, { from: keyOwner })
 
-        await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
+        await lock.purchase(keyPrice, keyOwner, web3.utils.padLeft(0, 40), [], {
           from: keyOwner,
         })
       })
@@ -102,7 +105,7 @@ contract('Unlock / uniswapValue', accounts => {
         await token.mint(keyOwner, price, { from: accounts[0] })
         await token.approve(lock.address, -1, { from: keyOwner })
 
-        await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
+        await lock.purchase(keyPrice, keyOwner, web3.utils.padLeft(0, 40), [], {
           from: keyOwner,
         })
       })
@@ -127,7 +130,7 @@ contract('Unlock / uniswapValue', accounts => {
       beforeEach(async () => {
         gdpBefore = new BigNumber(await unlock.grossNetworkProduct())
 
-        await lock.purchase(keyOwner, web3.utils.padLeft(0, 40), [], {
+        await lock.purchase(keyPrice, keyOwner, web3.utils.padLeft(0, 40), [], {
           from: keyOwner,
           value: price,
         })

--- a/smart-contracts/test/Unlock/upgrades/v0ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v0ToLatest.js
@@ -181,7 +181,7 @@ contract('Unlock / upgrades v0', accounts => {
 
         // Buy Key
         await lockLatest.methods
-          .purchase(keyOwner, web3.utils.padLeft(0, 40), [])
+          .purchase(0, keyOwner, web3.utils.padLeft(0, 40), [])
           .send({
             value: keyPrice,
             from: keyOwner,

--- a/smart-contracts/test/Unlock/upgrades/v1ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v1ToLatest.js
@@ -174,7 +174,7 @@ contract('Unlock / upgrades', accounts => {
 
         // Buy Key
         await lockLatest.methods
-          .purchase(keyOwner, web3.utils.padLeft(0, 40), [])
+          .purchase(0, keyOwner, web3.utils.padLeft(0, 40), [])
           .send({
             value: keyPrice,
             from: keyOwner,

--- a/smart-contracts/test/Unlock/upgrades/v2ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v2ToLatest.js
@@ -174,7 +174,7 @@ contract('Unlock / upgrades', accounts => {
 
         // Buy Key
         await lockLatest.methods
-          .purchase(keyOwner, web3.utils.padLeft(0, 40), [])
+          .purchase(0, keyOwner, web3.utils.padLeft(0, 40), [])
           .send({
             value: keyPrice,
             from: keyOwner,

--- a/smart-contracts/test/Unlock/upgrades/v3ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v3ToLatest.js
@@ -175,7 +175,7 @@ contract('Unlock / upgrades', accounts => {
 
         // Buy Key
         await lockLatest.methods
-          .purchase(keyOwner, web3.utils.padLeft(0, 40), [])
+          .purchase(0, keyOwner, web3.utils.padLeft(0, 40), [])
           .send({
             value: keyPrice,
             from: keyOwner,

--- a/smart-contracts/test/Unlock/upgrades/v4ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v4ToLatest.js
@@ -175,7 +175,7 @@ contract('Unlock / upgrades', accounts => {
 
         // Buy Key
         await lockLatest.methods
-          .purchase(keyOwner, web3.utils.padLeft(0, 40), [])
+          .purchase(0, keyOwner, web3.utils.padLeft(0, 40), [])
           .send({
             value: keyPrice,
             from: keyOwner,

--- a/smart-contracts/test/Unlock/upgrades/v5ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v5ToLatest.js
@@ -181,7 +181,7 @@ contract('Unlock / upgrades', accounts => {
 
         // Buy Key
         await lockLatest.methods
-          .purchase(keyOwner, web3.utils.padLeft(0, 40), [])
+          .purchase(0, keyOwner, web3.utils.padLeft(0, 40), [])
           .send({
             value: keyPrice,
             from: keyOwner,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Allows users to specify the value to pay when purchasing a key.  That value may be `>= keyPrice` in order to send a tip.  If set to 0, it's ignored and the current keyPrice is used.  

The front-end / JS implementation should always specify a value when using ERC-20 tokens.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4518
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
