### PR TITLE
Rename privateKeyReducer, remove TODO

### DIFF
--- a/unlock-app/src/__tests__/reducers/userDetails.test.ts
+++ b/unlock-app/src/__tests__/reducers/userDetails.test.ts
@@ -1,4 +1,4 @@
-import reducer, { initialState } from '../../reducers/privateKeyReducer'
+import reducer, { initialState } from '../../reducers/userDetails'
 
 import { SET_ENCRYPTED_PRIVATE_KEY } from '../../actions/user'
 
@@ -56,7 +56,7 @@ const newKeyState = {
   email: 'angrybees@BZZZZZZZZZZZZZ.STING',
 }
 
-describe('privateKeyReducer', () => {
+describe('userDetailsReducer', () => {
   it.each([SET_ACCOUNT, SET_PROVIDER, SET_NETWORK])(
     'should retain state when receiving %s',
     actionType => {

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -40,9 +40,9 @@ import lockFormVisibilityReducer, {
 import fullScreenModalsReducer, {
   initialState as defaultFullScreenModalsStatus,
 } from './reducers/fullScreenModalsReducer'
-import privateKeyReducer, {
-  initialState as defaultPrivateKeyState,
-} from './reducers/privateKeyReducer'
+import userDetailsReducer, {
+  initialState as defaultUserDetails,
+} from './reducers/userDetails'
 import cartReducer, {
   initialState as defaultCartState,
 } from './reducers/cartReducer'
@@ -78,7 +78,7 @@ export const createUnlockStore = (
     errors: errorsReducer,
     lockFormStatus: lockFormVisibilityReducer,
     fullScreenModalStatus: fullScreenModalsReducer,
-    userDetails: privateKeyReducer,
+    userDetails: userDetailsReducer,
     cart: cartReducer,
     recoveryPhrase: recoveryReducer,
     pageIsLocked: pageStatusReducer,
@@ -107,7 +107,7 @@ export const createUnlockStore = (
       errors: defaultError,
       lockFormStatus: defaultLockFormVisibility,
       fullScreenModalStatus: defaultFullScreenModalsStatus,
-      userDetails: defaultPrivateKeyState,
+      userDetails: defaultUserDetails,
       recoveryPhrase: defaultRecoveryPhrase,
       cart: defaultCartState,
       pageIsLocked: defaultPageStatus,

--- a/unlock-app/src/reducers/userDetails.ts
+++ b/unlock-app/src/reducers/userDetails.ts
@@ -4,8 +4,7 @@ import { Action, EncryptedPrivateKey } from '../unlockTypes' // eslint-disable-l
 type State = { key: EncryptedPrivateKey; email: string } | null
 export const initialState: State = null
 
-// TODO: this is not used: cleanup!
-const privateKeyReducer = (
+const userDetailsReducer = (
   state: State = initialState,
   action: Action
 ): State => {
@@ -23,4 +22,4 @@ const privateKeyReducer = (
   return state
 }
 
-export default privateKeyReducer
+export default userDetailsReducer


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

There was an erroneous TODO in the `privateKeyReducer` indicating that it wasn't being used anymore. To be more clear, I've renamed the reducer to `userDetails` (which is really more like what it does) and removed the TODO. Now it should be clear which state maps to which reducer for future readers.

There are no real behavior changes here.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [x] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [x] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
