### PR TITLE
Adjust key processing window and operating for all Locks

### DIFF
--- a/nudge/src/index.ts
+++ b/nudge/src/index.ts
@@ -2,9 +2,8 @@ import { CronJob } from 'cron'
 import { Processor } from './processor'
 
 const config = require('../config/config')
-const approvedLocks: string[] = []
 const runInterval = '*/5 * * * *'
 
 new CronJob(runInterval, () => {
-  new Processor(config.graphQLEndpoint, approvedLocks).processKeys()
+  new Processor(config.graphQLEndpoint).processKeys()
 }).start()

--- a/nudge/src/processor.ts
+++ b/nudge/src/processor.ts
@@ -4,22 +4,13 @@ import * as Dispatcher from './dispatcher'
 
 export class Processor {
   graphQLEndpoint: string
-  approvedLocks: string[]
 
-  constructor(graphQLEndpoint: string, approvedLocks: string[]) {
+  constructor(graphQLEndpoint: string) {
     this.graphQLEndpoint = graphQLEndpoint
-    this.approvedLocks = approvedLocks
-  }
-
-  normalizeLockAddresses(addresses: string[] = this.approvedLocks): string[] {
-    return addresses.map(lock => lock.toLowerCase())
   }
 
   async processKey(key: Key) {
-    if (
-      this.normalizeLockAddresses().includes(key.lockAddress.toLowerCase()) &&
-      !(await Dispatcher.check(key))
-    ) {
+    if (!(await Dispatcher.check(key))){
       if (await Dispatcher.dispatch(key)) {
         await Dispatcher.record(key)
         return true

--- a/nudge/src/querier.ts
+++ b/nudge/src/querier.ts
@@ -21,10 +21,13 @@ export class Querier {
   }
 
   async query() {
+    let secondsInDay = 86400
+    let startOfWindow = Math.floor(Date.now() / 1000 - secondsInDay)
+
     let queryResults = await this.client.query({
       query: gql`
         {
-          keys {
+          keys(where: { createdAt_gt: ${startOfWindow} }) {
             lock {
               address
               name

--- a/nudge/tests/processor.test.ts
+++ b/nudge/tests/processor.test.ts
@@ -1,7 +1,6 @@
 import { Processor } from '../src/processor'
 
 let testGraphQLEndpoint = 'http://example.com/graphQL'
-let approvedLocks = ['0xabc']
 
 let queryResults = jest
   .fn()
@@ -56,11 +55,11 @@ jest.mock('../src/dispatcher', () => {
 })
 
 describe('processKey', () => {
-  describe('when the key is for a non-approved lock', () => {
-    it('returns false', async () => {
+  describe('when an email has been previously dispatched', () => {
+    it('does not dispatch an email', async () => {
       expect(
-        await new Processor(testGraphQLEndpoint, approvedLocks).processKey({
-          lockAddress: '0xdef',
+        await new Processor(testGraphQLEndpoint).processKey({
+          lockAddress: '0xabc',
           keyId: '1',
           emailAddress: 'test@example.com',
           lockName: 'Lock Name'
@@ -68,45 +67,28 @@ describe('processKey', () => {
       ).toBe(false)
     })
   })
-
-  describe('when the key is for an approved lock', () => {
-    describe('when an email has been previously dispatched', () => {
-      it('does not dispatch an email', async () => {
+  describe('when an email has not been dispatched', () => {
+    describe('when dispatch successful', () => {
+      it('returns true', async () => {
         expect(
-          await new Processor(testGraphQLEndpoint, approvedLocks).processKey({
+          await new Processor(testGraphQLEndpoint).processKey({
             lockAddress: '0xabc',
-            keyId: '1',
+            keyId: '2',
             emailAddress: 'test@example.com',
             lockName: 'Lock Name'
           })
-        ).toBe(false)
+        ).toBe(true)
       })
     })
-    describe('when an email has not been dispatched', () => {
-      describe('when dispatch successful', () => {
-        it('returns true', async () => {
-          expect(
-            await new Processor(testGraphQLEndpoint, approvedLocks).processKey({
-              lockAddress: '0xabc',
-              keyId: '2',
-              emailAddress: 'test@example.com',
-              lockName: 'Lock Name'
-            })
-          ).toBe(true)
-        })
-      })
-
-      describe('when dispatch unsuccessful', () => {
-        it('returns true', async () => {
-          expect(
-            await new Processor(testGraphQLEndpoint, approvedLocks).processKey({
-              lockAddress: '0xabc',
-              keyId: '2',
-              emailAddress: 'test@example.com',
-              lockName: 'Lock Name'
-            })
-          ).toBe(false)
-        })
+    describe('when dispatch unsuccessful', () => {
+      it('returns true', async () => {
+        expect(
+          await new Processor(testGraphQLEndpoint).processKey({
+            lockAddress: '0xabc',
+            keyId: '2',
+            emailAddress: 'test@example.com',
+          })
+        ).toBe(false)
       })
     })
   })

--- a/nudge/tests/processor.test.ts
+++ b/nudge/tests/processor.test.ts
@@ -87,6 +87,7 @@ describe('processKey', () => {
             lockAddress: '0xabc',
             keyId: '2',
             emailAddress: 'test@example.com',
+            lockName: 'Lock Name'
           })
         ).toBe(false)
       })


### PR DESCRIPTION
# Description

As part of updating the code to function on all newly minted key, we need to reduce the window of query. As of now we are operating on a 24 hours rolling window with the current understand that items are processed every 5 minutes

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
