### PR TITLE
taking the tokens' decimals when yielding address balance

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.3.16
+
+- Using the right decimals number for ERC20 balances
+
 ## 0.3.15
 
 - TODO cleanup in web3Service tests

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/integration/web3ServiceIntegration.test.js
+++ b/unlock-js/src/__tests__/integration/web3ServiceIntegration.test.js
@@ -106,7 +106,7 @@ describe('Web3 Service Integration', () => {
         '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a'
       )
 
-      expect(balance).toBe('500.0')
+      expect(balance).toBe('500')
     })
 
     it('emits an error when balance cannot be retrieved', async () => {

--- a/unlock-js/src/erc20.js
+++ b/unlock-js/src/erc20.js
@@ -6,11 +6,11 @@ import erc20abi from './erc20abi'
 // This file provides ways to interact with an ERC20 contract
 export async function getErc20BalanceForAddress(
   erc20ContractAddress,
-  lockContractAddress,
+  address,
   provider
 ) {
   const contract = new ethers.Contract(erc20ContractAddress, erc20abi, provider)
-  const balance = await contract.balanceOf(lockContractAddress)
+  const balance = await contract.balanceOf(address)
   return utils.hexToNumberString(balance)
 }
 

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -4,7 +4,11 @@ import TransactionTypes from './transactionTypes'
 import UnlockService from './unlockService'
 import FetchJsonProvider from './FetchJsonProvider'
 import { UNLIMITED_KEYS_COUNT, KEY_ID } from './constants'
-import { getErc20TokenSymbol } from './erc20'
+import {
+  getErc20TokenSymbol,
+  getErc20BalanceForAddress,
+  getErc20Decimals,
+} from './erc20'
 
 /**
  * This service reads data from the RPC endpoint.
@@ -721,13 +725,19 @@ export default class Web3Service extends UnlockService {
    * @returns {Promise<string>}
    */
   async getTokenBalance(contractAddress, userWalletAddress) {
-    const abi = ['function balanceOf(address owner) view returns (uint)']
-    const contract = new ethers.Contract(contractAddress, abi, this.provider)
+    let balance, decimals
+    let result
     try {
-      const rawBalance = await contract.balanceOf(userWalletAddress)
-      return ethers.utils.formatEther(rawBalance)
+      balance = await getErc20BalanceForAddress(
+        contractAddress,
+        userWalletAddress,
+        this.provider
+      )
+      decimals = await getErc20Decimals(contractAddress, this.provider)
+      result = utils.fromDecimal(balance, decimals)
     } catch (e) {
       this.emit('error', e)
     }
+    return result
   }
 }


### PR DESCRIPTION
# Description

This fixes a bug where we assumed that all tokens had 16 digits when yielding balances.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread