### PR TITLE
not catching errors anymore when sending transactions

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Version (minor!)
 
+- Not catching errors on transaction emitted. These should be caught by the applications
 - createLock now returns a Promise of the deployed lock address
 - updateKeyPrice now uses the right decimals for erc20 contracts
 - getting erc20Address and decimals from the contract when purchasing a key

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -6,7 +6,7 @@
   "module": "esm/index.js",
   "sideEffects": false,
   "scripts": {
-    "test": "jest --bail",
+    "test": "jest",
     "lint": "eslint --ext .tsx,.ts,.js src/",
     "build-esm": "BABEL_ENV=esm ./node_modules/.bin/babel src --ignore src/__tests__ --out-dir esm",
     "build-cjs": "BABEL_ENV=cjs ./node_modules/.bin/babel src --ignore src/__tests__ --out-dir lib",

--- a/unlock-js/src/__tests__/helpers/walletServiceHelper.js
+++ b/unlock-js/src/__tests__/helpers/walletServiceHelper.js
@@ -152,15 +152,6 @@ export const prepContract = ({
           nock,
         })
       },
-      fail: error => {
-        errorTransactionNocks({
-          params: testParams,
-          transaction: testTransaction,
-          contract,
-          nock,
-          error,
-        })
-      },
     }
   }
 }

--- a/unlock-js/src/__tests__/v0/createLock.test.js
+++ b/unlock-js/src/__tests__/v0/createLock.test.js
@@ -1,13 +1,11 @@
 import { ethers } from 'ethers'
 import * as UnlockV0 from 'unlock-abi-0'
 import utils from '../../utils'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 import { UNLIMITED_KEYS_COUNT, ETHERS_MAX_UINT } from '../../../lib/constants'
 
