### PR TITLE
passing the network id to unlockjs to reduce the number of requests to alchemy

### DIFF
--- a/paywall/src/data-iframe/Mailbox.ts
+++ b/paywall/src/data-iframe/Mailbox.ts
@@ -221,8 +221,14 @@ export default class Mailbox {
       import('../providers/Web3ProxyProvider'),
       import('./blockchainHandler/BlockchainHandler'),
     ])
-
-    const web3Service = new Web3Service(this.constants)
+    const web3Service = new Web3Service({
+      readOnlyProvider: this.constants.readOnlyProvider,
+      unlockAddress: this.constants.unlockAddress,
+      blockTime: this.constants.blockTime,
+      requiredConfirmations: this.constants.requiredConfirmations,
+      network: this.constants.defaultNetwork,
+    })
+    // TODO : do not mass assign below
     const walletService = new WalletService(this.constants)
     const provider = new Web3ProxyProvider(this.window)
 

--- a/paywall/src/data-iframe/blockchainHandler/blockChainTypes.ts
+++ b/paywall/src/data-iframe/blockchainHandler/blockChainTypes.ts
@@ -63,6 +63,7 @@ export interface ConstantsType {
   blockTime: number
   requiredConfirmations: number
   defaultNetwork: unlockNetworks
+  readOnlyProvider: string
 }
 
 export interface BlockchainData {

--- a/paywall/src/data-iframe/index.2.0.ts
+++ b/paywall/src/data-iframe/index.2.0.ts
@@ -12,6 +12,7 @@ const {
   unlockAddress,
   blockTime,
   requiredConfirmations,
+  defaultNetwork,
 } = config
 
 const web3Service = new Web3Service({
@@ -19,6 +20,7 @@ const web3Service = new Web3Service({
   unlockAddress,
   blockTime,
   requiredConfirmations,
+  network: defaultNetwork,
 })
 
 let parent: Postmate.ChildAPI

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -27,6 +27,7 @@ const web3Middleware = config => {
     blockTime,
     requiredConfirmations,
     subgraphURI,
+    requiredNetworkId,
   } = config
   return ({ getState, dispatch }) => {
     const web3Service = new Web3Service({
@@ -34,6 +35,7 @@ const web3Middleware = config => {
       unlockAddress,
       blockTime,
       requiredConfirmations,
+      network: requiredNetworkId,
     })
 
     const graphService = new GraphService(subgraphURI)


### PR DESCRIPTION
# Description

By default, ethers will always query to get the network id unless one is passed.
Since we have that info, we should pass it to save 1 more request!


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->