### PR TITLE
Add conditional refund button to verification page

### DIFF
--- a/unlock-app/src/__tests__/components/interface/RefundButton.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/RefundButton.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { ethers } from 'ethers'
+import RefundButton from '../../../components/interface/RefundButton'
+
+jest.mock('ethers')
+
+let refundFunction = jest.fn()
+describe('RefundButton', () => {
+  beforeAll(() => {
+    ;(ethers.providers.Web3Provider as any).mockImplementation(() => {
+      return {
+        getSigner: jest.fn(),
+      }
+    })
+    ;(ethers.Contract as any).mockImplementation(() => {
+      return {
+        refund: refundFunction,
+      }
+    })
+  })
+  it('should render a button to initiate a refund', async () => {
+    expect.assertions(1)
+
+    const { getByText, findByText } = rtl.render(
+      <RefundButton
+        provider={{}}
+        accountAddress="0xdeadbeef"
+        externalRefundContractAddress="0xbadc0ffee"
+      />
+    )
+
+    const refundButton = getByText('Perform refund')
+
+    rtl.fireEvent.click(refundButton)
+
+    expect(refundFunction).toHaveBeenCalledWith('0xdeadbeef')
+
+    // Button text changes after click
+    await findByText('Refund Initiated')
+  })
+})

--- a/unlock-app/src/__tests__/components/interface/RefundButton.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/RefundButton.test.tsx
@@ -1,9 +1,17 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
 import { ethers } from 'ethers'
-import RefundButton from '../../../components/interface/RefundButton'
+import { RefundButton } from '../../../components/interface/RefundButton'
 
 jest.mock('ethers')
