### PR TITLE
Consolidate postMessages that should always be listened to

### DIFF
--- a/paywall/src/__tests__/unlock.js/postmessageHub.test.ts
+++ b/paywall/src/__tests__/unlock.js/postmessageHub.test.ts
@@ -1,0 +1,360 @@
+import { unconditionalStartup } from '../../unlock.js/postMessageHub'
+import { PostMessages } from '../../messageTypes'
+import FakeWindow from '../test-helpers/fakeWindowHelpers'
+import IframeHandler from '../../unlock.js/IframeHandler'
+
+interface initOptions {
+  usingManagedAccount?: boolean
+  blockchainData?: any
+  erc20ContractAddress?: string
+  toggleLockState?: () => void
+  hideCheckoutIframe?: () => void
+  showAccountIframe?: () => void
+  hideAccountIframe?: () => void
+  setUserAccountAddress?: (address: string | null) => void
+  setUserAccountNetwork?: (network: number) => void
+  paywallConfig?: any
+}
+
+const init = (overrides?: initOptions) => {
+  const window = new FakeWindow()
+  const iframes = new IframeHandler(window, 'http://d', 'http://c', 'http://a')
+  ;(iframes.checkout as any).postMessage = jest.fn()
+  ;(iframes.accounts as any).postMessage = jest.fn()
+  ;(iframes.data as any).postMessage = jest.fn()
+
+  let options = overrides || {}
+
+  unconditionalStartup({
+    iframes,
+    blockchainData: options.blockchainData || {},
+    usingManagedAccount: options.usingManagedAccount || false,
+    erc20ContractAddress: options.erc20ContractAddress || '0xneato',
+    toggleLockState: options.toggleLockState || jest.fn(),
+    paywallConfig: options.paywallConfig || {},
+    hideCheckoutIframe: options.hideCheckoutIframe || jest.fn(),
+    showAccountIframe: options.showAccountIframe || jest.fn(),
+    hideAccountIframe: options.hideAccountIframe || jest.fn(),
+    setUserAccountAddress: options.setUserAccountAddress || jest.fn(),
+    setUserAccountNetwork: options.setUserAccountNetwork || jest.fn(),
+  })
+
+  return {
+    window,
+    iframes,
+  }
+}
+
+describe('unconditionalStartup', () => {
+  describe('data iframe', () => {
+    describe('UPDATE_*', () => {
+      it.each([
+        [PostMessages.UPDATE_LOCKS, 'locks'],
+        [PostMessages.UPDATE_ACCOUNT, 'account'],
+        [PostMessages.UPDATE_NETWORK, 'network'],
+        [PostMessages.UPDATE_KEYS, 'keys'],
+        [PostMessages.UPDATE_TRANSACTIONS, 'transactions'],
+      ])(
+        'when data iframe emits %p, it sends payload to checkout, accounts, and main window',
+        (message, payload) => {
+          expect.assertions(3)
+
+          let blockchainData: { [key: string]: any } = {}
+          const { iframes } = init({ blockchainData })
+
+          iframes.data.emit(message as any, payload)
+
+          expect(iframes.checkout.postMessage).toHaveBeenCalledWith(
+            message,
+            payload
+          )
+          expect(iframes.accounts.postMessage).toHaveBeenCalledWith(
+            message,
+            payload
+          )
+          expect(blockchainData[payload]).toEqual(payload)
+        }
+      )
+    })
+
+    describe('UPDATE_ACCOUNT_BALANCE', () => {
+      it('should pass balance along when not using managed account', () => {
+        expect.assertions(2)
+
+        const blockchainData: any = {}
+        const { iframes } = init({ blockchainData })
+
+        const payload = {
+          eth: '7',
+          '0xneato': '8',
+        }
+
+        iframes.data.emit(PostMessages.UPDATE_ACCOUNT_BALANCE, payload)
+
+        expect(iframes.checkout.postMessage).toHaveBeenCalledWith(
+          PostMessages.UPDATE_ACCOUNT_BALANCE,
+          payload
+        )
+        expect(blockchainData.balance).toEqual(payload)
+      })
+
+      it('should intercept a certain erc20 address and zero out all other balances', () => {
+        expect.assertions(2)
+
+        const blockchainData: any = {}
+        const usingManagedAccount = true
+        const { iframes } = init({ blockchainData, usingManagedAccount })
+
+        const payload = {
+          eth: '7',
+          '0xneato': '8',
+        }
+
+        const expectedPayload = {
+          eth: '0',
+          '0xneato': '35',
+        }
+
+        iframes.data.emit(PostMessages.UPDATE_ACCOUNT_BALANCE, payload)
+
+        expect(iframes.checkout.postMessage).toHaveBeenCalledWith(
+          PostMessages.UPDATE_ACCOUNT_BALANCE,
+          expectedPayload
+        )
+        expect(blockchainData.balance).toEqual(expectedPayload)
+      })
+    })
+
+    describe('ERROR', () => {
+      it('should send all errors to checkout iframe', () => {
+        expect.assertions(2)
+
+        const toggleLockState = jest.fn()
+        const { iframes } = init({ toggleLockState })
+        const error = 'angry bees in the datacenter'
+        iframes.data.emit(PostMessages.ERROR, error)
+
+        expect(iframes.checkout.postMessage).toHaveBeenCalledWith(
+          PostMessages.ERROR,
+          error
+        )
+        expect(toggleLockState).not.toHaveBeenCalled()
+      })
+
+      it('should lock the page only on the no wallet error', () => {
+        expect.assertions(2)
+
+        const toggleLockState = jest.fn()
+        const { iframes } = init({ toggleLockState })
+        const error = 'no ethereum wallet is available'
+        iframes.data.emit(PostMessages.ERROR, error)
+
+        expect(iframes.checkout.postMessage).toHaveBeenCalledWith(
+          PostMessages.ERROR,
+          error
+        )
+        expect(toggleLockState).toHaveBeenCalledWith(PostMessages.LOCKED)
+      })
+    })
+
+    describe('LOCKED', () => {
+      it('should send LOCKED to checkout and toggleLockState', () => {
+        expect.assertions(2)
+
+        const toggleLockState = jest.fn()
+        const { iframes } = init({ toggleLockState })
+
+        iframes.data.emit(PostMessages.LOCKED)
+
+        expect(iframes.checkout.postMessage).toHaveBeenCalledWith(
+          PostMessages.LOCKED,
+          undefined
+        )
+        expect(toggleLockState).toHaveBeenCalledWith(PostMessages.LOCKED)
+      })
+    })
+
+    describe('UNLOCKED', () => {
+      it('should send UNLOCKED to checkout and toggleLockState', () => {
+        expect.assertions(2)
+
+        const toggleLockState = jest.fn()
+        const { iframes } = init({ toggleLockState })
+
+        iframes.data.emit(PostMessages.UNLOCKED, [])
+
+        expect(iframes.checkout.postMessage).toHaveBeenCalledWith(
+          PostMessages.UNLOCKED,
+          []
+        )
+        expect(toggleLockState).toHaveBeenCalledWith(PostMessages.UNLOCKED)
+      })
+    })
+
+    describe('READY', () => {
+      it('should send the paywall config down to data iframe', () => {
+        expect.assertions(1)
+
+        const paywallConfig = {
+          locks: 'several',
+        }
+
+        const { iframes } = init({ paywallConfig })
+
+        iframes.data.emit(PostMessages.READY)
+
+        expect(iframes.data.postMessage).toHaveBeenCalledWith(
+          PostMessages.CONFIG,
+          paywallConfig
+        )
+      })
+    })
+  })
+
+  describe('accounts iframe', () => {
+    describe('READY', () => {
+      it('should send the config and requests for network and account down to account iframe', () => {
+        expect.assertions(4)
+
+        const {
+          iframes: { accounts, data },
+        } = init()
+
+        accounts.emit(PostMessages.READY)
+
+        expect(accounts.postMessage).toHaveBeenNthCalledWith(
+          1,
+          PostMessages.CONFIG,
+          {}
+        )
+        expect(accounts.postMessage).toHaveBeenNthCalledWith(
+          2,
+          PostMessages.SEND_UPDATES,
+          'account'
+        )
+        expect(accounts.postMessage).toHaveBeenNthCalledWith(
+          3,
+          PostMessages.SEND_UPDATES,
+          'network'
+        )
+
+        // also we get locks from data iframe (obsolete with main window mirror?)
+        expect(data.postMessage).toHaveBeenCalledWith(
+          PostMessages.SEND_UPDATES,
+          'locks'
+        )
+      })
+    })
+
+    describe('*_ACCOUNTS_MODAL', () => {
+      it('calls the showAccountIframe function on SHOW_ACCOUNTS_MODAL', () => {
+        expect.assertions(1)
+
+        const showAccountIframe = jest.fn()
+        const {
+          iframes: { accounts },
+        } = init({ showAccountIframe })
+
+        accounts.emit(PostMessages.SHOW_ACCOUNTS_MODAL)
+
+        expect(showAccountIframe).toHaveBeenCalled()
+      })
+
+      it('calls the hideAccountIframe function on HIDE_ACCOUNTS_MODAL', () => {
+        expect.assertions(1)
+
+        const hideAccountIframe = jest.fn()
+        const {
+          iframes: { accounts },
+        } = init({ hideAccountIframe })
+
+        accounts.emit(PostMessages.HIDE_ACCOUNTS_MODAL)
+
+        expect(hideAccountIframe).toHaveBeenCalled()
+      })
+    })
+
+    describe('UPDATE_*', () => {
+      it('should call the setUserAccountAddress function on UPDATE_ACCOUNT', () => {
+        expect.assertions(1)
+
+        const setUserAccountAddress = jest.fn()
+        const {
+          iframes: { accounts },
+        } = init({ setUserAccountAddress })
+        accounts.emit(PostMessages.UPDATE_ACCOUNT, '0xbudgerigar')
+        expect(setUserAccountAddress).toHaveBeenCalledWith('0xbudgerigar')
+      })
+
+      it('should call the setUserAccountNetwork function on UPDATE_NETWORK', () => {
+        expect.assertions(1)
+
+        const setUserAccountNetwork = jest.fn()
+        const {
+          iframes: { accounts },
+        } = init({ setUserAccountNetwork })
+        accounts.emit(PostMessages.UPDATE_NETWORK, 1)
+        expect(setUserAccountNetwork).toHaveBeenCalledWith(1)
+      })
+    })
+
+    it('should pass INITIATED_TRANSACTION to data iframe', () => {
+      expect.assertions(1)
+
+      const {
+        iframes: { accounts, data },
+      } = init()
+
+      accounts.emit(PostMessages.INITIATED_TRANSACTION)
+      expect(data.postMessage).toHaveBeenLastCalledWith(
+        PostMessages.INITIATED_TRANSACTION,
+        undefined
+      )
+    })
+  })
+
+  describe('checkout iframe', () => {
+    it('should get all the data from data iframe on READY', () => {
+      expect.assertions(1)
+
+      const { iframes } = init()
+
+      iframes.checkout.emit(PostMessages.READY)
+
+      expect(iframes.data.postMessage).toHaveBeenCalledTimes(6)
+    })
+
+    it('should call the hideCheckoutIframe function on DISMISS_CHECKOUT', () => {
+      expect.assertions(1)
+
+      const hideCheckoutIframe = jest.fn()
+      const { iframes } = init({ hideCheckoutIframe })
+
+      iframes.checkout.emit(PostMessages.DISMISS_CHECKOUT)
+      expect(hideCheckoutIframe).toHaveBeenCalled()
+    })
+
+    describe('PURCHASE_KEY', () => {
+      it('should forward the request to the accounts iframe if usingManagedAccount', () => {
+        expect.assertions(2)
+
+        const usingManagedAccount = true
+        const {
+          iframes: { accounts, data, checkout },
+        } = init({ usingManagedAccount })
+
+        const request = {
+          lock: '0xneato',
+          extraTip: '0',
+        }
+
+        checkout.emit(PostMessages.PURCHASE_KEY, request)
+        expect(accounts.postMessage).toHaveBeenCalledWith(
+          PostMessages.PURCHASE_KEY,
+          request
+        )
+        expect(data.postMessage).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/utils/injectDefaultBalance.test.ts
+++ b/paywall/src/__tests__/utils/injectDefaultBalance.test.ts
@@ -1,0 +1,37 @@
+import injectDefaultBalance from '../../utils/injectDefaultBalance'
+import { DEFAULT_STABLECOIN_BALANCE } from '../../constants'
+
+describe('injectDefaultBalance helper', () => {
+  const erc20ContractAddress = '0xdeadbeef'
+  it('should return empty object given an empty object', () => {
+    expect.assertions(1)
+    expect(injectDefaultBalance({}, erc20ContractAddress)).toEqual({})
+  })
+
+  it('should zero out eth', () => {
+    expect.assertions(1)
+    const balance = {
+      eth: '123.4',
+    }
+    const expectedBalance = {
+      eth: '0',
+    }
+    expect(injectDefaultBalance(balance, erc20ContractAddress)).toEqual(
+      expectedBalance
+    )
+  })
+
+  it('should update balances for the managed purchase stablecoin address with the default', () => {
+    expect.assertions(1)
+    const balance = {
+      eth: '123.4',
+      '0x123abc': '0',
+      '0xdeadbeef': '0',
+    }
+    expect(injectDefaultBalance(balance, erc20ContractAddress)).toEqual({
+      eth: '0',
+      '0x123abc': '0',
+      '0xdeadbeef': DEFAULT_STABLECOIN_BALANCE,
+    })
+  })
+})

--- a/paywall/src/utils/injectDefaultBalance.ts
+++ b/paywall/src/utils/injectDefaultBalance.ts
@@ -1,0 +1,26 @@
+import { Balance } from '../unlockTypes'
+import { DEFAULT_STABLECOIN_BALANCE } from '../constants'
+
+export const injectDefaultBalance = (
+  oldBalance: Balance,
+  erc20ContractAddress: string
+): Balance => {
+  const newBalance: Balance = {}
+  const tokens = Object.keys(oldBalance)
+  tokens.forEach(token => {
+    if (token === erc20ContractAddress) {
+      // If the token is the one we allow, we give the user a default
+      // balance. TODO: only do this if the corresponding lock is approved.
+      newBalance[token] = DEFAULT_STABLECOIN_BALANCE
+    } else {
+      // the "null account" 0x0000000... has an enormous balance of eth and other tokens. We zero
+      // them out here so that we don't enable purchasing on the wrong locks for user
+      // account users.
+      newBalance[token] = '0'
+    }
+  })
+
+  return newBalance
+}
+
+export default injectDefaultBalance


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR is a chunk taken off #5362. It is the product of evaluating the several postMessage listeners we set up and taking all the ones that we should always listen to unconditionally. A next step will be to replace many of the various `init` and `setup` functions with it. Then another next step will be to decompose it into smaller functions (basically, one function per message?). Those functions should be more or less what we'll use on the main window side of a postmessaging library in the future.

I think we can also get the other listeners at this top level as well, we just need to invert some of the logic so that these can occur at the top level instead of buried deep in the hierarchy. In general, we need to go from a tall, skinny tree of modules to a short, broad tree of modules in the main window.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
