### PR TITLE
Make tests pass without automine enabled

### DIFF
--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -35,7 +35,7 @@ contract('Lock / freeTrial', accounts => {
     let initialLockBalance
 
     beforeEach(async () => {
-      await lock.updateRefundPenalty(5, 2000)
+      await lock.updateRefundPenalty(20, 2000)
       initialLockBalance = new BigNumber(
         await web3.eth.getBalance(lock.address)
       )
@@ -58,7 +58,7 @@ contract('Lock / freeTrial', accounts => {
 
     describe('should cancel and provide a partial refund after the trial expires', () => {
       beforeEach(async () => {
-        await sleep(6000)
+        await sleep(21000)
         await lock.cancelAndRefund({
           from: keyOwners[0],
         })

--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -2,7 +2,7 @@ const Units = require('ethereumjs-units')
 const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
-const sleep = require('../helpers/sleep')
+const { sleep, sleepTime } = require('../helpers/sleep')
 
 const unlockContract = artifacts.require('Unlock.sol')
 const getProxy = require('../helpers/proxy')
@@ -36,7 +36,7 @@ contract('Lock / freeTrial', accounts => {
     let initialLockBalance
 
     beforeEach(async () => {
-      await lock.updateRefundPenalty(20, 2000)
+      await lock.updateRefundPenalty(19, 2000)
       initialLockBalance = new BigNumber(
         await web3.eth.getBalance(lock.address)
       )
@@ -59,7 +59,7 @@ contract('Lock / freeTrial', accounts => {
 
     describe('should cancel and provide a partial refund after the trial expires', () => {
       beforeEach(async () => {
-        await sleep(21000)
+        await sleep(sleepTime)
         await lock.cancelAndRefund({
           from: keyOwners[0],
         })

--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -2,6 +2,7 @@ const Units = require('ethereumjs-units')
 const BigNumber = require('bignumber.js')
 
 const deployLocks = require('../helpers/deployLocks')
+const sleep = require('../helpers/sleep')
 
 const unlockContract = artifacts.require('Unlock.sol')
 const getProxy = require('../helpers/proxy')
@@ -74,7 +75,3 @@ contract('Lock / freeTrial', accounts => {
     })
   })
 })
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}

--- a/smart-contracts/test/Lock/grantKeys.js
+++ b/smart-contracts/test/Lock/grantKeys.js
@@ -13,7 +13,7 @@ let unlock, lock, locks, tx
 contract('Lock / grantKeys', accounts => {
   const lockOwner = accounts[1]
   const keyOwner = accounts[2]
-  const validExpirationTimestamp = Math.round(Date.now() / 1000 + 600)
+  const validExpirationTimestamp = Math.round(Date.now() / 1000 + 86400) // 24 hrs
 
   before(async () => {
     unlock = await getProxy(unlockContract)
@@ -96,6 +96,7 @@ contract('Lock / grantKeys', accounts => {
           expirationDates,
           { from: lockOwner }
         )
+        await sleep(20000)
       })
 
       it('should acknowledge that user owns key', async () => {

--- a/smart-contracts/test/Lock/grantKeys.js
+++ b/smart-contracts/test/Lock/grantKeys.js
@@ -3,7 +3,7 @@ const Web3Utils = require('web3-utils')
 const truffleAssert = require('truffle-assertions')
 const deployLocks = require('../helpers/deployLocks')
 const shouldFail = require('../helpers/shouldFail')
-const sleep = require('../helpers/sleep')
+const { sleep, sleepTime } = require('../helpers/sleep')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const getProxy = require('../helpers/proxy')
@@ -27,7 +27,7 @@ contract('Lock / grantKeys', accounts => {
         tx = await lock.grantKeys([keyOwner], [validExpirationTimestamp], {
           from: lockOwner,
         })
-        await sleep(20000)
+        await sleep(sleepTime)
       })
 
       it('should log Transfer event', async () => {
@@ -52,7 +52,7 @@ contract('Lock / grantKeys', accounts => {
         tx = await lock.grantKeys([keyOwner], [extendedExpiration], {
           from: lockOwner,
         })
-        await sleep(20000) // allow enough time for tx to be mined.
+        await sleep(sleepTime) // allow enough time for tx to be mined.
       })
 
       it('should log Transfer event', async () => {
@@ -96,7 +96,7 @@ contract('Lock / grantKeys', accounts => {
           expirationDates,
           { from: lockOwner }
         )
-        await sleep(20000)
+        await sleep(sleepTime)
       })
 
       it('should acknowledge that user owns key', async () => {

--- a/smart-contracts/test/Lock/grantKeys.js
+++ b/smart-contracts/test/Lock/grantKeys.js
@@ -3,6 +3,7 @@ const Web3Utils = require('web3-utils')
 const truffleAssert = require('truffle-assertions')
 const deployLocks = require('../helpers/deployLocks')
 const shouldFail = require('../helpers/shouldFail')
+const sleep = require('../helpers/sleep')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const getProxy = require('../helpers/proxy')
@@ -26,6 +27,7 @@ contract('Lock / grantKeys', accounts => {
         tx = await lock.grantKeys([keyOwner], [validExpirationTimestamp], {
           from: lockOwner,
         })
+        await sleep(20000)
       })
 
       it('should log Transfer event', async () => {
@@ -50,6 +52,7 @@ contract('Lock / grantKeys', accounts => {
         tx = await lock.grantKeys([keyOwner], [extendedExpiration], {
           from: lockOwner,
         })
+        await sleep(20000) // allow enough time for tx to be mined.
       })
 
       it('should log Transfer event', async () => {

--- a/smart-contracts/test/helpers/sleep.js
+++ b/smart-contracts/test/helpers/sleep.js
@@ -1,3 +1,6 @@
-module.exports = async function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
+module.exports = {
+  sleep: async function(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  },
+  sleepTime: 20000, // 20 seconds
 }

--- a/smart-contracts/test/helpers/sleep.js
+++ b/smart-contracts/test/helpers/sleep.js
@@ -1,0 +1,3 @@
+module.exports = async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
# Description
- I adjusted some of the time-based parameters for the failing tests. Most of the issues came from the fact that without automine, we need to wait after certain transactions for the block to be mined before testing to see if certain values have been set on the contract, etc...
As different networks will have different blocktimes, I tried to set worst-case values so they work with mainnet (and so should work with any other network too). 
- I refactored out the `sleep()` function that Nick added into its own module and made more extensive use of it to wait for mining. 
- I tested the entire smart-contract test suite with a blocktime of 3 seconds, and tested individual files with a blocktime of 14 seconds successfully.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #2466
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
