### PR TITLE
Only launch modal once on account updated

### DIFF
--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -115,7 +115,7 @@ export function startup(
   // go!
   mainWindow.init()
   if (launchModal) {
-    iframes.data.on(PostMessages.UPDATE_ACCOUNT, accountAddress => {
+    iframes.data.once(PostMessages.UPDATE_ACCOUNT, accountAddress => {
       if (accountAddress) {
         mainWindow.showCheckoutIframe()
       }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR makes sure we only launch the checkout modal once when receiving account updated (in the case that we are waiting for a user interaction to start up the paywall)


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
