### PR TITLE
BlockchainHandler can set user metadata

### DIFF
--- a/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setUserMetadata.test.ts
+++ b/paywall/src/__tests__/data-iframe/blockchainHandler/BlockchainHandler/setUserMetadata.test.ts
@@ -1,0 +1,91 @@
+import {
+  WalletServiceType,
+  PaywallState,
+  LocksmithTransactionsResult,
+} from '../../../../data-iframe/blockchainHandler/blockChainTypes'
+import BlockchainHandler from '../../../../data-iframe/blockchainHandler/BlockchainHandler'
+import {
+  defaultValuesOverride,
+  setupTestDefaults,
+  addresses,
+} from '../../../test-helpers/setupBlockchainHelpers'
+
+describe('BlockchainHandler - setUserMetadata', () => {
+  let walletService: WalletServiceType
+  let handler: BlockchainHandler
+
+  type OptionalBlockchainValues = Partial<PaywallState>
+
+  function setupDefaults(
+    valuesOverride: OptionalBlockchainValues = defaultValuesOverride,
+    jsonToFetch: { transactions?: LocksmithTransactionsResult[] } = {}
+  ) {
+    const defaults = setupTestDefaults(valuesOverride, jsonToFetch)
+    walletService = defaults.walletService
+    const web3Service = defaults.web3Service
+    const emitError = defaults.emitError
+    const emitChanges = defaults.emitChanges
+    const store = defaults.store
+    const constants = defaults.constants
+    const configuration = defaults.configuration
+    const fakeWindow = defaults.fakeWindow
+    handler = new BlockchainHandler({
+      walletService,
+      web3Service,
+      constants,
+      configuration,
+      emitChanges,
+      emitError,
+      window: fakeWindow,
+      store,
+    })
+
+    handler.init()
+  }
+
+  describe('no account yet', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should throw when attempting to set metadata', async () => {
+      expect.assertions(1)
+
+      await expect(
+        handler.setUserMetadata('0xlockaddress', {})
+      ).rejects.toEqual(
+        '[BlockchainHandler] store.account is null, cannot set metadata'
+      )
+    })
+  })
+
+  describe('account is available', () => {
+    beforeEach(() => {
+      setupDefaults({ account: addresses[1] })
+    })
+
+    it('should resolve with a value on success', async () => {
+      expect.assertions(1)
+
+      walletService.setUserMetadata = jest.fn((_: any, callback) => {
+        callback(undefined, 'success')
+      })
+
+      await expect(
+        handler.setUserMetadata('0xlockaddress', {})
+      ).resolves.toEqual('success')
+    })
+
+    it('should reject with an error on failure', async () => {
+      expect.assertions(1)
+
+      walletService.setUserMetadata = jest.fn((_: any, callback) => {
+        callback(new Error('fail'), undefined)
+      })
+
+      await expect(
+        handler.setUserMetadata('0xlockaddress', {})
+      ).rejects.toEqual(new Error('fail'))
+    })
+  })
+})

--- a/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
+++ b/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
@@ -637,6 +637,12 @@ export default class BlockchainHandler {
 
   async setUserMetadata(lockAddress: string, metadata: UserMetadata) {
     const userAddress = this.store.account
+    if (!userAddress) {
+      // eslint-disable-next-line promise/param-names
+      return new Promise((_, reject) => {
+        reject('[BlockchainHandler] store.account is null, cannot set metadata')
+      })
+    }
 
     return new Promise((resolve, reject) => {
       this.walletService.setUserMetadata(
@@ -646,7 +652,7 @@ export default class BlockchainHandler {
           locksmithHost: this.constants.locksmithUri,
           metadata,
         },
-        (error: Error, value: any) => {
+        (error: any, value: any) => {
           if (error) {
             reject(error)
           }

--- a/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
+++ b/paywall/src/data-iframe/blockchainHandler/BlockchainHandler.ts
@@ -5,6 +5,7 @@ import {
   Locks,
   TransactionType,
   TransactionStatus,
+  UserMetadata,
 } from '../../unlockTypes'
 import linkKeysToLocks from './linkKeysToLocks'
 import { POLLING_INTERVAL } from '../../constants'
@@ -632,6 +633,27 @@ export default class BlockchainHandler {
       // eslint-disable-next-line no-console
       console.error(e)
     }
+  }
+
+  async setUserMetadata(lockAddress: string, metadata: UserMetadata) {
+    const userAddress = this.store.account
+
+    return new Promise((resolve, reject) => {
+      this.walletService.setUserMetadata(
+        {
+          lockAddress,
+          userAddress,
+          locksmithHost: this.constants.locksmithUri,
+          metadata,
+        },
+        (error: Error, value: any) => {
+          if (error) {
+            reject(error)
+          }
+          resolve(value)
+        }
+      )
+    })
   }
 
   /**

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -165,3 +165,12 @@ export interface KeyResult {
 }
 
 export type KeyResults = { [key: string]: KeyResult }
+
+export interface UserMetadata {
+  publicData?: {
+    [key: string]: string
+  }
+  privateData?: {
+    [key: string]: string
+  }
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Third time's the charm. This PR adds a method to `BlockchainHandler` that wraps the `setUserMetadata` method in `unlock-js`. One part of that is wrapping the callback with an async function to better match the existing `BlockchainHandler` API. Future PRs will hook up the messaging infrastructure and finally integrate the form with the paywall.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
