### PR TITLE
Adds evaluation method to middleware

### DIFF
--- a/locksmith/__tests__/signatureValidationMiddleware.test.ts
+++ b/locksmith/__tests__/signatureValidationMiddleware.test.ts
@@ -18,7 +18,7 @@ let processor = signatureValidationMiddleware.generateProcessor({
   signee: 'owner',
 })
 
-let evaluator = signatureValidationMiddleware.evaluateSignature({
+let evaluator = signatureValidationMiddleware.generateSignatureEvaluator({
   name: 'user',
   required: ['publicKey'],
   signee: 'publicKey',
@@ -30,7 +30,7 @@ beforeAll(() => {
 })
 
 describe('Signature Validation Middleware', () => {
-  describe('evaluateSignature', () => {
+  describe('generateSignatureEvaluator', () => {
     describe('when the request has a token', () => {
       it('returns the signee', done => {
         expect.assertions(1)

--- a/locksmith/src/middlewares/signatureValidationMiddleware.ts
+++ b/locksmith/src/middlewares/signatureValidationMiddleware.ts
@@ -96,6 +96,30 @@ namespace SignatureValidationMiddleware {
       }
     }
   }
+
+  export const evaluateSignature = (
+    configuration: SignatureValidationConfiguration
+  ): any => {
+    return (req: any, _res: Response, next: any) => {
+      var signature = extractToken(req)
+
+      if (signature === null) {
+        next()
+      } else {
+        let decodedSignature = Base64.decode(signature)
+        let signee = handleSignaturePresent(
+          req.body,
+          decodedSignature,
+          configuration
+        )
+
+        if (signee) {
+          req.signee = signee
+        }
+        next()
+      }
+    }
+  }
 }
 
 export default SignatureValidationMiddleware

--- a/locksmith/src/middlewares/signatureValidationMiddleware.ts
+++ b/locksmith/src/middlewares/signatureValidationMiddleware.ts
@@ -97,7 +97,7 @@ namespace SignatureValidationMiddleware {
     }
   }
 
-  export const evaluateSignature = (
+  export const generateSignatureEvaluator = (
     configuration: SignatureValidationConfiguration
   ): any => {
     return (req: any, _res: Response, next: any) => {


### PR DESCRIPTION
# Description

As part of our need to allow lock owners the ability to view additional token metadata, we are providing a non-error returning path to the middleware. The general gist is that signature concerns will stay here and users/consumers will now have two paths.

1. Reject when appropriate
2. All requesters further downstream for conditional behavior.

**The tests have been shifted to typescript and will be consolidated in an additional pass**


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
