### PR TITLE
Show lock name on verification page, remove temporary refund button

### DIFF
--- a/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
@@ -38,9 +38,15 @@ describe('VerificationStatus', () => {
 
       const apolloSpy = jest.spyOn(apolloHooks, 'useQuery')
       apolloSpy.mockReturnValue({
-        loading: true,
+        loading: undefined,
         error: undefined,
-        data: undefined,
+        data: {
+          keyHolders: [
+            {
+              keys: [ownedKey],
+            },
+          ],
+        },
       } as any)
 
       const sigUtilSpy = jest.spyOn(sigUtil, 'recoverPersonalSignature')
@@ -59,6 +65,7 @@ describe('VerificationStatus', () => {
       )
 
       getByText('Identity is valid.')
+      getByText('Lock Around the Clock')
     })
   })
 

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -8,7 +8,6 @@ import {
   expirationAsDate,
 } from '../../utils/durations'
 import { OwnedKey } from './keychain/KeychainTypes'
-import RefundButton from './RefundButton'
 import keyHolderQuery from '../../queries/keyHolder'
 import 'cross-fetch/polyfill'
 
@@ -69,6 +68,7 @@ export const VerificationStatus = ({ data, sig, hexData }: Props) => {
 
   return (
     <div>
+      {matchingKey && <h1>{matchingKey.lock.name}</h1>}
       <Identity valid={identityIsValid} />
 
       <OwnsKey
@@ -80,14 +80,6 @@ export const VerificationStatus = ({ data, sig, hexData }: Props) => {
       <p>
         Signed {durationsAsTextFromSeconds(secondsElapsedFromSignature)} ago.
       </p>
-      {matchingKey && identityIsValid && (
-        <RefundButton
-          accountAddress={accountAddress}
-          lockAddress={lockAddress}
-          timestamp={timestamp}
-          signature={sig}
-        />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a heading with the lock name to the verification page. While I was in there, I deleted the code that shows the refund button (removing the component itself can be done in a future PR)

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/9300702/68691610-06e6f080-0542-11ea-9847-aea65f83632d.png">


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5248 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
