### PR TITLE
Switch from using fractions to basisPoints

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -60,7 +60,6 @@ contract PublicLock is
     MixinLockCore.initialize(_owner, _expirationDuration, _keyPrice, _maxNumberOfKeys);
     MixinLockMetadata.initialize(_lockName);
     MixinERC721Enumerable.initialize();
-    MixinTransfer.initialize();
     MixinRefunds.initialize();
     // registering the interface for erc721 with ERC165.sol using
     // the ID specified in the standard: https://eips.ethereum.org/EIPS/eip-721

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -51,6 +51,9 @@ contract MixinLockCore is
   // The account which will receive funds on withdrawal
   address public beneficiary;
 
+  // The denominator component for values specified in basis points.
+  uint public constant BASIS_POINTS_DEN = 10000;
+
   // Ensure that the Lock has not sold all of its keys.
   modifier notSoldOut() {
     require(maxNumberOfKeys > totalSupply, 'LOCK_SOLD_OUT');

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -158,7 +158,9 @@ contract('Lock / cancelAndRefund', accounts => {
     })
 
     it('should return the correct penalty', async () => {
-      const numerator = new BigNumber(await lock.refundPenaltyBasisPoints.call())
+      const numerator = new BigNumber(
+        await lock.refundPenaltyBasisPoints.call()
+      )
       const denominator = await lock.BASIS_POINTS_DEN.call()
       assert.equal(numerator.div(denominator).toFixed(), 0.2) // updated to 20%
     })

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -153,13 +153,13 @@ contract('Lock / cancelAndRefund', accounts => {
       })
       assert.equal(
         new BigNumber(event.args.refundPenaltyBasisPoints).toFixed(),
-        2
+        2000
       )
     })
 
     it('should return the correct penalty', async () => {
       const numerator = new BigNumber(await lock.refundPenaltyBasisPoints.call())
-      const denominator = await lock.refundPenaltyDenominator.call()
+      const denominator = await lock.BASIS_POINTS_DEN.call()
       assert.equal(numerator.div(denominator).toFixed(), 0.2) // updated to 20%
     })
 

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -33,8 +33,8 @@ contract('Lock / cancelAndRefund', accounts => {
   })
 
   it('should return the correct penalty', async () => {
-    const numerator = new BigNumber(await lock.refundPenaltyNumerator.call())
-    const denominator = await lock.refundPenaltyDenominator.call()
+    const numerator = new BigNumber(await lock.refundPenaltyBasisPoints.call())
+    const denominator = await lock.BASIS_POINTS_DEN.call()
     assert.equal(numerator.div(denominator).toFixed(), 0.1) // default of 10%
   })
 
@@ -144,7 +144,7 @@ contract('Lock / cancelAndRefund', accounts => {
     let tx
 
     before(async () => {
-      tx = await lock.updateRefundPenalty(0, 2, 10) // 20%
+      tx = await lock.updateRefundPenalty(0, 2000) // 20%
     })
 
     it('should trigger an event', async () => {
@@ -152,17 +152,13 @@ contract('Lock / cancelAndRefund', accounts => {
         return log.event === 'RefundPenaltyChanged'
       })
       assert.equal(
-        new BigNumber(event.args.refundPenaltyNumerator).toFixed(),
+        new BigNumber(event.args.refundPenaltyBasisPoints).toFixed(),
         2
-      )
-      assert.equal(
-        new BigNumber(event.args.refundPenaltyDenominator).toFixed(),
-        10
       )
     })
 
     it('should return the correct penalty', async () => {
-      const numerator = new BigNumber(await lock.refundPenaltyNumerator.call())
+      const numerator = new BigNumber(await lock.refundPenaltyBasisPoints.call())
       const denominator = await lock.refundPenaltyDenominator.call()
       assert.equal(numerator.div(denominator).toFixed(), 0.2) // updated to 20%
     })
@@ -208,10 +204,6 @@ contract('Lock / cancelAndRefund', accounts => {
         }),
         'KEY_NOT_VALID'
       )
-    })
-
-    it('attempt to set the denominator to 0', async () => {
-      await shouldFail(lock.updateRefundPenalty(0, 1, 0), 'INVALID_RATE')
     })
   })
 })

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -121,7 +121,7 @@ contract('Lock / disableLock', accounts => {
       await lock.updateLockName('Hardly')
     })
 
