### PR TITLE
using the provider to sign the ejection request

### DIFF
--- a/unlock-app/src/__tests__/actions/user.test.ts
+++ b/unlock-app/src/__tests__/actions/user.test.ts
@@ -41,6 +41,10 @@ import {
   welcomeEmail,
   QR_EMAIL,
   qrEmail,
+  signAccountEjection,
+  SIGN_ACCOUNT_EJECTION,
+  signedAccountEjection,
+  SIGNED_ACCOUNT_EJECTION,
 } from '../../actions/user'
 
 const key = {
@@ -278,6 +282,41 @@ describe('user account actions', () => {
       }
 
       expect(signedPaymentData({ data, sig })).toEqual(expectedAction)
+    })
+
+    it('should create an action requesting a user ejection signing', () => {
+      expect.assertions(1)
+      const userAddress = '0x123'
+
+      const expectedAction = {
+        type: SIGN_ACCOUNT_EJECTION,
+        userAddress,
+      }
+
+      expect(signAccountEjection(userAddress)).toEqual(expectedAction)
+    })
+
+    it('should create an action indicating that a user ejection has been signed', () => {
+      expect.assertions(1)
+      const data = {
+        message: {
+          publicKey: '0x123',
+        },
+      }
+      const sig = 'signature'
+
+      const expectedAction = {
+        type: SIGNED_ACCOUNT_EJECTION,
+        data,
+        sig,
+      }
+
+      expect(
+        signedAccountEjection({
+          data,
+          sig,
+        })
+      ).toEqual(expectedAction)
     })
   })
 

--- a/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
@@ -13,6 +13,7 @@ import {
   SIGN_USER_DATA,
   SIGN_PAYMENT_DATA,
   SIGN_PURCHASE_DATA,
+  SIGN_ACCOUNT_EJECTION,
   signUserData,
 } from '../../actions/user'
 import { resetRecoveryPhrase } from '../../actions/recovery'
@@ -27,6 +28,7 @@ const config = {
       signUserData: jest.fn(() => ({ data: {}, sig: {} })),
       signPaymentData: jest.fn(() => ({ data: {}, sig: {} })),
       signKeyPurchaseRequestData: jest.fn(() => ({ data: {}, sig: {} })),
+      generateSignedEjectionRequest: jest.fn(() => ({ data: {}, sig: {} })),
     },
     NUNLOCK: {
       enable: jest.fn(() => new Promise(resolve => resolve(true))),
@@ -245,6 +247,25 @@ describe('provider middleware', () => {
       })(next)({
         type: SIGN_PURCHASE_DATA,
         data,
+      })
+    })
+  })
+
+  describe('SIGN_ACCOUNT_EJECTION', () => {
+    it('should call UnlockProvider', () => {
+      expect.assertions(1)
+
+      const next = () => {
+        expect(
+          config.providers['UNLOCK'].generateSignedEjectionRequest
+        ).toHaveBeenCalledWith()
+      }
+
+      providerMiddleware(config)({
+        getState: () => ({ provider: 'UNLOCK' }),
+        dispatch,
+      })(next)({
+        type: SIGN_ACCOUNT_EJECTION,
       })
     })
   })

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -23,6 +23,8 @@ export const SIGNED_PURCHASE_DATA = 'userCredentials/SIGNED_PURCHASE_DATA'
 export const GET_STORED_PAYMENT_DETAILS = 'userAccount/GET_PAYMENT_DETAILS'
 export const KEY_PURCHASE_INITIATED = 'userAccount/KEY_PURCHASE_INITIATED'
 export const QR_EMAIL = 'keychain/QR_EMAIL'
+export const SIGN_ACCOUNT_EJECTION = 'userAccount/SIGN_ACCOUNT_EJECTION'
+export const SIGNED_ACCOUNT_EJECTION = 'userAccount/SIGNED_ACCOUNT_EJECTION'
 
 export interface Credentials {
   emailAddress: string
@@ -139,6 +141,29 @@ export const signedUserData = ({ data, sig }: SignedUserData) => ({
 export const signPaymentData = (stripeTokenId: string) => ({
   type: SIGN_PAYMENT_DATA,
   stripeTokenId,
+})
+
+export const signAccountEjection = (userAddress: string) => ({
+  type: SIGN_ACCOUNT_EJECTION,
+  userAddress,
+})
+
+interface SignedAccountEjection {
+  data: {
+    message: {
+      publicKey: string
+    }
+  }
+  sig: any
+}
+
+export const signedAccountEjection = ({
+  data,
+  sig,
+}: SignedAccountEjection) => ({
+  type: SIGNED_ACCOUNT_EJECTION,
+  data,
+  sig,
 })
 
 interface SignedPaymentData {

--- a/unlock-app/src/middlewares/providerMiddleware.ts
+++ b/unlock-app/src/middlewares/providerMiddleware.ts
@@ -19,6 +19,8 @@ import {
   SIGN_PURCHASE_DATA,
   signedPurchaseData,
   CHANGE_PASSWORD,
+  SIGN_ACCOUNT_EJECTION,
+  signedAccountEjection,
 } from '../actions/user'
 
 interface Provider {
@@ -139,6 +141,9 @@ export const providerMiddleware = (config: any) => {
         } else if (action.type === SIGN_PURCHASE_DATA) {
           const payload = provider.signKeyPurchaseRequestData(action.data)
           dispatch(signedPurchaseData(payload))
+        } else if (action.type === SIGN_ACCOUNT_EJECTION) {
+          const payload = provider.generateSignedEjectionRequest()
+          dispatch(signedAccountEjection(payload))
         }
 
         if (action.type === CHANGE_PASSWORD) {


### PR DESCRIPTION
# Description

Using the provider to sign the ejection request.

Needs #5238 to be rebased

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->