### PR TITLE
Allow empty lock names in paywall

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -498,21 +498,6 @@ describe('Form field validators', () => {
           ).toBe(false)
         })
 
-        it('lock has no name', () => {
-          expect.assertions(1)
-
-          expect(
-            validators.isValidPaywallConfig({
-              ...validConfig,
-              locks: {
-                [lock]: {
-                  whatthe: 'hey?',
-                },
-              },
-            })
-          ).toBe(false)
-        })
-
         it('lock name is not a string', () => {
           expect.assertions(4)
 
@@ -784,6 +769,36 @@ describe('Form field validators', () => {
           })
         ).toBe(true)
       })
+    })
+
+    it('is valid when lock has no name', () => {
+      expect.assertions(1)
+
+      expect(
+        validators.isValidPaywallConfig({
+          ...validConfig,
+          locks: {
+            [lock]: {
+              whatthe: 'hey?',
+            },
+          },
+        })
+      ).toBe(true)
+    })
+
+    it('is valid when lock name is an empty string', () => {
+      expect.assertions(1)
+
+      expect(
+        validators.isValidPaywallConfig({
+          ...validConfig,
+          locks: {
+            [lock]: {
+              name: '',
+            },
+          },
+        })
+      ).toBe(true)
     })
   })
 

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -95,7 +95,12 @@ export const isValidPaywallConfig = config => {
       if (!thisLock || typeof thisLock !== 'object') return false
       if (!Object.keys(thisLock).length) return true
       if (Object.keys(thisLock).length !== 1) return false
-      if (!thisLock.name || typeof thisLock.name !== 'string') return false
+      if (
+        typeof thisLock.name !== 'undefined' &&
+        typeof thisLock.name !== 'string'
+      ) {
+        return false
+      }
       return true
     }).length !== locks.length
   ) {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR changes the paywall config validator to allow locks to be empty strings or not set.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
