### PR TITLE
Update reducer to track multiple signatures at the same time

### DIFF
--- a/unlock-app/src/__tests__/actions/signature.test.js
+++ b/unlock-app/src/__tests__/actions/signature.test.js
@@ -25,9 +25,10 @@ describe('signature actions', () => {
     const expectation = {
       type: SIGN_DATA,
       data,
+      id: 'track this signature',
     }
 
-    expect(signData(data)).toEqual(expectation)
+    expect(signData(data, 'track this signature')).toEqual(expectation)
   })
 
   it('should have an action to show signed data', () => {
@@ -38,8 +39,11 @@ describe('signature actions', () => {
       type: SIGNED_DATA,
       data,
       signature,
+      id: 'track this signature',
     }
 
-    expect(signedData(data, signature)).toEqual(expectation)
+    expect(signedData(data, 'track this signature', signature)).toEqual(
+      expectation
+    )
   })
 })

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -661,7 +661,11 @@ describe('Wallet middleware', () => {
     it("should handle SIGN_DATA by calling walletService's signDataPersonal", () => {
       expect.assertions(2)
       const { next, invoke } = create()
-      const action = { type: SIGN_DATA, data: 'neat' }
+      const action = {
+        type: SIGN_DATA,
+        data: 'neat',
+        id: 'track this signature',
+      }
 
       mockWalletService.signDataPersonal = jest
         .fn()
@@ -702,7 +706,11 @@ describe('Wallet middleware', () => {
     it('should dispatch some typed data if there is no error', () => {
       expect.assertions(1)
       const { invoke, store } = create()
-      const action = { type: SIGN_DATA, data: 'neat' }
+      const action = {
+        type: SIGN_DATA,
+        data: 'neat',
+        id: 'track this signature',
+      }
 
       mockWalletService.signDataPersonal = jest
         .fn()
@@ -717,6 +725,7 @@ describe('Wallet middleware', () => {
         type: 'signature/SIGNED_DATA',
         data: 'neat',
         signature: 'here is your signature',
+        id: 'track this signature',
       })
     })
   })

--- a/unlock-app/src/__tests__/reducers/signatureReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/signatureReducer.test.js
@@ -1,59 +1,83 @@
-import reducer from '../../reducers/signatureReducer'
+import reducer, { initialState } from '../../reducers/signatureReducer'
 import { SET_ACCOUNT } from '../../actions/accounts'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
 import { SIGNED_DATA } from '../../actions/signature'
 
-const storedSignature = {
-  data: 'this is my data',
-  signature: 'this is the signature for my data',
+const stateWithSignature = {
+  theFirstSignature: {
+    data: 'this is my data',
+    signature: 'this is the signature for my data',
+  },
 }
 
 describe('signature reducer', () => {
   it('should return the initial state', () => {
     expect.assertions(1)
-    expect(reducer(undefined, {})).toEqual(null)
+    expect(reducer(undefined, {})).toEqual(initialState)
   })
 
   it('should return the initial state when receveing SET_PROVIDER', () => {
     expect.assertions(1)
     expect(
-      reducer(storedSignature, {
+      reducer(stateWithSignature, {
         type: SET_PROVIDER,
       })
-    ).toEqual(null)
+    ).toEqual(initialState)
   })
 
   it('should return the initial state when receveing SET_NETWORK', () => {
     expect.assertions(1)
     expect(
-      reducer(storedSignature, {
+      reducer(stateWithSignature, {
         type: SET_NETWORK,
       })
-    ).toEqual(null)
+    ).toEqual(initialState)
   })
 
   it('should return the initial state when receiving SET_ACCOUNT', () => {
     expect.assertions(1)
     expect(
-      reducer(storedSignature, {
+      reducer(stateWithSignature, {
         type: SET_ACCOUNT,
       })
-    ).toEqual(null)
+    ).toEqual(initialState)
   })
 
-  it('should store the signature when receiving SIGNED_DATA', () => {
+  it('should append the signature when receiving SIGNED_DATA', () => {
     expect.assertions(1)
 
     expect(
-      reducer(storedSignature, {
+      reducer(stateWithSignature, {
         type: SIGNED_DATA,
         signature: 'a different signature',
         data: 'some different data',
+        id: 'signature1',
       })
     ).toEqual({
-      signature: 'a different signature',
-      data: 'some different data',
+      ...stateWithSignature,
+      signature1: {
+        signature: 'a different signature',
+        data: 'some different data',
+      },
+    })
+  })
+
+  it('should overwrite an old signature when receiving a new one', () => {
+    expect.assertions(1)
+
+    expect(
+      reducer(stateWithSignature, {
+        type: SIGNED_DATA,
+        signature: 'a different signature',
+        data: 'some different data',
+        id: 'theFirstSignature',
+      })
+    ).toEqual({
+      theFirstSignature: {
+        signature: 'a different signature',
+        data: 'some different data',
+      },
     })
   })
 })

--- a/unlock-app/src/actions/signature.js
+++ b/unlock-app/src/actions/signature.js
@@ -9,17 +9,19 @@ export function signatureError(error) {
   }
 }
 
-export function signData(data) {
+export function signData(data, id) {
   return {
     type: SIGN_DATA,
     data,
+    id,
   }
 }
 
-export function signedData(data, signature) {
+export function signedData(data, id, signature) {
   return {
     type: SIGNED_DATA,
     data,
+    id,
     signature,
   }
 }

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -220,7 +220,7 @@ const walletMiddleware = config => {
             )
           })
         } else if (action.type === SIGN_DATA) {
-          const { data } = action
+          const { data, id } = action
           walletService.signDataPersonal(
             '', // account address -- unused in walletService
             data,
@@ -230,7 +230,7 @@ const walletMiddleware = config => {
                   setError(Wallet.Warning('Could not sign identity data.'))
                 )
               } else {
-                dispatch(signedData(data, signature))
+                dispatch(signedData(data, id, signature))
               }
             }
           )

--- a/unlock-app/src/reducers/signatureReducer.js
+++ b/unlock-app/src/reducers/signatureReducer.js
@@ -3,7 +3,7 @@ import { SET_PROVIDER } from '../actions/provider'
 import { SET_NETWORK } from '../actions/network'
 import { SIGNED_DATA } from '../actions/signature'
 
-export const initialState = null
+export const initialState = {}
 
 const signatureReducer = (state = initialState, action) => {
   if ([SET_PROVIDER, SET_NETWORK, SET_ACCOUNT].indexOf(action.type) > -1) {
@@ -12,8 +12,11 @@ const signatureReducer = (state = initialState, action) => {
 
   if (action.type === SIGNED_DATA) {
     return {
-      data: action.data,
-      signature: action.signature,
+      ...state,
+      [action.id]: {
+        data: action.data,
+        signature: action.signature,
+      },
     }
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR updates the signature handling code in `unlock-app` to be able to store signatures for multiple things at a time. Split off from #5024.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
