### PR TITLE
createLock now returns a Promise of the deployed lock address

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Version (minor!)
 
+- createLock now returns a Promise of the deployed lock address
 - updateKeyPrice now uses the right decimals for erc20 contracts
 - getting erc20Address and decimals from the contract when purchasing a key
 - Removed the 'owner' param on createLock since it is not really used (just emitted back)

--- a/unlock-js/src/__tests__/v0/createLock.test.js
+++ b/unlock-js/src/__tests__/v0/createLock.test.js
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers'
 import * as UnlockV0 from 'unlock-abi-0'
 import utils from '../../utils'
 import Errors from '../../errors'
@@ -20,6 +21,13 @@ const lock = {
   expirationDuration: 86400, // 1 day
   keyPrice: '0.1', // 0.1 Eth
   maxNumberOfKeys: 100,
+}
+
+const EventInfo = new ethers.utils.Interface(UnlockV0.Unlock.abi)
+const encoder = ethers.utils.defaultAbiCoder
+
+let receipt = {
+  logs: [],
 }
 
 describe('v0', () => {
@@ -49,6 +57,10 @@ describe('v0', () => {
         lock.expirationDuration,
         utils.toWei(lock.keyPrice, 'ether'),
         maxNumberOfKeys
+      )
+
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
       )
 
       transaction = testTransaction
@@ -146,6 +158,43 @@ describe('v0', () => {
 
       await walletService.createLock(lock)
       await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should yield a promise of lock address', async () => {
+      expect.assertions(1)
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      // For now we do not use this
+      const sender = '0x0000000000000000000000000000000000000000'
+
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve({
+          logs: [
+            {
+              transactionIndex: 1,
+              blockNumber: 19759,
+              transactionHash:
+                '0xace0af5853a98aff70ca427f21ad8a1a958cc219099789a3ea6fd5fac30f150c',
+              address: lock.address,
+              topics: [
+                EventInfo.events['NewLock(address,address)'].topic,
+                encoder.encode(['address'], [sender]),
+                encoder.encode(['address'], [lock.address]),
+              ],
+              data: '0x',
+              logIndex: 0,
+              blockHash:
+                '0xcb27b74a5ff04b129b645bbcfde46fe1a221c2d341223df4ad2ca87e9864678a',
+              transactionLogIndex: 0,
+            },
+          ],
+        })
+      )
+      const lockAddress = await walletService.createLock(lock)
+      await nock.resolveWhenAllNocksUsed()
+      expect(lockAddress).toEqual(lock.address)
     })
   })
 })

--- a/unlock-js/src/__tests__/v01/createLock.test.js
+++ b/unlock-js/src/__tests__/v01/createLock.test.js
@@ -22,7 +22,12 @@ const lock = {
   keyPrice: '0.1', // 0.1 Eth
   maxNumberOfKeys: 100,
 }
+const EventInfo = new ethers.utils.Interface(UnlockV01.Unlock.abi)
+const encoder = ethers.utils.defaultAbiCoder
 
+let receipt = {
+  logs: [],
+}
 describe('v01', () => {
   describe('createLock', () => {
     async function nockBeforeEach(maxNumberOfKeys = lock.maxNumberOfKeys) {
@@ -51,6 +56,10 @@ describe('v01', () => {
         ethers.constants.AddressZero,
         utils.toWei(lock.keyPrice, 'ether'),
         maxNumberOfKeys
+      )
+
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
       )
 
       transaction = testTransaction
@@ -148,6 +157,43 @@ describe('v01', () => {
 
       await walletService.createLock(lock)
       await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should yield a promise of lock address', async () => {
+      expect.assertions(1)
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      // For now we do not use this
+      const sender = '0x0000000000000000000000000000000000000000'
+
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve({
+          logs: [
+            {
+              transactionIndex: 1,
+              blockNumber: 19759,
+              transactionHash:
+                '0xace0af5853a98aff70ca427f21ad8a1a958cc219099789a3ea6fd5fac30f150c',
+              address: lock.address,
+              topics: [
+                EventInfo.events['NewLock(address,address)'].topic,
+                encoder.encode(['address'], [sender]),
+                encoder.encode(['address'], [lock.address]),
+              ],
+              data: '0x',
+              logIndex: 0,
+              blockHash:
+                '0xcb27b74a5ff04b129b645bbcfde46fe1a221c2d341223df4ad2ca87e9864678a',
+              transactionLogIndex: 0,
+            },
+          ],
+        })
+      )
+      const lockAddress = await walletService.createLock(lock)
+      await nock.resolveWhenAllNocksUsed()
+      expect(lockAddress).toEqual(lock.address)
     })
   })
 })