-const { FAILED_TO_CREATE_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -15,7 +13,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 const lock = {
   address: '0x0987654321098765432109876543210987654321',
   expirationDuration: 86400, // 1 day
@@ -52,7 +49,6 @@ describe('v0', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(
         lock.expirationDuration,
         utils.toWei(lock.keyPrice, 'ether'),
@@ -66,7 +62,6 @@ describe('v0', () => {
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -142,21 +137,6 @@ describe('v0', () => {
         maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
       })
 
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_CREATE_LOCK)
-      })
-
-      await walletService.createLock(lock)
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v0/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v0/purchaseKey.test.js
@@ -2,11 +2,9 @@ import { ethers } from 'ethers'
 import * as UnlockV0 from 'unlock-abi-0'
 import abis from '../../abis'
 import utils from '../../utils'
-import Errors from '../../errors'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 const UnlockVersion = abis.v0
@@ -15,7 +13,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v0', () => {
   describe('purchaseKey', () => {
@@ -76,12 +73,11 @@ describe('v0', () => {
       } else {
         result = callMethodData(owner, utils.utf8ToHex(''))
       }
-      const { testTransaction, testTransactionResult, success, fail } = result
+      const { testTransaction, testTransactionResult, success } = result
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -109,26 +105,6 @@ describe('v0', () => {
       await result.wait()
       expect(result).toEqual(transactionResult)
       expect(tokenId).toEqual(utils.bigNumberify(owner).toString())
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
-      })
-
-      await walletService.purchaseKey({
-        lockAddress,
-        owner,
-        keyPrice,
-        data,
-      })
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v0/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v0/updateKeyPrice.test.js
@@ -3,11 +3,9 @@ import * as UnlockV0 from 'unlock-abi-0'
 import abis from '../../abis'
 
 import utils from '../../utils'
-import Errors from '../../errors'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_UPDATE_KEY_PRICE } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 const UnlockVersion = abis.v0
@@ -16,7 +14,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v0', () => {
   describe('updateKeyPrice', () => {
@@ -42,13 +39,11 @@ describe('v0', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(utils.toWei(keyPrice, 'ether'))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -114,21 +109,6 @@ describe('v0', () => {
       expect(result).toEqual(transactionResult)
 
       expect(newKeyPrice).toEqual(newPrice)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
-      })
-
-      await walletService.updateKeyPrice({ lockAddress, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v0/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v0/withdrawFromLock.test.js
@@ -1,10 +1,8 @@
 import * as UnlockV0 from 'unlock-abi-0'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_WITHDRAW_FROM_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -12,7 +10,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v0', () => {
   describe('withdrawFromLock', () => {
@@ -37,13 +34,11 @@ describe('v0', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData()
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -69,20 +64,6 @@ describe('v0', () => {
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
-      })
-      await walletService.withdrawFromLock({ lockAddress })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v01/createLock.test.js
+++ b/unlock-js/src/__tests__/v01/createLock.test.js
@@ -1,13 +1,11 @@
 import { ethers } from 'ethers'
 import * as UnlockV01 from 'unlock-abi-0-1'
 import utils from '../../utils'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 import { UNLIMITED_KEYS_COUNT, ETHERS_MAX_UINT } from '../../../lib/constants'
 
-const { FAILED_TO_CREATE_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -15,7 +13,7 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
+
 const lock = {
   address: '0x0987654321098765432109876543210987654321',
   expirationDuration: 86400, // 1 day
@@ -50,7 +48,6 @@ describe('v01', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(
         lock.expirationDuration,
         ethers.constants.AddressZero,
@@ -65,7 +62,6 @@ describe('v01', () => {
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -141,21 +137,6 @@ describe('v01', () => {
         maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
       })
 
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_CREATE_LOCK)
-      })
-
-      await walletService.createLock(lock)
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v01/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v01/purchaseKey.test.js
@@ -2,12 +2,10 @@ import { ethers } from 'ethers'
 import * as UnlockV01 from 'unlock-abi-0-1'
 import abis from '../../abis'
 import utils from '../../utils'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 const UnlockVersion = abis.v01
@@ -16,7 +14,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v01', () => {
   describe('purchaseKey', () => {
@@ -74,13 +71,11 @@ describe('v01', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(owner)
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -114,21 +109,6 @@ describe('v01', () => {
       await result.wait()
       expect(result).toEqual(transactionResult)
       expect(tokenId).toEqual(utils.bigNumberify(owner).toString())
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
-      })
-
-      await walletService.purchaseKey({ lockAddress, owner, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v01/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v01/updateKeyPrice.test.js
@@ -2,11 +2,9 @@ import { ethers } from 'ethers'
 import * as UnlockV01 from 'unlock-abi-0-1'
 import abis from '../../abis'
 import utils from '../../utils'
-import Errors from '../../errors'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_UPDATE_KEY_PRICE } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 const UnlockVersion = abis.v01
@@ -15,7 +13,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v01', () => {
   describe('updateKeyPrice', () => {
@@ -41,13 +38,11 @@ describe('v01', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(utils.toWei(keyPrice, 'ether'))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -111,21 +106,6 @@ describe('v01', () => {
       await result.wait()
       expect(result).toEqual(transactionResult)
       expect(newKeyPrice).toEqual(newPrice)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
-      })
-
-      await walletService.updateKeyPrice({ lockAddress, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v01/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v01/withdrawFromLock.test.js
@@ -1,10 +1,8 @@
 import * as UnlockV01 from 'unlock-abi-0-1'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_WITHDRAW_FROM_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -12,7 +10,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v01', () => {
   describe('withdrawFromLock', () => {
@@ -37,13 +34,11 @@ describe('v01', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData()
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -69,20 +64,6 @@ describe('v01', () => {
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
-      })
-      await walletService.withdrawFromLock({ lockAddress })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v02/createLock.test.js
+++ b/unlock-js/src/__tests__/v02/createLock.test.js
@@ -1,13 +1,11 @@
 import { ethers } from 'ethers'
 import * as UnlockV02 from 'unlock-abi-0-2'
 import utils from '../../utils'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 import { UNLIMITED_KEYS_COUNT, ETHERS_MAX_UINT } from '../../../lib/constants'
 
-const { FAILED_TO_CREATE_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -15,7 +13,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 const lock = {
   address: '0x0987654321098765432109876543210987654321',
   expirationDuration: 86400, // 1 day
@@ -54,7 +51,6 @@ describe('v02', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(
         lock.expirationDuration,
         ethers.constants.AddressZero,
@@ -69,7 +65,6 @@ describe('v02', () => {
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     describe('when not explicitly providing the address of a denominating currency contract ', () => {
@@ -183,21 +178,6 @@ describe('v02', () => {
         maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
       })
 
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_CREATE_LOCK)
-      })
-
-      await walletService.createLock(lock)
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v02/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v02/purchaseKey.test.js
@@ -1,12 +1,10 @@
 import { ethers } from 'ethers'
 import * as UnlockV02 from 'unlock-abi-0-2'
 import abis from '../../abis'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -16,7 +14,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v02', () => {
   describe('purchaseKey', () => {
@@ -75,13 +72,11 @@ describe('v02', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(owner)
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -116,21 +111,6 @@ describe('v02', () => {
       await result.wait()
       expect(result).toEqual(transactionResult)
       expect(newTokenId).toEqual(tokenId)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
-      })
-
-      await walletService.purchaseKey({ lockAddress, owner, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v02/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v02/updateKeyPrice.test.js
@@ -2,11 +2,9 @@ import { ethers } from 'ethers'
 import * as UnlockV02 from 'unlock-abi-0-2'
 import abis from '../../abis'
 import utils from '../../utils'
-import Errors from '../../errors'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_UPDATE_KEY_PRICE } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 const UnlockVersion = abis.v02
@@ -15,7 +13,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v02', () => {
   describe('updateKeyPrice', () => {
@@ -41,13 +38,11 @@ describe('v02', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(utils.toWei(keyPrice, 'ether'))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -112,21 +107,6 @@ describe('v02', () => {
       await result.wait()
       expect(result).toEqual(transactionResult)
       expect(newKeyPrice).toEqual(newPrice)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
-      })
-
-      await walletService.updateKeyPrice({ lockAddress, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v02/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v02/withdrawFromLock.test.js
@@ -1,10 +1,8 @@
 import * as UnlockV02 from 'unlock-abi-0-2'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_WITHDRAW_FROM_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -12,7 +10,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v02', () => {
   describe('withdrawFromLock', () => {
@@ -37,13 +34,11 @@ describe('v02', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData()
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -69,20 +64,6 @@ describe('v02', () => {
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
-      })
-      await walletService.withdrawFromLock({ lockAddress })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v10/createLock.test.js
+++ b/unlock-js/src/__tests__/v10/createLock.test.js
@@ -1,14 +1,12 @@
 import { ethers } from 'ethers'
 import * as UnlockV10 from 'unlock-abi-1-0'
 import utils from '../../utils'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 import { UNLIMITED_KEYS_COUNT, ETHERS_MAX_UINT } from '../../../lib/constants'
 import erc20 from '../../erc20'
 
-const { FAILED_TO_CREATE_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -16,7 +14,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 const lock = {
   name: 'My Fancy Lock',
   address: '0x0987654321098765432109876543210987654321',
@@ -60,7 +57,6 @@ describe('v10', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(
         lock.expirationDuration,
         ethers.constants.AddressZero,
@@ -75,7 +71,6 @@ describe('v10', () => {
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     describe('when not explicitly providing the address of a denominating currency contract ', () => {
@@ -268,21 +263,6 @@ describe('v10', () => {
         maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
       })
 
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_CREATE_LOCK)
-      })
-
-      await walletService.createLock(lock)
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v10/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v10/purchaseKey.test.js
@@ -4,7 +4,6 @@ import * as UnlockV10 from 'unlock-abi-1-0'
 import abis from '../../abis'
 
 import utils from '../../utils'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
@@ -14,14 +13,12 @@ import { ZERO } from '../../constants'
 
 const UnlockVersion = abis.v02
 
-const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 jest.mock('../../erc20.js', () => {
   return { approveTransfer: jest.fn(), getErc20Decimals: jest.fn() }
@@ -113,13 +110,11 @@ describe('v10', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(owner)
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -248,21 +243,6 @@ describe('v10', () => {
       expect(tokenId).toEqual(tokenId.toString())
 
       expect(erc20.approveTransfer).not.toHaveBeenCalled()
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach({ value: keyPrice })
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
-      })
-
-      await walletService.purchaseKey({ lockAddress, owner, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v10/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v10/updateKeyPrice.test.js
@@ -2,13 +2,11 @@ import { ethers } from 'ethers'
 import * as UnlockV10 from 'unlock-abi-1-0'
 import utils from '../../utils'
 import { ZERO } from '../../constants'
-import Errors from '../../errors'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 import erc20 from '../../erc20'
 import abis from '../../abis'
 
-const { FAILED_TO_UPDATE_KEY_PRICE } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 const UnlockVersion = abis.v10
@@ -17,7 +15,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 jest.mock('../../erc20.js', () => {
   return { getErc20Decimals: jest.fn() }
@@ -61,13 +58,11 @@ describe('v10', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(utils.toDecimal(keyPrice, decimals))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     describe('when the decimals are passed', () => {
@@ -148,21 +143,6 @@ describe('v10', () => {
         await result.wait()
         expect(result).toEqual(transactionResult)
         expect(newKeyPrice).toEqual(keyPrice)
-        await nock.resolveWhenAllNocksUsed()
-      })
-
-      it('should emit an error if the transaction could not be sent', async () => {
-        expect.assertions(1)
-
-        const error = { code: 404, data: 'oops' }
-        await nockBeforeEach(decimals)
-        setupFail(error)
-
-        walletService.on('error', error => {
-          expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
-        })
-
-        await walletService.updateKeyPrice({ lockAddress, keyPrice, decimals })
         await nock.resolveWhenAllNocksUsed()
       })
     })

--- a/unlock-js/src/__tests__/v10/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v10/withdrawFromLock.test.js
@@ -1,10 +1,8 @@
 import * as UnlockV10 from 'unlock-abi-1-0'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_WITHDRAW_FROM_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -12,7 +10,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v10', () => {
   describe('withdrawFromLock', () => {
@@ -37,13 +34,11 @@ describe('v10', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData()
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -69,20 +64,6 @@ describe('v10', () => {
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
-      })
-      await walletService.withdrawFromLock({ lockAddress })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v11/createLock.test.js
+++ b/unlock-js/src/__tests__/v11/createLock.test.js
@@ -1,14 +1,12 @@
 import { ethers } from 'ethers'
 import * as UnlockV11 from 'unlock-abi-1-1'
 import utils from '../../utils'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 import { UNLIMITED_KEYS_COUNT, ETHERS_MAX_UINT } from '../../../lib/constants'
 import erc20 from '../../erc20'
 
-const { FAILED_TO_CREATE_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -16,7 +14,7 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
+
 const lock = {
   name: 'My Fancy Lock',
   address: '0x0987654321098765432109876543210987654321',
@@ -62,7 +60,6 @@ describe('v11', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(
         lock.expirationDuration,
         ethers.constants.AddressZero,
@@ -77,7 +74,6 @@ describe('v11', () => {
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     describe('when not explicitly providing the address of a denominating currency contract ', () => {
@@ -270,21 +266,6 @@ describe('v11', () => {
         maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
       })
 
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach()
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_CREATE_LOCK)
-      })
-
-      await walletService.createLock(lock)
       await nock.resolveWhenAllNocksUsed()
     })
 

--- a/unlock-js/src/__tests__/v11/purchaseKey.test.js
+++ b/unlock-js/src/__tests__/v11/purchaseKey.test.js
@@ -3,7 +3,6 @@ import { ethers } from 'ethers'
 import * as UnlockV11 from 'unlock-abi-1-1'
 import abis from '../../abis'
 
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
@@ -13,14 +12,12 @@ import { ZERO } from '../../constants'
 
 const UnlockVersion = abis.v02
 
-const { FAILED_TO_PURCHASE_KEY } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 jest.mock('../../erc20.js', () => {
   return { approveTransfer: jest.fn(), getErc20Decimals: jest.fn() }
@@ -113,13 +110,11 @@ describe('v11', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(owner)
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params', async () => {
@@ -240,24 +235,6 @@ describe('v11', () => {
       await walletService.purchaseKey({ lockAddress, owner, keyPrice })
 
       expect(erc20.approveTransfer).not.toHaveBeenCalled()
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction could not be sent', async () => {
-      expect.assertions(1)
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach({ value: keyPrice })
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_PURCHASE_KEY)
-      })
-
-      walletService.provider.waitForTransaction = jest.fn(() =>
-        Promise.resolve(receipt)
-      )
-      await walletService.purchaseKey({ lockAddress, owner, keyPrice })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/__tests__/v11/updateKeyPrice.test.js
+++ b/unlock-js/src/__tests__/v11/updateKeyPrice.test.js
@@ -2,13 +2,11 @@ import { ethers } from 'ethers'
 import * as UnlockV11 from 'unlock-abi-1-1'
 import utils from '../../utils'
 import { ZERO } from '../../constants'
-import Errors from '../../errors'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 import erc20 from '../../erc20'
 import abis from '../../abis'
 
-const { FAILED_TO_UPDATE_KEY_PRICE } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 const UnlockVersion = abis.v11
@@ -17,7 +15,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 jest.mock('../../erc20.js', () => {
   return { getErc20Decimals: jest.fn() }
@@ -61,13 +58,11 @@ describe('v11', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(utils.toDecimal(keyPrice, decimals))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     describe('when the decimals are passed', () => {
@@ -148,21 +143,6 @@ describe('v11', () => {
         await result.wait()
         expect(result).toEqual(transactionResult)
         expect(newKeyPrice).toEqual(keyPrice)
-        await nock.resolveWhenAllNocksUsed()
-      })
-
-      it('should emit an error if the transaction could not be sent', async () => {
-        expect.assertions(1)
-
-        const error = { code: 404, data: 'oops' }
-        await nockBeforeEach(decimals)
-        setupFail(error)
-
-        walletService.on('error', error => {
-          expect(error.message).toBe(FAILED_TO_UPDATE_KEY_PRICE)
-        })
-
-        await walletService.updateKeyPrice({ lockAddress, keyPrice, decimals })
         await nock.resolveWhenAllNocksUsed()
       })
     })

--- a/unlock-js/src/__tests__/v11/withdrawFromLock.test.js
+++ b/unlock-js/src/__tests__/v11/withdrawFromLock.test.js
@@ -1,11 +1,9 @@
 import * as UnlockV11 from 'unlock-abi-1-1'
 import utils from '../../utils'
-import Errors from '../../errors'
 import TransactionTypes from '../../transactionTypes'
 import NockHelper from '../helpers/nockHelper'
 import { prepWalletService, prepContract } from '../helpers/walletServiceHelper'
 
-const { FAILED_TO_WITHDRAW_FROM_LOCK } = Errors
 const endpoint = 'http://127.0.0.1:8545'
 const nock = new NockHelper(endpoint, false /** debug */)
 
@@ -13,7 +11,6 @@ let walletService
 let transaction
 let transactionResult
 let setupSuccess
-let setupFail
 
 describe('v11', () => {
   describe('withdrawFromLock', () => {
@@ -38,13 +35,11 @@ describe('v11', () => {
         testTransaction,
         testTransactionResult,
         success,
-        fail,
       } = callMethodData(utils.toWei(amount, 'ether'))
 
       transaction = testTransaction
       transactionResult = testTransactionResult
       setupSuccess = success
-      setupFail = fail
     }
 
     it('should invoke _handleMethodCall with the right params when no amount has been provided', async () => {
@@ -97,22 +92,6 @@ describe('v11', () => {
       const result = await mock.mock.calls[0][0]
       await result.wait()
       expect(result).toEqual(transactionResult)
-      await nock.resolveWhenAllNocksUsed()
-    })
-
-    it('should emit an error if the transaction cannot be sent', async () => {
-      expect.assertions(1)
-      const amount = '3'
-
-      const error = { code: 404, data: 'oops' }
-      await nockBeforeEach(amount)
-      setupFail(error)
-
-      walletService.on('error', error => {
-        expect(error.message).toBe(FAILED_TO_WITHDRAW_FROM_LOCK)
-      })
-
-      await walletService.withdrawFromLock({ lockAddress, amount })
       await nock.resolveWhenAllNocksUsed()
     })
   })

--- a/unlock-js/src/v0/createLock.js
+++ b/unlock-js/src/v0/createLock.js
@@ -13,52 +13,46 @@ export default async function(lock) {
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
     maxNumberOfKeys = ETHERS_MAX_UINT
   }
-  let transactionPromise
-  try {
-    transactionPromise = unlockContract.functions[
-      'createLock(uint256,uint256,uint256)'
-    ](
-      lock.expirationDuration,
-      ethersUtils.toWei(lock.keyPrice, 'ether'),
-      maxNumberOfKeys,
-      {
-        gasLimit: GAS_AMOUNTS.createLock,
-      }
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.LOCK_CREATION
-    )
-
-    // Let's update the lock to reflect that it is linked to this
-    // This is an exception because, until we are able to determine the lock address
-    // before the transaction is mined, we need to link the lock and transaction.
-    this.emit('lock.updated', lock.address, {
-      expirationDuration: lock.expirationDuration,
-      keyPrice: lock.keyPrice, // Must be expressed in Eth!
-      maxNumberOfKeys: lock.maxNumberOfKeys,
-      outstandingKeys: 0,
-      balance: '0',
-      transaction: hash,
-    })
-
-    // Let's now wait for the lock to be deployed before we return its address
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = unlockContract.interface
-    const newLockEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => event.name === 'NewLock')[0]
-
-    if (newLockEvent) {
-      return newLockEvent.values.newLockAddress
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
+  const transactionPromise = unlockContract.functions[
+    'createLock(uint256,uint256,uint256)'
+  ](
+    lock.expirationDuration,
+    ethersUtils.toWei(lock.keyPrice, 'ether'),
+    maxNumberOfKeys,
+    {
+      gasLimit: GAS_AMOUNTS.createLock,
     }
-  } catch (error) {
-    this.emit('error', new Error(TransactionTypes.FAILED_TO_CREATE_LOCK))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.LOCK_CREATION
+  )
+
+  // Let's update the lock to reflect that it is linked to this
+  // This is an exception because, until we are able to determine the lock address
+  // before the transaction is mined, we need to link the lock and transaction.
+  this.emit('lock.updated', lock.address, {
+    expirationDuration: lock.expirationDuration,
+    keyPrice: lock.keyPrice, // Must be expressed in Eth!
+    maxNumberOfKeys: lock.maxNumberOfKeys,
+    outstandingKeys: 0,
+    balance: '0',
+    transaction: hash,
+  })
+
+  // Let's now wait for the lock to be deployed before we return its address
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = unlockContract.interface
+  const newLockEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => event.name === 'NewLock')[0]
+
+  if (newLockEvent) {
+    return newLockEvent.values.newLockAddress
+  } else {
+    // There was no NewEvent log (transaction failed?)
     return null
   }
 }

--- a/unlock-js/src/v0/purchaseKey.js
+++ b/unlock-js/src/v0/purchaseKey.js
@@ -1,7 +1,6 @@
 import utils from '../utils'
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Purchase key function. This implementation requires the following
@@ -14,38 +13,33 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress, owner, keyPrice, data }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['purchaseFor(address,bytes)'](
-      owner,
-      utils.utf8ToHex(data || ''),
-      {
-        gasLimit: GAS_AMOUNTS.purchaseFor,
-        value: utils.toWei(keyPrice, 'ether'),
-      }
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.KEY_PURCHASE
-    )
-    // Let's now wait for the transaction to go thru to return the token id
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = lockContract.interface
-
-    const transferEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => {
-        return event.name === 'Transfer'
-      })[0]
-    if (transferEvent) {
-      return transferEvent.values._tokenId.toString()
-    } else {
-      // There was no Transfer log (transaction failed?)
-      return null
+  const transactionPromise = lockContract['purchaseFor(address,bytes)'](
+    owner,
+    utils.utf8ToHex(data || ''),
+    {
+      gasLimit: GAS_AMOUNTS.purchaseFor,
+      value: utils.toWei(keyPrice, 'ether'),
     }
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.KEY_PURCHASE
+  )
+  // Let's now wait for the transaction to go thru to return the token id
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = lockContract.interface
+
+  const transferEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => {
+      return event.name === 'Transfer'
+    })[0]
+  if (transferEvent) {
+    return transferEvent.values._tokenId.toString()
+  } else {
+    // There was no Transfer log (transaction failed?)
+    return null
   }
 }

--- a/unlock-js/src/v0/updateKeyPrice.js
+++ b/unlock-js/src/v0/updateKeyPrice.js
@@ -1,7 +1,6 @@
 import utils from '../utils'
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Changes the price of keys on a given lock
@@ -11,37 +10,32 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress, keyPrice }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['updateKeyPrice(uint256)'](
-      utils.toWei(keyPrice, 'ether'),
-      {
-        gasLimit: GAS_AMOUNTS.updateKeyPrice,
-      }
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.UPDATE_KEY_PRICE
-    )
-
-    // Let's now wait for the keyPrice to have been changed before we return it
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = lockContract.interface
-
-    const priceChangedEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => {
-        return event.name === 'PriceChanged'
-      })[0]
-    if (priceChangedEvent) {
-      return utils.fromWei(priceChangedEvent.values.keyPrice, 'ether')
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
+  const transactionPromise = lockContract['updateKeyPrice(uint256)'](
+    utils.toWei(keyPrice, 'ether'),
+    {
+      gasLimit: GAS_AMOUNTS.updateKeyPrice,
     }
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_UPDATE_KEY_PRICE))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.UPDATE_KEY_PRICE
+  )
+
+  // Let's now wait for the keyPrice to have been changed before we return it
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = lockContract.interface
+
+  const priceChangedEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => {
+      return event.name === 'PriceChanged'
+    })[0]
+  if (priceChangedEvent) {
+    return utils.fromWei(priceChangedEvent.values.keyPrice, 'ether')
+  } else {
+    // There was no NewEvent log (transaction failed?)
+    return null
   }
 }

--- a/unlock-js/src/v0/withdrawFromLock.js
+++ b/unlock-js/src/v0/withdrawFromLock.js
@@ -1,6 +1,5 @@
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Triggers a transaction to withdraw funds from the lock and assign them to the owner.
@@ -9,17 +8,13 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['withdraw()']({
-      gasLimit: GAS_AMOUNTS.withdraw,
-    })
-    const ret = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.WITHDRAWAL
-    )
-    return ret
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_WITHDRAW_FROM_LOCK))
-  }
+
+  const transactionPromise = lockContract['withdraw()']({
+    gasLimit: GAS_AMOUNTS.withdraw,
+  })
+  const ret = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.WITHDRAWAL
+  )
+  return ret
 }

--- a/unlock-js/src/v01/createLock.js
+++ b/unlock-js/src/v01/createLock.js
@@ -13,53 +13,47 @@ export default async function(lock) {
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
     maxNumberOfKeys = ETHERS_MAX_UINT
   }
-  let transactionPromise
-  try {
-    transactionPromise = unlockContract.functions[
-      'createLock(uint256,address,uint256,uint256)'
-    ](
-      lock.expirationDuration,
-      ZERO, // ERC20 address, 0 is for eth
-      ethersUtils.toWei(lock.keyPrice, 'ether'),
-      maxNumberOfKeys,
-      {
-        gasLimit: GAS_AMOUNTS.createLock,
-      }
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.LOCK_CREATION
-    )
-
-    // Let's update the lock to reflect that it is linked to this
-    // This is an exception because, until we are able to determine the lock address
-    // before the transaction is mined, we need to link the lock and transaction.
-    this.emit('lock.updated', lock.address, {
-      expirationDuration: lock.expirationDuration,
-      keyPrice: lock.keyPrice, // Must be expressed in Eth!
-      maxNumberOfKeys: lock.maxNumberOfKeys,
-      outstandingKeys: 0,
-      balance: '0',
-      transaction: hash,
-    })
-
-    // Let's now wait for the lock to be deployed before we return its address
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = unlockContract.interface
-    const newLockEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => event.name === 'NewLock')[0]
-
-    if (newLockEvent) {
-      return newLockEvent.values.newLockAddress
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
+  const transactionPromise = unlockContract.functions[
+    'createLock(uint256,address,uint256,uint256)'
+  ](
+    lock.expirationDuration,
+    ZERO, // ERC20 address, 0 is for eth
+    ethersUtils.toWei(lock.keyPrice, 'ether'),
+    maxNumberOfKeys,
+    {
+      gasLimit: GAS_AMOUNTS.createLock,
     }
-  } catch (error) {
-    this.emit('error', new Error(TransactionTypes.FAILED_TO_CREATE_LOCK))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.LOCK_CREATION
+  )
+
+  // Let's update the lock to reflect that it is linked to this
+  // This is an exception because, until we are able to determine the lock address
+  // before the transaction is mined, we need to link the lock and transaction.
+  this.emit('lock.updated', lock.address, {
+    expirationDuration: lock.expirationDuration,
+    keyPrice: lock.keyPrice, // Must be expressed in Eth!
+    maxNumberOfKeys: lock.maxNumberOfKeys,
+    outstandingKeys: 0,
+    balance: '0',
+    transaction: hash,
+  })
+
+  // Let's now wait for the lock to be deployed before we return its address
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = unlockContract.interface
+  const newLockEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => event.name === 'NewLock')[0]
+
+  if (newLockEvent) {
+    return newLockEvent.values.newLockAddress
+  } else {
+    // There was no NewEvent log (transaction failed?)
     return null
   }
 }

--- a/unlock-js/src/v01/purchaseKey.js
+++ b/unlock-js/src/v01/purchaseKey.js
@@ -1,7 +1,6 @@
 import Web3Utils from '../utils'
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Purchase key function. This implementation requires the following
@@ -12,34 +11,29 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress, owner, keyPrice }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['purchaseFor(address)'](owner, {
-      gasLimit: GAS_AMOUNTS.purchaseFor,
-      value: Web3Utils.toWei(keyPrice, 'ether'),
-    })
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.KEY_PURCHASE
-    )
-    // Let's now wait for the transaction to go thru to return the token id
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = lockContract.interface
+  const transactionPromise = lockContract['purchaseFor(address)'](owner, {
+    gasLimit: GAS_AMOUNTS.purchaseFor,
+    value: Web3Utils.toWei(keyPrice, 'ether'),
+  })
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.KEY_PURCHASE
+  )
+  // Let's now wait for the transaction to go thru to return the token id
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = lockContract.interface
 
-    const transferEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => {
-        return event.name === 'Transfer'
-      })[0]
-    if (transferEvent) {
-      return transferEvent.values._tokenId.toString()
-    } else {
-      // There was no Transfer log (transaction failed?)
-      return null
-    }
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
+  const transferEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => {
+      return event.name === 'Transfer'
+    })[0]
+  if (transferEvent) {
+    return transferEvent.values._tokenId.toString()
+  } else {
+    // There was no Transfer log (transaction failed?)
+    return null
   }
 }

--- a/unlock-js/src/v01/updateKeyPrice.js
+++ b/unlock-js/src/v01/updateKeyPrice.js
@@ -1,7 +1,6 @@
 import utils from '../utils'
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Changes the price of keys on a given lock
@@ -11,37 +10,32 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress, keyPrice }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['updateKeyPrice(uint256)'](
-      utils.toWei(keyPrice, 'ether'),
-      {
-        gasLimit: GAS_AMOUNTS.updateKeyPrice,
-      }
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.UPDATE_KEY_PRICE
-    )
-
-    // Let's now wait for the keyPrice to have been changed before we return it
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = lockContract.interface
-
-    const priceChangedEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => {
-        return event.name === 'PriceChanged'
-      })[0]
-    if (priceChangedEvent) {
-      return utils.fromWei(priceChangedEvent.values.keyPrice, 'ether')
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
+  const transactionPromise = lockContract['updateKeyPrice(uint256)'](
+    utils.toWei(keyPrice, 'ether'),
+    {
+      gasLimit: GAS_AMOUNTS.updateKeyPrice,
     }
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_UPDATE_KEY_PRICE))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.UPDATE_KEY_PRICE
+  )
+
+  // Let's now wait for the keyPrice to have been changed before we return it
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = lockContract.interface
+
+  const priceChangedEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => {
+      return event.name === 'PriceChanged'
+    })[0]
+  if (priceChangedEvent) {
+    return utils.fromWei(priceChangedEvent.values.keyPrice, 'ether')
+  } else {
+    // There was no NewEvent log (transaction failed?)
+    return null
   }
 }

--- a/unlock-js/src/v01/withdrawFromLock.js
+++ b/unlock-js/src/v01/withdrawFromLock.js
@@ -1,6 +1,5 @@
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Triggers a transaction to withdraw funds from the lock and assign them to the owner.
@@ -9,17 +8,12 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['withdraw()']({
-      gasLimit: GAS_AMOUNTS.withdraw,
-    })
-    const ret = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.WITHDRAWAL
-    )
-    return ret
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_WITHDRAW_FROM_LOCK))
-  }
+  const transactionPromise = lockContract['withdraw()']({
+    gasLimit: GAS_AMOUNTS.withdraw,
+  })
+  const ret = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.WITHDRAWAL
+  )
+  return ret
 }

--- a/unlock-js/src/v02/createLock.js
+++ b/unlock-js/src/v02/createLock.js
@@ -15,52 +15,46 @@ export default async function(lock) {
   }
   let currencyContractAddress = lock.currencyContractAddress || ZERO
 
-  let transactionPromise
-  try {
-    transactionPromise = unlockContract.functions[
-      'createLock(uint256,address,uint256,uint256)'
-    ](
-      lock.expirationDuration,
-      currencyContractAddress, // ERC20 address, 0 is for eth
-      ethersUtils.toWei(lock.keyPrice, 'ether'),
-      maxNumberOfKeys,
-      {
-        gasLimit: GAS_AMOUNTS.createLock,
-      }
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.LOCK_CREATION
-    )
-
-    // Let's update the lock to reflect that it is linked to this
-    // This is an exception because, until we are able to determine the lock address
-    // before the transaction is mined, we need to link the lock and transaction.
-    this.emit('lock.updated', lock.address, {
-      expirationDuration: lock.expirationDuration,
-      keyPrice: lock.keyPrice, // Must be expressed in Eth!
-      maxNumberOfKeys: lock.maxNumberOfKeys,
-      outstandingKeys: 0,
-      balance: '0',
-      transaction: hash,
-    })
-    // Let's now wait for the lock to be deployed before we return its address
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = unlockContract.interface
-    const newLockEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => event.name === 'NewLock')[0]
-
-    if (newLockEvent) {
-      return newLockEvent.values.newLockAddress
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
+  const transactionPromise = unlockContract.functions[
+    'createLock(uint256,address,uint256,uint256)'
+  ](
+    lock.expirationDuration,
+    currencyContractAddress, // ERC20 address, 0 is for eth
+    ethersUtils.toWei(lock.keyPrice, 'ether'),
+    maxNumberOfKeys,
+    {
+      gasLimit: GAS_AMOUNTS.createLock,
     }
-  } catch (error) {
-    this.emit('error', new Error(TransactionTypes.FAILED_TO_CREATE_LOCK))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.LOCK_CREATION
+  )
+
+  // Let's update the lock to reflect that it is linked to this
+  // This is an exception because, until we are able to determine the lock address
+  // before the transaction is mined, we need to link the lock and transaction.
+  this.emit('lock.updated', lock.address, {
+    expirationDuration: lock.expirationDuration,
+    keyPrice: lock.keyPrice, // Must be expressed in Eth!
+    maxNumberOfKeys: lock.maxNumberOfKeys,
+    outstandingKeys: 0,
+    balance: '0',
+    transaction: hash,
+  })
+  // Let's now wait for the lock to be deployed before we return its address
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = unlockContract.interface
+  const newLockEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => event.name === 'NewLock')[0]
+
+  if (newLockEvent) {
+    return newLockEvent.values.newLockAddress
+  } else {
+    // There was no NewEvent log (transaction failed?)
     return null
   }
 }

--- a/unlock-js/src/v02/purchaseKey.js
+++ b/unlock-js/src/v02/purchaseKey.js
@@ -1,7 +1,6 @@
 import Web3Utils from '../utils'
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Purchase key function. This implementation requires the following
@@ -12,34 +11,29 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress, owner, keyPrice }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['purchaseFor(address)'](owner, {
-      gasLimit: GAS_AMOUNTS.purchaseFor,
-      value: Web3Utils.toWei(keyPrice, 'ether'),
-    })
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.KEY_PURCHASE
-    )
-    // Let's now wait for the transaction to go thru to return the token id
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = lockContract.interface
+  const transactionPromise = lockContract['purchaseFor(address)'](owner, {
+    gasLimit: GAS_AMOUNTS.purchaseFor,
+    value: Web3Utils.toWei(keyPrice, 'ether'),
+  })
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.KEY_PURCHASE
+  )
+  // Let's now wait for the transaction to go thru to return the token id
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = lockContract.interface
 
-    const transferEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => {
-        return event.name === 'Transfer'
-      })[0]
-    if (transferEvent) {
-      return transferEvent.values._tokenId.toString()
-    } else {
-      // There was no Transfer log (transaction failed?)
-      return null
-    }
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
+  const transferEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => {
+      return event.name === 'Transfer'
+    })[0]
+  if (transferEvent) {
+    return transferEvent.values._tokenId.toString()
+  } else {
+    // There was no Transfer log (transaction failed?)
+    return null
   }
 }

--- a/unlock-js/src/v02/updateKeyPrice.js
+++ b/unlock-js/src/v02/updateKeyPrice.js
@@ -1,7 +1,6 @@
 import utils from '../utils'
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Changes the price of keys on a given lock
@@ -11,36 +10,31 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress, keyPrice }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['updateKeyPrice(uint256)'](
-      utils.toWei(keyPrice, 'ether'),
-      {
-        gasLimit: GAS_AMOUNTS.updateKeyPrice,
-      }
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.UPDATE_KEY_PRICE
-    )
-    // Let's now wait for the keyPrice to have been changed before we return it
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = lockContract.interface
-
-    const priceChangedEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => {
-        return event.name === 'PriceChanged'
-      })[0]
-    if (priceChangedEvent) {
-      return utils.fromWei(priceChangedEvent.values.keyPrice, 'ether')
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
+  const transactionPromise = lockContract['updateKeyPrice(uint256)'](
+    utils.toWei(keyPrice, 'ether'),
+    {
+      gasLimit: GAS_AMOUNTS.updateKeyPrice,
     }
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_UPDATE_KEY_PRICE))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.UPDATE_KEY_PRICE
+  )
+  // Let's now wait for the keyPrice to have been changed before we return it
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = lockContract.interface
+
+  const priceChangedEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => {
+      return event.name === 'PriceChanged'
+    })[0]
+  if (priceChangedEvent) {
+    return utils.fromWei(priceChangedEvent.values.keyPrice, 'ether')
+  } else {
+    // There was no NewEvent log (transaction failed?)
+    return null
   }
 }

--- a/unlock-js/src/v02/withdrawFromLock.js
+++ b/unlock-js/src/v02/withdrawFromLock.js
@@ -1,6 +1,5 @@
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Triggers a transaction to withdraw funds from the lock and assign them to the owner.
@@ -10,17 +9,12 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['withdraw()']({
-      gasLimit: GAS_AMOUNTS.withdraw,
-    })
-    const ret = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.WITHDRAWAL
-    )
-    return ret
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_WITHDRAW_FROM_LOCK))
-  }
+  const transactionPromise = lockContract['withdraw()']({
+    gasLimit: GAS_AMOUNTS.withdraw,
+  })
+  const ret = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.WITHDRAWAL
+  )
+  return ret
 }

--- a/unlock-js/src/v10/createLock.js
+++ b/unlock-js/src/v10/createLock.js
@@ -40,56 +40,50 @@ export default async function(lock) {
 
   let currencyContractAddress = lock.currencyContractAddress || ZERO
 
-  let transactionPromise
-  try {
-    const lockName = lock.name || 'New Lock'
-    transactionPromise = unlockContract.functions[
-      'createLock(uint256,address,uint256,uint256,string)'
-    ](
-      lock.expirationDuration,
-      currencyContractAddress, // ERC20 address, 0 is for eth
-      decimalKeyPrice, // FIX ME!
-      maxNumberOfKeys,
-      lockName,
-      {
-        gasLimit: GAS_AMOUNTS.createLock,
-      }
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.LOCK_CREATION
-    )
-
-    // Let's update the lock to reflect that it is linked to this
-    // This is an exception because, until we are able to determine the lock address
-    // before the transaction is mined, we need to link the lock and transaction.
-    this.emit('lock.updated', lock.address, {
-      expirationDuration: lock.expirationDuration,
-      keyPrice: lock.keyPrice, // Must be expressed in Eth!
-      maxNumberOfKeys: lock.maxNumberOfKeys,
-      outstandingKeys: 0,
-      balance: '0',
-      transaction: hash,
-      name: lockName,
-      currencyContractAddress: lock.currencyContractAddress,
-    })
-    // Let's now wait for the lock to be deployed before we return its address
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = unlockContract.interface
-    const newLockEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => event.name === 'NewLock')[0]
-
-    if (newLockEvent) {
-      return newLockEvent.values.newLockAddress
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
+  const lockName = lock.name || 'New Lock'
+  const transactionPromise = unlockContract.functions[
+    'createLock(uint256,address,uint256,uint256,string)'
+  ](
+    lock.expirationDuration,
+    currencyContractAddress, // ERC20 address, 0 is for eth
+    decimalKeyPrice, // FIX ME!
+    maxNumberOfKeys,
+    lockName,
+    {
+      gasLimit: GAS_AMOUNTS.createLock,
     }
-  } catch (error) {
-    this.emit('error', new Error(TransactionTypes.FAILED_TO_CREATE_LOCK))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.LOCK_CREATION
+  )
+
+  // Let's update the lock to reflect that it is linked to this
+  // This is an exception because, until we are able to determine the lock address
+  // before the transaction is mined, we need to link the lock and transaction.
+  this.emit('lock.updated', lock.address, {
+    expirationDuration: lock.expirationDuration,
+    keyPrice: lock.keyPrice, // Must be expressed in Eth!
+    maxNumberOfKeys: lock.maxNumberOfKeys,
+    outstandingKeys: 0,
+    balance: '0',
+    transaction: hash,
+    name: lockName,
+    currencyContractAddress: lock.currencyContractAddress,
+  })
+  // Let's now wait for the lock to be deployed before we return its address
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = unlockContract.interface
+  const newLockEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => event.name === 'NewLock')[0]
+
+  if (newLockEvent) {
+    return newLockEvent.values.newLockAddress
+  } else {
+    // There was no NewEvent log (transaction failed?)
     return null
   }
 }

--- a/unlock-js/src/v10/purchaseKey.js
+++ b/unlock-js/src/v10/purchaseKey.js
@@ -1,7 +1,6 @@
 import utils from '../utils'
 import { GAS_AMOUNTS, ZERO } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 import { approveTransfer, getErc20Decimals } from '../erc20'
 
 /**
@@ -54,37 +53,31 @@ export default async function({
     purchaseForOptions.value = actualAmount
   }
 
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['purchaseFor(address)'](
-      owner,
-      purchaseForOptions
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.KEY_PURCHASE
-    )
+  const transactionPromise = lockContract['purchaseFor(address)'](
+    owner,
+    purchaseForOptions
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.KEY_PURCHASE
+  )
 
-    // Let's now wait for the transaction to go thru to return the token id
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = lockContract.interface
+  // Let's now wait for the transaction to go thru to return the token id
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = lockContract.interface
 
-    const transferEvent = receipt.logs
-      .map(log => {
-        if (log.address !== lockAddress) return // Some events are triggered by the ERC20 contract
-        return parser.parseLog(log)
-      })
-      .filter(event => {
-        return event && event.name === 'Transfer'
-      })[0]
-    if (transferEvent) {
-      return transferEvent.values._tokenId.toString()
-    } else {
-      // There was no Transfer log (transaction failed?)
-      return null
-    }
-  } catch (error) {
-    // TODO remove all try catch non sense.
-    this.emit('error', new Error(Errors.FAILED_TO_PURCHASE_KEY))
+  const transferEvent = receipt.logs
+    .map(log => {
+      if (log.address !== lockAddress) return // Some events are triggered by the ERC20 contract
+      return parser.parseLog(log)
+    })
+    .filter(event => {
+      return event && event.name === 'Transfer'
+    })[0]
+  if (transferEvent) {
+    return transferEvent.values._tokenId.toString()
+  } else {
+    // There was no Transfer log (transaction failed?)
+    return null
   }
 }

--- a/unlock-js/src/v10/updateKeyPrice.js
+++ b/unlock-js/src/v10/updateKeyPrice.js
@@ -1,7 +1,6 @@
 import utils from '../utils'
 import { GAS_AMOUNTS, ZERO } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 import { getErc20Decimals } from '../erc20'
 
 /**
@@ -34,33 +33,31 @@ export default async function({
   }
   const actualAmount = utils.toDecimal(keyPrice, decimals)
 
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['updateKeyPrice(uint256)'](actualAmount, {
+  const transactionPromise = lockContract['updateKeyPrice(uint256)'](
+    actualAmount,
+    {
       gasLimit: GAS_AMOUNTS.updateKeyPrice,
-    })
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.UPDATE_KEY_PRICE
-    )
-    // Let's now wait for the keyPrice to have been changed before we return it
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = lockContract.interface
-
-    const priceChangedEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => {
-        return event.name === 'PriceChanged'
-      })[0]
-    if (priceChangedEvent) {
-      return utils.fromDecimal(priceChangedEvent.values.keyPrice, decimals)
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
     }
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_UPDATE_KEY_PRICE))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.UPDATE_KEY_PRICE
+  )
+  // Let's now wait for the keyPrice to have been changed before we return it
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = lockContract.interface
+
+  const priceChangedEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => {
+      return event.name === 'PriceChanged'
+    })[0]
+  if (priceChangedEvent) {
+    return utils.fromDecimal(priceChangedEvent.values.keyPrice, decimals)
+  } else {
+    // There was no NewEvent log (transaction failed?)
+    return null
   }
 }

--- a/unlock-js/src/v10/withdrawFromLock.js
+++ b/unlock-js/src/v10/withdrawFromLock.js
@@ -1,6 +1,5 @@
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Triggers a transaction to withdraw funds from the lock and assign them to the owner.
@@ -9,17 +8,12 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['withdraw()']({
-      gasLimit: GAS_AMOUNTS.withdraw,
-    })
-    const ret = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.WITHDRAWAL
-    )
-    return ret
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_WITHDRAW_FROM_LOCK))
-  }
+  const transactionPromise = lockContract['withdraw()']({
+    gasLimit: GAS_AMOUNTS.withdraw,
+  })
+  const ret = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.WITHDRAWAL
+  )
+  return ret
 }

--- a/unlock-js/src/v11/createLock.js
+++ b/unlock-js/src/v11/createLock.js
@@ -40,56 +40,50 @@ export default async function(lock) {
 
   let currencyContractAddress = lock.currencyContractAddress || ZERO
 
-  let transactionPromise
-  try {
-    const lockName = lock.name || 'New Lock'
-    transactionPromise = unlockContract.functions[
-      'createLock(uint256,address,uint256,uint256,string)'
-    ](
-      lock.expirationDuration,
-      currencyContractAddress,
-      decimalKeyPrice,
-      maxNumberOfKeys,
-      lockName,
-      {
-        gasLimit: GAS_AMOUNTS.createLock,
-      }
-    )
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.LOCK_CREATION
-    )
-
-    // Let's update the lock to reflect that it is linked to this
-    // This is an exception because, until we are able to determine the lock address
-    // before the transaction is mined, we need to link the lock and transaction.
-    this.emit('lock.updated', lock.address, {
-      expirationDuration: lock.expirationDuration,
-      keyPrice: lock.keyPrice, // Must be expressed in Eth!
-      maxNumberOfKeys: lock.maxNumberOfKeys,
-      outstandingKeys: 0,
-      balance: '0',
-      transaction: hash,
-      name: lockName,
-      currencyContractAddress: lock.currencyContractAddress,
-    })
-    // Let's now wait for the lock to be deployed before we return its address
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = unlockContract.interface
-    const newLockEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => event.name === 'NewLock')[0]
-
-    if (newLockEvent) {
-      return newLockEvent.values.newLockAddress
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
+  const lockName = lock.name || 'New Lock'
+  const transactionPromise = unlockContract.functions[
+    'createLock(uint256,address,uint256,uint256,string)'
+  ](
+    lock.expirationDuration,
+    currencyContractAddress,
+    decimalKeyPrice,
+    maxNumberOfKeys,
+    lockName,
+    {
+      gasLimit: GAS_AMOUNTS.createLock,
     }
-  } catch (error) {
-    this.emit('error', new Error(TransactionTypes.FAILED_TO_CREATE_LOCK))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.LOCK_CREATION
+  )
+
+  // Let's update the lock to reflect that it is linked to this
+  // This is an exception because, until we are able to determine the lock address
+  // before the transaction is mined, we need to link the lock and transaction.
+  this.emit('lock.updated', lock.address, {
+    expirationDuration: lock.expirationDuration,
+    keyPrice: lock.keyPrice, // Must be expressed in Eth!
+    maxNumberOfKeys: lock.maxNumberOfKeys,
+    outstandingKeys: 0,
+    balance: '0',
+    transaction: hash,
+    name: lockName,
+    currencyContractAddress: lock.currencyContractAddress,
+  })
+  // Let's now wait for the lock to be deployed before we return its address
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = unlockContract.interface
+  const newLockEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => event.name === 'NewLock')[0]
+
+  if (newLockEvent) {
+    return newLockEvent.values.newLockAddress
+  } else {
+    // There was no NewEvent log (transaction failed?)
     return null
   }
 }

--- a/unlock-js/src/v11/updateKeyPrice.js
+++ b/unlock-js/src/v11/updateKeyPrice.js
@@ -1,7 +1,6 @@
 import utils from '../utils'
 import { GAS_AMOUNTS, ZERO } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 import { getErc20Decimals } from '../erc20'
 
 /**
@@ -34,33 +33,31 @@ export default async function({
   }
   const actualAmount = utils.toDecimal(keyPrice, decimals)
 
-  let transactionPromise
-  try {
-    transactionPromise = lockContract['updateKeyPrice(uint256)'](actualAmount, {
+  const transactionPromise = lockContract['updateKeyPrice(uint256)'](
+    actualAmount,
+    {
       gasLimit: GAS_AMOUNTS.updateKeyPrice,
-    })
-    const hash = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.UPDATE_KEY_PRICE
-    )
-    // Let's now wait for the keyPrice to have been changed before we return it
-    const receipt = await this.provider.waitForTransaction(hash)
-    const parser = lockContract.interface
-
-    const priceChangedEvent = receipt.logs
-      .map(log => {
-        return parser.parseLog(log)
-      })
-      .filter(event => {
-        return event.name === 'PriceChanged'
-      })[0]
-    if (priceChangedEvent) {
-      return utils.fromDecimal(priceChangedEvent.values.keyPrice, decimals)
-    } else {
-      // There was no NewEvent log (transaction failed?)
-      return null
     }
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_UPDATE_KEY_PRICE))
+  )
+  const hash = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.UPDATE_KEY_PRICE
+  )
+  // Let's now wait for the keyPrice to have been changed before we return it
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = lockContract.interface
+
+  const priceChangedEvent = receipt.logs
+    .map(log => {
+      return parser.parseLog(log)
+    })
+    .filter(event => {
+      return event.name === 'PriceChanged'
+    })[0]
+  if (priceChangedEvent) {
+    return utils.fromDecimal(priceChangedEvent.values.keyPrice, decimals)
+  } else {
+    // There was no NewEvent log (transaction failed?)
+    return null
   }
 }

--- a/unlock-js/src/v11/withdrawFromLock.js
+++ b/unlock-js/src/v11/withdrawFromLock.js
@@ -1,7 +1,6 @@
 import utils from '../utils'
 import { GAS_AMOUNTS } from '../constants'
 import TransactionTypes from '../transactionTypes'
-import Errors from '../errors'
 
 /**
  * Triggers a transaction to withdraw funds from the lock and assign them to the owner.
@@ -13,20 +12,15 @@ import Errors from '../errors'
  */
 export default async function({ lockAddress, amount = '0', decimals = 18 }) {
   const lockContract = await this.getLockContract(lockAddress)
-  let transactionPromise
 
   const actualAmount = utils.toDecimal(amount, decimals)
 
-  try {
-    transactionPromise = lockContract['withdraw(uint256)'](actualAmount, {
-      gasLimit: GAS_AMOUNTS.withdraw,
-    })
-    const ret = await this._handleMethodCall(
-      transactionPromise,
-      TransactionTypes.WITHDRAWAL
-    )
-    return ret
-  } catch (error) {
-    this.emit('error', new Error(Errors.FAILED_TO_WITHDRAW_FROM_LOCK))
-  }
+  const transactionPromise = lockContract['withdraw(uint256)'](actualAmount, {
+    gasLimit: GAS_AMOUNTS.withdraw,
+  })
+  const ret = await this._handleMethodCall(
+    transactionPromise,
+    TransactionTypes.WITHDRAWAL
+  )
+  return ret
 }


### PR DESCRIPTION
# Description

The way we catch errors is really bad because if anything happens "downstream" then the error was caught by these blocks completely obfuscating what really happened.
Also I believe the application should be the one acting on these errors.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread