### PR TITLE
Get refund contract address from environment variable

### DIFF
--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -23,6 +23,7 @@ let requiredConfigVariables = {
   erc20ContractSymbol: process.env.ERC20_CONTRACT_SYMBOL,
   erc20ContractAddress: process.env.ERC20_CONTRACT_ADDRESS,
   stripeApiKey: process.env.STRIPE_KEY,
+  externalRefundContractAddress: process.env.EXTERNAL_REFUND_CONTRACT_ADDRESS,
 }
 
 let optionalConfigVariables = {

--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -23,6 +23,7 @@ let requiredConfigVariables = {
   erc20ContractSymbol: process.env.ERC20_CONTRACT_SYMBOL,
   erc20ContractAddress: process.env.ERC20_CONTRACT_ADDRESS,
   stripeApiKey: process.env.STRIPE_KEY,
+  // TODO: remove after EthWaterloo, this is temporary
   externalRefundContractAddress: process.env.EXTERNAL_REFUND_CONTRACT_ADDRESS,
 }
 

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -54,6 +54,7 @@ export default function configure(
     'http://localhost:3001/static/paywall.min.js'
   let unlockStaticUrl = runtimeConfig.unlockStaticUrl || 'http://localhost:3002'
   let httpProvider = runtimeConfig.httpProvider || '127.0.0.1'
+  // TODO: remove after EthWaterloo, this is temporary
   let externalRefundContractAddress =
     runtimeConfig.externalRefundContractAddress ||
     '0xb75f06e743f9CfFf2efa711427098304f5ccfFa4'

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -54,6 +54,9 @@ export default function configure(
     'http://localhost:3001/static/paywall.min.js'
   let unlockStaticUrl = runtimeConfig.unlockStaticUrl || 'http://localhost:3002'
   let httpProvider = runtimeConfig.httpProvider || '127.0.0.1'
+  let externalRefundContractAddress =
+    runtimeConfig.externalRefundContractAddress ||
+    '0xb75f06e743f9CfFf2efa711427098304f5ccfFa4'
   let blockTime = 8000 // in mseconds.
   let chainExplorerUrlBuilders = {
     etherScan: () => '',
@@ -200,5 +203,6 @@ export default function configure(
     chainExplorerUrlBuilders,
     stripeApiKey,
     subgraphURI,
+    externalRefundContractAddress,
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

To process refunds for EthWaterloo on the verification page, we'll need access to the contract that handles refunds. This PR adds the config to make sure we can pull it in from an environment variable. The default is set based on where it deployed on my local docker -- I assume that will remain constant.

~~This will fail once, then I'll set the environment var for Rinkeby~~
It did fail once, then I set the variable in Circle and it's green now

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #5108 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
