### PR TITLE
Updating user creation to be aware of ejected accounts

### DIFF
--- a/locksmith/__tests__/controllers/userController/userCreation.test.ts
+++ b/locksmith/__tests__/controllers/userController/userCreation.test.ts
@@ -1,6 +1,7 @@
 import models = require('../../../src/models')
 import app = require('../../../src/app')
 import Base64 = require('../../../src/utils/base64')
+let UserOperations = require('../../../src/operations/userOperations')
 
 function generateTypedData(message: any) {
   return {
@@ -119,6 +120,38 @@ describe('user creation', () => {
         .send(typedData)
 
       expect(response.statusCode).toBe(400)
+    })
+  })
+
+  describe('when attempting to re-create a previously ejected user', () => {
+    it('returns a 409', async () => {
+      expect.assertions(1)
+
+      let emailAddress = 'ejected_user@example.com'
+      let userCreationDetails = {
+        emailAddress: emailAddress,
+        publicKey: 'ejected_user_phrase_public_key',
+        passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
+      }
+
+      await UserOperations.createUser(userCreationDetails)
+      await UserOperations.eject(userCreationDetails.publicKey)
+
+      let message = {
+        user: {
+          emailAddress,
+          publicKey: userCreationDetails.publicKey,
+          passwordEncryptedPrivateKey:
+            userCreationDetails.passwordEncryptedPrivateKey,
+        },
+      }
+      generateTypedData(message)
+
+      let response = await request(app)
+        .post('/users')
+        .set('Accept', /json/)
+        .send(generateTypedData(message))
+      expect(response.statusCode).toBe(409)
     })
   })
 })

--- a/locksmith/__tests__/controllers/userController/userCreation.test.ts
+++ b/locksmith/__tests__/controllers/userController/userCreation.test.ts
@@ -145,7 +145,6 @@ describe('user creation', () => {
             userCreationDetails.passwordEncryptedPrivateKey,
         },
       }
-      generateTypedData(message)
 
       let response = await request(app)
         .post('/users')


### PR DESCRIPTION
# Description

As of right now we are not allowing ejected users the ability to recreate their accounts, we are returning a conflict code in the face of this scenario

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
