### PR TITLE
Provide an alternate signature validation path handling signPersonal signatures

### DIFF
--- a/locksmith/__tests__/signatureValidation/signPersonal.test.ts
+++ b/locksmith/__tests__/signatureValidation/signPersonal.test.ts
@@ -1,0 +1,295 @@
+import sigUtil from 'eth-sig-util'
+import signatureValidationMiddleware from '../../src/middlewares/signatureValidationMiddleware'
+
+import ethJsUtil = require('ethereumjs-util')
+import Base64 = require('../../src/utils/base64')
+const httpMocks = require('node-mocks-http')
+
+let request: any, response: any
+
+let privateKey: Buffer[] = [
+  ethJsUtil.toBuffer(
+    '0xe5986c22698a3c1eb5f84455895ad6826fbdff7b82dbeee240bad0024469d93a'
+  ),
+  ethJsUtil.toBuffer(
+    '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
+  ),
+]
+
+let body = {
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+    ],
+    Lock: [
+      { name: 'name', type: 'string' },
+      { name: 'owner', type: 'address' },
+      { name: 'address', type: 'address' },
+    ],
+  },
+  domain: { name: 'Unlock Dashboard', version: '1', chainId: 1984 },
+  primaryType: 'Lock',
+  message: {
+    lock: {
+      name: 'New Lock',
+      owner: '0xc66ef2e0d0edcce723b3fdd4307db6c5f0dda1b8',
+      address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
+    },
+  },
+}
+
+let validSignature = sigUtil.personalSign(privateKey[0], {
+  data: JSON.stringify(body),
+})
+
+let processor = signatureValidationMiddleware.generateProcessor({
+  name: 'lock',
+  required: ['name', 'owner', 'address'],
+  signee: 'owner',
+})
+
+let evaluator = signatureValidationMiddleware.generateSignatureEvaluator({
+  name: 'user',
+  required: ['publicKey'],
+  signee: 'publicKey',
+})
+
+const generateSignature = (privateKey: Buffer, body: any) => {
+  return sigUtil.personalSign(privateKey, {
+    data: JSON.stringify(body),
+  })
+}
+
+beforeAll(() => {
+  request = httpMocks.createRequest()
+  response = httpMocks.createResponse()
+})
+
+describe('Signature Validation Middleware', () => {
+  describe('generateSignatureEvaluator', () => {
+    describe('when the request has a token', () => {
+      it('returns the signee', done => {
+        expect.assertions(1)
+
+        let body = {
+          types: {
+            EIP712Domain: [
+              { name: 'name', type: 'string' },
+              { name: 'version', type: 'string' },
+              { name: 'chainId', type: 'uint256' },
+              { name: 'verifyingContract', type: 'address' },
+              { name: 'salt', type: 'bytes32' },
+            ],
+            User: [{ name: 'publickKey', type: 'address' }],
+          },
+          domain: { name: 'Unlock', version: '1' },
+          primaryType: 'User',
+          message: {
+            user: {
+              publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+            },
+          },
+        }
+
+        let sig = generateSignature(privateKey[1], body)
+        let request = httpMocks.createRequest({
+          headers: { Authorization: `Bearer-Simple ${Base64.encode(sig)}` },
+          body,
+        })
+
+        evaluator(request, response, function next() {
+          expect(request.signee).toBe(
+            '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+          )
+          done()
+        })
+      })
+    })
+
+    describe('when the request does not have a token', () => {
+      it('does not return a signee', done => {
+        expect.assertions(1)
+
+        let request = httpMocks.createRequest({
+          body: 'a sample body',
+        })
+
+        evaluator(request, response, function next() {
+          expect(request.signee).toBe(undefined)
+          done()
+        })
+      })
+    })
+  })
+
+  describe('when a valid signature is received', () => {
+    describe('a signature for User creation', () => {
+      it('moves the request to the application', done => {
+        expect.assertions(1)
+
+        let body = {
+          types: {
+            EIP712Domain: [
+              { name: 'name', type: 'string' },
+              { name: 'version', type: 'string' },
+              { name: 'chainId', type: 'uint256' },
+              { name: 'verifyingContract', type: 'address' },
+              { name: 'salt', type: 'bytes32' },
+            ],
+            User: [
+              { name: 'emailAddress', type: 'string' },
+              { name: 'publickKey', type: 'address' },
+              { name: 'passwordEncryptedPrivateKey', type: 'string' },
+            ],
+          },
+          domain: { name: 'Unlock', version: '1' },
+          primaryType: 'User',
+          message: {
+            user: {
+              emailAddress: 'new_user@example.com',
+              publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+              passwordEncryptedPrivateKey: 'an encrypted value',
+            },
+          },
+        }
+
+        let sig = generateSignature(privateKey[1], body)
+        let request = httpMocks.createRequest({
+          headers: {
+            Authorization: `Bearer-Simple ${Base64.encode(sig)}`,
+          },
+          body,
+        })
+
+        processor = signatureValidationMiddleware.generateProcessor({
+          name: 'user',
+          required: [
+            'emailAddress',
+            'publicKey',
+            'passwordEncryptedPrivateKey',
+          ],
+          signee: 'publicKey',
+        })
+        processor(request, response, function next() {
+          expect(request.owner).toBe(
+            '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+          )
+          done()
+        })
+      })
+    })
+
+    describe('a signature for Lock metadata', () => {
+      it('moves the request to the application', done => {
+        expect.assertions(1)
+        Date.now = jest.fn(() => 1546130835000)
+
+        let body = {
+          types: {
+            EIP712Domain: [
+              { name: 'name', type: 'string' },
+              { name: 'version', type: 'string' },
+              { name: 'chainId', type: 'uint256' },
+              { name: 'verifyingContract', type: 'address' },
+              { name: 'salt', type: 'bytes32' },
+            ],
+            Lock: [
+              { name: 'name', type: 'string' },
+              { name: 'owner', type: 'address' },
+              { name: 'address', type: 'address' },
+            ],
+          },
+          domain: { name: 'Unlock Dashboard', version: '1', chainId: 1984 },
+          primaryType: 'Lock',
+          message: {
+            lock: {
+              name: 'New Lock',
+              owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+              address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
+            },
+          },
+        }
+
+        let sig = generateSignature(privateKey[1], body)
+        let request = httpMocks.createRequest({
+          headers: {
+            Authorization: `Bearer-Simple ${Base64.encode(sig)}`,
+          },
+          body,
+        })
+
+        processor = signatureValidationMiddleware.generateProcessor({
+          name: 'lock',
+          required: ['name', 'owner', 'address'],
+          signee: 'owner',
+        })
+        processor(request, response, function next() {
+          expect(request.owner).toBe(
+            '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+          )
+          done()
+        })
+      })
+    })
+  })
+
+  describe('unauthorized conditions', () => {
+    describe('when a signature is not provided', () => {
+      test('returns a status 401 to the caller ', () => {
+        expect.assertions(1)
+        let spy = jest.spyOn(response, 'sendStatus')
+        processor(request, response)
+        expect(spy).toHaveBeenCalledWith(401)
+      })
+    })
+
+    describe('when the body provided is not well formed Typed Data ', () => {
+      test('returns a status 401 to the caller', () => {
+        expect.assertions(1)
+        let request = httpMocks.createRequest({
+          headers: {
+            Authorization: `Bearer-Simple ${Base64.encode(validSignature)}`,
+          },
+        })
+
+        let spy = jest.spyOn(response, 'sendStatus')
+        processor(request, response)
+        expect(spy).toHaveBeenCalledWith(401)
+      })
+    })
+
+    describe('when the signature is malformed', () => {
+      test('returns a  status 401 to the caller', () => {
+        expect.assertions(1)
+
+        let request = httpMocks.createRequest({
+          headers: { Authorization: `Bearer-Simple ${validSignature}xyz` },
+          body,
+        })
+
+        let spy = jest.spyOn(response, 'sendStatus')
+        processor(request, response)
+        expect(spy).toHaveBeenCalledWith(401)
+      })
+    })
+
+    describe('when the signee does not match the item owner', () => {
+      test('returns a status 401 to the caller ', () => {
+        expect.assertions(1)
+
+        let request = httpMocks.createRequest({
+          headers: { Authorization: `Bearer-Simple ${validSignature}` },
+          body,
+        })
+
+        let spy = jest.spyOn(response, 'sendStatus')
+        processor(request, response)
+        expect(spy).toHaveBeenCalledWith(401)
+      })
+    })
+  })
+})

--- a/locksmith/__tests__/signatureValidation/typedData.test.ts
+++ b/locksmith/__tests__/signatureValidation/typedData.test.ts
@@ -1,9 +1,9 @@
-import signatureValidationMiddleware from '../src/middlewares/signatureValidationMiddleware'
+import signatureValidationMiddleware from '../../src/middlewares/signatureValidationMiddleware'
 
 const ethJsUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
 const httpMocks = require('node-mocks-http')
-const Base64 = require('../src/utils/base64')
+const Base64 = require('../../src/utils/base64')
 
 let request: any, response: any
 

--- a/locksmith/src/middlewares/signatureValidationMiddleware.ts
+++ b/locksmith/src/middlewares/signatureValidationMiddleware.ts
@@ -5,12 +5,46 @@ import Normalizer from '../utils/normalizer'
 import { SignatureValidationConfiguration } from '../types' // eslint-disable-line no-unused-vars
 
 namespace SignatureValidationMiddleware {
-  const extractToken = (req: Request): string | null => {
+  const extractTypeDataSignee = (header: string, body: string) => {
+    let decodedSignature = Base64.decode(header)
+
+    try {
+      return sigUtil.recoverTypedSignature({
+        data: body,
+        sig: decodedSignature,
+      })
+    } catch {
+      return null
+    }
+  }
+
+  const extractPersonalSignSignee = (header: string, body: string) => {
+    let decodedSignature = Base64.decode(header)
+
+    try {
+      return sigUtil.recoverPersonalSignature({
+        data: JSON.stringify(body),
+        sig: decodedSignature,
+      })
+    } catch {
+      return null
+    }
+  }
+
+  const extractSignee = (req: Request): string | null => {
     if (
       req.headers.authorization &&
       req.headers.authorization.split(' ')[0] === 'Bearer'
     ) {
-      return req.headers.authorization.split(' ')[1]
+      let header = req.headers.authorization.split(' ')[1]
+
+      return extractTypeDataSignee(header, req.body)
+    } else if (
+      req.headers.authorization &&
+      req.headers.authorization.split(' ')[0] === 'Bearer-Simple'
+    ) {
+      let header = req.headers.authorization.split(' ')[1]
+      return extractPersonalSignSignee(header, req.body)
     } else {
       return null
     }
@@ -39,11 +73,7 @@ namespace SignatureValidationMiddleware {
     configuration: SignatureValidationConfiguration
   ) => {
     try {
-      let signee = sigUtil.recoverTypedSignature({
-        data: body,
-        sig: signature,
-      })
-
+      let signee = signature
       let potentialSignee: string =
         body.message[configuration.name][configuration.signee]
 
@@ -73,18 +103,13 @@ namespace SignatureValidationMiddleware {
     configuration: SignatureValidationConfiguration
   ): any => {
     return (req: any, res: Response, next: any) => {
-      var signature = extractToken(req)
+      var signature = extractSignee(req)
 
       if (signature === null) {
         res.sendStatus(401)
         return
       } else {
-        let decodedSignature = Base64.decode(signature)
-        let owner = handleSignaturePresent(
-          req.body,
-          decodedSignature,
-          configuration
-        )
+        let owner = handleSignaturePresent(req.body, signature, configuration)
 
         if (owner) {
           req.owner = owner
@@ -101,17 +126,12 @@ namespace SignatureValidationMiddleware {
     configuration: SignatureValidationConfiguration
   ): any => {
     return (req: any, _res: Response, next: any) => {
-      var signature = extractToken(req)
+      var signature = extractSignee(req)
 
       if (signature === null) {
         next()
       } else {
-        let decodedSignature = Base64.decode(signature)
-        let signee = handleSignaturePresent(
-          req.body,
-          decodedSignature,
-          configuration
-        )
+        let signee = handleSignaturePresent(req.body, signature, configuration)
 
         if (signee) {
           req.signee = signee

--- a/locksmith/src/middlewares/signatureValidationMiddleware.ts
+++ b/locksmith/src/middlewares/signatureValidationMiddleware.ts
@@ -69,11 +69,10 @@ namespace SignatureValidationMiddleware {
 
   const handleSignaturePresent = (
     body: any,
-    signature: string,
+    signee: string,
     configuration: SignatureValidationConfiguration
   ) => {
     try {
-      let signee = signature
       let potentialSignee: string =
         body.message[configuration.name][configuration.signee]
 


### PR DESCRIPTION
# Description

providing a lowest common denominator signature check to support the potential scenario of a caller not having the ability to support typed data as presented in EIP712

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
