### PR TITLE
Showing the erc20 symbol on applicable locks

### DIFF
--- a/paywall/package-lock.json
+++ b/paywall/package-lock.json
@@ -3062,13 +3062,13 @@
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
     },
     "@unlock-protocol/unlock-js": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@unlock-protocol/unlock-js/-/unlock-js-0.3.12.tgz",
-      "integrity": "sha512-xCd0PQCchovTk47L4Vtt0s66fGtr/3ArsrR4bMZ4l03sxW1m187yE3W8vWcERVYiyqYgXgInEZuxNSmulgzZ/Q==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@unlock-protocol/unlock-js/-/unlock-js-0.3.13.tgz",
+      "integrity": "sha512-jD3NK0c9Zk0DLQMYAUA/J2jGa5FQQnFX7n3U15jmQkLxLf/XmPofXHh8DbKK7LhCYtCajSyv2gKFKghtv5umgQ==",
       "requires": {
-        "eth-sig-util": "2.2.0",
+        "eth-sig-util": "2.4.4",
         "ethereumjs-utils": "5.2.5",
-        "ethers": "4.0.27"
+        "ethers": "4.0.37"
       }
     },
     "@webassemblyjs/ast": {
@@ -7104,9 +7104,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eth-sig-util": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.2.0.tgz",
-      "integrity": "sha512-bAxW35bL4U2lrtjjV8rFGJ8B27z4Sn5v9eIaNdpPUnPfUAtrvx5j8atfyV+k+JOnbppcvKhWCO1rQSBk4kkAhw==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.4.4.tgz",
+      "integrity": "sha512-iWGqEJwsUMgtk8AqQQqIDTjMz+pW8s2Sq8gN640dh9U9HoEFQJO3m6ro96DgV6hMB2LYu8F5812LQyynOgCbEw==",
       "requires": {
         "buffer": "^5.2.1",
         "elliptic": "^6.4.0",
@@ -7117,26 +7117,12 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
-          "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -7164,6 +7150,20 @@
         }
       }
     },
+    "ethereumjs-util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+      "requires": {
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "ethjs-util": "^0.1.3",
+        "keccak": "^1.0.2",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^3.0.1"
+      }
+    },
     "ethereumjs-utils": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-utils/-/ethereumjs-utils-5.2.5.tgz",
@@ -7179,9 +7179,9 @@
       }
     },
     "ethers": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz",
