### PR TITLE
Adds proxying key holder query to Graph QL service

### DIFF
--- a/locksmith/__tests__/graphql/datasource/keyHolder.test.ts
+++ b/locksmith/__tests__/graphql/datasource/keyHolder.test.ts
@@ -1,0 +1,29 @@
+import { KeyHolder } from '../../../src/graphql/datasource'
+
+describe('KeyHolder', () => {
+  describe('get', () => {
+    describe('when data is returned for the data source', () => {
+      it('return the requested data', async () => {
+        expect.assertions(1)
+        let keyHolder = new KeyHolder()
+        jest
+          .spyOn(keyHolder, 'get')
+          .mockImplementation(() => Promise.resolve([{ mocked: 'data' }]))
+
+        expect(await keyHolder.get('0xabce')).toEqual([
+          {
+            mocked: 'data',
+          },
+        ])
+      })
+    })
+
+    describe('when an error occurs in data fetch', () => {
+      it('returns an empty collection', async () => {
+        expect.assertions(1)
+        let keyHolder = new KeyHolder()
+        expect(await keyHolder.get('0xabce')).toEqual([])
+      })
+    })
+  })
+})

--- a/locksmith/src/graphql/datasource/index.ts
+++ b/locksmith/src/graphql/datasource/index.ts
@@ -1,3 +1,4 @@
 export * from './keyPurchase'
 export * from './lock'
 export * from './key'
+export * from './keyHolder'

--- a/locksmith/src/graphql/datasource/keyHolder.ts
+++ b/locksmith/src/graphql/datasource/keyHolder.ts
@@ -1,0 +1,39 @@
+import { gql } from 'apollo-server-express'
+import { UnlockGraphQLDataSource } from './unlockGraphQLDataSource'
+
+// eslint-disable-next-line import/prefer-default-export
+export class KeyHolder extends UnlockGraphQLDataSource {
+  async get(address: string) {
+    let keyHolderQuery = gql`
+      query KeyHolder($address: String!) {
+        keyHolders(where: { address: $address }) {
+          id
+          address
+          keys {
+            id
+            expiration
+            keyId
+            tokenURI
+            lock {
+              name
+              address
+              tokenAddress
+              price
+              expirationDuration
+            }
+          }
+        }
+      }
+    `
+
+    try {
+      let response = await this.query(keyHolderQuery, {
+        variables: { address: address },
+      })
+
+      return response.data.keyHolders
+    } catch (error) {
+      return []
+    }
+  }
+}

--- a/locksmith/src/graphql/resolvers.ts
+++ b/locksmith/src/graphql/resolvers.ts
@@ -1,5 +1,6 @@
 import { KeyPurchase, Lock, Key } from './datasource'
 import { generateMetadata } from './datasource/metaData'
+import { KeyHolder } from './datasource/keyHolder'
 
 // eslint-disable-next-line import/prefer-default-export
 export const resolvers = {
@@ -11,6 +12,9 @@ export const resolvers = {
     // eslint-disable-next-line no-unused-vars
     key: async (_root: any, args: any, _context: any, _info: any) => {
       return await new Key().getKey(args.id)
+    },
+    keyHolders: async (_root: any, args: any) => {
+      return await new KeyHolder().get(args.where.address)
     },
   },
   Key: {

--- a/locksmith/src/graphql/typeDefinitions.ts
+++ b/locksmith/src/graphql/typeDefinitions.ts
@@ -27,6 +27,11 @@ export const typeDefs = gql`
     keys(first: Int): [Key]
     locks: [Lock]
     keyPurchases: [KeyPurchase!]
+    keyHolders(where: KeyHolderQuery!): [KeyHolder]
+  }
+
+  input KeyHolderQuery {
+    address: String!
   }
 
   type Attribute {
@@ -45,6 +50,7 @@ export const typeDefs = gql`
   type KeyHolder {
     id: ID!
     address: String!
+    keys: [Key]
   }
 
   type Key {
@@ -54,5 +60,6 @@ export const typeDefs = gql`
     owner: KeyHolder!
     expiration: Int!
     metadata: Metadata
+    tokenURI: String
   }
 `


### PR DESCRIPTION
# Description

As part of updating the pass through service, we are adding a query for the pass through. At the moment we have support for the `where` predicate as it currently exists in production today. 

As this work wraps up we will need to determine a more robust way to support all of the predicate functionality as it exist at the source.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
