### PR TITLE
Introducing shim to exclude protected fields from requests

### DIFF
--- a/locksmith/__tests__/controllers/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/metadataController.test.ts
@@ -187,32 +187,37 @@ describe('Metadata Controller', () => {
     })
 
     describe('when the user has provided metadata', () => {
-      beforeAll(async () => {
-        await addMetadata({
-          tokenAddress: '0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691',
-          userAddress: '0xaBCD',
-          data: {
-            public: {
-              mock: 'values',
+      describe('when the user has provided public & protected metadata', () => {
+        beforeEach(async () => {
+          await addMetadata({
+            tokenAddress: '0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691',
+            userAddress: '0xaBCD',
+            data: {
+              protected: {
+                hidden: 'metadata',
+              },
+              public: {
+                mock: 'values',
+              },
             },
-          },
-        })
-      })
-
-      it('returns their payload in the response', async () => {
-        expect.assertions(2)
-        let response = await request(app)
-          .get('/api/key/0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691/1')
-          .set('Accept', 'json')
-
-        expect(response.status).toBe(200)
-        expect(response.body).toEqual(
-          expect.objectContaining({
-            description:
-              'A Key to an Unlock lock. Unlock is a protocol for memberships. https://unlock-protocol.com/',
-            userMetadata: { public: { mock: 'values' } },
           })
-        )
+        })
+
+        it('returns their payload in the response excluding the protected fields', async () => {
+          expect.assertions(2)
+          let response = await request(app)
+            .get('/api/key/0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691/1')
+            .set('Accept', 'json')
+
+          expect(response.status).toBe(200)
+          expect(response.body).toEqual(
+            expect.objectContaining({
+              description:
+                'A Key to an Unlock lock. Unlock is a protocol for memberships. https://unlock-protocol.com/',
+              userMetadata: { public: { mock: 'values' } },
+            })
+          )
+        })
       })
     })
   })

--- a/locksmith/src/controllers/metadataController.ts
+++ b/locksmith/src/controllers/metadataController.ts
@@ -13,10 +13,12 @@ namespace MetadataController {
   export const data = async (req: Request, res: Response): Promise<any> => {
     let address = Normalizer.ethereumAddress(req.params.address)
     let keyId = req.params.keyId.toLowerCase()
+    let lockOwner = false
 
     let keyMetadata = await metadataOperations.generateKeyMetadata(
       address,
-      keyId
+      keyId,
+      lockOwner
     )
 
     if (Object.keys(keyMetadata).length == 0) {

--- a/locksmith/src/operations/metadataOperations.ts
+++ b/locksmith/src/operations/metadataOperations.ts
@@ -28,7 +28,11 @@ export const updateDefaultLockMetadata = async (data: any) => {
   }
 }
 
-export const generateKeyMetadata = async (address: string, keyId: string) => {
+export const generateKeyMetadata = async (
+  address: string,
+  keyId: string,
+  isLockOwner: boolean
+) => {
   let onChainKeyMetadata = await fetchChainData(address, keyId)
   if (Object.keys(onChainKeyMetadata).length == 0) {
     return {}
@@ -36,7 +40,9 @@ export const generateKeyMetadata = async (address: string, keyId: string) => {
 
   let kd = new KeyData(config.web3ProviderHost)
   let data = await kd.get(address, keyId)
-  let userMetadata = data.owner ? await getMetadata(address, data.owner) : {}
+  let userMetadata = data.owner
+    ? await getMetadata(address, data.owner, isLockOwner)
+    : {}
 
   let keyCentricData = await getKeyCentricData(address, keyId)
   let baseTokenData = await getBaseTokenData(address)

--- a/locksmith/src/operations/userMetadataOperations.ts
+++ b/locksmith/src/operations/userMetadataOperations.ts
@@ -29,13 +29,21 @@ export async function addMetadata(metadata: UserTokenMetadataInput) {
   )
 }
 
-export async function getMetadata(tokenAddress: string, userAddress: string) {
+export async function getMetadata(
+  tokenAddress: string,
+  userAddress: string,
+  includeProtected = false
+) {
   let data = await UserTokenMetadata.findOne({
     where: {
       tokenAddress: Normalizer.ethereumAddress(tokenAddress),
       userAddress: Normalizer.ethereumAddress(userAddress),
     },
   })
+
+  if (data && !includeProtected) {
+    delete data.data.userMetadata.protected
+  }
 
   return data ? data.data : data
 }


### PR DESCRIPTION
# Description

As part of allowing key holders to provide their own metadata associated with tokens, we need to ensure that items intended only for the lock holder remain restricted. This is the first step of this process excluding all protected field from fetch for the time being.

The next step will be to ensure that the associated data is encrypted. 

Note: We currently have 3 data sources constructing token metadata, with some of it being conditionalized. In a future PR this will be regrouped for maintainability.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
