### PR TITLE
let's wait for newly deployed locks to be confirming rather than submitted

### DIFF
--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -78,10 +78,11 @@ describe('The Unlock Dashboard', () => {
         return !existingLocks.includes(lock)
       })
 
+      // Let's wait for the lock to at least be not "Submitted" anymore
       await wait.untilIsTrue(address => {
         return !!document
           .querySelector(`[data-address="${address}"]`)
-          .innerText.match(/Confirming|Submitted/)
+          .innerText.match(/Confirming/)
       }, newLock)
 
       // Get the locks' innerText


### PR DESCRIPTION
# Description

When the lock is "confirming", all of its data should have been loaded.
This should help with #5182 and #5195

# Issues

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->