### PR TITLE
Update keyholdersByLock to include lock address in response

### DIFF
--- a/unlock-app/src/queries/keyholdersByLock.js
+++ b/unlock-app/src/queries/keyholdersByLock.js
@@ -12,6 +12,7 @@ export default function keyholdersByLockQuery() {
           expiration
         }
         name
+        address
       }
     }
   `


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This is a trivial piece of #5232. It makes sure our GraphQL query includes the lock address in the response, which makes the code a little simpler when formatting data for the table.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
