### PR TITLE
Nudge add lockname email

### DIFF
--- a/nudge/src/email.ts
+++ b/nudge/src/email.ts
@@ -9,7 +9,7 @@ export class Email {
       recipient: key.emailAddress,
       params: {
         keyId: key.keyId,
-        lockName: 'The Ethereal Party',
+        lockName: key.lockName,
         keychainUrl: 'https://app.unlock-protocol.com/keychain/',
       },
     }

--- a/nudge/src/emailList.ts
+++ b/nudge/src/emailList.ts
@@ -1,29 +1,27 @@
 import { generateKeyMetadata } from './generateKeyMetadata'
 
 export async function extractEmails(results: any[]): Promise<Key[]> {
-  let keysData = results.map((result: any) =>
-    enrichKeyWithEmailAddress(result.lockAddress, result.keyId)
-  )
+  let keysData = results.map((result: any) => enrichKeyWithEmailAddress(result))
 
-  let filteredKeys = (await Promise.all(keysData)).filter(key => key.emailAddress != null)
+  let filteredKeys = (await Promise.all(keysData)).filter(
+    key => key.emailAddress != null
+  )
   return filteredKeys
 }
 
-async function enrichKeyWithEmailAddress(
-  lockAddress: string,
-  keyId: string
-): Promise<any> {
+async function enrichKeyWithEmailAddress(key: Key): Promise<any> {
   let keyMetadata: any
 
   try {
-    keyMetadata = await generateKeyMetadata(lockAddress, keyId)
+    keyMetadata = await generateKeyMetadata(key.lockAddress, key.keyId)
   } catch (_) {
     keyMetadata = {}
   }
 
   return {
-    lockAddress: lockAddress,
-    keyId: keyId,
     emailAddress: keyMetadata.userMetadata?.protected?.emailAddress,
+    keyId: key.keyId,
+    lockAddress: key.lockAddress,
+    lockName: key.lockName,
   }
 }

--- a/nudge/src/querier.ts
+++ b/nudge/src/querier.ts
@@ -27,6 +27,7 @@ export class Querier {
           keys {
             lock {
               address
+              name
             }
             keyId
           }
@@ -36,8 +37,9 @@ export class Querier {
 
     return queryResults.data.keys.map((currentResult: any) => {
       return {
-        lockAddress: currentResult.lock.address,
         keyId: currentResult.keyId,
+        lockAddress: currentResult.lock.address,
+        lockName: currentResult.lock.name  
       }
     })
   }

--- a/nudge/src/types.ts
+++ b/nudge/src/types.ts
@@ -1,11 +1,12 @@
 interface Key {
-  lockAddress: string
   emailAddress: string | undefined
   keyId: string
+  lockAddress: string
+  lockName: string| null
 }
 
 interface UserTokenMetadataInput {
+  data: any
   tokenAddress: string
   userAddress: string
-  data: any
 }

--- a/nudge/tests/email.test.ts
+++ b/nudge/tests/email.test.ts
@@ -16,6 +16,7 @@ describe('Email', () => {
           keyId: '1',
           emailAddress: 'email@example.com',
           lockAddress: 'lock address',
+          lockName: 'Test Lock Name'
         })
 
         expect(successfulDispatch).toBe(true)
@@ -29,6 +30,7 @@ describe('Email', () => {
           keyId: '2',
           emailAddress: 'email@example.com',
           lockAddress: 'lock address 2',
+          lockName: 'Test Lock Name'
         })
 
         expect(unsuccessfulDispatch).toBe(false)

--- a/nudge/tests/processor.test.ts
+++ b/nudge/tests/processor.test.ts
@@ -63,6 +63,7 @@ describe('processKey', () => {
           lockAddress: '0xdef',
           keyId: '1',
           emailAddress: 'test@example.com',
+          lockName: 'Lock Name'
         })
       ).toBe(false)
     })
@@ -76,6 +77,7 @@ describe('processKey', () => {
             lockAddress: '0xabc',
             keyId: '1',
             emailAddress: 'test@example.com',
+            lockName: 'Lock Name'
           })
         ).toBe(false)
       })
@@ -88,6 +90,7 @@ describe('processKey', () => {
               lockAddress: '0xabc',
               keyId: '2',
               emailAddress: 'test@example.com',
+              lockName: 'Lock Name'
             })
           ).toBe(true)
         })
@@ -100,6 +103,7 @@ describe('processKey', () => {
               lockAddress: '0xabc',
               keyId: '2',
               emailAddress: 'test@example.com',
+              lockName: 'Lock Name'
             })
           ).toBe(false)
         })


### PR DESCRIPTION
# Description

The Nudge code has been updated to ensure that the Lock's name is retrieved so that it can be included in the templated information passed along to the email service

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
