### PR TITLE
Renovate: separate patch PR from minor PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,14 +14,18 @@
         "*"
       ],
       "minor": {
-        "groupName": "all non-major dependencies",
-        "groupSlug": "all-minor-patch"
+        "groupName": "all dependencies minor updates",
+        "groupSlug": "all-minor"
+      },
+      "patch": {
+        "groupName": "all dependencies patch updates",
+        "groupSlug": "all-patch"
       }
     },
     {
       "packageNames": ["@unlock-protocol/unlock-js"],
       "schedule": ["at any time"],
-      "groupName": null
+      "groupSlug": "unlock-js"
     }
   ]
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Separates patch updates from minors.  All the patches should, in theory, be safe.  Minor updates often include breaking changes.  I'm hoping this way the patch PR is a straightforward merge and then there is less noise in the minor PR while investigating any issues.

I don't feel strongly about this, we can close if you prefer the current behavior.

I also updated the unlock-js slug as I think renovate missed the last update..

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
