### PR TITLE
Add lock owner to keyholder query

### DIFF
--- a/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/VerificationStatus.test.tsx
@@ -28,6 +28,7 @@ const ownedKey: OwnedKey = {
     expirationDuration: '123456',
     tokenAddress: 'a token address',
     price: '5',
+    owner: '0xaFAEfc6dd3C9feF66f92BA838b132644451F0715',
   },
   tokenURI: '',
   expiration: '12345678',

--- a/unlock-app/src/__tests__/components/interface/keychain/Key.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/keychain/Key.test.tsx
@@ -16,6 +16,7 @@ const aKey: OwnedKey = {
     name: 'ERC20 paywall lock',
     tokenAddress: '0xbadc0ffee',
     price: '50',
+    owner: '0xaFAEfc6dd3C9feF66f92BA838b132644451F0715',
   },
 }
 

--- a/unlock-app/src/__tests__/components/interface/keychain/KeyDetails.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/keychain/KeyDetails.test.tsx
@@ -19,6 +19,7 @@ const aKey: OwnedKey = {
     name: 'ERC20 paywall lock',
     tokenAddress: '0xbadc0ffee',
     price: '50',
+    owner: '0xaFAEfc6dd3C9feF66f92BA838b132644451F0715',
   },
 }
 

--- a/unlock-app/src/components/interface/keychain/KeychainTypes.ts
+++ b/unlock-app/src/components/interface/keychain/KeychainTypes.ts
@@ -9,5 +9,6 @@ export interface OwnedKey {
     expirationDuration: string
     tokenAddress: string
     price: string
+    owner: string
   }
 }

--- a/unlock-app/src/queries/keyHolder.js
+++ b/unlock-app/src/queries/keyHolder.js
@@ -17,6 +17,7 @@ export default function keyHolderQuery() {
             tokenAddress
             price
             expirationDuration
+            owner
           }
         }
       }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

For the verification page, we need to be able to see if the user on the page is also the owner of the lock in question. Adding this property to the query will allow us to determine that.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
