### PR TITLE
WalletMiddleware responds to request for metadata signature

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -705,7 +705,7 @@ describe('Wallet middleware', () => {
       invoke(action)
 
       expect(mockWalletService.signData).toHaveBeenCalledWith(
-        action.address,
+        action.owner,
         expectedTypedData,
         expect.any(Function)
       )

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -29,6 +29,11 @@ import { hideForm } from '../actions/lockFormVisibility'
 import { transactionTypeMapping } from '../utils/types' // TODO change POLLING_INTERVAL into ACCOUNT_POLLING_INTERVAL
 import { getStoredPaymentDetails } from '../actions/user'
 import { SIGN_DATA, signedData } from '../actions/signature'
+import {
+  SIGN_METADATA_REQUEST,
+  signMetadataResponse,
+} from '../actions/keyMetadata'
+import generateKeyTypedData from '../structured_data/keyMetadataTypedData'
 
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
@@ -225,6 +230,30 @@ const walletMiddleware = config => {
               }
             }
           )
+        } else if (action.type === SIGN_METADATA_REQUEST) {
+          const { address, owner, timestamp } = action
+          // Usage from locksmith tests for metadataController
+          const typedData = generateKeyTypedData({
+            LockMetaData: {
+              address,
+              owner,
+              timestamp,
+            },
+          })
+
+          walletService.signData(address, typedData, (error, signature) => {
+            if (error) {
+              dispatch(
+                setError(
+                  Wallet.Warning(
+                    'Could not sign typed data for metadata request.'
+                  )
+                )
+              )
+            } else {
+              dispatch(signMetadataResponse(typedData, signature))
+            }
+          })
         }
 
         next(action)

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -241,7 +241,7 @@ const walletMiddleware = config => {
             },
           })
 
-          walletService.signData(address, typedData, (error, signature) => {
+          walletService.signData(owner, typedData, (error, signature) => {
             if (error) {
               dispatch(
                 setError(

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -231,11 +231,12 @@ const walletMiddleware = config => {
             }
           )
         } else if (action.type === SIGN_METADATA_REQUEST) {
-          const { address, owner, timestamp } = action
+          const { address: lockAddress, owner, timestamp } = action
           // Usage from locksmith tests for metadataController
           const typedData = generateKeyTypedData({
             LockMetaData: {
-              address,
+              // used alias to indicate that the `address` field is a lock address.
+              address: lockAddress,
               owner,
               timestamp,
             },


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Next step on getting all key metadata, now walletMiddleware responds to requests for the necessary signature.

@akeem would appreciate your verifying that I have done the typed data correctly as per https://github.com/unlock-protocol/unlock/blob/19c2a51a4bcc1abf132bd77b830be4d3ad7f5b9e/locksmith/__tests__/controllers/metadataController.test.ts#L222

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
