### PR TITLE
WIP: Initial AccountApprovals implementation

### DIFF
--- a/smart-contracts/contracts/AccountApprovals.sol
+++ b/smart-contracts/contracts/AccountApprovals.sol
@@ -8,7 +8,7 @@ contract AccountApprovals is
 {
   mapping(address => bytes) public accountData;
 
-  event Approve(address operator, address account, bytes data);
+  event Approve(address indexed operator, address indexed account, bytes data);
 
   function approve(
     address _account,

--- a/smart-contracts/contracts/AccountApprovals.sol
+++ b/smart-contracts/contracts/AccountApprovals.sol
@@ -1,0 +1,22 @@
+pragma solidity 0.5.11;
+
+import 'openzeppelin-eth/contracts/access/roles/WhitelistedRole.sol';
+
+
+contract AccountApprovals is
+  WhitelistedRole
+{
+  mapping(address => bytes) accountData;
+
+  event Approve(address operator, address account, bytes data);
+
+  function approve(
+    address _account,
+    bytes calldata _data
+  ) external
+    onlyWhitelisted
+  {
+    accountData[_account] = _data;
+    emit Approve(msg.sender, _account, _data);
+  }
+}

--- a/smart-contracts/contracts/AccountApprovals.sol
+++ b/smart-contracts/contracts/AccountApprovals.sol
@@ -6,7 +6,7 @@ import 'openzeppelin-eth/contracts/access/roles/WhitelistedRole.sol';
 contract AccountApprovals is
   WhitelistedRole
 {
-  mapping(address => bytes) accountData;
+  mapping(address => bytes) public accountData;
 
   event Approve(address operator, address account, bytes data);
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

@akeem looking for confirmation on the approach.  If this is okay, I'll add some comments & tests and we can merge.

The `whitelist` combines two roles:
 - WhitelistAdmin can add/remove admins and add/remove whitelist operators.  It is possible to be a WhitelistAdmin without operator privileges 
 - Whitelist operators can issue the `approve` function here

This may be overkill.  We could simplify and use a single role instead of both operators and admins.  Let me know.

In terms of approvals themselves, you can set the data to anything if the account is approved.  Set it to an empty array to effectively remove approval.

Read approval data by calling `accountData(_account)`

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4753
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
