### PR TITLE
does not create a temporary key on failed transactions

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setupListeners.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setupListeners.test.ts
@@ -323,6 +323,22 @@ describe('BlockchainHandler - setupListeners', () => {
         expect(web3Service.getKeyByLockForOwner).not.toHaveBeenCalled()
       })
 
+      it('should not create a temporary key for a failed key purchase', () => {
+        expect.assertions(1)
+
+        const normalizedLockAddress = lockAddresses[0]
+        const spy = jest.spyOn(temporaryKeyExports, 'createTemporaryKey')
+
+        walletService.emit('transaction.updated', 'hash', {
+          to: normalizedLockAddress,
+          hash: 'hash',
+          status: TransactionStatus.FAILED,
+          type: TransactionType.KEY_PURCHASE,
+        })
+
+        expect(spy).not.toHaveBeenCalled()
+      })
+
       it('should not create a temporary key for a mined key purchase', () => {
         expect.assertions(1)
 

--- a/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
+++ b/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
@@ -331,7 +331,7 @@ export default class BlockchainHandler {
       {
         hash,
         blockNumber: Number.MAX_SAFE_INTEGER,
-        status: 'submitted',
+        status: TransactionStatus.SUBMITTED,
       },
       update
     )
@@ -352,6 +352,7 @@ export default class BlockchainHandler {
 
     const isMined = transaction.status === TransactionStatus.MINED
     const isStale = transaction.status === TransactionStatus.STALE
+    const isFailed = transaction.status === TransactionStatus.FAILED
     const recipient = transaction.lock || transaction.to
     const isKeyPurchase = transaction.type === TransactionType.KEY_PURCHASE
     const accountAddress = this.store.account as string
@@ -364,7 +365,7 @@ export default class BlockchainHandler {
 
     // If we receive a submitted or pending key purchase we should
     // create and store a temporary key.
-    if (isKeyPurchase && recipient && !isMined && !isStale) {
+    if (isKeyPurchase && recipient && !isMined && !isStale && !isFailed) {
       const lock = this.store.locks[recipient]
       const temporaryKey = createTemporaryKey(recipient, accountAddress, lock)
       this.store.keys[recipient] = temporaryKey

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -18,6 +18,7 @@ export enum TransactionStatus {
   PENDING = 'pending',
   MINED = 'mined',
   STALE = 'stale',
+  FAILED = 'failed',
   NONE = '', // for testing purposes
 }
 /* eslint-enable no-unused-vars */


### PR DESCRIPTION
# Description

While doing some tests with @cnasc, we found that failed transactions would still benefit from our optimistic unlocking.
This PR changes that: failed transaction should not be considered optimistic!

# Issues

Fixes #4858

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread