### PR TITLE
Reorganize main window scripts for modularity

### DIFF
--- a/paywall/src/__tests__/unlock.js/startup.test.ts
+++ b/paywall/src/__tests__/unlock.js/startup.test.ts
@@ -1,4 +1,4 @@
-import startup, { normalizeConfig } from '../../unlock.js/startup'
+import { startup, normalizeConfig } from '../../unlock.js/startup'
 import FakeWindow from '../test-helpers/fakeWindowHelpers'
 import StartupConstants from '../../unlock.js/startupTypes'
 import { PaywallConfig } from '../../unlockTypes'

--- a/paywall/src/unlock.js/constants.ts
+++ b/paywall/src/unlock.js/constants.ts
@@ -1,5 +1,16 @@
 import StartupConstants from './startupTypes'
 
+// Typechecking fails in CI (but not locally) unless we assert that process.env
+// will always be set to one of these values
+declare const process: {
+  env: {
+    UNLOCK_ENV: 'dev' | 'test' | 'staging' | 'prod'
+    DEBUG: any
+    PAYWALL_URL: string
+    USER_IFRAME_URL: string
+  }
+}
+
 const constants: { [key: string]: StartupConstants } = {
   dev: {
     network: 1984,

--- a/paywall/src/unlock.js/constants.ts
+++ b/paywall/src/unlock.js/constants.ts
@@ -1,0 +1,30 @@
+import StartupConstants from './startupTypes'
+
+const constants: { [key: string]: StartupConstants } = {
+  dev: {
+    network: 1984,
+    debug: process.env.DEBUG,
+    paywallUrl: process.env.PAYWALL_URL || 'http://localhost:3001',
+    accountsUrl: process.env.USER_IFRAME_URL || 'http://localhost:3000/account',
+  },
+  test: {
+    network: 1984,
+    debug: process.env.DEBUG,
+    paywallUrl: process.env.PAYWALL_URL || 'http://localhost:3001',
+    accountsUrl: process.env.USER_IFRAME_URL || 'http://localhost:3000/account',
+  },
+  staging: {
+    network: 4,
+    debug: process.env.DEBUG,
+    paywallUrl: process.env.PAYWALL_URL,
+    accountsUrl: process.env.USER_IFRAME_URL,
+  },
+  prod: {
+    network: 1,
+    debug: process.env.DEBUG,
+    paywallUrl: process.env.PAYWALL_URL,
+    accountsUrl: process.env.USER_IFRAME_URL,
+  },
+}
+
+export default constants

--- a/paywall/src/unlock.js/index.ts
+++ b/paywall/src/unlock.js/index.ts
@@ -1,61 +1,8 @@
-import startup from './startup'
+import startupWhenReady from './startup'
 import '../static/iframe.css'
-import { UnlockWindowNoProtocolYet } from '../windowTypes'
-import StartupConstants from './startupTypes'
+import constants from './constants'
 
-declare const process: {
-  env: {
-    UNLOCK_ENV: 'dev' | 'test' | 'staging' | 'prod'
-    DEBUG: any
-    PAYWALL_URL: string
-    USER_IFRAME_URL: string
-  }
-}
+const env = process.env.UNLOCK_ENV || 'dev'
+const startupConstants = constants[env]
 
-const constants: { [key: string]: StartupConstants } = {
-  dev: {
-    network: 1984,
-    debug: process.env.DEBUG,
-    paywallUrl: process.env.PAYWALL_URL || 'http://localhost:3001',
-    accountsUrl: process.env.USER_IFRAME_URL || 'http://localhost:3000/account',
-  },
-  test: {
-    network: 1984,
-    debug: process.env.DEBUG,
-    paywallUrl: process.env.PAYWALL_URL || 'http://localhost:3001',
-    accountsUrl: process.env.USER_IFRAME_URL || 'http://localhost:3000/account',
-  },
-  staging: {
-    network: 4,
-    debug: process.env.DEBUG,
-    paywallUrl: process.env.PAYWALL_URL,
-    accountsUrl: process.env.USER_IFRAME_URL,
-  },
-  prod: {
-    network: 1,
-    debug: process.env.DEBUG,
-    paywallUrl: process.env.PAYWALL_URL,
-    accountsUrl: process.env.USER_IFRAME_URL,
-  },
-}
-
-let started = false
-const startupConstants = constants[process.env.UNLOCK_ENV]
-if (document.readyState !== 'loading') {
-  // in most cases, we will start up after the document is interactive
-  // so listening for the DOMContentLoaded or load events is superfluous
-  startup((window as unknown) as UnlockWindowNoProtocolYet, startupConstants)
-  started = true
-} else {
-  const begin = () => {
-    if (!started)
-      startup(
-        (window as unknown) as UnlockWindowNoProtocolYet,
-        startupConstants
-      )
-    started = true
-  }
-  // if we reach here, the page is sitll loading
-  window.addEventListener('DOMContentLoaded', begin)
-  window.addEventListener('load', begin)
-}
+startupWhenReady(window, startupConstants)

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -34,7 +34,7 @@ export function normalizeConfig(unlockConfig: any) {
 /**
  * Start the unlock app!
  */
-export default function startup(
+export function startup(
   window: UnlockWindowNoProtocolYet,
   constants: StartupConstants
 ) {
@@ -80,4 +80,30 @@ export default function startup(
     usingManagedAccount: wallet.useUserAccounts,
   })
   return iframes // this is only useful in testing, it is ignored in the app
+}
+
+// Make sure the page is ready before we try to start the app!
+export default function startupWhenReady(
+  window: Window,
+  startupConstants: StartupConstants
+) {
+  let started = false
+  if (document.readyState !== 'loading') {
+    // in most cases, we will start up after the document is interactive
+    // so listening for the DOMContentLoaded or load events is superfluous
+    startup((window as unknown) as UnlockWindowNoProtocolYet, startupConstants)
+    started = true
+  } else {
+    const begin = () => {
+      if (!started)
+        startup(
+          (window as unknown) as UnlockWindowNoProtocolYet,
+          startupConstants
+        )
+      started = true
+    }
+    // if we reach here, the page is still loading
+    window.addEventListener('DOMContentLoaded', begin)
+    window.addEventListener('load', begin)
+  }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR moves around some elements of the `unlock.js` piece of the paywall for modularity. Constants have been pulled out to another file, and the code that calls startup when the page is ready has been extracted into a function and exported from `startup.ts`.

This trims down `index.ts` considerably. Now when we add an npm module to this repo (as explored in #4817), the duplication will be almost nonexistent.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
