### PR TITLE
refactored keyPurchase to yield a promise with the token id

### DIFF
--- a/unlock-js/src/__tests__/v0/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v0/purchaseKey.test.js
@@ -1,13 +1,15 @@
+import { ethers } from 'ethers'
 import * as UnlockV0 from 'unlock-abi-0'
+import abis from '../../abis'
 import utils from '../../utils'
 import Errors from '../../errors'
-import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
 const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
+const UnlockVersion = abis.v0
 
 let walletService
 let transaction
@@ -21,6 +23,36 @@ describe('v0', () => {
     const owner = '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e'
     const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
     const data = 'key data'
+    const EventInfo = new ethers.utils.Interface(UnlockVersion.PublicLock.abi)
+    const encoder = ethers.utils.defaultAbiCoder
+    const receipt = {
+      logs: [
+        {
+          transactionIndex: 1,
+          blockNumber: 19759,
+          transactionHash:
+            '0xace0af5853a98aff70ca427f21ad8a1a958cc219099789a3ea6fd5fac30f150c',
+          address: lockAddress,
+          topics: [
+            EventInfo.events['Transfer(address,address,uint256)'].topic,
+            encoder.encode(
+              ['address'],
+              ['0x0000000000000000000000000000000000000000']
+            ),
+            encoder.encode(['address'], [owner]),
+            encoder.encode(['uint256'], [owner]),
+          ],
+          data: encoder.encode(
+            ['address', 'address', 'uint256'],
+            ['0x0000000000000000000000000000000000000000', owner, owner]
+          ),
+          logIndex: 0,
+          blockHash:
+            '0xcb27b74a5ff04b129b645bbcfde46fe1a221c2d341223df4ad2ca87e9864678a',
+          transactionLogIndex: 0,
+        },
+      ],
+    }
 
     async function nockBeforeEach(sendData = true) {
       nock.cleanAll()
@@ -62,24 +94,21 @@ describe('v0', () => {
         Promise.resolve(transaction.hash)
       )
       const mock = walletService._handleMethodCall
-
-      await walletService.purchaseKey({
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
+      )
+      const tokenId = await walletService.purchaseKey({
         lockAddress,
         owner,
         keyPrice,
         data,
       })
-
-      expect(mock).toHaveBeenCalledWith(
-        expect.any(Promise),
-        TransactionTypes.KEY_PURCHASE
-      )
-
       // verify that the promise passed to _handleMethodCall actually resolves
       // to the result the chain returns from a sendTransaction call to createLock
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
+      expect(tokenId).toEqual(utils.bigNumberify(owner).toString())
       await nock.resolveWhenAllNocksUsed()
     })
 
@@ -108,14 +137,16 @@ describe('v0', () => {
 
       await nockBeforeEach(false)
       setupSuccess()
-
-      const result = await walletService.purchaseKey({
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
+      )
+      const tokenId = await walletService.purchaseKey({
         lockAddress,
         owner,
         keyPrice,
       })
       await nock.resolveWhenAllNocksUsed()
-      expect(result).toBe(transaction.hash)
+      expect(tokenId).toEqual(utils.bigNumberify(owner).toString())
     })
   })
 })

--- a/unlock-js/src/__tests__/v01/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v01/purchaseKey.test.js
@@ -1,4 +1,7 @@
+import { ethers } from 'ethers'
 import * as UnlockV01 from 'unlock-abi-0-1'
+import abis from '../../abis'
+import utils from '../../utils'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
@@ -7,6 +10,7 @@ import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
+const UnlockVersion = abis.v01
 
 let walletService
 let transaction
