### PR TITLE
Include network id in Web3ServiceParams

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+# Next Version
+- Updated Web3ServiceParams to include the network id, which is required
+
 # 0.8.2
 - Hardcoding the symbol for SAI
 

--- a/unlock-js/index.d.ts
+++ b/unlock-js/index.d.ts
@@ -7,7 +7,7 @@ interface Web3ServiceParams {
   unlockAddress: string
   blockTime: number
   requiredConfirmations: number
-  network: 1 | 4 | 1984
+  network: number
 }
 
 export interface PurchaseKeyParams {

--- a/unlock-js/index.d.ts
+++ b/unlock-js/index.d.ts
@@ -7,6 +7,7 @@ interface Web3ServiceParams {
   unlockAddress: string
   blockTime: number
   requiredConfirmations: number
+  network: 1 | 4 | 1984
 }
 
 export interface PurchaseKeyParams {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

The types exported from `unlock-js` are slightly wrong, because it doesn't recognize that `Web3Service` needs to take the network id in the constructor. This PR updates that. When it gets published we can revisit #5862 and replace some of the types defined there with the exported ones.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
