### PR TITLE
Exposes `creationBlock` attribute in the existing Lock Query

### DIFF
--- a/docker/development/subgraph.dockerfile
+++ b/docker/development/subgraph.dockerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
 RUN npm install -g npm@6.4.1
 RUN git clone https://github.com/unlock-protocol/unlock-subgraph.git
 WORKDIR /unlock-subgraph
+RUN git pull
 RUN git checkout local_dev
 
 COPY --chown=node ./deploy-subgraph.js /unlock-subgraph/.

--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -190,7 +190,7 @@ describe('The Unlock Dashboard', () => {
       let lockToEditSelector
       beforeEach(async () => {
         const existingLocks = await dashboard.listLocks()
-        lockToEditSelector = `[data-address="${existingLocks[0]}"]`
+        lockToEditSelector = `[data-address="${existingLocks[4]}"]`
       })
 
       it('a button exists to edit the Lock details', async () => {

--- a/tests/test/dashboard.test.js
+++ b/tests/test/dashboard.test.js
@@ -203,15 +203,18 @@ describe('The Unlock Dashboard', () => {
       it('allows the lock owner to update the price of the lock', async () => {
         expect.assertions(5)
         await expect(page).toClick(`${lockToEditSelector} button[title="Edit"]`)
-        const keyPriceInputSelector = 'input[name="keyPrice"]'
+        const keyPriceInputSelector = `${lockToEditSelector} input[name="keyPrice"]`
+
         await expect(page).toMatchElement(keyPriceInputSelector)
         const currentPrice = await page.evaluate(selector => {
           return document.querySelectorAll(selector)[0].value
         }, keyPriceInputSelector)
+
         const newPrice = Number(
           (parseFloat(currentPrice) * 2).toFixed(2)
         ).toString()
-        await expect(page).toFill(keyPriceInputSelector, newPrice)
+
+        await expect(page).toFill(`${keyPriceInputSelector}`, newPrice)
         await expect(page).toClick(`${lockToEditSelector} button`, {
           text: 'Submit',
         })

--- a/unlock-app/src/queries/locksByOwner.js
+++ b/unlock-app/src/queries/locksByOwner.js
@@ -11,6 +11,7 @@ export default function locksByOwnerQuery() {
         totalSupply
         maxNumberOfKeys
         owner
+        creationBlock
       }
     }
   `

--- a/unlock-app/src/queries/locksByOwner.js
+++ b/unlock-app/src/queries/locksByOwner.js
@@ -3,7 +3,11 @@ import { gql } from 'apollo-boost'
 export default function locksByOwnerQuery() {
   return gql`
     query Locks($owner: String!) {
-      locks(where: { owner: $owner }) {
+      locks(
+        where: { owner: $owner }
+        orderBy: creationBlock
+        orderDirection: desc
+      ) {
         id
         address
         name

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -122,6 +122,7 @@ export interface Lock {
   outstandingKeys?: number
   balance?: string
   owner?: string
+  creationBlock?: number
 }
 
 export interface Locks {


### PR DESCRIPTION
# Description

As the relevant subgraph has been updated, the Lock query used to power the creator dashboard can be updated.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #5438

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
