### PR TITLE
adding callbacks to transactions

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Version (minor!)
 
+- WalletService method which change state take a callback as argument which yields the transaction hash.
 - Not catching errors on transaction emitted. These should be caught by the applications
 - withdrawFromLock now returns a Promise of the withdrawn amount
 - purchaseKey now returns a Promise of the token id

--- a/unlock-js/src/v0/createLock.js
+++ b/unlock-js/src/v0/createLock.js
@@ -6,8 +6,9 @@ import { UNLIMITED_KEYS_COUNT } from '../../lib/constants'
 /**
  * Creates a lock on behalf of the user, using version v0
  * @param {PropTypes.lock} lock
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function(lock) {
+export default async function(lock, callback) {
   const unlockContract = await this.getUnlockContract()
   let maxNumberOfKeys = lock.maxNumberOfKeys
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
@@ -27,6 +28,10 @@ export default async function(lock) {
     transactionPromise,
     TransactionTypes.LOCK_CREATION
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's update the lock to reflect that it is linked to this
   // This is an exception because, until we are able to determine the lock address

--- a/unlock-js/src/v0/purchaseKey.js
+++ b/unlock-js/src/v0/purchaseKey.js
@@ -9,9 +9,12 @@ import TransactionTypes from '../transactionTypes'
  * - {PropTypes.address} owner
  * - {string} keyPrice
  * - {string} data
- * TODO: add callback to yield the transaction hash
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress, owner, keyPrice, data }) {
+export default async function(
+  { lockAddress, owner, keyPrice, data },
+  callback
+) {
   const lockContract = await this.getLockContract(lockAddress)
   const transactionPromise = lockContract['purchaseFor(address,bytes)'](
     owner,
@@ -25,6 +28,11 @@ export default async function({ lockAddress, owner, keyPrice, data }) {
     transactionPromise,
     TransactionTypes.KEY_PURCHASE
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
+
   // Let's now wait for the transaction to go thru to return the token id
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface

--- a/unlock-js/src/v0/updateKeyPrice.js
+++ b/unlock-js/src/v0/updateKeyPrice.js
@@ -7,8 +7,9 @@ import TransactionTypes from '../transactionTypes'
  * @param {object} params
  * - {PropTypes.address} lockAddress : address of the lock for which we update the price
  * - {string} keyPrice : new price for the lock, as a string (as wei)
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress, keyPrice }) {
+export default async function({ lockAddress, keyPrice }, callback) {
   const lockContract = await this.getLockContract(lockAddress)
   const transactionPromise = lockContract['updateKeyPrice(uint256)'](
     utils.toWei(keyPrice, 'ether'),
@@ -20,6 +21,10 @@ export default async function({ lockAddress, keyPrice }) {
     transactionPromise,
     TransactionTypes.UPDATE_KEY_PRICE
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's now wait for the keyPrice to have been changed before we return it
   const receipt = await this.provider.waitForTransaction(hash)

--- a/unlock-js/src/v0/withdrawFromLock.js
+++ b/unlock-js/src/v0/withdrawFromLock.js
@@ -6,8 +6,9 @@ import utils from '../utils'
  * Triggers a transaction to withdraw funds from the lock and assign them to the owner.
  * @param {object} params
  * - {PropTypes.address} lockAddress
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress }) {
+export default async function({ lockAddress }, callback) {
   const lockContract = await this.getLockContract(lockAddress)
 
   const transactionPromise = lockContract['withdraw()']({
@@ -17,6 +18,10 @@ export default async function({ lockAddress }) {
     transactionPromise,
     TransactionTypes.WITHDRAWAL
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's now wait for the funds to have been withdrawn
   const receipt = await this.provider.waitForTransaction(hash)

--- a/unlock-js/src/v01/createLock.js
+++ b/unlock-js/src/v01/createLock.js
@@ -6,8 +6,9 @@ import { UNLIMITED_KEYS_COUNT } from '../../lib/constants'
 /**
  * Creates a lock on behalf of the user, using version v01
  * @param {PropTypes.lock} lock
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function(lock) {
+export default async function(lock, callback) {
   const unlockContract = await this.getUnlockContract()
   let maxNumberOfKeys = lock.maxNumberOfKeys
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
@@ -28,6 +29,10 @@ export default async function(lock) {
     transactionPromise,
     TransactionTypes.LOCK_CREATION
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's update the lock to reflect that it is linked to this
   // This is an exception because, until we are able to determine the lock address

--- a/unlock-js/src/v01/purchaseKey.js
+++ b/unlock-js/src/v01/purchaseKey.js
@@ -8,8 +8,9 @@ import TransactionTypes from '../transactionTypes'
  * - {PropTypes.address} lockAddress
  * - {PropTypes.address} owner
  * - {string} keyPrice
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress, owner, keyPrice }) {
+export default async function({ lockAddress, owner, keyPrice }, callback) {
   const lockContract = await this.getLockContract(lockAddress)
   const transactionPromise = lockContract['purchaseFor(address)'](owner, {
     gasLimit: GAS_AMOUNTS.purchaseFor,
@@ -19,6 +20,11 @@ export default async function({ lockAddress, owner, keyPrice }) {
     transactionPromise,
     TransactionTypes.KEY_PURCHASE
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
+
   // Let's now wait for the transaction to go thru to return the token id
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface

--- a/unlock-js/src/v01/updateKeyPrice.js
+++ b/unlock-js/src/v01/updateKeyPrice.js
@@ -7,8 +7,9 @@ import TransactionTypes from '../transactionTypes'
  * @param {object} params
  * - {PropTypes.address} lockAddress : address of the lock for which we update the price
  * - {string} keyPrice : new price for the lock, as a string (as wei)
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress, keyPrice }) {
+export default async function({ lockAddress, keyPrice }, callback) {
   const lockContract = await this.getLockContract(lockAddress)
   const transactionPromise = lockContract['updateKeyPrice(uint256)'](
     utils.toWei(keyPrice, 'ether'),
@@ -20,6 +21,10 @@ export default async function({ lockAddress, keyPrice }) {
     transactionPromise,
     TransactionTypes.UPDATE_KEY_PRICE
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's now wait for the keyPrice to have been changed before we return it
   const receipt = await this.provider.waitForTransaction(hash)

--- a/unlock-js/src/v01/withdrawFromLock.js
+++ b/unlock-js/src/v01/withdrawFromLock.js
@@ -6,8 +6,9 @@ import utils from '../utils'
  * Triggers a transaction to withdraw funds from the lock and assign them to the owner.
  * @param {object} params
  * - {PropTypes.address} lockAddress
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress }) {
+export default async function({ lockAddress }, callback) {
   const lockContract = await this.getLockContract(lockAddress)
   const transactionPromise = lockContract['withdraw()']({
     gasLimit: GAS_AMOUNTS.withdraw,
@@ -16,6 +17,11 @@ export default async function({ lockAddress }) {
     transactionPromise,
     TransactionTypes.WITHDRAWAL
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
+
   // Let's now wait for the funds to have been withdrawn
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface

--- a/unlock-js/src/v02/createLock.js
+++ b/unlock-js/src/v02/createLock.js
@@ -6,8 +6,9 @@ import { UNLIMITED_KEYS_COUNT, ZERO } from '../../lib/constants'
 /**
  * Creates a lock on behalf of the user, using version v02
  * @param {PropTypes.lock} lock
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function(lock) {
+export default async function(lock, callback) {
   const unlockContract = await this.getUnlockContract()
   let maxNumberOfKeys = lock.maxNumberOfKeys
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
@@ -30,6 +31,10 @@ export default async function(lock) {
     transactionPromise,
     TransactionTypes.LOCK_CREATION
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's update the lock to reflect that it is linked to this
   // This is an exception because, until we are able to determine the lock address

--- a/unlock-js/src/v02/purchaseKey.js
+++ b/unlock-js/src/v02/purchaseKey.js
@@ -8,8 +8,9 @@ import TransactionTypes from '../transactionTypes'
  * - {PropTypes.address} lockAddress
  * - {PropTypes.address} owner
  * - {string} keyPrice
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress, owner, keyPrice }) {
+export default async function({ lockAddress, owner, keyPrice }, callback) {
   const lockContract = await this.getLockContract(lockAddress)
   const transactionPromise = lockContract['purchaseFor(address)'](owner, {
     gasLimit: GAS_AMOUNTS.purchaseFor,
@@ -22,6 +23,10 @@ export default async function({ lockAddress, owner, keyPrice }) {
   // Let's now wait for the transaction to go thru to return the token id
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   const transferEvent = receipt.logs
     .map(log => {

--- a/unlock-js/src/v02/updateKeyPrice.js
+++ b/unlock-js/src/v02/updateKeyPrice.js
@@ -7,8 +7,9 @@ import TransactionTypes from '../transactionTypes'
  * @param {object} params
  * - {PropTypes.address} lockAddress : address of the lock for which we update the price
  * - {string} keyPrice : new price for the lock, as a string (as wei)
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress, keyPrice }) {
+export default async function({ lockAddress, keyPrice }, callback) {
   const lockContract = await this.getLockContract(lockAddress)
   const transactionPromise = lockContract['updateKeyPrice(uint256)'](
     utils.toWei(keyPrice, 'ether'),
@@ -20,6 +21,11 @@ export default async function({ lockAddress, keyPrice }) {
     transactionPromise,
     TransactionTypes.UPDATE_KEY_PRICE
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
+
   // Let's now wait for the keyPrice to have been changed before we return it
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface

--- a/unlock-js/src/v02/withdrawFromLock.js
+++ b/unlock-js/src/v02/withdrawFromLock.js
@@ -7,8 +7,9 @@ import utils from '../utils'
  * Note: this version of the contract actually supports partialWithdraw() which we could use here.
  * @param {object} params
  * - {PropTypes.address} lockAddress
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress }) {
+export default async function({ lockAddress }, callback) {
   const lockContract = await this.getLockContract(lockAddress)
   const transactionPromise = lockContract['withdraw()']({
     gasLimit: GAS_AMOUNTS.withdraw,
@@ -17,6 +18,10 @@ export default async function({ lockAddress }) {
     transactionPromise,
     TransactionTypes.WITHDRAWAL
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's now wait for the funds to have been withdrawn
   const receipt = await this.provider.waitForTransaction(hash)

--- a/unlock-js/src/v10/createLock.js
+++ b/unlock-js/src/v10/createLock.js
@@ -28,8 +28,9 @@ async function _getKeyPrice(lock, provider) {
 /**
  * Creates a lock on behalf of the user, using version v10
  * @param {PropTypes.lock} lock
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function(lock) {
+export default async function(lock, callback) {
   const unlockContract = await this.getUnlockContract()
   let maxNumberOfKeys = lock.maxNumberOfKeys
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
@@ -57,6 +58,10 @@ export default async function(lock) {
     transactionPromise,
     TransactionTypes.LOCK_CREATION
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's update the lock to reflect that it is linked to this
   // This is an exception because, until we are able to determine the lock address

--- a/unlock-js/src/v10/purchaseKey.js
+++ b/unlock-js/src/v10/purchaseKey.js
@@ -11,15 +11,12 @@ import { approveTransfer, getErc20Decimals } from '../erc20'
  * - {string} keyPrice
  * - {PropTypes.address} erc20Address
  * - {number} decimals
- * @return {string} hash of the transaction
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({
-  lockAddress,
-  owner,
-  keyPrice,
-  erc20Address,
-  decimals,
-}) {
+export default async function(
+  { lockAddress, owner, keyPrice, erc20Address, decimals },
+  callback
+) {
   const lockContract = await this.getLockContract(lockAddress)
 
   if (!erc20Address || erc20Address !== ZERO) {
@@ -65,6 +62,9 @@ export default async function({
   // Let's now wait for the transaction to go thru to return the token id
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface
+  if (callback) {
+    callback(null, hash)
+  }
 
   const transferEvent = receipt.logs
     .map(log => {

--- a/unlock-js/src/v10/updateKeyPrice.js
+++ b/unlock-js/src/v10/updateKeyPrice.js
@@ -10,13 +10,12 @@ import { getErc20Decimals } from '../erc20'
  * - {string} keyPrice : new price for the lock, as a string (as wei)
  * - {string} decimals : Optional number of decimals (read from contract if unset)
  * - {string} erc20Address : Optional address of ERC20, to retrieve decimals (read from contract if unset)
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({
-  lockAddress,
-  keyPrice,
-  decimals,
-  erc20Address,
-}) {
+export default async function(
+  { lockAddress, keyPrice, decimals, erc20Address },
+  callback
+) {
   const lockContract = await this.getLockContract(lockAddress)
 
   if (decimals == null) {
@@ -43,6 +42,11 @@ export default async function({
     transactionPromise,
     TransactionTypes.UPDATE_KEY_PRICE
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
+
   // Let's now wait for the keyPrice to have been changed before we return it
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface

--- a/unlock-js/src/v10/withdrawFromLock.js
+++ b/unlock-js/src/v10/withdrawFromLock.js
@@ -6,8 +6,9 @@ import utils from '../utils'
  * Triggers a transaction to withdraw funds from the lock and assign them to the owner.
  * Note: this version of the contract actually supports partialWithdraw() which we could use here.
  * @param {PropTypes.address} lockAddress
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress }) {
+export default async function({ lockAddress }, callback) {
   const lockContract = await this.getLockContract(lockAddress)
   const transactionPromise = lockContract['withdraw()']({
     gasLimit: GAS_AMOUNTS.withdraw,
@@ -16,6 +17,9 @@ export default async function({ lockAddress }) {
     transactionPromise,
     TransactionTypes.WITHDRAWAL
   )
+  if (callback) {
+    callback(null, hash)
+  }
   // Let's now wait for the funds to have been withdrawn
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface

--- a/unlock-js/src/v11/createLock.js
+++ b/unlock-js/src/v11/createLock.js
@@ -28,8 +28,9 @@ async function _getKeyPrice(lock, provider) {
 /**
  * Creates a lock on behalf of the user, using version v11
  * @param {PropTypes.lock} lock
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function(lock) {
+export default async function(lock, callback) {
   const unlockContract = await this.getUnlockContract()
   let maxNumberOfKeys = lock.maxNumberOfKeys
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
@@ -57,6 +58,10 @@ export default async function(lock) {
     transactionPromise,
     TransactionTypes.LOCK_CREATION
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's update the lock to reflect that it is linked to this
   // This is an exception because, until we are able to determine the lock address

--- a/unlock-js/src/v11/purchaseKey.js
+++ b/unlock-js/src/v11/purchaseKey.js
@@ -11,15 +11,12 @@ import { approveTransfer, getErc20Decimals } from '../erc20'
  * - {string} keyPrice
  * - {PropTypes.address} erc20Address
  * - {number} decimals
- * @return {string} hash of the transaction
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({
-  lockAddress,
-  owner,
-  keyPrice,
-  erc20Address,
-  decimals,
-}) {
+export default async function(
+  { lockAddress, owner, keyPrice, erc20Address, decimals },
+  callback
+) {
   const lockContract = await this.getLockContract(lockAddress)
 
   if (!erc20Address || erc20Address !== ZERO) {
@@ -63,6 +60,10 @@ export default async function({
     transactionPromise,
     TransactionTypes.KEY_PURCHASE
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's now wait for the transaction to go thru to return the token id
   const receipt = await this.provider.waitForTransaction(hash)

--- a/unlock-js/src/v11/updateKeyPrice.js
+++ b/unlock-js/src/v11/updateKeyPrice.js
@@ -10,13 +10,12 @@ import { getErc20Decimals } from '../erc20'
  * - {string} keyPrice : new price for the lock, as a string (as wei)
  * - {string} decimals : Optional number of decimals (read from contract if unset)
  * - {string} erc20Address : Optional address of ERC20, to retrieve decimals (read from contract if unset)
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({
-  lockAddress,
-  keyPrice,
-  decimals,
-  erc20Address,
-}) {
+export default async function(
+  { lockAddress, keyPrice, decimals, erc20Address },
+  callback
+) {
   const lockContract = await this.getLockContract(lockAddress)
 
   if (decimals == null) {
@@ -43,6 +42,11 @@ export default async function({
     transactionPromise,
     TransactionTypes.UPDATE_KEY_PRICE
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
+
   // Let's now wait for the keyPrice to have been changed before we return it
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface

--- a/unlock-js/src/v11/withdrawFromLock.js
+++ b/unlock-js/src/v11/withdrawFromLock.js
@@ -9,8 +9,12 @@ import TransactionTypes from '../transactionTypes'
  * @param {string} amount
  * @param {number} decimals
  * TODO: get the decimal from the ERC20 contract
+ * @param {function} callback invoked with the transaction hash
  */
