### PR TITLE
Partitioning user provided metadata between public and protected

### DIFF
--- a/locksmith/__tests__/controllers/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/metadataController.test.ts
@@ -192,7 +192,9 @@ describe('Metadata Controller', () => {
           tokenAddress: '0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691',
           userAddress: '0xaBCD',
           data: {
-            mock: 'values',
+            public: {
+              mock: 'values',
+            },
           },
         })
       })
@@ -208,7 +210,7 @@ describe('Metadata Controller', () => {
           expect.objectContaining({
             description:
               'A Key to an Unlock lock. Unlock is a protocol for memberships. https://unlock-protocol.com/',
-            userMetadata: { mock: 'values' },
+            userMetadata: { public: { mock: 'values' } },
           })
         )
       })

--- a/locksmith/__tests__/operations/userMetadataOperations.test.ts
+++ b/locksmith/__tests__/operations/userMetadataOperations.test.ts
@@ -19,7 +19,12 @@ describe('userMetadataOperations', () => {
           tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
           userAddress: '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212',
           data: {
-            name: 'Bruce wayne',
+            public: {
+              name: 'Bruce wayne',
+            },
+            protected: {
+              email: 'batman@email.com',
+            },
           },
         })
 
@@ -27,7 +32,14 @@ describe('userMetadataOperations', () => {
 
         expect(result[0]).toEqual(
           expect.objectContaining({
-            data: { userMetadata: { name: 'Bruce wayne' } },
+            data: {
+              userMetadata: {
+                public: { name: 'Bruce wayne' },
+                protected: {
+                  email: 'batman@email.com',
+                },
+              },
+            },
             tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
             userAddress: '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212',
           })
@@ -42,7 +54,7 @@ describe('userMetadataOperations', () => {
           tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
           userAddress: '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212',
           data: {
-            name: 'Clark Kent',
+            public: { name: 'Clark Kent' },
           },
         })
 
@@ -50,7 +62,13 @@ describe('userMetadataOperations', () => {
 
         expect(result[0]).toEqual(
           expect.objectContaining({
-            data: { userMetadata: { name: 'Clark Kent' } },
+            data: {
+              userMetadata: {
+                public: {
+                  name: 'Clark Kent',
+                },
+              },
+            },
             tokenAddress: '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
             userAddress: '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212',
           })

--- a/locksmith/src/operations/userMetadataOperations.ts
+++ b/locksmith/src/operations/userMetadataOperations.ts
@@ -16,7 +16,10 @@ export async function addMetadata(metadata: UserTokenMetadataInput) {
       tokenAddress: Normalizer.ethereumAddress(metadata.tokenAddress),
       userAddress: Normalizer.ethereumAddress(metadata.userAddress),
       data: {
-        userMetadata: metadata.data,
+        userMetadata: {
+          protected: metadata.data.protected,
+          public: metadata.data.public,
+        },
       },
     },
     {


### PR DESCRIPTION
# Description

The first step in being able to provide protected data from key holders to the respective Lock owners.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
