### PR TITLE
Fix determination of expensiveness

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/BlockchainHandler.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/BlockchainHandler.test.ts
@@ -144,6 +144,36 @@ describe('BlockchainHandler class setup', () => {
     })
   })
 
+  describe('_reset', () => {
+    let handler: BlockchainHandler
+    beforeEach(async () => {
+      handler = await callSetupBlockchainHandler()
+    })
+
+    it('resets the keys to default keys', () => {
+      expect.assertions(1)
+      ;(handler as any).store.keys = {}
+      handler._reset()
+      expect((handler as any).store.keys).toEqual(
+        makeDefaultKeys(lockAddresses, null)
+      )
+    })
+
+    it('fetches token balances for erc20 locks if there is an account set', () => {
+      expect.assertions(1)
+      ;(handler as any).store.locks = {
+        '0x123abc': {
+          currencyContractAddress: '205 Hudson Street',
+        },
+      }
+      ;(handler as any).store.account = '0xdeadb33f'
+      const mock = jest.fn()
+      ;(handler as any).getTokenBalance = mock
+      handler._reset()
+      expect(mock).toHaveBeenCalledWith('205 Hudson Street')
+    })
+  })
+
   describe('account polling', () => {
     beforeEach(() => {
       setupDefaults()

--- a/paywall/src/__tests__/utils/locks.test.js
+++ b/paywall/src/__tests__/utils/locks.test.js
@@ -1,8 +1,48 @@
-import { currencySymbolForLock, isTooExpensiveForUser } from '../../utils/locks'
+import {
+  currencySymbolForLock,
+  isTooExpensiveForUser,
+  isTooExpensiveForUserByCurrency,
+  isEthLock,
+  isERC20Lock,
+} from '../../utils/locks'
 
 import configure from '../../config'
 
 const config = configure()
+
+const ethLock = {
+  keyPrice: '12',
+}
+const ethLockExpensive = {
+  keyPrice: '1200',
+}
+const ERC20Lock = {
+  currencyContractAddress: '0x123abc',
+  keyPrice: '2',
+}
+const ERC20LockExpensive = {
+  ...ERC20Lock,
+  keyPrice: '9001',
+}
+
+const accountWithoutBalance = {}
+const accountWithInvalidBalance = {
+  balance: {
+    eth: 'lmbo this string is not a float',
+  },
+}
+const accountWithValidBalance = {
+  balance: {
+    eth: '42',
+    '0x123abc': '9000',
+  },
+}
+const accountWithSameBalanceAsPrice = {
+  balance: {
+    eth: '12',
+    '0x123abc': '2',
+  },
+}
 
 describe('locks utilities', () => {
   describe('currencySymbolForLock', () => {
@@ -36,6 +76,142 @@ describe('locks utilities', () => {
         currencyContractAddress: '0xMyERC20',
       }
       expect(currencySymbolForLock(lock, config)).toBe('ERC20')
+    })
+  })
+
+  describe('isEthLock', () => {
+    it('should return true for locks that *do not* have a currencyContractAddress', () => {
+      expect.assertions(1)
+      expect(isEthLock(ethLock)).toBeTruthy()
+    })
+
+    it('should return false for locks that *do* have a currencyContractAddress', () => {
+      expect.assertions(1)
+      expect(isEthLock(ERC20Lock)).toBeFalsy()
+    })
+  })
+
+  describe('isERC20Lock', () => {
+    it('should return true for locks that *do* have a currencyContractAddress', () => {
+      expect.assertions(1)
+      expect(isERC20Lock(ERC20Lock)).toBeTruthy()
+    })
+
+    it('should return false for locks that *do not* have a currencyContractAddress', () => {
+      expect.assertions(1)
+      expect(isERC20Lock(ethLock)).toBeFalsy()
+    })
+  })
+
+  describe('isTooExpensiveForUserByCurrency', () => {
+    it('should be too expensive when there is no account', () => {
+      expect.assertions(2)
+      expect(
+        isTooExpensiveForUserByCurrency(ethLock, undefined, 'eth')
+      ).toBeTruthy()
+      expect(
+        isTooExpensiveForUserByCurrency(
+          ERC20Lock,
+          undefined,
+          ERC20Lock.currencyContractAddress
+        )
+      ).toBeTruthy()
+    })
+
+    it('should be too expensive when there is an account but no balance', () => {
+      expect.assertions(2)
+      expect(
+        isTooExpensiveForUserByCurrency(ethLock, accountWithoutBalance, 'eth')
+      ).toBeTruthy()
+      expect(
+        isTooExpensiveForUserByCurrency(
+          ERC20Lock,
+          accountWithoutBalance,
+          ERC20Lock.currencyContractAddress
+        )
+      ).toBeTruthy()
+    })
+
+    it('should be too expensive when there is a balance value, but it cannot be parsed', () => {
+      expect.assertions(2)
+      expect(
+        isTooExpensiveForUserByCurrency(
+          ethLock,
+          accountWithInvalidBalance,
+          'eth'
+        )
+      ).toBeTruthy()
+      expect(
+        isTooExpensiveForUserByCurrency(
+          ERC20Lock,
+          accountWithInvalidBalance,
+          ERC20Lock.currencyContractAddress
+        )
+      ).toBeTruthy()
+    })
+
+    it('should be too expensive when there is no keyPrice on a lock', () => {
+      expect.assertions(2)
+      expect(
+        isTooExpensiveForUserByCurrency({}, accountWithValidBalance, 'eth')
+      ).toBeTruthy()
+      expect(
+        isTooExpensiveForUserByCurrency(
+          {},
+          accountWithValidBalance,
+          ERC20Lock.currencyContractAddress
+        )
+      ).toBeTruthy()
+    })
+
+    it('should be too expensive if keyPrice is bigger than balance', () => {
+      expect.assertions(2)
+      expect(
+        isTooExpensiveForUserByCurrency(
+          ethLockExpensive,
+          accountWithValidBalance,
+          'eth'
+        )
+      ).toBeTruthy()
+      expect(
+        isTooExpensiveForUserByCurrency(
+          ERC20LockExpensive,
+          accountWithValidBalance,
+          ERC20Lock.currencyContractAddress
+        )
+      ).toBeTruthy()
+    })
+
+    it('should be affordable if balance is the same as keyPrice', () => {
+      expect.assertions(2)
+      expect(
+        isTooExpensiveForUserByCurrency(
+          ethLock,
+          accountWithSameBalanceAsPrice,
+          'eth'
+        )
+      ).toBeFalsy()
+      expect(
+        isTooExpensiveForUserByCurrency(
+          ERC20Lock,
+          accountWithSameBalanceAsPrice,
+          ERC20Lock.currencyContractAddress
+        )
+      ).toBeFalsy()
+    })
+
+    it('should be affordable if balance is bigger than keyPrice', () => {
+      expect.assertions(2)
+      expect(
+        isTooExpensiveForUserByCurrency(ethLock, accountWithValidBalance, 'eth')
+      ).toBeFalsy()
+      expect(
+        isTooExpensiveForUserByCurrency(
+          ERC20Lock,
+          accountWithValidBalance,
+          ERC20Lock.currencyContractAddress
+        )
+      ).toBeFalsy()
     })
   })
 

--- a/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
+++ b/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
@@ -26,6 +26,7 @@ import {
   normalizeAddressKeys,
   normalizeLockAddress,
 } from '../../utils/normalizeAddresses'
+import { isERC20Lock } from '../../utils/locks'
 import { createTemporaryKey } from './createTemporaryKey'
 
 /**
@@ -655,9 +656,7 @@ export default class BlockchainHandler {
     if (this.store.account) {
       this.web3Service.refreshAccountBalance({ address: this.store.account })
       // We need to refresh ERC20 token balances whenever we reset
-      const erc20locks = Object.values(this.store.locks).filter(
-        lock => !!lock.currencyContractAddress
-      )
+      const erc20locks = Object.values(this.store.locks).filter(isERC20Lock)
       erc20locks.forEach(lock =>
         this.getTokenBalance(lock.currencyContractAddress!)
       )

--- a/paywall/src/stories/lock/Lock.stories.js
+++ b/paywall/src/stories/lock/Lock.stories.js
@@ -53,6 +53,14 @@ const WindowProvider = WindowContext.Provider
 
 const storyConfig = configure()
 
+const accountWithBalance = {
+  balance: {
+    eth: '9001',
+    '0x123ERC20': '9001',
+    [storyConfig.erc20Contract.address]: '9001',
+  },
+}
+
 storiesOf('Lock', module)
   .addDecorator(getStory => (
     <ConfigProvider value={storyConfig}>
@@ -90,6 +98,7 @@ storiesOf('Lock', module)
     }
     return (
       <Lock
+        account={accountWithBalance}
         lock={erc20Lock}
         transaction={null}
         lockKey={null}
@@ -109,6 +118,7 @@ storiesOf('Lock', module)
     }
     return (
       <Lock
+        account={accountWithBalance}
         lock={erc20Lock}
         transaction={null}
         lockKey={null}
@@ -128,6 +138,7 @@ storiesOf('Lock', module)
     }
     return (
       <Lock
+        account={accountWithBalance}
         lock={shortLock}
         transaction={null}
         lockKey={null}
@@ -140,6 +151,7 @@ storiesOf('Lock', module)
   .add('with no key (check hover state too)', () => {
     return (
       <Lock
+        account={accountWithBalance}
         lock={lock}
         transaction={null}
         lockKey={null}
@@ -152,6 +164,7 @@ storiesOf('Lock', module)
   .add('with very long name', () => {
     return (
       <Lock
+        account={accountWithBalance}
         lock={lockWithLongName}
         transaction={null}
         lockKey={null}
@@ -164,6 +177,7 @@ storiesOf('Lock', module)
   .add('disabled - another lock has a pending key', () => {
     return (
       <Lock
+        account={accountWithBalance}
         disabled
         lock={lock}
         transaction={null}
@@ -245,6 +259,7 @@ storiesOf('Lock', module)
       const accountWithNotEnoughEth = {
         balance: {
           eth: '0',
+          [storyConfig.erc20Contract.address]: '75',
         },
         name: 'julien',
       }
@@ -418,6 +433,7 @@ storiesOf('Lock', module)
     }
     return (
       <Lock
+        account={accountWithBalance}
         lock={lockWithBalance}
         transaction={null}
         lockKey={null}
@@ -435,6 +451,7 @@ storiesOf('Lock', module)
     )
     return (
       <Lock
+        account={accountWithBalance}
         lock={lockWithInfiniteNumberOfKeys}
         transaction={null}
         lockKey={null}

--- a/paywall/src/utils/locks.js
+++ b/paywall/src/utils/locks.js
@@ -63,8 +63,10 @@ export function isTooExpensiveForUserByCurrency(lock, account, currencyKey) {
   }
 
   if (keyPrice <= balance) {
-    // This doesn't take gas into account. If keyPrice and balance are exactly
-    // equal, it's probable that no transaction can be carried out.
+    // This doesn't take gas into account. If a user has exactly as much eth as
+    // the price of a key, the wallet will warn that it cannot do the
+    // transaction without a little extra for gas. For an ERC20-priced lock, it
+    // makes sense to be able to spend all of your token on one thing.
     return LOCK_IS_AFFORDABLE
   }
 

--- a/paywall/src/utils/locks.js
+++ b/paywall/src/utils/locks.js
@@ -16,31 +16,76 @@ export function currencySymbolForLock(lock, config) {
 }
 
 /**
+ * Returns true if the keys for `lock` are priced in ERC20, false otherwise.
+ * @param {*} lock
+ */
+export const isERC20Lock = lock => {
+  return !!lock.currencyContractAddress
+}
+
+/**
+ * Returns true if the keys for `lock` are priced in Eth, false otherwise.
+ * @param {*} lock
+ */
+export const isEthLock = lock => {
+  return !lock.currencyContractAddress
+}
+
+// Just setting up named constants here so the code is more easily read, these
+// shouldn't be used outside of this file.
+const LOCK_IS_TOO_EXPENSIVE = true
+const LOCK_IS_AFFORDABLE = false
+
+/**
+ * Returns true if the lock is too expensive for user in a given currency
+ * @param {*} lock
+ * @param {*} account
+ * @param {string} currencyKey
+ * @returns {boolean}
+ */
+export function isTooExpensiveForUserByCurrency(lock, account, currencyKey) {
+  // Not having an account or an account balance should be treated like having 0
+  // of whatever currency.
+  if (!account || !account.balance) {
+    return LOCK_IS_TOO_EXPENSIVE
+  }
+
+  const balance = parseFloat(account.balance[currencyKey])
+  if (!balance) {
+    return LOCK_IS_TOO_EXPENSIVE
+  }
+
+  const keyPrice = parseFloat(lock.keyPrice)
+  if (!keyPrice) {
+    // All locks should have a keyPrice, but if for some reason one doesn't,
+    // we're in some kind of broken state and we'd better prevent purchasing.
+    return LOCK_IS_TOO_EXPENSIVE
+  }
+
+  if (keyPrice <= balance) {
+    // This doesn't take gas into account. If keyPrice and balance are exactly
+    // equal, it's probable that no transaction can be carried out.
+    return LOCK_IS_AFFORDABLE
+  }
+
+  return LOCK_IS_TOO_EXPENSIVE
+}
+
+/**
  * Returns true if the lock is too expensive for user in its currency
  * @param {*} lock
  * @param {*} account
  */
 export function isTooExpensiveForUser(lock, account) {
-  let tooExpensive = false
-  if (account && account.balance) {
-    // eth lock
-    if (
-      !lock.currencyContractAddress &&
-      account.balance.eth &&
-      parseFloat(account.balance.eth) <= parseFloat(lock.keyPrice)
-    ) {
-      tooExpensive = true
-    } else if (
-      // erc20 lock
-      lock.currencyContractAddress &&
-      account.balance[lock.currencyContractAddress] &&
-      parseFloat(account.balance[lock.currencyContractAddress]) <=
-        parseFloat(lock.keyPrice)
-    ) {
-      tooExpensive = true
-    }
+  if (isEthLock(lock)) {
+    return isTooExpensiveForUserByCurrency(lock, account, 'eth')
+  } else {
+    return isTooExpensiveForUserByCurrency(
+      lock,
+      account,
+      lock.currencyContractAddress
+    )
   }
-  return tooExpensive
 }
 
 export default {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

There was a bug in the function we use for determining whether a key is too expensive for a user. If there was no entry for a token's balance in the account, it would get parsed as `NaN`. And since `NaN` is _not smaller than_ anything (or bigger than anything, for that matter), the balance appeared to the app to be sufficient for a key purchase.

~~This PR fixes that, but in doing so peels back another layer and reveals a different bug. Balance updates aren't correctly fetched when a user logs in to MetaMask while on the page. So now the checkout shows insufficient funds when there is no entry for token balance, but the entry doesn't get added. I will have some more code shortly to address that, and we shouldn't merge this until we have that.~~

This PR also makes sure that when we reset the internal state of the blockchain handler, we also request balances for the currency contract address of each ERC20 lock on the page. In my testing on localhost, this resolved the issue.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #4950 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