@@ -20,6 +24,36 @@ describe('v01', () => {
     const owner = '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e'
     const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
 
+    const EventInfo = new ethers.utils.Interface(UnlockVersion.PublicLock.abi)
+    const encoder = ethers.utils.defaultAbiCoder
+    const receipt = {
+      logs: [
+        {
+          transactionIndex: 1,
+          blockNumber: 19759,
+          transactionHash:
+            '0xace0af5853a98aff70ca427f21ad8a1a958cc219099789a3ea6fd5fac30f150c',
+          address: lockAddress,
+          topics: [
+            EventInfo.events['Transfer(address,address,uint256)'].topic,
+            encoder.encode(
+              ['address'],
+              ['0x0000000000000000000000000000000000000000']
+            ),
+            encoder.encode(['address'], [owner]),
+            encoder.encode(['uint256'], [owner]),
+          ],
+          data: encoder.encode(
+            ['address', 'address', 'uint256'],
+            ['0x0000000000000000000000000000000000000000', owner, owner]
+          ),
+          logIndex: 0,
+          blockHash:
+            '0xcb27b74a5ff04b129b645bbcfde46fe1a221c2d341223df4ad2ca87e9864678a',
+          transactionLogIndex: 0,
+        },
+      ],
+    }
     async function nockBeforeEach() {
       nock.cleanAll()
       walletService = await prepWalletService(
@@ -50,7 +84,7 @@ describe('v01', () => {
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       await nockBeforeEach()
       setupSuccess()
@@ -59,8 +93,15 @@ describe('v01', () => {
         Promise.resolve(transaction.hash)
       )
       const mock = walletService._handleMethodCall
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
+      )
 
-      await walletService.purchaseKey({ lockAddress, owner, keyPrice })
+      const tokenId = await walletService.purchaseKey({
+        lockAddress,
+        owner,
+        keyPrice,
+      })
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -72,6 +113,7 @@ describe('v01', () => {
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
+      expect(tokenId).toEqual(utils.bigNumberify(owner).toString())
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v02/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v02/purchaseKey.test.js
@@ -1,4 +1,6 @@
+import { ethers } from 'ethers'
 import * as UnlockV02 from 'unlock-abi-0-2'
+import abis from '../../abis'
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
@@ -7,6 +9,8 @@ import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
+
+const UnlockVersion = abis.v02
 
 let walletService
 let transaction
@@ -19,6 +23,37 @@ describe('v02', () => {
     const keyPrice = '0.01'
     const owner = '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e'
     const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
+    const tokenId = '1'
+    const EventInfo = new ethers.utils.Interface(UnlockVersion.PublicLock.abi)
+    const encoder = ethers.utils.defaultAbiCoder
+    const receipt = {
+      logs: [
+        {
+          transactionIndex: 1,
+          blockNumber: 19759,
+          transactionHash:
+            '0xace0af5853a98aff70ca427f21ad8a1a958cc219099789a3ea6fd5fac30f150c',
+          address: lockAddress,
+          topics: [
+            EventInfo.events['Transfer(address,address,uint256)'].topic,
+            encoder.encode(
+              ['address'],
+              ['0x0000000000000000000000000000000000000000']
+            ),
+            encoder.encode(['address'], [owner]),
+            encoder.encode(['uint256'], [tokenId]),
+          ],
+          data: encoder.encode(
+            ['address', 'address', 'uint256'],
+            ['0x0000000000000000000000000000000000000000', owner, tokenId]
+          ),
+          logIndex: 0,
+          blockHash:
+            '0xcb27b74a5ff04b129b645bbcfde46fe1a221c2d341223df4ad2ca87e9864678a',
+          transactionLogIndex: 0,
+        },
+      ],
+    }
 
     async function nockBeforeEach() {
       nock.cleanAll()
@@ -50,7 +85,7 @@ describe('v02', () => {
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       await nockBeforeEach()
       setupSuccess()
@@ -60,7 +95,15 @@ describe('v02', () => {
       )
       const mock = walletService._handleMethodCall
 
-      await walletService.purchaseKey({ lockAddress, owner, keyPrice })
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
+      )
+
+      const newTokenId = await walletService.purchaseKey({
+        lockAddress,
+        owner,
+        keyPrice,
+      })
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -72,6 +115,7 @@ describe('v02', () => {
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
+      expect(newTokenId).toEqual(tokenId)
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v11/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v11/purchaseKey.test.js
@@ -1,5 +1,8 @@
 import { ethers } from 'ethers'
+
 import * as UnlockV11 from 'unlock-abi-1-1'
+import abis from '../../abis'
+
 import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
@@ -7,6 +10,8 @@ import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 import erc20 from '../../erc20'
 import utils from '../../utils'
 import { ZERO } from '../../constants'
+
+const UnlockVersion = abis.v02
 
 const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
@@ -27,6 +32,39 @@ describe('v11', () => {
     const owner = '0xab7c74abc0c4d48d1bdad5dcb26153fc8780f83e'
     const lockAddress = '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b'
     const erc20Address = '0x6F7a54D6629b7416E17fc472B4003aE8EF18EF4c'
+
+    const EventInfo = new ethers.utils.Interface(UnlockVersion.PublicLock.abi)
+    const encoder = ethers.utils.defaultAbiCoder
+    const tokenId = '1'
+
+    const receipt = {
+      logs: [
+        {
+          transactionIndex: 1,
+          blockNumber: 19759,
+          transactionHash:
+            '0xace0af5853a98aff70ca427f21ad8a1a958cc219099789a3ea6fd5fac30f150c',
+          address: lockAddress,
+          topics: [
+            EventInfo.events['Transfer(address,address,uint256)'].topic,
+            encoder.encode(
+              ['address'],
+              ['0x0000000000000000000000000000000000000000']
+            ),
+            encoder.encode(['address'], [owner]),
+            encoder.encode(['uint256'], [tokenId]),
+          ],
+          data: encoder.encode(
+            ['address', 'address', 'uint256'],
+            ['0x0000000000000000000000000000000000000000', owner, tokenId]
+          ),
+          logIndex: 0,
+          blockHash:
+            '0xcb27b74a5ff04b129b645bbcfde46fe1a221c2d341223df4ad2ca87e9864678a',
+          transactionLogIndex: 0,
+        },
+      ],
+    }
 
     async function nockBeforeEach(
       purchaseForOptions = {},
@@ -85,7 +123,7 @@ describe('v11', () => {
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       await nockBeforeEach({ value: keyPrice })
       setupSuccess()
@@ -96,7 +134,15 @@ describe('v11', () => {
 
       const mock = walletService._handleMethodCall
 
-      await walletService.purchaseKey({ lockAddress, owner, keyPrice })
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
+      )
+
+      const newTokenId = await walletService.purchaseKey({
+        lockAddress,
+        owner,
+        keyPrice,
+      })
 
       expect(mock).toHaveBeenCalledWith(
         expect.any(Promise),
@@ -108,6 +154,7 @@ describe('v11', () => {
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
+      expect(newTokenId).toEqual(tokenId)
       await nock.resolveWhenAllNocksUsed()
     })
 
@@ -125,6 +172,9 @@ describe('v11', () => {
           }
         )
 
+        walletService.provider.waitForTransaction = jest.fn(() =>
+          Promise.resolve(receipt)
+        )
         await walletService.purchaseKey({ lockAddress, owner, keyPrice })
 
         expect(erc20.approveTransfer).toHaveBeenCalledWith(
@@ -150,6 +200,9 @@ describe('v11', () => {
           }
         )
 
+        walletService.provider.waitForTransaction = jest.fn(() =>
+          Promise.resolve(receipt)
+        )
         await walletService.purchaseKey({ lockAddress, owner, keyPrice })
 
         expect(erc20.getErc20Decimals).toHaveBeenCalledWith(
@@ -181,6 +234,9 @@ describe('v11', () => {
         }
       )
 
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
+      )
       await walletService.purchaseKey({ lockAddress, owner, keyPrice })
 
       expect(erc20.approveTransfer).not.toHaveBeenCalled()
@@ -198,6 +254,9 @@ describe('v11', () => {
         expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
       })
 
+      walletService.provider.waitForTransaction = jest.fn(() =>
+        Promise.resolve(receipt)
+      )
       await walletService.purchaseKey({ lockAddress, owner, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })

--- a/unlock-js/src/v01/purchaseKey.js
+++ b/unlock-js/src/v01/purchaseKey.js
@@ -18,11 +18,27 @@ export default async function({ lockAddress, owner, keyPrice }) {
       gasLimit: GAS_AMOUNTS.purchaseFor,
       value: Web3Utils.toWei(keyPrice, 'ether'),
     })
-    const ret = await this._handleMethodCall(
+    const hash = await this._handleMethodCall(
       transactionPromise,
       TransactionTypes.KEY_PURCHASE
     )
-    return ret
+    // Let's now wait for the transaction to go thru to return the token id
+    const receipt = await this.provider.waitForTransaction(hash)
+    const parser = lockContract.interface
+
+    const transferEvent = receipt.logs
+      .map(log => {
+        return parser.parseLog(log)
+      })
+      .filter(event => {
+        return event.name === 'Transfer'
+      })[0]
+    if (transferEvent) {
+      return transferEvent.values._tokenId.toString()
+    } else {
+      // There was no Transfer log (transaction failed?)
+      return null
+    }
   } catch (error) {
     this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
   }

--- a/unlock-js/src/v02/purchaseKey.js
+++ b/unlock-js/src/v02/purchaseKey.js
@@ -18,11 +18,27 @@ export default async function({ lockAddress, owner, keyPrice }) {
       gasLimit: GAS_AMOUNTS.purchaseFor,
       value: Web3Utils.toWei(keyPrice, 'ether'),
     })
-    const ret = await this._handleMethodCall(
+    const hash = await this._handleMethodCall(
       transactionPromise,
       TransactionTypes.KEY_PURCHASE
     )
-    return ret
+    // Let's now wait for the transaction to go thru to return the token id
+    const receipt = await this.provider.waitForTransaction(hash)
+    const parser = lockContract.interface
+
+    const transferEvent = receipt.logs
+      .map(log => {
+        return parser.parseLog(log)
+      })
+      .filter(event => {
+        return event.name === 'Transfer'
+      })[0]
+    if (transferEvent) {
+      return transferEvent.values._tokenId.toString()
+    } else {
+      // There was no Transfer log (transaction failed?)
+      return null
+    }
   } catch (error) {
     this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
   }

--- a/unlock-js/src/v10/purchaseKey.js
+++ b/unlock-js/src/v10/purchaseKey.js
@@ -60,10 +60,28 @@ export default async function({
       owner,
       purchaseForOptions
     )
-    return await this._handleMethodCall(
+    const hash = await this._handleMethodCall(
       transactionPromise,
       TransactionTypes.KEY_PURCHASE
     )
+
+    // Let's now wait for the transaction to go thru to return the token id
+    const receipt = await this.provider.waitForTransaction(hash)
+    const parser = lockContract.interface
+
+    const transferEvent = receipt.logs
+      .map(log => {
+        return parser.parseLog(log)
+      })
+      .filter(event => {
+        return event.name === 'Transfer'
+      })[0]
+    if (transferEvent) {
+      return transferEvent.values._tokenId.toString()
+    } else {
+      // There was no Transfer log (transaction failed?)
+      return null
+    }
   } catch (error) {
     this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
   }

--- a/unlock-js/src/v11/purchaseKey.js
+++ b/unlock-js/src/v11/purchaseKey.js
@@ -60,10 +60,29 @@ export default async function({
       owner,
       purchaseForOptions
     )
-    return await this._handleMethodCall(
+
+    const hash = await this._handleMethodCall(
       transactionPromise,
       TransactionTypes.KEY_PURCHASE
     )
+
+    // Let's now wait for the transaction to go thru to return the token id
+    const receipt = await this.provider.waitForTransaction(hash)
+    const parser = lockContract.interface
+
+    const transferEvent = receipt.logs
+      .map(log => {
+        return parser.parseLog(log)
+      })
+      .filter(event => {
+        return event.name === 'Transfer'
+      })[0]
+    if (transferEvent) {
+      return transferEvent.values._tokenId.toString()
+    } else {
+      // There was no Transfer log (transaction failed?)
+      return null
+    }
   } catch (error) {
     this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
   }

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -158,6 +158,7 @@ export default class WalletService extends UnlockService {
    * - {string} data
    * - {PropTypes.address} erc20Address
    * - {number} decimals
+   * TODO: add an exta callback param which will be invoked with the transaction hash
    */
   async purchaseKey(params = {}) {
     if (!params.lockAddress) throw new Error('Missing lockAddress')


### PR DESCRIPTION
# Description

keyPurchase will now yield a promise of token id.
A future change will yield a callback with the hash so we can use that in our applications too.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread