### PR TITLE
Updates Lock query to support address_in query align with the query used upstream

### DIFF
--- a/locksmith/src/graphql/resolvers.ts
+++ b/locksmith/src/graphql/resolvers.ts
@@ -1,10 +1,16 @@
 import { KeyPurchase, Key, LocksByOwner } from './datasource'
 import { generateMetadata } from './datasource/metaData'
 import { KeyHolder } from './datasource/keyHolder'
+import { KeyHoldersByLock } from './datasource/keyholdersByLock'
 
 export const resolvers = {
   Query: {
-    locks: (_root: any, args: any) => new LocksByOwner().get(args.where.owner),
+    locks: (_root: any, args: any) => {
+      if (args.where.owner) {
+        return new LocksByOwner().get(args.where.owner)
+      }
+      return new KeyHoldersByLock().getKeyHolders(args.where.address_in)
+    },
     keyPurchases: () => new KeyPurchase().getKeyPurchases(),
     // eslint-disable-next-line no-unused-vars
     keys: (_root: any, args: any) => new Key().getKeys(args),

--- a/locksmith/src/graphql/typeDefinitions.ts
+++ b/locksmith/src/graphql/typeDefinitions.ts
@@ -2,6 +2,15 @@ import { gql } from 'apollo-server-express'
 
 // eslint-disable-next-line import/prefer-default-export
 export const typeDefs = gql`
+  input KeyHolderQuery {
+    address: String!
+  }
+
+  input LocksQuery {
+    owner: String
+    address_in: [String]
+  }
+
   type Lock {
     id: ID
     address: String
@@ -12,6 +21,7 @@ export const typeDefs = gql`
     totalSupply: Int
     maxNumberOfKeys: String
     owner: String
+    keys: [Key]
   }
 
   type KeyPurchase {
@@ -26,17 +36,9 @@ export const typeDefs = gql`
   type Query {
     key(id: ID!): Key
     keys(first: Int): [Key]
-    locks(where: LockByOwnerQuery!): [Lock]
+    locks(where: LocksQuery): [Lock]
     keyPurchases: [KeyPurchase!]
     keyHolders(where: KeyHolderQuery!): [KeyHolder]
-  }
-
-  input KeyHolderQuery {
-    address: String!
-  }
-
-  input LockByOwnerQuery {
-    owner: String!
   }
 
   type Attribute {


### PR DESCRIPTION
# Description

As a part of the work to ensure that pass through endpoint can be cutover without any issue, adding support for querying locks by a collection of addresses.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
