### PR TITLE
refactoring tests for v0/createLock.js

### DIFF
--- a/unlock-js/src/__tests__/helpers/contracts.js
+++ b/unlock-js/src/__tests__/helpers/contracts.js
@@ -1,0 +1,19 @@
+import { ethers } from 'ethers'
+
+// A helper which yields ether contract objects
+export const getTestUnlockContract = ({
+  unlockAddress = '0x559247Ec8A8771E8C97cDd39b96b9255651E39C5',
+  abi,
+  provider,
+}) => {
+  const contract = new ethers.Contract(unlockAddress, abi, provider)
+
+  // WARNING: this is really strange
+  // The ethers contract object defines read only properties
+  // which cannot be spied on...
+  // So we have to create an object which delegates to it for any method call
+  // except for the ones we explicitly redefine!
+  return Object.create({
+    ...contract,
+  })
+}

--- a/unlock-js/src/__tests__/helpers/provider.js
+++ b/unlock-js/src/__tests__/helpers/provider.js
@@ -1,0 +1,11 @@
+import { ethers } from 'ethers'
+
+// A helper which yields an ether provider
+
+export const getTestProvider = ({ accountAddress = '0xaccount' }) => {
+  const provider = new ethers.providers.JsonRpcProvider('')
+  provider.getSigner = () => ({
+    getAddress: jest.fn(() => Promise.resolve(accountAddress)),
+  })
+  return provider
+}

--- a/unlock-js/src/v0/createLock.js
+++ b/unlock-js/src/v0/createLock.js
@@ -1,5 +1,5 @@
 import ethersUtils from '../utils'
-import { GAS_AMOUNTS, ETHERS_MAX_UINT } from '../constants'
+import { ETHERS_MAX_UINT } from '../constants'
 import TransactionTypes from '../transactionTypes'
 import { UNLIMITED_KEYS_COUNT } from '../../lib/constants'
 
@@ -14,15 +14,10 @@ export default async function(lock, callback) {
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
     maxNumberOfKeys = ETHERS_MAX_UINT
   }
-  const transactionPromise = unlockContract.functions[
-    'createLock(uint256,uint256,uint256)'
-  ](
+  const transactionPromise = unlockContract.createLock(
     lock.expirationDuration,
     ethersUtils.toWei(lock.keyPrice, 'ether'),
-    maxNumberOfKeys,
-    {
-      gasLimit: GAS_AMOUNTS.createLock,
-    }
+    maxNumberOfKeys
   )
   const hash = await this._handleMethodCall(
     transactionPromise,


### PR DESCRIPTION
# Description

This is the first of many pull requests which removes our crazy "nock" setup in unlockjs unit tests.
Basicaly rather than mock things at the network level, we mock things inside of the class itself.
Integratiion tests do cover the the fact that we test what ethers does so there is no need to test
it in unit tests.

I believe this will bring a lot of simplication/cleanup when that is done.
I am commenting the PR for more details

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->