### PR TITLE
Wrap WalletService for data-iframe

### DIFF
--- a/paywall/src/__tests__/data-iframe/walletWrapper.test.ts
+++ b/paywall/src/__tests__/data-iframe/walletWrapper.test.ts
@@ -1,0 +1,72 @@
+import { walletWrapper } from '../../data-iframe/walletWrapper'
+import { getWalletService } from '../test-helpers/setupBlockchainHelpers'
+import { WalletServiceType } from '../../data-iframe/blockchainHandler/blockChainTypes'
+
+let mockWalletService: WalletServiceType
+
+jest.mock('@unlock-protocol/unlock-js', () => ({
+  WalletService: function() {
+    mockWalletService = getWalletService({})
+    mockWalletService.provider = 'unlock'
+    return mockWalletService
+  },
+}))
+
+describe('walletWrapper', () => {
+  let emitter = jest.fn()
+  beforeEach(() => {
+    emitter = jest.fn()
+    walletWrapper('the unlock address', emitter)
+  })
+
+  it('should try to retrieve account from walletService', () => {
+    expect.assertions(1)
+
+    expect(mockWalletService.getAccount).toHaveBeenCalled()
+  })
+
+  it('should pass through `account.changed` events', () => {
+    expect.assertions(1)
+
+    const message = 'account.changed'
+    const value = '0xmyaccount'
+
+    mockWalletService.emit(message, value)
+    expect(emitter).toHaveBeenCalledWith(message, value)
+  })
+
+  it('should pass through `network.changed` events', () => {
+    expect.assertions(1)
+
+    const message = 'network.changed'
+    const value = 7
+
+    mockWalletService.emit(message, value)
+    expect(emitter).toHaveBeenCalledWith(message, value)
+  })
+
+  it('should emit a formatted transaction on `transaction.new` events', () => {
+    expect.assertions(1)
+
+    mockWalletService.emit(
+      'transaction.new',
+      'aHash',
+      '0xaFAEfc6dd3C9feF66f92BA838b132644451F0715',
+      '0x84BCb1DFF32Ee9e7Bc7c6868954C3E6F346046b4',
+      '',
+      'KEY_PURCHASE',
+      'pending'
+    )
+
+    expect(emitter).toHaveBeenCalledWith('transaction.new', {
+      blockNumber: 9007199254740991,
+      for: '0xafaefc6dd3c9fef66f92ba838b132644451f0715',
+      from: '0xafaefc6dd3c9fef66f92ba838b132644451f0715',
+      hash: 'aHash',
+      input: '',
+      status: 'pending',
+      to: '0x84bcb1dff32ee9e7bc7c6868954c3e6f346046b4',
+      type: 'KEY_PURCHASE',
+    })
+  })
+})

--- a/paywall/src/data-iframe/ProxyWallet.ts
+++ b/paywall/src/data-iframe/ProxyWallet.ts
@@ -1,0 +1,45 @@
+export class ProxyWallet {
+  id: number = 0
+  isMetamask: boolean
+  noWallet: boolean
+  notEnabled: boolean
+  requests: { [id: number]: any } = {} // id->callback map
+  emit: (name: string, data?: any) => void
+
+  constructor(
+    walletInfo: {
+      isMetamask: boolean
+      noWallet: boolean
+      notEnabled: boolean
+    },
+    emit: (name: string, data?: any) => void
+  ) {
+    this.isMetamask = walletInfo.isMetamask
+    this.noWallet = walletInfo.noWallet
+    this.notEnabled = walletInfo.notEnabled
+    this.emit = emit
+  }
+
+  // TODO: get real types for these
+  async sendAsync({ method, params }: any, callback: any) {
+    const id = ++this.id
+
+    if (this.noWallet) {
+      callback(new Error('no ethereum wallet is available'))
+      return
+    }
+
+    if (this.notEnabled) {
+      callback(new Error('user declined to enable the ethereum wallet'))
+      return
+    }
+
+    this.requests[id] = callback
+    const payload = { method, params, id }
+
+    // TODO: don't use string literals for messages
+    this.emit('web3_call', payload)
+  }
+}
+
+export default ProxyWallet

--- a/paywall/src/data-iframe/index.2.0.ts
+++ b/paywall/src/data-iframe/index.2.0.ts
@@ -4,6 +4,8 @@ import { walletWrapper } from './walletWrapper'
 import { BlockchainReader } from './BlockchainReader'
 import { BlockchainDataStorable } from './BlockchainDataStorable'
 import config from './constants'
+import { WalletServiceType } from './blockchainHandler/blockChainTypes'
+import { ProxyWallet } from './ProxyWallet'
 
 const {
   readOnlyProvider,
@@ -11,12 +13,17 @@ const {
   blockTime,
   requiredConfirmations,
 } = config
+
 const web3Service = new Web3Service({
   readOnlyProvider,
   unlockAddress,
   blockTime,
   requiredConfirmations,
 })
+
+let parent: Postmate.ChildAPI
+let walletService: WalletServiceType
+let proxyWallet: ProxyWallet
 
 // Start with a null object, it will be replaced when the authenticate
 // method in the model is called.
@@ -38,16 +45,21 @@ const initializeReader = ({ lockAddresses, accountAddress }: ReaderArgs) => {
   )
 }
 
