### PR TITLE
Add storageService method to access batch metadata endpoint

### DIFF
--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -782,4 +782,66 @@ describe('StorageService', () => {
       )
     })
   })
+
+  describe('getBulkMetadataFor', () => {
+    it('should emit success on success', done => {
+      expect.assertions(2)
+
+      const lockAddress = 'address'
+      const typedData = {
+        data: 'typed',
+      }
+      const userMetadata = {
+        '1': {
+          public: {
+            seven: '7',
+          },
+          protected: {
+            'capital seven': '七',
+          },
+        },
+      }
+      axios.get.mockReturnValue({
+        data: {
+          userMetadata,
+        },
+      })
+
+      storageService.on(success.getBulkMetadataFor, result => {
+        expect(result).toEqual(userMetadata)
+
+        done()
+      })
+
+      storageService.getBulkMetadataFor(lockAddress, 'a signature', typedData)
+      expect(axios.get).toHaveBeenCalledWith(
+        `${serviceHost}/api/key/${lockAddress}/keyHolderMetadata`,
+        {
+          headers: {
+            Authorization: ' Bearer a signature',
+          },
+          params: {
+            data: JSON.stringify(typedData),
+            signature: 'a signature',
+          },
+        }
+      )
+    })
+
+    it('should emit failure on failure', done => {
+      expect.assertions(1)
+
+      const lockAddress = 'address'
+      const typedData = 'stringified-typed-data'
+
+      axios.get.mockRejectedValue('welp')
+
+      storageService.on(failure.getBulkMetadataFor, error => {
+        expect(error).toBe('welp')
+        done()
+      })
+
+      storageService.getBulkMetadataFor(lockAddress, 'a signature', typedData)
+    })
+  })
 })

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -791,20 +791,9 @@ describe('StorageService', () => {
       const typedData = {
         data: 'typed',
       }
-      const userMetadata = {
-        '1': {
-          public: {
-            seven: '7',
-          },
-          protected: {
-            'capital seven': '七',
-          },
-        },
-      }
+      const userMetadata = []
       axios.get.mockReturnValue({
-        data: {
-          userMetadata,
-        },
+        data: userMetadata,
       })
 
       storageService.on(success.getBulkMetadataFor, result => {

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -20,6 +20,7 @@ export const success = {
   getKeyPrice: 'getKeyPrice.success',
   ejectUser: 'ejectUser.success',
   getMetadataFor: 'getMetadataFor.success',
+  getBulkMetadataFor: 'getBulkMetadataFor.success',
 }
 
 export const failure = {
@@ -37,6 +38,7 @@ export const failure = {
   getKeyPrice: 'getKeyPrice.failure',
   ejectUser: 'ejectUser.failure',
   getMetadataFor: 'getMetadataFor.failure',
+  getBulkMetadataFor: 'getBulkMetadataFor.failure',
 }
 
 export class StorageService extends EventEmitter {
@@ -387,6 +389,38 @@ export class StorageService extends EventEmitter {
       this.emit(success.getMetadataFor, payload)
     } catch (error) {
       this.emit(failure.getMetadataFor, error)
+    }
+  }
+
+  /**
+   * Given a lock address and a typed data signature, get the metadata
+   * (public and protected) associated with each key on that lock.
+   * @param {string} lockAddress
+   * @param {string} signature
+   * @param {*} data
+   */
+  async getBulkMetadataFor(lockAddress, signature, data) {
+    const stringData = JSON.stringify(data)
+    const opts = {
+      headers: this.genAuthorizationHeader(signature),
+      // No body allowed in GET, so these are passed as query params for this
+      // call.
+      params: {
+        data: stringData,
+        signature: signature,
+      },
+    }
+    try {
+      const result = await axios.get(
+        `${this.host}/api/key/${lockAddress}/keyHolderMetadata`,
+        opts
+      )
+
+      if (result.data && result.data.userMetadata) {
+        this.emit(success.getBulkMetadataFor, result.data.userMetadata)
+      }
+    } catch (error) {
+      this.emit(failure.getBulkMetadataFor, error)
     }
   }
 }

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -416,9 +416,7 @@ export class StorageService extends EventEmitter {
         opts
       )
 
-      if (result.data && result.data.userMetadata) {
-        this.emit(success.getBulkMetadataFor, result.data.userMetadata)
-      }
+      this.emit(success.getBulkMetadataFor, result.data)
     } catch (error) {
       this.emit(failure.getBulkMetadataFor, error)
     }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR extends storageService in `unlock-app` to access the bulk metadata endpoint. Calling it is quite similar to calling the per-key version, just without specifying a `keyId`.

Addition to storageMiddleware to replace the current approach will happen after locksmith is updated.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
