### PR TITLE
Introducing the unlock-web module

### DIFF
--- a/paywall/.gitignore
+++ b/paywall/.gitignore
@@ -11,6 +11,7 @@
 # production
 /build
 /dist
+/src/unlock.js/dist
 .next/
 out/
 *.min.js*

--- a/paywall/package.json
+++ b/paywall/package.json
@@ -15,6 +15,7 @@
     "svg-2-components": "./node_modules/@svgr/cli/bin/svgr --title-prop --no-dimensions --template src/components/interface/svg/template.js --no-dimensions -d src/components/interface/svg/ src/static/images/svg/",
     "build-checkout": "npm run build-unlock.1.0.js && npm run build-data-iframe.1.0.js",
     "build-unlock.1.0.js": "webpack --config unlock.1.0.js.webpack.config.js",
+    "build-unlock-web": "webpack --config unlock-web-module.webpack.config.js",
     "build-data-iframe.1.0.js": "webpack --config data-iframe.1.0.webpack.config.js",
     "storybook": "start-storybook -p 9002 -c .storybook -s .",
     "ci": "npm run lint && npm test"

--- a/paywall/src/unlock.js/module.ts
+++ b/paywall/src/unlock.js/module.ts
@@ -1,0 +1,10 @@
+import startupWhenReady from './startup'
+import '../static/iframe.css'
+import constants from './constants'
+
+export default function startup() {
+  const env = process.env.UNLOCK_ENV || 'dev'
+  const startupConstants = constants[env]
+
+  startupWhenReady(window, startupConstants)
+}

--- a/paywall/src/unlock.js/package.json
+++ b/paywall/src/unlock.js/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "unlock-web",
+  "version": "0.0.1",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/unlock-protocol/unlock/issues"
+  }
+}

--- a/paywall/unlock-web-module.webpack.config.js
+++ b/paywall/unlock-web-module.webpack.config.js
@@ -36,7 +36,7 @@ module.exports = () => {
     devtool: 'source-map',
     entry: path.resolve(__dirname, 'src', 'unlock.js', 'module.ts'),
     output: {
-      library: 'unlock-checkout-builder',
+      library: 'unlock-web',
       libraryTarget: 'commonjs2',
       path: path.resolve(__dirname, 'src', 'unlock.js', 'dist'),
       filename: 'index.js',

--- a/paywall/unlock-web-module.webpack.config.js
+++ b/paywall/unlock-web-module.webpack.config.js
@@ -1,0 +1,71 @@
+/* eslint no-console: 0 */
+const dotenv = require('dotenv')
+var path = require('path')
+const webpack = require('webpack')
+
+const unlockEnv = process.env.UNLOCK_ENV || 'dev'
+const debug = process.env.DEBUG ? 1 : 0
+
+dotenv.config({
+  path: path.resolve(__dirname, '..', `.env.${unlockEnv}.local`),
+})
+
+const requiredConfigVariables = {
+  unlockEnv,
+  paywallUrl: process.env.PAYWALL_URL,
+  usersIframeUrl: process.env.USER_IFRAME_URL,
+}
+
+Object.keys(requiredConfigVariables).forEach(configVariableName => {
+  if (!requiredConfigVariables[configVariableName]) {
+    if (['dev', 'test'].indexOf(requiredConfigVariables.unlockEnv) > -1) {
+      return console.error(
+        `The configuration variable ${configVariableName} is falsy.`
+      )
+    }
+    throw new Error(
+      `The configuration variable ${configVariableName} is falsy.`
+    )
+  }
+})
+
+module.exports = () => {
+  return {
+    cache: false,
+    mode: 'production',
+    devtool: 'source-map',
+    entry: path.resolve(__dirname, 'src', 'unlock.js', 'module.ts'),
+    output: {
+      library: 'unlock-checkout-builder',
+      libraryTarget: 'commonjs2',
+      path: path.resolve(__dirname, 'src', 'unlock.js', 'dist'),
+      filename: 'index.js',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
+        },
+        {
+          test: /\.tsx?$/,
+          use: 'ts-loader',
+          exclude: /node_modules/,
+        },
+      ],
+    },
+    resolve: {
+      extensions: ['.ts', '.js'],
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.env.UNLOCK_ENV': "'" + unlockEnv + "'",
+        'process.env.DEBUG': debug,
+        'process.env.PAYWALL_URL':
+          "'" + requiredConfigVariables.paywallUrl + "'",
+        'process.env.USER_IFRAME_URL':
+          "'" + requiredConfigVariables.usersIframeUrl + "'",
+      }),
+    ],
+  }
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR supersedes #4817, introducing a new module that allows the main window paywall script to be downloaded from `npm`.

This has not been published to `npm` yet. At the moment this gets passed through webpack like the browser build , just configured to act like a library and without optimizations applied (since they are superfluous in this case).

Example usage:
- build the module: `npm run build-unlock-web` (from paywall root)
- publish it: `npm publish` (from `paywall/src/unlock.js/`)
- install in a project: `npm install unlock-web`
- import and use:
```javascript
import startup from 'unlock-web';

window.unlockProtocolConfig = { /* ... */ }; 

// Loads the unlock iframes, getting the config from the window
startup();
```

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
