### PR TITLE
Parse searchParams for unlockUserAccounts setting

### DIFF
--- a/tickets/src/components/content/NewEventContent.tsx
+++ b/tickets/src/components/content/NewEventContent.tsx
@@ -53,6 +53,13 @@ export class EventContent extends Component<
     if (typeof window !== 'undefined') {
       window.addEventListener('unlockProtocol', this.setPaywallStatus)
 
+      const url = new URL(
+        window.location.href,
+        'https://tickets.unlock-protocol.com'
+      )
+      const unlockUserAccounts =
+        url.searchParams.get('unlockUserAccounts') === 'true'
+
       // TODO: Make this nicer
       window.unlockProtocolConfig = {
         persistentCheckout: false,
@@ -62,6 +69,7 @@ export class EventContent extends Component<
         callToAction: {
           default: 'Buy a ticket',
         },
+        unlockUserAccounts,
       }
     }
   }

--- a/tickets/src/components/content/NewEventContent.tsx
+++ b/tickets/src/components/content/NewEventContent.tsx
@@ -54,8 +54,7 @@ export class EventContent extends Component<
       window.addEventListener('unlockProtocol', this.setPaywallStatus)
 
       const url = new URL(
-        window.location.href,
-        'https://tickets.unlock-protocol.com'
+        window.location.href
       )
       const unlockUserAccounts =
         url.searchParams.get('unlockUserAccounts') === 'true'

--- a/tickets/src/components/content/NewEventContent.tsx
+++ b/tickets/src/components/content/NewEventContent.tsx
@@ -53,9 +53,7 @@ export class EventContent extends Component<
     if (typeof window !== 'undefined') {
       window.addEventListener('unlockProtocol', this.setPaywallStatus)
 
-      const url = new URL(
-        window.location.href
-      )
+      const url = new URL(window.location.href)
       const unlockUserAccounts =
         url.searchParams.get('unlockUserAccounts') === 'true'
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds the capability to enable Unlock user accounts on the paywall-based tickets page.

Fixes #4828 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
