### PR TITLE
Show QR immediately on signing

### DIFF
--- a/unlock-app/src/__tests__/components/interface/keyChain/Key.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/keyChain/Key.test.tsx
@@ -87,6 +87,37 @@ describe('keyChain -- Key', () => {
     global.Date.now = realDateNow
   })
 
+  it('should display a QR code immediately after a signature is received', () => {
+    expect.assertions(2)
+
+    const { container, rerender } = rtl.render(
+      <Key
+        signData={signData}
+        qrEmail={qrEmail}
+        signature={null}
+        accountAddress={accountAddress}
+        ownedKey={aKey}
+      />
+    )
+
+    expect(container.querySelector('canvas')).toBeNull()
+
+    rerender(
+      <Key
+        signData={signData}
+        qrEmail={qrEmail}
+        signature={{
+          data: 'some data',
+          signature: 'a signature',
+        }}
+        accountAddress={accountAddress}
+        ownedKey={aKey}
+      />
+    )
+
+    expect(container.querySelector('canvas')).not.toBeNull()
+  })
+
   it('should display a qr code on button click when there is a signature', () => {
     expect.assertions(2)
 

--- a/unlock-app/src/components/interface/keyChain/Key.tsx
+++ b/unlock-app/src/components/interface/keyChain/Key.tsx
@@ -31,6 +31,14 @@ export class Key extends React.Component<Props, State> {
     }
   }
 
+  componentDidUpdate = ({ signature: prevSignature }: Props) => {
+    const { signature } = this.props
+    // If we have just received a signature, we should immediately display the QR code.
+    if (prevSignature === null && signature) {
+      this.toggleShowingQR()
+    }
+  }
+
   handleSignature = () => {
     const {
       accountAddress,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

When we receive a signature to assert key ownership, we immediately show the QR code modal.

![2019-10-24 10 17 24](https://user-images.githubusercontent.com/9300702/67495282-a2bec400-f648-11e9-8c59-53db4db64504.gif)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5107 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
