### PR TITLE
Page {locked,unlocked} status available in redux for account iframe

### DIFF
--- a/unlock-app/src/__tests__/actions/pageStatus.test.ts
+++ b/unlock-app/src/__tests__/actions/pageStatus.test.ts
@@ -1,0 +1,21 @@
+import { setLockedState, SET_LOCKED_STATE } from '../../actions/pageStatus'
+
+describe('setLockedState', () => {
+  it('should create an action for when the page is locked', () => {
+    expect.assertions(1)
+
+    expect(setLockedState(true)).toEqual({
+      type: SET_LOCKED_STATE,
+      isLocked: true,
+    })
+  })
+
+  it('should create an action for when the page is unlocked', () => {
+    expect.assertions(1)
+
+    expect(setLockedState(false)).toEqual({
+      type: SET_LOCKED_STATE,
+      isLocked: false,
+    })
+  })
+})

--- a/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/postOfficeMiddleware.test.ts
@@ -13,6 +13,7 @@ import {
   USER_ACCOUNT_ADDRESS_STORAGE_ID,
   DEFAULT_USER_ACCOUNT_ADDRESS,
 } from '../../constants'
+import { SET_LOCKED_STATE } from '../../actions/pageStatus'
 
 class MockPostOfficeService extends EventEmitter {
   constructor() {
@@ -165,6 +166,30 @@ describe('postOfficeMiddleware', () => {
         type: ADD_TO_CART,
         lock: 'this is the lock payload',
         tip,
+      })
+    })
+
+    it('should set locked state when receiving Locked', () => {
+      expect.assertions(1)
+
+      const { store } = makeMiddleware()
+      mockPostOfficeService.emit(PostOfficeEvents.Locked)
+
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: SET_LOCKED_STATE,
+        isLocked: true,
+      })
+    })
+
+    it('should set unlocked state when receiving Unlocked', () => {
+      expect.assertions(1)
+
+      const { store } = makeMiddleware()
+      mockPostOfficeService.emit(PostOfficeEvents.Unlocked)
+
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: SET_LOCKED_STATE,
+        isLocked: false,
       })
     })
   })

--- a/unlock-app/src/__tests__/reducers/pageStatusReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/pageStatusReducer.test.ts
@@ -1,0 +1,19 @@
+import reducer, { initialState } from '../../reducers/pageStatusReducer'
+import { setLockedState } from '../../actions/pageStatus'
+
+describe('pageStatusReducer', () => {
+  it('should set state in response to setLockedState', () => {
+    expect.assertions(3)
+    let isLocked: boolean = initialState
+
+    // State just takes whatever boolean is passed into it
+    isLocked = reducer(isLocked, setLockedState(true))
+    expect(isLocked).toBeTruthy()
+
+    isLocked = reducer(isLocked, setLockedState(false))
+    expect(isLocked).toBeFalsy()
+
+    isLocked = reducer(isLocked, setLockedState(true))
+    expect(isLocked).toBeTruthy()
+  })
+})

--- a/unlock-app/src/actions/pageStatus.ts
+++ b/unlock-app/src/actions/pageStatus.ts
@@ -1,0 +1,6 @@
+export const SET_LOCKED_STATE = 'accountsIframe/setLockedState'
+
+export const setLockedState = (isLocked: boolean) => ({
+  type: SET_LOCKED_STATE,
+  isLocked,
+})

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -54,6 +54,9 @@ import cartReducer, {
 import recoveryReducer, {
   initialState as defaultRecoveryPhrase,
 } from './reducers/recoveryReducer'
+import pageStatusReducer, {
+  initialState as defaultPageStatus,
+} from './reducers/pageStatusReducer'
 
 const config = configure()
 
@@ -79,6 +82,7 @@ export const createUnlockStore = (
     userDetails: privateKeyReducer,
     cart: cartReducer,
     recoveryPhrase: recoveryReducer,
+    pageIsLocked: pageStatusReducer,
   }
 
   // Cleanup the defaultState to remove all null values so that we do not overwrite existing
@@ -107,6 +111,7 @@ export const createUnlockStore = (
       userDetails: defaultPrivateKeyState,
       recoveryPhrase: defaultRecoveryPhrase,
       cart: defaultCartState,
+      pageIsLocked: defaultPageStatus,
     },
     {
       provider: Object.keys(config.providers)[0],

--- a/unlock-app/src/middlewares/postOfficeMiddleware.ts
+++ b/unlock-app/src/middlewares/postOfficeMiddleware.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_USER_ACCOUNT_ADDRESS,
 } from '../constants'
 import { isAccount } from '../utils/validators'
+import { setLockedState } from '../actions/pageStatus'
 
 const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
   const postOfficeService = new PostOfficeService(
@@ -59,6 +60,13 @@ const postOfficeMiddleware = (window: IframePostOfficeWindow, config: any) => {
         dispatch(addToCart({ lock, tip }))
         postOfficeService.showAccountModal()
       }
+    )
+
+    postOfficeService.on(PostOfficeEvents.Locked, () =>
+      dispatch(setLockedState(true))
+    )
+    postOfficeService.on(PostOfficeEvents.Unlocked, () =>
+      dispatch(setLockedState(false))
     )
 
     return (next: any) => {

--- a/unlock-app/src/reducers/pageStatusReducer.ts
+++ b/unlock-app/src/reducers/pageStatusReducer.ts
@@ -1,0 +1,14 @@
+import { SET_LOCKED_STATE } from '../actions/pageStatus'
+import { Action } from '../unlockTypes'
+
+export const initialState: boolean = false
+
+const pageStatusReducer = (state = initialState, action: Action) => {
+  if (action.type === SET_LOCKED_STATE) {
+    state = action.isLocked
+  }
+
+  return state
+}
+
+export default pageStatusReducer


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR finally stores the locked status of the page the accounts iframe is hosted in. This will allow us to prevent duplicate key purchases.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #4934 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