--- a/unlock-js/src/__tests__/v02/createLock.test.js
+++ b/unlock-js/src/__tests__/v02/createLock.test.js
@@ -32,6 +32,13 @@ const callMethodData = prepContract({
 
 let testERC20ContractAddress = '0x9409bd2f87f0698f89c04caee8ddb2fd9e44bcc3'
 
+const EventInfo = new ethers.utils.Interface(UnlockV02.Unlock.abi)
+const encoder = ethers.utils.defaultAbiCoder
+
+let receipt = {
+  logs: [],
+}
+
 describe('v02', () => {
   describe('createLock', () => {
     async function nockBeforeEach(maxNumberOfKeys = lock.maxNumberOfKeys) {
@@ -53,6 +60,10 @@ describe('v02', () => {
         ethers.constants.AddressZero,
         utils.toWei(lock.keyPrice, 'ether'),
         maxNumberOfKeys
+      )
+
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
       )
 
       transaction = testTransaction
@@ -188,6 +199,43 @@ describe('v02', () => {
 
       await walletService.createLock(lock)
       await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should yield a promise of lock address', async () => {
+      expect.assertions(1)
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      // For now we do not use this
+      const sender = '0x0000000000000000000000000000000000000000'
+
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve({
+          logs: [
+            {
+              transactionIndex: 1,
+              blockNumber: 19759,
+              transactionHash:
+                '0xace0af5853a98aff70ca427f21ad8a1a958cc219099789a3ea6fd5fac30f150c',
+              address: lock.address,
+              topics: [
+                EventInfo.events['NewLock(address,address)'].topic,
+                encoder.encode(['address'], [sender]),
+                encoder.encode(['address'], [lock.address]),
+              ],
+              data: '0x',
+              logIndex: 0,
+              blockHash:
+                '0xcb27b74a5ff04b129b645bbcfde46fe1a221c2d341223df4ad2ca87e9864678a',
+              transactionLogIndex: 0,
+            },
+          ],
+        })
+      )
+      const lockAddress = await walletService.createLock(lock)
+      await nock.resolveWhenAllNocksUsed()
+      expect(lockAddress).toEqual(lock.address)
     })
   })
 })

--- a/unlock-js/src/__tests__/v11/createLock.test.js
+++ b/unlock-js/src/__tests__/v11/createLock.test.js
@@ -40,6 +40,13 @@ jest.mock('../../erc20.js', () => {
 
 let testERC20ContractAddress = '0x9409bd2f87f0698f89c04caee8ddb2fd9e44bcc3'
 
+const EventInfo = new ethers.utils.Interface(UnlockV11.Unlock.abi)
+const encoder = ethers.utils.defaultAbiCoder
+
+let receipt = {
+  logs: [],
+}
+
 describe('v11', () => {
   describe('createLock', () => {
     async function nockBeforeEach(maxNumberOfKeys = lock.maxNumberOfKeys) {
@@ -64,6 +71,9 @@ describe('v11', () => {
         lock.name
       )
 
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
+      )
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
@@ -276,6 +286,43 @@ describe('v11', () => {
 
       await walletService.createLock(lock)
       await nock.resolveWhenAllNocksUsed()
+    })
+
+    it('should yield a promise of lock address', async () => {
+      expect.assertions(1)
+
+      await nockBeforeEach()
+      setupSuccess()
+
+      // For now we do not use this
+      const sender = '0x0000000000000000000000000000000000000000'
+
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve({
+          logs: [
+            {
+              transactionIndex: 1,
+              blockNumber: 19759,
+              transactionHash:
+                '0xace0af5853a98aff70ca427f21ad8a1a958cc219099789a3ea6fd5fac30f150c',
+              address: lock.address,
+              topics: [
+                EventInfo.events['NewLock(address,address)'].topic,
+                encoder.encode(['address'], [sender]),
+                encoder.encode(['address'], [lock.address]),
+              ],
+              data: '0x',
+              logIndex: 0,
+              blockHash:
+                '0xcb27b74a5ff04b129b645bbcfde46fe1a221c2d341223df4ad2ca87e9864678a',
+              transactionLogIndex: 0,
+            },
+          ],
+        })
+      )
+      const lockAddress = await walletService.createLock(lock)
+      await nock.resolveWhenAllNocksUsed()
+      expect(lockAddress).toEqual(lock.address)
     })
   })
 })

--- a/unlock-js/src/v0/createLock.js
+++ b/unlock-js/src/v0/createLock.js
@@ -41,7 +41,24 @@ export default async function(lock) {
       balance: '0',
       transaction: hash,
     })
+
+    // Let's now wait for the lock to be deployed before we return its address
+    const receipt = await this.provider.waitForTransaction(hash)
+    const parser = unlockContract.interface
+    const newLockEvent = receipt.logs
+      .map(log => {
+        return parser.parseLog(log)
+      })
+      .filter(event => event.name === 'NewLock')[0]
+
+    if (newLockEvent) {
+      return newLockEvent.values.newLockAddress
+    } else {
+      // There was no NewEvent log (transaction failed?)
+      return null
+    }
   } catch (error) {
     this.emit('error', new Error(TransactionTypes.FAILED_TO_CREATE_LOCK))
+    return null
   }
 }

--- a/unlock-js/src/v01/createLock.js
+++ b/unlock-js/src/v01/createLock.js
@@ -42,7 +42,24 @@ export default async function(lock) {
       balance: '0',
       transaction: hash,
     })
