### PR TITLE
Renovate: fix dupe groupName & add default minor groupName

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     "enabled": false
   },
   "minor": {
-    "groupName": "minor and patch updates",
+    "groupName": "minor and patch updates"
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,8 @@
   "node": {
     "enabled": false
   },
-  "patch": {
-    "groupName": "all dependencies patch updates",
+  "minor": {
+    "groupName": "all minor and patch updates",
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,9 @@
   "node": {
     "enabled": false
   },
+  "patch": {
+    "groupName": "all dependencies patch updates",
+  },
   "packageRules": [
     {
       "paths": ["locksmith/**"],
@@ -60,7 +63,7 @@
     {
       "packageNames": ["@unlock-protocol/unlock-js"],
       "schedule": ["at any time"],
-      "groupName": "unlock-js"
+      "groupName": "unlock-js npm package"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     "enabled": false
   },
   "minor": {
-    "groupName": "all minor and patch updates",
+    "groupName": "minor and patch updates",
   },
   "packageRules": [
     {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Fixes a dupe groupName - `unlock-js` was used for both the repo and the npm package, this PR separates them.

Also added a default minor/patch groupName which should apply to the root directory and any other repo not explicitly included in this config.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
