### PR TITLE
Retrieving the list of locks for a given user from the graph

### DIFF
--- a/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/storageMiddleware.test.js
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'events'
 import * as unlockJs from '@unlock-protocol/unlock-js'
 import storageMiddleware from '../../middlewares/storageMiddleware'
-import { getLock } from '../../actions/lock'
 import { addTransaction, NEW_TRANSACTION } from '../../actions/transaction'
 import { SET_ACCOUNT, UPDATE_ACCOUNT } from '../../actions/accounts'
 import { startLoading, doneLoading } from '../../actions/loading'
@@ -146,7 +145,6 @@ describe('Storage middleware', () => {
       const action = { type: SET_ACCOUNT, account }
 
       mockStorageService.getRecentTransactionsHashesSentBy = jest.fn()
-      mockStorageService.getLockAddressesForUser = jest.fn()
 
       invoke(action)
       expect(store.dispatch).toHaveBeenCalledWith(startLoading())
@@ -197,24 +195,6 @@ describe('Storage middleware', () => {
         setError(Storage.Diagnostic('getTransactionHashesSentBy failed.'))
       )
       expect(store.dispatch).toHaveBeenNthCalledWith(2, doneLoading())
-    })
-
-    it('should get the locks for that user from the storageService', () => {
-      expect.assertions(2)
-      const { next, invoke } = create()
-      const account = {
-        address: '0x123',
-      }
-      const action = { type: SET_ACCOUNT, account }
-
-      mockStorageService.getLockAddressesForUser = jest.fn()
-      mockStorageService.getRecentTransactionsHashesSentBy = jest.fn()
-
-      invoke(action)
-      expect(mockStorageService.getLockAddressesForUser).toHaveBeenCalledWith(
-        account.address
-      )
-      expect(next).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -600,20 +580,6 @@ describe('Storage middleware', () => {
       mockStorageService.emit(success.getCards, cards)
 
       expect(store.dispatch).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('getLockAddressesForUser', () => {
-    it('should handle success', () => {
-      expect.assertions(2)
-      const { store } = create()
-      const addresses = ['0x123', '0x456']
-
-      mockStorageService.emit(success.getLockAddressesForUser, addresses)
-
-      addresses.forEach(address => {
-        expect(store.dispatch).toHaveBeenCalledWith(getLock(address))
-      })
     })
   })
 

--- a/unlock-app/src/middlewares/storageMiddleware.js
+++ b/unlock-app/src/middlewares/storageMiddleware.js
@@ -4,7 +4,6 @@ import {
   createAccountAndPasswordEncryptKey,
   reEncryptPrivateKey,
 } from '@unlock-protocol/unlock-js'
-import { getLock } from '../actions/lock'
 
 import { startLoading, doneLoading } from '../actions/loading'
 
@@ -147,14 +146,6 @@ const storageMiddleware = config => {
       dispatch(setError(Storage.Warning('Unable to retrieve payment methods.')))
     })
 
-    // Note: we do not handle failures for now as most locks (except the pending or transfered ones...) should be eventually retrieved thru the transactions anyway
-    storageService.on(success.getLockAddressesForUser, addresses => {
-      // Once we have the locks, we should emit them so they can be retrieved from chain
-      addresses.forEach(address => {
-        dispatch(getLock(address))
-      })
-    })
-
     storageService.on(success.getKeyPrice, fees => {
       dispatch(updatePrice(fees))
     })
@@ -239,8 +230,6 @@ const storageMiddleware = config => {
           storageService.getRecentTransactionsHashesSentBy(
             action.account.address
           )
-          // When we set the account, we want to retrive the list of locks
-          storageService.getLockAddressesForUser(action.account.address)
         }
 
         if (action.type === SIGNED_USER_DATA) {


### PR DESCRIPTION
# Description

This makes the dashboard MUCH faster. I can now load the 52 locks on my staging account without hitting
rate limits either!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->