### PR TITLE
Emit locked early when invalidating config

### DIFF
--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -1,4 +1,4 @@
-import { PostMessages } from '../messageTypes'
+import { PostMessages } from 'src/messageTypes'
 import { UnlockWindowNoProtocolYet } from '../windowTypes'
 import IframeHandler from './IframeHandler'
 import Wallet from './Wallet'

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -1,4 +1,4 @@
-import { PostMessages } from 'src/messageTypes'
+import { PostMessages } from '../messageTypes'
 import { UnlockWindowNoProtocolYet } from '../windowTypes'
 import IframeHandler from './IframeHandler'
 import Wallet from './Wallet'

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -32,6 +32,26 @@ export function normalizeConfig(unlockConfig: any) {
   return normalizedConfig
 }
 
+// Temporary helper to dispatch locked event when we fail early
+function dispatchEvent(detail: any, window: any) {
+  let event
+  try {
+    event = new window.CustomEvent('unlockProtocol', { detail })
+  } catch (e) {
+    // older browsers do events this clunky way.
+    // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events#The_old-fashioned_way
+    // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent#Parameters
+    event = window.document.createEvent('customevent')
+    event.initCustomEvent(
+      'unlockProtocol',
+      true /* canBubble */,
+      true /* cancelable */,
+      detail
+    )
+  }
+  window.dispatchEvent(event)
+}
+
 /**
  * Start the unlock app!
  */
@@ -64,6 +84,7 @@ export function startup(
       // without ever querying for any locks.
       locks: {},
     }
+    dispatchEvent('locked', window)
   }
 
   const origin = '?origin=' + encodeURIComponent(window.origin)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Previous approach to handle load issue made it so that we wouldn't emit the `locked` event. This dispatches it right away when we know that there is no wallet and user accounts aren't allowed.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
