### PR TITLE
Adds metadata operation allowing users to persist their own data associated with a given lock

### DIFF
--- a/locksmith/__tests__/controllers/linkDrop.test.js
+++ b/locksmith/__tests__/controllers/linkDrop.test.js
@@ -6,30 +6,9 @@ describe('transactionController', () => {
   beforeEach(async () => {
     await Transaction.bulkCreate([
       {
-        transactionHash: '0x345546565',
+        transactionHash: '0x345546567',
         sender: '0xcAFe',
         recipient: '0xBeeFE',
-      },
-      {
-        transactionHash: '0x445546565',
-        sender: '0xcAFe',
-        recipient: '0xBeeFE',
-      },
-      {
-        transactionHash: '0x545546565',
-        sender: '0xcAFe2',
-        recipient: '0xBeeFE',
-      },
-      {
-        transactionHash: '0x645546565',
-        sender: '0xcAFe2',
-        recipient: '0xBEefb',
-      },
-      {
-        transactionHash: '0x645546567',
-        sender: '0xcAFe2',
-        recipient: '0xBEefb',
-        for: '0xcAFe2',
       },
     ])
   })
@@ -49,7 +28,7 @@ describe('transactionController', () => {
           .post('/api/linkdrop/transaction')
           .set('Accept', /json/)
           .send({
-            transactionHash: '0xsdbegjkbg,egf',
+            transactionHash: '0xsdbegjkbg,egfzz',
             sender: '0xSDgErGR',
             recipient: '0xSdaG433r',
             data: transactionData,
@@ -73,7 +52,7 @@ describe('transactionController', () => {
           .post('/api/linkdrop/transaction')
           .set('Accept', /json/)
           .send({
-            transactionHash: '0x345546565',
+            transactionHash: '0x345546567',
             sender: '0xcAFe',
             recipient: '0xBeeFE',
           })

--- a/locksmith/__tests__/operations/userMetadataOperations.test.ts
+++ b/locksmith/__tests__/operations/userMetadataOperations.test.ts
@@ -3,16 +3,15 @@ import addMetadata from '../../src/operations/userMetadataOperations'
 
 const models = require('../../src/models')
 
-let UserMetadata: any = models.UserMetadata
+const { UserTokenMetadata } = models
 
 describe('userMetadataOperations', () => {
-  afterAll(async () => {
-    await UserMetadata.truncate()
+  beforeAll(async () => {
+    await UserTokenMetadata.truncate()
   })
-
   describe('addMetadata', () => {
     describe('adding new metadata', () => {
-      it('should return true', async () => {
+      it('should persist the changes', async () => {
         expect.assertions(1)
         let metadataUpdate = addMetadata({
           tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
@@ -35,7 +34,7 @@ describe('userMetadataOperations', () => {
     })
 
     describe('updating existing metadata', () => {
-      it('should return true', async () => {
+      it('should persist the changes', async () => {
         expect.assertions(1)
         let metadataUpdate = addMetadata({
           tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',

--- a/locksmith/__tests__/operations/userMetadataOperations.test.ts
+++ b/locksmith/__tests__/operations/userMetadataOperations.test.ts
@@ -1,0 +1,60 @@
+// import * as Sequelize from 'sequelize'
+import addMetadata from '../../src/operations/userMetadataOperations'
+
+const models = require('../../src/models')
+
+let UserMetadata: any = models.UserMetadata
+
+describe('userMetadataOperations', () => {
+  afterAll(async () => {
+    await UserMetadata.truncate()
+  })
+
+  describe('addMetadata', () => {
+    describe('adding new metadata', () => {
+      it('should return true', async () => {
+        expect.assertions(1)
+        let metadataUpdate = addMetadata({
+          tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
+          userAddress: '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212',
+          data: {
+            name: 'Bruce wayne',
+          },
+        })
+
+        let result = await metadataUpdate
+
+        expect(result[0]).toEqual(
+          expect.objectContaining({
+            data: { userMetadata: { name: 'Bruce wayne' } },
+            tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
+            userAddress: '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212',
+          })
+        )
+      })
+    })
+
+    describe('updating existing metadata', () => {
+      it('should return true', async () => {
+        expect.assertions(1)
+        let metadataUpdate = addMetadata({
+          tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
+          userAddress: '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212',
+          data: {
+            name: 'Clark Kent',
+          },
+        })
+
+        let result = await metadataUpdate
+
+        expect(result[0]).toEqual(
+          expect.objectContaining({
+            data: { userMetadata: { name: 'Clark Kent' } },
+            tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
+            userAddress: '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212',
+          })
+        )
+      })
+    })
+  })
+})

--- a/locksmith/migrations/20191001184934-usermetadataConstraint.js
+++ b/locksmith/migrations/20191001184934-usermetadataConstraint.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const table ='UserTokenMetadata'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addConstraint(table, ['tokenAddress', 'userAddress'],{
+      type: 'unique',
+      name : 'token_user_address_unique_constraint'
+    } )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.removeContraint(table, 'token_user_address_unique_constraint')
+  }
+};

--- a/locksmith/src/models/index.ts
+++ b/locksmith/src/models/index.ts
@@ -10,6 +10,7 @@ import { EventLink } from './eventLink'
 import { LockMetadata } from './lockMetadata'
 import { KeyMetadata } from './keyMetadata'
 import { ParsedBlockForLockCreation } from './parsedBlockForLockCreation'
+import { UserTokenMetadata } from './usertokenmetadata'
 
 const env = process.env.NODE_ENV || 'development'
 const config = require('../../config/config')[env]
@@ -28,6 +29,7 @@ sequelize.addModels([
   LockMetadata,
   KeyMetadata,
   ParsedBlockForLockCreation,
+  UserTokenMetadata,
 ])
 
 User.removeAttribute('id')
@@ -44,3 +46,4 @@ export * from './lock'
 export * from './transaction'
 export * from './authorizedLock'
 export * from './eventLink'
+export * from './usertokenmetadata'

--- a/locksmith/src/models/usertokenmetadata.ts
+++ b/locksmith/src/models/usertokenmetadata.ts
@@ -3,10 +3,10 @@ import { Table, Column, Model, DataType } from 'sequelize-typescript'
 @Table({ tableName: 'UserTokenMetadata', timestamps: true })
 // eslint-disable-next-line import/prefer-default-export
 export class UserTokenMetadata extends Model<UserTokenMetadata> {
-  @Column
+  @Column({ unique: 'token_user_address_unique_constraint' })
   tokenAddress!: string
 
-  @Column
+  @Column({ unique: 'token_user_address_unique_constraint' })
   userAddress!: string
 
   @Column(DataType.JSON)

--- a/locksmith/src/operations/userMetadataOperations.ts
+++ b/locksmith/src/operations/userMetadataOperations.ts
@@ -1,0 +1,29 @@
+import * as Normalizer from '../utils/normalizer'
+
+const models = require('../models')
+
+const { UserTokenMetadata } = models
+
+interface UserTokenMetadataInput {
+  tokenAddress: string
+  userAddress: string
+  data: any
+}
+
+const addMetadata = async (metadata: UserTokenMetadataInput) => {
+  return await UserTokenMetadata.upsert(
+    {
+      tokenAddress: Normalizer.ethereumAddress(metadata.tokenAddress),
+      userAddress: Normalizer.ethereumAddress(metadata.userAddress),
+      data: {
+        userMetadata: metadata.data,
+      },
+    },
+    {
+      fields: ['data'],
+      returning: true,
+    }
+  )
+}
+
+export default addMetadata


### PR DESCRIPTION
# Description

As part of the work allowing user the ability to store their own information on a given lock, we are starting to leverage the persistence previously created. 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
