### PR TITLE
Allow key owners to view private metadata associated with their keys

### DIFF
--- a/locksmith/__tests__/controllers/metadataController/requestingTokenMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/requestingTokenMetadata.test.ts
@@ -58,34 +58,34 @@ function generateKeyTypedData(message: any) {
   }
 }
 
-describe('when the signee owns the lock', () => {
-  let typedData: any
-  beforeAll(() => {
-    typedData = generateKeyTypedData({
-      KeyMetaData: {
-        custom_field: 'custom value',
-        owner: owningAddress,
-      },
-    })
-
-    mockOnChainLockOwnership.owner = jest.fn(() => {
-      return Promise.resolve(owningAddress)
-    })
+let typedData: any
+beforeAll(() => {
+  typedData = generateKeyTypedData({
+    KeyMetaData: {
+      custom_field: 'custom value',
+      owner: owningAddress,
+    },
   })
 
-  describe('when missing relevant signature details', () => {
-    it('returns as unauthorized', async () => {
-      expect.assertions(1)
-
-      const response = await request(app)
-        .put(`/api/key/${lockAddress}/5`)
-        .set('Accept', 'json')
-        .send(typedData)
-
-      expect(response.status).toEqual(401)
-    })
+  mockOnChainLockOwnership.owner = jest.fn(() => {
+    return Promise.resolve(owningAddress)
   })
+})
 
+describe('when missing relevant signature details', () => {
+  it('returns as unauthorized', async () => {
+    expect.assertions(1)
+
+    const response = await request(app)
+      .put(`/api/key/${lockAddress}/5`)
+      .set('Accept', 'json')
+      .send(typedData)
+
+    expect(response.status).toEqual(401)
+  })
+})
+
+describe('When the signee is the Lock owner', () => {
   describe('when including signature details', () => {
     it('stores the provided key metadata', async () => {
       expect.assertions(1)

--- a/locksmith/__tests__/test-helpers/typeDataGenerators.ts
+++ b/locksmith/__tests__/test-helpers/typeDataGenerators.ts
@@ -1,0 +1,26 @@
+// eslint-disable-next-line import/prefer-default-export
+export function lockTypedData(message: any) {
+  return {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+        { name: 'salt', type: 'bytes32' },
+      ],
+      LockMetadata: [
+        { name: 'address', type: 'address' },
+        { name: 'name', type: 'string' },
+        { name: 'description', type: 'string' },
+        { name: 'image', type: 'string' },
+      ],
+    },
+    domain: {
+      name: 'Unlock',
+      version: '1',
+    },
+    primaryType: 'LockMetadata',
+    message,
+  }
+}

--- a/locksmith/src/utils/lockData.ts
+++ b/locksmith/src/utils/lockData.ts
@@ -30,4 +30,14 @@ export default class LockData {
       return false
     }
   }
+
+  async getKeyOwner(lockAddress: string, tokenId: number): Promise<string> {
+    let lock = new ethers.Contract(
+      lockAddress,
+      ['function ownerOf(uint256 _tokenId) constant view returns (address)'],
+      this.provider
+    )
+
+    return await lock.ownerOf(tokenId)
+  }
 }


### PR DESCRIPTION
# Description

As part of a request, with a well formed signature from a key owner -  protected
metadata is now provided with a  request for token metadata

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
