### PR TITLE
Reverse resolving ENS domains when displaying addresses

### DIFF
--- a/unlock-app/package-lock.json
+++ b/unlock-app/package-lock.json
@@ -2780,7 +2780,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.1.0.tgz",
       "integrity": "sha512-mwFDHXCQiyr0tQkYU4VkcwlCzR5YQ5k1/TCrL3hPslCM5MvS6pBhbl2z4UnCMV4DOyiUUXIvoMAf5kHT/hibTg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.4",
         "@types/testing-library__react-hooks": "^2.0.0"
@@ -2790,7 +2789,6 @@
           "version": "7.6.3",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
           "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -2982,7 +2980,6 @@
       "version": "16.9.1",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.1.tgz",
       "integrity": "sha512-nCXQokZN1jp+QkoDNmDZwoWpKY8HDczqevIDO4Uv9/s9rbGPbSpy8Uaxa5ixHKkcm/Wt0Y9C3wCxZivh4Al+rQ==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -3030,7 +3027,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-2.0.0.tgz",
       "integrity": "sha512-YUVqXGCChJKEJ4aAnMXqPCq0NfPAFVsJeGIb2y/iiMjxwyu+45+vR+AHOwjJHHKEHeC0ZhOGrZ5gSEmaJe4tyQ==",
-      "dev": true,
       "requires": {
         "@types/react": "*",
         "@types/react-test-renderer": "*"

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -12,6 +12,7 @@
     "@storybook/addon-viewport": "5.2.1",
     "@storybook/addons": "5.2.1",
     "@storybook/react": "5.2.1",
+    "@testing-library/react-hooks": "3.1.0",
     "@types/file-saver": "2.0.1",
     "@types/jest": "24.0.18",
     "@types/next": "8.0.6",
@@ -64,7 +65,6 @@
   },
   "devDependencies": {
     "@svgr/cli": "4.3.2",
-    "@testing-library/react-hooks": "3.1.0",
     "nodemon": "1.19.2",
     "npm-check": "5.9.0"
   },

--- a/unlock-app/src/__tests__/hooks/useEns.test.js
+++ b/unlock-app/src/__tests__/hooks/useEns.test.js
@@ -1,0 +1,28 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { ethers } from 'ethers'
+import useEns from '../../hooks/useEns'
+
+jest.mock('ethers')
+
+describe('useEns', () => {
+  beforeAll(() => {
+    ethers.providers.JsonRpcProvider = jest.fn(() => {
+      return {
+        lookupAddress: () => {
+          return 'julien.unlock-protocol.eth'
+        },
+      }
+    })
+  })
+
+  it('should yield the name if there one', async () => {
+    expect.assertions(2)
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useEns({ address: '0xabc' })
+    )
+
+    expect(result.current).toBe('0xabc')
+    await waitForNextUpdate()
+    expect(result.current).toBe('julien.unlock-protocol.eth')
+  })
+})

--- a/unlock-app/src/components/interface/Address.tsx
+++ b/unlock-app/src/components/interface/Address.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import React from 'react'
+import useEns from '../../hooks/useEns'
 
 interface Props {
   address: string
@@ -8,9 +9,10 @@ interface Props {
 }
 
 const Address = ({ id, className, address }: Props) => {
+  const name = useEns({ address })
   return (
     <Abbrevation id={id} className={className} title={address}>
-      {address}
+      {name}
     </Abbrevation>
   )
 }

--- a/unlock-app/src/hooks/useEns.js
+++ b/unlock-app/src/hooks/useEns.js
@@ -1,0 +1,34 @@
+import { ethers } from 'ethers'
+import { useState, useEffect } from 'react'
+import configure from '../config'
+
+const config = configure()
+/**
+ * This hook reverse resolves any Ethereum address using the Ethereum Name Service
+ * @param {*} address
+ */
+export const useEns = ({ address }) => {
+  const [name, setName] = useState(address)
+
+  const getNameForAddress = async () => {
+    const provider = new ethers.providers.JsonRpcProvider(
+      config.readOnlyProvider
+    )
+    let name
+    try {
+      name = await provider.lookupAddress(address)
+    } catch (error) {
+      // Resolution failed. So be it, we'll show the 0x address
+    }
+    if (name) {
+      setName(name)
+    }
+  }
+
+  useEffect(() => {
+    getNameForAddress()
+  })
+  return name
+}
+
+export default useEns


### PR DESCRIPTION
# Description

This will automagically replace addresses with the reverse resolved ENS look up when applicable.
Addresses which are not mapped to a domain do not change.

# Issues

Refs #5055

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread