### PR TITLE
prevent Safari from throwing errors when accessing localstorage

### DIFF
--- a/unlock-app/src/utils/localStorage.ts
+++ b/unlock-app/src/utils/localStorage.ts
@@ -3,7 +3,12 @@ import { LocalStorageWindow } from '../windowTypes'
 // copied from the MDN docs as the best way to detect localStorage presence
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Testing_for_availability
 export const localStorageAvailable = (window: LocalStorageWindow) => {
-  const storage = window.localStorage
+  let storage
+  try {
+    storage = window.localStorage // Safari will throw errors when *just* accessing this variable
+  } catch (e) {
+    return false
+  }
   try {
     const x = '__storage_test__'
     storage.setItem(x, x)


### PR DESCRIPTION
# Description

Prevent Safari from throwing errors when accessing localstorage


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->