### PR TITLE
Make sure to store encrypted key after user signs up

### DIFF
--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -425,8 +425,8 @@ describe('Storage middleware', () => {
     })
 
     describe('success', () => {
-      it('should dispatch gotEncryptedPrivateKeyPayload and welcomeEmail after an account is created', async () => {
-        expect.assertions(2)
+      it('should dispatch setEncryptedPrivateKey, gotEncryptedPrivateKeyPayload, and welcomeEmail after an account is created', async () => {
+        expect.assertions(3)
         const { store } = create()
 
         const passwordEncryptedPrivateKey = {
@@ -446,6 +446,11 @@ describe('Storage middleware', () => {
           password,
         })
 
+        expect(store.dispatch).toHaveBeenNthCalledWith(3, {
+          type: SET_ENCRYPTED_PRIVATE_KEY,
+          key: passwordEncryptedPrivateKey,
+          emailAddress,
+        })
         expect(store.dispatch).toHaveBeenNthCalledWith(2, {
           type: GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD,
           key: passwordEncryptedPrivateKey,

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -90,6 +90,9 @@ const storageMiddleware = config => {
             password
           )
         )
+        dispatch(
+          setEncryptedPrivateKey(passwordEncryptedPrivateKey, emailAddress)
+        )
       }
     )
     storageService.on(failure.createUser, () => {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
We never dispatched the action to save an encrypted key in the store when signing up. This PR rectifies that.

Needed for account ejection, it handles an edge-case

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5040 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
