### PR TITLE
getKeyMetadata now accepts an optional value triggering authorized request

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+# 0.8.0
+- BREAKING: getKeyMetadata now takes an object for non-callback
+  params, now including an optional signature to retrieve protected metadata
+- BREAKING: setKeyMetadata takes an object for non-callback params to
+  keep calling conventions consistent for the setter and the getter
+
 # 0.7.2
 - bumped gas limits
 - Adding script to initialize a template

--- a/unlock-js/index.d.ts
+++ b/unlock-js/index.d.ts
@@ -60,13 +60,27 @@ export class Web3Service extends EventEmitter {
   ) => Promise<string>;
 }
 
+interface SetKeyMetadataParams {
+  lockAddress: string
+  keyId: string
+  metadata: { [key: string]: string }
+  locksmithHost: string
+}
+
+interface GetKeyMetadataParams {
+  lockAddress: string
+  keyId: string
+  locksmithHost: string
+  getProtectedData?: boolean
+}
+
 export class WalletService extends EventEmitter {
-  constructor({ unlockAddress }: { unlockAddress: string })
-  ready: boolean
-  provider?: any
-  connect: (provider: Web3Provider) => Promise<void>
-  getAccount: () => Promise<string | false>
-  purchaseKey: (params: PurchaseKeyParams) => Promise<string>
-    setKeyMetadata: (lockAddress: string, keyId: string, metadata: { [key: string]: string }, locksmithHost: string, callback: any) => void
-  getKeyMetadata: (lockAddress: string, keyId: string, locksmithHost: string, callback: any) => void
+  constructor({ unlockAddress }: { unlockAddress: string });
+  ready: boolean;
+  provider?: any;
+  connect: (provider: Web3Provider) => Promise<void>;
+  getAccount: () => Promise<string | false>;
+  purchaseKey: (params: PurchaseKeyParams) => Promise<string>;
+  setKeyMetadata: (params: SetKeyMetadataParams, callback: any) => void;
+  getKeyMetadata: (params: GetKeyMetadataParams, callback: any) => void;
 }

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/walletService.test.js
+++ b/unlock-js/src/__tests__/walletService.test.js
@@ -441,6 +441,16 @@ describe('WalletService (ethers)', () => {
       window.fetch = originalFetch
     })
 
+    const options = {
+      lockAddress: '0xlockAddress',
+      keyId: '1',
+      metadata: {
+        color: 'blue',
+        bestBandNamedAfterAPlace: 'Chicago',
+      },
+      locksmithHost: 'https://locksmith',
+    }
+
     it('sends the request to the correct URL', async done => {
       expect.assertions(3)
 
@@ -450,16 +460,7 @@ describe('WalletService (ethers)', () => {
         done()
       }
 
-      await walletService.setKeyMetadata(
-        '0xlockAddress',
-        '1',
-        {
-          color: 'blue',
-          bestBandNamedAfterAPlace: 'Chicago',
-        },
-        'https://locksmith',
-        callback
-      )
+      await walletService.setKeyMetadata(options, callback)
 
       expect(window.fetch).toHaveBeenCalledWith(
         'https://locksmith/api/key/0xlockAddress/1',
@@ -484,16 +485,7 @@ describe('WalletService (ethers)', () => {
         }
       }
 
-      await walletService.setKeyMetadata(
-        '0xwhatever',
-        '1',
-        {
-          color: 'blue',
-          bestBandNamedAfterAPlace: 'Chicago',
-        },
-        'https://locksmith',
-        callback
-      )
+      await walletService.setKeyMetadata(options, callback)
     })
   })
 
@@ -512,6 +504,12 @@ describe('WalletService (ethers)', () => {
       window.fetch = originalFetch
     })
 
+    const options = {
+      lockAddress: '0xsomething',
+      keyId: '1',
+      locksmithHost: 'https://locksmith',
+    }
+
     it('should callback with the json in the response on success', done => {
       expect.assertions(2)
 
@@ -521,12 +519,7 @@ describe('WalletService (ethers)', () => {
         done()
       }
 
-      walletService.getKeyMetadata(
-        '0xsomething',
-        '1',
-        'http://locksmith',
-        callback
-      )
+      walletService.getKeyMetadata(options, callback)
     })
 
     it('should callback with an error on error', done => {
@@ -540,12 +533,7 @@ describe('WalletService (ethers)', () => {
         done()
       }
 
-      walletService.getKeyMetadata(
-        '0xsomething',
-        '1',
-        'http://locksmith',
-        callback
-      )
+      walletService.getKeyMetadata(options, callback)
     })
   })
 

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -350,13 +350,17 @@ export default class WalletService extends UnlockService {
   /**
    * Sign and send a request to update metadata specific to a given key.
    *
-   * @param {string} lockAddress - The address of the lock
-   * @param {string} keyId - The id of the key to set metadata on
-   * @param {Object.<string, string>} metadata - The metadata fields and values to set
-   * @param {string} locksmithHost - A url with no trailing slash
+   * @param {Object} params
+   * @param {string} params.lockAddress - The address of the lock
+   * @param {string} params.keyId - The id of the key to set metadata on
+   * @param {Object.<string, string>} params.metadata - The metadata fields and values to set
+   * @param {string} params.locksmithHost - A url with no trailing slash
    * @param {*} callback
    */
-  async setKeyMetadata(lockAddress, keyId, metadata, locksmithHost, callback) {
+  async setKeyMetadata(
+    { lockAddress, keyId, metadata, locksmithHost },
+    callback
+  ) {
     const url = `${locksmithHost}/api/key/${lockAddress}/${keyId}`
     try {
       const currentAddress = await this.getAccount()
@@ -392,12 +396,14 @@ export default class WalletService extends UnlockService {
   /**
    * Sign and send a request to read metadata specific to a given key.
    *
-   * @param {string} lockAddress - The address of the lock
-   * @param {string} keyId - The id of the key to set metadata on
-   * @param {string} locksmithHost - A url with no trailing slash
+   * @param {Object} params
+   * @param {string} params.lockAddress - The address of the lock
+   * @param {string} params.keyId - The id of the key to set metadata on
+   * @param {string} params.locksmithHost - A url with no trailing slash
+   * @param {boolean} params.getProtectedData - when truthy, will generate signature to get protected metadata
    * @param {*} callback
    */
-  async getKeyMetadata(lockAddress, keyId, locksmithHost, callback) {
+  async getKeyMetadata({ lockAddress, keyId, locksmithHost }, callback) {
     const url = `${locksmithHost}/api/key/${lockAddress}/${keyId}`
     try {
       const response = await fetch(url, {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR updates `getKeyMetadata` in `WalletService` to accept an optional parameter which makes the method include an authorization signature that allows locksmith to return a full set of data, including protected metadata.

As part of doing this, the function signature was changed to accept most params as an object, because we want to keep the callback as the last param. To ensure consistency, the setter now also takes its non-callback params in an object.

I won't build and publish this change until this PR is merged.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
