### PR TITLE
Remove default gas price for external refund

### DIFF
--- a/unlock-app/src/__tests__/components/interface/RefundButton.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/RefundButton.test.tsx
@@ -44,7 +44,6 @@ describe('RefundButton', () => {
 
     expect(refundFunction).toHaveBeenCalledWith('0xdeadbeef', {
       gasLimit: 600000,
-      gasPrice: 20000000000,
     })
 
     // Button text changes after click

--- a/unlock-app/src/components/interface/RefundButton.tsx
+++ b/unlock-app/src/components/interface/RefundButton.tsx
@@ -53,7 +53,6 @@ export class RefundButton extends React.Component<
     // We override the gas price and gas limit here because web3
     // wallets would error when they automatically calculated the values.
     await this.contract.refund(accountAddress, {
-      gasPrice: 20000000000,
       gasLimit: 600000,
     })
   }

--- a/unlock-app/src/components/interface/RefundButton.tsx
+++ b/unlock-app/src/components/interface/RefundButton.tsx
@@ -50,8 +50,8 @@ export class RefundButton extends React.Component<
     this.setState({
       refundInitiated: true,
     })
-    // We override the gas price and gas limit here because web3
-    // wallets would error when they automatically calculated the values.
+    // We override the gas limit here because web3 wallets would error when they
+    //automatically calculated the value.
     await this.contract.refund(accountAddress, {
       gasLimit: 600000,
     })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR removes the default gas price in our interaction with the refund contract so that we can refund people cheaply. We'll have to be careful testing this, the error the defaults fixed only showed up in staging before. The hope is that simply setting the gas limit without the price will still prevent the error.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
