### PR TITLE
WIP: adding timeMachine function

### DIFF
--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -202,7 +202,7 @@ contract MixinTransfer is
     address _owner,
     uint256 _deltaT,
     bool _addTime
-  ) public
+  ) internal
     hasValidKey(_owner)
   {
     Key storage key = keyByOwner[_owner];

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -189,6 +189,32 @@ contract MixinTransfer is
   }
 
   /**
+  * @notice Modify the expirationTimestamp of a key
+  * by a given amount.
+  * @param _owner The owner of the key to modify
+  * @param _deltaT The amount of time in seconds by which
+  * to modify the keys expirationTimestamp
+  * @param _addTime Choose whether to increase or decrease
+  * expirationTimestamp (false == decrease, true == increase)
+  * @dev Throws if owner does not have a valid key.
+  */
+  function timeMachine(
+    address _owner,
+    uint256 _deltaT,
+    bool _addTime
+  ) internal
+    hasValidKey(_owner)
+  {
+    Key storage key = keyByOwner[_owner];
+    uint formerTimestamp = key.expirationTimestamp;
+    if(_addTime) {
+      key.expirationTimestamp = formerTimestamp.add(_deltaT);
+    } else {
+      key.expirationTimestamp = formerTimestamp.sub(_deltaT);
+    }
+  }
+
+  /**
    * @dev Internal function to invoke `onERC721Received` on a target address
    * The call is not executed if the target address is not a contract
    * @param from address representing the previous owner of the given token ID

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -202,7 +202,7 @@ contract MixinTransfer is
     address _owner,
     uint256 _deltaT,
     bool _addTime
-  ) internal
+  ) public // This should probably be internal, but I wanted to test it directly.
     hasValidKey(_owner)
   {
     Key storage key = keyByOwner[_owner];

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -202,7 +202,7 @@ contract MixinTransfer is
     address _owner,
     uint256 _deltaT,
     bool _addTime
-  ) internal
+  ) public // change this to internal!!!
     hasValidKey(_owner)
   {
     Key storage key = keyByOwner[_owner];

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -60,6 +60,9 @@ contract MixinTransfer is
     Key storage toKey = keyByOwner[_recipient];
 
     uint previousExpiration = toKey.expirationTimestamp;
+    // subtract the fee from the senders key before the transfer
+    _timeMachine(_from, fee, false);
+
 
     if (toKey.tokenId == 0) {
       toKey.tokenId = fromKey.tokenId;
@@ -96,7 +99,7 @@ contract MixinTransfer is
       _tokenId
     );
 
-    _chargeAtLeast(fee);
+    // _chargeAtLeast(fee);
   }
 
   /**
@@ -180,10 +183,10 @@ contract MixinTransfer is
     uint fee;
     if(timeRemaining >= expirationDuration) {
       // Max the potential impact of this fee for keys with long durations remaining
-      fee = keyPrice;
+      fee = timeRemaining;
     } else {
       // Math: using safeMul in case keyPrice or timeRemaining is very large
-      fee = keyPrice.mul(timeRemaining) / expirationDuration;
+      fee = timeRemaining.mul(timeRemaining) / expirationDuration;
     }
     return fee.mul(transferFeeBasisPoints) / BASIS_POINTS_DEN;
   }

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -202,7 +202,7 @@ contract MixinTransfer is
     address _owner,
     uint256 _deltaT,
     bool _addTime
-  ) public // This should probably be internal, but I wanted to test it directly.
+  ) internal
     hasValidKey(_owner)
   {
     Key storage key = keyByOwner[_owner];

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -198,7 +198,7 @@ contract MixinTransfer is
   * expirationTimestamp (false == decrease, true == increase)
   * @dev Throws if owner does not have a valid key.
   */
