### PR TITLE
Calculate wallet status at startup

### DIFF
--- a/paywall/src/__tests__/unlock.js/Wallet/init.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/init.test.ts
@@ -29,19 +29,15 @@ describe('Wallet.init()', () => {
     accountsUrl: 'http://app/accounts',
     erc20ContractAddress: '0x591AD9066603f5499d12fF4bC207e2f577448c46',
   }
-  const userAccountsConfig: PaywallConfig = {
-    ...regularConfig,
-    unlockUserAccounts: true,
-  }
 
-  function makeWallet(configuration = regularConfig) {
+  function makeWallet() {
     iframes = new IframeHandler(
       fakeWindow,
       dataIframeUrl,
       checkoutIframeUrl,
       userIframeUrl
     )
-    return new Wallet(fakeWindow, iframes, configuration, startup)
+    return new Wallet(fakeWindow, iframes, regularConfig, startup)
   }
 
   function setupUserAccountsSpy() {
@@ -60,6 +56,7 @@ describe('Wallet.init()', () => {
     beforeEach(() => {
       fakeWindow = new FakeWindow()
       fakeWindow.makeWeb3()
+      jest.clearAllMocks()
     })
 
     it('should use crypto wallet if one exists on window', () => {
@@ -68,7 +65,11 @@ describe('Wallet.init()', () => {
       const handler = makeWallet()
       const setupUserAccounts = setupUserAccountsSpy()
 
-      handler.init()
+      handler.init({
+        shouldUseUserAccounts: false,
+        hasWallet: true,
+        isMetamask: true,
+      })
 
       expect(setupUserAccounts).not.toHaveBeenCalled()
     })
@@ -77,9 +78,13 @@ describe('Wallet.init()', () => {
       expect.assertions(1)
 
       fakeWindow.makeWeb3()
-      const handler = makeWallet(userAccountsConfig)
+      const handler = makeWallet()
       const setupWeb3ProxyWallet = setupWeb3ProxyWalletSpy()
-      handler.init()
+      handler.init({
+        shouldUseUserAccounts: true,
+        hasWallet: true,
+        isMetamask: true,
+      })
 
       expect(setupWeb3ProxyWallet).toHaveBeenCalled()
     })
@@ -89,7 +94,11 @@ describe('Wallet.init()', () => {
 
       const handler = makeWallet()
       const setupWeb3ProxyWallet = setupWeb3ProxyWalletSpy()
-      handler.init()
+      handler.init({
+        hasWallet: false,
+        shouldUseUserAccounts: false,
+        isMetamask: false,
+      })
 
       expect(setupWeb3ProxyWallet).toHaveBeenCalled()
     })
@@ -98,6 +107,7 @@ describe('Wallet.init()', () => {
   describe('has no crypto wallet', () => {
     beforeEach(() => {
       fakeWindow = new FakeWindow()
+      jest.clearAllMocks()
     })
 
     it('should use crypto wallet if config does not ask for user accounts', () => {
@@ -106,7 +116,11 @@ describe('Wallet.init()', () => {
       const handler = makeWallet()
       const setupUserAccounts = setupUserAccountsSpy()
 
-      handler.init()
+      handler.init({
+        shouldUseUserAccounts: false,
+        hasWallet: true,
+        isMetamask: true,
+      })
 
       expect(setupUserAccounts).not.toHaveBeenCalled()
     })
@@ -114,27 +128,15 @@ describe('Wallet.init()', () => {
     it('should use user accounts proxy wallet if user accounts specified', () => {
       expect.assertions(2)
 
-      const handler = makeWallet(userAccountsConfig)
+      const handler = makeWallet()
       const setupUserAccounts = setupUserAccountsSpy()
       const setupUserAccountsProxyWallet = setupUserAccountsProxyWalletSpy()
 
-      handler.init()
-
-      expect(setupUserAccounts).toHaveBeenCalled()
-      expect(setupUserAccountsProxyWallet).toHaveBeenCalled()
-    })
-
-    it('should use user accounts proxy wallet if user accounts specified as "true"', () => {
-      expect.assertions(2)
-
-      const handler = makeWallet({
-        ...userAccountsConfig,
-        unlockUserAccounts: 'true',
+      handler.init({
+        shouldUseUserAccounts: true,
+        hasWallet: false,
+        isMetamask: false,
       })
-      const setupUserAccounts = setupUserAccountsSpy()
-      const setupUserAccountsProxyWallet = setupUserAccountsProxyWalletSpy()
-
-      handler.init()
 
       expect(setupUserAccounts).toHaveBeenCalled()
       expect(setupUserAccountsProxyWallet).toHaveBeenCalled()
@@ -143,9 +145,13 @@ describe('Wallet.init()', () => {
     it('should setup user accounts for no wallet, user accounts in config', () => {
       expect.assertions(1)
 
-      const handler = makeWallet(userAccountsConfig)
+      const handler = makeWallet()
       const setupUserAccountsProxyWallet = setupUserAccountsProxyWalletSpy()
-      handler.init()
+      handler.init({
+        shouldUseUserAccounts: true,
+        hasWallet: false,
+        isMetamask: false,
+      })
 
       expect(setupUserAccountsProxyWallet).toHaveBeenCalled()
     })

--- a/paywall/src/__tests__/unlock.js/Wallet/setupWeb3ProxyWallet.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/setupWeb3ProxyWallet.test.ts
@@ -29,7 +29,7 @@ describe('setupWeb3ProxyWallet()', () => {
     }
     setupWeb3ProxyWallet({
       iframes: iframes as any,
-      hasWallet: hasWallet || true,
+      hasWallet: typeof hasWallet === 'undefined' ? true : hasWallet,
       setHasWeb3: setHasWeb3 || jest.fn(),
       getHasWeb3: getHasWeb3 || jest.fn(() => true),
       isMetamask: isMetamask || true,

--- a/paywall/src/__tests__/unlock.js/Wallet/setupWeb3ProxyWallet.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/setupWeb3ProxyWallet.test.ts
@@ -15,7 +15,7 @@ describe('setupWeb3ProxyWallet()', () => {
   const fakeAddress = '0x1234567890123456789012345678901234567890'
 
   function init({
-    getHasWallet,
+    hasWallet,
     setHasWeb3,
     getHasWeb3,
     isMetamask,
@@ -29,7 +29,7 @@ describe('setupWeb3ProxyWallet()', () => {
     }
     setupWeb3ProxyWallet({
       iframes: iframes as any,
-      getHasWallet: getHasWallet || jest.fn(() => true),
+      hasWallet: hasWallet || true,
       setHasWeb3: setHasWeb3 || jest.fn(),
       getHasWeb3: getHasWeb3 || jest.fn(() => true),
       isMetamask: isMetamask || true,
@@ -64,11 +64,11 @@ describe('setupWeb3ProxyWallet()', () => {
     it('should send WALLET_INFO indicating no crypto wallet is present', () => {
       expect.assertions(2)
 
-      const getHasWallet = jest.fn(() => false)
+      const hasWallet = false
       const setHasWeb3 = jest.fn()
 
       const { iframes } = init({
-        getHasWallet,
+        hasWallet,
         setHasWeb3,
       })
 

--- a/paywall/src/unlock.js/Wallet.ts
+++ b/paywall/src/unlock.js/Wallet.ts
@@ -25,7 +25,6 @@ import { WalletStatus } from '../utils/wallet'
 export default class Wallet {
   private readonly iframes: IframeHandler
   private readonly window: Web3Window
-  private readonly hasWallet: boolean = true
   private readonly config: PaywallConfig
   private hasWeb3: boolean = false
   useUserAccounts: boolean = false
@@ -59,10 +58,6 @@ export default class Wallet {
 
   getUserAccountNetwork = () => {
     return this.userAccountNetwork
-  }
-
-  getHasWallet = () => {
-    return this.hasWallet
   }
 
   setHasWeb3 = (value: boolean) => {
@@ -104,7 +99,7 @@ export default class Wallet {
       // if we have no wallet, and no use accounts, we use the web3 proxy wallet
       setupWeb3ProxyWallet({
         iframes: this.iframes,
-        getHasWallet: this.getHasWallet,
+        hasWallet,
         setHasWeb3: this.setHasWeb3,
         getHasWeb3: this.getHasWeb3,
         isMetamask: isMetamask,

--- a/paywall/src/unlock.js/postMessageHub.ts
+++ b/paywall/src/unlock.js/postMessageHub.ts
@@ -384,7 +384,7 @@ export function setupWeb3ProxyWallet({
     // initialize, we do this once the iframe is ready to receive information on the wallet
     // we need to tell the iframe if the wallet is metamask
     // TODO: pass the name of the wallet if we know it? (secondary importance right now, so omitting)
-    if (hasWallet) {
+    if (!hasWallet) {
       // the user has no crypto wallet
       setHasWeb3(false)
       iframes.data.postMessage(PostMessages.WALLET_INFO, {

--- a/paywall/src/unlock.js/postMessageHub.ts
+++ b/paywall/src/unlock.js/postMessageHub.ts
@@ -356,7 +356,7 @@ export function setupUserAccountsProxyWallet({
 
 interface setupWeb3ProxyWalletArgs {
   iframes: TemporaryIframeHandler
-  getHasWallet: () => boolean
+  hasWallet: boolean
   setHasWeb3: (value: boolean) => void
   getHasWeb3: () => boolean
   isMetamask: boolean
@@ -365,7 +365,7 @@ interface setupWeb3ProxyWalletArgs {
 
 export function setupWeb3ProxyWallet({
   iframes,
-  getHasWallet,
+  hasWallet,
   setHasWeb3,
   getHasWeb3,
   isMetamask,
@@ -384,7 +384,7 @@ export function setupWeb3ProxyWallet({
     // initialize, we do this once the iframe is ready to receive information on the wallet
     // we need to tell the iframe if the wallet is metamask
     // TODO: pass the name of the wallet if we know it? (secondary importance right now, so omitting)
-    if (!getHasWallet()) {
+    if (hasWallet) {
       // the user has no crypto wallet
       setHasWeb3(false)
       iframes.data.postMessage(PostMessages.WALLET_INFO, {

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -4,6 +4,7 @@ import Wallet from './Wallet'
 import MainWindowHandler from './MainWindowHandler'
 import CheckoutUIHandler from './CheckoutUIHandler'
 import StartupConstants from './startupTypes'
+import { walletStatus } from '../utils/wallet'
 
 /**
  * convert all of the lock addresses to lower-case so they are normalized across the app
@@ -79,10 +80,11 @@ export function startup(
 
   // go!
   mainWindow.init()
-  wallet.init()
+  wallet.init(walletStatus(window, config))
   checkoutIframeHandler.init({
     usingManagedAccount: wallet.useUserAccounts,
   })
+
   return iframes // this is only useful in testing, it is ignored in the app
 }
 

--- a/paywall/src/utils/wallet.ts
+++ b/paywall/src/utils/wallet.ts
@@ -2,11 +2,6 @@ import { Web3Window, CryptoWalletWindow } from '../windowTypes'
 import { PaywallConfig } from '../unlockTypes'
 
 export function hasWallet(window: Web3Window): boolean {
-  // eslint-disable-next-line no-console
-  console.log({
-    location: 'hasWallet',
-    web3: window.web3,
-  })
   return !!(window.web3 && window.web3.currentProvider)
 }
 

--- a/paywall/src/utils/wallet.ts
+++ b/paywall/src/utils/wallet.ts
@@ -2,6 +2,11 @@ import { Web3Window, CryptoWalletWindow } from '../windowTypes'
 import { PaywallConfig } from '../unlockTypes'
 
 export function hasWallet(window: Web3Window): boolean {
+  // eslint-disable-next-line no-console
+  console.log({
+    location: 'hasWallet',
+    web3: window.web3,
+  })
   return !!(window.web3 && window.web3.currentProvider)
 }
 

--- a/paywall/src/utils/wallet.ts
+++ b/paywall/src/utils/wallet.ts
@@ -28,3 +28,20 @@ export function shouldUseUserAccounts(
     config.unlockUserAccounts === 'true' || config.unlockUserAccounts === true
   )
 }
+
+export interface WalletStatus {
+  hasWallet: boolean
+  isMetamask: boolean
+  shouldUseUserAccounts: boolean
+}
+
+export function walletStatus(
+  window: Web3Window,
+  config: PaywallConfig
+): WalletStatus {
+  return {
+    hasWallet: hasWallet(window),
+    isMetamask: walletIsMetamask(window),
+    shouldUseUserAccounts: shouldUseUserAccounts(window, config),
+  }
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR moves the determination of wallet state (is present, is metamask, should use a user account) to the startup function. For the time being the results of this are passed into the `Wallet` init method, but the next PR will wipe out the wallet entirely and handle things from within the `MainWindowHandler`.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
