### PR TITLE
Safe transfers

### DIFF
--- a/smart-contracts/contracts/mixins/MixinFunds.sol
+++ b/smart-contracts/contracts/mixins/MixinFunds.sol
@@ -84,16 +84,11 @@ contract MixinFunds
   {
     if(_amount > 0) {
       if(_tokenAddress == address(0)) {
+        // https://diligence.consensys.net/blog/2019/09/stop-using-soliditys-transfer-now/
         address(uint160(_to)).sendValue(_amount);
       } else {
         IERC20 token = IERC20(_tokenAddress);
-        uint balanceBefore = token.balanceOf(_to);
         token.safeTransfer(_to, _amount);
-
-        // There are known bugs in popular ERC20 implements which means we cannot
-        // trust the return value of `transferFrom`.  This require statement ensures
-        // that a transfer occurred.
-        require(token.balanceOf(_to) > balanceBefore, 'TRANSFER_FAILED');
       }
     }
   }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Switch to use sendValue, safeTransfer, and safeTransferFrom.

About the sendValue change: https://diligence.consensys.net/blog/2019/09/stop-using-soliditys-transfer-now/

The potential downside is re-entrancy is possible with ETH transfers when it was not previously.  Now ETH transfers have similar risk to ERC-20 transfers.  Both take the same code path and we mitigate the risk with the 'Checks-Effects-Interactions Pattern'.  That said, maybe we should follow this up with a re-entrancy guard just in case.

While there I went ahead and switched to SafeERC20 instead of our custom checks.

Net net these changes shouldn't actually change any functionality, so no test changes included... Existing tests confirm we didn't break any functionality here, the only test we could add is potential re-entrancy scenarios but those are hard to test and are only really exercising the OZ library.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