-  function timeMachine(
+  function _timeMachine(
     address _owner,
     uint256 _deltaT,
     bool _addTime
@@ -208,9 +208,17 @@ contract MixinTransfer is
     Key storage key = keyByOwner[_owner];
     uint formerTimestamp = key.expirationTimestamp;
     if(_addTime) {
-      key.expirationTimestamp = formerTimestamp.add(_deltaT);
+      if(formerTimestamp.add(_deltaT) > block.timestamp.add(expirationDuration)) {
+        key.expirationTimestamp = block.timestamp.add(expirationDuration);
+      } else {
+        key.expirationTimestamp = formerTimestamp.add(_deltaT);
+      }
     } else {
-      key.expirationTimestamp = formerTimestamp.sub(_deltaT);
+      if(formerTimestamp.sub(_deltaT) <= block.timestamp) {
+        key.expirationTimestamp = block.timestamp;
+      } else {
+        key.expirationTimestamp = formerTimestamp - _deltaT;
+      }
     }
   }
 

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -202,7 +202,7 @@ contract MixinTransfer is
     address _owner,
     uint256 _deltaT,
     bool _addTime
-  ) internal
+  ) public
     hasValidKey(_owner)
   {
     Key storage key = keyByOwner[_owner];

--- a/smart-contracts/contracts/mocks/TimeMachineMock.sol
+++ b/smart-contracts/contracts/mocks/TimeMachineMock.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.0;
 
 import "../PublicLock.sol";
 
-contract TestTimeMachine is
+contract TimeMachineMock is
   PublicLock
 {
   /**

--- a/smart-contracts/contracts/test-artifacts/TestTimeMachine.sol
+++ b/smart-contracts/contracts/test-artifacts/TestTimeMachine.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.5.0;
+
+import "../PublicLock.sol";
+
+contract TestTimeMachine is
+  PublicLock
+{
+  /**
+  * @notice Modify the expirationTimestamp of a key
+  * by a given amount.
+  * @param _owner The owner of the key to modify
+  * @param _deltaT The amount of time in seconds by which
+  * to modify the keys expirationTimestamp
+  * @param _addTime Choose whether to increase or decrease
+  * expirationTimestamp (false == decrease, true == increase)
+  * @dev Throws if owner does not have a valid key.
+  */
+  function timeMachine(
+    address _owner,
+    uint256 _deltaT,
+    bool _addTime
+  ) public
+  {
+    _timeMachine(_owner, _deltaT, _addTime);
+  }
+}

--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -3,7 +3,7 @@ const BigNumber = require('bignumber.js')
 
 // const TestTimeMachine = artifacts.require('TestTimeMachine')
 const deployLocks = require('../helpers/deployLocks')
-// const shouldFail = require('../helpers/shouldFail')
+const shouldFail = require('../helpers/shouldFail')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const getProxy = require('../helpers/proxy')
@@ -14,6 +14,7 @@ contract('Lock / timeMachine', accounts => {
   let lock
   const keyPrice = new BigNumber(Units.convert('0.01', 'eth', 'wei'))
   const keyOwner = accounts[1]
+  const notKeyOwner = accounts[5]
   const expirationDuration = new BigNumber(60 * 60 * 24 * 30)
   const tooMuchTime = new BigNumber(60 * 60 * 24 * 42) // 42 days
   let timestampBefore, timestampAfter
@@ -79,6 +80,15 @@ contract('Lock / timeMachine', accounts => {
       )
       assert(timestampAfter.lte(Date.now()))
       assert.equal(await lock.getHasValidKey.call(keyOwner), false)
+    })
+
+    it('should fail without a valid key', async () => {
+      await shouldFail(
+        lock._timeMachine(notKeyOwner, 42, false, {
+          from: accounts[0],
+        }),
+        'KEY_NOT_VALID'
+      )
     })
   })
 })

