### PR TITLE
Add query to get all keys for a given lock

### DIFF
--- a/unlock-app/src/queries/keyholdersByLock.js
+++ b/unlock-app/src/queries/keyholdersByLock.js
@@ -1,0 +1,18 @@
+import { gql } from 'apollo-boost'
+
+export default function keyholdersByLockQuery() {
+  return gql`
+    query Lock($address: String!) {
+      locks(where: { address: $address }) {
+        keys {
+          owner {
+            address
+          }
+          keyId
+          expiration
+        }
+        name
+      }
+    }
+  `
+}

--- a/unlock-app/src/queries/keyholdersByLock.js
+++ b/unlock-app/src/queries/keyholdersByLock.js
@@ -2,8 +2,8 @@ import { gql } from 'apollo-boost'
 
 export default function keyholdersByLockQuery() {
   return gql`
-    query Lock($address: String!) {
-      locks(where: { address: $address }) {
+    query Lock($addresses: [String!]) {
+      locks(where: { address_in: $addresses }) {
         keys {
           owner {
             address


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

For #5209, we need to get the list of keys sold on a given lock. This PR adds a query against the graph which fetches them, and includes a number of helpful fields.

We'll get the lock name, all the keyholders, and each of the keyholders will include the address of the keyholder, the expiration date, and the `keyId` (which we'll need when we query `locksmith` to get the other metadata).

This query alone is essentially enough to get us to MVP stage, since we will be able to display the 3 pieces of metadata that are always present.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
