### PR TITLE
Return managed key purchase transaction hash from locksmith

### DIFF
--- a/locksmith/__tests__/controllers/purchaseController.test.ts
+++ b/locksmith/__tests__/controllers/purchaseController.test.ts
@@ -16,7 +16,7 @@ let privateKey = ethJsUtil.toBuffer(
 )
 let mockPaymentProcessor = {
   chargeUser: jest.fn().mockResolvedValue('true'),
-  initiatePurchase: jest.fn().mockResolvedValue('true'),
+  initiatePurchase: jest.fn().mockResolvedValue('this is a transaction hash'),
 }
 
 function generateTypedData(message: any) {
@@ -86,8 +86,8 @@ describe('Purchase Controller', () => {
         data: typedData,
       })
 
-      it('responds with a 202', async () => {
-        expect.assertions(2)
+      it('responds with a 200 and transaction hash', async () => {
+        expect.assertions(3)
 
         let response = await request(app)
           .post('/purchase')
@@ -95,7 +95,10 @@ describe('Purchase Controller', () => {
           .set('Authorization', `Bearer ${Base64.encode(sig)}`)
           .send(typedData)
 
-        expect(response.status).toBe(202)
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({
+          transactionHash: 'this is a transaction hash',
+        })
         expect(mockPaymentProcessor.initiatePurchase).toHaveBeenCalled()
       })
     })

--- a/locksmith/src/controllers/purchaseController.ts
+++ b/locksmith/src/controllers/purchaseController.ts
@@ -27,7 +27,7 @@ namespace PurchaseController {
         config.unlockContractAddress
       )
 
-      await paymentProcessor.initiatePurchase(
+      const hash = await paymentProcessor.initiatePurchase(
         purchaser,
         lock,
         config.purchaserCredentails,
@@ -35,7 +35,9 @@ namespace PurchaseController {
         purchaser
       )
 
-      return res.sendStatus(202)
+      return res.send({
+        transactionHash: hash,
+      })
     }
   }
 

--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -45,26 +45,31 @@ export default class Dispatcher {
       throw new Error('No Available Keys.')
     }
 
-    walletService.on(
-      'transaction.new',
-      async (
-        transactionHash: string,
-        sender: string,
-        recipient: string,
-        data: string
-      ) => {
-        await findOrCreateTransaction({
-          transactionHash: transactionHash,
-          sender: sender,
-          recipient: recipient,
-          chain: walletService.networkId,
-          for: this.buyer,
-          data: data,
-        })
-      }
-    )
+    const txHashPromise = new Promise(resolve => {
+      walletService.on(
+        'transaction.new',
+        async (
+          transactionHash: string,
+          sender: string,
+          recipient: string,
+          data: string
+        ) => {
+          await findOrCreateTransaction({
+            transactionHash: transactionHash,
+            sender: sender,
+            recipient: recipient,
+            chain: walletService.networkId,
+            for: this.buyer,
+            data: data,
+          })
+
+          resolve(transactionHash)
+        }
+      )
+    })
 
     await walletService.connect(this.provider)
     await walletService.purchaseKey(lockAddress, recipient, '0', this.buyer)
+    return txHashPromise
   }
 }

--- a/locksmith/src/payment/paymentProcessor.ts
+++ b/locksmith/src/payment/paymentProcessor.ts
@@ -118,7 +118,7 @@ export class PaymentProcessor {
         buyer
       )
 
-      await fulfillmentDispatcher.purchase(lock, recipient)
+      return fulfillmentDispatcher.purchase(lock, recipient)
     }
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR updates the managed key purchase path on locksmith to ultimately resolve with the transaction hash for the key purchase, which we'll be able to use on the paywall to keep track of new purchases.

@akeem would definitely appreciate any critique you may have on this

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Refs #5152 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
