### PR TITLE
Expose blockchain data on the paywall

### DIFF
--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -5,6 +5,10 @@ import {
 } from '../windowTypes'
 import IframeHandler from './IframeHandler'
 import { PostMessages } from '../messageTypes'
+import {
+  BlockchainData,
+  unlockNetworks,
+} from '../data-iframe/blockchainHandler/blockChainTypes'
 
 interface hasPrototype {
   prototype?: any
@@ -26,6 +30,14 @@ export default class MainWindowHandler {
   private showingCheckout: boolean = false
   private showingAccountsIframe: boolean = false
   private lockStatus: LockStatus = undefined
+  private blockchainData: BlockchainData = {
+    locks: {},
+    account: null,
+    balance: {},
+    network: 1,
+    keys: {},
+    transactions: {},
+  }
 
   constructor(window: UnlockWindowNoProtocolYet, iframes: IframeHandler) {
     this.window = window
@@ -58,6 +70,24 @@ export default class MainWindowHandler {
     })
     this.iframes.data.on(PostMessages.UNLOCKED, () => {
       this.toggleLockState(PostMessages.UNLOCKED)
+    })
+    this.iframes.data.on(PostMessages.UPDATE_LOCKS, locks => {
+      this.blockchainData.locks = locks
+    })
+    this.iframes.data.on(PostMessages.UPDATE_ACCOUNT, address => {
+      this.blockchainData.account = address
+    })
+    this.iframes.data.on(PostMessages.UPDATE_ACCOUNT_BALANCE, balance => {
+      this.blockchainData.balance = balance
+    })
+    this.iframes.data.on(PostMessages.UPDATE_NETWORK, network => {
+      this.blockchainData.network = network as unlockNetworks
+    })
+    this.iframes.data.on(PostMessages.UPDATE_KEYS, keys => {
+      this.blockchainData.keys = keys
+    })
+    this.iframes.data.on(PostMessages.UPDATE_TRANSACTIONS, transactions => {
+      this.blockchainData.transactions = transactions
     })
     this.iframes.data.on(PostMessages.ERROR, e => {
       if (e === 'no ethereum wallet is available') {

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -160,6 +160,7 @@ export default class MainWindowHandler {
       this.showCheckoutIframe()
     }
     const getState = () => this.lockStatus
+    const blockchainData = () => this.blockchainData
 
     const unlockProtocol: hasPrototype = {}
 
@@ -176,6 +177,10 @@ export default class MainWindowHandler {
       },
       getState: {
         value: getState,
+        ...immutable,
+      },
+      blockchainData: {
+        value: blockchainData,
         ...immutable,
       },
     })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR makes the main window handler track the state of the blockchain handler and adds a method to `window.unlockProtocol` that allows end users to get the relevant data.

<img width="504" alt="image" src="https://user-images.githubusercontent.com/9300702/65796743-6aa48e00-e13b-11e9-911f-da476ac0d122.png">

The state that it provides mirrors the internal state of the blockchain handler

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