--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -1,0 +1,53 @@
+const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
+
+const deployLocks = require('../helpers/deployLocks')
+// const shouldFail = require('../helpers/shouldFail')
+
+const unlockContract = artifacts.require('../Unlock.sol')
+const getProxy = require('../helpers/proxy')
+
+let unlock, locks
+
+contract('Lock / transferFee', accounts => {
+  let lock
+  const keyPrice = new BigNumber(Units.convert('0.01', 'eth', 'wei'))
+  const keyOwner = accounts[1]
+  let timestampBefore, timestampAfter
+
+  before(async () => {
+    unlock = await getProxy(unlockContract)
+    // TODO test using an ERC20 priced lock as well
+    locks = await deployLocks(unlock, accounts[0])
+    lock = locks['FIRST']
+    // Change the fee to 5%
+    await lock.updateTransferFee(500)
+    await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
+      value: keyPrice.toFixed(),
+    })
+  })
+
+  describe('reducing the time remaining for a key', () => {
+    it('should reduce the time by the amount specified', async () => {
+      let hasKey = await lock.getHasValidKey.call(keyOwner)
+      assert.equal(hasKey, true)
+      timestampBefore = new BigNumber(
+        await lock.keyExpirationTimestampFor.call(keyOwner)
+      )
+      await lock.timeMachine(keyOwner, 1000, false, {
+        from: accounts[0],
+      }) // decrease the time with "false"
+      timestampAfter = new BigNumber(
+        await lock.keyExpirationTimestampFor.call(keyOwner)
+      )
+      assert(timestampAfter.eq(timestampBefore.minus(1000)))
+    })
+
+    it('should prevent underflow & expire the key instead', async () => {})
+  })
+
+  describe('increasing the time remaining for a key', () => {
+    it('should increase the time by the amount specified', async () => {})
+    it('should prevent overflow & maximise the time remaining', async () => {})
+  })
+})

--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -1,6 +1,7 @@
 const Units = require('ethereumjs-units')
 const BigNumber = require('bignumber.js')
 
+// const TestTimeMachine = artifacts.require('TestTimeMachine')
 const deployLocks = require('../helpers/deployLocks')
 // const shouldFail = require('../helpers/shouldFail')
 
@@ -9,10 +10,12 @@ const getProxy = require('../helpers/proxy')
 
 let unlock, locks
 
