### PR TITLE
Require code at PublicLock address

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -32,6 +32,7 @@ import 'hardlydifficult-ethereum-contracts/contracts/proxies/Clone2Factory.sol';
 import './PublicLock.sol';
 import './interfaces/IUnlock.sol';
 import './interfaces/IUniswap.sol';
+import '@openzeppelin/contracts-ethereum-package/contracts/utils/Address.sol';
 
 
 /// @dev Must list the direct base contracts in the order from “most base-like” to “most derived”.
@@ -42,6 +43,8 @@ contract Unlock is
   Ownable,
   Clone2Factory
 {
+  using Address for address;
+
   /**
    * The struct for a lock
    * We use deployed to keep track of deployments.
@@ -224,6 +227,8 @@ contract Unlock is
   ) external
     onlyOwner
   {
+    // ensure that this is an address to which a contract has been deployed.
+    require(_publicLockAddress.isContract(), 'NOT_A_CONTRACT');
     publicLockAddress = _publicLockAddress;
     globalTokenSymbol = _symbol;
     globalBaseTokenURI = _URI;

--- a/smart-contracts/test/Unlock/unlockConfig.js
+++ b/smart-contracts/test/Unlock/unlockConfig.js
@@ -1,0 +1,41 @@
+const shouldFail = require('../helpers/shouldFail')
+
+const unlockContract = artifacts.require('Unlock.sol')
+const PublicLock = artifacts.require('PublicLock')
+const getProxy = require('../helpers/proxy')
+
+let unlock, lockTemplate, unlockOwner
+
+contract('Lock / configUnlock', accounts => {
+  before(async () => {
+    unlock = await getProxy(unlockContract)
+    lockTemplate = await PublicLock.new()
+    unlockOwner = accounts[0]
+  })
+
+  describe('configuring the Unlock contract', () => {
+    it('should let the owner configure the Unlock contract', async () => {
+      await unlock.configUnlock(lockTemplate.address, '', '', {
+        from: unlockOwner,
+      })
+    })
+
+    it('should revert if called by other than the owner', async () => {
+      await shouldFail(
+        unlock.configUnlock(lockTemplate.address, '', '', {
+          from: accounts[7],
+        }),
+        'Ownable: caller is not the owner'
+      )
+    })
+
+    it('should revert if the lock template address is not a contract', async () => {
+      await shouldFail(
+        unlock.configUnlock(accounts[7], '', '', {
+          from: unlockOwner,
+        }),
+        'NOT_A_CONTRACT'
+      )
+    })
+  })
+})


### PR DESCRIPTION
# Description
This adds a check to make sure that when calling `Unlock.configUnlock`, the address passed as the param for the lock template is actually a contract.
Note that this does NOT guarantee the contract is actually a deployed PublicLock.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5337 
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
