### PR TITLE
Running dev against Kovan

### DIFF
--- a/unlock-app/next.config.js
+++ b/unlock-app/next.config.js
@@ -36,7 +36,7 @@ Object.keys(requiredConfigVariables).forEach(configVariableName => {
     if (
       // 'unlock-provider-integration' is a environment only used by integration tests to test the case
       // where no HTTP provider has been injected into the page.
-      ['dev', 'test', 'unlock-provider-integration'].indexOf(
+      ['dev', 'dev-kovan', 'test', 'unlock-provider-integration'].indexOf(
         requiredConfigVariables.unlockEnv
       ) > -1
     ) {

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -144,6 +144,26 @@ export default function configure(
     blockTime = 8000
   }
 
+  if (env === 'dev-kovan') {
+    // In dev-kovan, the network can only be Kovan
+    isRequiredNetwork = networkId => networkId === 42
+    chainExplorerUrlBuilders.etherScan = address =>
+      `https://kovan.etherscan.io/address/${address}`
+    requiredNetworkId = 42
+    paywallUrl = 'https://'
+    supportedProviders = ['Metamask', 'Opera']
+    services['storage'] = { host: runtimeConfig.locksmithHost }
+    services['wedlocks'] = { host: runtimeConfig.wedlocksUri }
+    paywallUrl = runtimeConfig.paywallUrl
+    paywallScriptUrl = runtimeConfig.paywallScriptUrl
+
+    // Address for the Unlock smart contract on Kovan
+    unlockAddress = '0x0B9fe963b789151E53b8bd601590Ea32F9f2453D'
+
+    // Kovan average block time
+    blockTime = 4000
+  }
+
   if (env === 'prod') {
     // In prod, the network can only be mainnet
     isRequiredNetwork = networkId => networkId === 1

--- a/unlock-app/src/constants.ts
+++ b/unlock-app/src/constants.ts
@@ -10,6 +10,7 @@ export const ETHEREUM_NETWORKS_NAMES: { [id: number]: string[] } = {
   2: ['Morden', 'staging'],
   3: ['Ropsten', 'staging'],
   4: ['Rinkeby', 'staging'],
+  42: ['Kovan', 'staging'],
   1984: ['Winston', 'test'],
 }
 


### PR DESCRIPTION
# Description
This allows anyone to run den dev using kovan network instead of ganache. This can be used to deploy kovan locks.

I'll update the wiki to detail exactly how to do this and make it useable for developers.

At the moment, it is not possible to view previously deployed (on kovan) locks on the dashboard. But, etherscan works fine for this,
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
