### PR TITLE
SettingsContent now prompts for a login

### DIFF
--- a/unlock-app/src/__tests__/components/content/SettingsContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/SettingsContent.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { Provider } from 'react-redux'
+import createUnlockStore from '../../../createUnlockStore'
+import { ConfigContext } from '../../../utils/withConfig'
+import {
+  SettingsContent,
+  mapStateToProps,
+} from '../../../components/content/SettingsContent'
+
+const config = {
+  stripeApiKey: 'pk_not_a_real_key',
+}
+
+const store = createUnlockStore()
+
+/* const account = {
+ *   emailAddress: 'john@smi.th',
+ * }
+ *
+ * const mockCard: stripe.Card = {
+ *   id: 'not_a_real_id',
+ *   object: 'a string',
+ *   brand: 'Visa',
+ *   country: 'United States',
+ *   dynamic_last4: '4242',
+ *   exp_month: 12,
+ *   exp_year: 2021,
+ *   fingerprint: 'another string',
+ *   funding: 'credit',
+ *   last4: '4242',
+ *   metadata: {},
+ * } */
+
+describe('SettingsContent', () => {
+  describe('Possible rendering states', () => {
+    it('should prompt for login if there is no account', () => {
+      expect.assertions(0)
+      const { getByText } = rtl.render(
+        <Provider store={store}>
+          <ConfigContext.Provider value={config}>
+            <SettingsContent config={config} account={null} cards={[]} />
+          </ConfigContext.Provider>
+        </Provider>
+      )
+      getByText('Pay For Content Seamlessly')
+    })
+
+    it('should tell crypto users that they do not need the settings page', () => {
+      expect.assertions(0)
+      const { getByText } = rtl.render(
+        <Provider store={store}>
+          <ConfigContext.Provider value={config}>
+            <SettingsContent config={config} account={{}} cards={[]} />
+          </ConfigContext.Provider>
+        </Provider>
+      )
+      getByText(
+        "This page contains settings for managed account users. Crypto users (like you!) don't need it."
+      )
+    })
+
+    it('should show the account settings page for logged in managed account users', () => {
+      expect.assertions(0)
+      const { getByText } = rtl.render(
+        <Provider store={store}>
+          <ConfigContext.Provider value={config}>
+            <SettingsContent
+              config={config}
+              account={{ emailAddress: 'geoff@bitconnect.gov' }}
+              cards={[]}
+            />
+          </ConfigContext.Provider>
+        </Provider>
+      )
+      // We'll only ever see the change password text in this case!
+      getByText('Change Password')
+    })
+  })
+
+  describe('mapStateToProps', () => {
+    it('with default state it should return null account and empty cards list', () => {
+      expect.assertions(1)
+
+      expect(
+        mapStateToProps({
+          account: null,
+        })
+      ).toEqual({
+        account: null,
+        cards: [],
+      })
+    })
+  })
+})

--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -72,7 +72,6 @@ export class SettingsContent extends React.Component<
     }
   }
 
-  // SettingsContent is only relevant to managed account users, so this will only ever render a LogInSignUp for crypto users
   render() {
     const { stripe } = this.state
     const { cards, account } = this.props

--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -9,6 +9,7 @@ import AccountInfo from '../interface/user-account/AccountInfo'
 import ChangePassword from '../interface/user-account/ChangePassword'
 import PaymentDetails from '../interface/user-account/PaymentDetails'
 import PaymentMethods from '../interface/user-account/PaymentMethods'
+import LogInSignUp from '../interface/LogInSignUp'
 
 // TODO: tighten up this type
 declare global {
@@ -20,6 +21,9 @@ declare global {
 interface SettingsContentProps {
   config: {
     stripeApiKey: string
+  }
+  account?: {
+    emailAddress?: string
   }
   cards: stripe.Card[]
 }
@@ -68,9 +72,10 @@ export class SettingsContent extends React.Component<
     }
   }
 
+  // SettingsContent is only relevant to managed account users, so this will only ever render a LogInSignUp for crypto users
   render() {
     const { stripe } = this.state
-    const { cards } = this.props
+    const { cards, account } = this.props
 
     return (
       <Layout title="Account Settings">
@@ -79,10 +84,21 @@ export class SettingsContent extends React.Component<
           <script id="stripe-js" src="https://js.stripe.com/v3/" async></script>
         </Head>
         <Errors />
-        <AccountInfo />
-        <ChangePassword />
-        {cards.length > 0 && <PaymentMethods cards={cards} />}
-        {stripe && !cards.length && <PaymentDetails stripe={stripe} />}
+        {account && account.emailAddress && (
+          <>
+            <AccountInfo />
+            <ChangePassword />
+            {cards.length > 0 && <PaymentMethods cards={cards} />}
+            {stripe && !cards.length && <PaymentDetails stripe={stripe} />}
+          </>
+        )}
+        {!account && <LogInSignUp />}
+        {account && !account.emailAddress && (
+          <p>
+            This page contains settings for managed account users. Crypto users
+            (like you!) don&apos;t need it.
+          </p>
+        )}
       </Layout>
     )
   }
@@ -101,6 +117,7 @@ export const mapStateToProps = ({ account }: ReduxState) => {
   }
 
   return {
+    account,
     cards,
   }
 }

--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -22,9 +22,9 @@ interface SettingsContentProps {
   config: {
     stripeApiKey: string
   }
-  account?: {
+  account: {
     emailAddress?: string
-  }
+  } | null
   cards: stripe.Card[]
 }
 interface SettingsContentState {
@@ -104,9 +104,9 @@ export class SettingsContent extends React.Component<
 }
 
 interface ReduxState {
-  account?: {
+  account: {
     cards?: stripe.Card[]
-  }
+  } | null
 }
 
 export const mapStateToProps = ({ account }: ReduxState) => {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR resolves the blank settings page issue. If a user lands on the page without being signed in, they will be prompted to log in.

If a crypto user somehow ends up there, they will just get a message saying the page is unavailable to them (since SettingsContent is only meaningful for managed account users)

This works similarly to the way login is prompted on the (empty) KeyChain page, although KeyChain does allow crypto users.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