+const connectProxyWallet = (walletInfo: any) => {
+  proxyWallet = new ProxyWallet(walletInfo, parent.emit)
+  walletService.connect(proxyWallet)
+}
+
 const handshake = new Postmate.Model({
   locks: () => blockchainReader.locks,
   keys: () => blockchainReader.keys,
   transactions: () => blockchainReader.transactions,
   initializeReader,
+  connectProxyWallet,
 })
 
 handshake.then(parent => {
-  walletWrapper(unlockAddress, (name, data) => {
+  walletService = walletWrapper(unlockAddress, (name, data) => {
     parent.emit(name, data)
   })
-  parent.emit('ready')
 })

--- a/paywall/src/data-iframe/index.2.0.ts
+++ b/paywall/src/data-iframe/index.2.0.ts
@@ -1,5 +1,6 @@
 import Postmate from 'postmate'
 import { Web3Service } from '@unlock-protocol/unlock-js'
+import { walletWrapper } from './walletWrapper'
 import { BlockchainReader } from './BlockchainReader'
 import { BlockchainDataStorable } from './BlockchainDataStorable'
 import config from './constants'
@@ -45,5 +46,8 @@ const handshake = new Postmate.Model({
 })
 
 handshake.then(parent => {
+  walletWrapper(unlockAddress, (name, data) => {
+    parent.emit(name, data)
+  })
   parent.emit('ready')
 })

--- a/paywall/src/data-iframe/walletWrapper.ts
+++ b/paywall/src/data-iframe/walletWrapper.ts
@@ -1,0 +1,68 @@
+import { WalletService } from '@unlock-protocol/unlock-js'
+import {
+  WalletServiceType,
+  TransactionDefaults,
+} from './blockchainHandler/blockChainTypes'
+import { normalizeLockAddress } from '../utils/normalizeAddresses'
+import { POLLING_INTERVAL } from '../constants'
+
+// There are slight differences between what WalletService emits and
+// what our other code expects, this piece massages the data so that
+// they match.
+export const formatTransaction = (
+  hash: string,
+  from: string,
+  to: string,
+  input: string,
+  type: string,
+  status: string
+): TransactionDefaults => {
+  const normalizedTo = normalizeLockAddress(to)
+  const normalizedFrom = normalizeLockAddress(from)
+  return {
+    hash,
+    from: normalizedFrom,
+    for: normalizedFrom,
+    to: normalizedTo,
+    input,
+    type,
+    status,
+    blockNumber: Number.MAX_SAFE_INTEGER,
+  }
+}
+
+// hideous
+type NewTransactionArgs = [string, string, string, string, string, string]
+
+export const retrieveAccount = (walletService: WalletServiceType) => {
+  if (!walletService.provider) {
+    return
+  }
+  walletService.getAccount()
+}
+
+export const pollForAccountChanges = (walletService: WalletServiceType) => {
+  retrieveAccount(walletService)
+  window.setTimeout(pollForAccountChanges, POLLING_INTERVAL)
+}
+
+// Messages with one argument that are passed from the wrapper to the
+// main window unchanged
+const passThroughMessages = ['account.changed', 'network.changed']
+
+export const walletWrapper = (
+  unlockAddress: string,
+  emitter: (name: string, data?: any) => void
+) => {
+  const walletService: WalletServiceType = new WalletService({ unlockAddress })
+
+  passThroughMessages.forEach((msg: string) => {
+    walletService.on(msg, (arg: any) => emitter(msg, arg))
+  })
+
+  walletService.on('transaction.new', (...args: NewTransactionArgs) => {
+    emitter('transaction.new', formatTransaction(...args))
+  })
+
+  pollForAccountChanges(walletService)
+}

--- a/paywall/src/data-iframe/walletWrapper.ts
+++ b/paywall/src/data-iframe/walletWrapper.ts
@@ -43,7 +43,10 @@ export const retrieveAccount = (walletService: WalletServiceType) => {
 
 export const pollForAccountChanges = (walletService: WalletServiceType) => {
   retrieveAccount(walletService)
-  window.setTimeout(pollForAccountChanges, POLLING_INTERVAL)
+  window.setTimeout(
+    () => pollForAccountChanges(walletService),
+    POLLING_INTERVAL
+  )
 }
 
 // Messages with one argument that are passed from the wrapper to the

--- a/paywall/src/data-iframe/walletWrapper.ts
+++ b/paywall/src/data-iframe/walletWrapper.ts
@@ -56,7 +56,7 @@ const passThroughMessages = ['account.changed', 'network.changed']
 export const walletWrapper = (
   unlockAddress: string,
   emitter: (name: string, data?: any) => void
-) => {
+): WalletServiceType => {
   const walletService: WalletServiceType = new WalletService({ unlockAddress })
 
   passThroughMessages.forEach((msg: string) => {
@@ -68,4 +68,7 @@ export const walletWrapper = (
   })
 
   pollForAccountChanges(walletService)
+
+  // Return walletService so we can connect a wallet to it when we're ready
+  return walletService
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR replaces #5457. It's a somewhat simpler approach. There is a little more messaging involved, but it keeps the code itself cleaner and handles the complexity of interaction between web3service and walletservice (which are meant to be separate, but what happens in walletservice can impact web3service)

In short, the wallet wrapper is completely stateless. For the moment, it just passes messages up to the main window. In the event of an account or network change, the main window will handle it by reinitializing the blockchain reader. The main window will handle a new transaction by passing it back down as a transaction update (not yet implemented).

The data iframe will need a bit more work, but I'm hopeful that we can soon use it for real, at least for the read-only pieces.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
