### PR TITLE
Data iframe handles postMessages more fluidly

### DIFF
--- a/paywall/src/__tests__/unlock.js/IframeHandler.test.ts
+++ b/paywall/src/__tests__/unlock.js/IframeHandler.test.ts
@@ -85,17 +85,15 @@ describe('IframeHandler', () => {
     expect(ready).not.toHaveBeenCalled()
   })
 
-  it('should set up postmessage listeners for the data and checkout iframes', () => {
-    expect.assertions(2)
+  it('should set up postmessage listeners for the checkout iframe', () => {
+    expect.assertions(1)
 
     const iframeHandler = makeIframeHandler()
     iframeHandler.checkout.setupListeners = jest.fn()
-    iframeHandler.data.setupListeners = jest.fn()
 
     iframeHandler.init(config)
 
     expect(iframeHandler.checkout.setupListeners).toHaveBeenCalled()
-    expect(iframeHandler.data.setupListeners).toHaveBeenCalled()
   })
 
   it('should listen for PostMessages.READY emit, and send the config to the data iframe on receipt', () => {

--- a/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
+++ b/paywall/src/__tests__/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.test.ts
@@ -12,7 +12,6 @@ describe('DataIframeMessageEmitter', () => {
       fakeWindow,
       'http://fun.times/fakey'
     )
-    emitter.setupListeners()
     return emitter
   }
 
@@ -54,27 +53,9 @@ describe('DataIframeMessageEmitter', () => {
         dataOrigin // iframe origin
       )
     })
-
-    it('should set up addHandler', () => {
-      expect.assertions(1)
-
-      const fakeReady = jest.fn()
-      const emitter = makeEmitter(fakeWindow)
-
-      emitter.addHandler(PostMessages.READY, fakeReady)
-
-      fakeWindow.receivePostMessageFromIframe(
-        PostMessages.READY,
-        undefined,
-        emitter.iframe,
-        dataOrigin
-      )
-
-      expect(fakeReady).toHaveBeenCalled()
-    })
   })
 
-  describe('setupListeners', () => {
+  describe('emitting received postMessages', () => {
     let ready: () => void
 
     beforeEach(() => {

--- a/paywall/src/__tests__/unlock.js/startup.test.ts
+++ b/paywall/src/__tests__/unlock.js/startup.test.ts
@@ -104,12 +104,7 @@ describe('unlock.js startup', () => {
       fakeWindow.unlockProtocolConfig = config
       const iframes = startup(fakeWindow, constants)
 
-      fakeWindow.receivePostMessageFromIframe(
-        PostMessages.READY,
-        undefined,
-        iframes.data.iframe,
-        dataOrigin
-      )
+      iframes.data.emit(PostMessages.READY)
 
       await fakeWindow.waitForPostMessageToIframe(iframes.data.iframe)
 
@@ -192,12 +187,7 @@ describe('unlock.js startup', () => {
       fakeWindow.makeWeb3()
       const iframes = startup(fakeWindow, constants)
 
-      fakeWindow.receivePostMessageFromIframe(
-        PostMessages.READY_WEB3,
-        undefined,
-        iframes.data.iframe,
-        dataOrigin
-      )
+      iframes.data.emit(PostMessages.READY_WEB3)
 
       await fakeWindow.waitForPostMessageToIframe(iframes.data.iframe)
 
@@ -223,12 +213,7 @@ describe('unlock.js startup', () => {
       }
       const iframes = startup(fakeWindow, constants)
 
-      fakeWindow.receivePostMessageFromIframe(
-        PostMessages.READY_WEB3,
-        undefined,
-        iframes.data.iframe,
-        dataOrigin
-      )
+      iframes.data.emit(PostMessages.READY_WEB3)
 
       expect(
         ((fakeWindow as unknown) as UnlockWindow).unlockProtocol

--- a/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
+++ b/paywall/src/unlock.js/PostMessageEmitters/DataIframeMessageEmitter.ts
@@ -2,8 +2,7 @@ import { EventEmitter } from 'events'
 import { PostMessages } from '../../messageTypes'
 import {
   PostMessageResponder,
-  mainWindowPostOffice,
-  PostMessageListener,
+  emitPostMessagesFrom,
 } from '../../utils/postOffice'
 import {
   IframeType,
@@ -11,10 +10,7 @@ import {
   PostOfficeWindow,
 } from '../../windowTypes'
 import { makeIframe, addIframeToDocument } from '../iframeManager'
-import {
-  DataIframeEventEmitter,
-  DataIframeEvents,
-} from '../../EventEmitterTypes'
+import { DataIframeEventEmitter } from '../../EventEmitterTypes'
 
 interface UnvalidatedPayload {
   method?: any
@@ -30,16 +26,9 @@ class FancyEmitter extends (EventEmitter as {
  * This is an abstraction layer around the post office for the data iframe
  *
  * It is used both to listen for incoming messages, and to send outgoing messages.
- * For most, it simply emits what it receives, but in some cases it performs
- * additional logic, such as validating web3 method calls, or not forwarding
- * empty locks
+ * It simply emits all postMessages it receives as events.
  */
 export default class DataIframeMessageEmitter extends FancyEmitter {
-  public readonly addHandler: (
-    type: keyof DataIframeEvents,
-    listener: PostMessageListener
-  ) => void
-
   public readonly postMessage: PostMessageResponder<PostMessages>
   public readonly iframe: IframeType
 
@@ -53,15 +42,33 @@ export default class DataIframeMessageEmitter extends FancyEmitter {
     const url = new URL(this.iframe.src)
     addIframeToDocument(window, this.iframe)
 
-    const { postMessage, addHandler } = mainWindowPostOffice(
-      window,
-      this.iframe,
+    const { postMessage } = emitPostMessagesFrom(
+      this.iframe.contentWindow,
       url.origin,
-      'main window',
-      'Data iframe'
+      window,
+      this.emitWrapper
     )
     this.postMessage = postMessage
-    this.addHandler = addHandler
+  }
+
+  emitWrapper = (type: PostMessages, payload?: any) => {
+    // Don't emit a locks update if the update is empty
+    // TODO: move this logic elsewhere -- consumer should be able to
+    // handle an empty array
+    if (
+      type === PostMessages.UPDATE_LOCKS &&
+      payload &&
+      !Object.keys(payload).length
+    ) {
+      return
+    }
+
+    // Don't emit requests for WEB3 method calls that are poorly formed
+    if (type === PostMessages.WEB3 && !this.validateWeb3MethodCall(payload)) {
+      return
+    }
+
+    this.emit(type as any, payload)
   }
 
   /**
@@ -82,50 +89,5 @@ export default class DataIframeMessageEmitter extends FancyEmitter {
       return false
     }
     return true
-  }
-
-  public setupListeners() {
-    this.addHandler(PostMessages.READY, () => this.emit(PostMessages.READY))
-    this.addHandler(PostMessages.READY_WEB3, () =>
-      this.emit(PostMessages.READY_WEB3)
-    )
-    this.addHandler(PostMessages.LOCKED, () => this.emit(PostMessages.LOCKED))
-    this.addHandler(PostMessages.UNLOCKED, locks =>
-      this.emit(PostMessages.UNLOCKED, locks)
-    )
-    this.addHandler(PostMessages.ERROR, error =>
-      this.emit(PostMessages.ERROR, error)
-    )
-    this.addHandler(PostMessages.UPDATE_WALLET, update =>
-      this.emit(PostMessages.UPDATE_WALLET, update)
-    )
-    this.addHandler(PostMessages.WEB3, payload => {
-      // don't pass on anything that is not a valid web3 request
-      if (!this.validateWeb3MethodCall(payload)) return
-      this.emit(PostMessages.WEB3, payload)
-    })
-    this.addHandler(PostMessages.UPDATE_ACCOUNT, account =>
-      this.emit(PostMessages.UPDATE_ACCOUNT, account)
-    )
-    this.addHandler(PostMessages.UPDATE_ACCOUNT_BALANCE, balance =>
-      this.emit(PostMessages.UPDATE_ACCOUNT_BALANCE, balance)
-    )
-    this.addHandler(PostMessages.UPDATE_NETWORK, network =>
-      this.emit(PostMessages.UPDATE_NETWORK, network)
-    )
-    this.addHandler(PostMessages.UPDATE_LOCKS, locks => {
-      if (!Object.keys(locks).length) {
-        // this happens on a fresh start before the blockchain handler retrieves locks
-        // in this case, we ignore the update to simplify downstream
-        return
-      }
-      this.emit(PostMessages.UPDATE_LOCKS, locks)
-    })
-    this.addHandler(PostMessages.UPDATE_TRANSACTIONS, transactions => {
-      this.emit(PostMessages.UPDATE_TRANSACTIONS, transactions)
-    })
-    this.addHandler(PostMessages.UPDATE_KEYS, keys => {
-      this.emit(PostMessages.UPDATE_KEYS, keys)
-    })
   }
 }

--- a/paywall/src/unlock.js/postMessageHub.ts
+++ b/paywall/src/unlock.js/postMessageHub.ts
@@ -116,7 +116,6 @@ export function iframeHandlerInit({
 }: iframeHandlerInitArgs) {
   // TODO: consider removing the layer of event listeners and work with
   // postmessages directly
-  dataIframe.setupListeners()
   checkoutIframe.setupListeners()
   // account listener setup will be on-demand, done by the Wallet in setupWallet()
   // Comment above verbatim from original site. Will likely be changed.


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR is another piece of the postMessage refactoring and serves as a template for future work.

Currently, all the various iframes have an EventEmitter abstraction layer standing between them and the messages they want to receive. They all also have to register which messages they're interested in. As a result people don't know where to add code for new messages (I know @julien51 and I have both been bitten by this).

Any code changes to postMessages should only happen at 2 points: where the message is produced, and where the message is consumed. This PR moves us toward that, simplifying a lot of the interaction on the data iframe. Once we've done this for all the iframe event emitters, there will be a lot of dead code we can ditch.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
