### PR TITLE
Fix spelling of "isMetaMask"

### DIFF
--- a/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/init.test.ts
@@ -152,7 +152,7 @@ describe('Mailbox - init', () => {
     fakeWindow.receivePostMessageFromMainWindow(PostMessages.WALLET_INFO, {
       noWallet: false,
       notEnabled: false,
-      isMetamask: false,
+      isMetaMask: false,
     })
 
     await waitFor(() => testingMailbox().handler)
@@ -167,7 +167,7 @@ describe('Mailbox - init', () => {
     fakeWindow.receivePostMessageFromMainWindow(PostMessages.WALLET_INFO, {
       noWallet: false,
       notEnabled: false,
-      isMetamask: false,
+      isMetaMask: false,
     })
 
     await waitFor(() => testingMailbox().handler)

--- a/paywall/src/__tests__/unlock.js/Wallet/init.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/init.test.ts
@@ -68,7 +68,7 @@ describe('Wallet.init()', () => {
       handler.init({
         shouldUseUserAccounts: false,
         hasWallet: true,
-        isMetamask: true,
+        isMetaMask: true,
       })
 
       expect(setupUserAccounts).not.toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('Wallet.init()', () => {
       handler.init({
         shouldUseUserAccounts: true,
         hasWallet: true,
-        isMetamask: true,
+        isMetaMask: true,
       })
 
       expect(setupWeb3ProxyWallet).toHaveBeenCalled()
@@ -97,7 +97,7 @@ describe('Wallet.init()', () => {
       handler.init({
         hasWallet: false,
         shouldUseUserAccounts: false,
-        isMetamask: false,
+        isMetaMask: false,
       })
 
       expect(setupWeb3ProxyWallet).toHaveBeenCalled()
@@ -119,7 +119,7 @@ describe('Wallet.init()', () => {
       handler.init({
         shouldUseUserAccounts: false,
         hasWallet: true,
-        isMetamask: true,
+        isMetaMask: true,
       })
 
       expect(setupUserAccounts).not.toHaveBeenCalled()
@@ -135,7 +135,7 @@ describe('Wallet.init()', () => {
       handler.init({
         shouldUseUserAccounts: true,
         hasWallet: false,
-        isMetamask: false,
+        isMetaMask: false,
       })
 
       expect(setupUserAccounts).toHaveBeenCalled()
@@ -150,7 +150,7 @@ describe('Wallet.init()', () => {
       handler.init({
         shouldUseUserAccounts: true,
         hasWallet: false,
-        isMetamask: false,
+        isMetaMask: false,
       })
 
       expect(setupUserAccountsProxyWallet).toHaveBeenCalled()

--- a/paywall/src/__tests__/unlock.js/Wallet/setupUserAccountsProxyWallet.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/setupUserAccountsProxyWallet.test.ts
@@ -125,7 +125,7 @@ describe('setupUserAccountsProxyWallet()', () => {
       {
         noWallet: false,
         notEnabled: false,
-        isMetamask: false,
+        isMetaMask: false,
       },
       iframes.data.iframe,
       dataOrigin

--- a/paywall/src/__tests__/unlock.js/Wallet/setupWeb3ProxyWallet.test.ts
+++ b/paywall/src/__tests__/unlock.js/Wallet/setupWeb3ProxyWallet.test.ts
@@ -32,7 +32,7 @@ describe('setupWeb3ProxyWallet()', () => {
       hasWallet: typeof hasWallet === 'undefined' ? true : hasWallet,
       setHasWeb3: setHasWeb3 || jest.fn(),
       getHasWeb3: getHasWeb3 || jest.fn(() => true),
-      isMetamask: isMetamask || true,
+      isMetaMask: isMetamask || true,
       window: window || fakeWindow,
     })
 
@@ -80,7 +80,7 @@ describe('setupWeb3ProxyWallet()', () => {
         {
           noWallet: true,
           notEnabled: false,
-          isMetamask: false,
+          isMetaMask: false,
         }
       )
     })
@@ -100,7 +100,7 @@ describe('setupWeb3ProxyWallet()', () => {
           {
             noWallet: false,
             notEnabled: false,
-            isMetamask: true,
+            isMetaMask: true,
           }
         )
         done()
@@ -138,7 +138,7 @@ describe('setupWeb3ProxyWallet()', () => {
           {
             noWallet: false,
             notEnabled: true,
-            isMetamask: true,
+            isMetaMask: true,
           }
         )
         done()

--- a/paywall/src/__tests__/unlock.js/startup.test.ts
+++ b/paywall/src/__tests__/unlock.js/startup.test.ts
@@ -207,7 +207,7 @@ describe('unlock.js startup', () => {
         {
           noWallet: false,
           notEnabled: false,
-          isMetamask: false,
+          isMetaMask: false,
         },
         iframes.data.iframe,
         dataOrigin

--- a/paywall/src/__tests__/utils/wallet.test.ts
+++ b/paywall/src/__tests__/utils/wallet.test.ts
@@ -40,13 +40,13 @@ describe('wallet utilities', () => {
   })
 
   describe('walletIsMetamask', () => {
-    it('should be true when window.web3.currentProvider.isMetamask is true', () => {
+    it('should be true when window.web3.currentProvider.isMetaMask is true', () => {
       expect.assertions(1)
 
       const window: any = {
         web3: {
           currentProvider: {
-            isMetamask: true,
+            isMetaMask: true,
           },
         },
       }

--- a/paywall/src/providers/Web3ProxyProvider.js
+++ b/paywall/src/providers/Web3ProxyProvider.js
@@ -28,7 +28,7 @@ export default class Web3ProxyProvider {
       if (!walletInfo || typeof walletInfo !== 'object') {
         return
       }
-      this.isMetamask = !!walletInfo.isMetamask
+      this.isMetaMask = !!walletInfo.isMetaMask
       this.noWallet = !!walletInfo.noWallet
       this.notEnabled = !!walletInfo.notEnabled
       // now we are ready to do work

--- a/paywall/src/unlock.js/Wallet.ts
+++ b/paywall/src/unlock.js/Wallet.ts
@@ -71,7 +71,7 @@ export default class Wallet {
     return this.hasWeb3
   }
 
-  init({ shouldUseUserAccounts, hasWallet, isMetamask }: WalletStatus) {
+  init({ shouldUseUserAccounts, hasWallet, isMetaMask }: WalletStatus) {
     if (shouldUseUserAccounts) {
       // create the preconditions for using user accounts
       setupUserAccounts({
@@ -105,7 +105,7 @@ export default class Wallet {
         hasWallet,
         setHasWeb3: this.setHasWeb3,
         getHasWeb3: this.getHasWeb3,
-        isMetamask,
+        isMetaMask,
         window: this.window,
       })
     }

--- a/paywall/src/unlock.js/postMessageHub.ts
+++ b/paywall/src/unlock.js/postMessageHub.ts
@@ -326,7 +326,7 @@ export function setupUserAccountsProxyWallet({
     iframes.data.postMessage(PostMessages.WALLET_INFO, {
       noWallet: false,
       notEnabled: false,
-      isMetamask: false,
+      isMetaMask: false,
     })
   })
 
@@ -364,7 +364,7 @@ interface setupWeb3ProxyWalletArgs {
   hasWallet: boolean
   setHasWeb3: (value: boolean) => void
   getHasWeb3: () => boolean
-  isMetamask: boolean
+  isMetaMask: boolean
   window: Web3Window
 }
 
@@ -373,7 +373,7 @@ export function setupWeb3ProxyWallet({
   hasWallet,
   setHasWeb3,
   getHasWeb3,
-  isMetamask,
+  isMetaMask,
   window,
 }: setupWeb3ProxyWalletArgs) {
   // when receiving a key purchase request, we either pass it to the
@@ -395,7 +395,7 @@ export function setupWeb3ProxyWallet({
       iframes.data.postMessage(PostMessages.WALLET_INFO, {
         noWallet: true,
         notEnabled: false,
-        isMetamask: false,
+        isMetaMask: false,
       })
       return
     }
@@ -410,7 +410,7 @@ export function setupWeb3ProxyWallet({
       iframes.data.postMessage(PostMessages.WALLET_INFO, {
         noWallet: false,
         notEnabled: true, // user declined to enable the wallet
-        isMetamask, // this is used for some decisions in signing
+        isMetaMask, // this is used for some decisions in signing
       })
       return
     }
@@ -418,7 +418,7 @@ export function setupWeb3ProxyWallet({
     iframes.data.postMessage(PostMessages.WALLET_INFO, {
       noWallet: false,
       notEnabled: false,
-      isMetamask, // this is used for some decisions in signing
+      isMetaMask, // this is used for some decisions in signing
     })
   })
 

--- a/paywall/src/utils/wallet.ts
+++ b/paywall/src/utils/wallet.ts
@@ -9,7 +9,7 @@ export function walletIsMetamask(window: Web3Window): boolean {
   if (hasWallet(window)) {
     // Since hasWallet returned true, we know web3.currentProvider is
     // on the window
-    return !!(window as CryptoWalletWindow).web3.currentProvider.isMetamask
+    return !!(window as CryptoWalletWindow).web3.currentProvider.isMetaMask
   }
 
   return false
@@ -31,7 +31,7 @@ export function shouldUseUserAccounts(
 
 export interface WalletStatus {
   hasWallet: boolean
-  isMetamask: boolean
+  isMetaMask: boolean
   shouldUseUserAccounts: boolean
 }
 
@@ -41,7 +41,7 @@ export function walletStatus(
 ): WalletStatus {
   return {
     hasWallet: hasWallet(window),
-    isMetamask: walletIsMetamask(window),
+    isMetaMask: walletIsMetamask(window),
     shouldUseUserAccounts: shouldUseUserAccounts(window, config),
   }
 }

--- a/paywall/src/windowTypes.ts
+++ b/paywall/src/windowTypes.ts
@@ -68,7 +68,7 @@ export interface LocalStorageWindow {
 export interface Web3WalletInfo {
   noWallet: boolean
   notEnabled: boolean
-  isMetamask: boolean
+  isMetaMask: boolean
 }
 export interface web3MethodCall {
   method: string
@@ -106,7 +106,7 @@ export interface Web3Window extends PostOfficeWindow {
     currentProvider: {
       sendAsync?: web3Send
       send?: web3Send
-      isMetamask?: true // is only ever true or undefined
+      isMetaMask?: true // is only ever true or undefined
       enable?: () => Promise<void>
     }
   }
@@ -118,14 +118,14 @@ export type CryptoWalletWindow = Required<Web3Window>
 export interface SendAsyncProvider {
   sendAsync: web3Send
   send?: web3Send
-  isMetamask?: true // is only ever true or undefined
+  isMetaMask?: true // is only ever true or undefined
   enable?: () => Promise<void>
 }
 
 // some providers do not define sendAsync
 export interface SendProvider {
   send: web3Send
-  isMetamask?: true // is only ever true or undefined
+  isMetaMask?: true // is only ever true or undefined
   enable?: () => Promise<void>
 }
 // used in utils/postOffice.ts


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

While working on #5901, I discovered that the paywall handled the proxy wallet incorrectly. In particular, it checked for and exposed `isMetamask`, which is a misspelling of `isMetaMask`. This caused it to fail on signing typed data, which is currently the only feature that relied on MetaMask-specific behavior. We never noticed it before because everything else works fine and that feature wasn't used on the Paywall.

This PR corrects the misspelling and allows signing typed data from the paywall.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
