### PR TITLE
Less strict node engine requirement for unlock-js

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-# Next (patch)
+# 0.4.1
 - Adding a "latest" export which returns the latest supported lock version
 - Loosening the required node version to anything compatible with v10
 

--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Next (patch)
 - Adding a "latest" export which returns the latest supported lock version
+- Loosening the required node version to anything compatible with v10
 
 ## 0.4.0
 - Only approving if the approved amount is lower than the required price

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -32,7 +32,7 @@
     }
   },
   "engines": {
-    "node": "10.16.3"
+    "node": "^10"
   },
   "devDependencies": {
     "@babel/cli": "7.6.0",


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR loosens the engines requirement in unlock-js, which should allow it to be installed from any v10 of node, not just exactly 10.16.3. This won't change anything until the next release of unlock-js is published.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5166 (after unlock-js is published)
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
