### PR TITLE
Update zos mainnet file to sync with reality

### DIFF
--- a/smart-contracts/zos.mainnet.json
+++ b/smart-contracts/zos.mainnet.json
@@ -403,7 +403,9 @@
       {
         "address": "0x3d5409cce1d45233de1d4ebdee74b8e004abdd13",
         "version": "0.1.0",
-        "implementation": "0x49b41D8b11939D7ca9678792F8d93E96dd2D6ED9"
+        "implementation": "0xE36793f0b4DB71fF0A5216412F80ba89B2927445",
+        "admin": "0x79918A4389A437906538E0bbf39918BfA4F7690e",
+        "kind": "Upgradeable"
       }
     ],
     "unlock-protocol/UnlockDiscountToken": [


### PR DESCRIPTION
# Description
Somehow our zos network files had gotten out of sync. This sets things straight again. I have confirmed both implementation and admin addresses for both the Unlock proxy and the UDT proxy.
(I've also made the same changes (and confirmed the addresses) on rinkeby.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
