### PR TITLE
using multiple coins for stable coins

### DIFF
--- a/paywall/src/__tests__/unlock.js/postmessageHub.test.ts
+++ b/paywall/src/__tests__/unlock.js/postmessageHub.test.ts
@@ -100,12 +100,12 @@ describe('postMessageHub', () => {
 
         const payload = {
           eth: '7',
-          '0xneato': '8',
+          '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359': '8',
         }
 
         const expectedPayload = {
           eth: '0',
-          '0xneato': '35',
+          '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359': '35',
         }
 
         iframes.data.emit(PostMessages.UPDATE_ACCOUNT_BALANCE, payload)

--- a/paywall/src/__tests__/utils/injectDefaultBalance.test.ts
+++ b/paywall/src/__tests__/utils/injectDefaultBalance.test.ts
@@ -2,10 +2,9 @@ import injectDefaultBalance from '../../utils/injectDefaultBalance'
 import { DEFAULT_STABLECOIN_BALANCE } from '../../constants'
 
 describe('injectDefaultBalance helper', () => {
-  const erc20ContractAddress = '0xdeadbeef'
   it('should return empty object given an empty object', () => {
     expect.assertions(1)
-    expect(injectDefaultBalance({}, erc20ContractAddress)).toEqual({})
+    expect(injectDefaultBalance({})).toEqual({})
   })
 
   it('should zero out eth', () => {
@@ -16,22 +15,25 @@ describe('injectDefaultBalance helper', () => {
     const expectedBalance = {
       eth: '0',
     }
-    expect(injectDefaultBalance(balance, erc20ContractAddress)).toEqual(
-      expectedBalance
-    )
+    expect(injectDefaultBalance(balance)).toEqual(expectedBalance)
   })
 
   it('should update balances for the managed purchase stablecoin address with the default', () => {
     expect.assertions(1)
+
     const balance = {
       eth: '123.4',
       '0x123abc': '0',
-      '0xdeadbeef': '0',
+      '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359': '0', // SAI
+      '0x6b175474e89094c44da98b954eedeac495271d0f': '0', // DAI
+      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': '0', // USDC
     }
-    expect(injectDefaultBalance(balance, erc20ContractAddress)).toEqual({
+    expect(injectDefaultBalance(balance)).toEqual({
       eth: '0',
       '0x123abc': '0',
-      '0xdeadbeef': DEFAULT_STABLECOIN_BALANCE,
+      '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359': DEFAULT_STABLECOIN_BALANCE,
+      '0x6b175474e89094c44da98b954eedeac495271d0f': DEFAULT_STABLECOIN_BALANCE,
+      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': DEFAULT_STABLECOIN_BALANCE,
     })
   })
 })

--- a/paywall/src/constants.js
+++ b/paywall/src/constants.js
@@ -122,3 +122,10 @@ export const OPTIMISM_POLLING_INTERVAL = 15000
 // used to provide a default balance for stablecoins so that the paywall does
 // not show "insufficient funds" for managed user accounts
 export const DEFAULT_STABLECOIN_BALANCE = '35'
+
+// List of stable coins for which we allow credit card purchases
+export const STABLECOINS_ADDRESSES = [
+  '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', // SAI
+  '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+  '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+]

--- a/paywall/src/unlock.js/postMessageHub.ts
+++ b/paywall/src/unlock.js/postMessageHub.ts
@@ -34,7 +34,6 @@ export function checkoutHandlerInit({
   dataIframe,
   checkoutIframe,
   config,
-  constants,
 }: checkoutHandlerInitArgs) {
   // listen for updates to state from the data iframe, and forward them to the checkout UI
   dataIframe.on(PostMessages.UPDATE_ACCOUNT, account =>
@@ -43,8 +42,7 @@ export function checkoutHandlerInit({
   dataIframe.on(PostMessages.UPDATE_ACCOUNT_BALANCE, balance => {
     let balanceUpdate = balance
     if (usingManagedAccount) {
-      const { erc20ContractAddress } = constants
-      balanceUpdate = injectDefaultBalance(balance, erc20ContractAddress)
+      balanceUpdate = injectDefaultBalance(balance)
     }
     checkoutIframe.postMessage(
       PostMessages.UPDATE_ACCOUNT_BALANCE,
@@ -484,7 +482,6 @@ interface setupDataListenersArgs {
 export function setupDataListeners({
   iframes,
   blockchainData,
-  erc20ContractAddress,
   usingManagedAccount,
   toggleLockState,
   paywallConfig,
@@ -516,7 +513,7 @@ export function setupDataListeners({
   data.on(PostMessages.UPDATE_ACCOUNT_BALANCE, balance => {
     let balanceUpdate = balance
     if (usingManagedAccount) {
-      balanceUpdate = injectDefaultBalance(balance, erc20ContractAddress)
+      balanceUpdate = injectDefaultBalance(balance)
     }
     checkout.postMessage(PostMessages.UPDATE_ACCOUNT_BALANCE, balanceUpdate)
     blockchainData.balance = balanceUpdate

--- a/paywall/src/utils/injectDefaultBalance.ts
+++ b/paywall/src/utils/injectDefaultBalance.ts
@@ -1,14 +1,11 @@
 import { Balance } from '../unlockTypes'
-import { DEFAULT_STABLECOIN_BALANCE } from '../constants'
+import { DEFAULT_STABLECOIN_BALANCE, STABLECOINS_ADDRESSES } from '../constants'
 
-export const injectDefaultBalance = (
-  oldBalance: Balance,
-  erc20ContractAddress: string
-): Balance => {
+export const injectDefaultBalance = (oldBalance: Balance): Balance => {
   const newBalance: Balance = {}
   const tokens = Object.keys(oldBalance)
   tokens.forEach(token => {
-    if (token === erc20ContractAddress) {
+    if (STABLECOINS_ADDRESSES.indexOf(token) > -1) {
       // If the token is the one we allow, we give the user a default
       // balance. TODO: only do this if the corresponding lock is approved.
       newBalance[token] = DEFAULT_STABLECOIN_BALANCE


### PR DESCRIPTION
# Description

Ben wanted to add support for CC to a newly created DAI lock, but that does not work because we use the ERC20 address from the env variables... this provides a solution where the list of ERC20 for which we allow CC is hard coded until we have a (much) better system for CC payments! (blockchain based!)


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->