### PR TITLE
returning the erc20 symbol for erc20 locks

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,20 +1,29 @@
 # Changes
 
+## 0.3.13
+
+- Returning the token symbol when retrieving an ERC20 lock.
+
 ## 0.3.12
+
 - fixed a difference between pending transactions (node knows about them) and submitted transactions (which may be transactions that have been cancelled and will never succeed)
 
 ## 0.3.11
+
 - add `getTokenSymbol` method to web3Service to identify arbitrary ERC20 tokens (#4481)
 - add `getTokenBalance` method to web3Service to get the user's balance of arbitrary ERC20 tokens (#4431)
 
 ## 0.3.10
+
 - Add "for" field for pending/submitted key purchase transactions (#4190)
 - ignore events from other contracts (erc20 for instance) (#4187)
 
 ## 0.3.9
+
 - If a transaction is unknown poll immediately for it (#4149)
 
 ## 0.3.8
+
 - Moved scrypt/N back to the default from Web3 for speed of account interaction
 
 ## 0.3.7

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/v10/getLock.test.js
+++ b/unlock-js/src/__tests__/v10/getLock.test.js
@@ -21,6 +21,7 @@ const erc20ContractAddress = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359'
 
 jest.mock('../../erc20.js', () => {
   return {
+    getErc20TokenSymbol: jest.fn(() => Promise.resolve('TICKER')),
     getErc20BalanceForAddress: jest.fn(() => Promise.resolve(0)),
     getErc20Decimals: jest.fn(() => Promise.resolve(18)), // 18 is the most frequent default for ERC20
   }
@@ -170,12 +171,16 @@ describe('v10', () => {
     })
 
     it('should successfully yield a lock with an ERC20 currency, with the right balance', async () => {
-      expect.assertions(3)
+      expect.assertions(4)
       await nockBeforeEach()
       nockGetErc20Lock({ erc20ContractAddress })
       const balance = 1929
       erc20.getErc20BalanceForAddress = jest.fn(() => {
         return Promise.resolve(balance)
+      })
+      const symbol = 'SYMBOL'
+      erc20.getErc20TokenSymbol = jest.fn(() => {
+        return Promise.resolve(symbol)
       })
       const decimals = 3
       erc20.getErc20Decimals = jest.fn(() => {
@@ -190,6 +195,7 @@ describe('v10', () => {
           keyPrice: utils.fromDecimal('10000000000000000', decimals),
           expirationDuration: 2592000,
           maxNumberOfKeys: 10,
+          currencySymbol: symbol,
           owner,
           outstandingKeys: 17,
           asOf: 1337,
@@ -202,6 +208,10 @@ describe('v10', () => {
       expect(erc20.getErc20BalanceForAddress).toHaveBeenCalledWith(
         erc20ContractAddress,
         lockAddress,
+        web3Service.provider
+      )
+      expect(erc20.getErc20TokenSymbol).toHaveBeenCalledWith(
+        erc20ContractAddress,
         web3Service.provider
       )
     })

--- a/unlock-js/src/__tests__/v11/getLock.test.js
+++ b/unlock-js/src/__tests__/v11/getLock.test.js
@@ -21,6 +21,7 @@ const erc20ContractAddress = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359'
 
 jest.mock('../../erc20.js', () => {
   return {
+    getErc20TokenSymbol: jest.fn(() => Promise.resolve('TICKER')),
     getErc20BalanceForAddress: jest.fn(() => Promise.resolve(0)),
     getErc20Decimals: jest.fn(() => Promise.resolve(18)), // 18 is the most frequent default for ERC20
   }
@@ -170,9 +171,13 @@ describe('v11', () => {
     })
 
     it('should successfully yield a lock with an ERC20 currency, with the right balance', async () => {
-      expect.assertions(3)
+      expect.assertions(4)
       await nockBeforeEach()
       nockGetErc20Lock({ erc20ContractAddress })
+      const symbol = 'SYMBOL'
+      erc20.getErc20TokenSymbol = jest.fn(() => {
+        return Promise.resolve(symbol)
+      })
       const balance = 1929
       erc20.getErc20BalanceForAddress = jest.fn(() => {
         return Promise.resolve(balance)
@@ -190,6 +195,7 @@ describe('v11', () => {
           keyPrice: utils.fromDecimal('10000000000000000', decimals),
           expirationDuration: 2592000,
           maxNumberOfKeys: 10,
+          currencySymbol: 'SYMBOL',
           owner,
           outstandingKeys: 17,
           asOf: 1337,
@@ -202,6 +208,10 @@ describe('v11', () => {
       expect(erc20.getErc20BalanceForAddress).toHaveBeenCalledWith(
         erc20ContractAddress,
         lockAddress,
+        web3Service.provider
+      )
+      expect(erc20.getErc20TokenSymbol).toHaveBeenCalledWith(
+        erc20ContractAddress,
         web3Service.provider
       )
     })

--- a/unlock-js/src/erc20.js
+++ b/unlock-js/src/erc20.js
@@ -25,6 +25,17 @@ export async function getErc20Decimals(erc20ContractAddress, provider) {
   return utils.toNumber(decimals)
 }
 
+/**
+ * yields the symbole for the ERC20 contract
+ * @param {*} erc20ContractAddress
+ * @param {*} provider
+ */
+export async function getErc20TokenSymbol(erc20ContractAddress, provider) {
+  const contract = new ethers.Contract(erc20ContractAddress, erc20abi, provider)
+  const symbolPromise = await contract.symbol()
+  return symbolPromise
+}
+
 export async function approveTransfer(
   erc20ContractAddress,
   lockContractAddress,
@@ -44,4 +55,5 @@ export default {
   approveTransfer,
   getErc20BalanceForAddress,
   getErc20Decimals,
+  getErc20TokenSymbol,
 }

--- a/unlock-js/src/erc20abi.js
+++ b/unlock-js/src/erc20abi.js
@@ -6,6 +6,7 @@ const erc20abi = [
   'function transfer(address to, uint tokens) public returns (bool success)',
   'function approve(address spender, uint tokens) public returns (bool success)',
   'function transferFrom(address from, address to, uint tokens) public returns (bool success)',
+  'function symbol() public view returns (string)',
 
   'event Transfer(address indexed from, address indexed to, uint tokens)',
   'event Approval(address indexed tokenOwner, address indexed spender, uint tokens)',

--- a/unlock-js/src/v10/getLock.js
+++ b/unlock-js/src/v10/getLock.js
@@ -1,6 +1,10 @@
 import utils from '../utils'
 import { UNLIMITED_KEYS_COUNT, ZERO } from '../constants'
-import { getErc20BalanceForAddress, getErc20Decimals } from '../erc20'
+import {
+  getErc20BalanceForAddress,
+  getErc20Decimals,
+  getErc20TokenSymbol,
+} from '../erc20'
 
 /**
  * Refresh the lock's data.
@@ -46,7 +50,8 @@ export default async function(address) {
     update.keyPrice = utils.fromWei(update.keyPrice, 'ether')
     update.balance = await this.getAddressBalance(address)
   } else {
-    // Otherwise need to get the erc20's decimal and convert from there
+    // Otherwise need to get the erc20's decimal and convert from there, as well as the symbol
+    // TODO : make these calls in parallel
     const erc20Decimals = await getErc20Decimals(
       update.tokenAddress,
       this.provider
@@ -56,8 +61,14 @@ export default async function(address) {
       address,
       this.provider
     )
+    const erc20Symbol = await getErc20TokenSymbol(
+      update.tokenAddress,
+      this.provider
+    )
+
     update.keyPrice = utils.fromDecimal(update.keyPrice, erc20Decimals)
     update.balance = utils.fromDecimal(erc20Balance, erc20Decimals)
+    update.currencySymbol = erc20Symbol
   }
 
   // totalSupply was previously called outstandingKeys. In order to keep compatibility

--- a/unlock-js/src/v11/getLock.js
+++ b/unlock-js/src/v11/getLock.js
@@ -1,6 +1,10 @@
 import utils from '../utils'
 import { UNLIMITED_KEYS_COUNT, ZERO } from '../constants'
-import { getErc20BalanceForAddress, getErc20Decimals } from '../erc20'
+import {
+  getErc20BalanceForAddress,
+  getErc20Decimals,
+  getErc20TokenSymbol,
+} from '../erc20'
 
 /**
  * Refresh the lock's data.
@@ -46,7 +50,8 @@ export default async function(address) {
     update.keyPrice = utils.fromWei(update.keyPrice, 'ether')
     update.balance = await this.getAddressBalance(address)
   } else {
-    // Otherwise need to get the erc20's decimal and convert from there
+    // Otherwise need to get the erc20's decimal and convert from there, as well as the symbol
+    // TODO : make these calls in parallel
     const erc20Decimals = await getErc20Decimals(
       update.tokenAddress,
       this.provider
@@ -56,8 +61,14 @@ export default async function(address) {
       address,
       this.provider
     )
+    const erc20Symbol = await getErc20TokenSymbol(
+      update.tokenAddress,
+      this.provider
+    )
+
     update.keyPrice = utils.fromDecimal(update.keyPrice, erc20Decimals)
     update.balance = utils.fromDecimal(erc20Balance, erc20Decimals)
+    update.currencySymbol = erc20Symbol
   }
 
   // totalSupply was previously called outstandingKeys. In order to keep compatibility

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -4,6 +4,7 @@ import TransactionTypes from './transactionTypes'
 import UnlockService from './unlockService'
 import FetchJsonProvider from './FetchJsonProvider'
 import { UNLIMITED_KEYS_COUNT, KEY_ID } from './constants'
+import { getErc20TokenSymbol } from './erc20'
 
 /**
  * This service reads data from the RPC endpoint.
@@ -695,10 +696,7 @@ export default class Web3Service extends UnlockService {
    * @returns {Promise<string>}
    */
   async getTokenSymbol(contractAddress) {
-    const abi = ['function symbol() view returns (string)']
-    const contract = new ethers.Contract(contractAddress, abi, this.provider)
-    const symbolPromise = contract.symbol()
-
+    const symbolPromise = getErc20TokenSymbol(contractAddress, this.provider)
     this.emitTokenSymbol(contractAddress, symbolPromise)
     return symbolPromise
   }


### PR DESCRIPTION
# Description

I deployed an ERC20 lock for a user who wanted to use cDAI and cUSDC, but the paywall does not show the right currency...
This adds support to unlock-js so that we can then fix the paywall!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread