### PR TITLE
Making shareKey safe

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -435,16 +435,19 @@ contract IPublicLock is IERC721Enumerable, IERC721 {
   ///===================================================================
 
   /**
-  * @notice Allows the key owner to share their key (parent key) by
+  * @notice Allows the key owner to safely share their key (parent key) by
   * transferring a portion of the remaining time to a new key (child key).
   * @dev Throws if key is not valid.
   * @dev Throws if `_to` is the zero address
   * @param _to The recipient of the shared key
   * @param _tokenId the key to share
   * @param _timeShared The amount of time shared
+  * checks if `_to` is a smart contract (code size > 0). If so, it calls
+  * `onERC721Received` on `_to` and throws if the return value is not
+  * `bytes4(keccak256('onERC721Received(address,address,uint,bytes)'))`.
   * @dev Emit Transfer event
   */
-  function shareKey(
+  function safeShareKey(
     address _to,
     uint _tokenId,
     uint _timeShared

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -447,7 +447,7 @@ contract IPublicLock is IERC721Enumerable, IERC721 {
   * `bytes4(keccak256('onERC721Received(address,address,uint,bytes)'))`.
   * @dev Emit Transfer event
   */
-  function safeShareKey(
+  function shareKey(
     address _to,
     uint _tokenId,
     uint _timeShared

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -45,13 +45,13 @@ contract MixinTransfer is
   uint public transferFeeBasisPoints;
 
   /**
-  * @notice Allows the key owner to share their key (parent key) by
+  * @notice Allows the key owner to safely share their key (parent key) by
   * transferring a portion of the remaining time to a new key (child key).
   * @param _to The recipient of the shared key
   * @param _tokenId the key to share
   * @param _timeShared The amount of time shared
   */
-  function shareKey(
+  function safeShareKey(
     address _to,
     uint _tokenId,
     uint _timeShared
@@ -104,6 +104,8 @@ contract MixinTransfer is
       _to,
       iDTo
     );
+
+    require(_checkOnERC721Received(keyOwner, _to, _tokenId, ''), 'NON_COMPLIANT_ERC721_RECEIVER');
   }
 
   function transferFrom(

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -51,7 +51,7 @@ contract MixinTransfer is
   * @param _tokenId the key to share
   * @param _timeShared The amount of time shared
   */
-  function safeShareKey(
+  function shareKey(
     address _to,
     uint _tokenId,
     uint _timeShared

--- a/smart-contracts/test/Lock/safeShareKey.js
+++ b/smart-contracts/test/Lock/safeShareKey.js
@@ -80,13 +80,14 @@ contract('Lock / safeShareKey', accounts => {
 
     it('should fail if trying to share a key with a contract which does not implement onERC721Received', async () => {
       let nonCompliantContract = unlock.address
+      assert.equal(await lock.getHasValidKey.call(keyOwner2), true)
       await shouldFail(
         lock.safeShareKey(
           nonCompliantContract,
-          await lock.getTokenIdFor.call(keyOwner1),
+          await lock.getTokenIdFor.call(keyOwner2),
           1000,
           {
-            from: keyOwners[0],
+            from: keyOwner2,
           }
         ),
         'NON_COMPLIANT_ERC721_RECEIVER'

--- a/smart-contracts/test/Lock/safeShareKey.js
+++ b/smart-contracts/test/Lock/safeShareKey.js
@@ -80,18 +80,15 @@ contract('Lock / safeShareKey', accounts => {
 
     it('should fail if trying to share a key with a contract which does not implement onERC721Received', async () => {
       let nonCompliantContract = unlock.address
+      let ID = await lock.getTokenIdFor.call(keyOwner2)
       assert.equal(await lock.getHasValidKey.call(keyOwner2), true)
       await shouldFail(
-        lock.safeShareKey(
-          nonCompliantContract,
-          await lock.getTokenIdFor.call(keyOwner2),
-          1000,
-          {
-            from: keyOwner2,
-          }
-        ),
-        'NON_COMPLIANT_ERC721_RECEIVER'
+        lock.safeShareKey(nonCompliantContract, ID, 1000, {
+          from: keyOwner2,
+        })
       )
+      // make sure the key was not shared
+      assert.equal(await lock.getHasValidKey.call(nonCompliantContract), false)
     })
 
     describe('fallback behaviors', () => {

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -9,7 +9,7 @@ const getProxy = require('../helpers/proxy')
 
 let unlock, locks
 
-contract('Lock / safeShareKey', accounts => {
+contract('Lock / shareKey', accounts => {
   before(async () => {
     unlock = await getProxy(unlockContract)
     locks = await deployLocks(unlock, accounts[0])
@@ -42,7 +42,7 @@ contract('Lock / safeShareKey', accounts => {
     describe('not meeting pre-requisites', () => {
       it('sender is not approved', async () => {
         await shouldFail(
-          lock.safeShareKey(accounts[7], 11, 1000, {
+          lock.shareKey(accounts[7], 11, 1000, {
             from: accountWithNoKey1,
           }),
           'ONLY_KEY_OWNER_OR_APPROVED'
@@ -51,7 +51,7 @@ contract('Lock / safeShareKey', accounts => {
 
       it('called by other than keyOwner or approved ', async () => {
         await shouldFail(
-          lock.safeShareKey(
+          lock.shareKey(
             accounts[3],
             await lock.getTokenIdFor.call(keyOwners[0]),
             1000,
@@ -65,7 +65,7 @@ contract('Lock / safeShareKey', accounts => {
 
       it('should abort if the recipient is 0x', async () => {
         await shouldFail(
-          lock.safeShareKey(
+          lock.shareKey(
             Web3Utils.padLeft(0, 40),
             await lock.getTokenIdFor.call(keyOwners[0]),
             1000,
@@ -83,7 +83,7 @@ contract('Lock / safeShareKey', accounts => {
       let ID = await lock.getTokenIdFor.call(keyOwner2)
       assert.equal(await lock.getHasValidKey.call(keyOwner2), true)
       await shouldFail(
-        lock.safeShareKey(nonCompliantContract, ID, 1000, {
+        lock.shareKey(nonCompliantContract, ID, 1000, {
           from: keyOwner2,
         })
       )
@@ -96,14 +96,9 @@ contract('Lock / safeShareKey', accounts => {
         let tooMuchTime = new BigNumber(60 * 60 * 24 * 30 * 2) // 60 days
         tokenId1 = await lock.getTokenIdFor.call(keyOwner1)
         assert.equal(await lock.getHasValidKey.call(keyOwner1), true)
-        tx1 = await lock.safeShareKey(
-          accountWithNoKey1,
-          tokenId1,
-          tooMuchTime,
-          {
-            from: keyOwner1,
-          }
-        )
+        tx1 = await lock.shareKey(accountWithNoKey1, tokenId1, tooMuchTime, {
+          from: keyOwner1,
+        })
         let actualTimeShared = tx1.logs[2].args._amount.toNumber(10)
         assert.equal(await lock.getHasValidKey.call(accountWithNoKey1), true) // new owner now has a fresh key
         let newExpirationTimestamp = new BigNumber(
@@ -157,7 +152,7 @@ contract('Lock / safeShareKey', accounts => {
       )
       fee = new BigNumber(await lock.getTransferFee.call(keyOwner2, oneDay))
       tokenId2 = await lock.getTokenIdFor.call(keyOwner2)
-      tx2 = await lock.safeShareKey(accountWithNoKey2, tokenId2, oneDay, {
+      tx2 = await lock.shareKey(accountWithNoKey2, tokenId2, oneDay, {
         from: keyOwner2,
       })
       event = tx2.logs[0].event
@@ -224,7 +219,7 @@ contract('Lock / safeShareKey', accounts => {
       let oldExistingKeyExpiration = new BigNumber(
         await lock.keyExpirationTimestampFor.call(keyOwner3)
       )
-      await lock.safeShareKey(keyOwner3, tokenId2, oneDay, {
+      await lock.shareKey(keyOwner3, tokenId2, oneDay, {
         from: keyOwner2,
       })
       let newExistingKeyExpiration = new BigNumber(
@@ -237,7 +232,7 @@ contract('Lock / safeShareKey', accounts => {
       let token = new BigNumber(await lock.getTokenIdFor(keyOwner2))
       // make sure recipient does not have a key
       assert.equal(await lock.getHasValidKey.call(accountWithNoKey3), false)
-      await lock.safeShareKey(accountWithNoKey3, token, oneDay, {
+      await lock.shareKey(accountWithNoKey3, token, oneDay, {
         from: approvedAddress,
       })
       // make sure recipient has a key


### PR DESCRIPTION
# Description
This is switching `shareKey` to use the same pattern as `safeTransferFrom` for consistency.
(that is, using `require(_checkOnERC721Received())` in shareKey)
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
