### PR TITLE
adding generateLockAddress to the inputHandler in order to determine the upcoming lock address when it is not known

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+# 0.5.4
+
+- generateLockAddress on inputHandler as well
+
 # 0.5.3
 
 - Supports create2 in generateLockAddress

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/v0/web3Service.test.js
+++ b/unlock-js/src/__tests__/v0/web3Service.test.js
@@ -129,6 +129,7 @@ describe('Web3Service', () => {
       it('should emit lock.updated with correctly typed values', async done => {
         expect.assertions(2)
         await versionedNockBeforeEach()
+        const sender = '0xsender'
         const params = {
           _expirationDuration: '7',
           _maxNumberOfKeys: '5',
@@ -141,7 +142,12 @@ describe('Web3Service', () => {
           done()
         })
 
-        await web3Service.inputsHandlers.createLock('0x123', '0x456', params)
+        await web3Service.inputsHandlers.createLock(
+          '0x123',
+          '0x456',
+          sender,
+          params
+        )
       })
     })
 
@@ -150,6 +156,7 @@ describe('Web3Service', () => {
       await versionedNockBeforeEach()
       let resolveKeySaver
       let resolveTransactionUpdater
+      const sender = '0xsender'
       const owner = '0x9876'
       const fakeParams = {
         _recipient: owner,
@@ -186,6 +193,7 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers.purchaseFor(
         fakeHash,
         fakeContractAddress,
+        sender,
         fakeParams
       )
       await Promise.all([keySaver, transactionUpdater])
@@ -479,7 +487,7 @@ describe('Web3Service', () => {
     })
 
     it('should call the handler if the transaction input can be parsed', async done => {
-      expect.assertions(3)
+      expect.assertions(4)
       await versionedNockBeforeEach()
       web3Service._getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
       const input =
@@ -507,10 +515,12 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers[method.name] = (
         transactionHash,
         contractAddress,
+        sender,
         args
       ) => {
         expect(transactionHash).toEqual(transaction.hash)
         expect(contractAddress).toEqual(web3Service.unlockContractAddress)
+        expect(sender).toEqual(transaction.from)
         expect(args).toEqual(params)
         done()
       }
@@ -520,7 +530,8 @@ describe('Web3Service', () => {
         transaction.hash,
         FakeContract,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        transaction.from
       )
     })
   })

--- a/unlock-js/src/__tests__/v01/web3Service.test.js
+++ b/unlock-js/src/__tests__/v01/web3Service.test.js
@@ -129,6 +129,7 @@ describe('Web3Service', () => {
       it('should emit lock.updated with correctly typed values', async done => {
         expect.assertions(2)
         await versionedNockBeforeEach()
+        const sender = '0xsender'
         const params = {
           _expirationDuration: '7',
           _maxNumberOfKeys: '5',
@@ -141,7 +142,12 @@ describe('Web3Service', () => {
           done()
         })
 
-        await web3Service.inputsHandlers.createLock('0x123', '0x456', params)
+        await web3Service.inputsHandlers.createLock(
+          '0x123',
+          '0x456',
+          sender,
+          params
+        )
       })
     })
 
@@ -150,6 +156,7 @@ describe('Web3Service', () => {
       await versionedNockBeforeEach()
       let resolveKeySaver
       let resolveTransactionUpdater
+      const sender = '0xsender'
       const owner = '0x9876'
       const fakeParams = {
         _recipient: owner,
@@ -186,6 +193,7 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers.purchaseFor(
         fakeHash,
         fakeContractAddress,
+        sender,
         fakeParams
       )
       await Promise.all([keySaver, transactionUpdater])
@@ -447,7 +455,7 @@ describe('Web3Service', () => {
     })
 
     it('should call the handler if the transaction input can be parsed', async done => {
-      expect.assertions(3)
+      expect.assertions(4)
       await versionedNockBeforeEach()
       web3Service._getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
       const input =
@@ -475,10 +483,12 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers[method.name] = (
         transactionHash,
         contractAddress,
+        sender,
         args
       ) => {
         expect(transactionHash).toEqual(transaction.hash)
         expect(contractAddress).toEqual(web3Service.unlockContractAddress)
+        expect(sender).toEqual(transaction.from)
         expect(args).toEqual(params)
         done()
       }
@@ -488,7 +498,8 @@ describe('Web3Service', () => {
         transaction.hash,
         FakeContract,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        transaction.from
       )
     })
   })

--- a/unlock-js/src/__tests__/v02/web3Service.test.js
+++ b/unlock-js/src/__tests__/v02/web3Service.test.js
@@ -131,6 +131,7 @@ describe('Web3Service', () => {
       it('should emit lock.updated with correctly typed values', async done => {
         expect.assertions(2)
         await versionedNockBeforeEach()
+        const sender = '0xsender'
         const params = {
           _expirationDuration: '7',
           _maxNumberOfKeys: '5',
@@ -143,7 +144,12 @@ describe('Web3Service', () => {
           done()
         })
 
-        await web3Service.inputsHandlers.createLock('0x123', '0x456', params)
+        await web3Service.inputsHandlers.createLock(
+          '0x123',
+          '0x456',
+          sender,
+          params
+        )
       })
     })
 
@@ -153,6 +159,7 @@ describe('Web3Service', () => {
       let resolveKeySaver
       let resolveTransactionUpdater
       const owner = '0x9876'
+      const sender = '0xsender'
       const fakeParams = {
         _recipient: owner,
       }
@@ -188,6 +195,7 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers.purchaseFor(
         fakeHash,
         fakeContractAddress,
+        sender,
         fakeParams
       )
       await Promise.all([keySaver, transactionUpdater])
@@ -481,7 +489,7 @@ describe('Web3Service', () => {
     })
 
     it('should call the handler if the transaction input can be parsed', async done => {
-      expect.assertions(3)
+      expect.assertions(4)
       await versionedNockBeforeEach()
       web3Service._getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
       const input =
@@ -509,10 +517,12 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers[method.name] = (
         transactionHash,
         contractAddress,
+        sender,
         args
       ) => {
         expect(transactionHash).toEqual(transaction.hash)
         expect(contractAddress).toEqual(web3Service.unlockContractAddress)
+        expect(sender).toEqual(transaction.from)
         expect(args).toEqual(params)
         done()
       }
@@ -522,7 +532,8 @@ describe('Web3Service', () => {
         transaction.hash,
         FakeContract,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        transaction.from
       )
     })
   })

--- a/unlock-js/src/__tests__/v10/web3Service.test.js
+++ b/unlock-js/src/__tests__/v10/web3Service.test.js
@@ -138,6 +138,7 @@ describe('Web3Service', () => {
       it('should emit lock.updated with correctly typed values', async done => {
         expect.assertions(2)
         await versionedNockBeforeEach()
+        const sender = '0xsender'
         const params = {
           _expirationDuration: '7',
           _maxNumberOfKeys: '5',
@@ -150,7 +151,12 @@ describe('Web3Service', () => {
           done()
         })
 
-        await web3Service.inputsHandlers.createLock('0x123', '0x456', params)
+        await web3Service.inputsHandlers.createLock(
+          '0x123',
+          '0x456',
+          sender,
+          params
+        )
       })
     })
 
@@ -160,6 +166,7 @@ describe('Web3Service', () => {
       let resolveKeySaver
       let resolveTransactionUpdater
       const owner = '0x9876'
+      const sender = '0xsender'
       const fakeParams = {
         _recipient: owner,
       }
@@ -195,6 +202,7 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers.purchaseFor(
         fakeHash,
         fakeContractAddress,
+        sender,
         fakeParams
       )
       await Promise.all([keySaver, transactionUpdater])
@@ -487,7 +495,7 @@ describe('Web3Service', () => {
     })
 
     it('should call the handler if the transaction input can be parsed', async done => {
-      expect.assertions(3)
+      expect.assertions(4)
       await versionedNockBeforeEach()
       web3Service._getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
       const input =
@@ -515,10 +523,12 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers[method.name] = (
         transactionHash,
         contractAddress,
+        sender,
         args
       ) => {
         expect(transactionHash).toEqual(transaction.hash)
         expect(contractAddress).toEqual(web3Service.unlockContractAddress)
+        expect(sender).toEqual(transaction.from)
         expect(args).toEqual(params)
         done()
       }
@@ -528,7 +538,8 @@ describe('Web3Service', () => {
         transaction.hash,
         FakeContract,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        transaction.from
       )
     })
   })

--- a/unlock-js/src/__tests__/v11/web3Service.test.js
+++ b/unlock-js/src/__tests__/v11/web3Service.test.js
@@ -138,6 +138,7 @@ describe('Web3Service', () => {
       it('should emit lock.updated with correctly typed values', async done => {
         expect.assertions(2)
         await versionedNockBeforeEach()
+        const sender = '0xsender'
         const params = {
           _expirationDuration: '7',
           _maxNumberOfKeys: '5',
@@ -150,7 +151,12 @@ describe('Web3Service', () => {
           done()
         })
 
-        await web3Service.inputsHandlers.createLock('0x123', '0x456', params)
+        await web3Service.inputsHandlers.createLock(
+          '0x123',
+          '0x456',
+          sender,
+          params
+        )
       })
     })
 
@@ -160,6 +166,7 @@ describe('Web3Service', () => {
       let resolveKeySaver
       let resolveTransactionUpdater
       const owner = '0x9876'
+      const sender = '0xsender'
       const fakeParams = {
         _recipient: owner,
       }
@@ -195,6 +202,7 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers.purchaseFor(
         fakeHash,
         fakeContractAddress,
+        sender,
         fakeParams
       )
       await Promise.all([keySaver, transactionUpdater])
@@ -490,7 +498,7 @@ describe('Web3Service', () => {
     })
 
     it('should call the handler if the transaction input can be parsed', async done => {
-      expect.assertions(3)
+      expect.assertions(4)
       await versionedNockBeforeEach()
       web3Service._getTransactionType = jest.fn(() => 'TRANSACTION_TYPE')
       const input =
@@ -518,10 +526,12 @@ describe('Web3Service', () => {
       web3Service.inputsHandlers[method.name] = (
         transactionHash,
         contractAddress,
+        sender,
         args
       ) => {
         expect(transactionHash).toEqual(transaction.hash)
         expect(contractAddress).toEqual(web3Service.unlockContractAddress)
+        expect(sender).toEqual(transaction.from)
         expect(args).toEqual(params)
         done()
       }
@@ -531,7 +541,8 @@ describe('Web3Service', () => {
         transaction.hash,
         FakeContract,
         input,
-        web3Service.unlockContractAddress
+        web3Service.unlockContractAddress,
+        transaction.from
       )
     })
   })


### PR DESCRIPTION
# Description

I previously forgot that the inputsHandlers also called generateLockAddress...
This will let us "guess" the address of a new lock after a page refresh!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->