### PR TITLE
Remove change password from the settings page for now

### DIFF
--- a/unlock-app/src/__tests__/components/content/SettingsContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/SettingsContent.test.tsx
@@ -59,23 +59,6 @@ describe('SettingsContent', () => {
         "This page contains settings for managed account users. Crypto users (like you!) don't need it."
       )
     })
-
-    it('should show the account settings page for logged in managed account users', () => {
-      expect.assertions(0)
-      const { getByText } = rtl.render(
-        <Provider store={store}>
-          <ConfigContext.Provider value={config}>
-            <SettingsContent
-              config={config}
-              account={{ emailAddress: 'geoff@bitconnect.gov' }}
-              cards={[]}
-            />
-          </ConfigContext.Provider>
-        </Provider>
-      )
-      // We'll only ever see the change password text in this case!
-      getByText('Change Password')
-    })
   })
 
   describe('mapStateToProps', () => {

--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -6,7 +6,6 @@ import Layout from '../interface/Layout'
 import { pageTitle } from '../../constants'
 import Errors from '../interface/Errors'
 import AccountInfo from '../interface/user-account/AccountInfo'
-import ChangePassword from '../interface/user-account/ChangePassword'
 import PaymentDetails from '../interface/user-account/PaymentDetails'
 import PaymentMethods from '../interface/user-account/PaymentMethods'
 import LogInSignUp from '../interface/LogInSignUp'
@@ -86,7 +85,6 @@ export class SettingsContent extends React.Component<
         {account && account.emailAddress && (
           <>
             <AccountInfo />
-            <ChangePassword />
             {cards.length > 0 && <PaymentMethods cards={cards} />}
             {stripe && !cards.length && <PaymentDetails stripe={stripe} />}
           </>


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

We're removing the `ChangePassword` component from the settings page for now because it's a little janky.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
