### PR TITLE
Adding a test for timeMachine

### DIFF
--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -3,6 +3,7 @@ const BigNumber = require('bignumber.js')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const TimeMachineMock = artifacts.require('TimeMachineMock')
+const shouldFail = require('../helpers/shouldFail')
 const getProxy = require('../helpers/proxy')
 
 let unlock
@@ -84,6 +85,15 @@ contract('Lock / timeMachine', accounts => {
 
     it('should emit the ExpirationChanged event', async () => {
       assert.equal(tx.logs[0].event, 'ExpirationChanged')
+    })
+  })
+
+  describe('failures', async () => {
+    it('should not work for a non-existant key', async () => {
+      await shouldFail(
+        lock.timeMachine(17, 42, true, { from: accounts[3] }),
+        'NON_EXISTENT_KEY'
+      )
     })
   })
 })

--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -3,7 +3,7 @@ const BigNumber = require('bignumber.js')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const TimeMachineMock = artifacts.require('TimeMachineMock')
-const shouldFail = require('../helpers/shouldFail')
+const { reverts } = require('truffle-assertions')
 const getProxy = require('../helpers/proxy')
 
 let unlock
@@ -90,7 +90,7 @@ contract('Lock / timeMachine', accounts => {
 
   describe('failures', async () => {
     it('should not work for a non-existant key', async () => {
-      await shouldFail(
+      await reverts(
         lock.timeMachine(17, 42, true, { from: accounts[3] }),
         'NON_EXISTENT_KEY'
       )


### PR DESCRIPTION
# Description
This adds 1 test to ensure that the `timeMachine` function continues to only operate on valid keys.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
