### PR TITLE
WIP: Duplicate tokenIDs Bug

### DIFF
--- a/smart-contracts/test/Unlock/upgrades/v4ToLatest.js
+++ b/smart-contracts/test/Unlock/upgrades/v4ToLatest.js
@@ -154,7 +154,7 @@ contract('Unlock / upgrades', accounts => {
       })
 
       it('re-purchasing 2 expired keys from V4 should not duplicate tokenIDs', async () => {
-        let keyOwners = [keyOwner3, keyOwner4]
+        let keyOwners = [keyOwner3, keyOwner4, accounts[5], accounts[6]]
         const purchases = keyOwners.map(account => {
           return lockV4.methods.purchaseFor(account).send({
             value: keyPrice,
@@ -164,6 +164,12 @@ contract('Unlock / upgrades', accounts => {
         })
         // buy some keys
         await Promise.all(purchases)
+        let tokenId3Before = await lockV4.methods
+          .getTokenIdFor(keyOwner3)
+          .call()
+        let tokenId4Before = await lockV4.methods
+          .getTokenIdFor(keyOwner4)
+          .call()
         const keyExpirations = keyOwners.map(account => {
           return lockV4.methods.expireKeyFor(account).send({
             from: lockOwner,
@@ -184,10 +190,16 @@ contract('Unlock / upgrades', accounts => {
         })
         let ID3 = tx3.events.Transfer.returnValues._tokenId
         let ID4 = tx4.events.Transfer.returnValues._tokenId
-        tokenId3 = await lockV4.methods.getTokenIdFor(keyOwner3).call()
-        tokenId4 = await lockV4.methods.getTokenIdFor(keyOwner4).call()
-        assert.equal(tokenId3, ID3) // AssertionError: expected '4' to equal '5'
-        assert.equal(tokenId4, ID4)
+        let tokenId3After = await lockV4.methods.getTokenIdFor(keyOwner3).call()
+        let tokenId4After = await lockV4.methods.getTokenIdFor(keyOwner4).call()
+        // console.log(ID3) // 6
+        // console.log(ID4) // 6
+        // console.log(tokenId3After) // 4
+        // console.log(tokenId4After) // 5
+        assert.equal(tokenId3Before, tokenId3After)
+        assert.equal(tokenId4Before, tokenId4After)
+        assert.equal(tokenId3After, ID3) // AssertionError: expected '4' to equal '5'
+        assert.equal(tokenId4After, ID4)
       })
     })
 


### PR DESCRIPTION
# Description

I wrote this to try to reproduce a bug we found where duplicate tokenID's seemed to be getting created. I did manage to repro the bug, as well as to confirm that it is no longer an issue for post-v4 Locks.
I still don't know what the root cause of the issue is, but here's a description of what is happening.
So far, the only scenario that results in duplicate (but not really) tokenIds seems to be:
(let's say the tokenID is `46`)
- 2 key owners, each with an expired key
- both of them repurchase another key, one after the other. 
- the Transfer event emitted for both shows the tokenId as being `46` (this is the duplicate tokenID we're seeing)
- neither person has their actual tokenID modified. That is, calling `getTokenIdFor()` either one will return the tokenId of the first key they purchased. This is by design. 

So, the transfer event is emitting the wrong tokenID! 
In the current version of Lock code, this doensn't happen, and the actual tokenID matches the emitted event arg `_tokenID`

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #5026 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
