### PR TITLE
adding a check on the lock being loaded to remove a race condition in integration tests

### DIFF
--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -85,6 +85,13 @@ describe('The Unlock Dashboard', () => {
           .innerText.match(/Confirming/)
       }, newLock)
 
+      // We should wait for all the lock info to be loaded here (no more -)
+      await wait.untilIsTrue(address => {
+        return !document
+          .querySelector(`[data-address="${address}"]`)
+          .innerText.match('-')
+      }, newLock)
+
       // Get the locks' innerText
       const lockText = await page.evaluate(address => {
         return document.querySelector(`[data-address="${address}"]`).innerText


### PR DESCRIPTION
# Description

As I was looking at recent failures on CI I found that we look at the content of a lock too early...
This should prevent that from happening.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->