### PR TITLE
Cache account address when account is updated in walletservice

### DIFF
--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/init.test.ts
@@ -39,6 +39,27 @@ describe('MainWindowHandler - init', () => {
     fakeWindow = new FakeWindow()
   })
 
+  describe('handling account changes', () => {
+    it('should write the provided account address to localStorage', () => {
+      expect.assertions(1)
+
+      const handler = getMainWindowHandler()
+      handler.setCachedAccountAddress = jest.fn()
+      handler.init()
+
+      fakeWindow.receivePostMessageFromIframe(
+        PostMessages.UPDATE_ACCOUNT,
+        '0xaccountAddress',
+        iframes.data.iframe,
+        dataOrigin
+      )
+
+      expect(handler.setCachedAccountAddress).toHaveBeenCalledWith(
+        '0xaccountAddress'
+      )
+    })
+  })
+
   describe('toggling lock state', () => {
     it('should handle PostMessages.LOCKED by emitting a locked event', () => {
       expect.assertions(1)

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -56,6 +56,7 @@ export default class MainWindowHandler {
       showAccountIframe: this.showAccountIframe,
       hideCheckoutIframe: this.hideCheckoutIframe,
       blockchainData: this.blockchainData,
+      setCachedAccountAddress: this.setCachedAccountAddress,
     })
   }
 
@@ -106,14 +107,24 @@ export default class MainWindowHandler {
 
   setCachedLockedState = (newState: boolean) => {
     try {
-      // this is a fast cache. The value will only be used
-      // to prevent a flash of ads on startup. If a cheeky
-      // user attempts to prevent display of ads by setting
-      // the localStorage cache, it will only work for a
-      // few milliseconds
+      // this is a fast cache. The value will only be used to prevent
+      // a flash of ads on startup. If a user attempts to prevent
+      // display of ads by setting the localStorage cache, it will
+      // only work for a few milliseconds
       this.window.localStorage.setItem(
         '__unlockProtocol.locked',
         JSON.stringify(newState)
+      )
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  setCachedAccountAddress = (accountAddress: string) => {
+    try {
+      this.window.localStorage.setItem(
+        '__unlockProtocol.accountAddress',
+        accountAddress
       )
     } catch (e) {
       // ignore

--- a/paywall/src/unlock.js/postMessageHub.ts
+++ b/paywall/src/unlock.js/postMessageHub.ts
@@ -134,6 +134,7 @@ interface mainWindowHandlerInitArgs {
   hideCheckoutIframe: () => void
   showAccountIframe: () => void
   hideAccountIframe: () => void
+  setCachedAccountAddress: (accountAddress: string) => void
   blockchainData: BlockchainData
 }
 
@@ -144,6 +145,7 @@ export function mainWindowHandlerInit({
   showAccountIframe,
   hideCheckoutIframe,
   blockchainData,
+  setCachedAccountAddress,
 }: mainWindowHandlerInitArgs) {
   // respond to "unlocked" and "locked" events by
   // dispatching "unlockProtocol" on the main window
@@ -166,6 +168,9 @@ export function mainWindowHandlerInit({
   })
   iframes.data.on(PostMessages.UPDATE_ACCOUNT, address => {
     blockchainData.account = address
+    if (address) {
+      setCachedAccountAddress(address)
+    }
   })
   iframes.data.on(PostMessages.UPDATE_ACCOUNT_BALANCE, balance => {
     blockchainData.balance = balance


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR caches an account address in localStorage whenever we get an account address update from localstorage. This will allow us to defer loading the paywall unless we already have a stored account.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
