### PR TITLE
Don't defer startup for users with no wallet

### DIFF
--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -1,4 +1,3 @@
-import { PaywallConfig } from 'src/unlockTypes'
 import { UnlockWindowNoProtocolYet } from '../windowTypes'
 import IframeHandler from './IframeHandler'
 import Wallet from './Wallet'
@@ -139,17 +138,15 @@ export function startup(
 
 // Make sure the page is ready before we try to start the app!
 export default function startupWhenReady(
-  window: UnlockWindowNoProtocolYet,
+  window: Window,
   startupConstants: StartupConstants
 ) {
-  const config = window.unlockProtocolConfig || ({} as PaywallConfig)
-  const userAccountsAllowed = !!config.unlockUserAccounts
-  const web3Present = !!window.web3
+  const web3Present = !!(window as any).web3
 
   // Only try to do the deferred setup when we have a wallet. If we
   // don't, we can do setup rright away, since it will just result in
   // the no wallet message.
-  if (web3Present || userAccountsAllowed) {
+  if (web3Present) {
     try {
       // The presence of a cached account address indicates that the
       // user has previously connected to MetaMask. In that case, it is

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -144,7 +144,7 @@ export default function startupWhenReady(
   const web3Present = !!(window as any).web3
 
   // Only try to do the deferred setup when we have a wallet. If we
-  // don't, we can do setup rright away, since it will just result in
+  // don't, we can do setup right away, since it will just result in
   // the no wallet message.
   if (web3Present) {
     try {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR checks whether we have an injected wallet, and only does the deferred paywall startup if there is one. If not, we can just let the startup run because it should immediately end up in the expected state of showing the no wallet message.

# Issues
Refs #5518 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
