### PR TITLE
adding support for createdAfter when retriving transactions

### DIFF
--- a/locksmith/__tests__/operations/transactionOperations.test.js
+++ b/locksmith/__tests__/operations/transactionOperations.test.js
@@ -83,5 +83,30 @@ describe('lockOperations', () => {
         })
       })
     })
+
+    describe('when passed a createdAfter value', () => {
+      it('should only return transactions created after that date', async () => {
+        expect.assertions(1)
+        const sender = '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
+        const timestamp = 1573742842379
+        Transaction.findAll = jest.fn(() => {})
+        await getTransactionsByFilter({
+          sender: sender,
+          recipient: ['0xCA750f9232C1c38e34D27e77534e1631526eC99e'],
+          createdAfter: timestamp,
+        })
+        expect(Transaction.findAll).toHaveBeenCalledWith({
+          where: {
+            recipient: {
+              [Op.in]: ['0xCA750f9232C1c38e34D27e77534e1631526eC99e'],
+            },
+            sender: { [Op.eq]: '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5' },
+            createdAt: {
+              [Op.gte]: new Date(timestamp),
+            },
+          },
+        })
+      })
+    })
   })
 })

--- a/locksmith/src/controllers/transactionController.js
+++ b/locksmith/src/controllers/transactionController.js
@@ -66,6 +66,10 @@ const buildFilter = req => {
     filter.for = req.query.for
   }
 
+  if (req.query.createdAfter) {
+    filter.createdAfter = req.query.createdAfter
+  }
+
   return filter
 }
 

--- a/locksmith/src/operations/transactionOperations.ts
+++ b/locksmith/src/operations/transactionOperations.ts
@@ -58,5 +58,10 @@ const queryFilter = (filter: any) => {
     target.sender = { [Op.eq]: ethJsUtil.toChecksumAddress(filter.sender) }
   }
 
+  // createdAfter is a timestamp in microseconds Time. (new Date().getTime())
+  if (filter.createdAfter) {
+    target.createdAt = { [Op.gte]: new Date(parseInt(filter.createdAfter)) }
+  }
+
   return target
 }


### PR DESCRIPTION
# Description

In an effort to make the dashboard (much) faster, especially when the user has multiple locks, I found that we actually retreived *all* of a user's transactions when loading the dashboard.

I believe we could restrict that to only the ones sent in the last 24 hours to reduce the load and make rendering faster!


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->