-contract('Lock / transferFee', accounts => {
+contract('Lock / timeMachine', accounts => {
   let lock
   const keyPrice = new BigNumber(Units.convert('0.01', 'eth', 'wei'))
   const keyOwner = accounts[1]
+  const expirationDuration = new BigNumber(60 * 60 * 24 * 30)
+  const tooMuchTime = new BigNumber(60 * 60 * 24 * 42) // 42 days
   let timestampBefore, timestampAfter
 
   before(async () => {
@@ -20,6 +23,8 @@ contract('Lock / transferFee', accounts => {
     // TODO test using an ERC20 priced lock as well
     locks = await deployLocks(unlock, accounts[0])
     lock = locks['FIRST']
+    // testTimeMachine = await TestTimeMachine.new()
+    // lock = await TestTimeMachine.new()
     // Change the fee to 5%
     await lock.updateTransferFee(500)
     await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
@@ -27,14 +32,14 @@ contract('Lock / transferFee', accounts => {
     })
   })
 
-  describe('reducing the time remaining for a key', () => {
+  describe('modifying the time remaining for a key', () => {
     it('should reduce the time by the amount specified', async () => {
       let hasKey = await lock.getHasValidKey.call(keyOwner)
       assert.equal(hasKey, true)
       timestampBefore = new BigNumber(
         await lock.keyExpirationTimestampFor.call(keyOwner)
       )
-      await lock.timeMachine(keyOwner, 1000, false, {
+      await lock._timeMachine(keyOwner, 1000, false, {
         from: accounts[0],
       }) // decrease the time with "false"
       timestampAfter = new BigNumber(
@@ -43,11 +48,37 @@ contract('Lock / transferFee', accounts => {
       assert(timestampAfter.eq(timestampBefore.minus(1000)))
     })
 
-    it('should prevent underflow & expire the key instead', async () => {})
-  })
+    it('should increase the time by the amount specified', async () => {
+      timestampBefore = new BigNumber(
+        await lock.keyExpirationTimestampFor.call(keyOwner)
+      )
+      await lock._timeMachine(keyOwner, 42, true, {
+        from: accounts[0],
+      }) // increase the time with "true"
+      timestampAfter = new BigNumber(
+        await lock.keyExpirationTimestampFor.call(keyOwner)
+      )
+      assert(timestampAfter.eq(timestampBefore.plus(42)))
+    })
+    it('should prevent overflow & maximise the time remaining', async () => {
+      await lock._timeMachine(keyOwner, tooMuchTime, true, {
+        from: accounts[0],
+      })
+      timestampAfter = new BigNumber(
+        await lock.keyExpirationTimestampFor.call(keyOwner)
+      )
+      assert(timestampAfter.lte(expirationDuration.plus(Date.now())))
+    })
 
-  describe('increasing the time remaining for a key', () => {
-    it('should increase the time by the amount specified', async () => {})
-    it('should prevent overflow & maximise the time remaining', async () => {})
+    it('should prevent underflow & expire the key instead', async () => {
+      await lock._timeMachine(keyOwner, tooMuchTime, false, {
+        from: accounts[0],
+      })
+      timestampAfter = new BigNumber(
+        await lock.keyExpirationTimestampFor.call(keyOwner)
+      )
+      assert(timestampAfter.lte(Date.now()))
+      assert.equal(await lock.getHasValidKey.call(keyOwner), false)
+    })
   })
 })

--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -1,7 +1,7 @@
 const Units = require('ethereumjs-units')
 const BigNumber = require('bignumber.js')
 
-// const TestTimeMachine = artifacts.require('TestTimeMachine')
+// const deployMocks = require('../helpers/deployMocks')
 const deployLocks = require('../helpers/deployLocks')
 const shouldFail = require('../helpers/shouldFail')
 
@@ -21,11 +21,8 @@ contract('Lock / timeMachine', accounts => {
 
   before(async () => {
     unlock = await getProxy(unlockContract)
-    // TODO test using an ERC20 priced lock as well
     locks = await deployLocks(unlock, accounts[0])
     lock = locks['FIRST']
-    // testTimeMachine = await TestTimeMachine.new()
-    // lock = await TestTimeMachine.new()
     // Change the fee to 5%
     await lock.updateTransferFee(500)
     await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -36,53 +36,53 @@ contract('Lock / transferFee', accounts => {
       await lock.updateTransferFee(500)
     })
 
-    it('estimates the transfer fee, which is 5% of keyPrice or less', async () => {
+    it('estimates the transfer fee, which is 5% of remaining duration or less', async () => {
       const fee = new BigNumber(await lock.getTransferFee.call(keyOwner))
-      assert(fee.lte(keyPrice.times(0.05)))
+      let timestamp = new BigNumber(
+        await lock.keyExpirationTimestampFor.call(keyOwner)
+      )
+      assert(fee.lte(timestamp.minus(Date.now()).times(0.05)))
     })
 
     describe('when the key is transfered', () => {
       const newOwner = accounts[2]
 
-      it('should fail if the fee is not included', async () => {
-        await shouldFail(
-          lock.transferFrom(
-            keyOwner,
-            newOwner,
-            await lock.getTokenIdFor.call(keyOwner),
-            {
-              from: keyOwner,
-            }
-          )
-        )
-      })
+      // it.skip('should fail if the fee is not included', async () => {
+      //   await shouldFail(
+      //     lock.transferFrom(
+      //       keyOwner,
+      //       newOwner,
+      //       await lock.getTokenIdFor.call(keyOwner),
+      //       {
+      //         from: keyOwner,
+      //       }
+      //     )
+      //   )
+      // })
 
       describe('can transfer using transferFrom when the fee is paid', () => {
         let tokenId
-        let keyOwnerInitialBalance
-        let lockInitialBalance
-        let transferGasCost
-        let estimatedTransferFee
+        // let keyOwnerInitialBalance
+        // let lockInitialBalance
+        // let transferGasCost
+        // let estimatedTransferFee
 
         before(async () => {
-          keyOwnerInitialBalance = new BigNumber(
-            await web3.eth.getBalance(keyOwner)
-          )
-          lockInitialBalance = new BigNumber(
-            await web3.eth.getBalance(lock.address)
-          )
+          // keyOwnerInitialBalance = new BigNumber(
+          //   await web3.eth.getBalance(keyOwner)
+          // )
+          // lockInitialBalance = new BigNumber(
+          //   await web3.eth.getBalance(lock.address)
+          // )
           tokenId = await lock.getTokenIdFor.call(keyOwner)
-          estimatedTransferFee = await lock.getTransferFee.call(keyOwner)
+          // const tx = await lock.transferFrom(keyOwner, newOwner, tokenId, {
+          // from: keyOwner,
+          // })
 
-          const tx = await lock.transferFrom(keyOwner, newOwner, tokenId, {
-            from: keyOwner,
-            value: estimatedTransferFee,
-          })
-
-          const gasPrice = new BigNumber(
-            (await web3.eth.getTransaction(tx.tx)).gasPrice
-          )
-          transferGasCost = gasPrice.times(tx.receipt.gasUsed)
+          // const gasPrice = new BigNumber(
+          //   (await web3.eth.getTransaction(tx.tx)).gasPrice
+          // )
+          // transferGasCost = gasPrice.times(tx.receipt.gasUsed)
         })
 
         it('transfer was successful', async () => {
@@ -90,28 +90,28 @@ contract('Lock / transferFee', accounts => {
           assert.equal(owner, newOwner)
         })
 
-        it('transfer fee was paid by the keyOwner', async () => {
-          const keyOwnerBalance = new BigNumber(
-            await web3.eth.getBalance(keyOwner)
-          )
-          assert.equal(
-            keyOwnerBalance.toFixed(),
-            keyOwnerInitialBalance
-              .minus(transferGasCost)
-              .minus(estimatedTransferFee)
-              .toFixed()
-          )
-        })
+        // it.skip('transfer fee was paid by the keyOwner', async () => {
+        //   const keyOwnerBalance = new BigNumber(
+        //     await web3.eth.getBalance(keyOwner)
+        //   )
+        //   assert.equal(
+        //     keyOwnerBalance.toFixed(),
+        //     keyOwnerInitialBalance
+        //       .minus(transferGasCost)
+        //       .minus(estimatedTransferFee)
+        //       .toFixed()
+        //   )
+        // })
 
-        it('transfer fee was received by the contract', async () => {
-          const lockBalance = new BigNumber(
-            await web3.eth.getBalance(lock.address)
-          )
-          assert.equal(
-            lockBalance.toFixed(),
-            lockInitialBalance.plus(estimatedTransferFee).toFixed()
-          )
-        })
+        // it.skip('transfer fee was received by the contract', async () => {
+        //   const lockBalance = new BigNumber(
+        //     await web3.eth.getBalance(lock.address)
+        //   )
+        //   assert.equal(
+        //     lockBalance.toFixed(),
+        //     lockInitialBalance.plus(estimatedTransferFee).toFixed()
+        //   )
+        // })
 
         after(async () => {
           // Reset owners

--- a/smart-contracts/test/helpers/deployMocks.js
+++ b/smart-contracts/test/helpers/deployMocks.js
@@ -1,0 +1,38 @@
+// const PublicLock = artifacts.require('./PublicLock.sol')
+const TimeMachineMock = artifacts.require('TimeMachineMock')
+const Web3Utils = require('web3-utils')
+const Locks = require('../fixtures/locks')
+
+let saltCounter = 100
+
+module.exports = function deployMocks(
+  unlock,
+  from,
+  tokenAddress = Web3Utils.padLeft(0, 40)
+) {
+  let locks = {}
+  return Promise.all(
+    Object.keys(Locks).map(name => {
+      return unlock
+        .createLock(
+          Locks[name].expirationDuration.toFixed(),
+          tokenAddress,
+          Locks[name].keyPrice.toFixed(),
+          Locks[name].maxNumberOfKeys.toFixed(),
+          Locks[name].lockName,
+          // This ensures that the salt is unique even if we deploy locks multiple times
+          `0x${(saltCounter++).toString(16)}`,
+          { from }
+        )
+        .then(tx => {
+          const evt = tx.logs.find(v => v.event === 'NewLock')
+          return TimeMachineMock.at(evt.args.newLockAddress).then(address => {
+            locks[name] = address
+            locks[name].params = Locks[name]
+          })
+        })
+    })
+  ).then(() => {
+    return locks
+  })
+}


### PR DESCRIPTION
# Description
The idea here is to add a simple function capable of increasing or decreasing the `expirationTimestamp` for a given key by a given amount. This could be used for taking a time-based fee from a key, as well as in partial transfers to reduce the original keys time, and increase the new keys time.(this last use case is maybe not needed, and this could be simplified to only reduce time from a key).
- I've made it public for ease of testing, but it should be made internal.
- access control should be handled by the function which calls `timeMachine`
- tests are not complete, I just want to get another opinion on this approach.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
