### PR TITLE
does not attempt to retrieve metadata when there is none

### DIFF
--- a/unlock-app/src/__tests__/hooks/useMetadata.test.js
+++ b/unlock-app/src/__tests__/hooks/useMetadata.test.js
@@ -9,13 +9,26 @@ const metadata = {
 }
 
 describe('useMetadata', () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    jest.clearAllMocks()
     axios.get = jest.fn(() => {
       return Promise.resolve({
         data: () => {
           return metadata
         },
       })
+    })
+  })
+
+  it('should retrieve the default if there is no metadata uri', () => {
+    expect.assertions(2)
+    axios.get = jest.fn(() => {})
+    const tokenUri = ''
+    const { result } = renderHook(() => useMetadata(tokenUri))
+
+    expect(axios.get).not.toHaveBeenCalled()
+    expect(result.current).toStrictEqual({
+      image: 'https://assets.unlock-protocol.com/unlock-default-key-image.png',
     })
   })
 

--- a/unlock-app/src/hooks/useMetadata.js
+++ b/unlock-app/src/hooks/useMetadata.js
@@ -13,13 +13,15 @@ export const useMetadata = url => {
   const [metadata, setMetadata] = useState(defaultMetadata)
 
   const getMetadata = async () => {
-    let tokenMetadata = defaultMetadata
-    try {
-      tokenMetadata = await axios.get(url).then(response => response.data)
-    } catch (error) {
-      // Do not fail on error, we'll keep defaulting to the default values
+    if (url) {
+      let tokenMetadata = defaultMetadata
+      try {
+        tokenMetadata = await axios.get(url).then(response => response.data)
+      } catch (error) {
+        // Do not fail on error, we'll keep defaulting to the default values
+      }
+      setMetadata(tokenMetadata)
     }
-    setMetadata(tokenMetadata)
   }
 
   useEffect(() => {


### PR DESCRIPTION
# Description

This was creating issue for me on the keychain as I have a bunch of keys to old locks, with no data uri.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->