### PR TITLE
Add setUserMetadata to WalletService

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+# 0.8.1
+- Addition of setUserMetadata, which follows the same argument pattern
+  as the other metadata methods
+
 # 0.8.0
 - BREAKING: getKeyMetadata now takes an object for non-callback
   params, now including an optional signature to retrieve protected metadata

--- a/unlock-js/index.d.ts
+++ b/unlock-js/index.d.ts
@@ -67,6 +67,22 @@ interface SetKeyMetadataParams {
   locksmithHost: string
 }
 
+interface UserMetadata {
+  publicData?: {
+    [key: string]: string
+  }
+  privateData?: {
+    [key: string]: string
+  }
+}
+
+interface SetUserMetadataParams {
+  lockAddress: string
+  userAddress: string
+  metadata: UserMetadata
+  locksmithHost: string
+}
+
 interface GetKeyMetadataParams {
   lockAddress: string
   keyId: string
@@ -82,5 +98,6 @@ export class WalletService extends EventEmitter {
   getAccount: () => Promise<string | false>;
   purchaseKey: (params: PurchaseKeyParams) => Promise<string>;
   setKeyMetadata: (params: SetKeyMetadataParams, callback: any) => void;
+  setUserMetadata: (params: SetUserMetadataParams, callback: any) => void;
   getKeyMetadata: (params: GetKeyMetadataParams, callback: any) => void;
 }

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/typedData/keyHolderMetadata.test.js
+++ b/unlock-js/src/__tests__/typedData/keyHolderMetadata.test.js
@@ -19,7 +19,7 @@ const baseData = {
   primaryType: 'UserMetaData',
 }
 
-const privateData = {
+const protectedData = {
   favoriteColor: 'blue',
   age: '7',
 }
@@ -40,24 +40,24 @@ describe('Key holder metadata payload generation', () => {
           owner,
           data: {
             public: {},
-            private: {},
+            protected: {},
           },
         },
       },
     })
   })
 
-  it('returns an appropriate value with only private metadata', () => {
+  it('returns an appropriate value with only protected metadata', () => {
     expect.assertions(1)
 
-    expect(generateKeyHolderMetadataPayload(owner, { privateData })).toEqual({
+    expect(generateKeyHolderMetadataPayload(owner, { protectedData })).toEqual({
       ...baseData,
       message: {
         UserMetaData: {
           owner,
           data: {
             public: {},
-            private: privateData,
+            protected: protectedData,
           },
         },
       },
@@ -74,18 +74,18 @@ describe('Key holder metadata payload generation', () => {
           owner,
           data: {
             public: publicData,
-            private: {},
+            protected: {},
           },
         },
       },
     })
   })
 
-  it('returns an appropriate value with both public and private metadata', () => {
+  it('returns an appropriate value with both public and protected metadata', () => {
     expect.assertions(1)
 
     expect(
-      generateKeyHolderMetadataPayload(owner, { publicData, privateData })
+      generateKeyHolderMetadataPayload(owner, { publicData, protectedData })
     ).toEqual({
       ...baseData,
       message: {
@@ -93,7 +93,7 @@ describe('Key holder metadata payload generation', () => {
           owner,
           data: {
             public: publicData,
-            private: privateData,
+            protected: protectedData,
           },
         },
       },

--- a/unlock-js/src/typedData/keyHolderMetadata.js
+++ b/unlock-js/src/typedData/keyHolderMetadata.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {Object} metadata
  * @property {Object.<string, string>} [publicData={}] - Publicly available metadata
- * @property {Object.<string, string>} [privateData={}] - Restricted access metadata
+ * @property {Object.<string, string>} [protectedData={}] - Restricted access metadata
  */
 
 /**
@@ -10,13 +10,13 @@
  * @param {metadata} metadata - The data to store for this user
  */
 export function generateMessage(owner, metadata) {
-  const { publicData = {}, privateData = {} } = metadata
+  const { publicData = {}, protectedData = {} } = metadata
   return {
     UserMetaData: {
       owner,
       data: {
         public: publicData,
-        private: privateData,
+        protected: protectedData,
       },
     },
   }

--- a/unlock-js/src/walletService.js
+++ b/unlock-js/src/walletService.js
@@ -4,6 +4,7 @@ import FetchJsonProvider from './FetchJsonProvider'
 import { GAS_AMOUNTS } from './constants'
 import utils from './utils'
 import { generateKeyMetadataPayload } from './typedData/keyMetadata'
+import { generateKeyHolderMetadataPayload } from './typedData/keyHolderMetadata'
 import 'cross-fetch/polyfill'
 
 const bytecode = require('./bytecode').default
@@ -394,11 +395,64 @@ export default class WalletService extends UnlockService {
   }
 
   /**
+   * @typedef {Object} keyholderMetadata
+   * @property {Object.<string, string>} [publicData={}] - Publicly available metadata
+   * @property {Object.<string, string>} [protectedData={}] - Restricted access metadata
+   */
+
+  /**
+   * Sign and send a request to update metadata specific to a given
+   * user address for a given lock.
+   *
+   * @param {Object} params
+   * @param {string} params.lockAddress - The address of the lock
+   * @param {string} params.userAddress - The address of the user (optional, defaults to current wallet user)
+   * @param {keyholderMetadata} params.metadata - The metadata fields and values to set
+   * @param {string} params.locksmithHost - A url with no trailing slash
+   * @param {*} callback
+   */
+  async setUserMetadata(
+    { lockAddress, userAddress, metadata, locksmithHost },
+    callback
+  ) {
+    const url = `${locksmithHost}/api/key/${lockAddress}/user/${userAddress}`
+    try {
+      const currentAddress = await this.getAccount()
+      const payload = generateKeyHolderMetadataPayload(currentAddress, metadata)
+      const signature = await this.unformattedSignTypedData(
+        currentAddress,
+        payload
+      )
+
+      const response = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${Buffer.from(signature).toString('base64')}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      })
+
+      if (response.status !== 202) {
+        callback(
+          new Error(
+            `Received ${response.status} from locksmith: ${response.statusText}`
+          )
+        )
+        return
+      }
+      callback(null, true)
+    } catch (error) {
+      callback(error, null)
+    }
+  }
+
+  /**
    * Sign and send a request to read metadata specific to a given key.
    *
    * @param {Object} params
    * @param {string} params.lockAddress - The address of the lock
-   * @param {string} params.keyId - The id of the key to set metadata on
+   * @param {string} params.keyId - The id of the key to read metadata on
    * @param {string} params.locksmithHost - A url with no trailing slash
    * @param {boolean} params.getProtectedData - when truthy, will generate signature to get protected metadata
    * @param {*} callback


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a `setUserMetadata` method to `WalletService`. It follows the same pattern as the other methods, although this time it sets the personal per-user metadata rather than the per-key "sticky" metadata. This method moves us forward on paywall metadata collection.

In the process of doing this, I realized that some of the typed data definitions used wrong terminology, so I patched them up to be functional.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
