### PR TITLE
Validators for specification of metadata fields in paywall config

### DIFF
--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -1366,4 +1366,95 @@ describe('Form field validators', () => {
       ).toBe(true)
     })
   })
+
+  describe('isValidMetadataField', () => {
+    const name = 'field name'
+    const validType = 'date'
+    const invalidType = 'genome-sequence'
+
+    describe('failures', () => {
+      it('should be false if the name is missing', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            type: validType,
+            required: false,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the name is not a string', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name: 7,
+            type: validType,
+            required: true,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the type is missing', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            required: true,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the type is incorrect', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            type: invalidType,
+            required: true,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the required property is missing', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            type: validType,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the required property is not a boolean', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            type: validType,
+            required: 7,
+          })
+        ).toBeFalsy()
+      })
+    })
+
+    describe('successes', () => {
+      it('should be true for a valid field input', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            type: validType,
+            required: true,
+          })
+        ).toBeTruthy()
+      })
+    })
+  })
 })

--- a/paywall/src/__tests__/utils/validators.test.js
+++ b/paywall/src/__tests__/utils/validators.test.js
@@ -1457,4 +1457,54 @@ describe('Form field validators', () => {
       })
     })
   })
+
+  describe('isValidMetadataArray', () => {
+    describe('failures', () => {
+      it('should be false if input is not an array', () => {
+        expect.assertions(1)
+
+        expect(validators.isValidMetadataArray(7)).toBeFalsy()
+      })
+
+      it('should be false if input contains invalid metadata fields', () => {
+        expect.assertions(1)
+
+        const fields = [
+          {
+            name: 'Jeff',
+            type: 'person',
+            required: 7,
+          },
+        ]
+
+        expect(validators.isValidMetadataArray(fields)).toBeFalsy()
+      })
+    })
+
+    describe('successes', () => {
+      it('should be true if all fields are valid', () => {
+        expect.assertions(1)
+
+        const fields = [
+          {
+            name: 'Name',
+            type: 'text',
+            required: true,
+          },
+          {
+            name: 'Email',
+            type: 'email',
+            required: true,
+          },
+          {
+            name: 'Birthday',
+            type: 'date',
+            required: false,
+          },
+        ]
+
+        expect(validators.isValidMetadataArray(fields)).toBeTruthy()
+      })
+    })
+  })
 })

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -387,4 +387,22 @@ export const isValidMetadataField = field => {
 
   return true
 }
+
+export const isValidMetadataArray = fields => {
+  if (!Array.isArray(fields)) {
+    console.error('Paywall config metadata property is not an array.')
+    return false
+  }
+
+  // TODO: disallow multiple fields with the same name?
+  const validFields = fields.filter(isValidMetadataField)
+  if (validFields.length !== fields.length) {
+    console.error(
+      'Paywall config metadata contains an invalid field description.'
+    )
+    return false
+  }
+
+  return true
+}
 /* eslint-enable no-console */

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -186,7 +186,6 @@ export const isValidPaywallConfig = config => {
 
   return true
 }
-/* eslint-enable no-console */
 
 /**
  * helper function to assert on a thing being an
@@ -344,3 +343,48 @@ export const isValidBalance = balance => {
     )
   }, true)
 }
+
+const allowedInputTypes = ['text', 'date', 'color', 'email', 'url']
+
+/**
+ * A valid metadata field looks like:
+ * {
+ *   name: 'field name', // any string
+ *   type: 'date', // any valid html input type
+ *   required: false, // a boolean
+ * }
+ */
+export const isValidMetadataField = field => {
+  const requiredKeys = ['name', 'type', 'required']
+  const hasRequiredProperties = isValidObject(field, requiredKeys)
+
+  if (!hasRequiredProperties) {
+    // TODO: more specificity in error messages
+    console.error(
+      'A field in the metadata fields in the paywall config is missing a required property.'
+    )
+    return false
+  }
+
+  const { name, type, required } = field
+
+  if (typeof name !== 'string') {
+    console.error(`Paywall metadata field error: ${name} is not a string.`)
+    return false
+  }
+
+  if (!allowedInputTypes.includes(type)) {
+    console.error(
+      `Paywall metadata field error: ${type} is not an allowed input type.`
+    )
+    return false
+  }
+
+  if (typeof required !== 'boolean') {
+    console.error(`Paywall metadata field error: ${required} is not a boolean.`)
+    return false
+  }
+
+  return true
+}
+/* eslint-enable no-console */


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR is the first step toward integrating metadata collection with the paywall. This adds validators for metadata fields, which will be used in the near future to validate the fields supplied in the metadata config.

The idea is that a property called something like `metadataInputs` will contain an array of objects like
```javascript
{
  name: 'field name', // any string
  type: 'date', // any valid html input type
  required: false, // a boolean
}
```

When collecting metadata, the paywall will then render those fields in the order specified, with the appropriate attributes applied to the input (`type` and `required`) and the name used as a label for the input.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
