### PR TITLE
Quote the refund amount in refund contract standup

### DIFF
--- a/docker/development/deploy-unlock.js
+++ b/docker/development/deploy-unlock.js
@@ -79,7 +79,7 @@ serverIsUp(1000 /* every second */, 120 /* up to 2 minutes */)
 
         await ExternalRefundDeployer.deployExternalRefund(
           lockAddress,
-          21500000000000000000,
+          '21500000000000000000',
           tokenAddress,
           provider
         )


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Quick follow-on from my last PR. Forgot to include the quotes in the final PR, which caused the deployment of the refund contract to fail because this number constant is too large for JS.

Using a string here is the appropriate choice, it's one of the things `ethers` accepts: https://github.com/ethers-io/ethers.js/blob/26eb6cc01af02a359a59a655fec29c25dcb6ce09/src.ts/utils/bignumber.ts#L50

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
