### PR TITLE
Replace usage of `npm` in READMEs with `yarn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ cd unlock
 
 2. Install all dependencies
 
-This will install all dependencies required for all the Unlock components (smart contracts and react app).
+This will install all dependencies required for all the Unlock components (smart contracts and react app). You'll need [yarn](https://yarnpkg.com) installed globally.
 
 ```
-npm ci
+yarn
 ```
 
 3. Set up your environment variables
@@ -86,7 +86,7 @@ When starting this script does several things: deploys the unlock smart contract
 This applies to any of our applications, but we'll take `unlock-app` as an example as it is our "main" dashboard:
 
 ```
-cd unlock-app && npm run dev
+cd unlock-app && yarn dev
 ```
 
 ## Thank you

--- a/locksmith/README.md
+++ b/locksmith/README.md
@@ -48,7 +48,7 @@ You can configure your connection details in a few ways. Here are the suggested 
 2. If your configuration needs are more demanding than this, further configuration 
 can be established by modifying the storage configuration file `config\config.js`.
 
-Once configured, you will be able to start the application. `npm run dev` or `npm start`
+Once configured, you will be able to start the application. `yarn dev` or `yarn start`
 will suffice depending on your needs for running Locksmith.
 
 ### Persistence Information
@@ -59,10 +59,10 @@ permissions required.
 
 In development mode, migrations will run upon start up ensuring that your persistence 
 layer is up to date. In production, migrations will need to be performed manually. This 
-can be performed via `npm db:migrate`. Please review the migrations included so that you 
+can be performed via `yarn db:migrate`. Please review the migrations included so that you 
 are aware of the items included.
 
 ### Testing
 
-Tests can be run via `npm test`. Please note that the project includes end-to-end tests that
+Tests can be run via `yarn test`. Please note that the project includes end-to-end tests that
 will require database access.

--- a/smart-contracts/README.md
+++ b/smart-contracts/README.md
@@ -183,6 +183,6 @@ TODO
 ## Usage
 
 The smart contracts are written in solidity using the [truffle framework](http://truffleframework.com/).
-The can be compiled using `truffle compile` and tested using `truffle test`. Make sure dependencies are installed before running commands: `npm install`.
+The can be compiled using `truffle compile` and tested using `truffle test`. Make sure dependencies are installed before running commands: `yarn install`.
 
 Later this will also be used to deploy to the test and main chains.

--- a/unlock-js/README.md
+++ b/unlock-js/README.md
@@ -17,7 +17,7 @@ walletService provides a mechanism to send transactions and sign messages for a 
 ## HOW TO
 
 The code is written using es6 and exported after it's been transpiled to older versions of JS using babel.
-You can run test using `npm run test` and you need to run `npm run build` in order to generate the new transpiled code.
+You can run test using `yarn test` and you need to run `yarn build` in order to generate the new transpiled code.
 
 ## TODO
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Now that we're using Yarn for deps, we should indicate to users that it is the preferred build tool. This PR updates various READMEs that previously referenced `npm` to use `yarn` instead.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
