### PR TITLE
Add gasLimit and gasPrice overrides to external refund

### DIFF
--- a/unlock-app/src/__tests__/components/interface/RefundButton.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/RefundButton.test.tsx
@@ -42,7 +42,10 @@ describe('RefundButton', () => {
 
     rtl.fireEvent.click(refundButton)
 
-    expect(refundFunction).toHaveBeenCalledWith('0xdeadbeef')
+    expect(refundFunction).toHaveBeenCalledWith('0xdeadbeef', {
+      gasLimit: 600000,
+      gasPrice: 20000000000,
+    })
 
     // Button text changes after click
     await findByText('Refund Initiated')

--- a/unlock-app/src/components/interface/RefundButton.tsx
+++ b/unlock-app/src/components/interface/RefundButton.tsx
@@ -47,12 +47,12 @@ export class RefundButton extends React.Component<
 
   initiateRefund = async () => {
     const { accountAddress } = this.props
+    this.setState({
+      refundInitiated: true,
+    })
     await this.contract.refund(accountAddress, {
       gasPrice: 20000000000,
       gasLimit: 600000,
-    })
-    this.setState({
-      refundInitiated: true,
     })
   }
 

--- a/unlock-app/src/components/interface/RefundButton.tsx
+++ b/unlock-app/src/components/interface/RefundButton.tsx
@@ -47,7 +47,10 @@ export class RefundButton extends React.Component<
 
   initiateRefund = async () => {
     const { accountAddress } = this.props
-    await this.contract.refund(accountAddress)
+    await this.contract.refund(accountAddress, {
+      gasPrice: 20000000000,
+      gasLimit: 600000,
+    })
     this.setState({
       refundInitiated: true,
     })

--- a/unlock-app/src/components/interface/RefundButton.tsx
+++ b/unlock-app/src/components/interface/RefundButton.tsx
@@ -50,6 +50,8 @@ export class RefundButton extends React.Component<
     this.setState({
       refundInitiated: true,
     })
+    // We override the gas price and gas limit here because web3
+    // wallets would error when they automatically calculated the values.
     await this.contract.refund(accountAddress, {
       gasPrice: 20000000000,
       gasLimit: 600000,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

While testing before the external refund deploy, we noticed that web3 wallets would error when automatically calculating gas prices and limits for the refund transaction. This PR fixes that by specifying concrete values (based on @akeem's successful manual transaction [here](https://rinkeby.etherscan.io/tx/0xb12aba624674a47734b30c5e0b81ceafb9049470341f5916a8920c6e1c1242c1))

Additionally, because there is some lag when running on a real network, this PR makes the UI respond faster by disabling the button right away instead of waiting for the transaction promise to resolve.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