-    it('Lock owner can still updateRefundPenaltyDenominator', async () => {
+    it('Lock owner can still updateBASIS_POINTS_DEN', async () => {
       await lock.updateRefundPenalty(0, 5000)
     })
 

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -122,7 +122,7 @@ contract('Lock / disableLock', accounts => {
     })
 
     it('Lock owner can still updateRefundPenaltyDenominator', async () => {
-      await lock.updateRefundPenalty(0, 5, 100)
+      await lock.updateRefundPenalty(0, 5000)
     })
 
     it('should fail to setApprovalForAll', async () => {

--- a/smart-contracts/test/Lock/erc721/approveForAll.js
+++ b/smart-contracts/test/Lock/erc721/approveForAll.js
@@ -12,7 +12,7 @@ contract('Lock / erc721 / approveForAll', accounts => {
     unlock = await getProxy(unlockContract)
     const locks = await deployLocks(unlock, accounts[0])
     lock = locks['FIRST']
-    await lock.updateTransferFee(0, 1) // disable the transfer fee for this test
+    await lock.updateTransferFee(0) // disable the transfer fee for this test
   })
 
   let owner = accounts[1]

--- a/smart-contracts/test/Lock/erc721/safeTransferFrom.js
+++ b/smart-contracts/test/Lock/erc721/safeTransferFrom.js
@@ -13,7 +13,7 @@ contract('Lock / erc721 / safeTransferFrom', accounts => {
     unlock = await getProxy(unlockContract)
     const locks = await deployLocks(unlock, accounts[0])
     lock = locks['FIRST']
-    await lock.updateTransferFee(0, 1) // disable the transfer fee for this test
+    await lock.updateTransferFee(0) // disable the transfer fee for this test
   })
 
   // function safeTransferFrom() still uses transferFrom() under the hood, but adds an additional check afterwards. transferFrom is already well-tested, so here we add a few checks to test only the new functionality.

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -14,8 +14,8 @@ contract('Lock / erc721 / transferFrom', accounts => {
   before(async () => {
     unlock = await getProxy(unlockContract)
     locks = await deployLocks(unlock, accounts[0])
-    await locks['FIRST'].updateTransferFee(0, 1) // disable the transfer fee for this test
-    await locks['SINGLE KEY'].updateTransferFee(0, 1) // disable the transfer fee for this test
+    await locks['FIRST'].updateTransferFee(0) // disable the transfer fee for this test
+    await locks['SINGLE KEY'].updateTransferFee(0) // disable the transfer fee for this test
   })
 
   const from = accounts[1]

--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -35,7 +35,7 @@ contract('Lock / freeTrial', accounts => {
     let initialLockBalance
 
     beforeEach(async () => {
-      await lock.updateRefundPenalty(5, 2, 10)
+      await lock.updateRefundPenalty(5, 2000)
       initialLockBalance = new BigNumber(
         await web3.eth.getBalance(lock.address)
       )

--- a/smart-contracts/test/Lock/getHasValidKey.js
+++ b/smart-contracts/test/Lock/getHasValidKey.js
@@ -15,7 +15,7 @@ contract('Lock / getHasValidKey', accounts => {
     unlock = await getProxy(unlockContract)
     locks = await deployLocks(unlock, accounts[0])
     lock = locks['FIRST']
-    await lock.updateTransferFee(0, 1) // disable the transfer fee for this test
+    await lock.updateTransferFee(0) // disable the transfer fee for this test
   })
 
   it('should be false before purchasing a key', async () => {

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -13,7 +13,7 @@ contract('Lock / owners', accounts => {
     unlock = await getProxy(unlockContract)
     locks = await deployLocks(unlock, accounts[0])
     lock = locks['FIRST']
-    await lock.updateTransferFee(0, 1) // disable the transfer fee for this test
+    await lock.updateTransferFee(0) // disable the transfer fee for this test
   })
 
   before(() => {

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -25,7 +25,7 @@ contract('Lock / transferFee', accounts => {
   })
 
   it('has a default fee of 0%', async () => {
-    const feeNumerator = new BigNumber(await lock.refundPenaltyBasisPoints.call())
+    const feeNumerator = new BigNumber(await lock.transferFeeBasisPoints.call())
     const feeDenominator = new BigNumber(
       await lock.BASIS_POINTS_DEN.call()
     )
@@ -135,12 +135,12 @@ contract('Lock / transferFee', accounts => {
 
       before(async () => {
         // Change the fee to 0.025%
-        tx = await lock.updateTransferFee(1, 4000)
+        tx = await lock.updateTransferFee(25)
       })
 
       it('has an updated fee', async () => {
         const feeNumerator = new BigNumber(
-          await lock.refundPenaltyBasisPoints.call()
+          await lock.transferFeeBasisPoints.call()
         )
         const feeDenominator = new BigNumber(
           await lock.BASIS_POINTS_DEN.call()
@@ -148,22 +148,19 @@ contract('Lock / transferFee', accounts => {
         assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.00025)
       })
 
-      it('emits the BASIS_POINTS_DENChanged event', async () => {
+      it('emits TransferFeeChanged event', async () => {
         assert.equal(tx.logs[0].event, 'TransferFeeChanged')
-        assert.equal(tx.logs[0].args.oldrefundPenaltyBasisPoints, 5)
-        assert.equal(tx.logs[0].args.oldBASIS_POINTS_DEN, 100)
-        assert.equal(tx.logs[0].args.refundPenaltyBasisPoints, 1)
-        assert.equal(tx.logs[0].args.BASIS_POINTS_DEN, 4000)
+        assert.equal(tx.logs[0].args.transferFeeBasisPoints, 1)
       })
     })
 
     describe('should fail if', () => {
       it('called by an account which does not own the lock', async () => {
-        await shouldFail(lock.updateTransferFee(1, 100, { from: accounts[1] }))
+        await shouldFail(lock.updateTransferFee(1000, { from: accounts[1] }))
       })
 
       it('attempt to set the denominator to 0', async () => {
-        await shouldFail(lock.updateTransferFee(1, 0), 'INVALID_RATE')
+        await shouldFail(lock.updateTransferFee(1000), 'INVALID_RATE')
       })
     })
   })

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -25,7 +25,7 @@ contract('Lock / transferFee', accounts => {
   })
 
   it('has a default fee of 0%', async () => {
-    const feeNumerator = new BigNumber(await lock.transferFeeNumerator.call())
+    const feeNumerator = new BigNumber(await lock.refundPenaltyBasisPoints.call())
     const feeDenominator = new BigNumber(
       await lock.transferFeeDenominator.call()
     )
@@ -35,7 +35,7 @@ contract('Lock / transferFee', accounts => {
   describe('once a fee of 5% is set', () => {
     before(async () => {
       // Change the fee to 0.05%
-      await lock.updateTransferFee(5, 100)
+      await lock.updateTransferFee(5000)
     })
 
     it('estimates the transfer fee, which is 5% of keyPrice or less', async () => {
@@ -140,7 +140,7 @@ contract('Lock / transferFee', accounts => {
 
       it('has an updated fee', async () => {
         const feeNumerator = new BigNumber(
-          await lock.transferFeeNumerator.call()
+          await lock.refundPenaltyBasisPoints.call()
         )
         const feeDenominator = new BigNumber(
           await lock.transferFeeDenominator.call()
@@ -150,9 +150,9 @@ contract('Lock / transferFee', accounts => {
 
       it('emits the TransferFeeDenominatorChanged event', async () => {
         assert.equal(tx.logs[0].event, 'TransferFeeChanged')
-        assert.equal(tx.logs[0].args.oldTransferFeeNumerator, 5)
+        assert.equal(tx.logs[0].args.oldrefundPenaltyBasisPoints, 5)
         assert.equal(tx.logs[0].args.oldTransferFeeDenominator, 100)
-        assert.equal(tx.logs[0].args.transferFeeNumerator, 1)
+        assert.equal(tx.logs[0].args.refundPenaltyBasisPoints, 1)
         assert.equal(tx.logs[0].args.transferFeeDenominator, 4000)
       })
     })

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -34,8 +34,8 @@ contract('Lock / transferFee', accounts => {
 
   describe('once a fee of 5% is set', () => {
     before(async () => {
-      // Change the fee to 0.05%
-      await lock.updateTransferFee(5000)
+      // Change the fee to 5%
+      await lock.updateTransferFee(500)
     })
 
     it('estimates the transfer fee, which is 5% of keyPrice or less', async () => {
@@ -134,7 +134,7 @@ contract('Lock / transferFee', accounts => {
       let tx
 
       before(async () => {
-        // Change the fee to 0.025%
+        // Change the fee to 0.25%
         tx = await lock.updateTransferFee(25)
       })
 
@@ -145,22 +145,18 @@ contract('Lock / transferFee', accounts => {
         const feeDenominator = new BigNumber(
           await lock.BASIS_POINTS_DEN.call()
         )
-        assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.00025)
+        assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.0025)
       })
 
       it('emits TransferFeeChanged event', async () => {
         assert.equal(tx.logs[0].event, 'TransferFeeChanged')
-        assert.equal(tx.logs[0].args.transferFeeBasisPoints, 1)
+        assert.equal(tx.logs[0].args.transferFeeBasisPoints.toString(), 25)
       })
     })
 
     describe('should fail if', () => {
       it('called by an account which does not own the lock', async () => {
         await shouldFail(lock.updateTransferFee(1000, { from: accounts[1] }))
-      })
-
-      it('attempt to set the denominator to 0', async () => {
-        await shouldFail(lock.updateTransferFee(1000), 'INVALID_RATE')
       })
     })
   })

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -27,7 +27,7 @@ contract('Lock / transferFee', accounts => {
   it('has a default fee of 0%', async () => {
     const feeNumerator = new BigNumber(await lock.refundPenaltyBasisPoints.call())
     const feeDenominator = new BigNumber(
-      await lock.transferFeeDenominator.call()
+      await lock.BASIS_POINTS_DEN.call()
     )
     assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.0)
   })
@@ -143,17 +143,17 @@ contract('Lock / transferFee', accounts => {
           await lock.refundPenaltyBasisPoints.call()
         )
         const feeDenominator = new BigNumber(
-          await lock.transferFeeDenominator.call()
+          await lock.BASIS_POINTS_DEN.call()
         )
         assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.00025)
       })
 
-      it('emits the TransferFeeDenominatorChanged event', async () => {
+      it('emits the BASIS_POINTS_DENChanged event', async () => {
         assert.equal(tx.logs[0].event, 'TransferFeeChanged')
         assert.equal(tx.logs[0].args.oldrefundPenaltyBasisPoints, 5)
-        assert.equal(tx.logs[0].args.oldTransferFeeDenominator, 100)
+        assert.equal(tx.logs[0].args.oldBASIS_POINTS_DEN, 100)
         assert.equal(tx.logs[0].args.refundPenaltyBasisPoints, 1)
-        assert.equal(tx.logs[0].args.transferFeeDenominator, 4000)
+        assert.equal(tx.logs[0].args.BASIS_POINTS_DEN, 4000)
       })
     })
 

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -26,9 +26,7 @@ contract('Lock / transferFee', accounts => {
 
   it('has a default fee of 0%', async () => {
     const feeNumerator = new BigNumber(await lock.transferFeeBasisPoints.call())
-    const feeDenominator = new BigNumber(
-      await lock.BASIS_POINTS_DEN.call()
-    )
+    const feeDenominator = new BigNumber(await lock.BASIS_POINTS_DEN.call())
     assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.0)
   })
 
@@ -142,9 +140,7 @@ contract('Lock / transferFee', accounts => {
         const feeNumerator = new BigNumber(
           await lock.transferFeeBasisPoints.call()
         )
-        const feeDenominator = new BigNumber(
-          await lock.BASIS_POINTS_DEN.call()
-        )
+        const feeDenominator = new BigNumber(await lock.BASIS_POINTS_DEN.call())
         assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.0025)
       })
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Instead of using a numerator / denominator for values, we can simplify and define the units in basis points.  For the impacted use cases this should be plenty of precision, simplifies (for both users and the code itself) and would be a bit cheaper on gas.

Impacted transferFee and refundPenalty 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
