### PR TITLE
Add PublicLock to zos project

### DIFF
--- a/smart-contracts/.openzeppelin/project.json
+++ b/smart-contracts/.openzeppelin/project.json
@@ -2,7 +2,8 @@
   "manifestVersion": "2.2",
   "contracts": {
     "Unlock": "Unlock",
-    "UnlockDiscountToken": "UnlockDiscountToken"
+    "UnlockDiscountToken": "UnlockDiscountToken",
+    "PublicLock": "PublicLock"
   },
   "dependencies": {},
   "name": "unlock-protocol",


### PR DESCRIPTION
# Description
Adding a third contract, PublicLock to the project here will both simplify deployment (zos push will now deploy our PublicLock template as well) as well as make tracking the deployed address easier( as the PublicLock template's deployed address will be recorded in the network file, eg: zos.mainnet.json).
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5627 
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
  - [x] This PR only contains configuration changes (package.json, etc.)
  - [ ] This PR only contains code changes (if configuration changes are required, do a separate PR first, then re-base)
- [ ] My code follows the style guidelines of this project, including naming conventions
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If my code adds or changes components, I have written corresponding stories with Storybook
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
