### PR TITLE
Adds ability to limit size of result set of queried keys

### DIFF
--- a/locksmith/src/graphql/datasource/key.ts
+++ b/locksmith/src/graphql/datasource/key.ts
@@ -3,10 +3,12 @@ import { UnlockGraphQLDataSource } from './unlockGraphQLDataSource'
 
 // eslint-disable-next-line import/prefer-default-export
 export class Key extends UnlockGraphQLDataSource {
-  async getKeys() {
+  async getKeys(args: any) {
+    let queryPredicate = args.first ? `(first: ${args.first})` : ''
+
     let keysQuery = gql`
-      query Keys {
-        keys {
+      query Keys($first: Int) {
+        keys${queryPredicate}{
           id
           lock {
             id
@@ -28,7 +30,9 @@ export class Key extends UnlockGraphQLDataSource {
     `
 
     try {
-      let response = await this.query(keysQuery)
+      let response = await this.query(keysQuery, {
+        variables: { first: args.first },
+      })
       return response.data.keys
     } catch (error) {
       return []

--- a/locksmith/src/graphql/resolvers.ts
+++ b/locksmith/src/graphql/resolvers.ts
@@ -6,7 +6,8 @@ export const resolvers = {
   Query: {
     locks: () => new Lock().getLocks(),
     keyPurchases: () => new KeyPurchase().getKeyPurchases(),
-    keys: () => new Key().getKeys(),
+    // eslint-disable-next-line no-unused-vars
+    keys: (_root: any, args: any) => new Key().getKeys(args),
     // eslint-disable-next-line no-unused-vars
     key: async (_root: any, args: any, _context: any, _info: any) => {
       return await new Key().getKey(args.id)

--- a/locksmith/src/graphql/typeDefinitions.ts
+++ b/locksmith/src/graphql/typeDefinitions.ts
@@ -24,7 +24,7 @@ export const typeDefs = gql`
 
   type Query {
     key(id: ID!): Key
-    keys: [Key]
+    keys(first: Int): [Key]
     locks: [Lock]
     keyPurchases: [KeyPurchase!]
   }


### PR DESCRIPTION
# Description

As part of making the local graphql endpoint consistent with the service previously used, we are implementing the 'first' predicate to be passed to the service being utilized below

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
