### PR TITLE
Defer startup for users who don't have cached address

### DIFF
--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -5,6 +5,7 @@ import MainWindowHandler from './MainWindowHandler'
 import StartupConstants from './startupTypes'
 import { walletStatus } from '../utils/wallet'
 import { checkoutHandlerInit } from './postMessageHub'
+import { PostMessages } from '../messageTypes'
 
 /**
  * convert all of the lock addresses to lower-case so they are normalized across the app
@@ -57,7 +58,8 @@ function dispatchEvent(detail: any, window: any) {
  */
 export function startup(
   window: UnlockWindowNoProtocolYet,
-  constants: StartupConstants
+  constants: StartupConstants,
+  launchModal: boolean = false
 ) {
   // normalize all of the lock addresses
   let config = normalizeConfig(window.unlockProtocolConfig)
@@ -112,6 +114,13 @@ export function startup(
 
   // go!
   mainWindow.init()
+  if (launchModal) {
+    iframes.data.on(PostMessages.UPDATE_ACCOUNT, accountAddress => {
+      if (accountAddress) {
+        mainWindow.showCheckoutIframe()
+      }
+    })
+  }
 
   const walletInitParams = walletStatus(window, config)
   wallet.init(walletInitParams)
@@ -132,6 +141,36 @@ export default function startupWhenReady(
   window: Window,
   startupConstants: StartupConstants
 ) {
+  try {
+    // The presence of a cached account address indicates that the
+    // user has previously connected to MetaMask. In that case, it is
+    // acceptable for us to initialize the app right away. However, if
+    // there is no address in localStorage, we want to defer
+    // initializing the app until the user chooses to load the
+    // checkout modal.
+    const cachedAccountAddress = window.localStorage.getItem(
+      '__unlockProtocol.accountAddress'
+    )
+    if (!cachedAccountAddress) {
+      // We have to dispatch locked right away, otherwise it will
+      // never happen because we're stopping the rest of the app from
+      // loading.
+      ;(window as any).unlockProtocol = {
+        loadCheckoutModal: () => {
+          startup(
+            (window as unknown) as UnlockWindowNoProtocolYet,
+            startupConstants,
+            true
+          )
+        },
+      }
+      dispatchEvent('locked', window)
+      return
+    }
+  } catch (e) {
+    // ignore
+  }
+
   let started = false
   if (document.readyState !== 'loading') {
     // in most cases, we will start up after the document is interactive


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

In response to a request from Forbes, we won't try to connect to Metamask (or other wallets) until the user has interacted with the button. In the case of users for whom we have a cached address, we see that as indication they have previously chosen to connect, and go ahead and initialize the app.

This performed nicely in dev, but we should thoroughly run down the use cases in staging before doing a push.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
