### PR TITLE
Augment metadata table with additional fields from locksmith

### DIFF
--- a/unlock-app/src/__tests__/utils/metadataMunging.test.ts
+++ b/unlock-app/src/__tests__/utils/metadataMunging.test.ts
@@ -129,7 +129,20 @@ describe('metadata munging functions', () => {
                 keyId: '1',
                 expiration: '123456',
                 owner: {
-                  address: '0x123',
+                  address: '0x126',
+                },
+              },
+            ],
+          },
+          {
+            address: '0x124',
+            name: 'Dock',
+            keys: [
+              {
+                keyId: '1',
+                expiration: '123556',
+                owner: {
+                  address: '0x127',
                 },
               },
             ],
@@ -140,8 +153,13 @@ describe('metadata munging functions', () => {
       expect(mergeKeyholderMetadata(data, {})).toEqual([
         {
           expiration: 'Expired',
-          keyholderAddress: '0x123',
+          keyholderAddress: '0x126',
           lockName: 'Lock',
+        },
+        {
+          expiration: 'Expired',
+          keyholderAddress: '0x127',
+          lockName: 'Dock',
         },
       ])
     })

--- a/unlock-app/src/__tests__/utils/metadataMunging.test.ts
+++ b/unlock-app/src/__tests__/utils/metadataMunging.test.ts
@@ -1,0 +1,149 @@
+import {
+  generateColumns,
+  mergeSingleDatum,
+  mergeKeyholderMetadata,
+} from '../../utils/metadataMunging'
+
+const baseKeyMetadata = {
+  lockName: 'a lock',
+  expiration: '12345678',
+  keyholderAddress: '0x123abc',
+}
+
+describe('metadata munging functions', () => {
+  describe('generateColumns', () => {
+    it('returns the starting columns when given empty input', () => {
+      expect.assertions(2)
+
+      let columns = generateColumns([])
+      expect(columns).toEqual(['lockName', 'keyholderAddress', 'expiration'])
+
+      columns = generateColumns([], ['favoriteColor'])
+      expect(columns).toEqual(['favoriteColor'])
+    })
+
+    it('places the starting columns first and then alphabetizes additional columns', () => {
+      expect.assertions(1)
+      const keyMetadata = {
+        ...baseKeyMetadata,
+        zebras: 'true',
+        platypus: 'weird',
+        apples: 'oranges',
+        beagles: 'doggo',
+      }
+
+      const columns = generateColumns([keyMetadata])
+      expect(columns).toEqual([
+        'lockName',
+        'keyholderAddress',
+        'expiration',
+        // Alphabetizing starts here, after the starting columns
+        'apples',
+        'beagles',
+        'platypus',
+        'zebras',
+      ])
+    })
+
+    it('pulls columns from multiple pieces of data', () => {
+      expect.assertions(1)
+      const firstKey = {
+        ...baseKeyMetadata,
+        email: 'in@ter.net',
+      }
+      const secondKey = {
+        ...baseKeyMetadata,
+        xylophone: 'a value',
+      }
+
+      const columns = generateColumns([firstKey, secondKey])
+      expect(columns).toEqual([
+        'lockName',
+        'keyholderAddress',
+        'expiration',
+        'email',
+        'xylophone',
+      ])
+    })
+  })
+
+  describe('mergeSingleDatum', () => {
+    it('merges a base metadatum with additional fields from stored metadata', () => {
+      expect.assertions(1)
+      const lock = {
+        address: '0x123',
+        name: 'Lock',
+      }
+      const key = {
+        keyId: '1',
+        expiration: '123456',
+        owner: {
+          address: '0x123',
+        },
+      }
+      const storedMetadata = {
+        [lock.address]: {
+          [key.keyId]: {
+            protected: {
+              zebra: 'true',
+            },
+            public: {
+              elephant: 'trunk',
+            },
+          },
+        },
+      }
+      const metadatum = mergeSingleDatum(lock, key, storedMetadata)
+      expect(metadatum).toEqual({
+        lockName: 'Lock',
+        expiration: 'Expired',
+        keyholderAddress: '0x123',
+        elephant: 'trunk',
+        zebra: 'true',
+      })
+    })
+  })
+
+  describe('mergeKeyholderMetadata', () => {
+    it('returns empty array when there are no locks', () => {
+      expect.assertions(1)
+      expect(
+        mergeKeyholderMetadata(
+          {
+            locks: [],
+          },
+          {}
+        )
+      ).toEqual([])
+    })
+
+    it('adds metadata for each key in a lock', () => {
+      expect.assertions(1)
+      const data = {
+        locks: [
+          {
+            address: '0x123',
+            name: 'Lock',
+            keys: [
+              {
+                keyId: '1',
+                expiration: '123456',
+                owner: {
+                  address: '0x123',
+                },
+              },
+            ],
+          },
+        ],
+      }
+
+      expect(mergeKeyholderMetadata(data, {})).toEqual([
+        {
+          expiration: 'Expired',
+          keyholderAddress: '0x123',
+          lockName: 'Lock',
+        },
+      ])
+    })
+  })
+})

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -153,3 +153,39 @@ export interface PurchaseKeyRequest {
   lock: string // lock address
   extraTip: string // extra value to add in addition to key price
 }
+
+export interface KeyMetadata {
+  // These 3 properties are always present -- they come down from the graph as
+  // strings
+  lockName: string
+  expiration: string
+  keyholderAddress: string
+  // Can have any other arbitrary properies, as long as the values are strings.
+  [key: string]: string
+}
+
+// TODO: come up with one master type for the Redux store that we can
+// import from every connected component
+export interface ReduxMetadata {
+  [lockAddress: string]: {
+    [keyId: string]: {
+      protected?: { [key: string]: string }
+      public?: { [key: string]: string }
+    }
+  }
+}
+
+// Represents the keyholdersByLock GraphQL query result
+export interface KeyholdersByLock {
+  locks: {
+    address: string
+    name: string
+    keys: {
+      expiration: string
+      keyId: string
+      owner: {
+        address: string
+      }
+    }[]
+  }[]
+}

--- a/unlock-app/src/utils/metadataMunging.ts
+++ b/unlock-app/src/utils/metadataMunging.ts
@@ -1,0 +1,76 @@
+import { KeyMetadata, ReduxMetadata, KeyholdersByLock } from '../unlockTypes'
+import { expirationAsDate } from './durations'
+
+export const mergeSingleDatum = (
+  lock: any,
+  key: any,
+  dataFromRedux: ReduxMetadata
+): KeyMetadata => {
+  let metadatum: KeyMetadata = {
+    lockName: lock.name,
+    expiration: expirationAsDate(parseInt(key.expiration)),
+    keyholderAddress: key.owner.address,
+  }
+
+  if (dataFromRedux[lock.address] && dataFromRedux[lock.address][key.keyId]) {
+    const storedKeyMetadata = dataFromRedux[lock.address][key.keyId]
+    // If there are collisions between the various metadata fields (from the
+    // graph, and from the 2 possible fields from locksmith), they will be
+    // overwritten by whichever value comes last
+    if (storedKeyMetadata.protected) {
+      metadatum = {
+        ...metadatum,
+        ...storedKeyMetadata.protected,
+      }
+    }
+    if (storedKeyMetadata.public) {
+      metadatum = {
+        ...metadatum,
+        ...storedKeyMetadata.public,
+      }
+    }
+  }
+  return metadatum
+}
+
+export const mergeKeyholderMetadata = (
+  keyholdersByLock: KeyholdersByLock,
+  dataFromRedux: ReduxMetadata
+): KeyMetadata[] => {
+  let metadata: KeyMetadata[] = []
+
+  keyholdersByLock.locks.forEach(lock => {
+    lock.keys.forEach(key => {
+      const metadatum = mergeSingleDatum(lock, key, dataFromRedux)
+      metadata.push(metadatum)
+    })
+  })
+
+  return metadata
+}
+
+export const generateColumns = (
+  metadata: KeyMetadata[],
+  startingColumns: string[] = ['lockName', 'keyholderAddress', 'expiration']
+): string[] => {
+  // clone the passed array to avoid mutation
+  let columns = startingColumns.slice()
+
+  const columnSet: { [key: string]: boolean } = {}
+
+  metadata.forEach(datum => {
+    Object.keys(datum).forEach(key => {
+      // Don't want to include the pre-ordered starting columns
+      if (columns.indexOf(key) < 0) {
+        columnSet[key] = true
+      }
+    })
+  })
+
+  const keys = Object.keys(columnSet)
+  const newColumns = keys.sort((a: string, b: string) => {
+    return a.toLowerCase().localeCompare(b.toLowerCase())
+  })
+
+  return [...columns, ...newColumns]
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

<img width="1459" alt="image" src="https://user-images.githubusercontent.com/9300702/68431392-15b75700-0180-11ea-8d93-8447a1e3cd19.png">

This PR finalizes the members page, which displays metadata about keyholders for locks. This involves merging data from both the graph and locksmith and presenting them in the table.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5209 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
