### PR TITLE
adding support for create2 to determine expected lock address

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+# 0.5.3
+
+- Supports create2 in generateLockAddress
+
 # 0.5.2
 
 - Lets the user pass a network id when intantiating services

--- a/unlock-js/src/__tests__/integration/walletServiceIntegration.test.js
+++ b/unlock-js/src/__tests__/integration/walletServiceIntegration.test.js
@@ -104,9 +104,14 @@ describe('Wallet Service Integration', () => {
       describe.each(
         locks[versionName].map((lock, index) => [index, lock.name, lock])
       )('lock %i: %s', (lockIndex, lockName, lockParams) => {
-        let lock, lockAddress, lockCreationHash
+        let lock, expectedLockAddress, lockAddress, lockCreationHash
 
         beforeAll(async () => {
+          expectedLockAddress = await web3Service.generateLockAddress(
+            accounts[0],
+            lockParams
+          )
+
           lockAddress = await walletService.createLock(
             lockParams,
             (error, hash) => {
@@ -119,6 +124,11 @@ describe('Wallet Service Integration', () => {
         it('should have yielded a transaction hash', () => {
           expect.assertions(1)
           expect(lockCreationHash).toMatch(/^0x[0-9a-fA-F]{64}$/)
+        })
+
+        it('should have deployed a lock at the expected address', async () => {
+          expect.assertions(1)
+          expect(lockAddress).toEqual(expectedLockAddress)
         })
 
         it('should have deployed the right lock version', async () => {

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -135,17 +135,61 @@ export default class Web3Service extends UnlockService {
   }
 
   /**
-   * "Guesses" what the next Lock's address is going to be
+   * Method which returns the create2 address based on the factory contract (unlock), the lock template,
+   * the account and lock salt (both used to create a unique salt)
+   * 0x3d602d80600a3d3981f3363d3d373d3d3d363d73 and 5af43d82803e903d91602b57fd5bf3 are the
+   * bytecode for eip-1167 (which defines proxies for locks).
+   * @private
    */
-  async generateLockAddress() {
-    let transactionCount = await this.provider.getTransactionCount(
-      this.unlockContractAddress
-    )
+  _create2Address(unlockAddress, templateAddress, account, lockSalt) {
+    const saltHex = `${account}${lockSalt}`
+    const byteCode = `0x3d602d80600a3d3981f3363d3d373d3d3d363d73${templateAddress.replace(
+      /0x/,
+      ''
+    )}5af43d82803e903d91602b57fd5bf3`
+    const byteCodeHash = utils.sha3(byteCode)
 
-    return ethers.utils.getContractAddress({
-      from: this.unlockContractAddress,
-      nonce: transactionCount,
-    })
+    const seed = ['ff', unlockAddress, saltHex, byteCodeHash]
+      .map(x => x.replace(/0x/, ''))
+      .join('')
+
+    let address = utils.sha3(`0x${seed}`).slice(-40)
+
+    return utils.toChecksumAddress(`0x${address}`)
+  }
+
+  /**
+   * "Guesses" what the next Lock's address is going to be
+   * Before v12 (5) we do not need the lock object
+   * After that, we do because create2 uses a salt which is used to know the address
+   * TODO : ideally this code should be part of ethers... but it looks like it's not there yet.
+   * For now, losely inspired by
+   * https://github.com/HardlyDifficult/hardlydifficult-ethereum-contracts/blob/master/src/utils/create2.js#L29
+   */
+  async generateLockAddress(owner, lock) {
+    const version = await this.unlockContractAbiVersion()
+    if (version.version === 'v12') {
+      const unlockContact = await this.getUnlockContract()
+      const templateAddress = await unlockContact.publicLockAddress()
+      // Compute the hash identically to v12 (TODO: extract this?)
+      const lockSalt = utils.sha3(utils.utf8ToHex(lock.name)).substring(2, 26) // 2+24
+      return this._create2Address(
+        this.unlockContractAddress,
+        templateAddress,
+        owner,
+        lockSalt
+      )
+    } else {
+      // TODO: once the contracts have been moved to v12, get rid of the code below as no lock will ever be deployed again from the old unlock contract!
+      let transactionCount = await this.provider.getTransactionCount(
+        this.unlockContractAddress
+      )
+
+      return ethers.utils.getContractAddress({
+        from: this.unlockContractAddress,
+        nonce: transactionCount,
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
# Description

The old method to determine the lock address before it's been mined does not work anymore in v12 because we changed to use create2.
This PR adds support to create2.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->