### PR TITLE
Deploy UDT proxy on mainnet

### DIFF
--- a/smart-contracts/zos.mainnet.json
+++ b/smart-contracts/zos.mainnet.json
@@ -405,6 +405,15 @@
         "version": "0.1.0",
         "implementation": "0x49b41D8b11939D7ca9678792F8d93E96dd2D6ED9"
       }
+    ],
+    "unlock-protocol/UnlockDiscountToken": [
+      {
+        "address": "0x59F4ec8bad8F993eb051d369Ed528D0Cd5336ffD",
+        "version": "0.5.0",
+        "implementation": "0x513Acd2c94fCd195B0eB750535A542a8E719A1e2",
+        "admin": "0x79918A4389A437906538E0bbf39918BfA4F7690e",
+        "kind": "Upgradeable"
+      }
     ]
   },
   "zosversion": "2.2",


### PR DESCRIPTION
# Description
The UDT contract on mainnet is now upgradeable.
- The current minters are myself (0x4011d09a86D0acA8377a4A8baD691F1ACeeCd672) and the UnlockProxy at 0x3d5409cce1d45233de1d4ebdee74b8e004abdd13
- The minter role can be revoked from my address at any time.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