+
+const config = {
+  providers: {
+    Metamask: {},
+  },
+  externalRefundContractAddress: '0x123abc',
+  env: 'test' as any,
+}
 
 let refundFunction = jest.fn()
 describe('RefundButton', () => {
@@ -24,9 +32,9 @@ describe('RefundButton', () => {
 
     const { getByText, findByText } = rtl.render(
       <RefundButton
-        provider={{}}
         accountAddress="0xdeadbeef"
-        externalRefundContractAddress="0xbadc0ffee"
+        lockAddress="0x0AAF2059Cb2cE8Eeb1a0C60f4e0f2789214350a5"
+        config={config}
       />
     )
 
@@ -38,5 +46,19 @@ describe('RefundButton', () => {
 
     // Button text changes after click
     await findByText('Refund Initiated')
+  })
+
+  it('should render nothing if lock address does not match', async () => {
+    expect.assertions(1)
+
+    const { container } = rtl.render(
+      <RefundButton
+        accountAddress="0xdeadbeef"
+        lockAddress="0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2"
+        config={config}
+      />
+    )
+
+    expect(container.firstChild).toBeNull()
   })
 })

--- a/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import * as rtl from 'react-testing-library'
 import * as apolloHooks from '@apollo/react-hooks'
 import sigUtil from 'eth-sig-util'
-import VerificationStatus, {
+import {
+  VerificationStatus,
   Identity,
   OwnsKey,
 } from '../../../components/interface/VerificationStatus'
@@ -22,12 +23,19 @@ const ownedKey: OwnedKey = {
   keyId: 'a key id',
 }
 
+const config = {
+  externalRefundContractAddress: '0x123abc',
+  providers: {
+    Metamask: {},
+  },
+}
+
 describe('VerificationStatus', () => {
   describe('Main component', () => {
     it('should show an error if any required data is missing', () => {
       expect.assertions(0)
 
-      const { getByText } = rtl.render(<VerificationStatus />)
+      const { getByText } = rtl.render(<VerificationStatus config={config} />)
 
       getByText('No Signature Data Found')
     })
@@ -54,6 +62,7 @@ describe('VerificationStatus', () => {
           }}
           sig="this is a signature string, essentially"
           hexData="this is some hex data"
+          config={config}
         />
       )
 

--- a/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
@@ -2,17 +2,13 @@ import React from 'react'
 import * as rtl from 'react-testing-library'
 import * as apolloHooks from '@apollo/react-hooks'
 import sigUtil from 'eth-sig-util'
-import { ethers } from 'ethers'
 import {
   VerificationStatus,
   Identity,
   OwnsKey,
-  RefundButton,
 } from '../../../components/interface/VerificationStatus'
 import * as durations from '../../../utils/durations'
 import { OwnedKey } from '../../../components/interface/keyChain/KeychainTypes'
-
-jest.mock('ethers')
 
 const ownedKey: OwnedKey = {
   lock: {
@@ -34,21 +30,7 @@ const config = {
   },
 }
 
-let refundFunction = jest.fn()
-
 describe('VerificationStatus', () => {
-  beforeAll(() => {
-    ;(ethers.providers.Web3Provider as any).mockImplementation(() => {
-      return {
-        getSigner: jest.fn(),
-      }
-    })
-    ;(ethers.Contract as any).mockImplementation(() => {
-      return {
-        refund: refundFunction,
-      }
-    })
-  })
   describe('Main component', () => {
     it('should show an error if any required data is missing', () => {
       expect.assertions(0)
@@ -161,29 +143,6 @@ describe('VerificationStatus', () => {
       getByText(
         'This user DOES own a key, which is valid until November 14, 3021'
       )
-    })
-  })
-
-  describe('RefundButton', () => {
-    it('should render a button to initiate a refund', async () => {
-      expect.assertions(1)
-
-      const { getByText, findByText } = rtl.render(
-        <RefundButton
-          provider={{}}
-          accountAddress="0xdeadbeef"
-          externalRefundContractAddress="0xbadc0ffee"
-        />
-      )
-
-      const refundButton = getByText('Perform refund')
-
-      rtl.fireEvent.click(refundButton)
-
-      expect(refundFunction).toHaveBeenCalledWith('0xdeadbeef')
-
-      // Button text changes after click
-      await findByText('Refund Initiated')
     })
   })
 })

--- a/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
@@ -7,6 +7,20 @@ import VerificationStatus, {
   OwnsKey,
 } from '../../../components/interface/VerificationStatus'
 import * as durations from '../../../utils/durations'
+import { OwnedKey } from '../../../components/interface/keyChain/KeychainTypes'
+
+const ownedKey: OwnedKey = {
+  lock: {
+    address: '0x123abc',
+    name: 'Lock Around the Clock',
+    expirationDuration: '123456',
+    tokenAddress: 'a token address',
+    price: '5',
+  },
+  expiration: '12345678',
+  id: 'an id',
+  keyId: 'a key id',
+}
 
 describe('VerificationStatus', () => {
   describe('Main component', () => {
@@ -69,9 +83,7 @@ describe('VerificationStatus', () => {
     it('should indicate when it is loading', () => {
       expect.assertions(0)
 
-      const { getByText } = rtl.render(
-        <OwnsKey loading error={undefined} data={{}} lockAddress="0x123abc" />
-      )
+      const { getByText } = rtl.render(<OwnsKey loading error={undefined} />)
 
       getByText('Checking if user has a valid key...')
     })
@@ -80,12 +92,7 @@ describe('VerificationStatus', () => {
       expect.assertions(0)
 
       const { getByText } = rtl.render(
-        <OwnsKey
-          loading={false}
-          error={new Error('oh bother') as any}
-          data={{}}
-          lockAddress="0x123abc"
-        />
+        <OwnsKey loading={false} error={new Error('oh bother') as any} />
       )
 
       getByText('Error: oh bother')
@@ -95,18 +102,7 @@ describe('VerificationStatus', () => {
       expect.assertions(0)
 
       const { getByText } = rtl.render(
-        <OwnsKey
-          loading={false}
-          error={undefined}
-          data={{
-            keyHolders: [
-              {
-                keys: [],
-              },
-            ],
-          }}
-          lockAddress="0x123abc"
-        />
+        <OwnsKey loading={false} error={undefined} />
       )
 
       getByText('This user does not have a key to the lock.')
@@ -119,25 +115,7 @@ describe('VerificationStatus', () => {
       spy.mockReturnValue('Expired')
 
       const { getByText } = rtl.render(
-        <OwnsKey
-          loading={false}
-          error={undefined}
-          data={{
-            keyHolders: [
-              {
-                keys: [
-                  {
-                    lock: {
-                      address: '0x123abc',
-                    },
-                    expiration: '12345678',
-                  },
-                ],
-              },
-            ],
-          }}
-          lockAddress="0x123abc"
-        />
+        <OwnsKey loading={false} error={undefined} matchingKey={ownedKey} />
       )
 
       getByText('The key has EXPIRED')
@@ -147,28 +125,10 @@ describe('VerificationStatus', () => {
       expect.assertions(0)
 
       const spy = jest.spyOn(durations, 'expirationAsDate')
-      spy.mockReturnValue('November 14, 3021')
+      spy.mockReturnValueOnce('November 14, 3021')
 
       const { getByText } = rtl.render(
-        <OwnsKey
-          loading={false}
-          error={undefined}
-          data={{
-            keyHolders: [
-              {
-                keys: [
-                  {
-                    lock: {
-                      address: '0x123abc',
-                    },
-                    expiration: '12345678',
-                  },
-                ],
-              },
-            ],
-          }}
-          lockAddress="0x123abc"
-        />
+        <OwnsKey loading={false} error={undefined} matchingKey={ownedKey} />
       )
 
       getByText(

--- a/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
@@ -23,19 +23,12 @@ const ownedKey: OwnedKey = {
   keyId: 'a key id',
 }
 
-const config = {
-  externalRefundContractAddress: '0x123abc',
-  providers: {
-    Metamask: {},
-  },
-}
-
 describe('VerificationStatus', () => {
   describe('Main component', () => {
     it('should show an error if any required data is missing', () => {
       expect.assertions(0)
 
-      const { getByText } = rtl.render(<VerificationStatus config={config} />)
+      const { getByText } = rtl.render(<VerificationStatus />)
 
       getByText('No Signature Data Found')
     })
@@ -62,7 +55,6 @@ describe('VerificationStatus', () => {
           }}
           sig="this is a signature string, essentially"
           hexData="this is some hex data"
-          config={config}
         />
       )
 

--- a/unlock-app/src/components/interface/RefundButton.tsx
+++ b/unlock-app/src/components/interface/RefundButton.tsx
@@ -18,7 +18,7 @@ interface RefundButtonState {
 const lockAddressesByEnv = {
   dev: '0x0AAF2059Cb2cE8Eeb1a0C60f4e0f2789214350a5',
   test: '0x0AAF2059Cb2cE8Eeb1a0C60f4e0f2789214350a5',
-  staging: '',
+  staging: '0x5611E3b7092A9e14ACd2Eadf7252cbBe723fFD81',
   prod: '0xB0ad425cA5792DD4C4Af9177c636e5b0e6c317BF',
 }
 

--- a/unlock-app/src/components/interface/RefundButton.tsx
+++ b/unlock-app/src/components/interface/RefundButton.tsx
@@ -18,7 +18,7 @@ interface RefundButtonState {
 const lockAddressesByEnv = {
   dev: '0x0AAF2059Cb2cE8Eeb1a0C60f4e0f2789214350a5',
   test: '0x0AAF2059Cb2cE8Eeb1a0C60f4e0f2789214350a5',
-  staging: '0x5611E3b7092A9e14ACd2Eadf7252cbBe723fFD81',
+  staging: '0x3628D7170209c58DC1e8F51AD190b69d044FbBF2',
   prod: '0xB0ad425cA5792DD4C4Af9177c636e5b0e6c317BF',
 }
 

--- a/unlock-app/src/components/interface/RefundButton.tsx
+++ b/unlock-app/src/components/interface/RefundButton.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { ethers } from 'ethers'
+
+interface RefundButtonProps {
+  externalRefundContractAddress: string
+  accountAddress: string
+  provider: any
+}
+interface RefundButtonState {
+  refundInitiated: boolean
+}
+export default class RefundButton extends React.Component<
+  RefundButtonProps,
+  RefundButtonState
+> {
+  private contract: ethers.Contract
+  constructor(props: RefundButtonProps) {
+    super(props)
+    const { provider, externalRefundContractAddress } = props
+    const web3Provider = new ethers.providers.Web3Provider(provider)
+    const signer = web3Provider.getSigner()
+    const abi = ['function refund(address recipient)']
+    this.contract = new ethers.Contract(
+      externalRefundContractAddress,
+      abi,
+      signer
+    )
+
+    this.state = {
+      refundInitiated: false,
+    }
+  }
+
+  initiateRefund = async () => {
+    const { accountAddress } = this.props
+    await this.contract.refund(accountAddress)
+    this.setState({
+      refundInitiated: true,
+    })
+  }
+
+  render() {
+    const { refundInitiated } = this.state
+    if (refundInitiated) {
+      return (
+        <button type="button" disabled>
+          Refund Initiated
+        </button>
+      )
+    }
+    return (
+      <button type="button" onClick={this.initiateRefund}>
+        Perform refund
+      </button>
+    )
+  }
+}

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -10,7 +10,6 @@ import {
 import { OwnedKey } from './keyChain/KeychainTypes'
 import RefundButton from './RefundButton'
 import keyHolderQuery from '../../queries/keyHolder'
-import withConfig from '../../utils/withConfig'
 import 'cross-fetch/polyfill'
 
 interface VerificationData {
@@ -23,13 +22,9 @@ interface Props {
   data?: VerificationData
   sig?: string
   hexData?: string
-  config: {
-    externalRefundContractAddress: string
-    providers: { [name: string]: any }
-  }
 }
 
-export const VerificationStatus = ({ data, sig, hexData, config }: Props) => {
+export const VerificationStatus = ({ data, sig, hexData }: Props) => {
   if (!data || !sig || !hexData) {
     return (
       <DefaultError
@@ -72,9 +67,6 @@ export const VerificationStatus = ({ data, sig, hexData, config }: Props) => {
       sig,
     }) === accountAddress.toLowerCase()
 
-  const { providers, externalRefundContractAddress } = config
-  const provider = providers[Object.keys(providers)[0]]
-
   return (
     <div>
       <Identity valid={identityIsValid} />
@@ -88,16 +80,12 @@ export const VerificationStatus = ({ data, sig, hexData, config }: Props) => {
       <p>
         Signed {durationsAsTextFromSeconds(secondsElapsedFromSignature)} ago.
       </p>
-      {matchingKey &&
-        identityIsValid &&
-        lockAddress.toLowerCase() ===
-          '0x0AAF2059Cb2cE8Eeb1a0C60f4e0f2789214350a5'.toLowerCase() && (
-          <RefundButton
-            provider={provider}
-            externalRefundContractAddress={externalRefundContractAddress}
-            accountAddress={accountAddress}
-          />
-        )}
+      {matchingKey && identityIsValid && (
+        <RefundButton
+          accountAddress={accountAddress}
+          lockAddress={lockAddress}
+        />
+      )}
     </div>
   )
 }
@@ -131,4 +119,4 @@ export const OwnsKey = ({ loading, error, matchingKey }: OwnsKeyProps) => {
   return <p>This user DOES own a key, which is valid until {expiresIn}</p>
 }
 
-export default withConfig(VerificationStatus)
+export default VerificationStatus

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import sigUtil from 'eth-sig-util'
 import { useQuery } from '@apollo/react-hooks'
 import { ApolloError } from 'apollo-boost'
+import { ethers } from 'ethers'
 import { DefaultError } from '../creator/FatalError'
 import {
   durationsAsTextFromSeconds,
@@ -11,7 +12,6 @@ import { OwnedKey } from './keyChain/KeychainTypes'
 import keyHolderQuery from '../../queries/keyHolder'
 import withConfig from '../../utils/withConfig'
 import 'cross-fetch/polyfill'
-import { ethers } from 'ethers'
 
 interface VerificationData {
   accountAddress: string
@@ -29,7 +29,7 @@ interface Props {
   }
 }
 
-const refund = async (
+export const refund = async (
   contractAddress: string,
   provider: any,
   recipient: string
@@ -38,12 +38,12 @@ const refund = async (
   const web3Provider = new ethers.providers.Web3Provider(provider)
   const signer = web3Provider.getSigner()
   const contract = new ethers.Contract(contractAddress, abi, signer)
-  console.log('contract created, performing refund')
+
   try {
-    const result: any = await contract.refund(recipient)
-    console.log(result)
+    await contract.refund(recipient)
   } catch (e) {
-    console.log(e)
+    // eslint-disable-next-line no-console
+    console.error(e)
   }
 }
 
@@ -112,8 +112,9 @@ export const VerificationStatus = ({ data, sig, hexData, config }: Props) => {
           '0x0AAF2059Cb2cE8Eeb1a0C60f4e0f2789214350a5'.toLowerCase() && (
           <button
             type="button"
-            onClick={() =>
-              refund(externalRefundContractAddress, provider, accountAddress)}
+            onClick={() => {
+              refund(externalRefundContractAddress, provider, accountAddress)
+            }}
           >
             Perform refund
           </button>

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import sigUtil from 'eth-sig-util'
 import { useQuery } from '@apollo/react-hooks'
 import { ApolloError } from 'apollo-boost'
-import { ethers } from 'ethers'
 import { DefaultError } from '../creator/FatalError'
 import {
   durationsAsTextFromSeconds,
   expirationAsDate,
 } from '../../utils/durations'
 import { OwnedKey } from './keyChain/KeychainTypes'
+import RefundButton from './RefundButton'
 import keyHolderQuery from '../../queries/keyHolder'
 import withConfig from '../../utils/withConfig'
 import 'cross-fetch/polyfill'
@@ -100,61 +100,6 @@ export const VerificationStatus = ({ data, sig, hexData, config }: Props) => {
         )}
     </div>
   )
-}
-
-interface RefundButtonProps {
-  externalRefundContractAddress: string
-  accountAddress: string
-  provider: any
-}
-interface RefundButtonState {
-  refundInitiated: boolean
-}
-export class RefundButton extends React.Component<
-  RefundButtonProps,
-  RefundButtonState
-> {
-  private contract: ethers.Contract
-  constructor(props: RefundButtonProps) {
-    super(props)
-    const { provider, externalRefundContractAddress } = props
-    const web3Provider = new ethers.providers.Web3Provider(provider)
-    const signer = web3Provider.getSigner()
-    const abi = ['function refund(address recipient)']
-    this.contract = new ethers.Contract(
-      externalRefundContractAddress,
-      abi,
-      signer
-    )
-
-    this.state = {
-      refundInitiated: false,
-    }
-  }
-
-  initiateRefund = async () => {
-    const { accountAddress } = this.props
-    await this.contract.refund(accountAddress)
-    this.setState({
-      refundInitiated: true,
-    })
-  }
-
-  render() {
-    const { refundInitiated } = this.state
-    if (refundInitiated) {
-      return (
-        <button type="button" disabled>
-          Refund Initiated
-        </button>
-      )
-    }
-    return (
-      <button type="button" onClick={this.initiateRefund}>
-        Perform refund
-      </button>
-    )
-  }
 }
 
 export const Identity = ({ valid }: { valid: boolean }) => (


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a button to the verification page that will be used to interact with the external refund contract for EthWaterloo checkin.

It's not quite done yet, I'll add a comment inline where I need some guidance.

<img width="495" alt="image" src="https://user-images.githubusercontent.com/9300702/67711767-0f172b80-f999-11e9-9b56-1357ea70779a.png">


<img width="501" alt="image" src="https://user-images.githubusercontent.com/9300702/67711756-03c40000-f999-11e9-8811-f3a3d477774b.png">


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5108 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
