### PR TITLE
adding method to return svg icon

### DIFF
--- a/locksmith/__tests__/utils/lockIcon.test.ts
+++ b/locksmith/__tests__/utils/lockIcon.test.ts
@@ -1,0 +1,11 @@
+import { lockIcon } from '../../src/utils/lockIcon'
+
+describe('lockIcon', () => {
+  it('should generate the right svg for different locks', () => {
+    expect.assertions(2)
+    const lockIcon1 = lockIcon('0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2')
+    const lockIcon2 = lockIcon('0x95de5F777A3e283bFf0c47374998E10D8A2183C7')
+    expect(lockIcon1).toMatch(/^<svg/)
+    expect(lockIcon1).not.toEqual(lockIcon2)
+  })
+})

--- a/locksmith/package-lock.json
+++ b/locksmith/package-lock.json
@@ -4550,14 +4550,6 @@
       "resolved": "https://registry.npmjs.org/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz",
       "integrity": "sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg=="
     },
-    "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-      "requires": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      }
-    },
     "ethereumjs-account": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
@@ -12499,6 +12491,41 @@
           "requires": {
             "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
             "ethereumjs-util": "^5.1.1"
+          }
+        },
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+          "requires": {
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+              "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^2.0.0",
+                "rlp": "^2.2.3",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "keccak": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.0.0.tgz",
+              "integrity": "sha512-rKe/lRr0KGhjoz97cwg+oeT1Rj/Y4cjae6glArioUC8JBF9ROGZctwIaaruM7d7naovME4Q8WcQSO908A8qcyQ==",
+              "requires": {
+                "bindings": "^1.2.1",
+                "inherits": "^2.0.3",
+                "nan": "^2.2.1",
+                "safe-buffer": "^5.1.0"
+              }
+            }
           }
         },
         "ethereumjs-util": {

--- a/locksmith/src/color-scheme.d.ts
+++ b/locksmith/src/color-scheme.d.ts
@@ -1,0 +1,1 @@
+declare module 'color-scheme'

--- a/locksmith/src/controllers/lockController.js
+++ b/locksmith/src/controllers/lockController.js
@@ -2,6 +2,7 @@ import LockOwnership from '../data/lockOwnership'
 
 const logger = require('../locksmithLogger')
 const lockOperations = require('../operations/lockOperations')
+const lockIconUtils = require('../../src/utils/lockIcon').default
 
 const env = process.env.NODE_ENV || 'development'
 const config = require('../../config/config')[env]
@@ -43,4 +44,22 @@ const lockOwnershipCheck = async (req, res) => {
   return res.sendStatus(200)
 }
 
-module.exports = { lockGet, lockOwnerGet, lockSave, lockOwnershipCheck }
+/**
+ * Yiels the SVG icon for the lock
+ * @param {*} req
+ * @param {*} res
+ */
+const lockIcon = async (req, res) => {
+  let lockAddress = req.params.lockAddress
+  let svg = lockIconUtils.lockIcon(lockAddress)
+  res.setHeader('Content-Type', 'image/svg+xml')
+  return res.send(svg)
+}
+
+module.exports = {
+  lockGet,
+  lockOwnerGet,
+  lockSave,
+  lockOwnershipCheck,
+  lockIcon,
+}

--- a/locksmith/src/routes/lock.ts
+++ b/locksmith/src/routes/lock.ts
@@ -6,6 +6,7 @@ var lockController = require('../controllers/lockController')
 router.post('/lock', lockController.lockSave)
 router.get('/lock/:lockAddress', lockController.lockGet)
 router.get('/lock/:lockAddress/cycle', lockController.lockOwnershipCheck)
+router.get('/lock/:lockAddress/icon', lockController.lockIcon)
 router.get('/:owner/locks', lockController.lockOwnerGet)
 
 module.exports = router

--- a/locksmith/src/utils/lockIcon.ts
+++ b/locksmith/src/utils/lockIcon.ts
@@ -1,0 +1,150 @@
+import ColorScheme = require('color-scheme')
+
+export const lockIcon = (address: string) => {
+  /**
+   * This computes how much rotation to apply to the lock glyph
+   * @param {string} address
+   * @returns {number}
+   */
+  const degreesOfRotation = (address: string) => {
+    const n = parseInt(address)
+    return (n % 36) * 10
+  }
+
+  /**
+   * Translates and scales the lock glyph
+   * @param address
+   */
+  const translateAndScale = (address: string) => {
+    const n = parseInt(address)
+    return n % 2 == 0 ? '' : 'tranlate(216, 0) scale(-1, 1)'
+  }
+
+  // Default colors
+  const scheme = new ColorScheme()
+  const mainColor = address.substring(2, 8).toUpperCase()
+  scheme
+    .from_hex(mainColor)
+    .scheme('triade')
+    .variation('pastel')
+  const colors = scheme.colors().map((c: string) => `#${c}`)
+
+  // Default origin icon
+  const originalIcon = [
+    { x: 195.75, y: 114.75 },
+    { x: 33.75, y: 162 },
+    { x: 121.5, y: 0 },
+  ]
+
+  // Stripped variant
+  const stripedIcon = [
+    { x: 108, y: 108 },
+    { x: 146, y: 147 },
+    { x: 216, y: 216 },
+  ]
+
+  // Chomp variant
+  const chompIcon = [
+    { x: 108, y: 108 },
+    { x: 108, y: -64 },
+    { x: 108, y: 280 },
+  ]
+
+  // Bite variant
+  const biteIcon = [
+    { x: 108, y: 108 },
+    { x: 108, y: 0 },
+    { x: 108, y: 216 },
+  ]
+
+  // Tail variant
+  const tailIcon = [
+    { x: 108, y: 108 },
+    { x: 64, y: 0 },
+    { x: 64, y: 216 },
+  ]
+
+  // Traid variant
+  const triadIcon = [
+    { x: 108, y: 108 },
+    { x: 32, y: 0 },
+    { x: 32, y: 216 },
+  ]
+
+  /**
+   * This selects a set of 3 circles (specified by position) to use to construct the lock icon.
+   * @param {string} address
+   * @returns {object}
+   */
+  const circles = (address: string) => {
+    const options = [
+      originalIcon,
+      stripedIcon,
+      chompIcon,
+      biteIcon,
+      tailIcon,
+      triadIcon,
+    ]
+    const n = parseInt(address) % options.length
+    return options[n]
+  }
+
+  const innerCircles = circles(address)
+
+  const svg = `<svg
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 216 216"
+      width="100%"
+    >
+      <defs>
+        <circle id="a" cx="108" cy="108" r="108" />
+        <circle id="c" cx="108" cy="108" r="60.75" />
+      </defs>
+      <g>
+        <mask id="b" fill="#fff">
+          <use xlink:href="#a" />
+        </mask>
+        <g
+          transform="rotate(${degreesOfRotation(
+            address
+          )}, 108, 108) ${translateAndScale(address)}">
+          <circle
+            fill="${colors[0]}"
+            mask="url(#b)"
+            cx="${innerCircles[0].x}"
+            cy="${innerCircles[0].y}"
+            r="114.75"
+          />
+          <circle
+            fill="${colors[1]}"
+            mask="url(#b)"
+            cx="${innerCircles[1].x}"
+            cy="${innerCircles[1].y}"
+            r="114.75"
+          />
+          <circle
+            fill="${colors[2]}"
+            mask="url(#b)"
+            cx="${innerCircles[2].x}"
+            cy="${innerCircles[2].y}"
+            r="114.75"
+          />
+        </g>
+        <mask id="d" fill="#fff">
+          <use xlink:href="#c" />
+        </mask>
+        <use fill="#FFF" xlink:href="#c" />
+        <path
+          d="M121.179 116.422c-.001.895-.05 1.797-.168 2.683-1.047 7.845-9.512 12.951-17.006 10.275-5.482-1.958-8.917-6.786-8.921-12.582-.003-3.972-.003-7.944-.003-11.916h26.103c-.001 3.847-.002 7.694-.005 11.54m16.198-34.477V81h-16.335v16.198H94.936l.001-15.26v-.918h-16.28c-.014.196-.035.34-.035.483.001 5.232-.012 10.463-.019 15.695H74.25v7.694h4.353c.004 4.167.015 8.334.05 12.5.07 8.231 3.508 15.052 9.88 20.2 9.188 7.422 19.562 9 30.636 4.94 10.486-3.846 18.35-13.87 18.231-26.081-.037-3.853-.05-7.706-.054-11.559h4.404v-7.694h-4.4c.01-5.085.027-10.17.027-15.253"
+          fill="${colors[0]}"
+          mask="url(#d)"
+        />
+      </g>
+    </svg>`
+  return svg
+}
+
+export default {
+  lockIcon,
+}


### PR DESCRIPTION
# Description

In order to be consistent in our icons for NFT and locks, we need to have the icons be "served" by locksmith.
This PR does add the function to locksmith to serve the icon based on the lock address.


# Issues

Refs #5128

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [X] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->