### PR TITLE
not throwing when metadata cannot be retrieved

### DIFF
--- a/unlock-app/src/__tests__/hooks/useMetadata.test.js
+++ b/unlock-app/src/__tests__/hooks/useMetadata.test.js
@@ -32,4 +32,17 @@ describe('useMetadata', () => {
     await waitForNextUpdate()
     expect(result.current).toStrictEqual(metadata)
   })
+
+  it('should yield the default metadata for the token if metadata is not found', async () => {
+    expect.assertions(1)
+    axios.get = jest.fn(() => {
+      return Promise.reject()
+    })
+    const tokenUri = 'https://metadata'
+    const { result } = renderHook(() => useMetadata(tokenUri))
+
+    expect(result.current).toStrictEqual({
+      image: 'https://assets.unlock-protocol.com/unlock-default-key-image.png',
+    })
+  })
 })

--- a/unlock-app/src/hooks/useMetadata.js
+++ b/unlock-app/src/hooks/useMetadata.js
@@ -13,7 +13,12 @@ export const useMetadata = url => {
   const [metadata, setMetadata] = useState(defaultMetadata)
 
   const getMetadata = async () => {
-    let tokenMetadata = await axios.get(url).then(response => response.data)
+    let tokenMetadata = defaultMetadata
+    try {
+      tokenMetadata = await axios.get(url).then(response => response.data)
+    } catch (error) {
+      // Do not fail on error, we'll keep defaulting to the default values
+    }
     setMetadata(tokenMetadata)
   }
 


### PR DESCRIPTION
# Description

This will prevent integration tests from failure because of an Uncaught error.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->