### PR TITLE
Account iframe listens for locked/unlocked

### DIFF
--- a/unlock-app/src/__tests__/services/postOfficeService.test.ts
+++ b/unlock-app/src/__tests__/services/postOfficeService.test.ts
@@ -212,6 +212,32 @@ describe('postOfficeService', () => {
       })
     })
 
+    it('should add a handler for PostMessages.LOCKED', () => {
+      expect.assertions(1)
+
+      mockService = new PostOfficeService(fakeWindow, 2)
+
+      mockService.on(PostOfficeEvents.Locked, () => {
+        // Just verifying that this event is triggered
+        expect(true).toBeTruthy()
+      })
+
+      triggerListener<PostMessages.LOCKED>(PostMessages.LOCKED, undefined)
+    })
+
+    it('should add a handler for PostMessages.UNLOCKED', () => {
+      expect.assertions(1)
+
+      mockService = new PostOfficeService(fakeWindow, 2)
+
+      mockService.on(PostOfficeEvents.Unlocked, () => {
+        // Just verifying that this event is triggered
+        expect(true).toBeTruthy()
+      })
+
+      triggerListener<PostMessages.UNLOCKED>(PostMessages.UNLOCKED, undefined)
+    })
+
     it('should error if an invalid lock address is passed to PostMessages.PURCHASE_KEY', () => {
       expect.assertions(1)
 

--- a/unlock-app/src/__tests__/services/postOfficeService.test.ts
+++ b/unlock-app/src/__tests__/services/postOfficeService.test.ts
@@ -85,7 +85,7 @@ describe('postOfficeService', () => {
       expectPostMessage<PostMessages.READY>(PostMessages.READY, undefined)
     })
 
-    it('should add a handler for PostMessages.SEND_UPDATES', () => {
+    it('should add a handler for PostMessages.SEND_UPDATES (account)', () => {
       expect.assertions(1)
 
       mockService = new PostOfficeService(fakeWindow, 2)
@@ -94,6 +94,17 @@ describe('postOfficeService', () => {
         PostMessages.SEND_UPDATES,
         PostMessages.UPDATE_ACCOUNT
       >(PostMessages.SEND_UPDATES, 'account', PostMessages.UPDATE_ACCOUNT, null)
+    })
+
+    it('should add a handler for PostMessages.SEND_UPDATES (network)', () => {
+      expect.assertions(1)
+
+      mockService = new PostOfficeService(fakeWindow, 2)
+
+      expectListenerRespondsWith<
+        PostMessages.SEND_UPDATES,
+        PostMessages.UPDATE_NETWORK
+      >(PostMessages.SEND_UPDATES, 'network', PostMessages.UPDATE_NETWORK, 2)
     })
 
     it('should add a handler for PostMessages.UPDATE_LOCKS', done => {

--- a/unlock-app/src/messageTypes.ts
+++ b/unlock-app/src/messageTypes.ts
@@ -41,7 +41,7 @@ export type Message =
     }
   | {
       type: PostMessages.UNLOCKED
-      payload: string[]
+      payload: undefined
     }
   | {
       type: PostMessages.SCROLL_POSITION

--- a/unlock-app/src/services/postOfficeService.ts
+++ b/unlock-app/src/services/postOfficeService.ts
@@ -11,6 +11,8 @@ export enum PostOfficeEvents {
   LockUpdate = 'update.locks',
   KeyPurchase = 'purchase.key.request',
   Error = 'error',
+  Locked = 'locked',
+  Unlocked = 'unlocked',
 }
 
 export class PostOfficeService extends EventEmitter {
@@ -59,6 +61,12 @@ export class PostOfficeService extends EventEmitter {
         }
       }
     )
+    this.postOffice.addHandler(PostMessages.LOCKED, () => {
+      this.emit(PostOfficeEvents.Locked)
+    })
+    this.postOffice.addHandler(PostMessages.UNLOCKED, () => {
+      this.emit(PostOfficeEvents.Unlocked)
+    })
   }
 
   private sendAccount() {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Another link in the chain, now the user account iframe listens for the locked and unlocked postmessages and emits an event when it receives them.

Next steps: handle the event in `postOfficeMiddleware` and get the page status into Redux.

(also added a missing test for `SEND_UPDATES`)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
A step on the road to #4934 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
