### PR TITLE
Wait for the iframe to initialize before draining buffer

### DIFF
--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/AccountsIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/AccountsIframeMessageEmitter.test.ts
@@ -39,19 +39,24 @@ describe('AccountsIframeMessageEmitter', () => {
       emitter.postMessage(PostMessages.HIDE_ACCOUNTS_MODAL, undefined)
       expect(emitter.buffer).toHaveLength(2)
 
-      // Note that postMessage is mocked now -- the previous 2 calls
-      // haven't happened as far as it is concerned.
-      emitter.postMessage = jest.fn()
-      // createIframe will call sendBufferedMessages, which will send
-      // the buffered calls back through
+      // createIframe will set up the listeners, including the one for ready
       emitter.createIframe()
+      ;(emitter as any)._postMessage = jest.fn()
 
-      expect(emitter.postMessage).toHaveBeenNthCalledWith(
+      // After this fires, the buffer will start to drain
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.READY,
+        undefined,
+        emitter.iframe,
+        accountsOrigin
+      )
+
+      expect((emitter as any)._postMessage).toHaveBeenNthCalledWith(
         1,
         PostMessages.LOCKED,
         undefined
       )
-      expect(emitter.postMessage).toHaveBeenNthCalledWith(
+      expect((emitter as any)._postMessage).toHaveBeenNthCalledWith(
         2,
         PostMessages.HIDE_ACCOUNTS_MODAL,
         undefined

--- a/paywall/src/__tests__/unlock.js/Wallet/setupUserAccounts.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/setupUserAccounts.test.ts
@@ -81,6 +81,14 @@ describe('Wallet.setupUserAccounts()', () => {
       dataOrigin
     )
 
+    // messages to the accounts iframe are buffered until it is ready
+    fakeWindow.receivePostMessageFromIframe(
+      PostMessages.READY,
+      undefined,
+      iframes.accounts.iframe,
+      accountsOrigin
+    )
+
     fakeWindow.expectPostMessageSentToIframe(
       PostMessages.UPDATE_LOCKS,
       locks,

--- a/paywall/src/__tests__/unlock.js/Wallet/setupUserAccountsProxyWallet.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/setupUserAccountsProxyWallet.test.ts
@@ -123,6 +123,14 @@ describe('Wallet.setupUserAccounts()', () => {
       checkoutOrigin
     )
 
+    // Accounts iframe buffers postmessages until it receives READY
+    fakeWindow.receivePostMessageFromIframe(
+      PostMessages.READY,
+      undefined,
+      iframes.accounts.iframe,
+      accountsOrigin
+    )
+
     fakeWindow.expectPostMessageSentToIframe(
       PostMessages.PURCHASE_KEY,
       purchaseRequest,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Follow up on #4936, this PR just changes it so that we wait for the READY postMessage before sending the buffered messages. This guarantees that the iframe has its post office set up to catch them.


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
