### PR TITLE
Fixing homepage typo

### DIFF
--- a/unlock-protocol.com/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-protocol.com/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -12703,7 +12703,7 @@ Object {
           <p
             class="c17"
           >
-            Unlock lets you let’s you easily lock and manage access to your content, apps, community and even real life events and spaces.
+            Unlock lets you easily lock and manage access to your content, apps, community and even real life events and spaces.
           </p>
           <section
             class="c18"
@@ -13465,7 +13465,7 @@ Object {
         <p
           class="sc-1lwhgj0-9 iYPCes"
         >
-          Unlock lets you let’s you easily lock and manage access to your content, apps, community and even real life events and spaces.
+          Unlock lets you easily lock and manage access to your content, apps, community and even real life events and spaces.
         </p>
         <section
           class="hzj1u1-2 ezGDEr"

--- a/unlock-protocol.com/src/components/content/HomeContent.js
+++ b/unlock-protocol.com/src/components/content/HomeContent.js
@@ -77,8 +77,8 @@ export const HomeContent = () => {
       </Hero>
 
       <Headline>
-        Unlock lets you let’s you easily lock and manage access to your content,
-        apps, community and even real life events and spaces.
+        Unlock lets you easily lock and manage access to your content, apps,
+        community and even real life events and spaces.
       </Headline>
 
       <Demo isMember={isMember} becomeMember={becomeMember} />


### PR DESCRIPTION
# Description

Fixes a glaring typo on the homepage.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

<img width="1089" alt="Screen Shot 2019-12-11 at 2 48 18 PM" src="https://user-images.githubusercontent.com/624104/70667700-665e1c00-1c26-11ea-8dad-e37cfbd26147.png">

