### PR TITLE
Deploy PublicLock using a minimal proxy

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -99,6 +99,8 @@ contract Unlock is
     string memory _lockName
   ) public
   {
+    require(publicLockAddress != address(0), 'MISSING_LOCK_TEMPLATE');
+
     // create lock
     address newLock = createClone(publicLockAddress);
     PublicLock(newLock).initialize(

--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -69,10 +69,11 @@ contract Unlock is
   // Used by locks where the owner has not set a custom base URI.
   string public globalBaseTokenURI;
 
-   // global base token symbol
+  // global base token symbol
   // Used by locks where the owner has not set a custom symbol
   string public globalTokenSymbol;
 
+  // The address of the public lock template, used when `createLock` is called
   address public publicLockAddress;
 
   // Use initialize instead of a constructor to support proxies (for upgradeability via zos).

--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -30,6 +30,7 @@ import '@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol
 import '@openzeppelin/upgrades/contracts/Initializable.sol';
 import './PublicLock.sol';
 import './interfaces/IUnlock.sol';
+import './mixins/CloneFactory.sol';
 
 
 /// @dev Must list the direct base contracts in the order from “most base-like” to “most derived”.
@@ -37,7 +38,8 @@ import './interfaces/IUnlock.sol';
 contract Unlock is
   IUnlock,
   Initializable,
-  Ownable
+  Ownable,
+  CloneFactory
 {
   /**
    * The struct for a lock
@@ -71,6 +73,8 @@ contract Unlock is
   // Used by locks where the owner has not set a custom symbol
   string public globalTokenSymbol;
 
+  address public publicLockAddress;
+
   // Use initialize instead of a constructor to support proxies (for upgradeability via zos).
   function initialize(
     address _owner
@@ -96,7 +100,7 @@ contract Unlock is
   ) public
   {
     // create lock
-    address newLock = address(new PublicLock());
+    address newLock = createClone(publicLockAddress);
     PublicLock(newLock).initialize(
       msg.sender,
       _expirationDuration,
@@ -184,13 +188,16 @@ contract Unlock is
 
   // function for the owner to update configuration variables
   function configUnlock(
+    address _publicLockAddress,
     string calldata _symbol,
     string calldata _URI
   ) external
     onlyOwner
   {
+    publicLockAddress = _publicLockAddress;
     globalTokenSymbol = _symbol;
     globalBaseTokenURI = _URI;
-    emit ConfigUnlock(_symbol, _URI);
+
+    emit ConfigUnlock(_publicLockAddress, _symbol, _URI);
   }
 }

--- a/smart-contracts/contracts/interfaces/IUnlock.sol
+++ b/smart-contracts/contracts/interfaces/IUnlock.sol
@@ -16,6 +16,7 @@ interface IUnlock {
   );
 
   event ConfigUnlock(
+    address publicLockAddress,
     string globalTokenSymbol,
     string globalTokenURI
   );

--- a/smart-contracts/contracts/interfaces/IUnlock.sol
+++ b/smart-contracts/contracts/interfaces/IUnlock.sol
@@ -92,6 +92,7 @@ interface IUnlock {
    *  Should throw if called by other than owner.
    */
   function configUnlock(
+    address _publicLockAddress,
     string calldata _symbol,
     string calldata _URI
   )

--- a/smart-contracts/contracts/mixins/CloneFactory.sol
+++ b/smart-contracts/contracts/mixins/CloneFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.10;
+pragma solidity 0.5.11;
 
 // From https://github.com/optionality/clone-factory/blob/master/contracts/CloneFactory.sol
 // Updated to support Solidity 5
@@ -6,6 +6,7 @@ pragma solidity 0.5.10;
 contract CloneFactory {
   function createClone(address target) internal returns (address result) {
     bytes20 targetBytes = bytes20(target);
+    // solium-disable-next-line
     assembly {
       let clone := mload(0x40)
       mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)

--- a/smart-contracts/contracts/mixins/CloneFactory.sol
+++ b/smart-contracts/contracts/mixins/CloneFactory.sol
@@ -1,0 +1,17 @@
+pragma solidity 0.5.10;
+
+// From https://github.com/optionality/clone-factory/blob/master/contracts/CloneFactory.sol
+// Updated to support Solidity 5
+
+contract CloneFactory {
+  function createClone(address target) internal returns (address result) {
+    bytes20 targetBytes = bytes20(target);
+    assembly {
+      let clone := mload(0x40)
+      mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+      mstore(add(clone, 0x14), targetBytes)
+      mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+      result := create(0, clone, 0x37)
+    }
+  }
+}

--- a/smart-contracts/migrations/3_create_proxy.js
+++ b/smart-contracts/migrations/3_create_proxy.js
@@ -22,7 +22,7 @@ async function deploy(options, accounts) {
 
   // Deploy lock template
   const lockTemplate = await PublicLock.new()
-  let tx = await unlockContract.methods.configUnlock(
+  await unlockContract.methods.configUnlock(
     lockTemplate.address,
     '',
     ''

--- a/smart-contracts/migrations/3_create_proxy.js
+++ b/smart-contracts/migrations/3_create_proxy.js
@@ -2,13 +2,14 @@
 const { scripts, ConfigManager } = require('@openzeppelin/cli')
 
 const { create } = scripts
+const PublicLock = artifacts.require('PublicLock')
 
 async function deploy(options, accounts) {
   // default account used by ganache
   const unlockOwner = accounts[0]
 
   // Create an instance of MyContract
-  await create(
+  const unlockContract = await create(
     Object.assign(
       {
         contractAlias: 'Unlock',
@@ -18,6 +19,14 @@ async function deploy(options, accounts) {
       options
     )
   )
+
+  // Deploy lock template
+  const lockTemplate = await PublicLock.new()
+  let tx = await unlockContract.methods.configUnlock(
+    lockTemplate.address,
+    '',
+    ''
+  ).send({ from: unlockOwner })
 }
 
 module.exports = function(deployer, networkName, accounts) {

--- a/smart-contracts/test/Lock/erc721/tokenSymbol.js
+++ b/smart-contracts/test/Lock/erc721/tokenSymbol.js
@@ -21,6 +21,7 @@ contract('Lock / erc721 / tokenSymbol', accounts => {
 
     it('should allow the owner to set the global token Symbol', async () => {
       txObj = await unlock.configUnlock(
+        await unlock.publicLockAddress(),
         'KEY',
         await unlock.globalBaseTokenURI(),
         {
@@ -33,9 +34,13 @@ contract('Lock / erc721 / tokenSymbol', accounts => {
 
     it('should fail if someone other than the owner tries to set the symbol', async () => {
       await shouldFail(
-        unlock.configUnlock('BTC', await unlock.globalBaseTokenURI(), {
-          from: accounts[1],
-        })
+        unlock.configUnlock(
+          await unlock.publicLockAddress(),
+          'BTC', 
+          await unlock.globalBaseTokenURI(), {
+            from: accounts[1],
+          }
+        )
       )
     })
 

--- a/smart-contracts/test/Lock/erc721/tokenSymbol.js
+++ b/smart-contracts/test/Lock/erc721/tokenSymbol.js
@@ -36,8 +36,9 @@ contract('Lock / erc721 / tokenSymbol', accounts => {
       await shouldFail(
         unlock.configUnlock(
           await unlock.publicLockAddress(),
-          'BTC', 
-          await unlock.globalBaseTokenURI(), {
+          'BTC',
+          await unlock.globalBaseTokenURI(),
+          {
             from: accounts[1],
           }
         )

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -54,8 +54,8 @@ contract('Lock / erc721 / tokenURI', accounts => {
     it('should fail if someone other than the owner tries to set the URI', async () => {
       await shouldFail(
         unlock.configUnlock(
-        await unlock.publicLockAddress(),
-        await unlock.globalTokenSymbol(),
+          await unlock.publicLockAddress(),
+          await unlock.globalTokenSymbol(),
           'https://fakeURI.com',
           {
             from: accounts[1],

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -37,6 +37,7 @@ contract('Lock / erc721 / tokenURI', accounts => {
 
     it('should allow the owner to set the global base token URI', async () => {
       txObj = await unlock.configUnlock(
+        await unlock.publicLockAddress(),
         await unlock.globalTokenSymbol(),
         'https://newTokenURI.com/api/key',
         {
@@ -53,7 +54,8 @@ contract('Lock / erc721 / tokenURI', accounts => {
     it('should fail if someone other than the owner tries to set the URI', async () => {
       await shouldFail(
         unlock.configUnlock(
-          await unlock.globalTokenSymbol(),
+        await unlock.publicLockAddress(),
+        await unlock.globalTokenSymbol(),
           'https://fakeURI.com',
           {
             from: accounts[1],

--- a/smart-contracts/test/Lock/grantKeys.js
+++ b/smart-contracts/test/Lock/grantKeys.js
@@ -1,5 +1,6 @@
 const Web3Utils = require('web3-utils')
 
+const truffleAssert = require('truffle-assertions')
 const deployLocks = require('../helpers/deployLocks')
 const shouldFail = require('../helpers/shouldFail')
 
@@ -70,7 +71,7 @@ contract('Lock / grantKeys', accounts => {
       const keyOwnerList = [accounts[3], accounts[4], accounts[5]]
 
       it('should fail to grant keys when expiration dates are missing', async () => {
-        await shouldFail(
+        await truffleAssert.fails(
           lock.grantKeys(keyOwnerList, [validExpirationTimestamp], {
             from: lockOwner,
           }),

--- a/smart-contracts/test/Lock/grantKeys.js
+++ b/smart-contracts/test/Lock/grantKeys.js
@@ -74,7 +74,7 @@ contract('Lock / grantKeys', accounts => {
           lock.grantKeys(keyOwnerList, [validExpirationTimestamp], {
             from: lockOwner,
           }),
-          'invalid opcode'
+          'revert'
         )
       })
     })

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -1,5 +1,6 @@
 const BigNumber = require('bignumber.js')
 
+const truffleAssert = require('truffle-assertions')
 const deployLocks = require('../helpers/deployLocks')
 const shouldFail = require('../helpers/shouldFail')
 
@@ -60,7 +61,7 @@ contract('Lock / owners', accounts => {
   })
 
   it('should fail to access to an individual key owner when out of bounds', async () => {
-    await shouldFail(lock.owners.call(6), 'revert')
+    await truffleAssert.fails(lock.owners.call(6), 'revert')
   })
 
   describe('after a transfer to a new address', () => {

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -60,7 +60,7 @@ contract('Lock / owners', accounts => {
   })
 
   it('should fail to access to an individual key owner when out of bounds', async () => {
-    await shouldFail(lock.owners.call(6), 'invalid opcode')
+    await shouldFail(lock.owners.call(6), 'revert')
   })
 
   describe('after a transfer to a new address', () => {

--- a/smart-contracts/test/Unlock/UnlockProxy.js
+++ b/smart-contracts/test/Unlock/UnlockProxy.js
@@ -6,6 +6,7 @@ const shared = require('./behaviors/shared')
 
 ZWeb3.initialize(web3.currentProvider)
 const Unlock = Contracts.getFromLocal('Unlock')
+const PublicLock = artifacts.require('PublicLock')
 
 contract('Unlock / UnlockProxy', function(accounts) {
   const proxyAdmin = accounts[1]
@@ -20,6 +21,16 @@ contract('Unlock / UnlockProxy', function(accounts) {
       initArgs: [unlockOwner],
     })
     this.unlock = await Unlock.at(this.proxy.address)
+    const lock = await PublicLock.new()
+    await this.unlock.methods
+      .configUnlock(
+        lock.address,
+        await this.unlock.methods.globalTokenSymbol().call(),
+        await this.unlock.methods.globalBaseTokenURI().call()
+      )
+      .send({
+        from: unlockOwner,
+      })
   })
 
   describe('should function as a proxy', function() {

--- a/smart-contracts/test/Unlock/upgrades/v0ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v0ToLatest.js
@@ -77,8 +77,21 @@ contract('Unlock / upgrades', accounts => {
 
   describe('latest', () => {
     before(async () => {
-      project.upgradeProxy(proxy.address, UnlockLatest)
-      unlock = UnlockLatest.at(proxy.address)
+      await project.upgradeProxy(proxy.address, UnlockLatest)
+      unlock = await UnlockLatest.at(proxy.address)
+      const lock = await PublicLockLatest.new({
+        from: unlockOwner,
+        gas: 6700000,
+      })
+      await unlock.methods
+        .configUnlock(
+          lock.address,
+          await unlock.methods.globalTokenSymbol().call(),
+          await unlock.methods.globalBaseTokenURI().call()
+        )
+        .send({
+          from: unlockOwner,
+        })
     })
 
     describe('Lock created with UnlockV0 is still available', () => {

--- a/smart-contracts/test/Unlock/upgrades/v1ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v1ToLatest.js
@@ -79,8 +79,21 @@ contract('Unlock / upgrades', accounts => {
 
   describe('latest', () => {
     before(async () => {
-      project.upgradeProxy(proxy.address, UnlockLatest)
-      unlock = UnlockLatest.at(proxy.address)
+      await project.upgradeProxy(proxy.address, UnlockLatest)
+      unlock = await UnlockLatest.at(proxy.address)
+      const lock = await PublicLockLatest.new({
+        from: unlockOwner,
+        gas: 6700000,
+      })
+      await unlock.methods
+        .configUnlock(
+          lock.address,
+          await unlock.methods.globalTokenSymbol().call(),
+          await unlock.methods.globalBaseTokenURI().call()
+        )
+        .send({
+          from: unlockOwner,
+        })
     })
 
     describe('Lock created with UnlockV1 is still available', () => {

--- a/smart-contracts/test/Unlock/upgrades/v2ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v2ToLatest.js
@@ -79,8 +79,21 @@ contract('Unlock / upgrades', accounts => {
 
   describe('latest', () => {
     before(async () => {
-      project.upgradeProxy(proxy.address, UnlockLatest)
-      unlock = UnlockLatest.at(proxy.address)
+      await project.upgradeProxy(proxy.address, UnlockLatest)
+      unlock = await UnlockLatest.at(proxy.address)
+      const lock = await PublicLockLatest.new({
+        from: unlockOwner,
+        gas: 6700000,
+      })
+      await unlock.methods
+        .configUnlock(
+          lock.address,
+          await unlock.methods.globalTokenSymbol().call(),
+          await unlock.methods.globalBaseTokenURI().call()
+        )
+        .send({
+          from: unlockOwner,
+        })
     })
 
     describe('Lock created with UnlockV2 is still available', () => {

--- a/smart-contracts/test/Unlock/upgrades/v3ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v3ToLatest.js
@@ -80,8 +80,21 @@ contract('Unlock / upgrades', accounts => {
 
   describe('latest', () => {
     before(async () => {
-      project.upgradeProxy(proxy.address, UnlockLatest)
-      unlock = UnlockLatest.at(proxy.address)
+      await project.upgradeProxy(proxy.address, UnlockLatest)
+      unlock = await UnlockLatest.at(proxy.address)
+      const lock = await PublicLockLatest.new({
+        from: unlockOwner,
+        gas: 6700000,
+      })
+      await unlock.methods
+        .configUnlock(
+          lock.address,
+          await unlock.methods.globalTokenSymbol().call(),
+          await unlock.methods.globalBaseTokenURI().call()
+        )
+        .send({
+          from: unlockOwner,
+        })
     })
 
     describe('Lock created with UnlockV3 is still available', () => {

--- a/smart-contracts/test/Unlock/upgrades/v4ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v4ToLatest.js
@@ -80,8 +80,21 @@ contract('Unlock / upgrades', accounts => {
 
   describe('latest', () => {
     before(async () => {
-      project.upgradeProxy(proxy.address, UnlockLatest)
-      unlock = UnlockLatest.at(proxy.address)
+      await project.upgradeProxy(proxy.address, UnlockLatest)
+      unlock = await UnlockLatest.at(proxy.address)
+      const lock = await PublicLockLatest.new({
+        from: unlockOwner,
+        gas: 6700000,
+      })
+      await unlock.methods
+        .configUnlock(
+          lock.address,
+          await unlock.methods.globalTokenSymbol().call(),
+          await unlock.methods.globalBaseTokenURI().call()
+        )
+        .send({
+          from: unlockOwner,
+        })
     })
 
     describe('Lock created with UnlockV4 is still available', () => {

--- a/smart-contracts/test/Unlock/upgrades/v5ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v5ToLatest.js
@@ -82,8 +82,21 @@ contract('Unlock / upgrades', accounts => {
 
   describe('latest', () => {
     before(async () => {
-      project.upgradeProxy(proxy.address, UnlockLatest)
-      unlock = UnlockLatest.at(proxy.address)
+      await project.upgradeProxy(proxy.address, UnlockLatest)
+      unlock = await UnlockLatest.at(proxy.address)
+      const lock = await PublicLockLatest.new({
+        from: unlockOwner,
+        gas: 6700000,
+      })
+      await unlock.methods
+        .configUnlock(
+          lock.address,
+          await unlock.methods.globalTokenSymbol().call(),
+          await unlock.methods.globalBaseTokenURI().call()
+        )
+        .send({
+          from: unlockOwner,
+        })
     })
 
     describe('Lock created with UnlockV5 is still available', () => {

--- a/smart-contracts/test/helpers/deployLocks.js
+++ b/smart-contracts/test/helpers/deployLocks.js
@@ -38,7 +38,7 @@ module.exports = function deployLocks(
       } else {
         const tx = await createCall
         // THIS API IS LIKELY TO BREAK BECAUSE IT ASSUMES SO MUCH
-        const evt = tx.logs[1]
+        const evt = tx.logs.find(v => v.event === 'NewLock')
         locks[name] = await PublicLock.at(evt.args.newLockAddress)
         locks[name].params = Locks[name]
       }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Deploys a proxy on `createLock` instead of the full contract each time.  This is a significant gas savings for `createLock` and for deploying `Unlock.sol`

Nothing is free though:

```
Before:
purchase 23128  ·     243420  ·     164059 
After:
purchase 23128  ·     244273  ·     164586
```
Which is an additional 527 gas for the worst case column, or a 0.32% increase.

!! It's important to note that we must add this to the upgrade process / checklist.  Call `configUnlock` with the address of the latest PublicLock template. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4708
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
