### PR TITLE
Add a modal for QR codes

### DIFF
--- a/unlock-app/src/__tests__/actions/fullScreenModals.test.ts
+++ b/unlock-app/src/__tests__/actions/fullScreenModals.test.ts
@@ -3,10 +3,8 @@ import {
   DISMISS_MODAL,
   waitForWallet,
   dismissWalletCheck,
-  promptForPassword,
-  dismissPasswordPrompt,
-  promptForResetPassword,
-  dismissResetPasswordPrompt,
+  displayQR,
+  dismissQR,
 } from '../../actions/fullScreenModals'
 import { KindOfModal } from '../../unlockTypes'
 
@@ -31,43 +29,24 @@ describe('FullScreenModals actions', () => {
     expect(dismissWalletCheck()).toEqual(expectedAction)
   })
 
-  it('should create an action to prompt for password', () => {
+  it('should create an action to display a QR code', () => {
     expect.assertions(1)
     const expectedAction = {
       type: LAUNCH_MODAL,
-      kindOfModal: KindOfModal.PasswordPrompt,
+      kindOfModal: KindOfModal.QRDisplay,
+      data: 'some data',
     }
 
-    expect(promptForPassword()).toEqual(expectedAction)
+    expect(displayQR('some data')).toEqual(expectedAction)
   })
 
-  it('should create an action to dismiss a password prompt', () => {
+  it('should create an action to dismiss a QR code', () => {
     expect.assertions(1)
     const expectedAction = {
       type: DISMISS_MODAL,
-      kindOfModal: KindOfModal.PasswordPrompt,
+      kindOfModal: KindOfModal.QRDisplay,
     }
 
-    expect(dismissPasswordPrompt()).toEqual(expectedAction)
-  })
-
-  it('should create an action to prompt for password reset', () => {
-    expect.assertions(1)
-    const expectedAction = {
-      type: LAUNCH_MODAL,
-      kindOfModal: KindOfModal.ResetPasswordPrompt,
-    }
-
-    expect(promptForResetPassword()).toEqual(expectedAction)
-  })
-
-  it('should create an action to dismiss a password reset prompt', () => {
-    expect.assertions(1)
-    const expectedAction = {
-      type: DISMISS_MODAL,
-      kindOfModal: KindOfModal.ResetPasswordPrompt,
-    }
-
-    expect(dismissResetPasswordPrompt()).toEqual(expectedAction)
+    expect(dismissQR()).toEqual(expectedAction)
   })
 })

--- a/unlock-app/src/__tests__/components/interface/ModalTemplates.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/ModalTemplates.test.tsx
@@ -30,11 +30,11 @@ describe('Modal Templates', () => {
       expect.assertions(1)
       const dispatch = jest.fn()
 
-      const { getByText } = rtl.render(
+      const { getByTestId } = rtl.render(
         <QRDisplay dispatch={dispatch} data="some data" />
       )
 
-      const dismissButton = getByText('Dismiss')
+      const dismissButton = getByTestId('qr-quit-button')
       rtl.fireEvent.click(dismissButton)
 
       expect(dispatch).toHaveBeenCalledWith({

--- a/unlock-app/src/__tests__/components/interface/ModalTemplates.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/ModalTemplates.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { KindOfModal } from '../../../unlockTypes'
+import { DISMISS_MODAL } from '../../../actions/fullScreenModals'
+import {
+  WalletCheck,
+  QRDisplay,
+} from '../../../components/interface/modal-templates'
+
+describe('Modal Templates', () => {
+  describe('WalletCheck', () => {
+    it('should dismiss the overlay when the button is clicked', () => {
+      expect.assertions(1)
+      const dispatch = jest.fn()
+
+      const { getByText } = rtl.render(<WalletCheck dispatch={dispatch} />)
+
+      const dismissButton = getByText('Dismiss')
+      rtl.fireEvent.click(dismissButton)
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: DISMISS_MODAL,
+        kindOfModal: KindOfModal.WalletCheckOverlay,
+      })
+    })
+  })
+
+  describe('QRDisplay', () => {
+    it('should dismiss the overlay when the button is clicked', () => {
+      expect.assertions(1)
+      const dispatch = jest.fn()
+
+      const { getByText } = rtl.render(
+        <QRDisplay dispatch={dispatch} data="some data" />
+      )
+
+      const dismissButton = getByText('Dismiss')
+      rtl.fireEvent.click(dismissButton)
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: DISMISS_MODAL,
+        kindOfModal: KindOfModal.QRDisplay,
+      })
+    })
+  })
+})

--- a/unlock-app/src/__tests__/reducers/fullScreenModalsReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/fullScreenModalsReducer.test.ts
@@ -12,32 +12,44 @@ describe('fullScreenModalsReducer', () => {
     active: true,
     kindOfModal: KindOfModal.WalletCheckOverlay,
   }
-  const passwordModal = {
-    active: true,
-    kindOfModal: KindOfModal.PasswordPrompt,
-  }
   const walletAction = {
     type: LAUNCH_MODAL,
     kindOfModal: KindOfModal.WalletCheckOverlay,
   }
-  const passwordAction = {
+
+  const qrModal = {
+    active: true,
+    kindOfModal: KindOfModal.QRDisplay,
+    data: 'some data',
+  }
+
+  const qrAction = {
     type: LAUNCH_MODAL,
-    kindOfModal: KindOfModal.PasswordPrompt,
+    kindOfModal: KindOfModal.QRDisplay,
+    data: 'some data',
   }
 
   it.each([SET_ACCOUNT, SET_PROVIDER, SET_NETWORK, DISMISS_MODAL])(
     'should return initialState when receiving %s',
     actionType => {
-      expect.assertions(2)
+      expect.assertions(1)
       const action = { type: actionType }
       expect(reducer(walletModal, action)).toEqual(initialState)
-      expect(reducer(passwordModal, action)).toEqual(initialState)
     }
   )
 
   it('should launch the modal when given LAUNCH_MODAL', () => {
-    expect.assertions(2)
+    expect.assertions(1)
     expect(reducer(initialState, walletAction)).toEqual(walletModal)
-    expect(reducer(initialState, passwordAction)).toEqual(passwordModal)
+  })
+
+  it('should launch the modal when given LAUNCH_MODAL (with data)', () => {
+    expect.assertions(1)
+    expect(reducer(initialState, qrAction)).toEqual(qrModal)
+  })
+
+  it('should return the existing state when receiving some other action', () => {
+    expect.assertions(1)
+    expect(reducer(qrModal, { type: 'RELEASE_BEES' })).toEqual(qrModal)
   })
 })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -31192,6 +31192,7 @@ Object {
 
 .c1 {
   background: var(--white);
+  position: relative;
   min-width: 50%;
   max-width: 98%;
   border-radius: 4px;
@@ -32731,16 +32732,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-bYSBpT gXcQiX"
+      class="sc-jtRfpW gZekgG"
     >
       <div
-        class="sc-lhVmIH gZGkEg"
+        class="sc-elJkPf heWQOk"
       >
         <p>
           Please check your browser wallet.
         </p>
         <button
-          class="sc-cmTdod ftojYZ"
+          class="sc-btzYZH eDleNM"
         >
           Dismiss
         </button>
@@ -36510,6 +36511,387 @@ Object {
 }
 `;
 
+exports[`Storyshots Full Screen Modals The QRDisplay Overlay 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c3 {
+  background-color: var(--grey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 24px;
+  width: 24px;
+  display: inline-block;
+  padding: 0;
+  border: 0;
+  line-height: '15px';
+}
+
+.c3 > svg {
+  fill: white;
+  height: 24px;
+  width: 24px;
+}
+
+.c3:hover {
+  background-color: var(--link);
+}
+
+.c3:hover > svg {
+  fill: white;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c2:hover .c6 {
+  display: inline-block;
+}
+
+.c7 .c2 {
+  background-color: var(--white);
+  -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  opacity: 1;
+  pointer-events: visible;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c7 .c2:nth-child(1) {
+  pointer-events: none;
+}
+
+.c7 .c2:nth-child(2) {
+  pointer-events: none;
+  display: none;
+}
+
+.c7 .c2 > svg {
+  fill: var(--grey);
+}
+
+.c7 .c2:hover > svg {
+  fill: var(--grey);
+}
+
+.c8 .c2 {
+  margin: 24px;
+}
+
+.c8 .c2 small {
+  display: block;
+  color: var(--grey);
+  text-align: center;
+  top: 5px;
+  width: 100%;
+  text-align: center;
+}
+
+.c5 {
+  padding: 8px;
+  border: thin black solid;
+}
+
+.c4 {
+  position: absolute;
+  right: 8px;
+  top: 8px;
+}
+
+.c1 {
+  background: var(--white);
+  position: relative;
+  min-width: 50%;
+  max-width: 98%;
+  border-radius: 4px;
+  padding: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: var(--darkgrey);
+  font-size: 20px;
+}
+
+.c0 {
+  background: rgba(0,0,0,0.5);
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  left: 0;
+  top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  z-index: var(--alwaysontop);
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <a
+            class="c2 c3 c4"
+            data-testid="qr-quit-button"
+            target="_self"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <title>
+                Close
+              </title>
+              <path
+                clip-rule="evenodd"
+                d="M8.237 7.177a.75.75 0 10-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 101.06 1.06L12 13.061l3.763 3.762a.75.75 0 101.06-1.06L13.061 12l3.762-3.763a.75.75 0 00-1.06-1.06L12 10.939 8.237 7.177z"
+                fill-rule="evenodd"
+              />
+            </svg>
+            
+          </a>
+          <svg
+            class="c5"
+            height="256"
+            shape-rendering="crispEdges"
+            viewBox="0 0 21 21"
+            width="256"
+          >
+            <path
+              d="M0,0 h21v21H0z"
+              fill="#FFFFFF"
+            />
+            <path
+              d="M0 0h7v1H0zM8 0h1v1H8zM10 0h3v1H10zM14,0 h7v1H14zM0 1h1v1H0zM6 1h1v1H6zM10 1h2v1H10zM14 1h1v1H14zM20,1 h1v1H20zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM8 2h2v1H8zM11 2h1v1H11zM14 2h1v1H14zM16 2h3v1H16zM20,2 h1v1H20zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h2v1H8zM12 3h1v1H12zM14 3h1v1H14zM16 3h3v1H16zM20,3 h1v1H20zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM8 4h1v1H8zM11 4h1v1H11zM14 4h1v1H14zM16 4h3v1H16zM20,4 h1v1H20zM0 5h1v1H0zM6 5h1v1H6zM9 5h4v1H9zM14 5h1v1H14zM20,5 h1v1H20zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14,6 h7v1H14zM11 7h2v1H11zM0 8h4v1H0zM6 8h1v1H6zM8 8h6v1H8zM16 8h3v1H16zM20,8 h1v1H20zM2 9h1v1H2zM5 9h1v1H5zM8 9h6v1H8zM16 9h2v1H16zM20,9 h1v1H20zM0 10h3v1H0zM5 10h3v1H5zM11 10h1v1H11zM14 10h2v1H14zM18,10 h3v1H18zM3 11h1v1H3zM5 11h1v1H5zM9 11h3v1H9zM15 11h3v1H15zM20,11 h1v1H20zM0 12h1v1H0zM2 12h2v1H2zM5 12h2v1H5zM8 12h1v1H8zM10 12h1v1H10zM12 12h1v1H12zM14 12h2v1H14zM8 13h2v1H8zM11 13h1v1H11zM14 13h1v1H14zM16 13h1v1H16zM18 13h2v1H18zM0 14h7v1H0zM10 14h3v1H10zM15 14h3v1H15zM0 15h1v1H0zM6 15h1v1H6zM9 15h2v1H9zM15 15h1v1H15zM17 15h3v1H17zM0 16h1v1H0zM2 16h3v1H2zM6 16h1v1H6zM12 16h1v1H12zM14 16h2v1H14zM17 16h2v1H17zM0 17h1v1H0zM2 17h3v1H2zM6 17h1v1H6zM8 17h4v1H8zM14 17h1v1H14zM17 17h1v1H17zM19 17h1v1H19zM0 18h1v1H0zM2 18h3v1H2zM6 18h1v1H6zM8 18h1v1H8zM12 18h1v1H12zM14 18h1v1H14zM17 18h2v1H17zM0 19h1v1H0zM6 19h1v1H6zM8 19h2v1H8zM13 19h1v1H13zM17 19h1v1H17zM20,19 h1v1H20zM0 20h7v1H0zM8 20h1v1H8zM13 20h1v1H13zM16 20h1v1H16zM18 20h1v1H18z"
+              fill="#000000"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-jtRfpW gZekgG"
+    >
+      <div
+        class="sc-elJkPf heWQOk"
+      >
+        <a
+          class="sc-850ddk-0 iabPtF sc-jwKygS hWhrqh"
+          data-testid="qr-quit-button"
+          target="_self"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 10-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 101.06 1.06L12 13.061l3.763 3.762a.75.75 0 101.06-1.06L13.061 12l3.762-3.763a.75.75 0 00-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </a>
+        <svg
+          class="sc-cmTdod kfQwzw"
+          height="256"
+          shape-rendering="crispEdges"
+          viewBox="0 0 21 21"
+          width="256"
+        >
+          <path
+            d="M0,0 h21v21H0z"
+            fill="#FFFFFF"
+          />
+          <path
+            d="M0 0h7v1H0zM8 0h1v1H8zM10 0h3v1H10zM14,0 h7v1H14zM0 1h1v1H0zM6 1h1v1H6zM10 1h2v1H10zM14 1h1v1H14zM20,1 h1v1H20zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM8 2h2v1H8zM11 2h1v1H11zM14 2h1v1H14zM16 2h3v1H16zM20,2 h1v1H20zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h2v1H8zM12 3h1v1H12zM14 3h1v1H14zM16 3h3v1H16zM20,3 h1v1H20zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM8 4h1v1H8zM11 4h1v1H11zM14 4h1v1H14zM16 4h3v1H16zM20,4 h1v1H20zM0 5h1v1H0zM6 5h1v1H6zM9 5h4v1H9zM14 5h1v1H14zM20,5 h1v1H20zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14,6 h7v1H14zM11 7h2v1H11zM0 8h4v1H0zM6 8h1v1H6zM8 8h6v1H8zM16 8h3v1H16zM20,8 h1v1H20zM2 9h1v1H2zM5 9h1v1H5zM8 9h6v1H8zM16 9h2v1H16zM20,9 h1v1H20zM0 10h3v1H0zM5 10h3v1H5zM11 10h1v1H11zM14 10h2v1H14zM18,10 h3v1H18zM3 11h1v1H3zM5 11h1v1H5zM9 11h3v1H9zM15 11h3v1H15zM20,11 h1v1H20zM0 12h1v1H0zM2 12h2v1H2zM5 12h2v1H5zM8 12h1v1H8zM10 12h1v1H10zM12 12h1v1H12zM14 12h2v1H14zM8 13h2v1H8zM11 13h1v1H11zM14 13h1v1H14zM16 13h1v1H16zM18 13h2v1H18zM0 14h7v1H0zM10 14h3v1H10zM15 14h3v1H15zM0 15h1v1H0zM6 15h1v1H6zM9 15h2v1H9zM15 15h1v1H15zM17 15h3v1H17zM0 16h1v1H0zM2 16h3v1H2zM6 16h1v1H6zM12 16h1v1H12zM14 16h2v1H14zM17 16h2v1H17zM0 17h1v1H0zM2 17h3v1H2zM6 17h1v1H6zM8 17h4v1H8zM14 17h1v1H14zM17 17h1v1H17zM19 17h1v1H19zM0 18h1v1H0zM2 18h3v1H2zM6 18h1v1H6zM8 18h1v1H8zM12 18h1v1H12zM14 18h1v1H14zM17 18h2v1H17zM0 19h1v1H0zM6 19h1v1H6zM8 19h2v1H8zM13 19h1v1H13zM17 19h1v1H17zM20,19 h1v1H20zM0 20h7v1H0zM8 20h1v1H8zM13 20h1v1H13zM16 20h1v1H16zM18 20h1v1H18z"
+            fill="#000000"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Full Screen Modals The QRDisplay Overlay, inactive 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots Full Screen Modals The Wallet Check Overlay 1`] = `
 Object {
   "asFragment": [Function],
@@ -36530,6 +36912,7 @@ Object {
 
 .c1 {
   background: var(--white);
+  position: relative;
   min-width: 50%;
   max-width: 98%;
   border-radius: 4px;
@@ -36607,16 +36990,16 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-bYSBpT gXcQiX"
+      class="sc-jtRfpW gZekgG"
     >
       <div
-        class="sc-lhVmIH gZGkEg"
+        class="sc-elJkPf heWQOk"
       >
         <p>
           Please check your browser wallet.
         </p>
         <button
-          class="sc-cmTdod ftojYZ"
+          class="sc-btzYZH eDleNM"
         >
           Dismiss
         </button>
@@ -36764,6 +37147,275 @@ Object {
 }
 `;
 
+exports[`Storyshots Full Screen Modals/templates The QRDisplay Overlay 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c2 {
+  background-color: var(--grey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 24px;
+  width: 24px;
+  display: inline-block;
+  padding: 0;
+  border: 0;
+  line-height: '15px';
+}
+
+.c2 > svg {
+  fill: white;
+  height: 24px;
+  width: 24px;
+}
+
+.c2:hover {
+  background-color: var(--link);
+}
+
+.c2:hover > svg {
+  fill: white;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c1:hover .c5 {
+  display: inline-block;
+}
+
+.c6 .c1 {
+  background-color: var(--white);
+  -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  opacity: 1;
+  pointer-events: visible;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c6 .c1:nth-child(1) {
+  pointer-events: none;
+}
+
+.c6 .c1:nth-child(2) {
+  pointer-events: none;
+  display: none;
+}
+
+.c6 .c1 > svg {
+  fill: var(--grey);
+}
+
+.c6 .c1:hover > svg {
+  fill: var(--grey);
+}
+
+.c7 .c1 {
+  margin: 24px;
+}
+
+.c7 .c1 small {
+  display: block;
+  color: var(--grey);
+  text-align: center;
+  top: 5px;
+  width: 100%;
+  text-align: center;
+}
+
+.c4 {
+  padding: 8px;
+  border: thin black solid;
+}
+
+.c3 {
+  position: absolute;
+  right: 8px;
+  top: 8px;
+}
+
+.c0 {
+  background: var(--white);
+  position: relative;
+  min-width: 50%;
+  max-width: 98%;
+  border-radius: 4px;
+  padding: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: var(--darkgrey);
+  font-size: 20px;
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <a
+          class="c1 c2 c3"
+          data-testid="qr-quit-button"
+          target="_self"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 10-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 101.06 1.06L12 13.061l3.763 3.762a.75.75 0 101.06-1.06L13.061 12l3.762-3.763a.75.75 0 00-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </a>
+        <svg
+          class="c4"
+          height="256"
+          shape-rendering="crispEdges"
+          viewBox="0 0 21 21"
+          width="256"
+        >
+          <path
+            d="M0,0 h21v21H0z"
+            fill="#FFFFFF"
+          />
+          <path
+            d="M0 0h7v1H0zM8 0h1v1H8zM10 0h3v1H10zM14,0 h7v1H14zM0 1h1v1H0zM6 1h1v1H6zM10 1h2v1H10zM14 1h1v1H14zM20,1 h1v1H20zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM8 2h2v1H8zM11 2h1v1H11zM14 2h1v1H14zM16 2h3v1H16zM20,2 h1v1H20zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h2v1H8zM12 3h1v1H12zM14 3h1v1H14zM16 3h3v1H16zM20,3 h1v1H20zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM8 4h1v1H8zM11 4h1v1H11zM14 4h1v1H14zM16 4h3v1H16zM20,4 h1v1H20zM0 5h1v1H0zM6 5h1v1H6zM9 5h4v1H9zM14 5h1v1H14zM20,5 h1v1H20zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14,6 h7v1H14zM11 7h2v1H11zM0 8h4v1H0zM6 8h1v1H6zM8 8h6v1H8zM16 8h3v1H16zM20,8 h1v1H20zM2 9h1v1H2zM5 9h1v1H5zM8 9h6v1H8zM16 9h2v1H16zM20,9 h1v1H20zM0 10h3v1H0zM5 10h3v1H5zM11 10h1v1H11zM14 10h2v1H14zM18,10 h3v1H18zM3 11h1v1H3zM5 11h1v1H5zM9 11h3v1H9zM15 11h3v1H15zM20,11 h1v1H20zM0 12h1v1H0zM2 12h2v1H2zM5 12h2v1H5zM8 12h1v1H8zM10 12h1v1H10zM12 12h1v1H12zM14 12h2v1H14zM8 13h2v1H8zM11 13h1v1H11zM14 13h1v1H14zM16 13h1v1H16zM18 13h2v1H18zM0 14h7v1H0zM10 14h3v1H10zM15 14h3v1H15zM0 15h1v1H0zM6 15h1v1H6zM9 15h2v1H9zM15 15h1v1H15zM17 15h3v1H17zM0 16h1v1H0zM2 16h3v1H2zM6 16h1v1H6zM12 16h1v1H12zM14 16h2v1H14zM17 16h2v1H17zM0 17h1v1H0zM2 17h3v1H2zM6 17h1v1H6zM8 17h4v1H8zM14 17h1v1H14zM17 17h1v1H17zM19 17h1v1H19zM0 18h1v1H0zM2 18h3v1H2zM6 18h1v1H6zM8 18h1v1H8zM12 18h1v1H12zM14 18h1v1H14zM17 18h2v1H17zM0 19h1v1H0zM6 19h1v1H6zM8 19h2v1H8zM13 19h1v1H13zM17 19h1v1H17zM20,19 h1v1H20zM0 20h7v1H0zM8 20h1v1H8zM13 20h1v1H13zM16 20h1v1H16zM18 20h1v1H18z"
+            fill="#000000"
+          />
+        </svg>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-elJkPf heWQOk"
+    >
+      <a
+        class="sc-850ddk-0 iabPtF sc-jwKygS hWhrqh"
+        data-testid="qr-quit-button"
+        target="_self"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            clip-rule="evenodd"
+            d="M8.237 7.177a.75.75 0 10-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 101.06 1.06L12 13.061l3.763 3.762a.75.75 0 101.06-1.06L13.061 12l3.762-3.763a.75.75 0 00-1.06-1.06L12 10.939 8.237 7.177z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        
+      </a>
+      <svg
+        class="sc-cmTdod kfQwzw"
+        height="256"
+        shape-rendering="crispEdges"
+        viewBox="0 0 21 21"
+        width="256"
+      >
+        <path
+          d="M0,0 h21v21H0z"
+          fill="#FFFFFF"
+        />
+        <path
+          d="M0 0h7v1H0zM8 0h1v1H8zM10 0h3v1H10zM14,0 h7v1H14zM0 1h1v1H0zM6 1h1v1H6zM10 1h2v1H10zM14 1h1v1H14zM20,1 h1v1H20zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM8 2h2v1H8zM11 2h1v1H11zM14 2h1v1H14zM16 2h3v1H16zM20,2 h1v1H20zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h2v1H8zM12 3h1v1H12zM14 3h1v1H14zM16 3h3v1H16zM20,3 h1v1H20zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM8 4h1v1H8zM11 4h1v1H11zM14 4h1v1H14zM16 4h3v1H16zM20,4 h1v1H20zM0 5h1v1H0zM6 5h1v1H6zM9 5h4v1H9zM14 5h1v1H14zM20,5 h1v1H20zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14,6 h7v1H14zM11 7h2v1H11zM0 8h4v1H0zM6 8h1v1H6zM8 8h6v1H8zM16 8h3v1H16zM20,8 h1v1H20zM2 9h1v1H2zM5 9h1v1H5zM8 9h6v1H8zM16 9h2v1H16zM20,9 h1v1H20zM0 10h3v1H0zM5 10h3v1H5zM11 10h1v1H11zM14 10h2v1H14zM18,10 h3v1H18zM3 11h1v1H3zM5 11h1v1H5zM9 11h3v1H9zM15 11h3v1H15zM20,11 h1v1H20zM0 12h1v1H0zM2 12h2v1H2zM5 12h2v1H5zM8 12h1v1H8zM10 12h1v1H10zM12 12h1v1H12zM14 12h2v1H14zM8 13h2v1H8zM11 13h1v1H11zM14 13h1v1H14zM16 13h1v1H16zM18 13h2v1H18zM0 14h7v1H0zM10 14h3v1H10zM15 14h3v1H15zM0 15h1v1H0zM6 15h1v1H6zM9 15h2v1H9zM15 15h1v1H15zM17 15h3v1H17zM0 16h1v1H0zM2 16h3v1H2zM6 16h1v1H6zM12 16h1v1H12zM14 16h2v1H14zM17 16h2v1H17zM0 17h1v1H0zM2 17h3v1H2zM6 17h1v1H6zM8 17h4v1H8zM14 17h1v1H14zM17 17h1v1H17zM19 17h1v1H19zM0 18h1v1H0zM2 18h3v1H2zM6 18h1v1H6zM8 18h1v1H8zM12 18h1v1H12zM14 18h1v1H14zM17 18h2v1H17zM0 19h1v1H0zM6 19h1v1H6zM8 19h2v1H8zM13 19h1v1H13zM17 19h1v1H17zM20,19 h1v1H20zM0 20h7v1H0zM8 20h1v1H8zM13 20h1v1H13zM16 20h1v1H16zM18 20h1v1H18z"
+          fill="#000000"
+        />
+      </svg>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots Full Screen Modals/templates The Wallet Check Overlay 1`] = `
 Object {
   "asFragment": [Function],
@@ -36784,6 +37436,7 @@ Object {
 
 .c0 {
   background: var(--white);
+  position: relative;
   min-width: 50%;
   max-width: 98%;
   border-radius: 4px;
@@ -36832,13 +37485,13 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-lhVmIH gZGkEg"
+      class="sc-elJkPf heWQOk"
     >
       <p>
         Please check your browser wallet.
       </p>
       <button
-        class="sc-cmTdod ftojYZ"
+        class="sc-btzYZH eDleNM"
       >
         Dismiss
       </button>
@@ -41812,22 +42465,22 @@ Object {
         </header>
         <div>
           <h1
-            class="sc-iQKALj koADYe"
+            class="sc-hrWEMg dVjwtT"
           >
             Pay For Content Seamlessly
           </h1>
           <h2
-            class="sc-bwCtUz gMSTMj"
+            class="sc-eTuwsz WzRvq"
           >
             Unlock enables anyone to seamlessly buy and manage access to content using blockchain technology.
           </h2>
           <p
-            class="sc-hrWEMg hWCxgO"
+            class="sc-gwVKww fRHzKi"
           >
             At Unlock, we believe that the more accessible paid content is, the better it will be. To do that we're making it easy for readers like you to seamlessly pay for and manage your content.
           </p>
           <p
-            class="sc-hrWEMg hWCxgO"
+            class="sc-gwVKww fRHzKi"
           >
             If you want to know more about Unlock's decentralized payment protocol, check out
              
@@ -41842,25 +42495,25 @@ Object {
             .
           </p>
           <form
-            class="sc-eTuwsz eeROGq"
+            class="sc-hXRMBi bgDxAD"
           >
             <input
-              class="sc-gwVKww jnKnAF"
+              class="sc-epnACN ipflzZ"
               name="emailAddress"
               placeholder="Enter your email to get started"
               type="email"
             />
             <input
-              class="sc-hXRMBi fZLkLx"
+              class="sc-iQNlJl duKHhO"
               type="submit"
               value="Sign Up"
             />
             <p
-              class="sc-hrWEMg hWCxgO"
+              class="sc-gwVKww fRHzKi"
             >
               Already have an account? 
               <a
-                class="sc-iQNlJl fYRuoc"
+                class="sc-hZSUBg hGIzOw"
               >
                 Log in here
               </a>
@@ -52582,21 +53235,21 @@ Object {
     />
     <div>
       <h1
-        class="sc-iyvyFf iwStxs"
+        class="sc-kPVwWT icWkGi"
       >
         Log In to Your Account
       </h1>
       <form
-        class="sc-kIPQKe gmPiyO"
+        class="sc-ibxdXY zpHwl"
       >
         <label
-          class="sc-ibxdXY OeiNk"
+          class="sc-iQKALj lmAirJ"
           for="emailInput"
         >
           Email Address
         </label>
         <input
-          class="sc-kPVwWT kvXvce"
+          class="sc-esjQYD jxvvoB"
           id="emailInput"
           name="emailAddress"
           placeholder="Enter your email"
@@ -52604,13 +53257,13 @@ Object {
         />
         <br />
         <label
-          class="sc-ibxdXY OeiNk"
+          class="sc-iQKALj lmAirJ"
           for="passwordInput"
         >
           Password
         </label>
         <input
-          class="sc-kPVwWT kvXvce"
+          class="sc-esjQYD jxvvoB"
           id="passwordInput"
           name="password"
           placeholder="Enter your password"
@@ -52618,22 +53271,22 @@ Object {
         />
         <br />
         <div
-          class="sc-eXEjpC eVbGxa"
+          class="sc-RefOD vbmQD"
         >
           <input
-            class="sc-kfGgVZ sc-esjQYD cTKJOx"
+            class="sc-kIPQKe sc-eXEjpC goberq"
             type="submit"
             value="Retry"
           />
         </div>
       </form>
       <p
-        class="sc-hwwEjo jLOWeM"
+        class="sc-kfGgVZ dRHuau"
       >
         Don't have an account?
          
         <a
-          class="sc-RefOD isLSKU"
+          class="sc-bwCtUz leOxIb"
         >
           Sign up here.
         </a>
@@ -52836,21 +53489,21 @@ Object {
     />
     <div>
       <h1
-        class="sc-iyvyFf iwStxs"
+        class="sc-kPVwWT icWkGi"
       >
         Log In to Your Account
       </h1>
       <form
-        class="sc-kIPQKe gmPiyO"
+        class="sc-ibxdXY zpHwl"
       >
         <label
-          class="sc-ibxdXY OeiNk"
+          class="sc-iQKALj lmAirJ"
           for="emailInput"
         >
           Email Address
         </label>
         <input
-          class="sc-kPVwWT kvXvce"
+          class="sc-esjQYD jxvvoB"
           id="emailInput"
           name="emailAddress"
           placeholder="Enter your email"
@@ -52858,13 +53511,13 @@ Object {
         />
         <br />
         <label
-          class="sc-ibxdXY OeiNk"
+          class="sc-iQKALj lmAirJ"
           for="passwordInput"
         >
           Password
         </label>
         <input
-          class="sc-kPVwWT kvXvce"
+          class="sc-esjQYD jxvvoB"
           id="passwordInput"
           name="password"
           placeholder="Enter your password"
@@ -52872,22 +53525,22 @@ Object {
         />
         <br />
         <div
-          class="sc-eXEjpC eVbGxa"
+          class="sc-RefOD vbmQD"
         >
           <input
-            class="sc-kfGgVZ brJDaE"
+            class="sc-kIPQKe hmYLER"
             type="submit"
             value="Submit"
           />
         </div>
       </form>
       <p
-        class="sc-hwwEjo jLOWeM"
+        class="sc-kfGgVZ dRHuau"
       >
         Don't have an account?
          
         <a
-          class="sc-RefOD isLSKU"
+          class="sc-bwCtUz leOxIb"
         >
           Sign up here.
         </a>
@@ -53084,22 +53737,22 @@ Object {
     />
     <div>
       <h1
-        class="sc-iQKALj koADYe"
+        class="sc-hrWEMg dVjwtT"
       >
         Pay For Content Seamlessly
       </h1>
       <h2
-        class="sc-bwCtUz gMSTMj"
+        class="sc-eTuwsz WzRvq"
       >
         Unlock enables anyone to seamlessly buy and manage access to content using blockchain technology.
       </h2>
       <p
-        class="sc-hrWEMg hWCxgO"
+        class="sc-gwVKww fRHzKi"
       >
         At Unlock, we believe that the more accessible paid content is, the better it will be. To do that we're making it easy for readers like you to seamlessly pay for and manage your content.
       </p>
       <p
-        class="sc-hrWEMg hWCxgO"
+        class="sc-gwVKww fRHzKi"
       >
         If you want to know more about Unlock's decentralized payment protocol, check out
          
@@ -53114,25 +53767,25 @@ Object {
         .
       </p>
       <form
-        class="sc-eTuwsz eeROGq"
+        class="sc-hXRMBi bgDxAD"
       >
         <input
-          class="sc-gwVKww jnKnAF"
+          class="sc-epnACN ipflzZ"
           name="emailAddress"
           placeholder="Enter your email to get started"
           type="email"
         />
         <input
-          class="sc-hXRMBi fZLkLx"
+          class="sc-iQNlJl duKHhO"
           type="submit"
           value="Sign Up"
         />
         <p
-          class="sc-hrWEMg hWCxgO"
+          class="sc-gwVKww fRHzKi"
         >
           Already have an account? 
           <a
-            class="sc-iQNlJl fYRuoc"
+            class="sc-hZSUBg hGIzOw"
           >
             Log in here
           </a>
@@ -53764,21 +54417,21 @@ Object {
     />
     <div>
       <h1
-        class="sc-iyvyFf iwStxs"
+        class="sc-kPVwWT icWkGi"
       >
         Log In to Your Account
       </h1>
       <form
-        class="sc-kIPQKe gmPiyO"
+        class="sc-ibxdXY zpHwl"
       >
         <label
-          class="sc-ibxdXY OeiNk"
+          class="sc-iQKALj lmAirJ"
           for="emailInput"
         >
           Email Address
         </label>
         <input
-          class="sc-kPVwWT kvXvce"
+          class="sc-esjQYD jxvvoB"
           id="emailInput"
           name="emailAddress"
           placeholder="Enter your email"
@@ -53786,13 +54439,13 @@ Object {
         />
         <br />
         <label
-          class="sc-ibxdXY OeiNk"
+          class="sc-iQKALj lmAirJ"
           for="passwordInput"
         >
           Password
         </label>
         <input
-          class="sc-kPVwWT kvXvce"
+          class="sc-esjQYD jxvvoB"
           id="passwordInput"
           name="password"
           placeholder="Enter your password"
@@ -53800,22 +54453,22 @@ Object {
         />
         <br />
         <div
-          class="sc-eXEjpC eVbGxa"
+          class="sc-RefOD vbmQD"
         >
           <input
-            class="sc-kfGgVZ brJDaE"
+            class="sc-kIPQKe hmYLER"
             type="submit"
             value="Submit"
           />
         </div>
       </form>
       <p
-        class="sc-hwwEjo jLOWeM"
+        class="sc-kfGgVZ dRHuau"
       >
         Don't have an account?
          
         <a
-          class="sc-RefOD isLSKU"
+          class="sc-bwCtUz leOxIb"
         >
           Sign up here.
         </a>
@@ -54012,22 +54665,22 @@ Object {
     />
     <div>
       <h1
-        class="sc-iQKALj koADYe"
+        class="sc-hrWEMg dVjwtT"
       >
         Pay For Content Seamlessly
       </h1>
       <h2
-        class="sc-bwCtUz gMSTMj"
+        class="sc-eTuwsz WzRvq"
       >
         Unlock enables anyone to seamlessly buy and manage access to content using blockchain technology.
       </h2>
       <p
-        class="sc-hrWEMg hWCxgO"
+        class="sc-gwVKww fRHzKi"
       >
         At Unlock, we believe that the more accessible paid content is, the better it will be. To do that we're making it easy for readers like you to seamlessly pay for and manage your content.
       </p>
       <p
-        class="sc-hrWEMg hWCxgO"
+        class="sc-gwVKww fRHzKi"
       >
         If you want to know more about Unlock's decentralized payment protocol, check out
          
@@ -54042,25 +54695,25 @@ Object {
         .
       </p>
       <form
-        class="sc-eTuwsz eeROGq"
+        class="sc-hXRMBi bgDxAD"
       >
         <input
-          class="sc-gwVKww jnKnAF"
+          class="sc-epnACN ipflzZ"
           name="emailAddress"
           placeholder="Enter your email to get started"
           type="email"
         />
         <input
-          class="sc-hXRMBi fZLkLx"
+          class="sc-iQNlJl duKHhO"
           type="submit"
           value="Sign Up"
         />
         <p
-          class="sc-hrWEMg hWCxgO"
+          class="sc-gwVKww fRHzKi"
         >
           Already have an account? 
           <a
-            class="sc-iQNlJl fYRuoc"
+            class="sc-hZSUBg hGIzOw"
           >
             Log in here
           </a>
@@ -63209,22 +63862,22 @@ Object {
     />
     <div>
       <h1
-        class="sc-iQKALj koADYe"
+        class="sc-hrWEMg dVjwtT"
       >
         Pay For Content Seamlessly
       </h1>
       <h2
-        class="sc-bwCtUz gMSTMj"
+        class="sc-eTuwsz WzRvq"
       >
         Unlock enables anyone to seamlessly buy and manage access to content using blockchain technology.
       </h2>
       <p
-        class="sc-hrWEMg hWCxgO"
+        class="sc-gwVKww fRHzKi"
       >
         At Unlock, we believe that the more accessible paid content is, the better it will be. To do that we're making it easy for readers like you to seamlessly pay for and manage your content.
       </p>
       <p
-        class="sc-hrWEMg hWCxgO"
+        class="sc-gwVKww fRHzKi"
       >
         If you want to know more about Unlock's decentralized payment protocol, check out
          
@@ -63239,25 +63892,25 @@ Object {
         .
       </p>
       <form
-        class="sc-eTuwsz eeROGq"
+        class="sc-hXRMBi bgDxAD"
       >
         <input
-          class="sc-gwVKww jnKnAF"
+          class="sc-epnACN ipflzZ"
           name="emailAddress"
           placeholder="Enter your email to get started"
           type="email"
         />
         <input
-          class="sc-hXRMBi fZLkLx"
+          class="sc-iQNlJl duKHhO"
           type="submit"
           value="Sign Up"
         />
         <p
-          class="sc-hrWEMg hWCxgO"
+          class="sc-gwVKww fRHzKi"
         >
           Already have an account? 
           <a
-            class="sc-iQNlJl fYRuoc"
+            class="sc-hZSUBg hGIzOw"
           >
             Log in here
           </a>
@@ -64792,73 +65445,73 @@ Object {
           </button>
         </div>
         <div
-          class="sc-jtRfpW fVThxy"
+          class="sc-dqBHgY hxaZcM"
         >
           <div
-            class="sc-kTUwUJ dXMwOn"
+            class="sc-gxMtzJ gsxhrA"
           >
             Block Number
           </div>
           <div
-            class="sc-kTUwUJ dXMwOn"
+            class="sc-gxMtzJ gsxhrA"
           >
             Lock Name/Address
           </div>
           <div
-            class="sc-kTUwUJ dXMwOn"
+            class="sc-gxMtzJ gsxhrA"
           >
             Type
           </div>
           <div
-            class="sc-dqBHgY sc-gxMtzJ cnLuhM"
+            class="sc-dfVpRl sc-gzOgki rzCUi"
           >
             3
           </div>
           <a
-            class="sc-dfVpRl cfxeIL"
+            class="sc-iyvyFf hSLTdm"
             href=""
             target="_blank"
           >
             0xc43efE2C7116CB94d563b5A9D68F260CCc44256F
           </a>
           <div
-            class="sc-dqBHgY sc-gzOgki lnZrbI"
+            class="sc-dfVpRl sc-hwwEjo eeraiP"
             type="Lock Creation"
           >
             Lock Creation
           </div>
           <div
-            class="sc-dqBHgY sc-gxMtzJ cnLuhM"
+            class="sc-dfVpRl sc-gzOgki rzCUi"
           >
             2
           </div>
           <a
-            class="sc-dfVpRl cfxeIL"
+            class="sc-iyvyFf hSLTdm"
             href=""
             target="_blank"
           >
             0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
           </a>
           <div
-            class="sc-dqBHgY sc-gzOgki fQssos"
+            class="sc-dfVpRl sc-hwwEjo kWiKoL"
             type="Update Key Price"
           >
             Update Key Price
           </div>
           <div
-            class="sc-dqBHgY sc-gxMtzJ cnLuhM"
+            class="sc-dfVpRl sc-gzOgki rzCUi"
           >
             1
           </div>
           <a
-            class="sc-dfVpRl cfxeIL"
+            class="sc-iyvyFf hSLTdm"
             href=""
             target="_blank"
           >
             0x8DE3f95E2efd3B9704ccb0d0925EC951bC78cb8B
           </a>
           <div
-            class="sc-dqBHgY sc-gzOgki lnZrbI"
+            class="sc-dfVpRl sc-hwwEjo eeraiP"
             type="Lock Creation"
           >
             Lock Creation
@@ -65656,7 +66309,7 @@ Object {
           class="sc-dnqmqq kkgxkC"
         />
         <button
-          class="sc-iwsKbI sc-bsbRJL foHgoP"
+          class="sc-iwsKbI sc-cMhqgX hyImCK"
         >
           Update Password
         </button>
@@ -67388,7 +68041,7 @@ Object {
             class="sc-dnqmqq kkgxkC"
           />
           <button
-            class="sc-iwsKbI sc-bsbRJL foHgoP"
+            class="sc-iwsKbI sc-cMhqgX hyImCK"
           >
             Update Password
           </button>

--- a/unlock-app/src/actions/fullScreenModals.ts
+++ b/unlock-app/src/actions/fullScreenModals.ts
@@ -5,9 +5,10 @@ export const DISMISS_MODAL = 'fullScreenModal/DISMISS'
 
 // General events, in terms of which other kinds of modal interaction should be
 // defined.
-export const launchModal = (kindOfModal: KindOfModal) => ({
+export const launchModal = (kindOfModal: KindOfModal, data?: any) => ({
   type: LAUNCH_MODAL,
   kindOfModal,
+  data,
 })
 
 // The dismissal method is specialized on the off chance that an action gets set
@@ -23,14 +24,7 @@ export const waitForWallet = () => launchModal(KindOfModal.WalletCheckOverlay)
 export const dismissWalletCheck = () =>
   dismissModal(KindOfModal.WalletCheckOverlay)
 
-// Password prompts -- only responsible for launching and closing the
-// modal. Actually passing credentials around is the responsibility of the user
-// actions.
-export const promptForPassword = () => launchModal(KindOfModal.PasswordPrompt)
-export const dismissPasswordPrompt = () =>
-  dismissModal(KindOfModal.PasswordPrompt)
-
-export const promptForResetPassword = () =>
-  launchModal(KindOfModal.ResetPasswordPrompt)
-export const dismissResetPasswordPrompt = () =>
-  dismissModal(KindOfModal.ResetPasswordPrompt)
+// QRDisplay
+export const displayQR = (data: string) =>
+  launchModal(KindOfModal.QRDisplay, data)
+export const dismissQR = () => dismissModal(KindOfModal.QRDisplay)

--- a/unlock-app/src/components/interface/FullScreenModals.tsx
+++ b/unlock-app/src/components/interface/FullScreenModals.tsx
@@ -10,24 +10,18 @@ interface Props {
   data?: any
 }
 
+const templates = {
+  [KindOfModal.WalletCheckOverlay]: WalletCheck,
+  [KindOfModal.QRDisplay]: QRDisplay,
+}
+
 export const FullScreenModal = ({
   active,
   kindOfModal,
   dispatch,
   data,
 }: Props) => {
-  let Template: React.ComponentType<any>
-  switch (kindOfModal) {
-    case KindOfModal.WalletCheckOverlay:
-      Template = WalletCheck
-      break
-    case KindOfModal.QRDisplay:
-      Template = QRDisplay
-      break
-    default:
-      // We were given a KindOfModal that we don't have a template for. Do nothing.
-      return null
-  }
+  let Template = templates[kindOfModal]
 
   if (active) {
     // render a modal

--- a/unlock-app/src/components/interface/FullScreenModals.tsx
+++ b/unlock-app/src/components/interface/FullScreenModals.tsx
@@ -1,19 +1,28 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { KindOfModal, Dispatch } from '../../unlockTypes' // eslint-disable-line
-import { WalletCheck, styles } from './modal-templates'
+import { QRDisplay, WalletCheck, styles } from './modal-templates'
 
 interface Props {
   active: boolean
   kindOfModal: KindOfModal
   dispatch: Dispatch
+  data?: any
 }
 
-export const FullScreenModal = ({ active, kindOfModal, dispatch }: Props) => {
+export const FullScreenModal = ({
+  active,
+  kindOfModal,
+  dispatch,
+  data,
+}: Props) => {
   let Template: React.ComponentType<any>
   switch (kindOfModal) {
     case KindOfModal.WalletCheckOverlay:
       Template = WalletCheck
+      break
+    case KindOfModal.QRDisplay:
+      Template = QRDisplay
       break
     default:
       // We were given a KindOfModal that we don't have a template for. Do nothing.
@@ -24,7 +33,7 @@ export const FullScreenModal = ({ active, kindOfModal, dispatch }: Props) => {
     // render a modal
     return (
       <styles.Greyout>
-        <Template dispatch={dispatch} />
+        <Template dispatch={dispatch} data={data} />
       </styles.Greyout>
     )
   }
@@ -36,16 +45,18 @@ interface State {
   fullScreenModalStatus: {
     active: boolean
     kindOfModal: KindOfModal
+    data?: any
   }
 }
 
 const mapStateToProps = (state: State) => {
   const {
-    fullScreenModalStatus: { active, kindOfModal },
+    fullScreenModalStatus: { active, kindOfModal, data },
   } = state
   return {
     active,
     kindOfModal,
+    data,
   }
 }
 

--- a/unlock-app/src/components/interface/modal-templates/QRDisplay.tsx
+++ b/unlock-app/src/components/interface/modal-templates/QRDisplay.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import QRCode from 'qrcode.react'
+import { dismissQR } from '../../../actions/fullScreenModals'
+import { MessageBox, Dismiss } from './styles'
+import { Dispatch } from '../../../unlockTypes' // eslint-disable-line
+
+interface QRDisplayProps {
+  dispatch: Dispatch
+  data: string
+}
+const QRDisplay = ({ dispatch, data }: QRDisplayProps) => (
+  <MessageBox>
+    <Dismiss onClick={() => dispatch(dismissQR())}>Dismiss</Dismiss>
+    <QRCode value={data} renderAs="svg" includeMargin />
+  </MessageBox>
+)
+
+export default QRDisplay

--- a/unlock-app/src/components/interface/modal-templates/QRDisplay.tsx
+++ b/unlock-app/src/components/interface/modal-templates/QRDisplay.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import QRCode from 'qrcode.react'
 import { dismissQR } from '../../../actions/fullScreenModals'
-import { MessageBox, Dismiss } from './styles'
+import { MessageBox, Quit, QRCode } from './styles'
 import { Dispatch } from '../../../unlockTypes' // eslint-disable-line
 
 interface QRDisplayProps {
@@ -10,8 +9,8 @@ interface QRDisplayProps {
 }
 const QRDisplay = ({ dispatch, data }: QRDisplayProps) => (
   <MessageBox>
-    <Dismiss onClick={() => dispatch(dismissQR())}>Dismiss</Dismiss>
-    <QRCode value={data} renderAs="svg" includeMargin />
+    <Quit data-testid="qr-quit-button" onClick={() => dispatch(dismissQR())} />
+    <QRCode value={data} renderAs="svg" size={256} />
   </MessageBox>
 )
 

--- a/unlock-app/src/components/interface/modal-templates/index.ts
+++ b/unlock-app/src/components/interface/modal-templates/index.ts
@@ -1,4 +1,5 @@
+import QRDisplay from './QRDisplay'
 import WalletCheck from './WalletCheck'
 import * as styles from './styles'
 
-export { WalletCheck, styles }
+export { QRDisplay, WalletCheck, styles }

--- a/unlock-app/src/components/interface/modal-templates/styles.ts
+++ b/unlock-app/src/components/interface/modal-templates/styles.ts
@@ -1,4 +1,17 @@
 import styled from 'styled-components'
+import BasicQRCode from 'qrcode.react'
+import Close from '../buttons/layout/Close'
+
+export const QRCode = styled(BasicQRCode)`
+  padding: 8px;
+  border: thin black solid;
+`
+
+export const Quit = styled(Close)`
+  position: absolute;
+  right: 8px;
+  top: 8px;
+`
 
 export const Dismiss = styled.button`
   height: 24px;
@@ -32,6 +45,7 @@ export const Submit = styled(Dismiss)`
 
 export const MessageBox = styled.div`
   background: var(--white);
+  position: relative;
   min-width: 50%;
   max-width: 98%;
   border-radius: 4px;

--- a/unlock-app/src/reducers/fullScreenModalsReducer.ts
+++ b/unlock-app/src/reducers/fullScreenModalsReducer.ts
@@ -26,10 +26,11 @@ const fullScreenModalsReducer = (
   }
 
   if (action.type === LAUNCH_MODAL) {
-    const { kindOfModal } = action
+    const { kindOfModal, data } = action
     return {
       active: true,
       kindOfModal,
+      data,
     }
   }
 

--- a/unlock-app/src/stories/interface/FullScreenModals.stories.js
+++ b/unlock-app/src/stories/interface/FullScreenModals.stories.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { FullScreenModal } from '../../components/interface/FullScreenModals'
-import { WalletCheck } from '../../components/interface/modal-templates'
+import {
+  WalletCheck,
+  QRDisplay,
+} from '../../components/interface/modal-templates'
 import { KindOfModal } from '../../unlockTypes'
 import doNothing from '../../utils/doNothing'
 
@@ -25,10 +28,32 @@ storiesOf('Full Screen Modals', module)
       />
     )
   })
+  .add('The QRDisplay Overlay', () => {
+    return (
+      <FullScreenModal
+        active
+        kindOfModal={KindOfModal.QRDisplay}
+        data="some data"
+        dispatch={doNothing}
+      />
+    )
+  })
+  .add('The QRDisplay Overlay, inactive', () => {
+    // This is supposed to not render anything.
+    return (
+      <FullScreenModal
+        active={false}
+        kindOfModal={KindOfModal.QRDisplay}
+        data="some data"
+        dispatch={doNothing}
+      />
+    )
+  })
 
-storiesOf('Full Screen Modals/templates', module).add(
-  'The Wallet Check Overlay',
-  () => {
+storiesOf('Full Screen Modals/templates', module)
+  .add('The Wallet Check Overlay', () => {
     return <WalletCheck dispatch={doNothing} />
-  }
-)
+  })
+  .add('The QRDisplay Overlay', () => {
+    return <QRDisplay dispatch={doNothing} data="some data" />
+  })

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -23,8 +23,6 @@ export enum TransactionStatus {
 /* eslint-disable no-unused-vars */
 export enum KindOfModal {
   WalletCheckOverlay,
-  PasswordPrompt,
-  ResetPasswordPrompt,
   QRDisplay,
 }
 /* eslint-enable no-unused-vars */

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -25,6 +25,7 @@ export enum KindOfModal {
   WalletCheckOverlay,
   PasswordPrompt,
   ResetPasswordPrompt,
+  QRDisplay,
 }
 /* eslint-enable no-unused-vars */
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Split from #5024, this PR adds a modal to hold QR codes. You pass the action with the string representing the value that the QR code evaluates to.

Mobile
<img width="368" alt="image" src="https://user-images.githubusercontent.com/9300702/66867828-205c4300-ef6a-11e9-8d34-a8770b2bf058.png">

Desktop
<img width="874" alt="image" src="https://user-images.githubusercontent.com/9300702/66867859-2c480500-ef6a-11e9-80e1-b7f02d965f3f.png">

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
