### PR TITLE
Reduce load by removing parallel data iframe

### DIFF
--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -1,4 +1,3 @@
-import Postmate from 'postmate'
 import { UnlockWindowNoProtocolYet } from '../windowTypes'
 import IframeHandler from './IframeHandler'
 import Wallet from './Wallet'
@@ -65,12 +64,6 @@ export function startup(
     userIframeUrl
   )
   iframes.init(config)
-
-  // TODO: be able to include this as one of the iframes passed to MainWindowHandler
-  new Postmate({
-    url: constants.paywallUrl + '/static/data-iframe.2.0.html',
-    classListArray: ['unlock', 'start'],
-  })
 
   // user accounts is loaded on-demand inside of Wallet
   // set up the proxy wallet handler


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

It's possible that the presence of the second data iframe introduces some extra overhead in terms of alchemy requests. This PR removes the code that launches the second data iframe for the time being since it isn't being used yet.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
