### PR TITLE
refactored the lock action/reducer by removing ADD_LOCK

### DIFF
--- a/unlock-app/src/__tests__/actions/lock.test.js
+++ b/unlock-app/src/__tests__/actions/lock.test.js
@@ -1,5 +1,4 @@
 import {
-  addLock,
   createLock,
   deleteLock,
   getLock,
@@ -7,7 +6,6 @@ import {
   withdrawFromLock,
   updateKeyPrice,
   CREATE_LOCK,
-  ADD_LOCK,
   DELETE_LOCK,
   GET_LOCK,
   UPDATE_LOCK,
@@ -36,18 +34,6 @@ describe('lock actions', () => {
       update,
     }
     expect(updateLock(address, update)).toEqual(expectedAction)
-  })
-
-  it('should create an action to add the lock', () => {
-    expect.assertions(1)
-    const lock = {}
-    const address = '0x123'
-    const expectedAction = {
-      type: ADD_LOCK,
-      address,
-      lock,
-    }
-    expect(addLock(address, lock)).toEqual(expectedAction)
   })
 
   it('should create an action to get the lock', () => {

--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -1,12 +1,7 @@
 import UnlockJs from '@unlock-protocol/unlock-js'
 import EventEmitter from 'events'
 import web3Middleware from '../../middlewares/web3Middleware'
-import {
-  ADD_LOCK,
-  GET_LOCK,
-  UPDATE_LOCK,
-  CREATE_LOCK,
-} from '../../actions/lock'
+import { GET_LOCK, UPDATE_LOCK, CREATE_LOCK } from '../../actions/lock'
 import { UPDATE_ACCOUNT, setAccount } from '../../actions/accounts'
 import {
   ADD_TRANSACTION,
@@ -177,7 +172,7 @@ describe('Lock middleware', () => {
       })
     })
 
-    it('it should dispatch ADD_LOCK if the lock does not already exist', () => {
+    it('it should dispatch UPDATE_LOCK if the lock does not already exist', () => {
       expect.assertions(1)
       const { store } = create()
       const lock = {
@@ -190,14 +185,14 @@ describe('Lock middleware', () => {
       mockWeb3Service.emit('lock.updated', lock.address, update)
       expect(store.dispatch).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: ADD_LOCK,
+          type: UPDATE_LOCK,
           address: lock.address,
-          lock: update,
+          update,
         })
       )
     })
 
-    it('it should ADD_LOCK with the right unlimitedKey field', () => {
+    it('it should UPDATE_LOCK with the right unlimitedKey field', () => {
       expect.assertions(1)
       const { store } = create()
       const lock = {
@@ -212,9 +207,9 @@ describe('Lock middleware', () => {
       mockWeb3Service.emit('lock.updated', lock.address, update)
       expect(store.dispatch).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: ADD_LOCK,
+          type: UPDATE_LOCK,
           address: lock.address,
-          lock: expect.objectContaining({
+          update: expect.objectContaining({
             maxNumberOfKeys: UNLIMITED_KEYS_COUNT,
             unlimitedKeys: true,
           }),

--- a/unlock-app/src/__tests__/reducers/locksReducer.test.js
+++ b/unlock-app/src/__tests__/reducers/locksReducer.test.js
@@ -1,6 +1,5 @@
 import reducer, { initialState } from '../../reducers/locksReducer'
 import {
-  ADD_LOCK,
   CREATE_LOCK,
   DELETE_LOCK,
   UPDATE_LOCK,
@@ -145,58 +144,6 @@ describe('locks reducer', () => {
     })
   })
 
-  describe('ADD_LOCK', () => {
-    it('should keep state unchanged if the address is a mismatch', () => {
-      expect.assertions(1)
-      const state = {}
-      const action = {
-        type: ADD_LOCK,
-        address: '0x123',
-        lock: {
-          address: '0x456',
-        },
-      }
-      expect(reducer(state, action)).toEqual(state)
-    })
-
-    it('should keep state unchanged if the lock was previously added', () => {
-      expect.assertions(1)
-      const state = {
-        '0x123': {},
-      }
-      const action = {
-        type: ADD_LOCK,
-        address: '0x123',
-        lock: {
-          address: '0x123',
-        },
-      }
-      expect(reducer(state, action)).toEqual(state)
-    })
-
-    it('should add the lock and add its address', () => {
-      expect.assertions(1)
-      const state = {
-        '0x456': {},
-      }
-      const action = {
-        type: ADD_LOCK,
-        address: '0x123',
-        lock: {
-          name: 'hello',
-        },
-      }
-
-      expect(reducer(state, action)).toEqual({
-        '0x456': {},
-        '0x123': {
-          address: '0x123',
-          name: 'hello',
-        },
-      })
-    })
-  })
-
   describe('UPDATE_LOCK', () => {
     it('should keep state unchanged if trying to update the lock address', () => {
       expect.assertions(1)
@@ -216,7 +163,7 @@ describe('locks reducer', () => {
       expect(reducer(state, action)).toEqual(state)
     })
 
-    it('should keep state unchanged when the lock being updated does not exist', () => {
+    it('should insert the new lock when the lock being updated does not exist', () => {
       expect.assertions(1)
       const state = {
         '0x123': {
@@ -224,14 +171,18 @@ describe('locks reducer', () => {
           address: '0x123',
         },
       }
+      const newLock = {
+        address: '0x456',
+      }
       const action = {
         type: UPDATE_LOCK,
-        address: '0x456',
-        update: {
-          address: '0x456',
-        },
+        address: newLock.address,
+        update: newLock,
       }
-      expect(reducer(state, action)).toEqual(state)
+      expect(reducer(state, action)).toEqual({
+        ...state,
+        [newLock.address]: newLock,
+      })
     })
 
     it('should update the locks values', () => {

--- a/unlock-app/src/actions/lock.js
+++ b/unlock-app/src/actions/lock.js
@@ -1,4 +1,3 @@
-export const ADD_LOCK = 'lock/ADD_LOCK'
 export const CREATE_LOCK = 'lock/CREATE_LOCK'
 export const DELETE_LOCK = 'lock/DELETE_LOCK'
 export const GET_LOCK = 'lock/GET_LOCK'
@@ -8,12 +7,6 @@ export const WITHDRAW_FROM_LOCK = 'lock/WITHDRAW_FROM_LOCK'
 
 export const createLock = lock => ({
   type: CREATE_LOCK,
-  lock,
-})
-
-export const addLock = (address, lock) => ({
-  type: ADD_LOCK,
-  address,
   lock,
 })
 

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -1,13 +1,7 @@
 /* eslint promise/prefer-await-to-then: 0 */
 
 import { Web3Service } from '@unlock-protocol/unlock-js'
-import {
-  CREATE_LOCK,
-  GET_LOCK,
-  addLock,
-  updateLock,
-  createLock,
-} from '../actions/lock'
+import { CREATE_LOCK, GET_LOCK, updateLock, createLock } from '../actions/lock'
 
 import { startLoading, doneLoading } from '../actions/loading'
 import { updateAccount, SET_ACCOUNT } from '../actions/accounts'
@@ -60,13 +54,9 @@ const web3Middleware = config => {
         update.unlimitedKeys = update.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
       }
 
-      if (lock) {
-        // Only dispatch the updates which are more recent than the current value
-        if (!lock.asOf || lock.asOf < update.asOf) {
-          dispatch(updateLock(lock.address, update))
-        }
-      } else {
-        dispatch(addLock(address, update))
+      // Only dispatch the updates which are more recent than the current value
+      if (!lock || !lock.asOf || lock.asOf < update.asOf) {
+        dispatch(updateLock(address, update))
       }
     })
 

--- a/unlock-app/src/reducers/locksReducer.js
+++ b/unlock-app/src/reducers/locksReducer.js
@@ -1,5 +1,4 @@
 import {
-  ADD_LOCK,
   CREATE_LOCK,
   DELETE_LOCK,
   UPDATE_LOCK,
@@ -17,26 +16,6 @@ const locksReducer = (state = initialState, action) => {
     return initialState
   }
 
-  if (action.type === ADD_LOCK) {
-    if (action.lock.address && action.lock.address !== action.address) {
-      // 'Mismatch in lock address' => Let's not change state
-      return state
-    }
-
-    if (state[action.address]) {
-      // 'Lock already exists' => Let's not change state
-      return state
-    }
-
-    return {
-      ...state,
-      [action.address]: {
-        address: action.address,
-        ...action.lock,
-      },
-    }
-  }
-
   if (action.type === CREATE_LOCK) {
     if (action.lock.address) {
       return {
@@ -46,16 +25,10 @@ const locksReducer = (state = initialState, action) => {
     }
   }
 
-  // Replace the lock in list with the updated value
-  // This will change the locks value... except for its address!
+  // Upsets a lock (adds it if missing or update it if it exists)
   if (action.type === UPDATE_LOCK) {
     if (action.update.address && action.update.address !== action.address) {
       // 'Could not change the lock address' => Let's not change state
-      return state
-    }
-
-    if (!state[action.address]) {
-      // 'Could not update missing lock' => Let's not change state
       return state
     }
 


### PR DESCRIPTION
# Description

We had 2 actions ADD_LOCK and UPDATE_LOCK whose logic is pretty similar.
Rather than keep the confusion, UPDATE_LOCK will now upsert locks in the Redux store.



# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->