### PR TITLE
adding actions for user ejection

### DIFF
--- a/unlock-app/src/__tests__/actions/user.test.ts
+++ b/unlock-app/src/__tests__/actions/user.test.ts
@@ -41,6 +41,10 @@ import {
   welcomeEmail,
   QR_EMAIL,
   qrEmail,
+  signAccountEjection,
+  SIGN_ACCOUNT_EJECTION,
+  signedAccountEjection,
+  SIGNED_ACCOUNT_EJECTION,
 } from '../../actions/user'
 
 const key = {
@@ -278,6 +282,41 @@ describe('user account actions', () => {
       }
 
       expect(signedPaymentData({ data, sig })).toEqual(expectedAction)
+    })
+
+    it('should create an action requesting a user ejection signing', () => {
+      expect.assertions(1)
+      const userAddress = '0x123'
+
+      const expectedAction = {
+        type: SIGN_ACCOUNT_EJECTION,
+        userAddress,
+      }
+
+      expect(signAccountEjection(userAddress)).toEqual(expectedAction)
+    })
+
+    it('should create an action indicating that a user ejection has been signed', () => {
+      expect.assertions(1)
+      const data = {
+        message: {
+          publicKey: '0x123',
+        },
+      }
+      const sig = 'signature'
+
+      const expectedAction = {
+        type: SIGNED_ACCOUNT_EJECTION,
+        data,
+        sig,
+      }
+
+      expect(
+        signedAccountEjection({
+          data,
+          sig,
+        })
+      ).toEqual(expectedAction)
     })
   })
 

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -23,6 +23,8 @@ export const SIGNED_PURCHASE_DATA = 'userCredentials/SIGNED_PURCHASE_DATA'
 export const GET_STORED_PAYMENT_DETAILS = 'userAccount/GET_PAYMENT_DETAILS'
 export const KEY_PURCHASE_INITIATED = 'userAccount/KEY_PURCHASE_INITIATED'
 export const QR_EMAIL = 'keychain/QR_EMAIL'
+export const SIGN_ACCOUNT_EJECTION = 'userAccount/SIGN_ACCOUNT_EJECTION'
+export const SIGNED_ACCOUNT_EJECTION = 'userAccount/SIGNED_ACCOUNT_EJECTION'
 
 export interface Credentials {
   emailAddress: string
@@ -139,6 +141,29 @@ export const signedUserData = ({ data, sig }: SignedUserData) => ({
 export const signPaymentData = (stripeTokenId: string) => ({
   type: SIGN_PAYMENT_DATA,
   stripeTokenId,
+})
+
+export const signAccountEjection = (userAddress: string) => ({
+  type: SIGN_ACCOUNT_EJECTION,
+  userAddress,
+})
+
+interface SignedAccountEjection {
+  data: {
+    message: {
+      publicKey: string
+    }
+  }
+  sig: any
+}
+
+export const signedAccountEjection = ({
+  data,
+  sig,
+}: SignedAccountEjection) => ({
+  type: SIGNED_ACCOUNT_EJECTION,
+  data,
+  sig,
 })
 
 interface SignedPaymentData {


### PR DESCRIPTION
# Description

All in the title!
Two actions:
- one to sign the ejection request
- one to indicated that we have a signed ejection request


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->