### PR TITLE
locks with a keyPrice of 0 are not too expensive

### DIFF
--- a/paywall/src/__tests__/utils/locks.test.js
+++ b/paywall/src/__tests__/utils/locks.test.js
@@ -164,6 +164,28 @@ describe('locks utilities', () => {
       ).toBeTruthy()
     })
 
+    it('should not be too expensive when the keyPrice is 0 on a lock', () => {
+      expect.assertions(2)
+      expect(
+        isTooExpensiveForUserByCurrency(
+          {
+            keyPrice: '0',
+          },
+          accountWithValidBalance,
+          'eth'
+        )
+      ).toBeFalsy()
+      expect(
+        isTooExpensiveForUserByCurrency(
+          {
+            keyPrice: '0',
+          },
+          accountWithValidBalance,
+          ERC20Lock.currencyContractAddress
+        )
+      ).toBeFalsy()
+    })
+
     it('should be too expensive if keyPrice is bigger than balance', () => {
       expect.assertions(2)
       expect(

--- a/paywall/src/utils/locks.js
+++ b/paywall/src/utils/locks.js
@@ -49,16 +49,16 @@ export function isTooExpensiveForUserByCurrency(lock, account, currencyKey) {
   if (!account || !account.balance) {
     return LOCK_IS_TOO_EXPENSIVE
   }
-
   const balance = parseFloat(account.balance[currencyKey])
   if (!balance) {
     return LOCK_IS_TOO_EXPENSIVE
   }
 
   const keyPrice = parseFloat(lock.keyPrice)
-  if (!keyPrice) {
+  if (typeof keyPrice !== 'number') {
     // All locks should have a keyPrice, but if for some reason one doesn't,
     // we're in some kind of broken state and we'd better prevent purchasing.
+    // On locks with no keyPrice the float would be Nan
     return LOCK_IS_TOO_EXPENSIVE
   }
 


### PR DESCRIPTION
# Description

Unfortunately purchasing keys on our blog is broken because of this (because the key price is 0).

This fixes and adds the corresponding regression tests.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->