-      "integrity": "sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==",
+      "version": "4.0.37",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.37.tgz",
+      "integrity": "sha512-B7bDdyQ45A5lPr6k2HOkEKMtYOuqlfy+nNf8glnRvWidkDQnToKw1bv7UyrwlbsIgY2mE03UxTVtouXcT6Vvcw==",
       "requires": {
         "@types/node": "^10.3.2",
         "aes-js": "3.0.0",
@@ -7196,9 +7196,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.16",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
-          "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA=="
+          "version": "10.14.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
+          "integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ=="
         },
         "elliptic": {
           "version": "6.3.3",
@@ -14718,18 +14718,25 @@
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
     "secp256k1": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.6.2.tgz",
-      "integrity": "sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
       "requires": {
-        "bindings": "^1.2.1",
-        "bip66": "^1.1.3",
-        "bn.js": "^4.11.3",
-        "create-hash": "^1.1.2",
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
         "drbg.js": "^1.0.1",
-        "elliptic": "^6.2.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
+        "elliptic": "^6.4.1",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "select": {

--- a/paywall/package.json
+++ b/paywall/package.json
@@ -34,7 +34,7 @@
     "@types/react": "16.9.2",
     "@types/react-dom": "16.9.0",
     "@types/styled-components": "4.1.19",
-    "@unlock-protocol/unlock-js": "0.3.12",
+    "@unlock-protocol/unlock-js": "0.3.13",
     "@zeit/next-css": "1.0.1",
     "@zeit/next-source-maps": "0.0.3",
     "@zeit/next-typescript": "1.1.1",

--- a/paywall/src/__tests__/components/helpers/BalanceProvider.test.js
+++ b/paywall/src/__tests__/components/helpers/BalanceProvider.test.js
@@ -68,7 +68,7 @@ describe('BalanceProvider Component', () => {
     renderIt({
       amount: '100',
       render: (ethValue, fiatValue) => {
-        expect(ethValue).toEqual('100.00')
+        expect(ethValue).toEqual('100')
         expect(fiatValue).toEqual('---')
       },
     })
@@ -79,8 +79,8 @@ describe('BalanceProvider Component', () => {
     renderIt({
       amount: '100',
       render: (ethValue, fiatValue) => {
-        expect(ethValue).toEqual('100.00')
-        expect(fiatValue).toEqual('19,599')
+        expect(ethValue).toEqual('100')
+        expect(fiatValue).toEqual('19.6k')
       },
     })
   })
@@ -98,15 +98,15 @@ describe('BalanceProvider Component', () => {
     })
   })
 
-  describe('when the balance is < 0.0001 Eth', () => {
+  describe('when the balance is < 0.001 Eth', () => {
     const amount = '0.000070'
 
-    it('shows the default minimum value of 三 < 0.0001', () => {
+    it('shows the default minimum value of 三 < 0.001', () => {
       expect.assertions(2)
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
-          expect(ethValue).toEqual('< 0.0001')
+          expect(ethValue).toEqual('< 0.001')
           expect(fiatValue).toEqual('0.014')
         },
       })
@@ -121,7 +121,7 @@ describe('BalanceProvider Component', () => {
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
-          expect(ethValue).toEqual('0.0002')
+          expect(ethValue).toEqual('< 0.001')
           expect(fiatValue).toEqual('0.039')
         },
       })
@@ -136,8 +136,8 @@ describe('BalanceProvider Component', () => {
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
-          expect(ethValue).toEqual('2.00')
-          expect(fiatValue).toEqual('391.98')
+          expect(ethValue).toEqual('2')
+          expect(fiatValue).toEqual('392')
         },
       })
     })
@@ -151,7 +151,7 @@ describe('BalanceProvider Component', () => {
       renderIt({
         amount,
         render: ethValue => {
-          expect(ethValue).toEqual('2.00')
+          expect(ethValue).toEqual('2')
         },
       })
     })
@@ -165,7 +165,7 @@ describe('BalanceProvider Component', () => {
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
-          expect(ethValue).toEqual('20.00')
+          expect(ethValue).toEqual('20')
           expect(fiatValue).toEqual('3,920')
         },
       })
@@ -195,7 +195,7 @@ describe('BalanceProvider Component', () => {
       renderIt({
         amount,
         render: (ethValue, fiatValue) => {
-          expect(ethValue).toEqual('20,000')
+          expect(ethValue).toEqual('20k')
           expect(fiatValue).toEqual('3.9m')
         },
       })

--- a/paywall/src/__tests__/selectors/currency.test.js
+++ b/paywall/src/__tests__/selectors/currency.test.js
@@ -2,9 +2,9 @@ import { formatCurrency } from '../../selectors/currency'
 
 describe('currency conversion and formatting selectors', () => {
   describe('formatCurrency', () => {
-    it('< 0.0001', () => {
+    it('< 0.001', () => {
       expect.assertions(1)
-      expect(formatCurrency('0.00009')).toBe('< 0.0001')
+      expect(formatCurrency('0.0009')).toBe('< 0.001')
     })
     it('< 0.01', () => {
       expect.assertions(1)
@@ -15,18 +15,24 @@ describe('currency conversion and formatting selectors', () => {
       expect(formatCurrency('0.01')).toBe('0.01')
       expect(formatCurrency('0.991')).toBe('0.99')
     })
-    it('1 to 999', () => {
+    it('1 to 100', () => {
       expect.assertions(2)
-      expect(formatCurrency('1')).toBe('1.00')
-      expect(formatCurrency('999.99')).toBe('999.99')
+      expect(formatCurrency('1')).toBe('1')
+      expect(formatCurrency('99.99')).toBe('99.99')
     })
-    it('1000 to 99,999', () => {
+    it('100 to 1000', () => {
+      expect.assertions(2)
+      expect(formatCurrency('101.09')).toBe('101')
+      expect(formatCurrency('999.99')).toBe('1000')
+    })
+    it('1000 to 9,999', () => {
       expect.assertions(2)
       expect(formatCurrency('1000')).toBe('1,000')
-      expect(formatCurrency('99999')).toBe('99,999')
+      expect(formatCurrency('9999')).toBe('9,999')
     })
-    it('100k to 1 million', () => {
-      expect.assertions(3)
+    it('10,000 to 1 million', () => {
+      expect.assertions(4)
+      expect(formatCurrency('10000')).toBe('10k')
       expect(formatCurrency('100000')).toBe('100k')
       expect(formatCurrency('100100')).toBe('100.1k')
       expect(formatCurrency('999911')).toBe('999.9k')

--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2324,7 +2324,6 @@ Object {
 
 .c10 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -2589,7 +2588,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.1
                
@@ -2825,7 +2824,6 @@ Object {
 
 .c10 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -3066,7 +3064,7 @@ Object {
               <div
                 class="c10 price"
               >
-                3.00
+                3
                  
                 Eth
               </div>
@@ -3172,7 +3170,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.1
                
@@ -3213,7 +3211,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.3
                
@@ -3254,9 +3252,9 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              3.00
+              3
                
               Eth
             </div>
@@ -3609,7 +3607,6 @@ Object {
 
 .c17 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -3851,7 +3848,7 @@ Object {
               <div
                 class="c17 price"
               >
-                3.00
+                3
                  
                 Eth
               </div>
@@ -3999,7 +3996,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.3
                
@@ -4040,9 +4037,9 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              3.00
+              3
                
               Eth
             </div>
@@ -4395,7 +4392,6 @@ Object {
 
 .c17 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -4633,7 +4629,7 @@ Object {
               <div
                 class="c17 price"
               >
-                3.00
+                3
                  
                 Eth
               </div>
@@ -4777,7 +4773,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.3
                
@@ -4818,9 +4814,9 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              3.00
+              3
                
               Eth
             </div>
@@ -5173,7 +5169,6 @@ Object {
 
 .c10 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -5411,7 +5406,7 @@ Object {
               <div
                 class="c10 price"
               >
-                3.00
+                3
                  
                 Eth
               </div>
@@ -5514,7 +5509,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.1
                
@@ -5596,9 +5591,9 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              3.00
+              3
                
               Eth
             </div>
@@ -5870,7 +5865,6 @@ Object {
 
 .c11 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -6040,7 +6034,6 @@ Object {
 
 .c28 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -6370,7 +6363,7 @@ Object {
               <div
                 class="c28 price"
               >
-                3.00
+                3
                  
                 Eth
               </div>
@@ -6474,7 +6467,7 @@ Object {
             class="sc-1549ebs-3 ynhyps-5 fUiyRE"
           >
             <div
-              class="ynhyps-1 WzAoK price"
+              class="ynhyps-1 foCVaf price"
             >
               0.1
                
@@ -6549,7 +6542,7 @@ Object {
             class="sc-1549ebs-3 ynhyps-5 fUiyRE"
           >
             <div
-              class="ynhyps-1 WzAoK price"
+              class="ynhyps-1 foCVaf price"
             >
               0.3
                
@@ -6626,9 +6619,9 @@ Object {
             disabled=""
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              3.00
+              3
                
               Eth
             </div>
@@ -6901,7 +6894,6 @@ Object {
 
 .c11 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -7071,7 +7063,6 @@ Object {
 
 .c28 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -7366,7 +7357,7 @@ Object {
               <div
                 class="c28 price"
               >
-                3.00
+                3
                  
                 Eth
               </div>
@@ -7470,7 +7461,7 @@ Object {
             class="sc-1549ebs-3 ynhyps-5 fUiyRE"
           >
             <div
-              class="ynhyps-1 WzAoK price"
+              class="ynhyps-1 foCVaf price"
             >
               0.1
                
@@ -7545,7 +7536,7 @@ Object {
             disabled=""
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.3
                
@@ -7587,9 +7578,9 @@ Object {
             disabled=""
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              3.00
+              3
                
               Eth
             </div>
@@ -7862,7 +7853,6 @@ Object {
 
 .c11 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -8032,7 +8022,6 @@ Object {
 
 .c28 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -8360,7 +8349,7 @@ Object {
               <div
                 class="c28 price"
               >
-                3.00
+                3
                  
                 Eth
               </div>
@@ -8464,7 +8453,7 @@ Object {
             class="sc-1549ebs-3 ynhyps-5 fUiyRE"
           >
             <div
-              class="ynhyps-1 WzAoK price"
+              class="ynhyps-1 foCVaf price"
             >
               0.1
                
@@ -8537,7 +8526,7 @@ Object {
             class="sc-1549ebs-3 ynhyps-5 fUiyRE"
           >
             <div
-              class="ynhyps-1 WzAoK price"
+              class="ynhyps-1 foCVaf price"
             >
               0.3
                
@@ -8614,9 +8603,9 @@ Object {
             disabled=""
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              3.00
+              3
                
               Eth
             </div>
@@ -24373,7 +24362,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -24488,7 +24476,7 @@ Object {
             disabled=""
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.23
                
@@ -24667,7 +24655,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -24782,7 +24769,7 @@ Object {
             disabled=""
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.23
                
@@ -24961,7 +24948,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -25008,7 +24994,7 @@ Object {
               <div
                 class="c5 price"
               >
-                10.00
+                10
                  
                 DEV
               </div>
@@ -25059,9 +25045,9 @@ Object {
             disabled=""
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              10.00
+              10
                
               DEV
             </div>
@@ -25232,7 +25218,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -25347,7 +25332,7 @@ Object {
             disabled=""
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.23
                
@@ -25530,7 +25515,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -25575,7 +25559,7 @@ Object {
               <div
                 class="c5 price"
               >
-                66.00
+                66
                  
                 DEV
               </div>
@@ -25623,9 +25607,9 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              66.00
+              66
                
               DEV
             </div>
@@ -25799,7 +25783,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -25909,7 +25892,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.23
                
@@ -26504,7 +26487,6 @@ Object {
 
 .c6 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -26656,7 +26638,7 @@ Object {
               <div
                 class="c5 c6 price"
               >
-                66.00
+                66
                  
                 DEV
               </div>
@@ -26738,9 +26720,9 @@ Object {
             class="sc-1549ebs-3 ynhyps-5 fUiyRE"
           >
             <div
-              class="ynhyps-1 WzAoK price"
+              class="ynhyps-1 foCVaf price"
             >
-              66.00
+              66
                
               DEV
             </div>
@@ -27023,7 +27005,7 @@ Object {
                 <div
                   class="c6"
                 >
-                  66.00
+                  66
                    
                   DEV
                 </div>
@@ -27077,7 +27059,7 @@ Object {
               <div
                 class="sc-1549ebs-4 cXGnbO"
               >
-                66.00
+                66
                  
                 DEV
               </div>
@@ -27335,7 +27317,6 @@ Object {
 
 .c6 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -27586,7 +27567,7 @@ Object {
             class="sc-1549ebs-3 ynhyps-5 fUiyRE"
           >
             <div
-              class="ynhyps-1 WzAoK price"
+              class="ynhyps-1 foCVaf price"
             >
               0.23
                
@@ -28199,7 +28180,7 @@ Object {
                 <div
                   class="c6"
                 >
-                  66.00
+                  66
                    
                   DEV
                 </div>
@@ -28249,7 +28230,7 @@ Object {
               <div
                 class="sc-1549ebs-4 cXGnbO"
               >
-                66.00
+                66
                  
                 DEV
               </div>
@@ -28420,7 +28401,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -28530,7 +28510,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.23
                
@@ -28712,7 +28692,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -28822,7 +28801,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.23
                
@@ -29004,7 +28983,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -29049,7 +29027,7 @@ Object {
               <div
                 class="c5 price"
               >
-                10.00
+                10
                  
                 DEV
               </div>
@@ -29097,9 +29075,9 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              10.00
+              10
                
               DEV
             </div>
@@ -29273,7 +29251,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -29318,7 +29295,7 @@ Object {
               <div
                 class="c5 price"
               >
-                66.00
+                66
                  
                 ERC20
               </div>
@@ -29366,9 +29343,9 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
-              66.00
+              66
                
               ERC20
             </div>
@@ -29542,7 +29519,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -29652,7 +29628,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.23
                
@@ -29834,7 +29810,6 @@ Object {
 
 .c5 {
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 }
@@ -29944,7 +29919,7 @@ Object {
             class="sc-1549ebs-3 sc-5sgq84-2 dyJsTl"
           >
             <div
-              class="sc-5sgq84-3 bIZSQm price"
+              class="sc-5sgq84-3 jSlcrK price"
             >
               0.23
                

--- a/paywall/src/__tests__/utils/locks.test.js
+++ b/paywall/src/__tests__/utils/locks.test.js
@@ -12,6 +12,14 @@ describe('locks utilities', () => {
       expect(currencySymbolForLock(lock, config)).toBe('Eth')
     })
 
+    it('should returnt the symbol if one exists', () => {
+      expect.assertions(1)
+      const lock = {
+        currencySymbol: 'cDAI',
+      }
+      expect(currencySymbolForLock(lock, config)).toBe('cDAI')
+    })
+
     it('should return the configs symbold if this is an ERC20 matching the config', () => {
       expect.assertions(1)
       const lock = {

--- a/paywall/src/components/lock/ConfirmedKeyLock.js
+++ b/paywall/src/components/lock/ConfirmedKeyLock.js
@@ -65,7 +65,6 @@ const EthPrice = styled.div.attrs({
   className: 'price',
 })`
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 `

--- a/paywall/src/components/lock/NoKeyLock.js
+++ b/paywall/src/components/lock/NoKeyLock.js
@@ -118,7 +118,6 @@ const EthPrice = styled.div.attrs({
   className: 'price',
 })`
   font-size: 30px;
-  text-transform: uppercase;
   color: var(--slate);
   font-weight: bold;
 `

--- a/paywall/src/selectors/currency.js
+++ b/paywall/src/selectors/currency.js
@@ -1,6 +1,4 @@
-const DECIMAL_PLACES = 2
-const SIGNIFICANT_DIGITS = 2
-const MINIMUM_THRESHOLD = 0.0001
+const MINIMUM_THRESHOLD = 0.001
 
 /**
  * Format currency values, which can be potentially very large, to human-readable strings that are compact
@@ -8,7 +6,8 @@ const MINIMUM_THRESHOLD = 0.0001
  * This returns 7 tiers of possible representation
  * - less than 1/100 of a value returns 0
  * - between 0.01 and 1 returns a value formatted as 0.XX
- * - between 1 and 1000, returns the number formatted as XXX.YY with no leading zeros
+ * - between 1 and 100, returns the number formatted as XX.YY with no leading zeros
+ * - between 100 and 1000, returns the number formatted as XXX with no leading zeros
  * - between 1000 and 100,000, returns the rounded number as X,XXX or XX,XXX using locale-formatted number
  * - between 100,000 and 1 million, returns XXXk
  * - between 1 million and 1 billion, returns XXX.Ym with no leading zeros
@@ -19,18 +18,17 @@ const MINIMUM_THRESHOLD = 0.0001
 export function formatCurrency(amount) {
   let currency = Number(amount)
   if (currency === 0) return '0'
-  if (currency < MINIMUM_THRESHOLD) return '< 0.0001'
-  if (currency < 1)
-    return parseFloat(currency.toPrecision(SIGNIFICANT_DIGITS)).toString()
-  if (currency >= 1000 && currency < 1e5)
-    return Math.round(currency).toLocaleString()
-  if (currency >= 1e5 && currency < 1e6)
+  if (currency < MINIMUM_THRESHOLD) return '< 0.001'
+  if (currency < 1) return parseFloat(currency.toPrecision(2)).toString() // 0.12
+  if (currency < 10) return parseFloat(currency.toPrecision(3)).toString() // 1.32
+  if (currency < 100) return parseFloat(currency.toPrecision(4)).toString() // 12.32
+  if (currency < 1000) return parseFloat(currency.toPrecision(3)).toString() // 123
+  if (currency < 1e4) return Math.round(currency).toLocaleString()
+  if (currency < 1e6)
     return (+(currency / 1e3).toFixed(1)).toLocaleString() + 'k'
-  if (currency >= 1e6 && currency < 1e9)
+  if (currency < 1e9)
     return (+(currency / 1e6).toFixed(1)).toLocaleString() + 'm'
-  if (currency >= 1e9)
-    return (+(currency / 1e9).toFixed(1)).toLocaleString() + 'b'
-  return currency.toFixed(DECIMAL_PLACES)
+  return (+(currency / 1e9).toFixed(1)).toLocaleString() + 'b'
 }
 
 export default {

--- a/paywall/src/utils/locks.js
+++ b/paywall/src/utils/locks.js
@@ -3,6 +3,10 @@
  */
 export function currencySymbolForLock(lock, config) {
   let currency = 'Eth'
+  if (lock.currencySymbol) {
+    return lock.currencySymbol
+  }
+  // TODO: remove me, as we now get the currency symbol from the contract
   if (lock.currencyContractAddress === config.erc20Contract.address) {
     currency = config.erc20Contract.name
   } else if (lock.currencyContractAddress) {


### PR DESCRIPTION
# Description

This PR just shows the erc20 symbol on applicable locks and fixes the UI so that we never show more than 4 characters on prices. Longer prices wrap and this looks bad.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread