### PR TITLE
Switch signature to v,r,s components

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -313,11 +313,13 @@ contract IPublicLock is IERC721Enumerable {
   /**
    * @dev Cancels a key owned by a different user and sends the funds to the msg.sender.
    * @param _keyOwner this user's key will be canceled
-   * @param _signature getCancelAndRefundApprovalHash signed by the _keyOwner
+   * @param _v _r _s getCancelAndRefundApprovalHash signed by the _keyOwner
    */
   function cancelAndRefundFor(
     address _keyOwner,
-    bytes calldata _signature
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
   ) external;
 
   /**

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -69,16 +69,23 @@ contract MixinRefunds is
   /**
    * @dev Cancels a key owned by a different user and sends the funds to the msg.sender.
    * @param _keyOwner this user's key will be canceled
-   * @param _signature getCancelAndRefundApprovalHash signed by the _keyOwner
+   * @param _v _r _s getCancelAndRefundApprovalHash signed by the _keyOwner
    */
   function cancelAndRefundFor(
     address _keyOwner,
-    bytes calldata _signature
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
   ) external
-    consumeOffchainApproval(getCancelAndRefundApprovalHash(_keyOwner, msg.sender), _signature, _keyOwner)
+    consumeOffchainApproval(
+      getCancelAndRefundApprovalHash(_keyOwner, msg.sender),
+      _keyOwner,
+      _v,
+      _r,
+      _s
+    )
   {
     uint refund = _getCancelAndRefundValue(_keyOwner);
-
     _cancelAndRefund(_keyOwner, refund);
   }
 

--- a/smart-contracts/contracts/mixins/MixinSignatures.sol
+++ b/smart-contracts/contracts/mixins/MixinSignatures.sol
@@ -18,14 +18,18 @@ contract MixinSignatures
   /// @dev If valid the nonce is consumed, else revert.
   modifier consumeOffchainApproval(
     bytes32 _hash,
-    bytes memory _signature,
-    address _keyOwner
+    address _keyOwner,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
   )
   {
     require(
-      ECDSA.recover(
+      ecrecover(
         ECDSA.toEthSignedMessageHash(_hash),
-        _signature
+        _v,
+        _r,
+        _s
       ) == _keyOwner, 'INVALID_SIGNATURE'
     );
     keyOwnerToNonce[_keyOwner]++;


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Switch from using the signature `bytes` to the v, r, s components.  As you can see in the JS tests, these components are just substr from the bytes we used previously.  This saves a little bit of gas verifying the signature, and moves our implementation closer to the EIP-712 sample implementation as well as the new DAI/CHAI `permit` implementation.

Functionally this should be on-par with what we had previously.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #5333

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
