### PR TITLE
Deploy the unlock-subgraph locally as part of the development container stand up

### DIFF
--- a/docker/development/deploy-subgraph.js
+++ b/docker/development/deploy-subgraph.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+const net = require('net')
+const { execSync } = require('child_process')
+
+let graphHost = 'graph-node'
+let graphPort = '8020'
+let subgraph = 'unlock-protocol/unlock'
+let ipfsHost = 'ipfs'
+
+let creationCommand = `npx graph create --node http://${graphHost}:${graphPort}/ ${subgraph}`
+let deploymentCommand = `npx graph deploy --node http://${graphHost}:${graphPort}/ --ipfs http://${ipfsHost}:5001 ${subgraph}`
+
+const serverIsUp = (delay, maxAttempts) =>
+  new Promise((resolve, reject) => {
+    let attempts = 1
+    const tryConnecting = () => {
+      const socket = net.connect(graphPort, graphHost, () => {
+        resolve()
+        return socket.end() // clean-up
+      })
+
+      socket.on('error', error => {
+        if (error.code === 'ECONNREFUSED') {
+          if (attempts < maxAttempts) {
+            attempts += 1
+            return setTimeout(tryConnecting, delay)
+          }
+          return reject(error)
+        }
+        return reject(error)
+      })
+    }
+    tryConnecting()
+  })
+
+serverIsUp(1000 /* every second */, 120 /* up to 2 minutes */)
+  .then(() => {
+    let createOutput = execSync(creationCommand)
+    console.log(createOutput.toString())
+    let deployOutput = execSync(deploymentCommand)
+    console.log(deployOutput.toString())
+  })
+  .catch(error => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/docker/development/subgraph.dockerfile
+++ b/docker/development/subgraph.dockerfile
@@ -1,0 +1,22 @@
+FROM node:10.17.0-alpine
+LABEL Graph Protocol Subgraph <ops@unlock-protocol.com>
+LABEL maintainer="ops@unlock-protocol.com"
+
+RUN apk add --no-cache git openssh libsecret-dev
+RUN apk add --no-cache \
+    python \
+    python-dev \
+    py-pip \
+    build-base \
+    && pip install virtualenv
+
+RUN npm install -g npm@6.4.1
+RUN git clone https://github.com/unlock-protocol/unlock-subgraph.git
+WORKDIR /unlock-subgraph
+RUN git checkout local_dev
+
+COPY --chown=node ./deploy-subgraph.js /unlock-subgraph/.
+
+RUN npm ci
+RUN npm run codegen
+RUN npm run build

--- a/docker/docker-compose.development.yml
+++ b/docker/docker-compose.development.yml
@@ -82,3 +82,10 @@ services:
       PURCHASER_CREDENTIALS: '0x08491b7e20566b728ce21a07c88b12ed8b785b3826df93a7baceb21ddacf8b61'
     depends_on:
       - postgres
+  subgraph_deployment:
+    build:
+      context: ./development
+      dockerfile: subgraph.dockerfile
+    command: ["node", "./deploy-subgraph.js"]   
+    depends_on:
+      - graph-node


### PR DESCRIPTION
# Description

Partially by request and as a component of setting up an aggregation GraphQL service, making it easier to query the datastore locally.

For the end developer everything will work ask expected when running the image. 
In a subsequent pass we can begin to trim the fat on the development environment stand up. 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
