### PR TITLE
Use bulk metadata endpoint on members page

### DIFF
--- a/unlock-app/src/__tests__/actions/keyMetadata.test.ts
+++ b/unlock-app/src/__tests__/actions/keyMetadata.test.ts
@@ -1,13 +1,12 @@
 import {
-  SIGN_METADATA_REQUEST,
-  SIGN_METADATA_RESPONSE,
-  GOT_METADATA,
-  signMetadataRequest,
-  signMetadataResponse,
-  gotMetadata,
+  SIGN_BULK_METADATA_REQUEST,
+  SIGN_BULK_METADATA_RESPONSE,
+  GOT_BULK_METADATA,
+  signBulkMetadataRequest,
+  signBulkMetadataResponse,
+  gotBulkMetadata,
 } from '../../actions/keyMetadata'
 
-const keyIds = ['1', '13']
 const lockAddress = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
 
 describe('Key metadata signature actions', () => {
@@ -16,13 +15,12 @@ describe('Key metadata signature actions', () => {
       expect.assertions(1)
 
       const owner = '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a'
-      const result = signMetadataRequest(lockAddress, owner, keyIds)
+      const result = signBulkMetadataRequest(lockAddress, owner)
 
       expect(result).toEqual({
-        type: SIGN_METADATA_REQUEST,
+        type: SIGN_BULK_METADATA_REQUEST,
         lockAddress,
         owner,
-        keyIds,
         timestamp: expect.any(Number),
       })
     })
@@ -32,18 +30,16 @@ describe('Key metadata signature actions', () => {
     it('should create an action to return a signature', () => {
       expect.assertions(1)
 
-      const result = signMetadataResponse(
+      const result = signBulkMetadataResponse(
         'some data',
         'a signature',
-        keyIds,
         lockAddress
       )
 
       expect(result).toEqual({
-        type: SIGN_METADATA_RESPONSE,
+        type: SIGN_BULK_METADATA_RESPONSE,
         data: 'some data',
         signature: 'a signature',
-        keyIds,
         lockAddress,
       })
     })
@@ -53,12 +49,11 @@ describe('Key metadata signature actions', () => {
     it('should create an action to put the metadata in redux', () => {
       expect.assertions(1)
 
-      const result = gotMetadata('a lock address', '1', 'some data')
+      const result = gotBulkMetadata('a lock address', 'some data')
 
       expect(result).toEqual({
-        type: GOT_METADATA,
+        type: GOT_BULK_METADATA,
         lockAddress: 'a lock address',
-        keyId: '1',
         data: 'some data',
       })
     })

--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -23,15 +23,13 @@ import {
   SIGNED_ACCOUNT_EJECTION,
 } from '../../actions/user'
 import { success, failure } from '../../services/storageService'
-import Error from '../../utils/Error'
+import { Storage } from '../../utils/Error'
 import { setError, SET_ERROR } from '../../actions/error'
 import { ADD_TO_CART, UPDATE_PRICE } from '../../actions/keyPurchase'
 import UnlockUser from '../../structured_data/unlockUser'
-import { GOT_METADATA } from '../../actions/keyMetadata'
+import { GOT_BULK_METADATA } from '../../actions/keyMetadata'
 
 jest.mock('@unlock-protocol/unlock-js')
-
-const { Storage } = Error
 
 /**
  * This is a "fake" middleware caller
@@ -740,23 +738,17 @@ describe('Storage middleware', () => {
   describe('Key metadata', () => {
     const lockAddress = 'an address'
     const data = 'some data'
-    const keyId = '1'
     it('should dispatch a message when a request succeeds', () => {
       expect.assertions(1)
 
       const { store } = create()
 
-      mockStorageService.emit(success.getMetadataFor, {
-        lockAddress,
-        data,
-        keyId,
-      })
+      mockStorageService.emit(success.getBulkMetadataFor, lockAddress, data)
 
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: GOT_METADATA,
+        type: GOT_BULK_METADATA,
         lockAddress,
         data,
-        keyId,
       })
     })
 
@@ -765,14 +757,17 @@ describe('Storage middleware', () => {
 
       const { store } = create()
 
-      mockStorageService.emit(failure.getMetadataFor, 'something broke')
+      mockStorageService.emit(
+        failure.getBulkMetadataFor,
+        new Error('something broke')
+      )
 
       expect(store.dispatch).toHaveBeenCalledWith({
         type: SET_ERROR,
         error: {
           kind: 'Storage',
           level: 'Diagnostic',
-          message: 'Could not retrieve some key metadata.',
+          message: 'Could not get bulk metadata: something broke',
         },
       })
     })

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -29,8 +29,8 @@ import { HIDE_FORM } from '../../actions/lockFormVisibility'
 import { GET_STORED_PAYMENT_DETAILS } from '../../actions/user'
 import { SIGN_DATA } from '../../actions/signature'
 import {
-  SIGN_METADATA_REQUEST,
-  SIGN_METADATA_RESPONSE,
+  SIGN_BULK_METADATA_REQUEST,
+  SIGN_BULK_METADATA_RESPONSE,
 } from '../../actions/keyMetadata'
 
 let mockConfig
@@ -688,20 +688,19 @@ describe('Wallet middleware', () => {
     })
   })
 
-  describe('SIGN_METADATA_REQUEST', () => {
+  describe('SIGN_BULK_METADATA_REQUEST', () => {
     const action = {
-      type: SIGN_METADATA_REQUEST,
+      type: SIGN_BULK_METADATA_REQUEST,
       lockAddress: '0xe29ec42F0b620b1c9A716f79A02E9DC5A5f5F98a',
       owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
       timestamp: 1234567890,
-      keyIds: ['1', '13'],
     }
 
     const expectedTypedData = expect.objectContaining({
       primaryType: 'KeyMetadata',
     })
 
-    it("should handle SIGN_METADATA_REQUEST by calling walletService's signData", () => {
+    it("should handle SIGN_BULK_METADATA_REQUEST by calling walletService's signData", () => {
       expect.assertions(2)
       const { invoke, store } = create()
 
@@ -736,7 +735,7 @@ describe('Wallet middleware', () => {
       expect(store.dispatch).toHaveBeenNthCalledWith(2, dismissWalletCheck())
 
       expect(store.dispatch).toHaveBeenNthCalledWith(3, {
-        type: SIGN_METADATA_RESPONSE,
+        type: SIGN_BULK_METADATA_RESPONSE,
         data: expectedTypedData,
         signature: 'a signature',
         lockAddress: action.lockAddress,

--- a/unlock-app/src/__tests__/reducers/metadataReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/metadataReducer.test.ts
@@ -72,7 +72,7 @@ describe('metadataReducer', () => {
     const result = reducer(undefined, gotBulkMetadata(lockAddress, metadata))
 
     expect(result).toEqual({
-      [lockAddress]: {
+      [lockAddress.toLowerCase()]: {
         [userAddress]: {
           public: {
             color: 'blue',
@@ -85,7 +85,7 @@ describe('metadataReducer', () => {
   it('should append data when a lock address is already present', () => {
     expect.assertions(1)
     const initialState = {
-      [lockAddress]: {
+      [lockAddress.toLowerCase()]: {
         '0x123': {
           protected: {
             color: 'red',
@@ -97,13 +97,13 @@ describe('metadataReducer', () => {
     const result = reducer(initialState, gotBulkMetadata(lockAddress, metadata))
 
     expect(result).toEqual({
-      [lockAddress]: {
+      [lockAddress.toLowerCase()]: {
         '0x123': {
           protected: {
             color: 'red',
           },
         },
-        [userAddress]: {
+        [userAddress.toLowerCase()]: {
           public: {
             color: 'blue',
           },

--- a/unlock-app/src/__tests__/reducers/metadataReducer.test.ts
+++ b/unlock-app/src/__tests__/reducers/metadataReducer.test.ts
@@ -1,11 +1,27 @@
 import { SET_ACCOUNT } from '../../actions/accounts'
 import { SET_PROVIDER } from '../../actions/provider'
 import { SET_NETWORK } from '../../actions/network'
-import reducer, { initialState } from '../../reducers/metadataReducer'
-import { GOT_METADATA } from '../../actions/keyMetadata'
+import reducer, { initialState, Datum } from '../../reducers/metadataReducer'
+import { gotBulkMetadata } from '../../actions/keyMetadata'
+
+const lockAddress = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+const userAddress = '0xd4bb4b501ac12f35db35d60c845c8625b5f28fd1'
+
+const metadata: Datum[] = [
+  {
+    userAddress,
+    data: {
+      userMetadata: {
+        public: {
+          color: 'blue',
+        },
+      },
+    },
+  },
+]
 
 describe('metadataReducer', () => {
-  it('should return the initial state when receiveing SET_PROVIDER', () => {
+  it('should return the initial state when receiving SET_PROVIDER', () => {
     expect.assertions(1)
     const result = reducer(
       {
@@ -18,7 +34,7 @@ describe('metadataReducer', () => {
     expect(result).toBe(initialState)
   })
 
-  it('should return the initial state when receiveing SET_ACCOUNT', () => {
+  it('should return the initial state when receiving SET_ACCOUNT', () => {
     expect.assertions(1)
     const result = reducer(
       {
@@ -31,7 +47,7 @@ describe('metadataReducer', () => {
     expect(result).toBe(initialState)
   })
 
-  it('should return the initial state when receiveing SET_NETWORK', () => {
+  it('should return the initial state when receiving SET_NETWORK', () => {
     expect.assertions(1)
     const result = reducer(
       {
@@ -53,20 +69,11 @@ describe('metadataReducer', () => {
 
   it('adds a lock to the state with metadata', () => {
     expect.assertions(1)
-    const result = reducer(undefined, {
-      type: GOT_METADATA,
-      lockAddress: 'my address',
-      keyId: '7',
-      data: {
-        public: {
-          color: 'blue',
-        },
-      },
-    })
+    const result = reducer(undefined, gotBulkMetadata(lockAddress, metadata))
 
     expect(result).toEqual({
-      'my address': {
-        '7': {
+      [lockAddress]: {
+        [userAddress]: {
           public: {
             color: 'blue',
           },
@@ -78,36 +85,27 @@ describe('metadataReducer', () => {
   it('should append data when a lock address is already present', () => {
     expect.assertions(1)
     const initialState = {
-      'my address': {
-        '7': {
-          public: {
-            color: 'blue',
+      [lockAddress]: {
+        '0x123': {
+          protected: {
+            color: 'red',
           },
         },
       },
     }
 
-    const result = reducer(initialState, {
-      type: GOT_METADATA,
-      lockAddress: 'my address',
-      keyId: '8',
-      data: {
-        public: {
-          emailAddress: 'in@ter.net',
-        },
-      },
-    })
+    const result = reducer(initialState, gotBulkMetadata(lockAddress, metadata))
 
     expect(result).toEqual({
-      'my address': {
-        '7': {
-          public: {
-            color: 'blue',
+      [lockAddress]: {
+        '0x123': {
+          protected: {
+            color: 'red',
           },
         },
-        '8': {
+        [userAddress]: {
           public: {
-            emailAddress: 'in@ter.net',
+            color: 'blue',
           },
         },
       },

--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -796,11 +796,14 @@ describe('StorageService', () => {
         data: userMetadata,
       })
 
-      storageService.on(success.getBulkMetadataFor, result => {
-        expect(result).toEqual(userMetadata)
+      storageService.on(
+        success.getBulkMetadataFor,
+        (returnedLockAddress, result) => {
+          expect(result).toEqual(userMetadata)
 
-        done()
-      })
+          done()
+        }
+      )
 
       storageService.getBulkMetadataFor(lockAddress, 'a signature', typedData)
       expect(axios.get).toHaveBeenCalledWith(

--- a/unlock-app/src/__tests__/utils/metadataMunging.test.ts
+++ b/unlock-app/src/__tests__/utils/metadataMunging.test.ts
@@ -83,7 +83,7 @@ describe('metadata munging functions', () => {
       }
       const storedMetadata = {
         [lock.address]: {
-          [key.keyId]: {
+          [key.owner.address]: {
             protected: {
               zebra: 'true',
             },

--- a/unlock-app/src/actions/keyMetadata.ts
+++ b/unlock-app/src/actions/keyMetadata.ts
@@ -1,41 +1,35 @@
-export const SIGN_METADATA_REQUEST = 'keyMetadata/SIGN_METADATA_REQUEST'
-export const SIGN_METADATA_RESPONSE = 'keyMetadata/SIGN_METADATA_RESPONSE'
-export const GOT_METADATA = 'keyMetadata/GOT_METADATA'
+export const SIGN_BULK_METADATA_REQUEST =
+  'keyMetadata/SIGN_BULK_METADATA_REQUEST'
+export const SIGN_BULK_METADATA_RESPONSE =
+  'keyMetadata/SIGN_BULK_METADATA_RESPONSE'
+export const GOT_BULK_METADATA = 'keyMetadata/GOT_BULK_METADATA'
 
-export function signMetadataRequest(
-  lockAddress: string,
-  owner: string,
-  keyIds: string[]
-) {
+export function signBulkMetadataRequest(lockAddress: string, owner: string) {
   return {
-    type: SIGN_METADATA_REQUEST,
+    type: SIGN_BULK_METADATA_REQUEST,
     lockAddress,
     owner,
-    keyIds,
     timestamp: Date.now(),
   }
 }
 
-export function signMetadataResponse(
+export function signBulkMetadataResponse(
   data: any,
   signature: any,
-  keyIds: string[],
   lockAddress: string
 ) {
   return {
-    type: SIGN_METADATA_RESPONSE,
+    type: SIGN_BULK_METADATA_RESPONSE,
     data,
     signature,
-    keyIds,
     lockAddress,
   }
 }
 
-export function gotMetadata(lockAddress: string, keyId: string, data: any) {
+export function gotBulkMetadata(lockAddress: string, data: any) {
   return {
-    type: GOT_METADATA,
+    type: GOT_BULK_METADATA,
     lockAddress,
-    keyId,
     data,
   }
 }

--- a/unlock-app/src/components/content/MembersContent.tsx
+++ b/unlock-app/src/components/content/MembersContent.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../unlockTypes'
 import { MetadataTable } from '../interface/MetadataTable'
 import keyHolderQuery from '../../queries/keyholdersByLock'
-import { signMetadataRequest } from '../../actions/keyMetadata'
+import { signBulkMetadataRequest } from '../../actions/keyMetadata'
 import {
   mergeKeyholderMetadata,
   generateColumns,
@@ -27,7 +27,7 @@ interface Props {
   account: AccountType
   network: Network
   lockAddresses: string[]
-  signMetadataRequest: typeof signMetadataRequest
+  signBulkMetadataRequest: typeof signBulkMetadataRequest
   metadata: ReduxMetadata
 }
 
@@ -35,7 +35,7 @@ export const MembersContent = ({
   account,
   network,
   lockAddresses,
-  signMetadataRequest,
+  signBulkMetadataRequest,
   metadata,
 }: Props) => {
   return (
@@ -48,7 +48,7 @@ export const MembersContent = ({
           <Account network={network} account={account} />
           <MetadataTableWrapper
             lockAddresses={lockAddresses}
-            signMetadataRequest={signMetadataRequest}
+            signBulkMetadataRequest={signBulkMetadataRequest}
             accountAddress={account.address}
             storedMetadata={metadata}
           />
@@ -60,7 +60,7 @@ export const MembersContent = ({
 
 interface MetadataTableWrapperProps {
   lockAddresses: string[]
-  signMetadataRequest: typeof signMetadataRequest
+  signBulkMetadataRequest: typeof signBulkMetadataRequest
   accountAddress: string
   storedMetadata: ReduxMetadata
 }
@@ -71,7 +71,7 @@ interface MetadataTableWrapperProps {
  */
 const MetadataTableWrapper = ({
   lockAddresses,
-  signMetadataRequest,
+  signBulkMetadataRequest,
   accountAddress,
   storedMetadata,
 }: MetadataTableWrapperProps) => {
@@ -80,11 +80,10 @@ const MetadataTableWrapper = ({
   })
 
   useEffect(() => {
-    // Dispatch request for key metadata here, only when data changes
+    // Dispatch requests for key metadata here, only when data changes
     if (data) {
       ;(data as KeyholdersByLock).locks.forEach(lock => {
-        const keyIds = lock.keys.map(key => key.keyId)
-        signMetadataRequest(lock.address, accountAddress, keyIds)
+        signBulkMetadataRequest(lock.address, accountAddress)
       })
     }
   }, [data])
@@ -138,4 +137,6 @@ export const mapStateToProps = ({
   }
 }
 
-export default connect(mapStateToProps, { signMetadataRequest })(MembersContent)
+export default connect(mapStateToProps, { signBulkMetadataRequest })(
+  MembersContent
+)

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -30,8 +30,8 @@ import { transactionTypeMapping } from '../utils/types' // TODO change POLLING_I
 import { getStoredPaymentDetails } from '../actions/user'
 import { SIGN_DATA, signedData } from '../actions/signature'
 import {
-  SIGN_METADATA_REQUEST,
-  signMetadataResponse,
+  SIGN_BULK_METADATA_REQUEST,
+  signBulkMetadataResponse,
 } from '../actions/keyMetadata'
 import generateKeyTypedData from '../structured_data/keyMetadataTypedData'
 
@@ -230,8 +230,8 @@ const walletMiddleware = config => {
               }
             }
           )
-        } else if (action.type === SIGN_METADATA_REQUEST) {
-          const { lockAddress, owner, timestamp, keyIds } = action
+        } else if (action.type === SIGN_BULK_METADATA_REQUEST) {
+          const { lockAddress, owner, timestamp } = action
 
           // Usage from locksmith tests for metadataController
           const typedData = generateKeyTypedData({
@@ -257,7 +257,7 @@ const walletMiddleware = config => {
             } else {
               dispatch(dismissWalletCheck())
               dispatch(
-                signMetadataResponse(typedData, signature, keyIds, lockAddress)
+                signBulkMetadataResponse(typedData, signature, lockAddress)
               )
             }
           })

--- a/unlock-app/src/reducers/metadataReducer.ts
+++ b/unlock-app/src/reducers/metadataReducer.ts
@@ -36,15 +36,17 @@ const metadataReducer = (state = initialState, action: Action) => {
 
   if (action.type === GOT_BULK_METADATA) {
     const { lockAddress, data } = action
+    const normalizedLockAddress = lockAddress.toLowerCase()
     const bulkData: Datum[] = data
 
     // make sure we always have a bucket to put our metadata into
-    if (!state[lockAddress]) {
-      state[lockAddress] = {}
+    if (!state[normalizedLockAddress]) {
+      state[normalizedLockAddress] = {}
     }
 
     bulkData.forEach(datum => {
-      state[lockAddress][datum.userAddress] = {
+      const userAddress = datum.userAddress.toLowerCase()
+      state[normalizedLockAddress][userAddress] = {
         public: datum.data.userMetadata.public,
         protected: datum.data.userMetadata.protected,
       }

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -416,7 +416,7 @@ export class StorageService extends EventEmitter {
         opts
       )
 
-      this.emit(success.getBulkMetadataFor, result.data)
+      this.emit(success.getBulkMetadataFor, lockAddress, result.data)
     } catch (error) {
       this.emit(failure.getBulkMetadataFor, error)
     }

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -159,7 +159,7 @@ export interface KeyMetadata {
 // import from every connected component
 export interface ReduxMetadata {
   [lockAddress: string]: {
-    [keyId: string]: {
+    [userAddress: string]: {
       protected?: { [key: string]: string }
       public?: { [key: string]: string }
     }

--- a/unlock-app/src/utils/metadataMunging.ts
+++ b/unlock-app/src/utils/metadataMunging.ts
@@ -12,8 +12,12 @@ export const mergeSingleDatum = (
     keyholderAddress: key.owner.address,
   }
 
-  if (dataFromRedux[lock.address] && dataFromRedux[lock.address][key.keyId]) {
-    const storedKeyMetadata = dataFromRedux[lock.address][key.keyId]
+  if (
+    dataFromRedux[lock.address] &&
+    dataFromRedux[lock.address][metadatum.keyholderAddress]
+  ) {
+    const storedKeyMetadata =
+      dataFromRedux[lock.address][metadatum.keyholderAddress]
     // If there are collisions between the various metadata fields (from the
     // graph, and from the 2 possible fields from locksmith), they will be
     // overwritten by whichever value comes last


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR updates the members page to use the bulk metadata endpoint to get all keyholder information in a single pass.

<img width="1668" alt="image" src="https://user-images.githubusercontent.com/9300702/68894257-ef9c3480-06f4-11ea-94bc-67b7b78088c8.png">
(screenshot proof that it works as before)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
