### PR TITLE
Add messaging infrastructure for setting user metadata

### DIFF
--- a/paywall/src/EventEmitterTypes.ts
+++ b/paywall/src/EventEmitterTypes.ts
@@ -43,6 +43,9 @@ export interface DataIframeEvents {
   ) => void
   // this has to be more specific because WEB3 is overloaded
   [PostMessages.WEB3]: (request: web3MethodCall) => void
+  [PostMessages.SET_USER_METADATA_SUCCESS]: (
+    update: ExtractPayload<PostMessages.SET_USER_METADATA_SUCCESS>
+  ) => void
 }
 
 /**
@@ -62,6 +65,9 @@ export interface CheckoutIframeEvents {
   ) => void
   [PostMessages.UPDATE_WALLET]: (
     request: ExtractPayload<PostMessages.UPDATE_WALLET>
+  ) => void
+  [PostMessages.SET_USER_METADATA]: (
+    request: ExtractPayload<PostMessages.SET_USER_METADATA>
   ) => void
 }
 

--- a/paywall/src/__tests__/data-iframe/Mailbox/setUserMetadata.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/setUserMetadata.test.ts
@@ -1,0 +1,123 @@
+import { IframePostOfficeWindow } from '../../../windowTypes'
+import {
+  ConstantsType,
+  FetchWindow,
+  SetTimeoutWindow,
+  WalletServiceType,
+  Web3ServiceType,
+} from '../../../data-iframe/blockchainHandler/blockChainTypes'
+import Mailbox from '../../../data-iframe/Mailbox'
+import {
+  setupTestDefaults,
+  MailboxTestDefaults,
+} from '../../test-helpers/setupMailboxHelpers'
+import FakeWindow from '../../test-helpers/fakeWindowHelpers'
+import { PostMessages } from '../../../messageTypes'
+import {
+  getWalletService,
+  getWeb3Service,
+} from '../../test-helpers/setupBlockchainHelpers'
+
+let mockWalletService: WalletServiceType
+let mockWeb3Service: Web3ServiceType
+jest.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    WalletService: () => {
+      mockWalletService = getWalletService({})
+      mockWalletService.connect = jest.fn((provider: any) => {
+        mockWalletService.provider = provider
+        return Promise.resolve()
+      })
+      return mockWalletService
+    },
+    Web3Service: () => {
+      mockWeb3Service = getWeb3Service({})
+      return mockWeb3Service
+    },
+  }
+})
+
+describe('Mailbox - setUserMetadata', () => {
+  let constants: ConstantsType
+  let win: FetchWindow & SetTimeoutWindow & IframePostOfficeWindow
+  let fakeWindow: FakeWindow
+  let mailbox: Mailbox
+  let defaults: MailboxTestDefaults
+
+  function setupDefaults() {
+    defaults = setupTestDefaults()
+    constants = defaults.constants
+    win = defaults.fakeWindow
+    fakeWindow = win as FakeWindow
+    mailbox = new Mailbox(constants, fakeWindow)
+  }
+
+  function testingMailbox(): any {
+    return mailbox as any
+  }
+
+  describe('handler is not set', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should emit an error', async () => {
+      expect.assertions(1)
+
+      mailbox.setUserMetadata({
+        lockAddress: '0xlockaddress',
+        metadata: {},
+      })
+
+      await fakeWindow.waitForPostMessage()
+
+      fakeWindow.expectPostMessageSent(
+        PostMessages.ERROR,
+        'blockchain handler not instantiated, cannot set metadata'
+      )
+    })
+  })
+
+  describe('handler is set', () => {
+    beforeEach(() => {
+      setupDefaults()
+    })
+
+    it('should notify the checkout iframe of success', async () => {
+      expect.assertions(1)
+
+      testingMailbox().handler = {
+        setUserMetadata: jest.fn().mockResolvedValue(''),
+      }
+
+      mailbox.setUserMetadata({
+        lockAddress: '0xlockaddress',
+        metadata: {},
+      })
+
+      await fakeWindow.waitForPostMessage()
+
+      fakeWindow.expectPostMessageSent(
+        PostMessages.SET_USER_METADATA_SUCCESS,
+        undefined
+      )
+    })
+
+    it('should notify the checkout iframe of failure', async () => {
+      expect.assertions(1)
+
+      testingMailbox().handler = {
+        setUserMetadata: jest.fn().mockRejectedValue(new Error('fail')),
+      }
+
+      mailbox.setUserMetadata({
+        lockAddress: '0xlockaddress',
+        metadata: {},
+      })
+
+      await fakeWindow.waitForPostMessage()
+
+      fakeWindow.expectPostMessageSent(PostMessages.ERROR, 'fail')
+    })
+  })
+})

--- a/paywall/src/messageTypes.ts
+++ b/paywall/src/messageTypes.ts
@@ -4,6 +4,7 @@ import {
   PurchaseKeyRequest,
   Transactions,
   Balance,
+  UserMetadata,
 } from './unlockTypes'
 import { web3MethodCall, Web3WalletInfo, web3MethodResult } from './windowTypes'
 import {
@@ -46,6 +47,9 @@ export enum PostMessages {
 
   SHOW_ACCOUNTS_MODAL = 'show/accountsModal',
   HIDE_ACCOUNTS_MODAL = 'hide/accountsModal',
+
+  SET_USER_METADATA = 'setMetadata/user',
+  SET_USER_METADATA_SUCCESS = 'setMetadata/user/success',
 }
 // all the possible message types
 export type Message =
@@ -155,6 +159,17 @@ export type Message =
     }
   | {
       type: PostMessages.USING_MANAGED_ACCOUNT
+      payload: undefined
+    }
+  | {
+      type: PostMessages.SET_USER_METADATA
+      payload: {
+        metadata: UserMetadata
+        lockAddress: string
+      }
+    }
+  | {
+      type: PostMessages.SET_USER_METADATA_SUCCESS
       payload: undefined
     }
 

--- a/paywall/src/unlock.js/postMessageHub.ts
+++ b/paywall/src/unlock.js/postMessageHub.ts
@@ -84,6 +84,16 @@ export function checkoutHandlerInit({
     )
   })
 
+  checkoutIframe.on(PostMessages.SET_USER_METADATA, payload => {
+    dataIframe.postMessage(PostMessages.SET_USER_METADATA, payload)
+  })
+  dataIframe.on(PostMessages.SET_USER_METADATA_SUCCESS, () => {
+    checkoutIframe.postMessage(
+      PostMessages.SET_USER_METADATA_SUCCESS,
+      undefined
+    )
+  })
+
   // pass on any errors
   dataIframe.on(PostMessages.ERROR, error =>
     checkoutIframe.postMessage(PostMessages.ERROR, error)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

I forgot just how labyrinthine this subsystem could be. This PR adds the necessary messages for the checkout iframe to request that metadata be set for a user and for the data iframe to indicate that it did so successfully. I'll annotate inline, because there are some pieces here that are a little different from the other messages.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
