### PR TITLE
Fix usePaywallConfig loop

### DIFF
--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -65,6 +65,10 @@ export const Wrapper: React.FunctionComponent<WrapperProps> = ({
  */
 export default function CheckoutContent() {
   const window = useWindow()
+
+  // This is the ONLY place where usePaywallConfig should be
+  // called. Calling it anywhere else will introduce loops that break the
+  // app.
   const paywallConfig = usePaywallConfig()
   const { account, network, locks, checkWallet } = useBlockchainData(
     window,

--- a/paywall/src/components/content/CheckoutContent.tsx
+++ b/paywall/src/components/content/CheckoutContent.tsx
@@ -10,7 +10,7 @@ import useBlockchainData from '../../hooks/useBlockchainData'
 import useWindow from '../../hooks/browser/useWindow'
 import usePaywallConfig from '../../hooks/usePaywallConfig'
 import usePostMessage from '../../hooks/browser/usePostMessage'
-import { Key, Locks, NetworkNames } from '../../unlockTypes'
+import { Key, Locks, NetworkNames, PaywallConfig } from '../../unlockTypes'
 
 import { PostMessages } from '../../messageTypes'
 
@@ -22,11 +22,13 @@ import CheckoutConfirmingModal from '../checkout/CheckoutConfirmingModal'
 
 interface WrapperProps {
   allowClose: boolean
+  config: PaywallConfig
 }
 
 /* eslint-disable react/prop-types */
 export const Wrapper: React.FunctionComponent<WrapperProps> = ({
   allowClose,
+  config,
   children,
 }) => {
   const { postMessage } = usePostMessage('Checkout UI')
@@ -38,8 +40,6 @@ export const Wrapper: React.FunctionComponent<WrapperProps> = ({
     })
   }, [postMessage])
 
-  const paywallConfig = usePaywallConfig()
-
   return (
     <Greyout onClick={allowClose ? hideCheckout : () => {}}>
       <CheckoutWrapper
@@ -49,7 +49,7 @@ export const Wrapper: React.FunctionComponent<WrapperProps> = ({
         onClick={e => {
           e.stopPropagation()
         }}
-        icon={paywallConfig.icon}
+        icon={config.icon}
       >
         <Head>
           <title>{pageTitle('Checkout')}</title>
@@ -187,7 +187,7 @@ export default function CheckoutContent() {
 
   if (!account) {
     return (
-      <Wrapper allowClose>
+      <Wrapper allowClose config={paywallConfig}>
         <NoWallet config={paywallConfig} />
       </Wrapper>
     )
@@ -195,7 +195,7 @@ export default function CheckoutContent() {
 
   if (requiredNetworkId !== network) {
     return (
-      <Wrapper allowClose={allowClosingCheckout}>
+      <Wrapper allowClose={allowClosingCheckout} config={paywallConfig}>
         <WrongNetwork
           currentNetwork={currentNetwork}
           requiredNetworkId={requiredNetworkId}
@@ -218,7 +218,7 @@ export default function CheckoutContent() {
     // unless they have dismissed it. Then we display the checkout component
     // we will use the first confirming lock in the list
     return (
-      <Wrapper allowClose={allowClosingCheckout}>
+      <Wrapper allowClose={allowClosingCheckout} config={paywallConfig}>
         <CheckoutConfirmingModal
           account={account}
           hideCheckout={hideConfirmingModal}
@@ -229,7 +229,7 @@ export default function CheckoutContent() {
   }
   // for everyone else, display the checkout component
   return (
-    <Wrapper allowClose={allowClosingCheckout}>
+    <Wrapper allowClose={allowClosingCheckout} config={paywallConfig}>
       <Checkout
         account={account}
         locks={locks}

--- a/paywall/src/hooks/usePaywallConfig.js
+++ b/paywall/src/hooks/usePaywallConfig.js
@@ -6,6 +6,14 @@ import useListenForPostMessage from './browser/useListenForPostMessage'
 import usePostMessage from './browser/usePostMessage'
 
 /**
+ * NOTE: Do not use this hook anywhere other than CheckoutContent. It
+ * is not safely written, so having more than one instance of it will
+ * introduce major breakage.
+ *
+ * We should consider it deprecated at this point.
+ */
+
+/**
  * Merge in the call to action sentences from defaults for any that the
  * paywall configuration did not define
  *


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This is a partial fix for the weird issue we found on local dev today. Calling `usePaywallConfig` twice caused a loop that a) rendered the paywall nonfunctional on Firefox (and sometimes Chrome) and b) would grind my machine to a halt in relatively short order.

Removing the second call and making the component take the config as a param stops the bleeding, although it doesn't explain why we saw different behavior in different environments.


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
