### PR TITLE
Add InlineModal component

### DIFF
--- a/unlock-app/src/__tests__/components/interface/InlineModal.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/InlineModal.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import InlineModal from '../../../components/interface/InlineModal'
+
+describe('InlineModal', () => {
+  it('should not render anything when inactive', () => {
+    expect.assertions(1)
+    const dismiss = jest.fn()
+
+    const { container } = rtl.render(
+      <InlineModal active={false} dismiss={dismiss}>
+        <p>Just some text</p>
+      </InlineModal>
+    )
+
+    expect(container.innerHTML).toHaveLength(0)
+  })
+
+  it('should call the dismiss function when the quit button is clicked', () => {
+    expect.assertions(2)
+    const dismiss = jest.fn()
+
+    const { container } = rtl.render(
+      <InlineModal active dismiss={dismiss}>
+        <p>Just some text</p>
+      </InlineModal>
+    )
+
+    expect(dismiss).not.toHaveBeenCalled()
+
+    const quit = container.querySelector('a')
+
+    if (quit) {
+      rtl.fireEvent.click(quit)
+      expect(dismiss).toHaveBeenCalled()
+    }
+  })
+})

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -40547,6 +40547,354 @@ Object {
 }
 `;
 
+exports[`Storyshots InlineModal When active 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c3 {
+  background-color: var(--grey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 24px;
+  width: 24px;
+  display: inline-block;
+  padding: 0;
+  border: 0;
+  line-height: '15px';
+}
+
+.c3 > svg {
+  fill: white;
+  height: 24px;
+  width: 24px;
+}
+
+.c3:hover {
+  background-color: var(--link);
+}
+
+.c3:hover > svg {
+  fill: white;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c2:hover .c5 {
+  display: inline-block;
+}
+
+.c6 .c2 {
+  background-color: var(--white);
+  -webkit-transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  transition: all 500ms cubic-bezier(0.165,0.84,0.44,1);
+  opacity: 1;
+  pointer-events: visible;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c6 .c2:nth-child(1) {
+  pointer-events: none;
+}
+
+.c6 .c2:nth-child(2) {
+  pointer-events: none;
+  display: none;
+}
+
+.c6 .c2 > svg {
+  fill: var(--grey);
+}
+
+.c6 .c2:hover > svg {
+  fill: var(--grey);
+}
+
+.c7 .c2 {
+  margin: 24px;
+}
+
+.c7 .c2 small {
+  display: block;
+  color: var(--grey);
+  text-align: center;
+  top: 5px;
+  width: 100%;
+  text-align: center;
+}
+
+.c4 {
+  position: absolute;
+  right: 8px;
+  top: 8px;
+}
+
+.c1 {
+  background: var(--white);
+  position: relative;
+  min-width: 50%;
+  max-width: 98%;
+  border-radius: 4px;
+  padding: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: var(--darkgrey);
+  font-size: 20px;
+}
+
+.c0 {
+  background: rgba(0,0,0,0.5);
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  left: 0;
+  top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  z-index: var(--alwaysontop);
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <a
+            class="c2 c3 c4"
+            target="_self"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <title>
+                Close
+              </title>
+              <path
+                clip-rule="evenodd"
+                d="M8.237 7.177a.75.75 0 10-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 101.06 1.06L12 13.061l3.763 3.762a.75.75 0 101.06-1.06L13.061 12l3.762-3.763a.75.75 0 00-1.06-1.06L12 10.939 8.237 7.177z"
+                fill-rule="evenodd"
+              />
+            </svg>
+            
+          </a>
+          <p>
+            Just some text to show the modal with.
+          </p>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-esjQYD guseNj"
+    >
+      <div
+        class="sc-kfGgVZ eUEmJT"
+      >
+        <a
+          class="sc-850ddk-0 iabPtF sc-gzOgki EcayX"
+          target="_self"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 10-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 101.06 1.06L12 13.061l3.763 3.762a.75.75 0 101.06-1.06L13.061 12l3.762-3.763a.75.75 0 00-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </a>
+        <p>
+          Just some text to show the modal with.
+        </p>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots InlineModal When inactive (renders nothing) 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllBySelectText": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getAllByValue": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getBySelectText": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "getByValue": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllBySelectText": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryAllByValue": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryBySelectText": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "queryByValue": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Storyshots KeyChainContent the key chain, no keys 1`] = `
 Object {
   "asFragment": [Function],

--- a/unlock-app/src/components/interface/InlineModal.tsx
+++ b/unlock-app/src/components/interface/InlineModal.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode } from 'react'
+import propTypes from 'prop-types'
+import { Greyout, MessageBox, Quit } from './modal-templates/styles'
+
+interface Props {
+  active: boolean
+  dismiss: () => void
+  children: ReactNode
+}
+
+export const InlineModal: React.FunctionComponent<Props> = ({
+  children,
+  active,
+  dismiss,
+}) => {
+  if (active) {
+    return (
+      <Greyout>
+        <MessageBox>
+          <Quit onClick={dismiss} />
+          {children}
+        </MessageBox>
+      </Greyout>
+    )
+  }
+
+  return null
+}
+
+InlineModal.propTypes = {
+  active: propTypes.bool.isRequired,
+  dismiss: propTypes.func.isRequired,
+  children: propTypes.node.isRequired,
+}
+
+export default InlineModal

--- a/unlock-app/src/stories/interface/InlineModal.stories.js
+++ b/unlock-app/src/stories/interface/InlineModal.stories.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import InlineModal from '../../components/interface/InlineModal'
+
+storiesOf('InlineModal', module)
+  .add('When active', () => {
+    return (
+      <InlineModal active dismiss={() => {}}>
+        <p>Just some text to show the modal with.</p>
+      </InlineModal>
+    )
+  })
+  .add('When inactive (renders nothing)', () => {
+    return (
+      <InlineModal active={false} dismiss={() => {}}>
+        <p>Just some text to show the modal with.</p>
+      </InlineModal>
+    )
+  })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

We had some concerns in #5029 about the right approach for QR code modals. Now that we're adding the ability to email a QR code from the keychain, it makes sense to re-evaluate that design. This PR adds an `InlineModal` component -- the key difference here is that rather than being triggered by a redux action, it is triggered by a parent component. It looks the same as the higher-level implementation because they share styles.

<img width="920" alt="image" src="https://user-images.githubusercontent.com/9300702/67236116-9f43f680-f416-11e9-812f-88242f7ff247.png">

Essentially there are 2 kinds of modals:

1. "Globally available" and "dumb" modals. For example, the "check your wallet" modal. These are always the same, and may need to be triggered from anywhere (e.g., if a certain web3 call gets triggered)
2. Context-specific modals (like on the keychain). These modals will render differently based on different input and may have specific behaviors that will be cumbersome to implement with redux (and don't need to be done with redux because everything is local to the parent component.)

Separating these 2 kinds of modals lets us implement the QR code email form very cleanly, and I'll be able to clean up the `FullScreenModal` implementation in the future as a result.

Next steps: implementing a template for the QR code (mostly copied from the existing `FullScreenModal` version), and the form for the email address.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #5060, #5036 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
