### PR TITLE
Adds endpoint for storing UserMetadata associated with Locks

### DIFF
--- a/locksmith/__tests__/controllers/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/metadataController.test.ts
@@ -307,6 +307,94 @@ describe('Metadata Controller', () => {
     })
   })
 
+  describe('updating address holder metadata', () => {
+    it('stores the passed data', async () => {
+      expect.assertions(1)
+
+      let typedData = generateKeyTypedData({
+        UserMetaData: {
+          owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+          data: {
+            emailAddress: 'emailAddress@example.com',
+          },
+        },
+      })
+
+      const sig = sigUtil.signTypedData(privateKey, {
+        data: typedData,
+        from: '',
+      })
+
+      let response = await request(app)
+        .put(
+          '/api/key/0x95de5F777A3e283bFf0c47374998E10D8A2183C7/user/0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+        )
+        .set('Accept', 'json')
+        .set('Authorization', `Bearer ${Base64.encode(sig)}`)
+        .send(typedData)
+
+      expect(response.status).toEqual(202)
+    })
+
+    it('should update existing data if it already exists', async () => {
+      expect.assertions(1)
+
+      let typedData = generateKeyTypedData({
+        UserMetaData: {
+          owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+          data: {
+            emailAddress: 'updatedEmailAddress@example.com',
+          },
+        },
+      })
+
+      const sig = sigUtil.signTypedData(privateKey, {
+        data: typedData,
+        from: '',
+      })
+
+      let response = await request(app)
+        .put(
+          '/api/key/0x95de5F777A3e283bFf0c47374998E10D8A2183C7/user/0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+        )
+        .set('Accept', 'json')
+        .set('Authorization', `Bearer ${Base64.encode(sig)}`)
+        .send(typedData)
+
+      expect(response.status).toEqual(202)
+    })
+
+    describe('when an invalid signature is passed', () => {
+      it('', async () => {
+        expect.assertions(1)
+
+        let typedData = generateKeyTypedData({
+          UserMetaData: {
+            owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+            data: {
+              emailAddress: 'updatedEmailAddress@example.com',
+            },
+          },
+        })
+
+        const sig = sigUtil.signTypedData(privateKey, {
+          data: typedData,
+          from: '',
+        })
+
+        let response = await request(app)
+          .put(
+            '/api/key/0x95de5F777A3e283bFf0c47374998E10D8A2183C7/user/0x6f7a54d6629b7416e17fc472b4003ae8ef18ef4c'
+          )
+          .set('Accept', 'json')
+          .set('Authorization', `Bearer ${Base64.encode(sig)}`)
+          .send(typedData)
+
+        expect(response.status).toEqual(401)
+      })
+    })
+  })
+
   describe('when the signee owns the lock', () => {
     let typedData: any
     beforeAll(() => {

--- a/locksmith/src/controllers/metadataController.ts
+++ b/locksmith/src/controllers/metadataController.ts
@@ -3,6 +3,8 @@ import Normalizer from '../utils/normalizer'
 import { SignedRequest } from '../types' // eslint-disable-line no-unused-vars, import/no-unresolved
 import LockData from '../utils/lockData'
 
+import addMetadata from '../operations/userMetadataOperations'
+
 const env = process.env.NODE_ENV || 'development'
 const config = require('../../config/config')[env]
 const metadataOperations = require('../operations/metadataOperations')
@@ -77,6 +79,29 @@ namespace MetadataController {
       } else {
         res.sendStatus(400)
       }
+    }
+  }
+
+  export const updateUserMetadata = async (
+    req: SignedRequest,
+    res: Response
+  ): Promise<any> => {
+    let userAddress = Normalizer.ethereumAddress(req.params.userAddress)
+    let tokenAddress = Normalizer.ethereumAddress(req.params.address)
+
+    let metadata = req.body.message['UserMetaData']
+    let data = metadata.data
+
+    if (req.owner == userAddress) {
+      await addMetadata({
+        userAddress,
+        tokenAddress,
+        data,
+      })
+
+      res.sendStatus(202)
+    } else {
+      res.sendStatus(401)
     }
   }
 

--- a/locksmith/src/operations/userMetadataOperations.ts
+++ b/locksmith/src/operations/userMetadataOperations.ts
@@ -10,7 +10,7 @@ interface UserTokenMetadataInput {
   data: any
 }
 
-const addMetadata = async (metadata: UserTokenMetadataInput) => {
+export default async function addMetadata(metadata: UserTokenMetadataInput) {
   return await UserTokenMetadata.upsert(
     {
       tokenAddress: Normalizer.ethereumAddress(metadata.tokenAddress),
@@ -25,5 +25,3 @@ const addMetadata = async (metadata: UserTokenMetadataInput) => {
     }
   )
 }
-
-export default addMetadata

--- a/locksmith/src/routes/metadata.ts
+++ b/locksmith/src/routes/metadata.ts
@@ -15,6 +15,12 @@ let keyMetaDataConfiguration = {
   signee: 'owner',
 }
 
+let userMetaDataConfiguration = {
+  name: 'UserMetaData',
+  required: ['owner', 'data'],
+  signee: 'owner',
+}
+
 router.put(
   '/:address',
   signatureValidationMiddleware.generateProcessor(metaDataConfiguration)
@@ -25,10 +31,16 @@ router.put(
   signatureValidationMiddleware.generateProcessor(keyMetaDataConfiguration)
 )
 
+router.put(
+  '/:address/user/:userAddress',
+  signatureValidationMiddleware.generateProcessor(userMetaDataConfiguration)
+)
+
 var metaDataController = require('../controllers/metadataController')
 
 router.get('/:address/:keyId', metaDataController.data)
 router.put('/:address/:keyId', metaDataController.updateKeyMetadata)
 router.put('/:address', metaDataController.updateDefaults)
+router.put('/:address/user/:userAddress', metaDataController.updateUserMetadata)
 
 module.exports = router


### PR DESCRIPTION
# Description

As part of allowing people to store their own data associated with tokens that they may own on Locks.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
