### PR TITLE
Remove events from interface

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -84,6 +84,23 @@ contract Unlock is
   // Used for GDP calculations
   mapping (address => IUniswap) public uniswapExchanges;
 
+  // Events
+  event NewLock(
+    address indexed lockOwner,
+    address indexed newLockAddress
+  );
+
+  event ConfigUnlock(
+    address publicLockAddress,
+    string globalTokenSymbol,
+    string globalTokenURI
+  );
+
+  event ResetTrackedValue(
+    uint grossNetworkProduct,
+    uint totalDiscountGranted
+  );
+
   // Use initialize instead of a constructor to support proxies (for upgradeability via zos).
   function initialize(
     address _owner

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -13,57 +13,6 @@ contract IPublicLock is IERC721Enumerable {
 // https://github.com/duaraghav8/Ethlint/issues/268
 // solium-disable indentation
 
-  /// Events
-  event Destroy(
-    uint balance,
-    address indexed owner
-  );
-
-  event Disable();
-
-  event Withdrawal(
-    address indexed sender,
-    address indexed tokenAddress,
-    address indexed beneficiary,
-    uint amount
-  );
-
-  event CancelKey(
-    uint indexed tokenId,
-    address indexed owner,
-    address indexed sendTo,
-    uint refund
-  );
-
-  event RefundPenaltyChanged(
-    uint freeTrialLength,
-    uint refundPenaltyBasisPoints
-  );
-
-  event PricingChanged(
-    uint oldKeyPrice,
-    uint keyPrice,
-    address oldTokenAddress,
-    address tokenAddress
-  );
-
-  event ExpireKey(uint indexed tokenId);
-
-  event NewLockSymbol(
-    string symbol
-  );
-
-  event TransferFeeChanged(
-    uint transferFeeBasisPoints
-  );
-
-  /// @notice emits anytime the nonce used for off-chain approvals changes.
-  event NonceChanged(
-    address indexed keyOwner,
-    uint nextAvailableNonce
-  );
-  ///===================================================================
-
   /// Functions
 
   function initialize(

--- a/smart-contracts/contracts/interfaces/IUnlock.sol
+++ b/smart-contracts/contracts/interfaces/IUnlock.sol
@@ -8,24 +8,6 @@ pragma solidity 0.5.14;
 
 interface IUnlock {
 
-
-  // Events
-  event NewLock(
-    address indexed lockOwner,
-    address indexed newLockAddress
-  );
-
-  event ConfigUnlock(
-    address publicLockAddress,
-    string globalTokenSymbol,
-    string globalTokenURI
-  );
-
-  event ResetTrackedValue(
-    uint grossNetworkProduct,
-    uint totalDiscountGranted
-  );
-
   // Use initialize instead of a constructor to support proxies (for upgradeability via zos).
   function initialize(address _owner) external;
 


### PR DESCRIPTION
# Description
This is just removing event definitions from our interfaces (IUnlock & IPublicLock). I've not touched the other interfaces we use, such as IERC721.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #5866
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
