### PR TITLE
fixing size of the modal on the paywall

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -2164,6 +2164,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -2171,6 +2172,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -2278,11 +2280,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -2292,7 +2296,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2311,6 +2314,18 @@ Object {
   .c15 {
     height: 16px;
     width: 16px;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -2422,7 +2437,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -2460,10 +2475,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -2633,6 +2648,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -2640,6 +2656,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -2747,11 +2764,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -2761,7 +2780,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2780,6 +2798,18 @@ Object {
   .c15 {
     height: 16px;
     width: 16px;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -2961,7 +2991,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -2999,10 +3029,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -3037,7 +3067,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x456"
         >
           <header
@@ -3072,7 +3102,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x789"
         >
           <header
@@ -3224,6 +3254,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -3231,6 +3262,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c8 {
@@ -3347,6 +3379,7 @@ Object {
 .c14 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -3354,6 +3387,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -3461,11 +3495,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -3475,7 +3511,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3494,6 +3529,18 @@ Object {
   .c21 {
     height: 16px;
     width: 16px;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -3676,7 +3723,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -3711,10 +3758,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -3753,7 +3800,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x456"
         >
           <header
@@ -3788,7 +3835,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x789"
         >
           <header
@@ -3940,6 +3987,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -3947,6 +3995,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c8 {
@@ -4063,6 +4112,7 @@ Object {
 .c14 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -4070,6 +4120,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -4177,11 +4228,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -4191,7 +4244,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4210,6 +4262,18 @@ Object {
   .c21 {
     height: 16px;
     width: 16px;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -4388,7 +4452,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -4423,10 +4487,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -4461,7 +4525,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x456"
         >
           <header
@@ -4496,7 +4560,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x789"
         >
           <header
@@ -4648,6 +4712,7 @@ Object {
 .c14 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -4655,6 +4720,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c8 {
@@ -4771,6 +4837,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -4778,6 +4845,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -4885,11 +4953,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -4899,7 +4969,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4918,6 +4987,18 @@ Object {
   .c21 {
     height: 16px;
     width: 16px;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -5096,7 +5177,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -5131,10 +5212,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -5169,7 +5250,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x456"
         >
           <header
@@ -5204,7 +5285,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x789"
         >
           <header
@@ -5382,6 +5463,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -5389,6 +5471,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c8 {
@@ -5570,6 +5653,7 @@ Object {
 .c24 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -5577,6 +5661,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: not-allowed;
 }
 
@@ -5680,11 +5765,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -5694,7 +5781,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5735,6 +5821,18 @@ Object {
 
   .c9 .c17 {
     display: block;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -5984,7 +6082,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -6019,10 +6117,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -6091,7 +6189,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x456"
         >
           <header
@@ -6160,7 +6258,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 ccttpN lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 gwwDnY lock"
           data-address="0x789"
           disabled=""
         >
@@ -6341,6 +6439,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -6348,6 +6447,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c8 {
@@ -6529,6 +6629,7 @@ Object {
 .c24 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -6536,6 +6637,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: not-allowed;
 }
 
@@ -6639,11 +6741,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -6653,7 +6757,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -6694,6 +6797,18 @@ Object {
 
   .c9 .c17 {
     display: block;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -6908,7 +7023,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -6943,10 +7058,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -7015,7 +7130,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 ccttpN lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 gwwDnY lock"
           data-address="0x456"
           disabled=""
         >
@@ -7051,7 +7166,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 ccttpN lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 gwwDnY lock"
           data-address="0x789"
           disabled=""
         >
@@ -7230,6 +7345,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -7237,6 +7353,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c8 {
@@ -7418,6 +7535,7 @@ Object {
 .c24 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -7425,6 +7543,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: not-allowed;
 }
 
@@ -7528,11 +7647,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -7542,7 +7663,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7583,6 +7703,18 @@ Object {
 
   .c9 .c17 {
     display: block;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -7830,7 +7962,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -7865,10 +7997,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -7937,7 +8069,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x456"
         >
           <header
@@ -8004,7 +8136,7 @@ Object {
           </div>
         </li>
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 ccttpN lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 gwwDnY lock"
           data-address="0x789"
           disabled=""
         >
@@ -8159,6 +8291,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -8166,6 +8299,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c8 {
@@ -8274,11 +8408,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -8288,7 +8424,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8307,6 +8442,18 @@ Object {
   .c12 {
     height: 16px;
     width: 16px;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -8397,7 +8544,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -8432,10 +8579,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address=""
         >
           <header
@@ -8569,6 +8716,7 @@ Object {
 .c7 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -8576,6 +8724,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c8 {
@@ -8684,11 +8833,13 @@ Object {
   list-style: none;
   margin: 0px;
   padding: 0px;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit,minmax(186px,200px));
+  grid-gap: 20px;
 }
 
 .c2 {
@@ -8698,7 +8849,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8717,6 +8867,18 @@ Object {
   .c12 {
     height: 16px;
     width: 16px;
+  }
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
   }
 }
 
@@ -8810,7 +8972,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -8848,10 +9010,10 @@ Object {
         </p>
       </header>
       <ul
-        class="sc-htoDjs ekOEwM"
+        class="sc-htoDjs eEkLwz"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address=""
         >
           <header
@@ -8978,7 +9140,6 @@ Object {
 }
 
 .c1 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -9165,6 +9326,18 @@ Object {
 .c0 > * {
   max-height: 100%;
   overflow-y: scroll;
+}
+
+@media only screen and (min-width:736px) {
+  .c1 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c1 {
+    width: 100%;
+  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -10746,7 +10919,7 @@ Object {
       class="sc-hSdWYo rRMtl"
     >
       <section
-        class="sc-iwsKbI gtsSOj"
+        class="sc-iwsKbI bXpKnQ"
       >
         <a
           class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -12387,7 +12560,6 @@ Object {
 }
 
 .c1 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -12574,6 +12746,18 @@ Object {
 .c0 > * {
   max-height: 100%;
   overflow-y: scroll;
+}
+
+@media only screen and (min-width:736px) {
+  .c1 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c1 {
+    width: 100%;
+  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -14155,7 +14339,7 @@ Object {
       class="sc-hSdWYo rRMtl"
     >
       <section
-        class="sc-iwsKbI gtsSOj"
+        class="sc-iwsKbI bXpKnQ"
       >
         <a
           class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -15796,7 +15980,6 @@ Object {
 }
 
 .c1 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -15983,6 +16166,18 @@ Object {
 .c0 > * {
   max-height: 100%;
   overflow-y: scroll;
+}
+
+@media only screen and (min-width:736px) {
+  .c1 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c1 {
+    width: 100%;
+  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -17564,7 +17759,7 @@ Object {
       class="sc-hSdWYo rRMtl"
     >
       <section
-        class="sc-iwsKbI gtsSOj"
+        class="sc-iwsKbI bXpKnQ"
       >
         <a
           class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -19201,6 +19396,7 @@ Object {
 .c8 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -19208,6 +19404,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c10 {
@@ -19328,7 +19525,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -19354,7 +19550,7 @@ Object {
   outline: none;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
-  width: 280px;
+  width: 100%;
   height: 60px;
 }
 
@@ -19453,6 +19649,18 @@ Object {
 .c6 > div > p {
   margin-top: 0;
   font-size: 20px;
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
+  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -19613,7 +19821,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -19651,7 +19859,7 @@ Object {
         class="sc-chPdSV cmNFso"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x456"
         >
           <header
@@ -19697,7 +19905,7 @@ Object {
             You'll see the status of your order on the left.
           </p>
           <button
-            class="sc-gZMcBi sc-gqjmRU jJKIqv"
+            class="sc-gZMcBi sc-gqjmRU fRdfpf"
           >
             Continue
           </button>
@@ -19809,6 +20017,7 @@ Object {
 .c8 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -19816,6 +20025,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c10 {
@@ -19936,7 +20146,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -19962,7 +20171,7 @@ Object {
   outline: none;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
-  width: 280px;
+  width: 100%;
   height: 60px;
 }
 
@@ -20061,6 +20270,18 @@ Object {
 .c6 > div > p {
   margin-top: 0;
   font-size: 20px;
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
+  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -20217,7 +20438,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -20255,7 +20476,7 @@ Object {
         class="sc-chPdSV cmNFso"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x456"
         >
           <header
@@ -20297,7 +20518,7 @@ Object {
             You'll see the status of your order on the left.
           </p>
           <button
-            class="sc-gZMcBi sc-gqjmRU jJKIqv"
+            class="sc-gZMcBi sc-gqjmRU fRdfpf"
           >
             Continue
           </button>
@@ -20409,6 +20630,7 @@ Object {
 .c8 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -20416,6 +20638,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c10 {
@@ -20536,7 +20759,6 @@ Object {
 }
 
 .c0 {
-  max-width: 800px;
   padding: 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -20562,7 +20784,7 @@ Object {
   outline: none;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
-  width: 280px;
+  width: 100%;
   height: 60px;
 }
 
@@ -20661,6 +20883,18 @@ Object {
 .c6 > div > p {
   margin-top: 0;
   font-size: 20px;
+}
+
+@media only screen and (min-width:736px) {
+  .c0 {
+    width: 600px;
+  }
+}
+
+@media only screen and (min-width:257px) and (max-width:736px) {
+  .c0 {
+    width: 100%;
+  }
 }
 
 @media only screen and (min-width:257px) and (max-width:736px) {
@@ -20817,7 +21051,7 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-iwsKbI gtsSOj"
+      class="sc-iwsKbI bXpKnQ"
     >
       <a
         class="is925m-0 bYsUmJ sc-dnqmqq hlAVVM closeButton"
@@ -20855,7 +21089,7 @@ Object {
         class="sc-chPdSV cmNFso"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x456"
         >
           <header
@@ -20897,7 +21131,7 @@ Object {
             You'll see the status of your order on the left.
           </p>
           <button
-            class="sc-gZMcBi sc-gqjmRU jJKIqv"
+            class="sc-gZMcBi sc-gqjmRU fRdfpf"
           >
             Continue
           </button>
@@ -23915,6 +24149,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -23922,6 +24157,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: not-allowed;
 }
 
@@ -24058,7 +24294,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 ccttpN lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 gwwDnY lock"
           data-address="0x123"
           disabled=""
         >
@@ -24177,6 +24413,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -24184,6 +24421,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: not-allowed;
 }
 
@@ -24320,7 +24558,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 ccttpN lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 gwwDnY lock"
           data-address="0x123"
           disabled=""
         >
@@ -24439,6 +24677,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -24446,6 +24685,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: not-allowed;
 }
 
@@ -24582,7 +24822,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 ccttpN lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 gwwDnY lock"
           data-address="0x123"
           disabled=""
         >
@@ -24701,6 +24941,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -24708,6 +24949,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: not-allowed;
 }
 
@@ -24844,7 +25086,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 ccttpN lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 gwwDnY lock"
           data-address="0x123"
           disabled=""
         >
@@ -24963,6 +25205,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -24970,6 +25213,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -25107,7 +25351,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -25223,6 +25467,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -25230,6 +25475,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -25367,7 +25613,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -25465,6 +25711,7 @@ Object {
     .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -25472,6 +25719,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c3 {
@@ -25659,7 +25907,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -25832,6 +26080,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -25839,6 +26088,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c3 {
@@ -26143,7 +26393,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -26275,6 +26525,7 @@ Object {
     .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -26282,6 +26533,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c3 {
@@ -26469,7 +26721,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -26642,6 +26894,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -26649,6 +26902,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c3 {
@@ -26953,7 +27207,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -27085,6 +27339,7 @@ Object {
     .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -27092,6 +27347,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c3 {
@@ -27275,7 +27531,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -27373,6 +27629,7 @@ Object {
     .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -27380,6 +27637,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 }
 
 .c3 {
@@ -27563,7 +27821,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 uyDPU lock"
+          class="sc-1549ebs-0 dNfSih lock"
           data-address="0x123"
         >
           <header
@@ -27679,6 +27937,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -27686,6 +27945,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -27823,7 +28083,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -27939,6 +28199,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -27946,6 +28207,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -28083,7 +28345,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -28199,6 +28461,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -28206,6 +28469,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -28343,7 +28607,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -28459,6 +28723,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -28466,6 +28731,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -28603,7 +28869,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -28719,6 +28985,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -28726,6 +28993,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -28863,7 +29131,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header
@@ -28979,6 +29247,7 @@ Object {
 .c1 {
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans','Helvetica Neue',Arial,sans-serif;
@@ -28986,6 +29255,7 @@ Object {
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
   cursor: pointer;
 }
 
@@ -29123,7 +29393,7 @@ Object {
         style="height: 200px; display: grid;"
       >
         <li
-          class="sc-1549ebs-0 sc-5sgq84-0 gdICwj lock"
+          class="sc-1549ebs-0 sc-5sgq84-0 dicuUm lock"
           data-address="0x123"
         >
           <header

--- a/paywall/src/components/checkout/Checkout.tsx
+++ b/paywall/src/components/checkout/Checkout.tsx
@@ -155,6 +155,8 @@ const CheckoutLocks = styled.ul`
   list-style: none;
   margin: 0px;
   padding: 0px;
-  justify-content: space-around;
+  justify-content: center;
+  justify-items: center;
   grid-template-columns: repeat(auto-fit, minmax(186px, 200px));
+  grid-gap: 20px;
 `

--- a/paywall/src/components/checkout/CheckoutConfirmingModal.tsx
+++ b/paywall/src/components/checkout/CheckoutConfirmingModal.tsx
@@ -60,7 +60,7 @@ export const CheckoutConfirmingModal = ({
 export default CheckoutConfirmingModal
 
 const Continue = styled(ActionButton)`
-  width: 280px;
+  width: 100%;
   height: 60px;
   ${Media.phone`
     width: 100%;

--- a/paywall/src/components/checkout/CheckoutWrapper.tsx
+++ b/paywall/src/components/checkout/CheckoutWrapper.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import Close from '../interface/buttons/layout/Close'
+import Media from '../../theme/media'
 
 interface WrapperProps {
   children: any
@@ -48,7 +49,6 @@ const CloseButton = styled(Close).attrs(() => ({
 `
 
 const Wrapper = styled.section`
-  max-width: 800px;
   padding: 10px 40px;
   display: flex;
   flex-direction: column;
@@ -56,4 +56,10 @@ const Wrapper = styled.section`
   color: var(--darkgrey);
   border-radius: 4px;
   position: relative;
+  ${Media.nophone`
+    width: 600px;
+  `}
+  ${Media.phone`
+    width: 100%;
+  `}
 `

--- a/paywall/src/components/lock/LockStyles.js
+++ b/paywall/src/components/lock/LockStyles.js
@@ -7,6 +7,7 @@ export const LockWrapper = styled.li.attrs(props => ({
 }))`
   display: grid;
   justify-items: stretch;
+  justify-self: center;
   margin: 0px;
   padding: 0px;
   font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
@@ -14,6 +15,7 @@ export const LockWrapper = styled.li.attrs(props => ({
   grid-gap: 8px;
   background-clip: padding-box;
   grid-template-rows: 1fr 140px;
+  margin: auto;
 `
 
 export const LockHeader = styled.header`


### PR DESCRIPTION
# Description

This is a first step to make sure it stops being all over the place in terms of sizes.
With the current size, on desktop it will show at most 2 locks side by side on each line.
On mobile, it will always be 100% of the width of the screen.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->