### PR TITLE
Add test for updating beneficiary

### DIFF
--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -164,8 +164,8 @@ contract MixinLockCore is
   function updateBeneficiary(
     address _beneficiary
   ) external
-    onlyOwnerOrBeneficiary
   {
+    require(msg.sender == beneficiary, 'ONLY_BENEFICIARY');
     require(_beneficiary != address(0), 'INVALID_ADDRESS');
     beneficiary = _beneficiary;
   }

--- a/smart-contracts/test/Lock/withdraw.js
+++ b/smart-contracts/test/Lock/withdraw.js
@@ -1,8 +1,8 @@
 const Units = require('ethereumjs-units')
 const BigNumber = require('bignumber.js')
 
+const { reverts } = require('truffle-assertions')
 const deployLocks = require('../helpers/deployLocks')
-const shouldFail = require('../helpers/shouldFail')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 const getProxy = require('../helpers/proxy')
@@ -26,7 +26,7 @@ contract('Lock / withdraw', accounts => {
 
   it('should only allow the owner to withdraw', async () => {
     assert.notEqual(owner, accounts[1]) // Making sure
-    await shouldFail(
+    await reverts(
       lock.withdraw(tokenAddress, 0, {
         from: accounts[1],
       }),
@@ -66,7 +66,7 @@ contract('Lock / withdraw', accounts => {
     })
 
     it('should fail if there is nothing left to withdraw', async () => {
-      await shouldFail(
+      await reverts(
         lock.withdraw(tokenAddress, 0, {
           from: owner,
         }),
@@ -120,7 +120,7 @@ contract('Lock / withdraw', accounts => {
       })
 
       it('withdraw should fail', async () => {
-        await shouldFail(
+        await reverts(
           lock.withdraw(tokenAddress, 42, {
             from: owner,
           }),
@@ -138,6 +138,12 @@ contract('Lock / withdraw', accounts => {
 
       await lock.updateBeneficiary(beneficiary, { from: owner })
     })
+    it('the owner can no longer update the beneficiary', async () => {
+      await reverts(
+        lock.updateBeneficiary(owner, { from: owner }),
+        'ONLY_BENEFICIARY'
+      )
+    })
 
     it('can withdraw from beneficiary account', async () => {
       await lock.withdraw(tokenAddress, 42, {
@@ -152,7 +158,7 @@ contract('Lock / withdraw', accounts => {
     })
 
     it('should fail to withdraw as non-owner or beneficiary', async () => {
-      await shouldFail(
+      await reverts(
         lock.withdraw(tokenAddress, 42, {
           from: accounts[4],
         }),


### PR DESCRIPTION
# Description
This just changes permissions for `updateBeneficiary` to only allow the beneficiary. It adds one test case for this, and I migrated all the `shouldFail`'s in the file to use truffle-assertions/revert.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
