### PR TITLE
Don't prompt for signature on newEvent

### DIFF
--- a/tickets/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/tickets/src/__tests__/middlewares/walletMiddleware.test.js
@@ -321,7 +321,7 @@ describe('Wallet middleware', () => {
     expect(next).toHaveBeenCalledWith(action)
   })
 
-  it('should handle SIGN_ADDRESS and emit a signed address', () => {
+  it('should handle SIGN_ADDRESS and emit a signed address on the event page', () => {
     expect.assertions(3)
     const {
       next,
@@ -332,6 +332,12 @@ describe('Wallet middleware', () => {
     const action = {
       type: SIGN_ADDRESS,
       address,
+    }
+
+    state.router = {
+      location: {
+        pathname: '/event/0x3628D7170209c58DC1e8F51AD190b69d044FbBF2',
+      },
     }
 
     const data = UnlockEventRSVP.build({
@@ -353,6 +359,27 @@ describe('Wallet middleware', () => {
         `ENCRYPTED: ${JSON.stringify(JSON.stringify(data))}`
       )
     )
+    expect(next).toHaveBeenCalledWith(action)
+  })
+
+  it('should ignore SIGN_ADDRESS on other pages', () => {
+    expect.assertions(2)
+    const { next, invoke } = create()
+    const address = '0x12345678'
+    const action = {
+      type: SIGN_ADDRESS,
+      address,
+    }
+
+    state.router = {
+      location: {
+        pathname: '/newevent/0x3628D7170209c58DC1e8F51AD190b69d044FbBF2',
+      },
+    }
+
+    mockWalletService.signDataPersonal = jest.fn()
+    invoke(action)
+    expect(mockWalletService.signDataPersonal).not.toHaveBeenCalled()
     expect(next).toHaveBeenCalledWith(action)
   })
 

--- a/tickets/src/middlewares/walletMiddleware.js
+++ b/tickets/src/middlewares/walletMiddleware.js
@@ -150,27 +150,32 @@ const walletMiddleware = config => {
         }
 
         if (action.type === SIGN_ADDRESS) {
-          const { account } = getState()
+          const { account, router } = getState()
           const { address } = action
 
-          // Because signData uses eth_signTypedData, we need to use structured data
-          const data = UnlockEventRSVP.build({
-            publicKey: account.address,
-            eventAddress: address,
-          })
+          const pathname = router.location.pathname
 
-          walletService.signDataPersonal(
-            account.address,
-            JSON.stringify(data),
-            (error, signedAddress) => {
-              if (error) {
-                // TODO: Does this need to be handled in the error consumer?
-                dispatch(setError(FAILED_TO_SIGN_ADDRESS, error))
-              } else {
-                dispatch(gotSignedAddress(address, signedAddress))
+          // We only want to sign on the original event page, not on newevent
+          if (pathname.startsWith('/event/')) {
+            // Because signData uses eth_signTypedData, we need to use structured data
+            const data = UnlockEventRSVP.build({
+              publicKey: account.address,
+              eventAddress: address,
+            })
+
+            walletService.signDataPersonal(
+              account.address,
+              JSON.stringify(data),
+              (error, signedAddress) => {
+                if (error) {
+                  // TODO: Does this need to be handled in the error consumer?
+                  dispatch(setError(FAILED_TO_SIGN_ADDRESS, error))
+                } else {
+                  dispatch(gotSignedAddress(address, signedAddress))
+                }
               }
-            }
-          )
+            )
+          }
         }
 
         if (action.type === SIGN_DATA) {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR parses the router in tickets' `walletMiddleware` to make sure we don't prompt for signature on the `newevent` page because we are going to direct those users to the keychain for their key ownership proof. The signature is not actually used on the `newevent` page currently, so this is an annoyance we can safely remove.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5061 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
