### PR TITLE
fixing the svg size as Chrome renders them slightly differently if we do not force it

### DIFF
--- a/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/paywall/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -9188,6 +9188,7 @@ Object {
 }
 
 .c10 > svg {
+  width: 80px;
   margin: 20px;
 }
 
@@ -10951,7 +10952,7 @@ Object {
               Chrome & Firefox
             </span>
             <div
-              class="sc-kpOJdX hglwz"
+              class="sc-kpOJdX enKQLh"
             >
               <svg
                 fill="none"
@@ -11064,7 +11065,7 @@ Object {
               iOS & Android
             </span>
             <div
-              class="sc-kpOJdX hglwz"
+              class="sc-kpOJdX enKQLh"
             >
               <svg
                 fill="none"
@@ -11120,7 +11121,7 @@ Object {
               iOS & Android
             </span>
             <div
-              class="sc-kpOJdX hglwz"
+              class="sc-kpOJdX enKQLh"
             >
               <svg
                 fill="none"
@@ -12604,6 +12605,7 @@ Object {
 }
 
 .c10 > svg {
+  width: 80px;
   margin: 20px;
 }
 
@@ -14367,7 +14369,7 @@ Object {
               Chrome & Firefox
             </span>
             <div
-              class="sc-kpOJdX hglwz"
+              class="sc-kpOJdX enKQLh"
             >
               <svg
                 fill="none"
@@ -14480,7 +14482,7 @@ Object {
               iOS & Android
             </span>
             <div
-              class="sc-kpOJdX hglwz"
+              class="sc-kpOJdX enKQLh"
             >
               <svg
                 fill="none"
@@ -14536,7 +14538,7 @@ Object {
               iOS & Android
             </span>
             <div
-              class="sc-kpOJdX hglwz"
+              class="sc-kpOJdX enKQLh"
             >
               <svg
                 fill="none"
@@ -16020,6 +16022,7 @@ Object {
 }
 
 .c10 > svg {
+  width: 80px;
   margin: 20px;
 }
 
@@ -17783,7 +17786,7 @@ Object {
               Chrome & Firefox
             </span>
             <div
-              class="sc-kpOJdX hglwz"
+              class="sc-kpOJdX enKQLh"
             >
               <svg
                 fill="none"
@@ -17896,7 +17899,7 @@ Object {
               iOS & Android
             </span>
             <div
-              class="sc-kpOJdX hglwz"
+              class="sc-kpOJdX enKQLh"
             >
               <svg
                 fill="none"
@@ -17952,7 +17955,7 @@ Object {
               iOS & Android
             </span>
             <div
-              class="sc-kpOJdX hglwz"
+              class="sc-kpOJdX enKQLh"
             >
               <svg
                 fill="none"

--- a/paywall/src/components/checkout/NoWallet.tsx
+++ b/paywall/src/components/checkout/NoWallet.tsx
@@ -107,6 +107,7 @@ const WalletOption = styled.div`
   }
 
   > svg {
+    width: 80px;
     margin: 20px;
   }
 `


### PR DESCRIPTION
# Description

This fixes a small UI bug which rendered Opera's icon smaller than the other ones...

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->