### PR TITLE
Use lazy styles in unlock-web

### DIFF
--- a/paywall/src/unlock.js/CHANGELOG.md
+++ b/paywall/src/unlock.js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # unlock-web
 
+### Next version
+- using lazy style tags for iframe CSS to avoid `document` undefined errors during server-side rendering
+
 ### 0.0.3
 - Including a basic `.d.ts` so this package can be included in TypeScript projects
 

--- a/paywall/src/unlock.js/module.ts
+++ b/paywall/src/unlock.js/module.ts
@@ -1,8 +1,14 @@
 import startupWhenReady from './startup'
-import '../static/iframe.css'
 import constants from './constants'
 
+// Using require here so that we can use CSS modules without creating types for each declaration
+const styles = require('../static/iframe.css')
+
 export default function startup() {
+  // Styles will be deferred until here, where they will load. This
+  // prevents issues with `document` being undefined in SSR
+  styles.use()
+
   const env = process.env.UNLOCK_ENV || 'dev'
   const startupConstants = constants[env]
 

--- a/paywall/unlock-web-module.webpack.config.js
+++ b/paywall/unlock-web-module.webpack.config.js
@@ -45,7 +45,10 @@ module.exports = () => {
       rules: [
         {
           test: /\.css$/,
-          use: ['style-loader', 'css-loader'],
+          use: [
+            { loader: 'style-loader', options: { injectType: 'lazyStyleTag' } },
+            'css-loader',
+          ],
         },
         {
           test: /\.tsx?$/,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

To address some issues that cropped up during testing with server-side rendering, this PR enables lazy style tags, which will not be injected until the document is ready.

I won't publish a new version until I also have the environment setup sorted

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
