### PR TITLE
Add message to existing tickets verification page for NewEvent QRs

### DIFF
--- a/tickets/src/__tests__/components/content/EventVerify.test.js
+++ b/tickets/src/__tests__/components/content/EventVerify.test.js
@@ -78,6 +78,31 @@ describe('EventVerify', () => {
 
     expect(wrapper.getByText('Ticket Validating')).not.toBeNull()
   })
+
+  it('should display the secondary checkin notice when only the lock address is set', () => {
+    expect.assertions(0)
+
+    const { getByText } = rtl.render(
+      <Provider store={store}>
+        <ConfigProvider value={config}>
+          <EventVerify
+            lock={{}}
+            event={{}}
+            valid={null}
+            publicKey={null}
+            signature={null}
+            config={{
+              unlockAppUrl: 'http://localhost:3000',
+            }}
+            lockAddress="0x123abc"
+            loadEvent={() => {}}
+          />
+        </ConfigProvider>
+      </Provider>
+    )
+
+    getByText('This QR code cannot be verified.')
+  })
 })
 
 describe('mapStateToProps', () => {
@@ -118,6 +143,7 @@ describe('mapStateToProps', () => {
       },
       publicKey: '0x49dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
       signature: decodedSignature,
+      lockAddress: '0x42dbdc4CdBda8dc99c82D66d97B264386E41c0E9',
     }
 
     expect(props).toEqual(expectedProps)

--- a/tickets/src/__tests__/utils/routes.test.js
+++ b/tickets/src/__tests__/utils/routes.test.js
@@ -36,18 +36,28 @@ describe('route utilities', () => {
       expect(rsvpRoute('/lock')).toEqual(rsvpBaseRoute)
     })
 
-    it('should return the right prefix and lockAddress value when it matches', () => {
+    it('should return the right prefix and lockAddress value when it matches the full URL', () => {
       expect.assertions(1)
       expect(
         rsvpRoute(
           '/checkin/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54/0x80b8825a3e7Fb15263D0DD455B8aAfc08503bb54/MMdskljfsdIOJWERO79b8825a3e7Fb15263D0DD455B8aAfc08503bb54d23493439'
         )
       ).toEqual({
-        ...baseRoute,
         lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         publicKey: '0x80b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         signature:
           'MMdskljfsdIOJWERO79b8825a3e7Fb15263D0DD455B8aAfc08503bb54d23493439',
+        prefix: 'checkin',
+      })
+    })
+
+    it('should return the right prefix and lockAddress value when it matches the partial URL', () => {
+      expect.assertions(1)
+      expect(
+        rsvpRoute('/checkin/0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54')
+      ).toEqual({
+        ...rsvpBaseRoute,
+        lockAddress: '0x79b8825a3e7Fb15263D0DD455B8aAfc08503bb54',
         prefix: 'checkin',
       })
     })

--- a/tickets/src/constants.ts
+++ b/tickets/src/constants.ts
@@ -72,6 +72,11 @@ export const EVENT_PATH_NAME_REGEXP = new RegExp(
   `(?:/(${prefix}))?/(${lockAddress})/(${userAddress})/(${signature})`
 )
 
+// This regex matches the URL in early QR codes generated for EthWaterloo.
+export const UNSIGNED_TICKET_PATH_NAME_REGEXP = new RegExp(
+  `(?:/(${prefix}))?/(${lockAddress})`
+)
+
 export const PAGE_DESCRIPTION =
   'Unlock is a protocol which enables creators to monetize their content with a few lines of code in a fully decentralized way.'
 

--- a/tickets/src/utils/routes.js
+++ b/tickets/src/utils/routes.js
@@ -1,4 +1,8 @@
-import { LOCK_PATH_NAME_REGEXP, EVENT_PATH_NAME_REGEXP } from '../constants'
+import {
+  LOCK_PATH_NAME_REGEXP,
+  EVENT_PATH_NAME_REGEXP,
+  UNSIGNED_TICKET_PATH_NAME_REGEXP,
+} from '../constants'
 
 if (!global.URL) {
   // polyfill for server
@@ -38,21 +42,29 @@ export const lockRoute = path => {
 export const rsvpRoute = path => {
   const url = new URL(path, 'http://tickets.unlock-protocol.com')
   const match = url.pathname.match(EVENT_PATH_NAME_REGEXP)
+  const unsignedMatch = url.pathname.match(UNSIGNED_TICKET_PATH_NAME_REGEXP)
 
-  if (!match) {
+  if (!match && !unsignedMatch) {
     return {
       signature: null,
       publicKey: null,
       lockAddress: null,
       prefix: null,
     }
-  }
-
-  return {
-    signature: match[4] || null,
-    publicKey: match[3] || null,
-    lockAddress: match[2] || null,
-    prefix: match[1] || null,
+  } else if (match) {
+    return {
+      signature: match[4] || null,
+      publicKey: match[3] || null,
+      lockAddress: match[2] || null,
+      prefix: match[1] || null,
+    }
+  } else if (unsignedMatch) {
+    return {
+      signature: null,
+      publicKey: null,
+      lockAddress: unsignedMatch[2] || null,
+      prefix: unsignedMatch[1] || null,
+    }
   }
 }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

<img width="1127" alt="image" src="https://user-images.githubusercontent.com/9300702/67511792-a0b72e00-f665-11e9-9aa2-066e2359b06b.png">

This PR adds a message on the incomplete route used in EthWaterloo tickets indicating that the ticket holder should be directed to either open the keychain and generate a new QR code or go to the secondary verification agent.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5109 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
