### PR TITLE
Fixes newsletter

### DIFF
--- a/newsletter/components/content/HomeContent.jsx
+++ b/newsletter/components/content/HomeContent.jsx
@@ -16,23 +16,18 @@ const config = configure()
 /**
  * The form
  */
-export const EmailForm = ({ email, onSubmit, onChange, label }) => {
-  if (email === undefined) {
-    return <Loading />
-  }
-  return (
-    <Form onSubmit={onSubmit}>
-      <Input
-        value={email}
-        required
-        type="email"
-        placeholder="Enter your email address"
-        onChange={onChange}
-      />
-      <Button type="submit" value={label} />
-    </Form>
-  )
-}
+export const EmailForm = ({ email, onSubmit, onChange, label }) => (
+  <Form onSubmit={onSubmit}>
+    <Input
+      value={email}
+      required
+      type="email"
+      placeholder="Enter your email address"
+      onChange={onChange}
+    />
+    <Button type="submit" value={label} />
+  </Form>
+)
 
 EmailForm.propTypes = {
   email: PropTypes.string.isRequired,
@@ -71,7 +66,13 @@ export default function HomeContent() {
     }
   }
   useEffect(() => {
-    retrieveEmail()
+    // Connect (this is not cool becuase it pops up immediately for the user...)
+    // But this is currently the only way we can prompt the user to get their saved
+    // address. Also, this means the unlock status is loaded immediately
+    window.web3.currentProvider.enable()
+    if (lockState === 'unlocked') {
+      retrieveEmail()
+    }
   }, [lockWithKey])
 
   const onSubmit = async (event, isUpdate) => {

--- a/newsletter/hooks/usePaywall.js
+++ b/newsletter/hooks/usePaywall.js
@@ -42,7 +42,7 @@ sc.parentNode.insertBefore(js, sc); }(document, "script"));`)
       const handler = event => {
         // WARNING: THIS IS NOT DOCUMENTED!
         // Let's look at the data that we have
-        if (window.unlockProtocol) {
+        if (window.unlockProtocol && window.unlockProtocol.blockchainData) {
           const data = window.unlockProtocol.blockchainData()
           if (data.keys) {
             // They should be indexed by lock.


### PR DESCRIPTION
# Description

Our recent changes in the paywall only triggerd the application to enable the web3 provider once the user opens the checkout modal.
The newsletter application actually requires the web3 address to be known in order to load the saved email address or to save an email address.
This PR fixes this (tempoarily) by forcing the wallet to be enabled when the page is loaded.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->