### PR TITLE
Make sure to zero out eth balance for logged out users

### DIFF
--- a/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
+++ b/paywall/src/__tests__/unlock.js/CheckoutUIHandler.test.ts
@@ -251,7 +251,7 @@ describe('CheckoutUIHandler', () => {
       }
 
       const expectedPayload = {
-        eth: '123.4',
+        eth: '0',
         '0xdeadbeef': DEFAULT_STABLECOIN_BALANCE,
       }
 
@@ -278,12 +278,15 @@ describe('CheckoutUIHandler - injectDefaultBalance helper', () => {
     expect(injectDefaultBalance({})).toEqual({})
   })
 
-  it('should leave eth alone', () => {
+  it('should zero out eth', () => {
     expect.assertions(1)
     const balance = {
       eth: '123.4',
     }
-    expect(injectDefaultBalance(balance)).toEqual(balance)
+    const expectedBalance = {
+      eth: '0',
+    }
+    expect(injectDefaultBalance(balance)).toEqual(expectedBalance)
   })
 
   it('should update any non-eth balances with the default', () => {
@@ -294,7 +297,7 @@ describe('CheckoutUIHandler - injectDefaultBalance helper', () => {
       '0xdeadbeef': '0',
     }
     expect(injectDefaultBalance(balance)).toEqual({
-      eth: '123.4',
+      eth: '0',
       '0x123abc': DEFAULT_STABLECOIN_BALANCE,
       '0xdeadbeef': DEFAULT_STABLECOIN_BALANCE,
     })

--- a/paywall/src/__tests__/unlock.js/Wallet/enableCryptoWallet.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/enableCryptoWallet.test.ts
@@ -24,6 +24,8 @@ describe('Wallet.setupProxyWallet()', () => {
     debug: 0,
     paywallUrl: 'http://paywall',
     accountsUrl: 'http://app/accounts',
+    managedPurchaseStablecoinAddress:
+      '0x591AD9066603f5499d12fF4bC207e2f577448c46',
   }
 
   function makeWallet() {

--- a/paywall/src/__tests__/unlock.js/Wallet/init.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/init.test.ts
@@ -25,6 +25,8 @@ describe('Wallet.init()', () => {
     debug: 0,
     paywallUrl: 'http://paywall',
     accountsUrl: 'http://app/accounts',
+    managedPurchaseStablecoinAddress:
+      '0x591AD9066603f5499d12fF4bC207e2f577448c46',
   }
   const userAccountsConfig: PaywallConfig = {
     ...regularConfig,

--- a/paywall/src/__tests__/unlock.js/Wallet/setupUserAccounts.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/setupUserAccounts.test.ts
@@ -30,6 +30,8 @@ describe('Wallet.setupUserAccounts()', () => {
     debug: 0,
     paywallUrl: 'http://paywall',
     accountsUrl: 'http://app/accounts',
+    managedPurchaseStablecoinAddress:
+      '0x591AD9066603f5499d12fF4bC207e2f577448c46',
   }
 
   function makeWallet() {

--- a/paywall/src/__tests__/unlock.js/Wallet/setupUserAccountsProxyWallet.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/setupUserAccountsProxyWallet.test.ts
@@ -31,6 +31,8 @@ describe('Wallet.setupUserAccounts()', () => {
     debug: 0,
     paywallUrl: 'http://paywall',
     accountsUrl: 'http://app/accounts',
+    managedPurchaseStablecoinAddress:
+      '0x591AD9066603f5499d12fF4bC207e2f577448c46',
   }
 
   function makeWallet() {

--- a/paywall/src/__tests__/unlock.js/Wallet/setupWeb3ProxyWallet.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/setupWeb3ProxyWallet.test.ts
@@ -30,6 +30,8 @@ describe('Wallet.setupUserAccounts()', () => {
     debug: 0,
     paywallUrl: 'http://paywall',
     accountsUrl: 'http://app/accounts',
+    managedPurchaseStablecoinAddress:
+      '0x591AD9066603f5499d12fF4bC207e2f577448c46',
   }
   function makeWallet() {
     iframes = new IframeHandler(

--- a/paywall/src/__tests__/unlock.js/startup.test.ts
+++ b/paywall/src/__tests__/unlock.js/startup.test.ts
@@ -77,6 +77,8 @@ describe('unlock.js startup', () => {
       debug: 0,
       paywallUrl: 'http://paywall',
       accountsUrl: 'http://app/account',
+      managedPurchaseStablecoinAddress:
+        '0x591AD9066603f5499d12fF4bC207e2f577448c46',
     }
     const dataOrigin = 'http://paywall'
     const checkoutOrigin = 'http://paywall'

--- a/paywall/src/unlock.js/CheckoutUIHandler.ts
+++ b/paywall/src/unlock.js/CheckoutUIHandler.ts
@@ -7,10 +7,15 @@ export const injectDefaultBalance = (oldBalance: Balance): Balance => {
   const newBalance: Balance = {}
   const tokens = Object.keys(oldBalance)
   tokens.forEach(token => {
-    if (token.startsWith('0x')) {
-      newBalance[token] = DEFAULT_STABLECOIN_BALANCE
+    if (token === 'eth') {
+      // the "null account" 0x0000000... has an enormous balance of eth. We zero
+      // it out here so that we don't enable purchasing on eth locks for user
+      // account users.
+      newBalance[token] = '0'
     } else {
-      newBalance[token] = oldBalance[token]
+      // all other tokens should have the default balance -- assumption is you
+      // can only create stablecoin locks that we support purchasing on
+      newBalance[token] = DEFAULT_STABLECOIN_BALANCE
     }
   })
 

--- a/paywall/src/unlock.js/constants.ts
+++ b/paywall/src/unlock.js/constants.ts
@@ -17,24 +17,32 @@ const constants: { [key: string]: StartupConstants } = {
     debug: process.env.DEBUG,
     paywallUrl: process.env.PAYWALL_URL || 'http://localhost:3001',
     accountsUrl: process.env.USER_IFRAME_URL || 'http://localhost:3000/account',
+    managedPurchaseStablecoinAddress:
+      '0x591AD9066603f5499d12fF4bC207e2f577448c46',
   },
   test: {
     network: 1984,
     debug: process.env.DEBUG,
     paywallUrl: process.env.PAYWALL_URL || 'http://localhost:3001',
     accountsUrl: process.env.USER_IFRAME_URL || 'http://localhost:3000/account',
+    managedPurchaseStablecoinAddress:
+      '0x591AD9066603f5499d12fF4bC207e2f577448c46',
   },
   staging: {
     network: 4,
     debug: process.env.DEBUG,
     paywallUrl: process.env.PAYWALL_URL,
     accountsUrl: process.env.USER_IFRAME_URL,
+    managedPurchaseStablecoinAddress:
+      '0x8f2e097E79B1c51Be9cBA42658862f0192C3E487',
   },
   prod: {
     network: 1,
     debug: process.env.DEBUG,
     paywallUrl: process.env.PAYWALL_URL,
     accountsUrl: process.env.USER_IFRAME_URL,
+    managedPurchaseStablecoinAddress:
+      '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359',
   },
 }
 

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -65,7 +65,11 @@ export function startup(
   iframes.init(config)
 
   // set up the communication with the checkout iframe
-  const checkoutIframeHandler = new CheckoutUIHandler(iframes, config)
+  const checkoutIframeHandler = new CheckoutUIHandler(
+    iframes,
+    config,
+    constants
+  )
   // user accounts is loaded on-demand inside of Wallet
   // set up the proxy wallet handler
   // the config must not be falsy here, so the checking "config.unlockUserAccounts" does not throw a TyoeError

--- a/paywall/src/unlock.js/startupTypes.ts
+++ b/paywall/src/unlock.js/startupTypes.ts
@@ -3,4 +3,5 @@ export default interface StartupConstants {
   debug: any
   paywallUrl: string
   accountsUrl: string
+  managedPurchaseStablecoinAddress: string
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

In #4949, we noticed that the [null ethereum account](https://etherscan.io/address/0x0000000000000000000000000000000000000000) that we use as the default for users who are not logged in actually has an enormous eth balance, which allowed people to initiate key purchases on eth locks that would fail immediately. This PR makes sure we intercept that balance and zero it out so that the eth lock is always disabled for user accounts.

This PR makes an assumption that eth should always be zeroed and all other tokens should receive the default stablecoin balance constant, under the assumption that locks can only be created with stablecoins that we allow purchasing on (presently, DAI). If that is not correct, we should ensure that we zero everything except for approved tokens.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
