### PR TITLE
removed lock lookup from locksmith

### DIFF
--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import * as unlockJs from '@unlock-protocol/unlock-js'
 import storageMiddleware from '../../middlewares/storageMiddleware'
-import { UPDATE_LOCK, updateLock, getLock } from '../../actions/lock'
+import { getLock } from '../../actions/lock'
 import { addTransaction, NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ACCOUNT, UPDATE_ACCOUNT } from '../../actions/accounts'
 import { startLoading, doneLoading } from '../../actions/loading'
@@ -216,43 +216,6 @@ describe('Storage middleware', () => {
         account.address
       )
       expect(next).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  describe('handling UPDATE_LOCK', () => {
-    it('should call storageService', () => {
-      expect.assertions(2)
-      const { next, invoke } = create()
-      const action = { type: UPDATE_LOCK, address: lock.address, update: {} }
-      delete state.locks[lock.address].name
-
-      mockStorageService.lockLookUp = jest.fn()
-      invoke(action)
-      expect(mockStorageService.lockLookUp).toHaveBeenCalledWith(lock.address)
-      expect(next).toHaveBeenCalledTimes(1)
-    })
-
-    it('should get the name and pass it on', () => {
-      expect.assertions(1)
-      const { store } = create()
-      const address = '0x123'
-      const name =
-        'Shirley, Shirley Bo-ber-ley, bo-na-na fanna Fo-fer-ley. fee fi mo-mer-ley, Shirley!'
-
-      mockStorageService.emit(success.lockLookUp, { address, name })
-
-      expect(store.dispatch).toHaveBeenCalledWith(updateLock(address, { name }))
-    })
-
-    it('should handle failure events', () => {
-      expect.assertions(1)
-      const { store } = create()
-
-      mockStorageService.emit(failure.lockLookUp, 'Not enough vespene gas.')
-
-      expect(store.dispatch).toHaveBeenCalledWith(
-        setError(Storage.Diagnostic('Could not look up lock details.'))
-      )
     })
   })
 

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -55,62 +55,6 @@ describe('StorageService', () => {
     storageService = new StorageService(serviceHost)
   })
 
-  describe('lockLookUp', () => {
-    describe('when the requested lock exists', () => {
-      it('returns the details', done => {
-        expect.assertions(3)
-        axios.get.mockReturnValue({
-          data: {
-            name: 'hello',
-          },
-        })
-
-        storageService.lockLookUp('0x42')
-
-        storageService.on(success.lockLookUp, ({ address, name }) => {
-          expect(address).toBe('0x42')
-          expect(name).toBe('hello')
-          done()
-        })
-
-        expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x42`)
-      })
-    })
-
-    describe('when the requested lock exists but does not have a name', () => {
-      it('emits a failure', done => {
-        expect.assertions(2)
-        axios.get.mockReturnValue({
-          data: {},
-        })
-
-        storageService.lockLookUp('0x42')
-
-        storageService.on(failure.lockLookUp, error => {
-          expect(error).toBe('No name for this lock.')
-          done()
-        })
-
-        expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x42`)
-      })
-    })
-
-    describe('when the requested lock doesnt exist', () => {
-      it('raises an appropriate error', done => {
-        expect.assertions(2)
-        axios.get.mockRejectedValue('An Error')
-        storageService.lockLookUp('0x1234243')
-
-        storageService.on(failure.lockLookUp, error => {
-          expect(error).toEqual('An Error')
-          done()
-        })
-
-        expect(axios.get).toHaveBeenCalledWith(`${serviceHost}/lock/0x1234243`)
-      })
-    })
-  })
-
   describe('storeLockDetails', () => {
     describe('when storing a new lock', () => {
       it('emits a success', done => {

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -4,7 +4,7 @@ import {
   createAccountAndPasswordEncryptKey,
   reEncryptPrivateKey,
 } from '@unlock-protocol/unlock-js'
-import { UPDATE_LOCK, updateLock, getLock } from '../actions/lock'
+import { getLock } from '../actions/lock'
 
 import { startLoading, doneLoading } from '../actions/loading'
 
@@ -58,14 +58,6 @@ const storageMiddleware = config => {
         setError(Storage.Diagnostic('getTransactionHashesSentBy failed.'))
       )
       dispatch(doneLoading())
-    })
-
-    // UPDATE_LOCK
-    storageService.on(success.lockLookUp, ({ address, name }) => {
-      dispatch(updateLock(address, { name }))
-    })
-    storageService.on(failure.lockLookUp, () => {
-      dispatch(setError(Storage.Diagnostic('Could not look up lock details.')))
     })
 
     // SIGNUP_CREDENTIALS
@@ -231,14 +223,6 @@ const storageMiddleware = config => {
           storageService.getTransactionsHashesSentBy(action.account.address)
           // When we set the account, we want to retrive the list of locks
           storageService.getLockAddressesForUser(action.account.address)
-        }
-
-        if (action.type === UPDATE_LOCK) {
-          // Only look up the name for a lock for which the name is empty/not-set
-          const lock = getState().locks[action.address]
-          if (lock && !lock.name) {
-            storageService.lockLookUp(action.address)
-          }
         }
 
         if (action.type === SIGNED_USER_DATA) {

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -10,7 +10,6 @@ export const success = {
   storeTransaction: 'storeTransaction.success',
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.success',
   getLockAddressesForUser: 'getLockAddressesForUser.success',
-  lockLookUp: 'lockLookUp.success',
   storeLockDetails: 'storeLockDetails.success',
   createUser: 'createUser.success',
   updateUser: 'updateUser.success',
@@ -27,7 +26,6 @@ export const failure = {
   storeTransaction: 'storeTransaction.failure',
   getTransactionHashesSentBy: 'getTransactionHashesSentBy.failure',
   getLockAddressesForUser: 'getLockAddressesForUser.failure',
-  lockLookUp: 'lockLookUp.failure',
   storeLockDetails: 'storeLockDetails.failure',
   createUser: 'createUser.failure',
   updateUser: 'updateUser.failure',
@@ -100,27 +98,6 @@ export class StorageService extends EventEmitter {
 
   genAuthorizationHeader = token => {
     return { Authorization: ` Bearer ${token}` }
-  }
-
-  /**
-   * Returns the name of the request Lock,
-   * in a failure scenario a rejected promise is returned
-   * to the caller.
-   *
-   * @param {*} address
-   */
-  async lockLookUp(address) {
-    try {
-      const result = await axios.get(`${this.host}/lock/${address}`)
-      if (result.data && result.data.name) {
-        const name = result.data.name
-        this.emit(success.lockLookUp, { address, name })
-      } else {
-        this.emit(failure.lockLookUp, 'No name for this lock.')
-      }
-    } catch (error) {
-      this.emit(failure.lockLookUp, error)
-    }
   }
 
   /**


### PR DESCRIPTION
# Description

Removing the lock look up which is not required anymore as lock names are on chain, but for locks on v0... which I believe are not used in any meaningful way.
This considerably loads the load on locksmth on dashbaord pages with many locks!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->