### PR TITLE
Improving the way we stand up the external refund contract

### DIFF
--- a/docker/development/deploy-external-refund.js
+++ b/docker/development/deploy-external-refund.js
@@ -12,6 +12,7 @@ async function deployExternalRefund(
   provider
 ) {
   let wallet = await provider.getSigner(0)
+  const walletAddress = await wallet.getAddress()
   let factory = new ethers.ContractFactory(
     externalRefund.abi,
     externalRefund.bytecode,
@@ -23,7 +24,20 @@ async function deployExternalRefund(
   })
 
   let deployment = await contract.deployed()
-  console.log('The External Refund was deployed: ', deployment.address)
+
+  // the "first" account (typically
+  // 0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2) is admin of the
+  // contract, but is not whitelisted by default. So after we deploy
+  // the contract, we enable that address to perform refunds.
+  let abi = [
+    'function addWhitelisted(address account)',
+  ]
+  let deployedContract = new ethers.Contract(deployment.address, abi, wallet)
+  await deployedContract.addWhitelisted(walletAddress)
+  
+  console.log('The External Refund was deployed:   ', deployment.address)
+  console.log('The External Refund contract admin: ', walletAddress)
+  console.log(`The External Refund lock address:   ${lockAddress}`)
 }
 
 module.exports = {

--- a/docker/development/deploy-unlock.js
+++ b/docker/development/deploy-unlock.js
@@ -79,7 +79,7 @@ serverIsUp(1000 /* every second */, 120 /* up to 2 minutes */)
 
         await ExternalRefundDeployer.deployExternalRefund(
           lockAddress,
-          424242,
+          21500000000000000000,
           tokenAddress,
           provider
         )


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR makes some tweaks to the way we stand up the external refund contract for local dev.

- We approve the "first" account on the whitelist (it is the admin of the contract, but needs to whitelist itself before it can perform a refund)
- Logging more details about the deployment, including the lock address it is for
- Setting the refund amount to something larger (21.5TT) because before it was so small a number that it was hard to verify the refund completed successfully.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
