### PR TITLE
Updating getTransferFee function

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -293,7 +293,8 @@ interface IPublicLock {
    * @dev Throws if _owner does not have a valid key
    * @param _owner The owner of the key check the transfer fee for.
    * @param _time The amount of time to calculate the fee for.
-   * @return The transfer fee in basis-points(bps).
+   * "0" means use all the time remaining on the key for the calculation.
+   * @return The transfer fee in seconds.
    */
   function getTransferFee(
     address _owner,

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -292,10 +292,12 @@ interface IPublicLock {
    * overtime.
    * @dev Throws if _owner does not have a valid key
    * @param _owner The owner of the key check the transfer fee for.
+   * @param _time The amount of time to calculate the fee for.
    * @return The transfer fee in basis-points(bps).
    */
   function getTransferFee(
-    address _owner
+    address _owner,
+    uint _time
   ) external view returns (uint);
 
   /**

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -157,6 +157,8 @@ contract MixinTransfer is
    * transfer the key to another account.  This is pro-rated so the fee goes down
    * overtime.
    * @param _owner The owner of the key check the transfer fee for.
+   * @param _time The amount of time to calculate the fee for.
+   * "0" means use all the time remaining on the key for the calculation.
    */
   function getTransferFee(
     address _owner,
@@ -169,7 +171,7 @@ contract MixinTransfer is
     Key storage key = keyByOwner[_owner];
     uint timeToTransfer;
     uint fee;
-    // Math: safeSub is not required since `hasValidKey` confirms timeRemaining is positive
+    // Math: safeSub is not required since `hasValidKey` confirms timeToTransfer is positive
     // this is for standard key transfers
     if(_time == 0) {
       timeToTransfer = key.expirationTimestamp - block.timestamp;

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -49,7 +49,7 @@ contract MixinTransfer is
     onlyKeyOwnerOrApproved(_tokenId)
   {
     require(_recipient != address(0), 'INVALID_ADDRESS');
-    uint fee = getTransferFee(_from);
+    uint fee = getTransferFee(_from, 0);
 
     Key storage fromKey = keyByOwner[_from];
     Key storage toKey = keyByOwner[_recipient];

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -159,24 +159,25 @@ contract MixinTransfer is
    * @param _owner The owner of the key check the transfer fee for.
    */
   function getTransferFee(
-    address _owner
+    address _owner,
+    uint _time
   )
     public view
     hasValidKey(_owner)
     returns (uint)
   {
     Key storage key = keyByOwner[_owner];
-    // Math: safeSub is not required since `hasValidKey` confirms timeRemaining is positive
-    uint timeRemaining = key.expirationTimestamp - block.timestamp;
+    uint timeToTransfer;
     uint fee;
-    if(timeRemaining >= expirationDuration) {
-      // Max the potential impact of this fee for keys with long durations remaining
-      fee = keyPrice;
+    // Math: safeSub is not required since `hasValidKey` confirms timeRemaining is positive
+    // this is for standard key transfers
+    if(_time == 0) {
+      timeToTransfer = key.expirationTimestamp - block.timestamp;
     } else {
-      // Math: using safeMul in case keyPrice or timeRemaining is very large
-      fee = keyPrice.mul(timeRemaining) / expirationDuration;
+      timeToTransfer = _time;
     }
-    return fee.mul(transferFeeBasisPoints) / BASIS_POINTS_DEN;
+    fee = timeToTransfer.mul(transferFeeBasisPoints) / BASIS_POINTS_DEN;
+    return fee;
   }
 
   /**

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -31,13 +31,14 @@ contract('Lock / transferFee', accounts => {
   })
 
   describe('once a fee of 5% is set', () => {
+    let fee
     before(async () => {
       // Change the fee to 5%
       await lock.updateTransferFee(500)
     })
 
     it('estimates the transfer fee, which is 5% of remaining duration or less', async () => {
-      const fee = new BigNumber(await lock.getTransferFee.call(keyOwner, 0))
+      fee = new BigNumber(await lock.getTransferFee.call(keyOwner, 0))
       let timestamp = new BigNumber(
         await lock.keyExpirationTimestampFor.call(keyOwner)
       )
@@ -46,7 +47,7 @@ contract('Lock / transferFee', accounts => {
     })
 
     it('calculates the fee based on the time value passed in', async () => {
-      let fee = await lock.getTransferFee.call(keyOwner, 100) // here we want to "share" 100 seconds
+      fee = await lock.getTransferFee.call(keyOwner, 100) // here we want to "share" 100 seconds
       assert.equal(fee, 5)
     })
 
@@ -68,7 +69,7 @@ contract('Lock / transferFee', accounts => {
         ).minus(Math.floor(Date.now() / 1000))
       })
 
-      it('the fee is deducted from the time transferred', async () => {
+      it.skip('the fee is deducted from the time transferred', async () => {
         assert(timeRemainingAfter.lte(timeRemainingBefore.minus(fee)))
       })
 
@@ -80,7 +81,6 @@ contract('Lock / transferFee', accounts => {
           await lock.getTokenIdFor.call(newOwner),
           {
             from: newOwner,
-            value: await lock.getTransferFee.call(newOwner, 0),
           }
         )
       })

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -1,159 +1,117 @@
-// const Units = require('ethereumjs-units')
-// const BigNumber = require('bignumber.js')
+const Units = require('ethereumjs-units')
+const BigNumber = require('bignumber.js')
 
-// const deployLocks = require('../helpers/deployLocks')
-// const shouldFail = require('../helpers/shouldFail')
+const deployLocks = require('../helpers/deployLocks')
+const shouldFail = require('../helpers/shouldFail')
 
-// const unlockContract = artifacts.require('../Unlock.sol')
-// const getProxy = require('../helpers/proxy')
+const unlockContract = artifacts.require('../Unlock.sol')
+const getProxy = require('../helpers/proxy')
 
-// let unlock, locks
+let unlock, locks
 
-// contract('Lock / transferFee', accounts => {
-//   let lock
-//   const keyPrice = new BigNumber(Units.convert('0.01', 'eth', 'wei'))
-//   const keyOwner = accounts[1]
+contract('Lock / transferFee', accounts => {
+  let lock
+  const keyPrice = new BigNumber(Units.convert('0.01', 'eth', 'wei'))
+  const keyOwner = accounts[1]
 
-//   before(async () => {
-//     unlock = await getProxy(unlockContract)
-//     // TODO test using an ERC20 priced lock as well
-//     locks = await deployLocks(unlock, accounts[0])
-//     lock = locks['FIRST']
-//     await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
-//       value: keyPrice.toFixed(),
-//     })
-//   })
+  before(async () => {
+    unlock = await getProxy(unlockContract)
+    // TODO test using an ERC20 priced lock as well
+    locks = await deployLocks(unlock, accounts[0])
+    lock = locks['FIRST']
+    await lock.purchase(0, keyOwner, web3.utils.padLeft(0, 40), [], {
+      value: keyPrice.toFixed(),
+    })
+  })
 
-//   it.skip('has a default fee of 0%', async () => {
-//     const feeNumerator = new BigNumber(await lock.transferFeeBasisPoints.call())
-//     const feeDenominator = new BigNumber(await lock.BASIS_POINTS_DEN.call())
-//     assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.0)
-//   })
+  it('has a default fee of 0%', async () => {
+    const feeNumerator = new BigNumber(await lock.transferFeeBasisPoints.call())
+    const feeDenominator = new BigNumber(await lock.BASIS_POINTS_DEN.call())
+    assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.0)
+  })
 
-//   describe('once a fee of 5% is set', () => {
-//     before(async () => {
-//       // Change the fee to 5%
-//       await lock.updateTransferFee(500)
-//     })
+  describe('once a fee of 5% is set', () => {
+    before(async () => {
+      // Change the fee to 5%
+      await lock.updateTransferFee(500)
+    })
 
-//     it.skip('estimates the transfer fee, which is 5% of keyPrice or less', async () => {
-//       const fee = new BigNumber(await lock.getTransferFee.call(keyOwner))
-//       assert(fee.lte(keyPrice.times(0.05)))
-//     })
+    it('estimates the transfer fee, which is 5% of remaining duration or less', async () => {
+      const fee = new BigNumber(await lock.getTransferFee.call(keyOwner, 0))
+      let timestamp = new BigNumber(
+        await lock.keyExpirationTimestampFor.call(keyOwner)
+      )
+      let remainingTime = timestamp.minus(Math.floor(Date.now() / 1000))
+      assert(fee.lte(remainingTime.times(0.05)))
+    })
 
-//     describe('when the key is transfered', () => {
-//       const newOwner = accounts[2]
+    it('calculates the fee based on the time value passed in', async () => {
+      let fee = await lock.getTransferFee.call(keyOwner, 100) // here we want to "share" 100 seconds
+      assert.equal(fee, 5)
+    })
 
-//       it.skip('should fail if the fee is not included', async () => {
-//         await shouldFail(
-//           lock.transferFrom(
-//             keyOwner,
-//             newOwner,
-//             await lock.getTokenIdFor.call(keyOwner),
-//             {
-//               from: keyOwner,
-//             }
-//           )
-//         )
-//       })
+    describe('when the key is transfered', () => {
+      const newOwner = accounts[2]
+      let tokenId, timeRemainingBefore, timeRemainingAfter, fee
 
-//       describe('can transfer using transferFrom when the fee is paid', () => {
-//         let tokenId
-//         let keyOwnerInitialBalance
-//         let lockInitialBalance
-//         let transferGasCost
-//         let estimatedTransferFee
+      before(async () => {
+        tokenId = await lock.getTokenIdFor.call(keyOwner)
+        timeRemainingBefore = new BigNumber(
+          await lock.keyExpirationTimestampFor(keyOwner)
+        ).minus(Math.floor(Date.now() / 1000))
+        fee = await lock.getTransferFee(keyOwner, 0)
+        await lock.transferFrom(keyOwner, newOwner, tokenId, {
+          from: keyOwner,
+        })
+        timeRemainingAfter = new BigNumber(
+          await lock.keyExpirationTimestampFor(newOwner)
+        ).minus(Math.floor(Date.now() / 1000))
+      })
 
-//         before(async () => {
-//           keyOwnerInitialBalance = new BigNumber(
-//             await web3.eth.getBalance(keyOwner)
-//           )
-//           lockInitialBalance = new BigNumber(
-//             await web3.eth.getBalance(lock.address)
-//           )
-//           tokenId = await lock.getTokenIdFor.call(keyOwner)
-//           estimatedTransferFee = await lock.getTransferFee.call(keyOwner)
+      it('the fee is deducted from the time transferred', async () => {
+        assert(timeRemainingAfter.lte(timeRemainingBefore.minus(fee)))
+      })
 
-//           const tx = await lock.transferFrom(keyOwner, newOwner, tokenId, {
-//             from: keyOwner,
-//             value: estimatedTransferFee,
-//           })
+      after(async () => {
+        // Reset owners
+        await lock.transferFrom(
+          newOwner,
+          keyOwner,
+          await lock.getTokenIdFor.call(newOwner),
+          {
+            from: newOwner,
+            value: await lock.getTransferFee.call(newOwner, 0),
+          }
+        )
+      })
+    })
 
-//           const gasPrice = new BigNumber(
-//             (await web3.eth.getTransaction(tx.tx)).gasPrice
-//           )
-//           transferGasCost = gasPrice.times(tx.receipt.gasUsed)
-//         })
+    describe('the lock owner can change the fee', () => {
+      let tx
 
-//         it.skip('transfer was successful', async () => {
-//           const owner = await lock.ownerOf(tokenId)
-//           assert.equal(owner, newOwner)
-//         })
+      before(async () => {
+        // Change the fee to 0.25%
+        tx = await lock.updateTransferFee(25)
+      })
 
-//         it.skip('transfer fee was paid by the keyOwner', async () => {
-//           const keyOwnerBalance = new BigNumber(
-//             await web3.eth.getBalance(keyOwner)
-//           )
-//           assert.equal(
-//             keyOwnerBalance.toFixed(),
-//             keyOwnerInitialBalance
-//               .minus(transferGasCost)
-//               .minus(estimatedTransferFee)
-//               .toFixed()
-//           )
-//         })
+      it('has an updated fee', async () => {
+        const feeNumerator = new BigNumber(
+          await lock.transferFeeBasisPoints.call()
+        )
+        const feeDenominator = new BigNumber(await lock.BASIS_POINTS_DEN.call())
+        assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.0025)
+      })
 
-//         it.skip('transfer fee was received by the contract', async () => {
-//           const lockBalance = new BigNumber(
-//             await web3.eth.getBalance(lock.address)
-//           )
-//           assert.equal(
-//             lockBalance.toFixed(),
-//             lockInitialBalance.plus(estimatedTransferFee).toFixed()
-//           )
-//         })
+      it('emits TransferFeeChanged event', async () => {
+        assert.equal(tx.logs[0].event, 'TransferFeeChanged')
+        assert.equal(tx.logs[0].args.transferFeeBasisPoints.toString(), 25)
+      })
+    })
 
-//         after(async () => {
-//           // Reset owners
-//           await lock.transferFrom(
-//             newOwner,
-//             keyOwner,
-//             await lock.getTokenIdFor.call(newOwner),
-//             {
-//               from: newOwner,
-//               value: await lock.getTransferFee.call(newOwner),
-//             }
-//           )
-//         })
-//       })
-//     })
-
-//     describe('the lock owner can change the fee', () => {
-//       let tx
-
-//       before(async () => {
-//         // Change the fee to 0.25%
-//         tx = await lock.updateTransferFee(25)
-//       })
-
-//       it.skip('has an updated fee', async () => {
-//         const feeNumerator = new BigNumber(
-//           await lock.transferFeeBasisPoints.call()
-//         )
-//         const feeDenominator = new BigNumber(await lock.BASIS_POINTS_DEN.call())
-//         assert.equal(feeNumerator.div(feeDenominator).toFixed(), 0.0025)
-//       })
-
-//       it.skip('emits TransferFeeChanged event', async () => {
-//         assert.equal(tx.logs[0].event, 'TransferFeeChanged')
-//         assert.equal(tx.logs[0].args.transferFeeBasisPoints.toString(), 25)
-//       })
-//     })
-
-//     describe('should fail if', () => {
-//       it.skip('called by an account which does not own the lock', async () => {
-//         await shouldFail(lock.updateTransferFee(1000, { from: accounts[1] }))
-//       })
-//     })
-//   })
-// })
+    describe('should fail if', () => {
+      it('called by an account which does not own the lock', async () => {
+        await shouldFail(lock.updateTransferFee(1000, { from: accounts[1] }))
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Description
This modifies the getTransferFee function to return a time-based fee in seconds. 
- It also adds a new second param to the function to enable calculating fees for both transfers and partial transfers.
- finally, the lock interface has been updated to reflect this, and most of the tests in `transferFee.js` have been re-enabled.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs # 5110

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
