### PR TITLE
AccountContent recognizes when user has a key

### DIFF
--- a/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
@@ -40,7 +40,11 @@ describe('AccountContent', () => {
       expect.assertions(0)
       const { getByText } = rtl.render(
         <Provider store={store}>
-          <AccountContent config={config} dismissPurchaseModal={() => true} />
+          <AccountContent
+            config={config}
+            dismissPurchaseModal={() => true}
+            pageIsLocked={false}
+          />
         </Provider>
       )
       getByText((_, node) => {
@@ -58,6 +62,7 @@ describe('AccountContent', () => {
             emailAddress="john@smi.th"
             cards={[]}
             dismissPurchaseModal={() => true}
+            pageIsLocked={false}
           />
         </Provider>
       )
@@ -75,6 +80,7 @@ describe('AccountContent', () => {
             emailAddress="john@smi.th"
             cards={[mockCard]}
             dismissPurchaseModal={() => true}
+            pageIsLocked={false}
           />
         </Provider>
       )
@@ -94,6 +100,7 @@ describe('AccountContent', () => {
             emailAddress="john@smi.th"
             cards={[mockCard]}
             dismissPurchaseModal={dismissPurchaseModal}
+            pageIsLocked={false}
           />
         </Provider>
       )
@@ -109,11 +116,24 @@ describe('AccountContent', () => {
   })
 
   describe('mapStateToProps', () => {
-    it('should return empty object if no account in state', () => {
+    it('should return object without account if no account in state', () => {
       expect.assertions(2)
-      expect(mapStateToProps({})).toEqual({})
+      expect(
+        mapStateToProps({
+          pageIsLocked: false,
+        })
+      ).toEqual({
+        pageIsLocked: false,
+      })
       // or if state has an account with no contents
-      expect(mapStateToProps({ account: {} })).toEqual({})
+      expect(
+        mapStateToProps({
+          account: {},
+          pageIsLocked: false,
+        })
+      ).toEqual({
+        pageIsLocked: false,
+      })
     })
 
     it('should grab and pass email and cards from account if available', () => {
@@ -125,11 +145,13 @@ describe('AccountContent', () => {
           emailAddress,
           cards,
         },
+        pageIsLocked: true,
       }
 
       expect(mapStateToProps(state)).toEqual({
         emailAddress,
         cards,
+        pageIsLocked: true,
       })
     })
   })

--- a/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
@@ -52,7 +52,7 @@ describe('AccountContent', () => {
       })
     })
 
-    it('Should collect payment details if there are no cards in account', () => {
+    it('Should collect payment details if there are no cards in account and the page is locked', () => {
       expect.assertions(0)
 
       const { getByText } = rtl.render(
@@ -62,7 +62,7 @@ describe('AccountContent', () => {
             emailAddress="john@smi.th"
             cards={[]}
             dismissPurchaseModal={() => true}
-            pageIsLocked={false}
+            pageIsLocked
           />
         </Provider>
       )
@@ -70,7 +70,7 @@ describe('AccountContent', () => {
       getByText('Card Details')
     })
 
-    it('Should prompt to confirm purchase if we have an account with cards', () => {
+    it('Should prompt to confirm purchase if we have an account with cards and the page is locked', () => {
       expect.assertions(0)
 
       const { getByText } = rtl.render(
@@ -80,7 +80,7 @@ describe('AccountContent', () => {
             emailAddress="john@smi.th"
             cards={[mockCard]}
             dismissPurchaseModal={() => true}
-            pageIsLocked={false}
+            pageIsLocked
           />
         </Provider>
       )

--- a/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/AccountContent.test.tsx
@@ -52,6 +52,24 @@ describe('AccountContent', () => {
       })
     })
 
+    it('Should show the message about already having a key if the page is unlocked after logging in', () => {
+      expect.assertions(0)
+
+      const { getByText } = rtl.render(
+        <Provider store={store}>
+          <AccountContent
+            config={config}
+            emailAddress="john@smi.th"
+            cards={[]}
+            dismissPurchaseModal={() => true}
+            pageIsLocked={false}
+          />
+        </Provider>
+      )
+
+      getByText('You already own a key to this lock!')
+    })
+
     it('Should collect payment details if there are no cards in account and the page is locked', () => {
       expect.assertions(0)
 

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -181,13 +181,13 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-bbmXgH fNYDXK"
+      class="sc-jnlKLf jKMWma"
     >
       <div
-        class="sc-jnlKLf ggYeg"
+        class="sc-tilXH jqgYeL"
       >
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         >
           <div
             class="paper"
@@ -244,36 +244,36 @@ Object {
           </div>
         </div>
         <div
-          class="sc-tilXH kFhjLe"
+          class="sc-ktHwxA hHPiDD"
         >
           Address
           <span
-            class="sc-gGBfsJ jlOwIx"
+            class="sc-fYxtnH iWHWCo"
             id="NetworkName"
           >
             Rinkeby
           </span>
         </div>
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-hEsumM jtGKlD"
+          class="sc-cIShpX ePXlrt"
           id="UserAddress"
         >
           0x3ca206264762caf81a8f0a843bbb850987b41e16
@@ -524,13 +524,13 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-bbmXgH fNYDXK"
+      class="sc-jnlKLf jKMWma"
     >
       <div
-        class="sc-jnlKLf ggYeg"
+        class="sc-tilXH jqgYeL"
       >
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         >
           <div
             class="paper"
@@ -587,36 +587,36 @@ Object {
           </div>
         </div>
         <div
-          class="sc-tilXH kFhjLe"
+          class="sc-ktHwxA hHPiDD"
         >
           Address
           <span
-            class="sc-gGBfsJ jlOwIx"
+            class="sc-fYxtnH iWHWCo"
             id="NetworkName"
           >
             Rinkeby
           </span>
         </div>
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-fYxtnH hlxwSY"
+          class="sc-hEsumM kQujec"
         />
         <div
-          class="sc-hEsumM jtGKlD"
+          class="sc-cIShpX ePXlrt"
           id="UserAddress"
         >
           0x3ca206264762caf81a8f0a843bbb850987b41e16
@@ -7823,7 +7823,7 @@ Object {
           class="sc-9upljg-3 kjuFdI"
         >
           <button
-            class="sc-ktHwxA sc-9upljg-0 cTMzWy"
+            class="sc-kafWEX sc-9upljg-0 cTMzWy"
           >
             Go to Your Dashboard
           </button>
@@ -8631,7 +8631,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-ksYbfQ cEjxfP"
+          class="sc-frDJqD cUzIMQ"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -8667,7 +8667,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-hmzhuo jSiJYK"
+          class="sc-kvZOFW iRNTBN"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -9481,7 +9481,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-ksYbfQ cEjxfP"
+          class="sc-frDJqD cUzIMQ"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -9517,7 +9517,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-hmzhuo jSiJYK"
+          class="sc-kvZOFW iRNTBN"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -10192,7 +10192,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-ksYbfQ cEjxfP"
+          class="sc-frDJqD cUzIMQ"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -10214,7 +10214,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-hmzhuo jSiJYK"
+          class="sc-kvZOFW iRNTBN"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -11050,7 +11050,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-ksYbfQ cEjxfP"
+          class="sc-frDJqD cUzIMQ"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -11086,7 +11086,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-hmzhuo jSiJYK"
+          class="sc-kvZOFW iRNTBN"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -11814,7 +11814,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-ksYbfQ cEjxfP"
+          class="sc-frDJqD cUzIMQ"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -11850,7 +11850,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-hmzhuo jSiJYK"
+          class="sc-kvZOFW iRNTBN"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -12430,7 +12430,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-ksYbfQ cEjxfP"
+          class="sc-frDJqD cUzIMQ"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -12452,7 +12452,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-hmzhuo jSiJYK"
+          class="sc-kvZOFW iRNTBN"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -13263,7 +13263,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-ksYbfQ cEjxfP"
+          class="sc-frDJqD cUzIMQ"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -13299,7 +13299,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-hmzhuo jSiJYK"
+          class="sc-kvZOFW iRNTBN"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -14231,7 +14231,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-ksYbfQ cEjxfP"
+          class="sc-frDJqD cUzIMQ"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -14267,7 +14267,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-hmzhuo jSiJYK"
+          class="sc-kvZOFW iRNTBN"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -15199,7 +15199,7 @@ Object {
         class="mlglvd-3 VbhUE"
       >
         <div
-          class="sc-ksYbfQ cEjxfP"
+          class="sc-frDJqD cUzIMQ"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -15235,7 +15235,7 @@ Object {
           </div>
         </div>
         <div
-          class="sc-hmzhuo jSiJYK"
+          class="sc-kvZOFW iRNTBN"
         >
           <div
             class="buwkmd-0 bYclZI"
@@ -20872,12 +20872,12 @@ Object {
           class="sc-1olgoav-3 hxpbwC"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             Balance
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             Balance
           </div>
@@ -21021,7 +21021,7 @@ Object {
           class="mlglvd-3 VbhUE"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -21057,7 +21057,7 @@ Object {
             </div>
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -21319,7 +21319,7 @@ Object {
           class="mlglvd-3 VbhUE"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -21355,7 +21355,7 @@ Object {
             </div>
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -21480,7 +21480,7 @@ Object {
         </div>
       </div>
       <section
-        class="sc-hqyNC hrCEFr"
+        class="sc-dNLxif jEFmuO"
       >
         <svg
           alt="loading"
@@ -22060,19 +22060,19 @@ Object {
           class="sc-1olgoav-3 hxpbwC"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             Balance
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             Balance
           </div>
         </div>
       </div>
       <section
-        class="sc-hqyNC hrCEFr"
+        class="sc-dNLxif jEFmuO"
       >
         <svg
           alt="loading"
@@ -23357,12 +23357,12 @@ Object {
           class="sc-1olgoav-3 hxpbwC"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             Balance
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             Balance
           </div>
@@ -23506,7 +23506,7 @@ Object {
           class="mlglvd-3 VbhUE"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -23542,7 +23542,7 @@ Object {
             </div>
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -23804,7 +23804,7 @@ Object {
           class="mlglvd-3 VbhUE"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -23840,7 +23840,7 @@ Object {
             </div>
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -24289,26 +24289,26 @@ Object {
           class="sc-1olgoav-3 hxpbwC"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             Balance
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             Balance
           </div>
         </div>
       </div>
       <section
-        class="sc-dNLxif gyDelK"
+        class="sc-uJMKN jdudSz"
       >
         <img
-          class="sc-jqCOkK byRdQy"
+          class="sc-bbmXgH dChXtj"
           src="/static/images/illustrations/lock.svg"
         />
         <div
-          class="sc-uJMKN jKDTPW"
+          class="sc-gGBfsJ dPJdVq"
         >
           <h1>
             Create a lock to get started
@@ -24953,12 +24953,12 @@ Object {
           class="sc-1olgoav-3 hxpbwC"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             Balance
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             Balance
           </div>
@@ -25953,12 +25953,12 @@ Object {
           class="sc-1olgoav-3 hxpbwC"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             Balance
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             Balance
           </div>
@@ -26102,7 +26102,7 @@ Object {
           class="mlglvd-3 VbhUE"
         >
           <div
-            class="sc-ksYbfQ cEjxfP"
+            class="sc-frDJqD cUzIMQ"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -26138,7 +26138,7 @@ Object {
             </div>
           </div>
           <div
-            class="sc-hmzhuo jSiJYK"
+            class="sc-kvZOFW iRNTBN"
           >
             <div
               class="buwkmd-0 bYclZI"
@@ -29451,16 +29451,16 @@ Object {
           />
         </header>
         <div
-          class="sc-kafWEX gDTgRH"
+          class="sc-iELTvK cSEIZI"
         >
           <section
-            class="sc-bbmXgH fNYDXK"
+            class="sc-jnlKLf jKMWma"
           >
             <div
-              class="sc-jnlKLf ggYeg"
+              class="sc-tilXH jqgYeL"
             >
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               >
                 <div
                   class="paper"
@@ -29517,36 +29517,36 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-tilXH kFhjLe"
+                class="sc-ktHwxA hHPiDD"
               >
                 Address
                 <span
-                  class="sc-gGBfsJ jlOwIx"
+                  class="sc-fYxtnH iWHWCo"
                   id="NetworkName"
                 >
                   Winston
                 </span>
               </div>
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-hEsumM jtGKlD"
+                class="sc-cIShpX ePXlrt"
                 id="UserAddress"
               >
                 0x3ca206264762caf81a8f0a843bbb850987b41e16
@@ -29554,7 +29554,7 @@ Object {
             </div>
           </section>
           <button
-            class="sc-ktHwxA sc-cIShpX jMyVPp"
+            class="sc-kafWEX sc-feJyhm kFPMYx"
             id="CreateLockButton"
           >
             Create Lock
@@ -29595,12 +29595,12 @@ Object {
               class="sc-1olgoav-3 hxpbwC"
             >
               <div
-                class="sc-ksYbfQ cEjxfP"
+                class="sc-frDJqD cUzIMQ"
               >
                 Balance
               </div>
               <div
-                class="sc-hmzhuo jSiJYK"
+                class="sc-kvZOFW iRNTBN"
               >
                 Balance
               </div>
@@ -29744,7 +29744,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-ksYbfQ cEjxfP"
+                class="sc-frDJqD cUzIMQ"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -29780,7 +29780,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-hmzhuo jSiJYK"
+                class="sc-kvZOFW iRNTBN"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -30042,7 +30042,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-ksYbfQ cEjxfP"
+                class="sc-frDJqD cUzIMQ"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -30078,7 +30078,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-hmzhuo jSiJYK"
+                class="sc-kvZOFW iRNTBN"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -30340,7 +30340,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-ksYbfQ cEjxfP"
+                class="sc-frDJqD cUzIMQ"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -30376,7 +30376,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-hmzhuo jSiJYK"
+                class="sc-kvZOFW iRNTBN"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -32731,16 +32731,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-btzYZH fjFKkF"
+      class="sc-bYSBpT gXcQiX"
     >
       <div
-        class="sc-jwKygS dSWNAf"
+        class="sc-lhVmIH gZGkEg"
       >
         <p>
           Please check your browser wallet.
         </p>
         <button
-          class="sc-feJyhm oFfvn"
+          class="sc-cmTdod ftojYZ"
         >
           Dismiss
         </button>
@@ -32988,16 +32988,16 @@ Object {
           />
         </header>
         <div
-          class="sc-kafWEX gDTgRH"
+          class="sc-iELTvK cSEIZI"
         >
           <section
-            class="sc-bbmXgH fNYDXK"
+            class="sc-jnlKLf jKMWma"
           >
             <div
-              class="sc-jnlKLf ggYeg"
+              class="sc-tilXH jqgYeL"
             >
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               >
                 <div
                   class="paper"
@@ -33054,36 +33054,36 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-tilXH kFhjLe"
+                class="sc-ktHwxA hHPiDD"
               >
                 Address
                 <span
-                  class="sc-gGBfsJ jlOwIx"
+                  class="sc-fYxtnH iWHWCo"
                   id="NetworkName"
                 >
                   Winston
                 </span>
               </div>
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-hEsumM jtGKlD"
+                class="sc-cIShpX ePXlrt"
                 id="UserAddress"
               >
                 0x3ca206264762caf81a8f0a843bbb850987b41e16
@@ -33091,7 +33091,7 @@ Object {
             </div>
           </section>
           <button
-            class="sc-ktHwxA sc-cIShpX jMyVPp"
+            class="sc-kafWEX sc-feJyhm kFPMYx"
             id="CreateLockButton"
           >
             Create Lock
@@ -33132,12 +33132,12 @@ Object {
               class="sc-1olgoav-3 hxpbwC"
             >
               <div
-                class="sc-ksYbfQ cEjxfP"
+                class="sc-frDJqD cUzIMQ"
               >
                 Balance
               </div>
               <div
-                class="sc-hmzhuo jSiJYK"
+                class="sc-kvZOFW iRNTBN"
               >
                 Balance
               </div>
@@ -33281,7 +33281,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-ksYbfQ cEjxfP"
+                class="sc-frDJqD cUzIMQ"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -33317,7 +33317,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-hmzhuo jSiJYK"
+                class="sc-kvZOFW iRNTBN"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -33579,7 +33579,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-ksYbfQ cEjxfP"
+                class="sc-frDJqD cUzIMQ"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -33615,7 +33615,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-hmzhuo jSiJYK"
+                class="sc-kvZOFW iRNTBN"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -33877,7 +33877,7 @@ Object {
               class="mlglvd-3 VbhUE"
             >
               <div
-                class="sc-ksYbfQ cEjxfP"
+                class="sc-frDJqD cUzIMQ"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -33913,7 +33913,7 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-hmzhuo jSiJYK"
+                class="sc-kvZOFW iRNTBN"
               >
                 <div
                   class="buwkmd-0 bYclZI"
@@ -35055,14 +35055,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-dNLxif gyDelK"
+      class="sc-uJMKN jdudSz"
     >
       <img
-        class="sc-jqCOkK byRdQy"
+        class="sc-bbmXgH dChXtj"
         src="/static/images/illustrations/wallet.svg"
       />
       <div
-        class="sc-uJMKN bWWiOJ"
+        class="sc-gGBfsJ iYeVWi"
       >
         <h1>
           Need account
@@ -35218,14 +35218,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-dNLxif gyDelK"
+      class="sc-uJMKN jdudSz"
     >
       <img
-        class="sc-jqCOkK byRdQy"
+        class="sc-bbmXgH dChXtj"
         src="/static/images/illustrations/error.svg"
       />
       <div
-        class="sc-uJMKN bWWiOJ"
+        class="sc-gGBfsJ iYeVWi"
       >
         <h1>
           Fatal Error
@@ -35381,14 +35381,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-dNLxif gyDelK"
+      class="sc-uJMKN jdudSz"
     >
       <img
-        class="sc-jqCOkK byRdQy"
+        class="sc-bbmXgH dChXtj"
         src="/static/images/illustrations/network.svg"
       />
       <div
-        class="sc-uJMKN bWWiOJ"
+        class="sc-gGBfsJ iYeVWi"
       >
         <h1>
           Network mismatch
@@ -35540,13 +35540,13 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-dNLxif gyDelK"
+      class="sc-uJMKN jdudSz"
     >
       <img
-        class="sc-jqCOkK byRdQy"
+        class="sc-bbmXgH dChXtj"
       />
       <div
-        class="sc-uJMKN jKDTPW"
+        class="sc-gGBfsJ dPJdVq"
       >
         <h1>
           Non-critical error
@@ -35699,14 +35699,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-dNLxif gyDelK"
+      class="sc-uJMKN jdudSz"
     >
       <img
-        class="sc-jqCOkK byRdQy"
+        class="sc-bbmXgH dChXtj"
         src="/static/images/illustrations/wallet.svg"
       />
       <div
-        class="sc-uJMKN bWWiOJ"
+        class="sc-gGBfsJ iYeVWi"
       >
         <h1>
           Not enabled in provider
@@ -35862,14 +35862,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-dNLxif gyDelK"
+      class="sc-uJMKN jdudSz"
     >
       <img
-        class="sc-jqCOkK byRdQy"
+        class="sc-bbmXgH dChXtj"
         src="/static/images/illustrations/error.svg"
       />
       <div
-        class="sc-uJMKN bWWiOJ"
+        class="sc-gGBfsJ iYeVWi"
       >
         <h1>
           Unlock not deployed
@@ -36032,14 +36032,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-dNLxif gyDelK"
+      class="sc-uJMKN jdudSz"
     >
       <img
-        class="sc-jqCOkK byRdQy"
+        class="sc-bbmXgH dChXtj"
         src="/static/images/illustrations/wallet.svg"
       />
       <div
-        class="sc-uJMKN bWWiOJ"
+        class="sc-gGBfsJ iYeVWi"
       >
         <h1>
           Wallet missing
@@ -36607,16 +36607,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-btzYZH fjFKkF"
+      class="sc-bYSBpT gXcQiX"
     >
       <div
-        class="sc-jwKygS dSWNAf"
+        class="sc-lhVmIH gZGkEg"
       >
         <p>
           Please check your browser wallet.
         </p>
         <button
-          class="sc-feJyhm oFfvn"
+          class="sc-cmTdod ftojYZ"
         >
           Dismiss
         </button>
@@ -36832,13 +36832,13 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-jwKygS dSWNAf"
+      class="sc-lhVmIH gZGkEg"
     >
       <p>
         Please check your browser wallet.
       </p>
       <button
-        class="sc-feJyhm oFfvn"
+        class="sc-cmTdod ftojYZ"
       >
         Dismiss
       </button>
@@ -39009,7 +39009,7 @@ Object {
         href="/dashboard"
       >
         <button
-          class="sc-ktHwxA sc-9upljg-1 cKpQTs"
+          class="sc-kafWEX sc-9upljg-1 cKpQTs"
         >
           I Agree
         </button>
@@ -39152,7 +39152,7 @@ Object {
       class="sc-9upljg-3 kjuFdI"
     >
       <button
-        class="sc-ktHwxA sc-9upljg-0 cTMzWy"
+        class="sc-kafWEX sc-9upljg-0 cTMzWy"
       >
         Go to Your Dashboard
       </button>
@@ -40796,13 +40796,13 @@ Object {
           />
         </header>
         <section
-          class="sc-bbmXgH fNYDXK"
+          class="sc-jnlKLf jKMWma"
         >
           <div
-            class="sc-jnlKLf ggYeg"
+            class="sc-tilXH jqgYeL"
           >
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             >
               <div
                 class="paper"
@@ -40859,36 +40859,36 @@ Object {
               </div>
             </div>
             <div
-              class="sc-tilXH kFhjLe"
+              class="sc-ktHwxA hHPiDD"
             >
               Address
               <span
-                class="sc-gGBfsJ jlOwIx"
+                class="sc-fYxtnH iWHWCo"
                 id="NetworkName"
               >
                 Winston
               </span>
             </div>
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-hEsumM jtGKlD"
+              class="sc-cIShpX ePXlrt"
               id="UserAddress"
             >
               0x3ca206264762caf81a8f0a843bbb850987b41e16
@@ -41812,22 +41812,22 @@ Object {
         </header>
         <div>
           <h1
-            class="sc-ibxdXY bDglKX"
+            class="sc-iQKALj koADYe"
           >
             Pay For Content Seamlessly
           </h1>
           <h2
-            class="sc-RefOD jXmkJR"
+            class="sc-bwCtUz gMSTMj"
           >
             Unlock enables anyone to seamlessly buy and manage access to content using blockchain technology.
           </h2>
           <p
-            class="sc-iQKALj jdBvyZ"
+            class="sc-hrWEMg hWCxgO"
           >
             At Unlock, we believe that the more accessible paid content is, the better it will be. To do that we're making it easy for readers like you to seamlessly pay for and manage your content.
           </p>
           <p
-            class="sc-iQKALj jdBvyZ"
+            class="sc-hrWEMg hWCxgO"
           >
             If you want to know more about Unlock's decentralized payment protocol, check out
              
@@ -41842,25 +41842,25 @@ Object {
             .
           </p>
           <form
-            class="sc-bwCtUz ijXSVh"
+            class="sc-eTuwsz eeROGq"
           >
             <input
-              class="sc-hrWEMg cOMjlI"
+              class="sc-gwVKww jnKnAF"
               name="emailAddress"
               placeholder="Enter your email to get started"
               type="email"
             />
             <input
-              class="sc-eTuwsz hZmVVW"
+              class="sc-hXRMBi fZLkLx"
               type="submit"
               value="Sign Up"
             />
             <p
-              class="sc-iQKALj jdBvyZ"
+              class="sc-hrWEMg hWCxgO"
             >
               Already have an account? 
               <a
-                class="sc-hXRMBi eKoAES"
+                class="sc-iQNlJl fYRuoc"
               >
                 Log in here
               </a>
@@ -42838,13 +42838,13 @@ Object {
           />
         </header>
         <section
-          class="sc-bbmXgH fNYDXK"
+          class="sc-jnlKLf jKMWma"
         >
           <div
-            class="sc-jnlKLf ggYeg"
+            class="sc-tilXH jqgYeL"
           >
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             >
               <div
                 class="paper"
@@ -42901,36 +42901,36 @@ Object {
               </div>
             </div>
             <div
-              class="sc-tilXH kFhjLe"
+              class="sc-ktHwxA hHPiDD"
             >
               Address
               <span
-                class="sc-gGBfsJ jlOwIx"
+                class="sc-fYxtnH iWHWCo"
                 id="NetworkName"
               >
                 Winston
               </span>
             </div>
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-fYxtnH hlxwSY"
+              class="sc-hEsumM kQujec"
             />
             <div
-              class="sc-hEsumM jtGKlD"
+              class="sc-cIShpX ePXlrt"
               id="UserAddress"
             >
               0x3ca206264762caf81a8f0a843bbb850987b41e17
@@ -51510,21 +51510,21 @@ Object {
     />
     <div>
       <h1
-        class="sc-dfVpRl dHduiY"
+        class="sc-iyvyFf iwStxs"
       >
         Log In to Your Account
       </h1>
       <form
-        class="sc-kfGgVZ jRYXwm"
+        class="sc-kIPQKe gmPiyO"
       >
         <label
-          class="sc-kIPQKe fVhheS"
+          class="sc-ibxdXY OeiNk"
           for="emailInput"
         >
           Email Address
         </label>
         <input
-          class="sc-iyvyFf ietjSf"
+          class="sc-kPVwWT kvXvce"
           id="emailInput"
           name="emailAddress"
           placeholder="Enter your email"
@@ -51532,13 +51532,13 @@ Object {
         />
         <br />
         <label
-          class="sc-kIPQKe fVhheS"
+          class="sc-ibxdXY OeiNk"
           for="passwordInput"
         >
           Password
         </label>
         <input
-          class="sc-iyvyFf ietjSf"
+          class="sc-kPVwWT kvXvce"
           id="passwordInput"
           name="password"
           placeholder="Enter your password"
@@ -51546,22 +51546,22 @@ Object {
         />
         <br />
         <div
-          class="sc-esjQYD hhGGKy"
+          class="sc-eXEjpC eVbGxa"
         >
           <input
-            class="sc-hwwEjo sc-kPVwWT diYoIW"
+            class="sc-kfGgVZ sc-esjQYD cTKJOx"
             type="submit"
             value="Retry"
           />
         </div>
       </form>
       <p
-        class="sc-gzOgki dfasbY"
+        class="sc-hwwEjo jLOWeM"
       >
         Don't have an account?
          
         <a
-          class="sc-eXEjpC WmuLj"
+          class="sc-RefOD isLSKU"
         >
           Sign up here.
         </a>
@@ -51764,21 +51764,21 @@ Object {
     />
     <div>
       <h1
-        class="sc-dfVpRl dHduiY"
+        class="sc-iyvyFf iwStxs"
       >
         Log In to Your Account
       </h1>
       <form
-        class="sc-kfGgVZ jRYXwm"
+        class="sc-kIPQKe gmPiyO"
       >
         <label
-          class="sc-kIPQKe fVhheS"
+          class="sc-ibxdXY OeiNk"
           for="emailInput"
         >
           Email Address
         </label>
         <input
-          class="sc-iyvyFf ietjSf"
+          class="sc-kPVwWT kvXvce"
           id="emailInput"
           name="emailAddress"
           placeholder="Enter your email"
@@ -51786,13 +51786,13 @@ Object {
         />
         <br />
         <label
-          class="sc-kIPQKe fVhheS"
+          class="sc-ibxdXY OeiNk"
           for="passwordInput"
         >
           Password
         </label>
         <input
-          class="sc-iyvyFf ietjSf"
+          class="sc-kPVwWT kvXvce"
           id="passwordInput"
           name="password"
           placeholder="Enter your password"
@@ -51800,22 +51800,22 @@ Object {
         />
         <br />
         <div
-          class="sc-esjQYD hhGGKy"
+          class="sc-eXEjpC eVbGxa"
         >
           <input
-            class="sc-hwwEjo jdnHxj"
+            class="sc-kfGgVZ brJDaE"
             type="submit"
             value="Submit"
           />
         </div>
       </form>
       <p
-        class="sc-gzOgki dfasbY"
+        class="sc-hwwEjo jLOWeM"
       >
         Don't have an account?
          
         <a
-          class="sc-eXEjpC WmuLj"
+          class="sc-RefOD isLSKU"
         >
           Sign up here.
         </a>
@@ -52012,22 +52012,22 @@ Object {
     />
     <div>
       <h1
-        class="sc-ibxdXY bDglKX"
+        class="sc-iQKALj koADYe"
       >
         Pay For Content Seamlessly
       </h1>
       <h2
-        class="sc-RefOD jXmkJR"
+        class="sc-bwCtUz gMSTMj"
       >
         Unlock enables anyone to seamlessly buy and manage access to content using blockchain technology.
       </h2>
       <p
-        class="sc-iQKALj jdBvyZ"
+        class="sc-hrWEMg hWCxgO"
       >
         At Unlock, we believe that the more accessible paid content is, the better it will be. To do that we're making it easy for readers like you to seamlessly pay for and manage your content.
       </p>
       <p
-        class="sc-iQKALj jdBvyZ"
+        class="sc-hrWEMg hWCxgO"
       >
         If you want to know more about Unlock's decentralized payment protocol, check out
          
@@ -52042,25 +52042,25 @@ Object {
         .
       </p>
       <form
-        class="sc-bwCtUz ijXSVh"
+        class="sc-eTuwsz eeROGq"
       >
         <input
-          class="sc-hrWEMg cOMjlI"
+          class="sc-gwVKww jnKnAF"
           name="emailAddress"
           placeholder="Enter your email to get started"
           type="email"
         />
         <input
-          class="sc-eTuwsz hZmVVW"
+          class="sc-hXRMBi fZLkLx"
           type="submit"
           value="Sign Up"
         />
         <p
-          class="sc-iQKALj jdBvyZ"
+          class="sc-hrWEMg hWCxgO"
         >
           Already have an account? 
           <a
-            class="sc-hXRMBi eKoAES"
+            class="sc-iQNlJl fYRuoc"
           >
             Log in here
           </a>
@@ -52692,21 +52692,21 @@ Object {
     />
     <div>
       <h1
-        class="sc-dfVpRl dHduiY"
+        class="sc-iyvyFf iwStxs"
       >
         Log In to Your Account
       </h1>
       <form
-        class="sc-kfGgVZ jRYXwm"
+        class="sc-kIPQKe gmPiyO"
       >
         <label
-          class="sc-kIPQKe fVhheS"
+          class="sc-ibxdXY OeiNk"
           for="emailInput"
         >
           Email Address
         </label>
         <input
-          class="sc-iyvyFf ietjSf"
+          class="sc-kPVwWT kvXvce"
           id="emailInput"
           name="emailAddress"
           placeholder="Enter your email"
@@ -52714,13 +52714,13 @@ Object {
         />
         <br />
         <label
-          class="sc-kIPQKe fVhheS"
+          class="sc-ibxdXY OeiNk"
           for="passwordInput"
         >
           Password
         </label>
         <input
-          class="sc-iyvyFf ietjSf"
+          class="sc-kPVwWT kvXvce"
           id="passwordInput"
           name="password"
           placeholder="Enter your password"
@@ -52728,22 +52728,22 @@ Object {
         />
         <br />
         <div
-          class="sc-esjQYD hhGGKy"
+          class="sc-eXEjpC eVbGxa"
         >
           <input
-            class="sc-hwwEjo jdnHxj"
+            class="sc-kfGgVZ brJDaE"
             type="submit"
             value="Submit"
           />
         </div>
       </form>
       <p
-        class="sc-gzOgki dfasbY"
+        class="sc-hwwEjo jLOWeM"
       >
         Don't have an account?
          
         <a
-          class="sc-eXEjpC WmuLj"
+          class="sc-RefOD isLSKU"
         >
           Sign up here.
         </a>
@@ -52940,22 +52940,22 @@ Object {
     />
     <div>
       <h1
-        class="sc-ibxdXY bDglKX"
+        class="sc-iQKALj koADYe"
       >
         Pay For Content Seamlessly
       </h1>
       <h2
-        class="sc-RefOD jXmkJR"
+        class="sc-bwCtUz gMSTMj"
       >
         Unlock enables anyone to seamlessly buy and manage access to content using blockchain technology.
       </h2>
       <p
-        class="sc-iQKALj jdBvyZ"
+        class="sc-hrWEMg hWCxgO"
       >
         At Unlock, we believe that the more accessible paid content is, the better it will be. To do that we're making it easy for readers like you to seamlessly pay for and manage your content.
       </p>
       <p
-        class="sc-iQKALj jdBvyZ"
+        class="sc-hrWEMg hWCxgO"
       >
         If you want to know more about Unlock's decentralized payment protocol, check out
          
@@ -52970,25 +52970,25 @@ Object {
         .
       </p>
       <form
-        class="sc-bwCtUz ijXSVh"
+        class="sc-eTuwsz eeROGq"
       >
         <input
-          class="sc-hrWEMg cOMjlI"
+          class="sc-gwVKww jnKnAF"
           name="emailAddress"
           placeholder="Enter your email to get started"
           type="email"
         />
         <input
-          class="sc-eTuwsz hZmVVW"
+          class="sc-hXRMBi fZLkLx"
           type="submit"
           value="Sign Up"
         />
         <p
-          class="sc-iQKALj jdBvyZ"
+          class="sc-hrWEMg hWCxgO"
         >
           Already have an account? 
           <a
-            class="sc-hXRMBi eKoAES"
+            class="sc-iQNlJl fYRuoc"
           >
             Log in here
           </a>
@@ -57455,7 +57455,7 @@ Object {
         </div>
         <div>
           <section
-            class="sc-hqyNC hrCEFr"
+            class="sc-dNLxif jEFmuO"
           >
             <svg
               alt="loading"
@@ -62137,22 +62137,22 @@ Object {
     />
     <div>
       <h1
-        class="sc-ibxdXY bDglKX"
+        class="sc-iQKALj koADYe"
       >
         Pay For Content Seamlessly
       </h1>
       <h2
-        class="sc-RefOD jXmkJR"
+        class="sc-bwCtUz gMSTMj"
       >
         Unlock enables anyone to seamlessly buy and manage access to content using blockchain technology.
       </h2>
       <p
-        class="sc-iQKALj jdBvyZ"
+        class="sc-hrWEMg hWCxgO"
       >
         At Unlock, we believe that the more accessible paid content is, the better it will be. To do that we're making it easy for readers like you to seamlessly pay for and manage your content.
       </p>
       <p
-        class="sc-iQKALj jdBvyZ"
+        class="sc-hrWEMg hWCxgO"
       >
         If you want to know more about Unlock's decentralized payment protocol, check out
          
@@ -62167,25 +62167,25 @@ Object {
         .
       </p>
       <form
-        class="sc-bwCtUz ijXSVh"
+        class="sc-eTuwsz eeROGq"
       >
         <input
-          class="sc-hrWEMg cOMjlI"
+          class="sc-gwVKww jnKnAF"
           name="emailAddress"
           placeholder="Enter your email to get started"
           type="email"
         />
         <input
-          class="sc-eTuwsz hZmVVW"
+          class="sc-hXRMBi fZLkLx"
           type="submit"
           value="Sign Up"
         />
         <p
-          class="sc-iQKALj jdBvyZ"
+          class="sc-hrWEMg hWCxgO"
         >
           Already have an account? 
           <a
-            class="sc-hXRMBi eKoAES"
+            class="sc-iQNlJl fYRuoc"
           >
             Log in here
           </a>
@@ -63610,16 +63610,16 @@ Object {
           />
         </header>
         <div
-          class="sc-kafWEX gDTgRH"
+          class="sc-iELTvK cSEIZI"
         >
           <section
-            class="sc-bbmXgH fNYDXK"
+            class="sc-jnlKLf jKMWma"
           >
             <div
-              class="sc-jnlKLf ggYeg"
+              class="sc-tilXH jqgYeL"
             >
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               >
                 <div
                   class="paper"
@@ -63676,36 +63676,36 @@ Object {
                 </div>
               </div>
               <div
-                class="sc-tilXH kFhjLe"
+                class="sc-ktHwxA hHPiDD"
               >
                 Address
                 <span
-                  class="sc-gGBfsJ jlOwIx"
+                  class="sc-fYxtnH iWHWCo"
                   id="NetworkName"
                 >
                   Winston
                 </span>
               </div>
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-fYxtnH hlxwSY"
+                class="sc-hEsumM kQujec"
               />
               <div
-                class="sc-hEsumM jtGKlD"
+                class="sc-cIShpX ePXlrt"
                 id="UserAddress"
               >
                 0x3ca206264762caf81a8f0a843bbb850987b41e16
@@ -63713,80 +63713,80 @@ Object {
             </div>
           </section>
           <button
-            class="sc-ktHwxA sc-cIShpX jMyVPp"
+            class="sc-kafWEX sc-feJyhm kFPMYx"
             id="CreateLockButton"
           >
             Create Lock
           </button>
         </div>
         <div
-          class="sc-bYSBpT jNImdo"
+          class="sc-jtRfpW fVThxy"
         >
           <div
-            class="sc-elJkPf rnNBI"
+            class="sc-kTUwUJ dXMwOn"
           >
             Block Number
           </div>
           <div
-            class="sc-elJkPf rnNBI"
+            class="sc-kTUwUJ dXMwOn"
           >
             Lock Name/Address
           </div>
           <div
-            class="sc-elJkPf rnNBI"
+            class="sc-kTUwUJ dXMwOn"
           >
             Type
           </div>
           <div
-            class="sc-jtRfpW sc-kTUwUJ GBfWZ"
+            class="sc-dqBHgY sc-gxMtzJ cnLuhM"
           >
             3
           </div>
           <a
-            class="sc-dqBHgY dOVbKX"
+            class="sc-dfVpRl cfxeIL"
             href=""
             target="_blank"
           >
             0xc43efE2C7116CB94d563b5A9D68F260CCc44256F
           </a>
           <div
-            class="sc-jtRfpW sc-gxMtzJ hPVtWL"
+            class="sc-dqBHgY sc-gzOgki lnZrbI"
             type="Lock Creation"
           >
             Lock Creation
           </div>
           <div
-            class="sc-jtRfpW sc-kTUwUJ GBfWZ"
+            class="sc-dqBHgY sc-gxMtzJ cnLuhM"
           >
             2
           </div>
           <a
-            class="sc-dqBHgY dOVbKX"
+            class="sc-dfVpRl cfxeIL"
             href=""
             target="_blank"
           >
             0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
           </a>
           <div
-            class="sc-jtRfpW sc-gxMtzJ cHOpdj"
+            class="sc-dqBHgY sc-gzOgki fQssos"
             type="Update Key Price"
           >
             Update Key Price
           </div>
           <div
-            class="sc-jtRfpW sc-kTUwUJ GBfWZ"
+            class="sc-dqBHgY sc-gxMtzJ cnLuhM"
           >
             1
           </div>
           <a
-            class="sc-dqBHgY dOVbKX"
+            class="sc-dfVpRl cfxeIL"
             href=""
             target="_blank"
           >
             0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
           </a>
           <div
-            class="sc-jtRfpW sc-gxMtzJ hPVtWL"
+            class="sc-dqBHgY sc-gzOgki lnZrbI"
             type="Lock Creation"
           >
             Lock Creation
@@ -64584,7 +64584,7 @@ Object {
           class="sc-dnqmqq kkgxkC"
         />
         <button
-          class="sc-iwsKbI sc-epnACN cwIEug"
+          class="sc-iwsKbI sc-bsbRJL foHgoP"
         >
           Update Password
         </button>
@@ -66316,7 +66316,7 @@ Object {
             class="sc-dnqmqq kkgxkC"
           />
           <button
-            class="sc-iwsKbI sc-epnACN cwIEug"
+            class="sc-iwsKbI sc-bsbRJL foHgoP"
           >
             Update Password
           </button>

--- a/unlock-app/src/components/content/AccountContent.tsx
+++ b/unlock-app/src/components/content/AccountContent.tsx
@@ -11,6 +11,7 @@ import KeyPurchaseConfirmation from '../interface/user-account/KeyPurchaseConfir
 import { GridPadding, IframeWrapper } from '../interface/user-account/styles'
 import Close from '../interface/buttons/layout/Close'
 import { dismissPurchaseModal } from '../../actions/keyPurchase'
+import svg from '../interface/svg'
 
 interface StripeWindow {
   Stripe?: stripe.StripeStatic
@@ -36,7 +37,11 @@ interface AccountContentState {
   stripe: stripe.Stripe | null
 }
 
-type PageMode = 'LogIn' | 'CollectPaymentDetails' | 'ConfirmPurchase'
+type PageMode =
+  | 'LogIn'
+  | 'CollectPaymentDetails'
+  | 'ConfirmPurchase'
+  | 'Unlocked'
 
 export class AccountContent extends React.Component<
   FullAccountContentProps,
@@ -67,15 +72,18 @@ export class AccountContent extends React.Component<
         </GridPadding>
       ),
       ConfirmPurchase: <KeyPurchaseConfirmation />,
+      Unlocked: <AlreadyOwned />,
     }
 
     return components[mode]
   }
 
   currentPageMode = (): PageMode => {
-    const { emailAddress, cards } = this.props
+    const { emailAddress, cards, pageIsLocked } = this.props
     if (!emailAddress) {
       return 'LogIn'
+    } else if (!pageIsLocked) {
+      return 'Unlocked'
     } else if (!cards || !cards.length) {
       return 'CollectPaymentDetails'
     } else {
@@ -186,3 +194,27 @@ const ErrorContainer = styled.div`
 const StyledIframeWrapper = styled(IframeWrapper)`
   max-width: 456px;
 `
+
+const AlreadyOwnedWrapper = styled.div`
+  color: var(--slate);
+  margin: 16px 32px 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+const CircleCheck = styled(svg.Checkmark)`
+  width: 48px;
+  border: thin var(--slate) solid;
+  border-radius: 48px;
+  margin-right: 16px;
+`
+
+const AlreadyOwned = () => {
+  return (
+    <AlreadyOwnedWrapper>
+      <CircleCheck />
+      You already own a key to this lock!
+    </AlreadyOwnedWrapper>
+  )
+}

--- a/unlock-app/src/components/content/AccountContent.tsx
+++ b/unlock-app/src/components/content/AccountContent.tsx
@@ -23,6 +23,7 @@ declare global {
 interface AccountContentProps {
   emailAddress?: string
   cards?: stripe.Card[]
+  pageIsLocked: boolean
 }
 
 interface FullAccountContentProps extends AccountContentProps {
@@ -127,16 +128,19 @@ interface ReduxState {
     emailAddress?: string
     cards?: stripe.Card[]
   }
+  pageIsLocked: boolean
 }
-export const mapStateToProps = (state: ReduxState) => {
-  let props: AccountContentProps = {}
+export const mapStateToProps = ({ account, pageIsLocked }: ReduxState) => {
+  let props: AccountContentProps = {
+    pageIsLocked,
+  }
 
-  if (state.account) {
-    const { emailAddress, cards } = state.account
+  if (account) {
+    const { emailAddress, cards } = account
     if (emailAddress) {
       props.emailAddress = emailAddress
     }
-    if (state.account.cards) {
+    if (account.cards) {
       props.cards = cards
     }
   }

--- a/unlock-app/src/stories/content/AccountContent.stories.js
+++ b/unlock-app/src/stories/content/AccountContent.stories.js
@@ -8,10 +8,11 @@ import AccountContent from '../../components/content/AccountContent'
 
 const baseState = {
   account: {},
+  pageIsLocked: true,
 }
 
 const baseStateWithError = {
-  account: {},
+  ...baseState,
   errors: [
     {
       kind: 'LogIn',
@@ -21,6 +22,7 @@ const baseStateWithError = {
   ],
 }
 const loggedInState = {
+  ...baseState,
   account: {
     emailAddress: 'jenny@googlemail.com',
   },
@@ -37,6 +39,7 @@ const loggedInWithError = {
   ],
 }
 const loggedInWithCards = {
+  ...baseState,
   account: {
     emailAddress: 'jenny@googlemail.com',
     cards: [
@@ -82,6 +85,11 @@ const loggedInWithCardsAndError = {
   ],
 }
 
+const loggedInWithCardsAndUnlocked = {
+  ...loggedInWithCards,
+  pageIsLocked: false,
+}
+
 const config = {
   stripeApiKey: 'pk_this_is_not_a_real_key',
 }
@@ -97,6 +105,7 @@ storiesOf('AccountContent (iframe embed for paywall)', module)
       'Logged in (error)': loggedInWithError,
       'Logged in with cards': loggedInWithCards,
       'Logged in with cards (error)': loggedInWithCardsAndError,
+      'Logged in with cards (unlocked page)': loggedInWithCardsAndUnlocked,
     }
     const defaultValue = baseState
     const groupId = 'Group1'


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds another render state to `AccountContent`; after logging in, if the page is unlocked, the following element is shown instead of a prompt for credit card or purchase confirmation:

<img width="426" alt="image" src="https://user-images.githubusercontent.com/9300702/66161869-388fa200-e5fb-11e9-8afc-74fa5fe85d97.png">

This is a bit of a stopgap in the absence of an easier way to coordinate the visibility of the checkout and account iframes, but it will stop the duplicate purchase case.

We can (and should) spruce up the visual design here at some point in the future.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4934 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
