### PR TITLE
Use a dummy address to initialize paywall for user accounts

### DIFF
--- a/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
@@ -9,7 +9,10 @@ import postOfficeMiddleware from '../../middlewares/postOfficeMiddleware'
 import { ADD_TO_CART } from '../../actions/keyPurchase'
 import { KEY_PURCHASE_INITIATED } from '../../actions/user'
 import { SET_ACCOUNT } from '../../actions/accounts'
-import { USER_ACCOUNT_ADDRESS_STORAGE_ID } from '../../constants'
+import {
+  USER_ACCOUNT_ADDRESS_STORAGE_ID,
+  DEFAULT_USER_ACCOUNT_ADDRESS,
+} from '../../constants'
 
 class MockPostOfficeService extends EventEmitter {
   constructor() {
@@ -89,15 +92,17 @@ describe('postOfficeMiddleware', () => {
   })
 
   describe('setting account', () => {
-    it('should set account to null when there is nothing in localStorage', () => {
+    it('should set account to the default address when there is nothing in localStorage', () => {
       expect.assertions(1)
 
       makeMiddleware()
 
-      expect(mockPostOfficeService.setAccount).toHaveBeenLastCalledWith(null)
+      expect(mockPostOfficeService.setAccount).toHaveBeenLastCalledWith(
+        DEFAULT_USER_ACCOUNT_ADDRESS
+      )
     })
 
-    it('should set account to null when localStorage contains a malformed value', () => {
+    it('should set account to the default address when localStorage contains a malformed value', () => {
       expect.assertions(1)
 
       const anAddress = 'some random garbage'
@@ -105,7 +110,9 @@ describe('postOfficeMiddleware', () => {
 
       makeMiddleware()
 
-      expect(mockPostOfficeService.setAccount).toHaveBeenLastCalledWith(null)
+      expect(mockPostOfficeService.setAccount).toHaveBeenLastCalledWith(
+        DEFAULT_USER_ACCOUNT_ADDRESS
+      )
     })
 
     it('should set account to the value provided by localStorage, if it is a real address', () => {
@@ -164,7 +171,7 @@ describe('postOfficeMiddleware', () => {
 
   describe('handling actions', () => {
     it('should tell the paywall about account changes', () => {
-      expect.assertions(3)
+      expect.assertions(2)
       const { invoke } = makeMiddleware()
       const action = {
         type: SET_ACCOUNT,
@@ -180,7 +187,6 @@ describe('postOfficeMiddleware', () => {
         '0x123abc'
       )
       expect(mockPostOfficeService.setAccount).toHaveBeenCalledWith('0x123abc')
-      expect(mockPostOfficeService.hideAccountModal).toHaveBeenCalled()
     })
 
     it('should tell the paywall about a purchase and dismiss itself when receiving KEY_PURCHASE_INITIATED', () => {

--- a/unlock-app/src/constants.ts
+++ b/unlock-app/src/constants.ts
@@ -105,3 +105,9 @@ export const POLLING_INTERVAL = 2000
 export const CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL = 10000
 
 export const USER_ACCOUNT_ADDRESS_STORAGE_ID = 'managedUserAccountAddress'
+
+// This represents an account that will never hold any keys. It's a bit of an
+// ugly hack, but it allows us to initialize the paywall without asking a user
+// to log in and without granting any unauthorized access.
+export const DEFAULT_USER_ACCOUNT_ADDRESS =
+  '0x0000000000000000000000000000000000000000'

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -10,7 +10,10 @@ import { KEY_PURCHASE_INITIATED } from '../actions/user'
 import { PostOffice } from '../utils/Error'
 import { addToCart, DISMISS_PURCHASE_MODAL } from '../actions/keyPurchase'
 import { SET_ACCOUNT } from '../actions/accounts'
-import { USER_ACCOUNT_ADDRESS_STORAGE_ID } from '../constants'
+import {
+  USER_ACCOUNT_ADDRESS_STORAGE_ID,
+  DEFAULT_USER_ACCOUNT_ADDRESS,
+} from '../constants'
 import { isAccount } from '../utils/validators'
 
 const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
@@ -25,11 +28,12 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
   // have keys to without logging in. This value should not go into
   // redux within `unlock-app`. Let the sign-in process handle that.
   let userAccountAddress = getItem(window, USER_ACCOUNT_ADDRESS_STORAGE_ID)
-  let gotAddressFromStorage = !!userAccountAddress
   if (!isAccount(userAccountAddress)) {
-    // Value retrieved from storage isn't a real account -- garbage crept in somewhere.
-    userAccountAddress = null
-    gotAddressFromStorage = false
+    // Value retrieved from storage isn't a real account -- either it was null
+    // or an invalid address was somehow stored.  We pass an address that will
+    // never own any keys, this way user account login is deferred until
+    // actually necessary.
+    userAccountAddress = DEFAULT_USER_ACCOUNT_ADDRESS
   }
 
   postOfficeService.setAccount(userAccountAddress)
@@ -68,22 +72,6 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
             USER_ACCOUNT_ADDRESS_STORAGE_ID,
             action.account.address
           )
-          // There are two paths for logging in:
-          //
-          // 1. The user had previously logged in, and we pulled their address
-          // from localStorage and "optimistically" browsed the page without
-          // logging in. Then, by attempting to purchase a key, they submitted a
-          // login. In that case, we should not hide the account modal, since
-          // they will need it open for the next step (key purchase
-          // confirmation).
-          //
-          // 2. The user had not previously logged in (address was null in
-          // localStorage). In this case, they were confronted with the login
-          // modal immediately upon visiting the page and will need it to get
-          // out of the way so that they can interact with the checkout.
-          if (!gotAddressFromStorage) {
-            postOfficeService.hideAccountModal()
-          }
         } else if (action.type === KEY_PURCHASE_INITIATED) {
           postOfficeService.transactionInitiated()
           postOfficeService.hideAccountModal()


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

For users who have previously logged in, we store their public key in localstorage to use as a default when initializing the paywall. For those who haven't previously logged in, we used to send null as a trigger to launch the account login modal.

This PR changes that by sending a "dummy" address when there isn't a prior login in localstorage. This allows us to defer launching the account login modal until the user interacts with the page.

I'd like to demo this a few times before merging, but feel free to have a look at the code in the meantime.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4857, fixes #4202 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
