### PR TITLE
Return a 404 when attempting to update ejected users payment details

### DIFF
--- a/locksmith/src/controllers/userController.ts
+++ b/locksmith/src/controllers/userController.ts
@@ -110,13 +110,21 @@ namespace UserController {
     res: Response
   ): Promise<any> => {
     let publicKey = req.body.message.user.publicKey
+    let emailAddress = req.params.emailAddress
     let token = req.body.message.user.stripeTokenId
-    let result = await UserOperations.updatePaymentDetails(token, publicKey)
 
-    if (result) {
-      return res.sendStatus(202)
+    let ejected = await UserOperations.ejectionStatus(emailAddress)
+
+    if (ejected) {
+      return res.sendStatus(404)
     } else {
-      return res.sendStatus(400)
+      let result = await UserOperations.updatePaymentDetails(token, publicKey)
+
+      if (result) {
+        return res.sendStatus(202)
+      } else {
+        return res.sendStatus(400)
+      }
     }
   }
 


### PR DESCRIPTION
# Description

As part of making the service aware of ejected users we are returning 404 when attempting to update payment details of an ejected user

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
