### PR TITLE
Improve metadata actions

### DIFF
--- a/unlock-app/src/__tests__/actions/keyMetadata.test.ts
+++ b/unlock-app/src/__tests__/actions/keyMetadata.test.ts
@@ -1,8 +1,10 @@
 import {
   SIGN_METADATA_REQUEST,
   SIGN_METADATA_RESPONSE,
+  GOT_METADATA,
   signMetadataRequest,
   signMetadataResponse,
+  gotMetadata,
 } from '../../actions/keyMetadata'
 
 describe('Key metadata signature actions', () => {
@@ -33,6 +35,21 @@ describe('Key metadata signature actions', () => {
         type: SIGN_METADATA_RESPONSE,
         data: 'some data',
         signature: 'a signature',
+      })
+    })
+  })
+
+  describe('gotMetadata', () => {
+    it('should create an action to put the metadata in redux', () => {
+      expect.assertions(1)
+
+      const result = gotMetadata('a lock address', '1', 'some data')
+
+      expect(result).toEqual({
+        type: GOT_METADATA,
+        lockAddress: 'a lock address',
+        keyId: '1',
+        data: 'some data',
       })
     })
   })

--- a/unlock-app/src/__tests__/actions/keyMetadata.test.ts
+++ b/unlock-app/src/__tests__/actions/keyMetadata.test.ts
@@ -7,19 +7,22 @@ import {
   gotMetadata,
 } from '../../actions/keyMetadata'
 
+const keyIds = ['1', '13']
+const lockAddress = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
+
 describe('Key metadata signature actions', () => {
   describe('signMetadataRequest', () => {
     it('should create an action to request a signature', () => {
       expect.assertions(1)
 
-      const address = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
       const owner = '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a'
-      const result = signMetadataRequest(address, owner)
+      const result = signMetadataRequest(lockAddress, owner, keyIds)
 
       expect(result).toEqual({
         type: SIGN_METADATA_REQUEST,
-        address,
+        lockAddress,
         owner,
+        keyIds,
         timestamp: expect.any(Number),
       })
     })
@@ -29,12 +32,19 @@ describe('Key metadata signature actions', () => {
     it('should create an action to return a signature', () => {
       expect.assertions(1)
 
-      const result = signMetadataResponse('some data', 'a signature')
+      const result = signMetadataResponse(
+        'some data',
+        'a signature',
+        keyIds,
+        lockAddress
+      )
 
       expect(result).toEqual({
         type: SIGN_METADATA_RESPONSE,
         data: 'some data',
         signature: 'a signature',
+        keyIds,
+        lockAddress,
       })
     })
   })

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -689,6 +689,7 @@ describe('Wallet middleware', () => {
       address: '0xe29ec42F0b620b1c9A716f79A02E9DC5A5f5F98a',
       owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
       timestamp: 1234567890,
+      keyIds: ['1', '13'],
     }
 
     const expectedTypedData = expect.objectContaining({
@@ -728,6 +729,8 @@ describe('Wallet middleware', () => {
         type: SIGN_METADATA_RESPONSE,
         data: expectedTypedData,
         signature: 'a signature',
+        lockAddress: action.address,
+        keyIds: action.keyIds,
       })
     })
 

--- a/unlock-app/src/actions/keyMetadata.ts
+++ b/unlock-app/src/actions/keyMetadata.ts
@@ -1,5 +1,6 @@
 export const SIGN_METADATA_REQUEST = 'keyMetadata/SIGN_METADATA_REQUEST'
 export const SIGN_METADATA_RESPONSE = 'keyMetadata/SIGN_METADATA_RESPONSE'
+export const GOT_METADATA = 'keyMetadata/GOT_METADATA'
 
 export function signMetadataRequest(address: string, owner: string) {
   return {
@@ -15,5 +16,14 @@ export function signMetadataResponse(data: any, signature: any) {
     type: SIGN_METADATA_RESPONSE,
     data,
     signature,
+  }
+}
+
+export function gotMetadata(lockAddress: string, keyId: string, data: any) {
+  return {
+    type: GOT_METADATA,
+    lockAddress,
+    keyId,
+    data,
   }
 }

--- a/unlock-app/src/actions/keyMetadata.ts
+++ b/unlock-app/src/actions/keyMetadata.ts
@@ -2,20 +2,32 @@ export const SIGN_METADATA_REQUEST = 'keyMetadata/SIGN_METADATA_REQUEST'
 export const SIGN_METADATA_RESPONSE = 'keyMetadata/SIGN_METADATA_RESPONSE'
 export const GOT_METADATA = 'keyMetadata/GOT_METADATA'
 
-export function signMetadataRequest(address: string, owner: string) {
+export function signMetadataRequest(
+  lockAddress: string,
+  owner: string,
+  keyIds: string[]
+) {
   return {
     type: SIGN_METADATA_REQUEST,
-    address,
+    lockAddress,
     owner,
+    keyIds,
     timestamp: Date.now(),
   }
 }
 
-export function signMetadataResponse(data: any, signature: any) {
+export function signMetadataResponse(
+  data: any,
+  signature: any,
+  keyIds: string[],
+  lockAddress: string
+) {
   return {
     type: SIGN_METADATA_RESPONSE,
     data,
     signature,
+    keyIds,
+    lockAddress,
   }
 }
 

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -231,7 +231,7 @@ const walletMiddleware = config => {
             }
           )
         } else if (action.type === SIGN_METADATA_REQUEST) {
-          const { address: lockAddress, owner, timestamp } = action
+          const { address: lockAddress, owner, timestamp, keyIds } = action
           // Usage from locksmith tests for metadataController
           const typedData = generateKeyTypedData({
             LockMetaData: {
@@ -252,7 +252,9 @@ const walletMiddleware = config => {
                 )
               )
             } else {
-              dispatch(signMetadataResponse(typedData, signature))
+              dispatch(
+                signMetadataResponse(typedData, signature, keyIds, lockAddress)
+              )
             }
           })
         }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

While implementing #5232, I found that the set of actions around key metadata weren't quite enough.

- The actions for getting authentication signatures now carry a payload including key IDs and lock address. This allows us to react to the signature response in storageMiddleware immediately when a signature is available, since all other required data comes with it. (I believe these actions should be forward-compatible, because they should contain all the data necessary to make a compound query to locksmith when that functionality becomes available.)
- Added an action that signifies the result of a successful locksmith metadata call, which will be used to store the metadata in redux.
- Updated walletMiddleware to make sure it uses these new pieces of data.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
