### PR TITLE
Remove unnecessary generics in tests

### DIFF
--- a/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
+++ b/paywall/src/__tests__/test-helpers/fakeWindowHelpers.ts
@@ -230,10 +230,7 @@ export default class FakeWindow
     ;(this.parent as any).postMessage.mockClear()
   }
 
-  public expectPostMessageSent<T extends PostMessages = PostMessages>(
-    type: T,
-    payload: ExtractPayload<T>
-  ) {
+  public expectPostMessageSent(type: any, payload: any) {
     expect(this.parent.postMessage).toHaveBeenCalledWith(
       {
         type,
@@ -243,10 +240,7 @@ export default class FakeWindow
     )
   }
 
-  public expectPostMessageNotSent<T extends PostMessages = PostMessages>(
-    type: T,
-    payload: ExtractPayload<T>
-  ) {
+  public expectPostMessageNotSent(type: any, payload: any) {
     expect(this.parent.postMessage).not.toHaveBeenCalledWith(
       {
         type,
@@ -256,9 +250,9 @@ export default class FakeWindow
     )
   }
 
-  public expectPostMessageSentToIframe<T extends PostMessages = PostMessages>(
-    type: T,
-    payload: ExtractPayload<T>,
+  public expectPostMessageSentToIframe(
+    type: any,
+    payload: any,
     iframe: IframeType,
     iframeOrigin: string
   ) {

--- a/unlock-app/src/__tests__/services/postOfficeService.test.ts
+++ b/unlock-app/src/__tests__/services/postOfficeService.test.ts
@@ -3,18 +3,14 @@ import {
   PostOfficeEvents,
 } from '../../services/postOfficeService'
 import { IframePostOfficeWindow } from '../../utils/postOffice'
-import { PostMessages, ExtractPayload } from '../../messageTypes'
+import { PostMessages } from '../../messageTypes'
 import { Locks } from '../../unlockTypes'
 
 describe('postOfficeService', () => {
   let mockService: PostOfficeService
   let fakeWindow: IframePostOfficeWindow
 
-  function expectPostMessage<T>(
-    type: T,
-    payload: ExtractPayload<T>,
-    index = 1
-  ) {
+  function expectPostMessage(type: any, payload: any, index = 1) {
     expect(fakeWindow.parent.postMessage).toHaveBeenNthCalledWith(
       index,
       {
@@ -25,7 +21,7 @@ describe('postOfficeService', () => {
     )
   }
 
-  function triggerListener<T>(type: T, payload: ExtractPayload<T>) {
+  function triggerListener(type: any, payload: any) {
     const first: any = fakeWindow.addEventListener
     const listener = first.mock.calls[0][1]
 
@@ -41,13 +37,13 @@ describe('postOfficeService', () => {
     })
   }
 
-  function expectListenerRespondsWith<T, U>(
-    type: T,
-    payload: ExtractPayload<T>,
-    sendType: U,
-    sendPayload: ExtractPayload<U>
+  function expectListenerRespondsWith(
+    type: any,
+    payload: any,
+    sendType: any,
+    sendPayload: any
   ) {
-    triggerListener<T>(type, payload)
+    triggerListener(type, payload)
 
     expect(fakeWindow.parent.postMessage).toHaveBeenCalledWith(
       {
@@ -82,7 +78,7 @@ describe('postOfficeService', () => {
 
       mockService = new PostOfficeService(fakeWindow, 2)
 
-      expectPostMessage<PostMessages.READY>(PostMessages.READY, undefined)
+      expectPostMessage(PostMessages.READY, undefined)
     })
 
     it('should add a handler for PostMessages.SEND_UPDATES (account)', () => {
@@ -90,10 +86,12 @@ describe('postOfficeService', () => {
 
       mockService = new PostOfficeService(fakeWindow, 2)
 
-      expectListenerRespondsWith<
+      expectListenerRespondsWith(
         PostMessages.SEND_UPDATES,
-        PostMessages.UPDATE_ACCOUNT
-      >(PostMessages.SEND_UPDATES, 'account', PostMessages.UPDATE_ACCOUNT, null)
+        'account',
+        PostMessages.UPDATE_ACCOUNT,
+        null
+      )
     })
 
     it('should add a handler for PostMessages.SEND_UPDATES (network)', () => {
@@ -101,10 +99,12 @@ describe('postOfficeService', () => {
 
       mockService = new PostOfficeService(fakeWindow, 2)
 
-      expectListenerRespondsWith<
+      expectListenerRespondsWith(
         PostMessages.SEND_UPDATES,
-        PostMessages.UPDATE_NETWORK
-      >(PostMessages.SEND_UPDATES, 'network', PostMessages.UPDATE_NETWORK, 2)
+        'network',
+        PostMessages.UPDATE_NETWORK,
+        2
+      )
     })
 
     it('should add a handler for PostMessages.UPDATE_LOCKS', done => {
@@ -151,10 +151,7 @@ describe('postOfficeService', () => {
         done()
       })
 
-      triggerListener<PostMessages.UPDATE_LOCKS>(
-        PostMessages.UPDATE_LOCKS,
-        fakeLocks
-      )
+      triggerListener(PostMessages.UPDATE_LOCKS, fakeLocks)
     })
 
     it('should error if invalid locks are passed to PostMessages.UPDATE_LOCKS', done => {
@@ -199,7 +196,7 @@ describe('postOfficeService', () => {
         done()
       })
 
-      triggerListener<PostMessages.UPDATE_LOCKS>(
+      triggerListener(
         PostMessages.UPDATE_LOCKS,
         (fakeLocks as unknown) as Locks // override types to test invalid case
       )
@@ -217,7 +214,7 @@ describe('postOfficeService', () => {
         expect(extraTip).toBe('0')
       })
 
-      triggerListener<PostMessages.PURCHASE_KEY>(PostMessages.PURCHASE_KEY, {
+      triggerListener(PostMessages.PURCHASE_KEY, {
         lock: lockAddress,
         extraTip: '0',
       })
@@ -233,7 +230,7 @@ describe('postOfficeService', () => {
         expect(true).toBeTruthy()
       })
 
-      triggerListener<PostMessages.LOCKED>(PostMessages.LOCKED, undefined)
+      triggerListener(PostMessages.LOCKED, undefined)
     })
 
     it('should add a handler for PostMessages.UNLOCKED', () => {
@@ -246,7 +243,7 @@ describe('postOfficeService', () => {
         expect(true).toBeTruthy()
       })
 
-      triggerListener<PostMessages.UNLOCKED>(PostMessages.UNLOCKED, undefined)
+      triggerListener(PostMessages.UNLOCKED, undefined)
     })
 
     it('should error if an invalid lock address is passed to PostMessages.PURCHASE_KEY', () => {
@@ -260,7 +257,7 @@ describe('postOfficeService', () => {
         expect(error).toBe('invalid lock, cannot purchase a key')
       })
 
-      triggerListener<PostMessages.PURCHASE_KEY>(PostMessages.PURCHASE_KEY, {
+      triggerListener(PostMessages.PURCHASE_KEY, {
         lock: lockAddress,
         extraTip: '0',
       })
@@ -279,10 +276,7 @@ describe('postOfficeService', () => {
 
       mockService.setAccount('hi')
 
-      expectPostMessage<PostMessages.UPDATE_ACCOUNT>(
-        PostMessages.UPDATE_ACCOUNT,
-        'hi'
-      )
+      expectPostMessage(PostMessages.UPDATE_ACCOUNT, 'hi')
     })
 
     it('should trigger show of the accounts modal if the user is not logged in', () => {
@@ -290,7 +284,7 @@ describe('postOfficeService', () => {
 
       mockService.setAccount(null)
 
-      expectPostMessage<PostMessages.SHOW_ACCOUNTS_MODAL>(
+      expectPostMessage(
         PostMessages.SHOW_ACCOUNTS_MODAL,
         undefined,
         2 /* which call to postMessage */
@@ -309,11 +303,7 @@ describe('postOfficeService', () => {
 
       mockService.showAccountModal()
 
-      expectPostMessage<PostMessages.SHOW_ACCOUNTS_MODAL>(
-        PostMessages.SHOW_ACCOUNTS_MODAL,
-        undefined,
-        2
-      )
+      expectPostMessage(PostMessages.SHOW_ACCOUNTS_MODAL, undefined, 2)
     })
 
     it('should send a request to hide the accounts modal when hideAccountModal is called', () => {
@@ -321,11 +311,7 @@ describe('postOfficeService', () => {
 
       mockService.hideAccountModal()
 
-      expectPostMessage<PostMessages.HIDE_ACCOUNTS_MODAL>(
-        PostMessages.HIDE_ACCOUNTS_MODAL,
-        undefined,
-        2
-      )
+      expectPostMessage(PostMessages.HIDE_ACCOUNTS_MODAL, undefined, 2)
     })
 
     it('should send a key purchase transaction initiated when transactionInitiated is called', () => {
@@ -333,11 +319,7 @@ describe('postOfficeService', () => {
 
       mockService.transactionInitiated()
 
-      expectPostMessage<PostMessages.INITIATED_TRANSACTION>(
-        PostMessages.INITIATED_TRANSACTION,
-        undefined,
-        2
-      )
+      expectPostMessage(PostMessages.INITIATED_TRANSACTION, undefined, 2)
     })
   })
 })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

In the renovate update, some test functions written for the postmessages gave some trouble because of the generic types they were using. The code itself runs fine, but the types raised an issue. This PR resolves the problem for the moment by using `any`. The longer term solution will be to move our postmessaging off this hand-rolled infrastructure to something more well-formed.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Unblocks #5259 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
