### PR TITLE
Removing unused dockers script to pull images

### DIFF
--- a/scripts/pull-image.sh
+++ b/scripts/pull-image.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-IMAGE_NAME=$1
-IMAGE_TAG=$2
-IMAGE_CACHE="$DOCKER_REPOSITORY/$IMAGE_NAME:$IMAGE_TAG"
-
-docker pull $IMAGE_CACHE
-docker tag $IMAGE_CACHE $IMAGE_NAME


### PR DESCRIPTION
# Description

This functionality now appears to be handled in `build-image` & `docker-compose-build`

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
