### PR TITLE
handling methods when account ejection has been signed

### DIFF
--- a/unlock-app/src/__tests__/actions/user.test.ts
+++ b/unlock-app/src/__tests__/actions/user.test.ts
@@ -41,6 +41,10 @@ import {
   welcomeEmail,
   QR_EMAIL,
   qrEmail,
+  signAccountEjection,
+  SIGN_ACCOUNT_EJECTION,
+  signedAccountEjection,
+  SIGNED_ACCOUNT_EJECTION,
 } from '../../actions/user'
 
 const key = {
@@ -278,6 +282,41 @@ describe('user account actions', () => {
       }
 
       expect(signedPaymentData({ data, sig })).toEqual(expectedAction)
+    })
+
+    it('should create an action requesting a user ejection signing', () => {
+      expect.assertions(1)
+      const userAddress = '0x123'
+
+      const expectedAction = {
+        type: SIGN_ACCOUNT_EJECTION,
+        userAddress,
+      }
+
+      expect(signAccountEjection(userAddress)).toEqual(expectedAction)
+    })
+
+    it('should create an action indicating that a user ejection has been signed', () => {
+      expect.assertions(1)
+      const data = {
+        message: {
+          publicKey: '0x123',
+        },
+      }
+      const sig = 'signature'
+
+      const expectedAction = {
+        type: SIGNED_ACCOUNT_EJECTION,
+        data,
+        sig,
+      }
+
+      expect(
+        signedAccountEjection({
+          data,
+          sig,
+        })
+      ).toEqual(expectedAction)
     })
   })
 

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -20,6 +20,7 @@ import {
   WELCOME_EMAIL,
   gotEncryptedPrivateKeyPayload,
   SET_ENCRYPTED_PRIVATE_KEY,
+  SIGNED_ACCOUNT_EJECTION,
 } from '../../actions/user'
 import { success, failure } from '../../services/storageService'
 import Error from '../../utils/Error'
@@ -334,6 +335,32 @@ describe('Storage middleware', () => {
           message: 'Could not add payment method.',
         },
       })
+    })
+  })
+
+  describe('handling SIGNED_ACCOUNT_EJECTION', () => {
+    it('should call storageService to eject the user', () => {
+      expect.assertions(2)
+      const publicKey = '0x123'
+      const data = {
+        message: {
+          user: {
+            publicKey,
+          },
+        },
+      }
+      const sig = ''
+      const { next, invoke } = create()
+      const action = { type: SIGNED_ACCOUNT_EJECTION, data, sig }
+      mockStorageService.ejectUser = jest.fn()
+
+      invoke(action)
+      expect(mockStorageService.ejectUser).toHaveBeenCalledWith(
+        publicKey,
+        data,
+        sig
+      )
+      expect(next).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/unlock-app/src/actions/user.ts
+++ b/unlock-app/src/actions/user.ts
@@ -23,6 +23,8 @@ export const SIGNED_PURCHASE_DATA = 'userCredentials/SIGNED_PURCHASE_DATA'
 export const GET_STORED_PAYMENT_DETAILS = 'userAccount/GET_PAYMENT_DETAILS'
 export const KEY_PURCHASE_INITIATED = 'userAccount/KEY_PURCHASE_INITIATED'
 export const QR_EMAIL = 'keychain/QR_EMAIL'
+export const SIGN_ACCOUNT_EJECTION = 'userAccount/SIGN_ACCOUNT_EJECTION'
+export const SIGNED_ACCOUNT_EJECTION = 'userAccount/SIGNED_ACCOUNT_EJECTION'
 
 export interface Credentials {
   emailAddress: string
@@ -139,6 +141,29 @@ export const signedUserData = ({ data, sig }: SignedUserData) => ({
 export const signPaymentData = (stripeTokenId: string) => ({
   type: SIGN_PAYMENT_DATA,
   stripeTokenId,
+})
+
+export const signAccountEjection = (userAddress: string) => ({
+  type: SIGN_ACCOUNT_EJECTION,
+  userAddress,
+})
+
+interface SignedAccountEjection {
+  data: {
+    message: {
+      publicKey: string
+    }
+  }
+  sig: any
+}
+
+export const signedAccountEjection = ({
+  data,
+  sig,
+}: SignedAccountEjection) => ({
+  type: SIGNED_ACCOUNT_EJECTION,
+  data,
+  sig,
 })
 
 interface SignedPaymentData {

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -22,6 +22,7 @@ import {
   SIGNED_PAYMENT_DATA,
   GET_STORED_PAYMENT_DETAILS,
   SIGNED_PURCHASE_DATA,
+  SIGNED_ACCOUNT_EJECTION,
   keyPurchaseInitiated,
   welcomeEmail,
 } from '../actions/user'
@@ -256,6 +257,11 @@ const storageMiddleware = config => {
             data,
             sig
           )
+        }
+
+        if (action.type === SIGNED_ACCOUNT_EJECTION) {
+          const { data, sig } = action
+          storageService.ejectUser(data.message.user.publicKey, data, sig)
         }
 
         if (action.type === SIGNED_PURCHASE_DATA) {


### PR DESCRIPTION
# Description

Once the ejection request has been signed, we invoke storageService to actually eject the account.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread