### PR TITLE
Private key ejection aware

### DIFF
--- a/locksmith/__tests__/controllers/userController/passwordEncryptedPrivateKey.test.ts
+++ b/locksmith/__tests__/controllers/userController/passwordEncryptedPrivateKey.test.ts
@@ -36,7 +36,7 @@ function generateTypedData(message: any) {
   }
 }
 
-beforeAll(async () => {
+beforeAll(() => {
   let UserReference = models.UserReference
   let User = models.User
 

--- a/locksmith/__tests__/controllers/userController/passwordEncryptedPrivateKey.test.ts
+++ b/locksmith/__tests__/controllers/userController/passwordEncryptedPrivateKey.test.ts
@@ -1,3 +1,5 @@
+import models = require('../../../src/models')
+
 jest.mock('../../../src/utils/ownedKeys', () => {
   return {
     keys: jest
@@ -35,10 +37,13 @@ function generateTypedData(message: any) {
 }
 
 beforeAll(async () => {
-  let models = require('../../../src/models')
-
   let UserReference = models.UserReference
-  return UserReference.truncate({ cascade: true })
+  let User = models.User
+
+  return Promise.all([
+    UserReference.truncate({ cascade: true }),
+    User.truncate({ cascade: true }),
+  ])
 })
 
 describe("updating a user's password encrypted private key", () => {

--- a/locksmith/src/controllers/userController.ts
+++ b/locksmith/src/controllers/userController.ts
@@ -39,18 +39,24 @@ namespace UserController {
     res: Response
   ): Promise<any> => {
     let emailAddress = req.params.emailAddress
-    let result = await UserOperations.getUserPrivateKeyByEmailAddress(
-      emailAddress
-    )
+    let ejected = await UserOperations.ejectionStatus(emailAddress)
 
-    if (result) {
-      return res.json({ passwordEncryptedPrivateKey: result })
+    if (ejected) {
+      return res.sendStatus(404)
     } else {
-      let result = await new DecoyUser().encryptedPrivateKey()
+      let result = await UserOperations.getUserPrivateKeyByEmailAddress(
+        emailAddress
+      )
 
-      return res.json({
-        passwordEncryptedPrivateKey: result,
-      })
+      if (result) {
+        return res.json({ passwordEncryptedPrivateKey: result })
+      } else {
+        let result = await new DecoyUser().encryptedPrivateKey()
+
+        return res.json({
+          passwordEncryptedPrivateKey: result,
+        })
+      }
     }
   }
 


### PR DESCRIPTION
# Description

As part of making downstream applications aware of user ejections, requesting a password encrypted private key will return a not found  when  the account has been ejected


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
