### PR TITLE
WedlockService can send QR code emails

### DIFF
--- a/unlock-app/src/__tests__/services/wedlockService.test.js
+++ b/unlock-app/src/__tests__/services/wedlockService.test.js
@@ -3,7 +3,7 @@ import WedlockService, { emailTemplate } from '../../services/wedlockService'
 
 jest.mock('axios')
 
-let w
+let w = new WedlockService('http://notareal.host')
 describe('Wedlocks Service', () => {
   beforeEach(() => {
     w = new WedlockService('http://notareal.host')
@@ -23,6 +23,7 @@ describe('Wedlocks Service', () => {
           value: recipient,
         },
       },
+      attachments: [],
     }
     axios.post.mockReturnValue()
     await w.confirmEmail(recipient, 'https://mcdonalds.gov')
@@ -48,6 +49,7 @@ describe('Wedlocks Service', () => {
         recoveryLink: 'https://recovery',
         email: encodeURIComponent(recipient),
       },
+      attachments: [],
     }
     axios.post.mockReturnValue()
     await w.welcomeEmail(recipient, 'https://recovery')
@@ -73,9 +75,39 @@ describe('Wedlocks Service', () => {
         recoveryLink: 'https://recovery',
         email: encodeURIComponent(recipient),
       },
+      attachments: [],
     }
     axios.post.mockReturnValue()
     await w.welcomeEmail(recipient, 'https://recovery')
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://notareal.host',
+      expectedPayload,
+      {
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    )
+  })
+
+  it('should request a QR code email, with the right headers and params', async () => {
+    expect.assertions(1)
+    const recipient = 'jefferson@airpla.ne'
+    const keychainLink = 'https://app.unlock-protocol.com/keychain'
+    const lockName = 'Unlock Blog Members'
+    const qrData = 'image a huge base64 string of image data'
+    const expectedPayload = {
+      template: emailTemplate.keyOwnership,
+      recipient,
+      params: {
+        keychainLink,
+        lockName,
+      },
+      attachments: [{ path: qrData }],
+    }
+    axios.post.mockReturnValue()
+    await w.keychainQREmail(recipient, keychainLink, lockName, qrData)
 
     expect(axios.post).toHaveBeenCalledWith(
       'http://notareal.host',

--- a/unlock-app/src/services/wedlockService.ts
+++ b/unlock-app/src/services/wedlockService.ts
@@ -1,14 +1,17 @@
 import axios from 'axios'
 
-/* eslint-disable no-unused-vars */
 export enum emailTemplate {
   signupConfirmation = 'confirmEmail',
   welcome = 'welcome',
+  keyOwnership = 'keyOwnership',
 }
-/* eslint-enable no-unused-vars */
 
 type Params = {
   [key: string]: any
+}
+
+type Attachment = {
+  path: string
 }
 
 export default class WedlockService {
@@ -21,12 +24,14 @@ export default class WedlockService {
   sendEmail = (
     template: emailTemplate,
     recipient: string,
-    params: Params = {}
+    params: Params = {},
+    attachments: Attachment[] = []
   ) => {
     const payload = {
       template,
       recipient,
       params,
+      attachments,
     }
     const result = axios.post(this.uri, payload, {
       headers: {
@@ -53,5 +58,22 @@ export default class WedlockService {
       email: encodeURIComponent(recipient),
       recoveryLink: recoveryLink,
     })
+  }
+
+  keychainQREmail = (
+    recipient: string,
+    keychainLink: string,
+    lockName: string,
+    keyQR: string
+  ) => {
+    return this.sendEmail(
+      emailTemplate.keyOwnership,
+      recipient,
+      {
+        keychainLink,
+        lockName,
+      },
+      [{ path: keyQR }]
+    )
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

(#5064 should be merged first)

This PR adds a method to `wedlockService` which can send request that an email using the `keyOwnership` template be sent.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #5060 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
