### PR TITLE
normalizing lock addresses in store

### DIFF
--- a/unlock-app/src/__tests__/reducers/locksReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/locksReducer.test.js
@@ -48,12 +48,15 @@ describe('locks reducer', () => {
     ).toBe(initialState)
   })
 
-  it('should add the lock when receiving CREATE_LOCK and if it was not there yet', () => {
+  it('should add the lock with a nornalized address when receiving CREATE_LOCK and if it was not there yet', () => {
     expect.assertions(1)
     expect(
       reducer(undefined, {
         type: CREATE_LOCK,
-        lock,
+        lock: {
+          ...lock,
+          address: lock.address.toUpperCase(),
+        },
       })
     ).toEqual({
       [lock.address]: lock,
@@ -161,6 +164,28 @@ describe('locks reducer', () => {
         },
       }
       expect(reducer(state, action)).toEqual(state)
+    })
+
+    it('should set the lock address if it is missing from the update', () => {
+      expect.assertions(1)
+      const state = {
+        '0x123': {
+          name: 'hello',
+          address: '0x123',
+        },
+      }
+      const newLock = {
+        name: 'Lock',
+      }
+      const action = {
+        type: UPDATE_LOCK,
+        address: '0x567',
+        update: newLock,
+      }
+      expect(reducer(state, action)).toEqual({
+        ...state,
+        [newLock.address]: newLock,
+      })
     })
 
     it('should insert the new lock when the lock being updated does not exist', () => {

--- a/unlock-app/src/reducers/locksReducer.js
+++ b/unlock-app/src/reducers/locksReducer.js
@@ -18,38 +18,59 @@ const locksReducer = (state = initialState, action) => {
 
   if (action.type === CREATE_LOCK) {
     if (action.lock.address) {
+      // Normalize to lower case to avoid dupes
+      const normalizedLockAddress = action.lock.address.toLowerCase()
       return {
         ...state,
-        [action.lock.address]: action.lock,
+        [normalizedLockAddress]: {
+          ...action.lock,
+          address: normalizedLockAddress,
+        },
       }
     }
   }
 
   // Upsets a lock (adds it if missing or update it if it exists)
   if (action.type === UPDATE_LOCK) {
-    if (action.update.address && action.update.address !== action.address) {
+    if (!action.address) {
+      return state
+    }
+
+    const normalizedLockAddress = action.address.toLowerCase()
+    if (
+      action.update.address &&
+      action.update.address.toLowerCase() !== normalizedLockAddress
+    ) {
       // 'Could not change the lock address' => Let's not change state
       return state
     }
 
+    // Making sure we set the address to be the same
+    action.update.address = normalizedLockAddress
+
     return {
       ...state,
-      [action.address]: { ...state[action.address], ...action.update },
+      [normalizedLockAddress]: {
+        ...state[normalizedLockAddress],
+        ...action.update,
+      },
     }
   }
 
   if (action.type === UPDATE_LOCK_KEY_PRICE) {
+    const normalizedLockAddress = action.address.toLowerCase()
     return {
       ...state,
-      [action.address]: {
-        ...state[action.address],
+      [normalizedLockAddress]: {
+        ...state[normalizedLockAddress],
         keyPrice: action.price,
       },
     }
   }
 
   if (action.type === DELETE_LOCK) {
-    delete state[action.address]
+    const normalizedLockAddress = action.address.toLowerCase()
+    delete state[normalizedLockAddress]
     return {
       ...state,
     }


### PR DESCRIPTION
# Description

This will avoid adding duplicate locks to the store when the addresses are dlightly different (case).

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->