-export default async function({ lockAddress, amount = '0', decimals = 18 }) {
+export default async function(
+  { lockAddress, amount = '0', decimals = 18 },
+  callback
+) {
   const lockContract = await this.getLockContract(lockAddress)
 
   const actualAmount = utils.toDecimal(amount, decimals)
@@ -22,6 +26,10 @@ export default async function({ lockAddress, amount = '0', decimals = 18 }) {
     transactionPromise,
     TransactionTypes.WITHDRAWAL
   )
+
+  if (callback) {
+    callback(null, hash)
+  }
 
   // Let's now wait for the funds to have been withdrawn
   const receipt = await this.provider.waitForTransaction(hash)

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -129,41 +129,42 @@ export default class WalletService extends UnlockService {
    * Updates the key price on a lock
    * @param {PropTypes.address} lockAddress : address of the lock for which we update the price
    * @param {string} price : new price for the lock
+   * @param {function} callback : callback invoked with the transaction hash
    * @return Promise<PropTypes.number> newKeyPrice
-   * TODO: add a callback @param which is invoked with the transaction hash of the transaction (this pattern should actually be implemented for all calls)
    */
-  async updateKeyPrice(params = {}) {
+  async updateKeyPrice(params = {}, callback) {
     if (!params.lockAddress) throw new Error('Missing lockAddress')
     const version = await this.lockContractAbiVersion(params.lockAddress)
-    return version.updateKeyPrice.bind(this)(params)
+    return version.updateKeyPrice.bind(this)(params, callback)
   }
 
   /**
    * Creates a lock on behalf of the user.
    * @param {PropTypes.lock} lock
+   * @param {function} callback : callback invoked with the transaction hash
    * @return Promise<PropTypes.address> lockAddress
    */
-  async createLock(lock) {
+  async createLock(lock, callback) {
     const version = await this.unlockContractAbiVersion()
-    return version.createLock.bind(this)(lock)
+    return version.createLock.bind(this)(lock, callback)
   }
 
   /**
    * Purchase a key to a lock by account.
    * The key object is passed so we can keep track of it from the application
-   * TODO: retrieve the keyPrice, erc20Address from chain when applicablle
+   * TODO: retrieve the keyPrice, erc20Address from chain when applicable
    * - {PropTypes.address} lockAddress
    * - {PropTypes.address} owner
    * - {string} keyPrice
    * - {string} data
    * - {PropTypes.address} erc20Address
    * - {number} decimals
-   * TODO: add an exta callback param which will be invoked with the transaction hash
+   * @param {function} callback : callback invoked with the transaction hash
    */
-  async purchaseKey(params = {}) {
+  async purchaseKey(params = {}, callback) {
     if (!params.lockAddress) throw new Error('Missing lockAddress')
     const version = await this.lockContractAbiVersion(params.lockAddress)
-    return version.purchaseKey.bind(this)(params)
+    return version.purchaseKey.bind(this)(params, callback)
   }
 
   /**
@@ -171,12 +172,12 @@ export default class WalletService extends UnlockService {
    * @param {object} params
    * - {PropTypes.address} lockAddress
    * - {string} amount
-   * TODO: add a callback param which yields the transaction hash
+   * @param {function} callback : callback invoked with the transaction hash
    */
-  async withdrawFromLock(params = {}) {
+  async withdrawFromLock(params = {}, callback) {
     if (!params.lockAddress) throw new Error('Missing lockAddress')
     const version = await this.lockContractAbiVersion(params.lockAddress)
-    return version.withdrawFromLock.bind(this)(params)
+    return version.withdrawFromLock.bind(this)(params, callback)
   }
 
   /**


### PR DESCRIPTION
# Description

When triggering a transaction, the hash is now passed in a callback.
this will enable apps to "monitor" the pending transaction more easily!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->