### PR TITLE
encoding addresses in recovery emails

### DIFF
--- a/unlock-app/src/__tests__/middlewares/wedlocksMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/wedlocksMiddleware.test.ts
@@ -50,9 +50,9 @@ describe('Wedlocks Middleware', () => {
 
     expect(wedlocksService.welcomeEmail).toHaveBeenCalledWith(
       emailAddress,
-      `http://localhost/recover/?email=tim@cern.ch&recoveryKey=${encodeURIComponent(
-        JSON.stringify(recoveryKey)
-      )}`
+      `http://localhost/recover/?email=${encodeURIComponent(
+        'tim@cern.ch'
+      )}&recoveryKey=${encodeURIComponent(JSON.stringify(recoveryKey))}`
     )
   })
 })

--- a/unlock-app/src/__tests__/services/wedlockService.test.js
+++ b/unlock-app/src/__tests__/services/wedlockService.test.js
@@ -62,4 +62,29 @@ describe('Wedlocks Service', () => {
       }
     )
   })
+
+  it('should request a welcome email, with the right headers and params, including an encoded URL', async () => {
+    expect.assertions(1)
+    const recipient = 'julien+hello@unlock-protocol.com'
+    const expectedPayload = {
+      template: emailTemplate.welcome,
+      recipient,
+      params: {
+        recoveryLink: 'https://recovery',
+        email: encodeURIComponent(recipient),
+      },
+    }
+    axios.post.mockReturnValue()
+    await w.welcomeEmail(recipient, 'https://recovery')
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://notareal.host',
+      expectedPayload,
+      {
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    )
+  })
 })

--- a/unlock-app/src/middlewares/wedlocksMiddleware.ts
+++ b/unlock-app/src/middlewares/wedlocksMiddleware.ts
@@ -23,9 +23,9 @@ const wedlocksMiddleware = (config: any) => {
           // TODO: then and catch? I think we really only need to worry about errors.
           wedlockService.welcomeEmail(
             action.emailAddress,
-            `${origin}/recover/?email=${
+            `${origin}/recover/?email=${encodeURIComponent(
               action.emailAddress
-            }&recoveryKey=${encodeURIComponent(
+            )}&recoveryKey=${encodeURIComponent(
               JSON.stringify(action.recoveryKey)
             )}`
           )

--- a/unlock-app/src/services/wedlockService.ts
+++ b/unlock-app/src/services/wedlockService.ts
@@ -51,7 +51,7 @@ export default class WedlockService {
   welcomeEmail = (recipient: string, recoveryLink: string) => {
     return this.sendEmail(emailTemplate.welcome, recipient, {
       email: encodeURIComponent(recipient),
-      recoveryLink,
+      recoveryLink: recoveryLink,
     })
   }
 }


### PR DESCRIPTION
# Description

This will fix the recovery links for people using a `+` in their to identify them!

# Issues

Fixes #4975


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread