### PR TITLE
Add a query to get locks by owner from the graph

### DIFF
--- a/unlock-app/src/queries/locksByOwner.js
+++ b/unlock-app/src/queries/locksByOwner.js
@@ -1,0 +1,26 @@
+import { gql } from 'apollo-boost'
+
+export default function locksByOwnerQuery() {
+  return gql`
+    query Locks($owner: String!) {
+      locks(where: { owner: $owner }) {
+        id
+        address
+        name
+        tokenAddress
+        price
+        expirationDuration
+        totalSupply
+        maxNumberOfKeys
+        keys {
+          id
+          lock
+          keyId
+          owner
+          expiration
+        }
+        owner
+      }
+    }
+  `
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This is a graphql query that gets all locks owned by a given address. I ran it in localdev using one of the accounts that creates locks for integration tests (`0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2`) and got the following results:

I'm not sure how this will perform on larger lists of locks, and we may want to see if we can page this data (although even for a very large number of locks the payload should be quite small)

```javascript
{ locks:
   { locks:
      [ { id: '0x0aaf2059cb2ce8eeb1a0c60f4e0f2789214350a5',
          address: '0x0aaf2059cb2ce8eeb1a0c60f4e0f2789214350a5',
          name: 'ERC20 adblock lock 3',
          tokenAddress: '0x591ad9066603f5499d12ff4bc207e2f577448c46',
          price: '100000000000000000000',
          expirationDuration: '31536000',
          totalSupply: '0',
          maxNumberOfKeys:
           '115792089237316195423570985008687907853269984665640564039457584007913129639935',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' },
        { id: '0x1c0e27f7967899578ef138384f8cfc0bf579d063',
          address: '0x1c0e27f7967899578ef138384f8cfc0bf579d063',
          name: 'ERC20 adblock lock 1',
          tokenAddress: '0x591ad9066603f5499d12ff4bc207e2f577448c46',
          price: '1000000000000000000',
          expirationDuration: '604800',
          totalSupply: '0',
          maxNumberOfKeys:
           '115792089237316195423570985008687907853269984665640564039457584007913129639935',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' },
        { id: '0x1c7ec43575239a482a01ac8a2a73d0c68887e151',
          address: '0x1c7ec43575239a482a01ac8a2a73d0c68887e151',
          name: 'ETH adblock lock 3',
          tokenAddress: '0x0000000000000000000000000000000000000000',
          price: '100000000000000000',
          expirationDuration: '31536000',
          totalSupply: '0',
          maxNumberOfKeys:
           '115792089237316195423570985008687907853269984665640564039457584007913129639935',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' },
        { id: '0x45debf700ab8120ac0665119467ea82bdb45e00b',
          address: '0x45debf700ab8120ac0665119467ea82bdb45e00b',
          name: 'ETH paywall lock',
          tokenAddress: '0x0000000000000000000000000000000000000000',
          price: '100000000000000000',
          expirationDuration: '300',
          totalSupply: '0',
          maxNumberOfKeys: '1000',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' },
        { id: '0x5cd3fc283c42b4d5083dba4a6be5ac58fc0f0267',
          address: '0x5cd3fc283c42b4d5083dba4a6be5ac58fc0f0267',
          name: 'ETH Lock',
          tokenAddress: '0x0000000000000000000000000000000000000000',
          price: '10000000000000000',
          expirationDuration: '300',
          totalSupply: '0',
          maxNumberOfKeys:
           '115792089237316195423570985008687907853269984665640564039457584007913129639935',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' },
        { id: '0x80bc6d2870bb72cb3e37b648c160da20733386f7',
          address: '0x80bc6d2870bb72cb3e37b648c160da20733386f7',
          name: 'ERC20 paywall lock',
          tokenAddress: '0x591ad9066603f5499d12ff4bc207e2f577448c46',
          price: '1000000000000000000',
          expirationDuration: '300',
          totalSupply: '0',
          maxNumberOfKeys:
           '115792089237316195423570985008687907853269984665640564039457584007913129639935',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' },
        { id: '0x8276a24c03b7ff9307c5bb9c0f31aa60d284375f',
          address: '0x8276a24c03b7ff9307c5bb9c0f31aa60d284375f',
          name: 'ERC20 Lock',
          tokenAddress: '0x591ad9066603f5499d12ff4bc207e2f577448c46',
          price: '1000000000000000000',
          expirationDuration: '60',
          totalSupply: '0',
          maxNumberOfKeys:
           '115792089237316195423570985008687907853269984665640564039457584007913129639935',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' },
        { id: '0xc11ef3e2cce6963653c2c9f66b52e5bd2d274564',
          address: '0xc11ef3e2cce6963653c2c9f66b52e5bd2d274564',
          name: 'ETH adblock lock 1',
          tokenAddress: '0x0000000000000000000000000000000000000000',
          price: '10000000000000000',
          expirationDuration: '604800',
          totalSupply: '0',
          maxNumberOfKeys:
           '115792089237316195423570985008687907853269984665640564039457584007913129639935',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' },
        { id: '0xce341cc78d9774808f0e5b654af8b57b5126c6ba',
          address: '0xce341cc78d9774808f0e5b654af8b57b5126c6ba',
          name: 'ERC20 adblock lock 2',
          tokenAddress: '0x591ad9066603f5499d12ff4bc207e2f577448c46',
          price: '5000000000000000000',
          expirationDuration: '2592000',
          totalSupply: '0',
          maxNumberOfKeys:
           '115792089237316195423570985008687907853269984665640564039457584007913129639935',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' },
        { id: '0xd9b3865d630941c54b6aa263a4dd4b8e66ab3c5c',
          address: '0xd9b3865d630941c54b6aa263a4dd4b8e66ab3c5c',
          name: 'ETH adblock lock 2',
          tokenAddress: '0x0000000000000000000000000000000000000000',
          price: '50000000000000000',
          expirationDuration: '2592000',
          totalSupply: '0',
          maxNumberOfKeys:
           '115792089237316195423570985008687907853269984665640564039457584007913129639935',
          keys: [],
          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
          __typename: 'Lock' } ] } }
```

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
