### PR TITLE
Add setUserMetadata wrapper for paywall

### DIFF
--- a/paywall/src/__tests__/utils/setUserMetadata.test.tsx
+++ b/paywall/src/__tests__/utils/setUserMetadata.test.tsx
@@ -1,0 +1,59 @@
+import { setUserMetadata } from '../../utils/setUserMetadata'
+
+class MockWalletService {
+  setUserMetadata: any
+
+  constructor() {
+    this.setUserMetadata = jest.fn()
+  }
+
+  connect() {}
+}
+let mockWalletService = new MockWalletService()
+
+jest.mock('@unlock-protocol/unlock-js', () => {
+  const mockUnlock = require.requireActual('@unlock-protocol/unlock-js') // Original module
+  return {
+    ...mockUnlock,
+    WalletService() {
+      return mockWalletService
+    },
+  }
+})
+
+const lockAddress = '0xlockaddress'
+const userAddress = '0xuseraddress'
+
+describe('setUserMetadata', () => {
+  it('calls back on success', done => {
+    expect.assertions(2)
+
+    mockWalletService.setUserMetadata = jest.fn((_, callback) => {
+      callback(undefined, 'success!')
+    })
+
+    const callback = (error: any, value: any) => {
+      expect(error).toBeUndefined()
+      expect(value).toBeTruthy()
+      done()
+    }
+
+    setUserMetadata(lockAddress, userAddress, {}, callback)
+  })
+
+  it('calls back on error', done => {
+    expect.assertions(2)
+
+    mockWalletService.setUserMetadata = jest.fn((_, callback) => {
+      callback(new Error('fail'), undefined)
+    })
+
+    const callback = (error: any, value: any) => {
+      expect(error).toBeInstanceOf(Error)
+      expect(value).toBeUndefined()
+      done()
+    }
+
+    setUserMetadata(lockAddress, userAddress, {}, callback)
+  })
+})

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -165,3 +165,12 @@ export interface KeyResult {
 }
 
 export type KeyResults = { [key: string]: KeyResult }
+
+export interface UserMetadata {
+  publicData?: {
+    [key: string]: string
+  }
+  privateData?: {
+    [key: string]: string
+  }
+}

--- a/paywall/src/utils/setUserMetadata.ts
+++ b/paywall/src/utils/setUserMetadata.ts
@@ -1,0 +1,27 @@
+import { WalletService } from '@unlock-protocol/unlock-js'
+import { UserMetadata } from '../unlockTypes'
+import configure from '../config'
+
+export function setUserMetadata(
+  lockAddress: string,
+  userAddress: string,
+  metadata: UserMetadata,
+  callback: (error: any, value: any) => void
+) {
+  const { unlockAddress, locksmithUri } = configure()
+
+  // TODO: investigate having a singleton WalletService to avoid any
+  // instantiation overhead if we start to use it more frequently
+  const walletService = new WalletService({ unlockAddress })
+  walletService.setUserMetadata(
+    {
+      lockAddress,
+      userAddress,
+      locksmithHost: locksmithUri,
+      metadata,
+    },
+    callback
+  )
+}
+
+export default setUserMetadata


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR contains a simple wrapper over the unlock-js method for setting user metadata so that we can conveniently access it in the paywall. Next step will be to render the form and hook it up with this function when metadata is present in the config.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