+
+    // Let's now wait for the lock to be deployed before we return its address
+    const receipt = await this.provider.waitForTransaction(hash)
+    const parser = unlockContract.interface
+    const newLockEvent = receipt.logs
+      .map(log => {
+        return parser.parseLog(log)
+      })
+      .filter(event => event.name === 'NewLock')[0]
+
+    if (newLockEvent) {
+      return newLockEvent.values.newLockAddress
+    } else {
+      // There was no NewEvent log (transaction failed?)
+      return null
+    }
   } catch (error) {
     this.emit('error', new Error(TransactionTypes.FAILED_TO_CREATE_LOCK))
+    return null
   }
 }

--- a/unlock-js/src/v02/createLock.js
+++ b/unlock-js/src/v02/createLock.js
@@ -44,7 +44,23 @@ export default async function(lock) {
       balance: '0',
       transaction: hash,
     })
+    // Let's now wait for the lock to be deployed before we return its address
+    const receipt = await this.provider.waitForTransaction(hash)
+    const parser = unlockContract.interface
+    const newLockEvent = receipt.logs
+      .map(log => {
+        return parser.parseLog(log)
+      })
+      .filter(event => event.name === 'NewLock')[0]
+
+    if (newLockEvent) {
+      return newLockEvent.values.newLockAddress
+    } else {
+      // There was no NewEvent log (transaction failed?)
+      return null
+    }
   } catch (error) {
     this.emit('error', new Error(TransactionTypes.FAILED_TO_CREATE_LOCK))
+    return null
   }
 }

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -139,6 +139,7 @@ export default class WalletService extends UnlockService {
   /**
    * Creates a lock on behalf of the user.
    * @param {PropTypes.lock} lock
+   * @return Promise<PropTypes.address> lockAddress
    */
   async createLock(lock) {
     const version = await this.unlockContractAbiVersion()


### PR DESCRIPTION
# Description

This will make writing the integration tests much easier and will also let us refactor some complexity in the docker setup.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread