### PR TITLE
Moving the _timeMachine function to MixinKeys

### DIFF
--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -23,8 +23,10 @@ contract MixinKeys is
     uint expirationTimestamp;
   }
 
-  // Called when the Lock owner expires a user's Key
+  // Emitted when the Lock owner expires a user's Key
   event ExpireKey(uint indexed tokenId);
+
+  // Emitted when the expiration of a key is modified
   event ExpirationChanged(
     uint indexed _tokenId,
     uint _amount,

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -2,6 +2,7 @@ pragma solidity 0.5.14;
 
 import '@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol';
 import './MixinLockCore.sol';
+import '@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol';
 
 
 /**
@@ -14,6 +15,8 @@ contract MixinKeys is
   Ownable,
   MixinLockCore
 {
+  using SafeMath for uint;
+
   // The struct for a key
   struct Key {
     uint tokenId;
@@ -22,6 +25,11 @@ contract MixinKeys is
 
   // Called when the Lock owner expires a user's Key
   event ExpireKey(uint indexed tokenId);
+  event ExpirationChanged(
+    uint indexed _tokenId,
+    uint _amount,
+    bool _timeAdded
+  );
 
   // Keys
   // Each owner can have at most exactly one key
@@ -249,5 +257,38 @@ contract MixinKeys is
       // We register the owner of the tokenID
       _ownerOf[_tokenId] = _owner;
     }
+  }
+
+  /**
+  * @notice Modify the expirationTimestamp of a key
+  * by a given amount.
+  * @param _tokenId The ID of the key to modify.
+  * @param _deltaT The amount of time in seconds by which
+  * to modify the keys expirationTimestamp
+  * @param _addTime Choose whether to increase or decrease
+  * expirationTimestamp (false == decrease, true == increase)
+  * @dev Throws if owner does not have a valid key.
+  */
+  function _timeMachine(
+    uint _tokenId,
+    uint256 _deltaT,
+    bool _addTime
+  ) internal
+  {
+    address tokenOwner = _ownerOf[_tokenId];
+    require(tokenOwner != address(0), 'NON_EXISTENT_KEY');
+    Key storage key = keyByOwner[tokenOwner];
+    uint formerTimestamp = key.expirationTimestamp;
+    bool validKey = getHasValidKey(tokenOwner);
+    if(_addTime) {
+      if(validKey) {
+        key.expirationTimestamp = formerTimestamp.add(_deltaT);
+      } else {
+        key.expirationTimestamp = block.timestamp.add(_deltaT);
+      }
+    } else {
+      key.expirationTimestamp = formerTimestamp.sub(_deltaT);
+    }
+    emit ExpirationChanged(_tokenId, _deltaT, _addTime);
   }
 }

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -255,39 +255,6 @@ contract MixinTransfer is
   }
 
   /**
-  * @notice Modify the expirationTimestamp of a key
-  * by a given amount.
-  * @param _tokenId The ID of the key to modify.
-  * @param _deltaT The amount of time in seconds by which
-  * to modify the keys expirationTimestamp
-  * @param _addTime Choose whether to increase or decrease
-  * expirationTimestamp (false == decrease, true == increase)
-  * @dev Throws if owner does not have a valid key.
-  */
-  function _timeMachine(
-    uint _tokenId,
-    uint256 _deltaT,
-    bool _addTime
-  ) internal
-  {
-    address tokenOwner = _ownerOf[_tokenId];
-    require(tokenOwner != address(0), 'NON_EXISTENT_KEY');
-    Key storage key = keyByOwner[tokenOwner];
-    uint formerTimestamp = key.expirationTimestamp;
-    bool validKey = getHasValidKey(tokenOwner);
-    if(_addTime) {
-      if(validKey) {
-        key.expirationTimestamp = formerTimestamp.add(_deltaT);
-      } else {
-        key.expirationTimestamp = block.timestamp.add(_deltaT);
-      }
-    } else {
-      key.expirationTimestamp = formerTimestamp.sub(_deltaT);
-    }
-    emit ExpirationChanged(_tokenId, _deltaT, _addTime);
-  }
-
-  /**
    * @dev Internal function to invoke `onERC721Received` on a target address
    * The call is not executed if the target address is not a contract
    * @param from address representing the previous owner of the given token ID

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -30,12 +30,6 @@ contract MixinTransfer is
     uint transferFeeBasisPoints
   );
 
-  event ExpirationChanged(
-    uint indexed _tokenId,
-    uint _amount,
-    bool _timeAdded
-  );
-
   // 0x150b7a02 == bytes4(keccak256('onERC721Received(address,address,uint256,bytes)'))
   bytes4 private constant _ERC721_RECEIVED = 0x150b7a02;
 


### PR DESCRIPTION
# Description

This is preparation for refactoring the `purchase` function to use `_timeMachine`. This would get us to a point where we consistently reuse the same logic  in `shareKeys`, `transferFrom` and `purchase`. This should also pave the way for refactoring the events we emit around these flows, as well as where/when we emit them. 
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #5728

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
