### PR TITLE
Paywall tells accounts iframe if page is locked/unlocked

### DIFF
--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
@@ -131,11 +131,12 @@ describe('MainWindowHandler - init', () => {
     })
 
     it('should dispatch unlockProtocol event, locked', () => {
-      expect.assertions(1)
+      expect.assertions(2)
 
       const handler = getMainWindowHandler()
       handler.init()
       handler.dispatchEvent = jest.fn()
+      iframes.accounts.postMessage = jest.fn()
 
       fakeWindow.receivePostMessageFromIframe(
         PostMessages.LOCKED,
@@ -145,6 +146,10 @@ describe('MainWindowHandler - init', () => {
       )
 
       expect(handler.dispatchEvent).toHaveBeenCalledWith('locked')
+      expect(iframes.accounts.postMessage).toHaveBeenCalledWith(
+        PostMessages.LOCKED,
+        undefined
+      )
     })
 
     it('should set unlocked state for react apps', () => {
@@ -181,11 +186,12 @@ describe('MainWindowHandler - init', () => {
     })
 
     it('should dispatch unlockProtocol event, unlocked', () => {
-      expect.assertions(1)
+      expect.assertions(2)
 
       const handler = getMainWindowHandler()
       handler.init()
       handler.dispatchEvent = jest.fn()
+      iframes.accounts.postMessage = jest.fn()
 
       const unlockedLockAddresses = ['address']
       fakeWindow.receivePostMessageFromIframe(
@@ -196,6 +202,10 @@ describe('MainWindowHandler - init', () => {
       )
 
       expect(handler.dispatchEvent).toHaveBeenCalledWith('unlocked')
+      expect(iframes.accounts.postMessage).toHaveBeenCalledWith(
+        PostMessages.UNLOCKED,
+        undefined
+      )
     })
 
     it('should dispatch locked when receiving a no crypto wallet error', () => {

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -91,6 +91,8 @@ export default class MainWindowHandler {
       this.setCachedLockedState(isLocked)
       // Update the user-facing status with locked/unlocked updates
       this.lockStatus = message
+      // Let the user account iframe know the status by propagating the message
+      this.iframes.accounts.postMessage(message, undefined)
     }
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

In order to resolve an issue with the paywall prompting user account users to purchase a key they already own, this PR has the paywall tell the accounts iframe whether the page is locked or not. In a follow-on PR, the accounts iframe will use that information to determine whether it should show the purchase prompt.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #4934 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
