### PR TITLE
Adding an endpoint to retrieve user centric metadata

### DIFF
--- a/locksmith/__tests__/controllers/metadataController/readAddressHolderMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/readAddressHolderMetadata.test.ts
@@ -1,0 +1,145 @@
+import request from 'supertest'
+import * as sigUtil from 'eth-sig-util'
+import * as ethJsUtil from 'ethereumjs-util'
+import { keyTypedData } from '../../test-helpers/typeDataGenerators'
+import { addMetadata } from '../../../src/operations/userMetadataOperations'
+
+import app = require('../../../src/app')
+import Base64 = require('../../../src/utils/base64')
+
+const keyHolder = [
+  '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+  '0x6f7a54d6629b7416e17fc472b4003ae8ef18ef4c',
+]
+const lockAddress = '0x95de5F777A3e283bFf0c47374998E10D8A2183C7'
+const privateKey = ethJsUtil.toBuffer(
+  '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
+)
+
+const mockOnChainLockOwnership = {
+  owner: jest.fn(() => {
+    return Promise.resolve(keyHolder[0])
+  }),
+}
+
+const mockKeyHoldersByLock = {
+  getKeyHoldingAddresses: jest.fn(() => {
+    return Promise.resolve([keyHolder[0]])
+  }),
+}
+
+jest.mock('../../../src/utils/lockData', () => {
+  return function() {
+    return mockOnChainLockOwnership
+  }
+})
+
+jest.mock('../../../src/graphql/datasource/keyholdersByLock', () => ({
+  __esModule: true,
+  KeyHoldersByLock: jest.fn(() => {
+    return mockKeyHoldersByLock
+  }),
+}))
+
+describe('reading address holder metadata', () => {
+  beforeAll(async () => {
+    await addMetadata({
+      tokenAddress: lockAddress,
+      userAddress: keyHolder[0],
+      data: {
+        protected: {
+          hidden: 'metadata',
+        },
+        public: {
+          mock: 'values',
+        },
+      },
+    })
+  })
+
+  it('yields the stored passed data if the timestamp is recent', async () => {
+    expect.assertions(2)
+    const typedData = keyTypedData({
+      UserMetaData: {
+        owner: keyHolder[0],
+        timestamp: Date.now(),
+      },
+    })
+
+    const sig = sigUtil.signTypedData(privateKey, {
+      data: typedData,
+    })
+
+    const response = await request(app)
+      .get(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
+      .set('Accept', 'json')
+      .set('Authorization', `Bearer ${Base64.encode(sig)}`)
+      .query({ data: encodeURIComponent(JSON.stringify(typedData)) })
+
+    expect(response.status).toEqual(200)
+    expect(response.body).toEqual({
+      userMetadata: {
+        protected: {
+          hidden: 'metadata',
+        },
+        public: {
+          mock: 'values',
+        },
+      },
+    })
+  })
+
+  it('does not yield the stored passed data if the timestamp is old', async () => {
+    expect.assertions(2)
+    const typedData = keyTypedData({
+      UserMetaData: {
+        owner: keyHolder[0],
+        timestamp: 0,
+      },
+    })
+
+    const sig = sigUtil.signTypedData(privateKey, {
+      data: typedData,
+    })
+
+    const response = await request(app)
+      .get(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
+      .set('Accept', 'json')
+      .set('Authorization', `Bearer ${Base64.encode(sig)}`)
+      .query({ data: encodeURIComponent(JSON.stringify(typedData)) })
+
+    expect(response.status).toEqual(401)
+    expect(response.body).toEqual({})
+  })
+
+  describe('when an invalid signature is passed', () => {
+    it('returns unauthorized', async () => {
+      expect.assertions(2)
+
+      const typedData = keyTypedData({
+        UserMetaData: {
+          owner: keyHolder[0],
+          protected: {
+            hidden: 'metadata',
+          },
+          public: {
+            mock: 'values',
+          },
+        },
+      })
+
+      const sig = sigUtil.signTypedData(privateKey, {
+        data: typedData,
+      })
+
+      const response = await request(app)
+        .get(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
+        .set('Accept', 'json')
+        .set('Authorization', `Bearer ${Base64.encode(sig)}`)
+        .query({ data: encodeURIComponent(JSON.stringify(typedData)) })
+
+      expect(response.status).toEqual(401)
+      expect(response.body).toEqual({})
+    })
+  })
+})

--- a/locksmith/src/routes/metadata.ts
+++ b/locksmith/src/routes/metadata.ts
@@ -22,6 +22,12 @@ const userMetaDataConfiguration = {
   signee: 'owner',
 }
 
+const readUserMetaDataConfiguration = {
+  name: 'UserMetaData',
+  required: ['owner', 'timestamp'],
+  signee: 'owner',
+}
+
 const lockOwnerMetaDataConfiguration = {
   name: 'LockMetaData',
   required: ['address', 'owner', 'timestamp'],
@@ -43,6 +49,14 @@ router.put(
   signatureValidationMiddleware.generateProcessor(userMetaDataConfiguration)
 )
 
+// Reads the user centric metadata
+router.get(
+  '/:address/user/:userAddress',
+  signatureValidationMiddleware.generateSignatureEvaluator(
+    readUserMetaDataConfiguration
+  )
+)
+
 router.get(
   '/:address/:keyId',
   signatureValidationMiddleware.generateSignatureEvaluator(
@@ -62,5 +76,6 @@ router.get('/:address/:keyId', MetadataController.data)
 router.put('/:address/:keyId', MetadataController.updateKeyMetadata)
 router.put('/:address', MetadataController.updateDefaults)
 router.put('/:address/user/:userAddress', MetadataController.updateUserMetadata)
+router.get('/:address/user/:userAddress', MetadataController.readUserMetadata)
 
 module.exports = router


### PR DESCRIPTION
# Description

Adding an endpoint to retrieve user centric metadata so that a user can view the stuff they saved under their own address for a given lock.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->