### PR TITLE
Move publicLockVersion for reuse

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -69,12 +69,4 @@ contract PublicLock is
     // the ID specified in the standard: https://eips.ethereum.org/EIPS/eip-721
     _registerInterface(0x80ac58cd);
   }
-
-  // The version number of the current implementation on this network
-  function publicLockVersion(
-  ) external pure
-    returns (uint16)
-  {
-    return 5;
-  }
 }

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -71,7 +71,7 @@ contract IPublicLock is IERC721Enumerable, IERC721 {
   * @notice The version number of the current implementation on this network.
   * @return The current version number.
   */
-  function publicLockVersion() external pure returns (uint16);
+  function publicLockVersion() public pure returns (uint);
 
   /**
   * @notice Gets the current balance of the account provided.

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -84,6 +84,14 @@ contract MixinLockCore is
     maxNumberOfKeys = _maxNumberOfKeys;
   }
 
+  // The version number of the current implementation on this network
+  function publicLockVersion(
+  ) public pure
+    returns (uint)
+  {
+    return 5;
+  }
+
   /**
    * @dev Called by owner to withdraw all funds from the lock and send them to the `beneficiary`.
    * @param _tokenAddress specifies the token address to withdraw or 0 for ETH. This is usually


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Moving the publicLockVersion function into one of the Mixins so we can reuse the information.  I'd like to use this for the EIP-712 migration so we don't have redundant version information.

I also switched from uint16 to uint.  From previous testing we now know that using small uint types does not offer the expected benefit (and in fact costs more than uint256 if used by another contract).

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #5333

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
