### PR TITLE
add `blockchainData()` method to `window.unlockProtocol`

### DIFF
--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/blockchainData.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/blockchainData.test.ts
@@ -1,0 +1,168 @@
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import IframeHandler from '../../../unlock.js/IframeHandler'
+import MainWindowHandler from '../../../unlock.js/MainWindowHandler'
+import {
+  BlockchainData,
+  KeyResults,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import {
+  Locks,
+  Transactions,
+  TransactionStatus,
+  TransactionType,
+} from '../../../unlockTypes'
+import { PostMessages } from '../../../messageTypes'
+
+const defaultState: BlockchainData = {
+  account: null,
+  balance: {},
+  keys: {},
+  locks: {},
+  network: 1,
+  transactions: {},
+}
+
+describe('MainWindowHandler - blockchainData', () => {
+  let fakeWindow: FakeWindow
+  let iframes: IframeHandler
+  let handler: MainWindowHandler
+
+  function getBlockchainData() {
+    return (fakeWindow as any).unlockProtocol.blockchainData()
+  }
+
+  beforeAll(() => {
+    fakeWindow = new FakeWindow()
+    iframes = new IframeHandler(fakeWindow, 'http://t', 'http://u', 'http://v')
+    handler = new MainWindowHandler(fakeWindow, iframes)
+    handler.init()
+  })
+
+  it('should have empty state before any messages are received', () => {
+    expect.assertions(1)
+
+    expect(getBlockchainData()).toEqual(defaultState)
+  })
+
+  describe('handling messages', () => {
+    // These tests are stateful, this way we test that updates don't wipe out
+    // unrelated state
+    const accountAddress = '0xdeadbeef'
+    const keys: KeyResults = {
+      '0x123abc': {
+        lock: '0x123abc',
+        expiration: Date.now(),
+        owner: accountAddress,
+      },
+    }
+    const locks: Locks = {
+      '0x123abc': {
+        name: 'Rupert',
+        address: '0x123abc',
+        keyPrice: '2.3',
+        expirationDuration: 1010101013,
+        key: {
+          ...keys['0x123abc'],
+          transactions: [],
+          status: 'confirmed',
+          confirmations: 1337,
+        },
+        currencyContractAddress: '',
+      },
+    }
+    const balance = {
+      WEENUS: '1550',
+    }
+    const network = 1984
+    const transactions: Transactions = {
+      '0xC0FFEE': {
+        status: TransactionStatus.MINED,
+        confirmations: 15,
+        hash: '0xC0FFEE',
+        type: TransactionType.KEY_PURCHASE,
+        blockNumber: 143566669,
+      },
+    }
+
+    it('should store locks in response to UPDATE_LOCKS', () => {
+      expect.assertions(1)
+
+      iframes.data.emit(PostMessages.UPDATE_LOCKS, locks)
+
+      expect(getBlockchainData()).toEqual({
+        ...defaultState,
+        locks,
+      })
+    })
+
+    it('should store account address in response to UPDATE_ACCOUNT', () => {
+      expect.assertions(1)
+
+      iframes.data.emit(PostMessages.UPDATE_ACCOUNT, accountAddress)
+
+      expect(getBlockchainData()).toEqual({
+        ...defaultState,
+        locks,
+        account: accountAddress,
+      })
+    })
+
+    it('should store account balance in response to UPDATE_ACCOUNT_BALANCE', () => {
+      expect.assertions(1)
+
+      iframes.data.emit(PostMessages.UPDATE_ACCOUNT_BALANCE, balance)
+
+      expect(getBlockchainData()).toEqual({
+        ...defaultState,
+        locks,
+        account: accountAddress,
+        balance,
+      })
+    })
+
+    it('should store current network in response to UPDATE_NETWORK', () => {
+      expect.assertions(1)
+
+      iframes.data.emit(PostMessages.UPDATE_NETWORK, network)
+
+      expect(getBlockchainData()).toEqual({
+        ...defaultState,
+        locks,
+        account: accountAddress,
+        balance,
+        network,
+      })
+    })
+
+    it('should store keys in response to UPDATE_KEYS', () => {
+      expect.assertions(1)
+
+      iframes.data.emit(PostMessages.UPDATE_KEYS, keys)
+
+      expect(getBlockchainData()).toEqual({
+        ...defaultState,
+        locks,
+        account: accountAddress,
+        balance,
+        network,
+        keys,
+      })
+    })
+
+    it('should store transactions in response to UPDATE_TRANSACTIONS', () => {
+      expect.assertions(1)
+
+      iframes.data.emit(PostMessages.UPDATE_TRANSACTIONS, transactions)
+
+      expect(getBlockchainData()).toEqual({
+        ...defaultState,
+        locks,
+        account: accountAddress,
+        balance,
+        network,
+        keys,
+        transactions,
+      })
+    })
+  })
+})

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -71,6 +71,13 @@ export default class MainWindowHandler {
     this.iframes.data.on(PostMessages.UNLOCKED, () => {
       this.toggleLockState(PostMessages.UNLOCKED)
     })
+    this.iframes.data.on(PostMessages.ERROR, e => {
+      if (e === 'no ethereum wallet is available') {
+        this.toggleLockState(PostMessages.LOCKED)
+      }
+    })
+
+    // When the data iframe sends updates, store them in the mirror
     this.iframes.data.on(PostMessages.UPDATE_LOCKS, locks => {
       this.blockchainData.locks = locks
     })
@@ -88,11 +95,6 @@ export default class MainWindowHandler {
     })
     this.iframes.data.on(PostMessages.UPDATE_TRANSACTIONS, transactions => {
       this.blockchainData.transactions = transactions
-    })
-    this.iframes.data.on(PostMessages.ERROR, e => {
-      if (e === 'no ethereum wallet is available') {
-        this.toggleLockState(PostMessages.LOCKED)
-      }
     })
 
     // handle display of checkout and account UI

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -5,6 +5,10 @@ import {
 } from '../windowTypes'
 import IframeHandler from './IframeHandler'
 import { PostMessages } from '../messageTypes'
+import {
+  BlockchainData,
+  unlockNetworks,
+} from '../data-iframe/blockchainHandler/blockChainTypes'
 
 interface hasPrototype {
   prototype?: any
@@ -26,6 +30,14 @@ export default class MainWindowHandler {
   private showingCheckout: boolean = false
   private showingAccountsIframe: boolean = false
   private lockStatus: LockStatus = undefined
+  private blockchainData: BlockchainData = {
+    locks: {},
+    account: null,
+    balance: {},
+    network: 1,
+    keys: {},
+    transactions: {},
+  }
 
   constructor(window: UnlockWindowNoProtocolYet, iframes: IframeHandler) {
     this.window = window
@@ -58,6 +70,24 @@ export default class MainWindowHandler {
     })
     this.iframes.data.on(PostMessages.UNLOCKED, () => {
       this.toggleLockState(PostMessages.UNLOCKED)
+    })
+    this.iframes.data.on(PostMessages.UPDATE_LOCKS, locks => {
+      this.blockchainData.locks = locks
+    })
+    this.iframes.data.on(PostMessages.UPDATE_ACCOUNT, address => {
+      this.blockchainData.account = address
+    })
+    this.iframes.data.on(PostMessages.UPDATE_ACCOUNT_BALANCE, balance => {
+      this.blockchainData.balance = balance
+    })
+    this.iframes.data.on(PostMessages.UPDATE_NETWORK, network => {
+      this.blockchainData.network = network as unlockNetworks
+    })
+    this.iframes.data.on(PostMessages.UPDATE_KEYS, keys => {
+      this.blockchainData.keys = keys
+    })
+    this.iframes.data.on(PostMessages.UPDATE_TRANSACTIONS, transactions => {
+      this.blockchainData.transactions = transactions
     })
     this.iframes.data.on(PostMessages.ERROR, e => {
       if (e === 'no ethereum wallet is available') {

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -160,6 +160,7 @@ export default class MainWindowHandler {
       this.showCheckoutIframe()
     }
     const getState = () => this.lockStatus
+    const blockchainData = () => this.blockchainData
 
     const unlockProtocol: hasPrototype = {}
 
@@ -176,6 +177,10 @@ export default class MainWindowHandler {
       },
       getState: {
         value: getState,
+        ...immutable,
+      },
+      blockchainData: {
+        value: blockchainData,
         ...immutable,
       },
     })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a `blockchainData()` method to `window.unlockProtocol` which provides a mirror of the internal state of the blockchain handler. This allows consumers to get relevant information about the state of the chain.

The only contract provided here is that it mirrors the blockchain handler, and those internal details could change in the future (e.g., if we start using the graph and stop munging together the different kinds of data).

The immediate need is for this PR to expose the public key of the account using the paywall.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
