### PR TITLE
Use circleci-agent per the docs

### DIFF
--- a/scripts/monorepo.sh
+++ b/scripts/monorepo.sh
@@ -12,7 +12,7 @@ if [ ! "$BRANCH" = "master" ]; then
   HAS_CHANGES=$(git diff `git merge-base HEAD origin/master` --name-only -- $SHARED_CONFIG_FILES $SERVICE)
   if [ ! -n "$HAS_CHANGES" ]; then
     echo "No change in $SERVICE, skipping job."
-    circleci step halt
+    circleci-agent step halt
   fi
 fi
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Ran into some errors on circle builds saying `scripts/monorepo.sh: line 15: circleci: command not found`. Essentially, it caused CI builds on unchanged subrepos to fail because it could not find the command.

@akeem noticed that the official docs recommend using `circleci-agent` as the command. I anticipate that if tests pass in this build, then other PRs should resume working as well after a rebase.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
