### PR TITLE
Be able to convert form submission to metadata format

### DIFF
--- a/paywall/src/__tests__/utils/userMetadata.test.ts
+++ b/paywall/src/__tests__/utils/userMetadata.test.ts
@@ -28,7 +28,7 @@ const formResult = {
 
 describe('userMetadata utils', () => {
   describe('getPublicInputs', () => {
-    it('returns an object mapping protected inputs to true', () => {
+    it('returns an object mapping public inputs to true', () => {
       expect.assertions(1)
 
       const result = getPublicInputs(inputs)

--- a/paywall/src/__tests__/utils/userMetadata.test.ts
+++ b/paywall/src/__tests__/utils/userMetadata.test.ts
@@ -1,0 +1,63 @@
+import { MetadataInput } from '../../unlockTypes'
+import {
+  getProtectedInputs,
+  formResultToMetadata,
+} from '../../utils/userMetadata'
+
+const inputs: MetadataInput[] = [
+  {
+    name: 'First Name',
+    type: 'text',
+    required: false,
+  },
+  {
+    name: 'Last Name',
+    type: 'text',
+    required: false,
+    protected: true,
+  },
+  {
+    name: 'Email Address',
+    type: 'text',
+    required: false,
+    protected: true,
+  },
+]
+
+const formResult = {
+  'First Name': 'Saxton',
+  'Last Name': 'Hale',
+  'Email Address': 'ceo@mann.co',
+}
+
+describe('userMetadata utils', () => {
+  describe('getProtectedInputs', () => {
+    it('returns an object mapping protected inputs to true', () => {
+      expect.assertions(1)
+
+      const result = getProtectedInputs(inputs)
+
+      expect(result).toEqual({
+        'First Name': false,
+        'Last Name': true,
+        'Email Address': true,
+      })
+    })
+  })
+
+  describe('formResultToMetadata', () => {
+    it('processes a form submission into the correct structure', () => {
+      expect.assertions(1)
+
+      expect(formResultToMetadata(formResult, inputs)).toEqual({
+        privateData: {
+          'Last Name': 'Hale',
+          'Email Address': 'ceo@mann.co',
+        },
+        publicData: {
+          'First Name': 'Saxton',
+        },
+      })
+    })
+  })
+})

--- a/paywall/src/__tests__/utils/userMetadata.test.ts
+++ b/paywall/src/__tests__/utils/userMetadata.test.ts
@@ -1,26 +1,22 @@
 import { MetadataInput } from '../../unlockTypes'
-import {
-  getProtectedInputs,
-  formResultToMetadata,
-} from '../../utils/userMetadata'
+import { getPublicInputs, formResultToMetadata } from '../../utils/userMetadata'
 
 const inputs: MetadataInput[] = [
   {
     name: 'First Name',
     type: 'text',
     required: false,
+    public: true,
   },
   {
     name: 'Last Name',
     type: 'text',
     required: false,
-    protected: true,
   },
   {
     name: 'Email Address',
     type: 'text',
     required: false,
-    protected: true,
   },
 ]
 
@@ -31,16 +27,16 @@ const formResult = {
 }
 
 describe('userMetadata utils', () => {
-  describe('getProtectedInputs', () => {
+  describe('getPublicInputs', () => {
     it('returns an object mapping protected inputs to true', () => {
       expect.assertions(1)
 
-      const result = getProtectedInputs(inputs)
+      const result = getPublicInputs(inputs)
 
       expect(result).toEqual({
-        'First Name': false,
-        'Last Name': true,
-        'Email Address': true,
+        'First Name': true,
+        'Last Name': false,
+        'Email Address': false,
       })
     })
   })
@@ -50,7 +46,7 @@ describe('userMetadata utils', () => {
       expect.assertions(1)
 
       expect(formResultToMetadata(formResult, inputs)).toEqual({
-        privateData: {
+        protectedData: {
           'Last Name': 'Hale',
           'Email Address': 'ceo@mann.co',
         },

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -78,6 +78,7 @@ export interface MetadataInput {
   name: string
   type: 'text' | 'date' | 'color' | 'email' | 'url'
   required: boolean
+  protected?: true // optional, all non-protected fields are treated as public
 }
 
 // This interface describes an individual paywall's config

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -78,7 +78,7 @@ export interface MetadataInput {
   name: string
   type: 'text' | 'date' | 'color' | 'email' | 'url'
   required: boolean
-  protected?: true // optional, all non-protected fields are treated as public
+  public?: true // optional, all non-public fields are treated as protected
 }
 
 // This interface describes an individual paywall's config
@@ -171,7 +171,7 @@ export interface UserMetadata {
   publicData?: {
     [key: string]: string
   }
-  privateData?: {
+  protectedData?: {
     [key: string]: string
   }
 }

--- a/paywall/src/utils/userMetadata.ts
+++ b/paywall/src/utils/userMetadata.ts
@@ -1,0 +1,30 @@
+import { UserMetadata, MetadataInput } from '../unlockTypes'
+
+export function getProtectedInputs(
+  inputs: MetadataInput[]
+): { [name: string]: boolean } {
+  let result: { [key: string]: boolean } = {}
+  inputs.forEach(input => (result[input.name] = input.protected || false))
+  return result
+}
+
+export function formResultToMetadata(
+  formResult: { [key: string]: string },
+  inputs: MetadataInput[]
+): UserMetadata {
+  let result: UserMetadata = {
+    publicData: {},
+    privateData: {},
+  }
+
+  const protectedInputs = getProtectedInputs(inputs)
+  Object.keys(formResult).forEach(name => {
+    if (protectedInputs[name]) {
+      result.privateData![name] = formResult[name]
+    } else {
+      result.publicData![name] = formResult[name]
+    }
+  })
+
+  return result
+}

--- a/paywall/src/utils/userMetadata.ts
+++ b/paywall/src/utils/userMetadata.ts
@@ -1,10 +1,10 @@
 import { UserMetadata, MetadataInput } from '../unlockTypes'
 
-export function getProtectedInputs(
+export function getPublicInputs(
   inputs: MetadataInput[]
 ): { [name: string]: boolean } {
   let result: { [key: string]: boolean } = {}
-  inputs.forEach(input => (result[input.name] = input.protected || false))
+  inputs.forEach(input => (result[input.name] = input.public || false))
   return result
 }
 
@@ -14,15 +14,15 @@ export function formResultToMetadata(
 ): UserMetadata {
   let result: UserMetadata = {
     publicData: {},
-    privateData: {},
+    protectedData: {},
   }
 
-  const protectedInputs = getProtectedInputs(inputs)
+  const publicInputs = getPublicInputs(inputs)
   Object.keys(formResult).forEach(name => {
-    if (protectedInputs[name]) {
-      result.privateData![name] = formResult[name]
-    } else {
+    if (publicInputs[name]) {
       result.publicData![name] = formResult[name]
+    } else {
+      result.protectedData![name] = formResult[name]
     }
   })
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Required for #5901 

This PR introduces a small util that converts the output of the metadata form (a string:string dictionary) into the metadata format we need for user metadata. For maximum flexibility we can specify in the paywall config whether a field should be public. If not, it is assumed to be protected. 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
