### PR TITLE
locksmith yields the recoveryPhrase on account creation

### DIFF
--- a/locksmith/__tests__/operations/userOperations.test.ts
+++ b/locksmith/__tests__/operations/userOperations.test.ts
@@ -102,7 +102,7 @@ describe('User creation', () => {
       })
 
       let result = await UserOperations.createUser(userCreationDetails)
-      expect(result).toBe(true)
+      expect(result).toBe(RecoveryPhrase.generate())
     })
   })
 
@@ -114,7 +114,7 @@ describe('User creation', () => {
       })
 
       let result = await UserOperations.createUser(userCreationDetails)
-      expect(result).toBe(false)
+      expect(result).toBe(undefined)
     })
   })
 })

--- a/locksmith/src/controllers/userController.ts
+++ b/locksmith/src/controllers/userController.ts
@@ -15,14 +15,18 @@ namespace UserController {
 
     try {
       if (user) {
-        let creationStatus: Boolean = await UserOperations.createUser({
+        let recoveryPhrase:
+          | String
+          | undefined = await UserOperations.createUser({
           emailAddress: user.emailAddress,
           publicKey: user.publicKey,
           passwordEncryptedPrivateKey: user.passwordEncryptedPrivateKey,
         })
 
-        let status = creationStatus ? 200 : 400
-        return res.sendStatus(status)
+        let status = recoveryPhrase ? 200 : 400
+        return res.status(status).json({
+          recoveryPhrase,
+        })
       }
     } catch (e) {
       return res.sendStatus(400)

--- a/locksmith/src/operations/userOperations.ts
+++ b/locksmith/src/operations/userOperations.ts
@@ -17,7 +17,7 @@ const Op = Sequelize.Op
 namespace UserOperations {
   export const createUser = async (
     input: UserCreationInput
-  ): Promise<Boolean> => {
+  ): Promise<String | undefined> => {
     let recoveryPhrase = RecoveryPhrase.generate()
     let userReference = await UserReference.create(
       {
@@ -34,9 +34,9 @@ namespace UserOperations {
     )
 
     if (userReference) {
-      return true
+      return recoveryPhrase
     } else {
-      return false
+      return
     }
   }
 


### PR DESCRIPTION
# Description

The recovery phrase will be used to encode the private key on the frontend and send it by email to users.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread