### PR TITLE
Add yarn.lock to some dockerfiles that don't have it

### DIFF
--- a/docker/integration-tests.dockerfile
+++ b/docker/integration-tests.dockerfile
@@ -24,6 +24,7 @@ COPY .prettierrc /home/unlock/.prettierrc
 # Let's now copy all the tests stuff from unlock/tests
 # And install things
 RUN mkdir /home/unlock/tests
+COPY tests/yarn.lock /home/unlock/tests/.
 COPY tests/package.json /home/unlock/tests/.
 WORKDIR /home/unlock/tests
 RUN yarn --production

--- a/docker/smart-contracts.dockerfile
+++ b/docker/smart-contracts.dockerfile
@@ -2,6 +2,7 @@ FROM unlock-core
 
 # Dependencies for smart-contracts
 RUN mkdir /home/unlock/smart-contracts
+COPY --chown=node smart-contracts/yarn.lock /home/unlock/smart-contracts/.
 COPY --chown=node smart-contracts/package.json /home/unlock/smart-contracts/.
 WORKDIR /home/unlock/smart-contracts
 RUN yarn --production

--- a/docker/tickets.dockerfile
+++ b/docker/tickets.dockerfile
@@ -2,6 +2,7 @@ FROM unlock-core
 
 # Dependencies for tickets
 RUN mkdir /home/unlock/tickets
+COPY --chown=node tickets/yarn.lock /home/unlock/tickets/.
 COPY --chown=node tickets/package.json /home/unlock/tickets/.
 WORKDIR /home/unlock/tickets
 RUN yarn --production

--- a/docker/unlock-core.dockerfile
+++ b/docker/unlock-core.dockerfile
@@ -32,6 +32,7 @@ USER node
 # dependencies again if they are not changed.
 
 COPY --chown=node scripts/postinstall.sh /home/unlock/scripts/postinstall.sh
+COPY --chown=node yarn.lock /home/unlock/.
 COPY --chown=node package.json /home/unlock/.
 COPY --chown=node .eslintrc.js /home/unlock/.
 COPY --chown=node .prettierrc /home/unlock/.

--- a/docker/unlock-js.dockerfile
+++ b/docker/unlock-js.dockerfile
@@ -2,6 +2,7 @@ FROM unlock-core
 
 # Dependencies for unlock-js
 RUN mkdir /home/unlock/unlock-js
+COPY --chown=node unlock-js/yarn.lock /home/unlock/unlock-js/.
 COPY --chown=node unlock-js/package.json /home/unlock/unlock-js/.
 WORKDIR /home/unlock/unlock-js
 RUN yarn

--- a/docker/wedlocks.dockerfile
+++ b/docker/wedlocks.dockerfile
@@ -2,6 +2,7 @@ FROM unlock-core
 
 # Dependencies for wedlocks
 RUN mkdir /home/unlock/wedlocks
+COPY --chown=node wedlocks/yarn.lock /home/unlock/wedlocks/.
 COPY --chown=node wedlocks/package.json /home/unlock/wedlocks/.
 WORKDIR /home/unlock/wedlocks
 RUN yarn --production


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

In #5636 we removed the `package-lock.json` from a number of dockerfiles, but did not replace with the associated `yarn.lock`. We should include the `yarn.lock` so we can be sure we always get the exact dependency tree we expect.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
