### PR TITLE
Removed price polling whih is generating re-rendering of our apps when the odds of a price changing significantly are not that important

### DIFF
--- a/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/currencyConversionMiddleware.test.js
@@ -4,15 +4,12 @@ import configure from '../../config'
 jest.mock('../../services/currencyLookupService', () => () => ({
   lookupPrice: jest
     .fn()
-    .mockResolvedValueOnce({ currency: 'USD', amount: '195.99' })
-    .mockResolvedValueOnce({ currency: 'USD', amount: '198.20' })
     .mockResolvedValueOnce({ currency: 'USD', amount: '195.99' }),
 }))
 
 describe('Currency conversion service retrieval middleware', () => {
   it('service called, action dispatched to set currency conversion rate', async () => {
-    expect.assertions(2)
-    jest.useFakeTimers()
+    expect.assertions(1)
     const config = configure()
     const middleware = require('../../middlewares/currencyConversionMiddleware')
       .default
@@ -27,13 +24,6 @@ describe('Currency conversion service retrieval middleware', () => {
 
     expect(store.dispatch).toHaveBeenCalledWith(
       setConversionRate('USD', '195.99')
-    )
-
-    store.dispatch = jest.fn() // reset
-    await jest.advanceTimersByTime(10000) // test the setInterval
-
-    expect(store.dispatch).toHaveBeenCalledWith(
-      setConversionRate('USD', '198.20')
     )
   })
 

--- a/unlock-app/src/constants.ts
+++ b/unlock-app/src/constants.ts
@@ -98,9 +98,6 @@ export const MAX_UINT =
 
 // the number of ms between checking for account changes in walletService
 export const ACCOUNT_POLLING_INTERVAL = 2000
-
-export const CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL = 10000
-
 export const USER_ACCOUNT_ADDRESS_STORAGE_ID = 'managedUserAccountAddress'
 
 // This represents an account that will never hold any keys. It's a bit of an

--- a/unlock-app/src/middlewares/currencyConversionMiddleware.js
+++ b/unlock-app/src/middlewares/currencyConversionMiddleware.js
@@ -2,7 +2,6 @@
 
 import { setConversionRate } from '../actions/currencyConvert'
 import CurrencyLookupService from '../services/currencyLookupService'
-import { CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL } from '../constants'
 
 export default config => {
   const { services } = config
@@ -18,14 +17,6 @@ export default config => {
         store.dispatch(setConversionRate(info.currency, info.amount))
       )
 
-    setInterval(() => {
-      currencyLookupService.lookupPrice('ETH', 'USD').then(info => {
-        const current = store.getState().currency[info.currency]
-        if (current === info.amount) return
-
-        store.dispatch(setConversionRate(info.currency, info.amount))
-      })
-    }, CURRENCY_CONVERSION_MIDDLEWARE_RETRY_INTERVAL)
     return next => action => next(action)
   }
 }


### PR DESCRIPTION
# Description

In an effort to make the app MUCH snappier I am removing this polling mechanism which is IMO pre-mature optimization.
The price we show is *just* indicative and the odds of it changing significantly in the time spent on the page are very slim anyway.


Eventually we should move this to a hook (if we can memoize the value)

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->