### PR TITLE
Updating token metadata endpoint to include User Metadata

### DIFF
--- a/locksmith/__tests__/controllers/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/metadataController.test.ts
@@ -3,6 +3,7 @@ import * as sigUtil from 'eth-sig-util'
 import * as ethJsUtil from 'ethereumjs-util'
 import { LockMetadata } from '../../src/models/lockMetadata'
 import { KeyMetadata } from '../../src/models/keyMetadata'
+import { addMetadata } from '../../src/operations/userMetadataOperations'
 
 const app = require('../../src/app')
 const Base64 = require('../../src/utils/base64')
@@ -180,6 +181,34 @@ describe('Metadata Controller', () => {
               'https://assets.unlock-protocol.com/nft-images/week-in-ethereum.png',
             name: 'Unlock Key to Week in Ethereum News',
             custom_item: 'custom value',
+          })
+        )
+      })
+    })
+
+    describe('when the user has provided metadata', () => {
+      beforeAll(async () => {
+        await addMetadata({
+          tokenAddress: '0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691',
+          userAddress: '0xaBCD',
+          data: {
+            mock: 'values',
+          },
+        })
+      })
+
+      it('returns their payload in the response', async () => {
+        expect.assertions(2)
+        let response = await request(app)
+          .get('/api/key/0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691/1')
+          .set('Accept', 'json')
+
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            description:
+              'A Key to an Unlock lock. Unlock is a protocol for memberships. https://unlock-protocol.com/',
+            userMetadata: { mock: 'values' },
           })
         )
       })

--- a/locksmith/__tests__/operations/userMetadataOperations.test.ts
+++ b/locksmith/__tests__/operations/userMetadataOperations.test.ts
@@ -1,5 +1,7 @@
-// import * as Sequelize from 'sequelize'
-import addMetadata from '../../src/operations/userMetadataOperations'
+import {
+  addMetadata,
+  getMetadata,
+} from '../../src/operations/userMetadataOperations'
 
 const models = require('../../src/models')
 
@@ -51,6 +53,39 @@ describe('userMetadataOperations', () => {
             data: { userMetadata: { name: 'Clark Kent' } },
             tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
             userAddress: '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212',
+          })
+        )
+      })
+    })
+  })
+
+  describe('getMetadata', () => {
+    describe("when metadata for the pair doesn't exist ", () => {
+      it('returns null', async () => {
+        expect.assertions(1)
+
+        let metaData = await getMetadata(
+          '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
+          '0xabbc'
+        )
+        let result = await metaData
+        expect(result).toBe(null)
+      })
+    })
+
+    describe('when metadata for the pair exists', () => {
+      it('returns the metadata', async () => {
+        expect.assertions(1)
+
+        let metaData = getMetadata(
+          '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
+          '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212'
+        )
+        let result = await metaData
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            userMetadata: expect.anything(),
           })
         )
       })

--- a/locksmith/src/controllers/metadataController.ts
+++ b/locksmith/src/controllers/metadataController.ts
@@ -3,7 +3,7 @@ import Normalizer from '../utils/normalizer'
 import { SignedRequest } from '../types' // eslint-disable-line no-unused-vars, import/no-unresolved
 import LockData from '../utils/lockData'
 
-import addMetadata from '../operations/userMetadataOperations'
+import { addMetadata } from '../operations/userMetadataOperations'
 
 const env = process.env.NODE_ENV || 'development'
 const config = require('../../config/config')[env]
@@ -22,9 +22,7 @@ namespace MetadataController {
     if (Object.keys(keyMetadata).length == 0) {
       res.sendStatus(404)
     } else {
-      return res.json(
-        await metadataOperations.generateKeyMetadata(address, keyId)
-      )
+      return res.json(keyMetadata)
     }
   }
 

--- a/locksmith/src/operations/metadataOperations.ts
+++ b/locksmith/src/operations/metadataOperations.ts
@@ -2,10 +2,13 @@ import { KeyMetadata } from '../models/keyMetadata'
 import { LockMetadata } from '../models/lockMetadata'
 import Metadata from '../../config/metadata'
 import KeyData from '../utils/keyData'
+import { getMetadata } from './userMetadataOperations'
 
 const env = process.env.NODE_ENV || 'development'
 const config = require('../../config/config')[env]
 const Asset = require('../utils/assets')
+
+let baseURIFragement = 'https://assets.unlock-protocol.com'
 
 export const updateKeyMetadata = async (data: any) => {
   try {
@@ -30,9 +33,19 @@ export const generateKeyMetadata = async (address: string, keyId: string) => {
   if (Object.keys(onChainKeyMetadata).length == 0) {
     return {}
   }
+
+  let kd = new KeyData(config.web3ProviderHost)
+  let data = await kd.get(address, keyId)
+  let userMetadata = data.owner ? await getMetadata(address, data.owner) : {}
+
   let keyCentricData = await getKeyCentricData(address, keyId)
   let baseTokenData = await getBaseTokenData(address)
-  return Object.assign(baseTokenData, keyCentricData, onChainKeyMetadata)
+  return Object.assign(
+    baseTokenData,
+    keyCentricData,
+    onChainKeyMetadata,
+    userMetadata
+  )
 }
 
 const getBaseTokenData = async (address: string) => {
@@ -42,7 +55,7 @@ const getBaseTokenData = async (address: string) => {
   })
 
   let assetLocation = Asset.tokenMetadataDefaultImage({
-    base: 'https://assets.unlock-protocol.com',
+    base: baseURIFragement,
     address: address,
   })
 
@@ -66,7 +79,7 @@ const getKeyCentricData = async (address: string, tokenId: string) => {
   })
 
   let assetLocation = Asset.tokenCentricImage({
-    base: 'https://assets.unlock-protocol.com',
+    base: baseURIFragement,
     address: address,
     tokenId: tokenId,
   })
@@ -90,7 +103,7 @@ const defaultMappings = (address: string) => {
   let defaultResponse = {
     name: 'Unlock Key',
     description: 'A Key to an Unlock lock.',
-    image: 'https://assets.unlock-protocol.com/unlock-default-key-image.png',
+    image: `${baseURIFragement}/unlock-default-key-image.png`,
   }
 
   // Custom mappings

--- a/locksmith/src/operations/userMetadataOperations.ts
+++ b/locksmith/src/operations/userMetadataOperations.ts
@@ -10,7 +10,7 @@ interface UserTokenMetadataInput {
   data: any
 }
 
-export default async function addMetadata(metadata: UserTokenMetadataInput) {
+export async function addMetadata(metadata: UserTokenMetadataInput) {
   return await UserTokenMetadata.upsert(
     {
       tokenAddress: Normalizer.ethereumAddress(metadata.tokenAddress),
@@ -24,4 +24,15 @@ export default async function addMetadata(metadata: UserTokenMetadataInput) {
       returning: true,
     }
   )
+}
+
+export async function getMetadata(tokenAddress: string, userAddress: string) {
+  let data = await UserTokenMetadata.findOne({
+    where: {
+      tokenAddress: Normalizer.ethereumAddress(tokenAddress),
+      userAddress: Normalizer.ethereumAddress(userAddress),
+    },
+  })
+
+  return data ? data.data : data
 }


### PR DESCRIPTION
# Description

Supporting the use case of appending user provided metadata to
a token that may not currently exist, we provide a way to retrieve
stored data in addition to the existing metadata that was already being returned.

**At some point will need to follow this up with a clean up, as this functionality can & should be extracted for use outside of Unlock**


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
