### PR TITLE
updateKeyPrice now uses the right decimals for erc20 contracts

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Version (minor!)
 
+- updateKeyPrice now uses the right decimals for erc20 contracts
 - Removed the 'owner' param on createLock since it is not really used (just emitted back)
 - Refactored signature to accept objects to be more flexible (this is a breaking change)
 

--- a/unlock-js/src/__tests__/v0/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v0/updateKeyPrice.test.js
@@ -18,7 +18,7 @@ let setupFail
 describe('v0', () => {
   describe('updateKeyPrice', () => {
     const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
-    const price = '100000000'
+    const keyPrice = '100000000'
 
     async function nockBeforeEach() {
       nock.cleanAll()
@@ -40,7 +40,7 @@ describe('v0', () => {
         testTransactionResult,
         success,
         fail,
-      } = callMethodData(utils.toWei(price, 'ether'))
+      } = callMethodData(utils.toWei(keyPrice, 'ether'))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
@@ -59,7 +59,7 @@ describe('v0', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.updateKeyPrice({ lockAddress, price })
+      await walletService.updateKeyPrice({ lockAddress, keyPrice })
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -85,7 +85,7 @@ describe('v0', () => {
         expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
       })
 
-      await walletService.updateKeyPrice({ lockAddress, price })
+      await walletService.updateKeyPrice({ lockAddress, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v01/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v01/updateKeyPrice.test.js
@@ -18,7 +18,7 @@ let setupFail
 describe('v01', () => {
   describe('updateKeyPrice', () => {
     const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
-    const price = '100000000'
+    const keyPrice = '100000000'
 
     async function nockBeforeEach() {
       nock.cleanAll()
@@ -40,7 +40,7 @@ describe('v01', () => {
         testTransactionResult,
         success,
         fail,
-      } = callMethodData(utils.toWei(price, 'ether'))
+      } = callMethodData(utils.toWei(keyPrice, 'ether'))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
@@ -59,7 +59,7 @@ describe('v01', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.updateKeyPrice({ lockAddress, price })
+      await walletService.updateKeyPrice({ lockAddress, keyPrice })
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -85,7 +85,7 @@ describe('v01', () => {
         expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
       })
 
-      await walletService.updateKeyPrice({ lockAddress, price })
+      await walletService.updateKeyPrice({ lockAddress, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v02/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v02/updateKeyPrice.test.js
@@ -18,7 +18,7 @@ let setupFail
 describe('v02', () => {
   describe('updateKeyPrice', () => {
     const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
-    const price = '100000000'
+    const keyPrice = '100000000'
 
     async function nockBeforeEach() {
       nock.cleanAll()
@@ -40,7 +40,7 @@ describe('v02', () => {
         testTransactionResult,
         success,
         fail,
-      } = callMethodData(utils.toWei(price, 'ether'))
+      } = callMethodData(utils.toWei(keyPrice, 'ether'))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
@@ -59,7 +59,7 @@ describe('v02', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.updateKeyPrice({ lockAddress, price })
+      await walletService.updateKeyPrice({ lockAddress, keyPrice })
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -85,7 +85,7 @@ describe('v02', () => {
         expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
       })
 
-      await walletService.updateKeyPrice({ lockAddress, price })
+      await walletService.updateKeyPrice({ lockAddress, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v10/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v10/updateKeyPrice.test.js
@@ -1,9 +1,12 @@
+import { ethers } from 'ethers'
 import * as UnlockV10 from 'unlock-abi-1-0'
 import utils from '../../utils'
+import { ZERO } from '../../constants'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
+import erc20 from '../../erc20'
 
 const { FAILED_TO_UPDATE_KEY_PRICE } = Errors
 const endpoint = 'http://127.0.0.1:8545'
@@ -15,18 +18,37 @@ let transactionResult
 let setupSuccess
 let setupFail
 
+jest.mock('../../erc20.js', () => {
+  return { getErc20Decimals: jest.fn() }
+})
+
 describe('v10', () => {
   describe('updateKeyPrice', () => {
     const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
-    const price = '100000000'
+    const keyPrice = '100000000'
+    const decimals = 8 // Do not test with 18 which is the default...
+    const erc20Address = '0x6F7a54D6629b7416E17fc472B4003aE8EF18EF4c'
 
-    async function nockBeforeEach() {
+    async function nockBeforeEach(decimals = 18, erc20Address) {
       nock.cleanAll()
       walletService = await prepWalletService(
         UnlockV10.PublicLock,
         endpoint,
         nock
       )
+
+      const metadata = new ethers.utils.Interface(UnlockV10.PublicLock.abi)
+      const contractMethods = metadata.functions
+      const resultEncoder = ethers.utils.defaultAbiCoder
+
+      // Mock the call to get erc20Address (only if it has been set!)
+      if (erc20Address) {
+        nock.ethCallAndYield(
+          contractMethods.tokenAddress.encode([]),
+          utils.toChecksumAddress(lockAddress),
+          resultEncoder.encode(['uint256'], [erc20Address])
+        )
+      }
 
       const callMethodData = prepContract({
         contract: UnlockV10.PublicLock,
@@ -40,7 +62,7 @@ describe('v10', () => {
         testTransactionResult,
         success,
         fail,
-      } = callMethodData(utils.toWei(price, 'ether'))
+      } = callMethodData(utils.toDecimal(keyPrice, decimals))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
@@ -48,45 +70,150 @@ describe('v10', () => {
       setupFail = fail
     }
 
-    it('should invoke _handleMethodCall with the right params', async () => {
-      expect.assertions(2)
+    describe('when the decimals are passed', () => {
+      it('should invoke _handleMethodCall with the right params', async () => {
+        expect.assertions(2)
 
-      await nockBeforeEach()
-      setupSuccess()
+        await nockBeforeEach(decimals)
+        setupSuccess()
 
-      walletService._handleMethodCall = jest.fn(() =>
-        Promise.resolve(transaction.hash)
-      )
-      const mock = walletService._handleMethodCall
+        walletService._handleMethodCall = jest.fn(() =>
+          Promise.resolve(transaction.hash)
+        )
+        const mock = walletService._handleMethodCall
 
-      await walletService.updateKeyPrice({ lockAddress, price })
+        await walletService.updateKeyPrice({ lockAddress, keyPrice, decimals })
 
-      expect(mock).toHaveBeenCalledWith(
-        expect.any(Promise),
-        TransactionTypes.UPDATE_KEY_PRICE
-      )
+        expect(mock).toHaveBeenCalledWith(
+          expect.any(Promise),
+          TransactionTypes.UPDATE_KEY_PRICE
+        )
 
-      // verify that the promise passed to _handleMethodCall actually resolves
-      // to the result the chain returns from a sendTransaction call to createLock
-      const result = await mock.mock.calls[0][0]
-      await result.wait()
-      expect(result).toEqual(transactionResult)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
+        // verify that the promise passed to _handleMethodCall actually resolves
+        // to the result the chain returns from a sendTransaction call to createLock
+        const result = await mock.mock.calls[0][0]
+        await result.wait()
+        expect(result).toEqual(transactionResult)
+        await nock.resolveWhenAllNocksUsed()
       })
 
-      await walletService.updateKeyPrice({ lockAddress, price })
-      await nock.resolveWhenAllNocksUsed()
+      it('should emit an error if the transaction could not be sent', async () => {
+        expect.assertions(1)
+
+        const error = { code: 404, data: 'oops' }
+        await nockBeforeEach(decimals)
+        setupFail(error)
+
+        walletService.on('error', error => {
+          expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
+        })
+
+        await walletService.updateKeyPrice({ lockAddress, keyPrice, decimals })
+        await nock.resolveWhenAllNocksUsed()
+      })
+    })
+
+    describe('when the decimals are not passed', () => {
+      describe('when the erc20Address is passed', () => {
+        it('should retrieve the decimals from the contract', async () => {
+          expect.assertions(1)
+
+          await nockBeforeEach(decimals)
+          setupSuccess()
+
+          walletService._handleMethodCall = jest.fn(() =>
+            Promise.resolve(transaction.hash)
+          )
+          const mock = walletService._handleMethodCall
+
+          // For ERC20 lock, we will retrieve the decimals
+          if (erc20Address !== ZERO) {
+            erc20.getErc20Decimals = jest.fn(() => {
+              return Promise.resolve(decimals)
+            })
+          }
+          await walletService.updateKeyPrice({
+            lockAddress,
+            keyPrice,
+            erc20Address,
+          })
+
+          expect(erc20.getErc20Decimals).toHaveBeenCalledWith(
+            erc20Address,
+            walletService.provider
+          )
+          // verify that the promise passed to _handleMethodCall actually resolves
+          // to the result the chain returns from a sendTransaction call to createLock
+          const result = await mock.mock.calls[0][0]
+          await result.wait()
+          await nock.resolveWhenAllNocksUsed()
+        })
+      })
+      describe('when the erc20Address is not passed', () => {
+        describe('when the lock is an ERC20 lock', () => {
+          it('should retrieve the decimals from the contract', async () => {
+            expect.assertions(1)
+
+            await nockBeforeEach(decimals, erc20Address)
+            setupSuccess()
+
+            walletService._handleMethodCall = jest.fn(() =>
+              Promise.resolve(transaction.hash)
+            )
+            const mock = walletService._handleMethodCall
+
+            erc20.getErc20Decimals = jest.fn(() => {
+              return Promise.resolve(decimals)
+            })
+            await walletService.updateKeyPrice({
+              lockAddress,
+              keyPrice,
+            })
+
+            expect(erc20.getErc20Decimals).toHaveBeenCalledWith(
+              erc20Address,
+              walletService.provider
+            )
+            // verify that the promise passed to _handleMethodCall actually resolves
+            // to the result the chain returns from a sendTransaction call to createLock
+            const result = await mock.mock.calls[0][0]
+            await result.wait()
+            await nock.resolveWhenAllNocksUsed()
+          })
+        })
+        describe('when the lock is an Ether lock', () => {
+          it('should use 18 as decimals', async () => {
+            expect.assertions(1)
+
+            await nockBeforeEach(
+              18 /* decimals for an ether lock */,
+              ZERO /* no erc20 contract */
+            )
+            setupSuccess()
+
+            walletService._handleMethodCall = jest.fn(() =>
+              Promise.resolve(transaction.hash)
+            )
+            const mock = walletService._handleMethodCall
+
+            erc20.getErc20Decimals = jest.fn(() => {
+              return Promise.resolve(decimals)
+            })
+            await walletService.updateKeyPrice({
+              lockAddress,
+              keyPrice,
+            })
+
+            expect(erc20.getErc20Decimals).not.toHaveBeenCalled()
+
+            // verify that the promise passed to _handleMethodCall actually resolves
+            // to the result the chain returns from a sendTransaction call to createLock
+            const result = await mock.mock.calls[0][0]
+            await result.wait()
+            await nock.resolveWhenAllNocksUsed()
+          })
+        })
+      })
     })
   })
 })

--- a/unlock-js/src/__tests__/v11/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v11/updateKeyPrice.test.js
@@ -1,9 +1,12 @@
+import { ethers } from 'ethers'
 import * as UnlockV11 from 'unlock-abi-1-1'
 import utils from '../../utils'
+import { ZERO } from '../../constants'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
+import erc20 from '../../erc20'
 
 const { FAILED_TO_UPDATE_KEY_PRICE } = Errors
 const endpoint = 'http://127.0.0.1:8545'
@@ -15,18 +18,37 @@ let transactionResult
 let setupSuccess
 let setupFail
 
+jest.mock('../../erc20.js', () => {
+  return { getErc20Decimals: jest.fn() }
+})
+
 describe('v11', () => {
   describe('updateKeyPrice', () => {
     const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
-    const price = '100000000'
+    const keyPrice = '100000000'
+    const decimals = 8 // Do not test with 18 which is the default...
+    const erc20Address = '0x6F7a54D6629b7416E17fc472B4003aE8EF18EF4c'
 
-    async function nockBeforeEach() {
+    async function nockBeforeEach(decimals = 18, erc20Address) {
       nock.cleanAll()
       walletService = await prepWalletService(
         UnlockV11.PublicLock,
         endpoint,
         nock
       )
+
+      const metadata = new ethers.utils.Interface(UnlockV11.PublicLock.abi)
+      const contractMethods = metadata.functions
+      const resultEncoder = ethers.utils.defaultAbiCoder
+
+      // Mock the call to get erc20Address (only if it has been set!)
+      if (erc20Address) {
+        nock.ethCallAndYield(
+          contractMethods.tokenAddress.encode([]),
+          utils.toChecksumAddress(lockAddress),
+          resultEncoder.encode(['uint256'], [erc20Address])
+        )
+      }
 
       const callMethodData = prepContract({
         contract: UnlockV11.PublicLock,
@@ -40,7 +62,7 @@ describe('v11', () => {
         testTransactionResult,
         success,
         fail,
-      } = callMethodData(utils.toWei(price, 'ether'))
+      } = callMethodData(utils.toDecimal(keyPrice, decimals))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
@@ -48,45 +70,150 @@ describe('v11', () => {
       setupFail = fail
     }
 
-    it('should invoke _handleMethodCall with the right params', async () => {
-      expect.assertions(2)
+    describe('when the decimals are passed', () => {
+      it('should invoke _handleMethodCall with the right params', async () => {
+        expect.assertions(2)
 
-      await nockBeforeEach()
-      setupSuccess()
+        await nockBeforeEach(decimals)
+        setupSuccess()
 
-      walletService._handleMethodCall = jest.fn(() =>
-        Promise.resolve(transaction.hash)
-      )
-      const mock = walletService._handleMethodCall
+        walletService._handleMethodCall = jest.fn(() =>
+          Promise.resolve(transaction.hash)
+        )
+        const mock = walletService._handleMethodCall
 
-      await walletService.updateKeyPrice({ lockAddress, price })
+        await walletService.updateKeyPrice({ lockAddress, keyPrice, decimals })
 
-      expect(mock).toHaveBeenCalledWith(
-        expect.any(Promise),
-        TransactionTypes.UPDATE_KEY_PRICE
-      )
+        expect(mock).toHaveBeenCalledWith(
+          expect.any(Promise),
+          TransactionTypes.UPDATE_KEY_PRICE
+        )
 
-      // verify that the promise passed to _handleMethodCall actually resolves
-      // to the result the chain returns from a sendTransaction call to createLock
-      const result = await mock.mock.calls[0][0]
-      await result.wait()
-      expect(result).toEqual(transactionResult)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
+        // verify that the promise passed to _handleMethodCall actually resolves
+        // to the result the chain returns from a sendTransaction call to createLock
+        const result = await mock.mock.calls[0][0]
+        await result.wait()
+        expect(result).toEqual(transactionResult)
+        await nock.resolveWhenAllNocksUsed()
       })
 
-      await walletService.updateKeyPrice({ lockAddress, price })
-      await nock.resolveWhenAllNocksUsed()
+      it('should emit an error if the transaction could not be sent', async () => {
+        expect.assertions(1)
+
+        const error = { code: 404, data: 'oops' }
+        await nockBeforeEach(decimals)
+        setupFail(error)
+
+        walletService.on('error', error => {
+          expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
+        })
+
+        await walletService.updateKeyPrice({ lockAddress, keyPrice, decimals })
+        await nock.resolveWhenAllNocksUsed()
+      })
+    })
+
+    describe('when the decimals are not passed', () => {
+      describe('when the erc20Address is passed', () => {
+        it('should retrieve the decimals from the contract', async () => {
+          expect.assertions(1)
+
+          await nockBeforeEach(decimals)
+          setupSuccess()
+
+          walletService._handleMethodCall = jest.fn(() =>
+            Promise.resolve(transaction.hash)
+          )
+          const mock = walletService._handleMethodCall
+
+          // For ERC20 lock, we will retrieve the decimals
+          if (erc20Address !== ZERO) {
+            erc20.getErc20Decimals = jest.fn(() => {
+              return Promise.resolve(decimals)
+            })
+          }
+          await walletService.updateKeyPrice({
+            lockAddress,
+            keyPrice,
+            erc20Address,
+          })
+
+          expect(erc20.getErc20Decimals).toHaveBeenCalledWith(
+            erc20Address,
+            walletService.provider
+          )
+          // verify that the promise passed to _handleMethodCall actually resolves
+          // to the result the chain returns from a sendTransaction call to createLock
+          const result = await mock.mock.calls[0][0]
+          await result.wait()
+          await nock.resolveWhenAllNocksUsed()
+        })
+      })
+      describe('when the erc20Address is not passed', () => {
+        describe('when the lock is an ERC20 lock', () => {
+          it('should retrieve the decimals from the contract', async () => {
+            expect.assertions(1)
+
+            await nockBeforeEach(decimals, erc20Address)
+            setupSuccess()
+
+            walletService._handleMethodCall = jest.fn(() =>
+              Promise.resolve(transaction.hash)
+            )
+            const mock = walletService._handleMethodCall
+
+            erc20.getErc20Decimals = jest.fn(() => {
+              return Promise.resolve(decimals)
+            })
+            await walletService.updateKeyPrice({
+              lockAddress,
+              keyPrice,
+            })
+
+            expect(erc20.getErc20Decimals).toHaveBeenCalledWith(
+              erc20Address,
+              walletService.provider
+            )
+            // verify that the promise passed to _handleMethodCall actually resolves
+            // to the result the chain returns from a sendTransaction call to createLock
+            const result = await mock.mock.calls[0][0]
+            await result.wait()
+            await nock.resolveWhenAllNocksUsed()
+          })
+        })
+        describe('when the lock is an Ether lock', () => {
+          it('should use 18 as decimals', async () => {
+            expect.assertions(1)
+
+            await nockBeforeEach(
+              18 /* decimals for an ether lock */,
+              ZERO /* no erc20 contract */
+            )
+            setupSuccess()
+
+            walletService._handleMethodCall = jest.fn(() =>
+              Promise.resolve(transaction.hash)
+            )
+            const mock = walletService._handleMethodCall
+
+            erc20.getErc20Decimals = jest.fn(() => {
+              return Promise.resolve(decimals)
+            })
+            await walletService.updateKeyPrice({
+              lockAddress,
+              keyPrice,
+            })
+
+            expect(erc20.getErc20Decimals).not.toHaveBeenCalled()
+
+            // verify that the promise passed to _handleMethodCall actually resolves
+            // to the result the chain returns from a sendTransaction call to createLock
+            const result = await mock.mock.calls[0][0]
+            await result.wait()
+            await nock.resolveWhenAllNocksUsed()
+          })
+        })
+      })
     })
   })
 })

--- a/unlock-js/src/v0/updateKeyPrice.js
+++ b/unlock-js/src/v0/updateKeyPrice.js
@@ -7,14 +7,14 @@ import Errors from '../errors'
  * Changes the price of keys on a given lock
  * @param {object} params
  * - {PropTypes.address} lockAddress : address of the lock for which we update the price
- * - {string} price : new price for the lock, as a string (as wei)
+ * - {string} keyPrice : new price for the lock, as a string (as wei)
  */
-export default async function({ lockAddress, price }) {
+export default async function({ lockAddress, keyPrice }) {
   const lockContract = await this.getLockContract(lockAddress)
   let transactionPromise
   try {
     transactionPromise = lockContract['updateKeyPrice(uint256)'](
-      utils.toWei(price, 'ether'),
+      utils.toWei(keyPrice, 'ether'),
       {
         gasLimit: GAS_AMOUNTS.updateKeyPrice,
       }

--- a/unlock-js/src/v01/updateKeyPrice.js
+++ b/unlock-js/src/v01/updateKeyPrice.js
@@ -7,14 +7,14 @@ import Errors from '../errors'
  *
  * @param {object} params
  * - {PropTypes.address} lock : address of the lock for which we update the price
- * - {string} price : new price for the lock
+ * - {string} keyPrice : new price for the lock
  */
-export default async function({ lockAddress, price }) {
+export default async function({ lockAddress, keyPrice }) {
   const lockContract = await this.getLockContract(lockAddress)
   let transactionPromise
   try {
     transactionPromise = lockContract['updateKeyPrice(uint256)'](
-      utils.toWei(price, 'ether'),
+      utils.toWei(keyPrice, 'ether'),
       {
         gasLimit: GAS_AMOUNTS.updateKeyPrice,
       }

--- a/unlock-js/src/v02/updateKeyPrice.js
+++ b/unlock-js/src/v02/updateKeyPrice.js
@@ -7,14 +7,14 @@ import Errors from '../errors'
  * Changes the price of keys on a given lock
  * @param {object} params
  * - {PropTypes.address} lockAddress : address of the lock for which we update the price
- * - {string} price : new price for the lock, as a string (as wei)
+ * - {string} keyPrice : new price for the lock, as a string (as wei)
  */
-export default async function({ lockAddress, price }) {
+export default async function({ lockAddress, keyPrice }) {
   const lockContract = await this.getLockContract(lockAddress)
   let transactionPromise
   try {
     transactionPromise = lockContract['updateKeyPrice(uint256)'](
-      utils.toWei(price, 'ether'),
+      utils.toWei(keyPrice, 'ether'),
       {
         gasLimit: GAS_AMOUNTS.updateKeyPrice,
       }

--- a/unlock-js/src/v10/updateKeyPrice.js
+++ b/unlock-js/src/v10/updateKeyPrice.js
@@ -1,25 +1,45 @@
 import utils from '../utils'
-import { GAS_AMOUNTS } from '../constants'
+import { GAS_AMOUNTS, ZERO } from '../constants'
 import TransactionTypes from '../transactionTypes'
 import Errors from '../errors'
+import { getErc20Decimals } from '../erc20'
 
 /**
  * Changes the price of keys on a given lock
  * @param {object} params
  * - {PropTypes.address} lockAddress : address of the lock for which we update the price
- * - {string} price : new price for the lock, as a string (as wei)
- * TODO: retrieve the decimals rather than assume ether/18!
+ * - {string} keyPrice : new price for the lock, as a string (as wei)
+ * - {string} decimals : Optional number of decimals (read from contract if unset)
+ * - {string} erc20Address : Optional address of ERC20, to retrieve decimals (read from contract if unset)
  */
-export default async function({ lockAddress, price }) {
+export default async function({
+  lockAddress,
+  keyPrice,
+  decimals,
+  erc20Address,
+}) {
   const lockContract = await this.getLockContract(lockAddress)
+
+  if (decimals == null) {
+    // Get the decimals address from the contract
+    if (!erc20Address || erc20Address !== ZERO) {
+      erc20Address = await lockContract.tokenAddress()
+    }
+
+    if (erc20Address && erc20Address !== ZERO) {
+      decimals = await getErc20Decimals(erc20Address, this.provider)
+    } else {
+      decimals = 18
+    }
+  }
+
+  const actualAmount = utils.toDecimal(keyPrice, decimals)
+
   let transactionPromise
   try {
-    transactionPromise = lockContract['updateKeyPrice(uint256)'](
-      utils.toWei(price, 'ether'),
-      {
-        gasLimit: GAS_AMOUNTS.updateKeyPrice,
-      }
-    )
+    transactionPromise = lockContract['updateKeyPrice(uint256)'](actualAmount, {
+      gasLimit: GAS_AMOUNTS.updateKeyPrice,
+    })
     const ret = await this._handleMethodCall(
       transactionPromise,
       TransactionTypes.UPDATE_KEY_PRICE

--- a/unlock-js/src/v10/updateKeyPrice.js
+++ b/unlock-js/src/v10/updateKeyPrice.js
@@ -22,7 +22,7 @@ export default async function({
 
   if (decimals == null) {
     // Get the decimals address from the contract
-    if (!erc20Address || erc20Address !== ZERO) {
+    if (!erc20Address) {
       erc20Address = await lockContract.tokenAddress()
     }
 
@@ -32,7 +32,6 @@ export default async function({
       decimals = 18
     }
   }
-
   const actualAmount = utils.toDecimal(keyPrice, decimals)
 
   let transactionPromise

--- a/unlock-js/src/v11/updateKeyPrice.js
+++ b/unlock-js/src/v11/updateKeyPrice.js
@@ -1,25 +1,45 @@
 import utils from '../utils'
-import { GAS_AMOUNTS } from '../constants'
+import { GAS_AMOUNTS, ZERO } from '../constants'
 import TransactionTypes from '../transactionTypes'
 import Errors from '../errors'
+import { getErc20Decimals } from '../erc20'
 
 /**
  * Changes the price of keys on a given lock
  * @param {object} params
  * - {PropTypes.address} lockAddress : address of the lock for which we update the price
- * - {string} price : new price for the lock, as a string (as wei)
- * TODO: retrieve the decimals rather than assume ether/18!
+ * - {string} keyPrice : new price for the lock, as a string (as wei)
+ * - {string} decimals : Optional number of decimals (read from contract if unset)
+ * - {string} erc20Address : Optional address of ERC20, to retrieve decimals (read from contract if unset)
  */
-export default async function({ lockAddress, price }) {
+export default async function({
+  lockAddress,
+  keyPrice,
+  decimals,
+  erc20Address,
+}) {
   const lockContract = await this.getLockContract(lockAddress)
+
+  if (decimals == null) {
+    // Get the decimals address from the contract
+    if (!erc20Address || erc20Address !== ZERO) {
+      erc20Address = await lockContract.tokenAddress()
+    }
+
+    if (erc20Address && erc20Address !== ZERO) {
+      decimals = await getErc20Decimals(erc20Address, this.provider)
+    } else {
+      decimals = 18
+    }
+  }
+
+  const actualAmount = utils.toDecimal(keyPrice, decimals)
+
   let transactionPromise
   try {
-    transactionPromise = lockContract['updateKeyPrice(uint256)'](
-      utils.toWei(price, 'ether'),
-      {
-        gasLimit: GAS_AMOUNTS.updateKeyPrice,
-      }
-    )
+    transactionPromise = lockContract['updateKeyPrice(uint256)'](actualAmount, {
+      gasLimit: GAS_AMOUNTS.updateKeyPrice,
+    })
     const ret = await this._handleMethodCall(
       transactionPromise,
       TransactionTypes.UPDATE_KEY_PRICE

--- a/unlock-js/src/v11/updateKeyPrice.js
+++ b/unlock-js/src/v11/updateKeyPrice.js
@@ -22,7 +22,7 @@ export default async function({
 
   if (decimals == null) {
     // Get the decimals address from the contract
-    if (!erc20Address || erc20Address !== ZERO) {
+    if (!erc20Address) {
       erc20Address = await lockContract.tokenAddress()
     }
 
@@ -32,7 +32,6 @@ export default async function({
       decimals = 18
     }
   }
-
   const actualAmount = utils.toDecimal(keyPrice, decimals)
 
   let transactionPromise


### PR DESCRIPTION
# Description

Our key price update was not using the rigth number of decimals for ERC20 contract with decimals not equal to 18.
We are now retrieving the number of decimals from the ERC20 contract itself.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread