### PR TITLE
adding retries on rate limits

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.3.14
+
+- Adding retries on error 419 (rate limiting)
+
 ## 0.3.13
 
 - Returning the token symbol when retrieving an ERC20 lock.

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
# Description

The Alchemy API is rate limited.
This pull requests removes some unused features/complexity around FetchJsonProvider and adds retries on rate limits.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread