### PR TITLE
saving terms of service acceptance in localstorage

### DIFF
--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -163,11 +163,9 @@ describe('The Unlock Dashboard', () => {
 
     describe('Data existing after refresh', () => {
       it('should retain the lock address, key price, duration and maximum number of keys', async () => {
-        expect.assertions(2)
+        expect.assertions(1)
         await page.reload({ waitUntil: 'networkidle2' })
-        // Accept Terms of service again!
         await wait.forLoadingDone()
-        await expect(page).toClick('button', { text: 'I agree' })
         await expect(page).toMatchElement(lockSelector)
       })
     })

--- a/unlock-app/src/__tests__/hooks/useTermsOfService.test.js
+++ b/unlock-app/src/__tests__/hooks/useTermsOfService.test.js
@@ -1,0 +1,42 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import useTermsOfService, {
+  localStorageKey,
+} from '../../hooks/useTermsOfService'
+
+describe('useTermsOfService', () => {
+  beforeAll(() => {})
+
+  it('should default to false if no value is set in localtorage', async () => {
+    expect.assertions(1)
+    const { result } = renderHook(() => useTermsOfService())
+    const termsAccepted = result.current[0]
+    expect(termsAccepted).toBe(false)
+  })
+
+  it('should return true if the correct value is set in localstorage', async () => {
+    expect.assertions(1)
+    window.localStorage.setItem(localStorageKey, 'true')
+    const { result } = renderHook(() => useTermsOfService())
+    const termsAccepted = result.current[0]
+    expect(termsAccepted).toBe(true)
+  })
+
+  it('should return false if the value in localstorage is not correct', async () => {
+    expect.assertions(1)
+    window.localStorage.setItem(localStorageKey, 'hello')
+    const { result } = renderHook(() => useTermsOfService())
+    const termsAccepted = result.current[0]
+    expect(termsAccepted).toBe(false)
+  })
+
+  it('should set the value in localstorage', async () => {
+    expect.assertions(1)
+    const { result } = renderHook(() => useTermsOfService())
+    const acceptTerms = result.current[1]
+    act(() => {
+      acceptTerms()
+    })
+    const savedValue = window.localStorage.getItem(localStorageKey)
+    expect(savedValue).toBe('true')
+  })
+})

--- a/unlock-app/src/components/interface/Layout.js
+++ b/unlock-app/src/components/interface/Layout.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
 import Header from './Header'
@@ -10,9 +10,10 @@ import { styles } from './modal-templates'
 import { MessageBox } from './modal-templates/styles'
 import { ActionButton } from './buttons/ActionButton'
 import withConfig from '../../utils/withConfig'
+import useTermsOfService from '../../hooks/useTermsOfService'
 
 export default function Layout({ forContent, title, children }) {
-  const [tosAccepted, setTosAccepted] = useState(false)
+  const [tosAccepted, setTosAccepted] = useTermsOfService()
   return (
     <Container>
       <Left>

--- a/unlock-app/src/hooks/useTermsOfService.js
+++ b/unlock-app/src/hooks/useTermsOfService.js
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+
+export const localStorageKey = 'terms-of-service'
+
+/**
+ * This hook retrieves metadata for a token
+ * @param {*} address
+ */
+export const useTermsOfService = () => {
+  const [tosAccepted, setTosAccepted] = useState(() => {
+    try {
+      return window.localStorage.getItem(localStorageKey) === 'true'
+    } catch (error) {
+      // No localstorage, assume false!
+      return false
+    }
+  })
+
+  const saveTosAccepted = () => {
+    setTosAccepted(true)
+    try {
+      window.localStorage.setItem(localStorageKey, true)
+    } catch (error) {
+      // Could not store in localstorage.
+    }
+  }
+  return [tosAccepted, saveTosAccepted]
+}
+
+export default useTermsOfService


### PR DESCRIPTION
# Description


In order to improve the experience we only ask for terms of service acceptance on the first loading of the page

# Issues

Fixes #5573


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [ ] This PR only contains configuration changes (package.json, etc.)
  - [X] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [X] My code follows the style guidelines of this project, including naming conventions
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->