### PR TITLE
Renovate: fix group by subrepo config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,40 +17,58 @@
   "packageRules": [
     {
       "paths": ["locksmith/**"],
-      "groupName": "locksmith"
+      "minor": {
+        "groupName": "locksmith"
+      }
     },
     {
       "paths": ["paywall/**"],
-      "groupName": "paywall"
+      "minor": {
+        "groupName": "paywall"
+      }
     },
     {
       "paths": ["rover/**"],
-      "groupName": "rover"
+      "minor": {
+        "groupName": "rover"
+      }
     },
     {
       "paths": ["smart-contracts/**"],
-      "groupName": "smart-contracts",
+      "minor": {
+        "groupName": "smart-contracts"
+      },
       "reviewers": ["NickCuso"]
     },
     {
       "paths": ["tickets/**"],
-      "groupName": "tickets"
+      "minor": {
+        "groupName": "tickets"
+      }
     },
     {
       "paths": ["unlock-app/**"],
-      "groupName": "unlock-app"
+      "minor": {
+        "groupName": "unlock-app"
+      }
     },
     {
       "paths": ["unlock-js/**"],
-      "groupName": "unlock-js"
+      "minor": {
+        "groupName": "unlock-js"
+      }
     },
     {
       "paths": ["unlock-protocol.com/**"],
-      "groupName": "unlock-protocol.com"
+      "minor": {
+        "groupName": "unlock-protocol.com"
+      }
     },
     {
       "paths": ["wedlocks/**"],
-      "groupName": "wedlocks"
+      "minor": {
+        "groupName": "wedlocks"
+      }
     },
     {
       "packagePatterns": [
@@ -63,7 +81,9 @@
     {
       "packageNames": ["@unlock-protocol/unlock-js"],
       "schedule": ["at any time"],
-      "groupName": "unlock-js npm package"
+      "minor": {
+        "groupName": "unlock-js npm package"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
We previously attempted to config Renovate to open one PR per-subrepo.  I believe this fixes that config.  I tested something similar in the https://github.com/unlock-protocol/swap-and-call repo

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
