### PR TITLE
CheckoutContent reads paywall config from URL param

### DIFF
--- a/unlock-app/jest.config.js
+++ b/unlock-app/jest.config.js
@@ -21,7 +21,7 @@ module.exports = {
       branches: 85.2,
       functions: 88.7,
       lines: 95.3,
-      statements: -165,
+      statements: -172,
     },
   },
 }

--- a/unlock-app/src/__tests__/utils/checkoutValidators.test.js
+++ b/unlock-app/src/__tests__/utils/checkoutValidators.test.js
@@ -1,0 +1,1545 @@
+import * as validators from '../../utils/checkoutValidators'
+
+describe('Form field validators', () => {
+  it('isMissing', () => {
+    expect.assertions(6)
+    expect(validators.isNotEmpty('hi')).toBeTruthy()
+    expect(validators.isNotEmpty('0')).toBeTruthy()
+    expect(validators.isNotEmpty(0)).toBeTruthy()
+
+    expect(validators.isNotEmpty('')).toBeFalsy()
+    expect(validators.isNotEmpty(null)).toBeFalsy()
+    expect(validators.isNotEmpty(false)).toBeFalsy()
+  })
+
+  it('isPositiveInteger', () => {
+    expect.assertions(8)
+    expect(validators.isPositiveInteger('1')).toBeTruthy()
+    expect(
+      validators.isPositiveInteger(
+        '178941236598123465918347651983476519387456918736459813476598123645891765894765'
+      )
+    ).toBeTruthy()
+
+    expect(validators.isPositiveInteger('0')).toBeTruthy()
+    expect(validators.isPositiveInteger('-1')).toBeFalsy()
+    expect(validators.isPositiveInteger('1.1')).toBeFalsy()
+    expect(validators.isPositiveInteger('av')).toBeFalsy()
+    expect(validators.isPositiveInteger(null)).toBeFalsy()
+    expect(validators.isPositiveInteger(false)).toBeFalsy()
+  })
+
+  it('isPositiveNumber', () => {
+    expect.assertions(7)
+    expect(validators.isPositiveNumber('1.3')).toBeTruthy()
+    expect(validators.isPositiveNumber('0.002')).toBeTruthy()
+
+    expect(validators.isPositiveNumber('0')).toBeTruthy()
+    expect(validators.isPositiveNumber('-1')).toBeFalsy()
+    expect(validators.isPositiveNumber('av')).toBeFalsy()
+    expect(validators.isPositiveNumber(null)).toBeFalsy()
+    expect(validators.isPositiveNumber(false)).toBeFalsy()
+  })
+
+  it('isAccount', () => {
+    expect.assertions(5)
+
+    expect(
+      validators.isAccount('0x12345678901234567890abcdef0123ABCDEF0123')
+    ).toBeTruthy()
+    expect(
+      validators.isAccount('00x12345678901234567890abcdef0123ABCDEF0123')
+    ).toBeFalsy()
+    expect(
+      validators.isAccount('0x12345678901234567890abcdef0123ABCDEF01234')
+    ).toBeFalsy()
+    expect(
+      validators.isAccount('0X12345678901234567890abcdef0123ABCDEF0123')
+    ).toBeFalsy()
+    expect(validators.isAccount(null)).toBeFalsy()
+  })
+
+  it('isAccountOrNull', () => {
+    expect.assertions(5)
+
+    expect(
+      validators.isAccountOrNull('0x12345678901234567890abcdef0123ABCDEF0123')
+    ).toBeTruthy()
+    expect(
+      validators.isAccountOrNull('00x12345678901234567890abcdef0123ABCDEF0123')
+    ).toBeFalsy()
+    expect(
+      validators.isAccountOrNull('0x12345678901234567890abcdef0123ABCDEF01234')
+    ).toBeFalsy()
+    expect(
+      validators.isAccountOrNull('0X12345678901234567890abcdef0123ABCDEF0123')
+    ).toBeFalsy()
+    expect(validators.isAccountOrNull(null)).toBeTruthy()
+  })
+
+  describe('isValidPaywallConfig', () => {
+    const lock = '0x1234567890123456789012345678901234567890'
+    const validConfig = {
+      callToAction: {
+        default: 'hi',
+        expired: 'there',
+        pending: 'pending',
+        confirmed: 'confirmed',
+      },
+      locks: {
+        [lock]: {
+          name: 'hi',
+        },
+      },
+      icon: 'http://hi.com',
+    }
+
+    describe('failures', () => {
+      it('config is falsy', () => {
+        expect.assertions(4)
+
+        expect(validators.isValidPaywallConfig(false)).toBe(false)
+        expect(validators.isValidPaywallConfig(null)).toBe(false)
+        expect(validators.isValidPaywallConfig(0)).toBe(false)
+        expect(validators.isValidPaywallConfig('')).toBe(false)
+      })
+
+      it('config is not an object', () => {
+        expect.assertions(3)
+
+        expect(validators.isValidPaywallConfig('hi')).toBe(false)
+        expect(validators.isValidPaywallConfig(1)).toBe(false)
+        expect(validators.isValidPaywallConfig([])).toBe(false)
+      })
+
+      it('config has wrong number of properties', () => {
+        expect.assertions(2)
+
+        expect(
+          validators.isValidPaywallConfig({
+            hi: 1,
+            there: 2,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            hi: 1,
+            there: 2,
+            I: 3,
+            suck: 4,
+          })
+        ).toBe(false)
+      })
+
+      it('config keys are unrecognized', () => {
+        expect.assertions(3)
+
+        expect(
+          validators.isValidPaywallConfig({
+            locks: 1,
+            icon: 2,
+            callToLaziness: 3,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            locks: 1,
+            iconic: 2,
+            callToAction: 3,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            goldilocks: 1,
+            icon: 2,
+            callToAction: 3,
+          })
+        ).toBe(false)
+      })
+
+      it('should fail when metadataInputs is present but invalid', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            metadataInputs: {},
+          })
+        ).toBeFalsy()
+      })
+
+      it('icon', () => {
+        expect.assertions(3)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: {},
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: 1,
+          })
+        ).toBe(false)
+      })
+
+      it('icon is data URI', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon:
+              'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMDAgNTQiPg0KICA8cGF0aCBkPSJNMTEzLjMgMTguMmMwLTUuOC4xLTExLjIuNC0xNi4yTDk4LjQgNC45djEuNGwxLjUuMmMxLjEuMSAxLjguNSAyLjIgMS4xLjQuNy43IDEuNy45IDMuMi4yIDIuOS40IDkuNS4zIDE5LjkgMCAxMC4zLS4xIDE2LjgtLjMgMTkuMyA1LjUgMS4yIDkuOCAxLjcgMTMgMS43IDYgMCAxMC43LTEuNyAxNC4xLTUuMiAzLjQtMy40IDUuMi04LjIgNS4yLTE0LjEgMC00LjctMS4zLTguNi0zLjktMTEuNy0yLjYtMy4xLTUuOS00LjYtOS44LTQuNi0yLjYgMC01LjMuNy04LjMgMi4xem0uMyAzMC44Yy0uMi0zLjItLjQtMTIuOC0uNC0yOC41LjktLjMgMi4xLS41IDMuNi0uNSAyLjQgMCA0LjMgMS4yIDUuNyAzLjcgMS40IDIuNSAyLjEgNS41IDIuMSA5LjMgMCA0LjctLjggOC41LTIuNCAxMS43LTEuNiAzLjEtMy42IDQuNy02LjEgNC43LS44LS4yLTEuNi0uMy0yLjUtLjR6TTQxIDNIMXYybDIuMS4yYzEuNi4zIDIuNy45IDMuNCAxLjguNyAxIDEuMSAyLjYgMS4yIDQuOC44IDEwLjguOCAyMC45IDAgMzAuMi0uMiAyLjItLjYgMy44LTEuMiA0LjgtLjcgMS0xLjggMS42LTMuNCAxLjhsLTIuMS4zdjJoMjUuOHYtMmwtMi43LS4yYy0xLjYtLjItMi43LS45LTMuNC0xLjgtLjctMS0xLjEtMi42LTEuMi00LjgtLjMtNC0uNS04LjYtLjUtMTMuN2w1LjQuMWMyLjkuMSA0LjkgMi4zIDUuOSA2LjdoMlYxOC45aC0yYy0xIDQuMy0yLjkgNi41LTUuOSA2LjZsLTUuNC4xYzAtOSAuMi0xNS40LjUtMTkuM2g3LjljNS42IDAgOS40IDMuNiAxMS42IDEwLjhsMi40LS43TDQxIDN6bS00LjcgMzAuOGMwIDUuMiAxLjUgOS41IDQuNCAxMi45IDIuOSAzLjQgNy4yIDUgMTIuNiA1czkuOC0xLjcgMTMtNS4yYzMuMi0zLjQgNC43LTcuNyA0LjctMTIuOXMtMS41LTkuNS00LjQtMTIuOWMtMi45LTMuNC03LjItNS0xMi42LTVzLTkuOCAxLjctMTMgNS4yYy0zLjIgMy40LTQuNyA3LjctNC43IDEyLjl6bTIyLjMtMTEuNGMxLjIgMi45IDEuNyA2LjcgMS43IDExLjMgMCAxMC42LTIuMiAxNS44LTYuNSAxNS44LTIuMiAwLTMuOS0xLjUtNS4xLTQuNS0xLjItMy0xLjctNi44LTEuNy0xMS4zQzQ3IDIzLjIgNDkuMiAxOCA1My41IDE4YzIuMi0uMSAzLjkgMS40IDUuMSA0LjR6bTg0LjUgMjQuM2MzLjMgMy4zIDcuNSA1IDEyLjUgNSAzLjEgMCA1LjgtLjYgOC4yLTEuOSAyLjQtMS4yIDQuMy0yLjcgNS42LTQuNWwtMS0xLjJjLTIuMiAxLjctNC43IDIuNS03LjYgMi41LTQgMC03LjEtMS4zLTkuMi00LTIuMi0yLjctMy4yLTYuMS0zLTEwLjVIMTcwYzAtNC44LTEuMi04LjctMy43LTExLjgtMi41LTMtNi00LjUtMTAuNS00LjUtNS42IDAtOS45IDEuOC0xMyA1LjMtMy4xIDMuNS00LjYgNy44LTQuNiAxMi45IDAgNS4yIDEuNiA5LjQgNC45IDEyLjd6bTcuNC0yNS4xYzEuMS0yLjQgMi41LTMuNiA0LjQtMy42IDMgMCA0LjUgMy44IDQuNSAxMS41bC0xMC42LjJjLjEtMyAuNi01LjcgMS43LTguMXptNDYuNC00Yy0yLjctMS4yLTYuMS0xLjktMTAuMi0xLjktNC4yIDAtNy41IDEuMS0xMCAzLjJzLTMuOCA0LjctMy44IDcuOGMwIDIuNy44IDQuOCAyLjMgNi4zIDEuNSAxLjUgMy45IDIuOCA3IDMuOSAyLjggMSA0LjggMiA1LjggMi45IDEgMSAxLjYgMi4xIDEuNiAzLjYgMCAxLjQtLjUgMi43LTEuNiAzLjctMSAxLjEtMi40IDEuNi00LjIgMS42LTQuNCAwLTcuNy0zLjItMTAtOS42bC0xLjcuNS40IDEwYzMuNiAxLjQgNy42IDIuMSAxMiAyLjEgNC42IDAgOC4xLTEgMTAuNy0zLjEgMi42LTIgMy45LTQuOSAzLjktOC41IDAtMi40LS42LTQuNC0xLjktNS45LTEuMy0xLjUtMy40LTIuOC02LjQtNC0zLjMtMS4yLTUuNi0yLjMtNi44LTMuMy0xLjItMS0xLjgtMi4yLTEuOC0zLjdzLjQtMi43IDEuMy0zLjcgMi0xLjQgMy40LTEuNGM0IDAgNi45IDIuOSA4LjcgOC42bDEuNy0uNS0uNC04LjZ6bS05Ni4yLS45Yy0xLjQtLjctMi45LTEtNC42LTEtMS43IDAtMy40LjctNS4zIDIuMS0xLjkgMS40LTMuMyAzLjMtNC40IDUuOWwuMS04LTE1LjIgM3YxLjRsMS41LjFjMS45LjIgMyAxLjcgMy4yIDQuNC42IDYuMi42IDEyLjggMCAxOS44LS4yIDIuNy0xLjMgNC4xLTMuMiA0LjRsLTEuNS4ydjEuOWgyMS4yVjQ5bC0yLjctLjJjLTEuOS0uMi0zLTEuNy0zLjItNC40LS42LTUuOC0uNy0xMi0uMi0xOC40LjYtMSAxLjktMS42IDMuOS0xLjggMi0uMiA0LjMuNCA2LjcgMS44bDMuNy05LjN6Ij48L3BhdGg+DQo8L3N2Zz4=',
+          })
+        ).toBe(true)
+      })
+
+      describe('callToAction', () => {
+        const noConfirmed = {
+          default: 'default',
+          expired: 'expired',
+          pending: 'pending',
+        }
+        const noPending = {
+          default: 'default',
+          expired: 'expired',
+          confirmed: 'confirmed',
+        }
+        const noExpired = {
+          default: 'default',
+          pending: 'pending',
+          confirmed: 'confirmed',
+        }
+        const noDefault = {
+          expired: 'expired',
+          pending: 'pending',
+          confirmed: 'confirmed',
+        }
+
+        it('callToAction has too many keys', () => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              callToAction: {
+                oops: 1,
+                I: 2,
+                did: 3,
+                it: 4,
+                again: 5,
+              },
+            })
+          ).toBe(false)
+        })
+
+        it.each([noConfirmed, noPending, noExpired, noDefault])(
+          'callToAction has unrecognized keys',
+          defaults => {
+            expect.assertions(1)
+
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  ...defaults,
+                  nubbin: 'oops',
+                },
+              })
+            ).toBe(false)
+          }
+        )
+
+        it.each(['default', 'expired', 'pending', 'confirmed'])(
+          'callToAction.%s is malformed',
+          key => {
+            expect.assertions(5)
+
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: false,
+              })
+            ).toBe(false)
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  [key]: false,
+                },
+              })
+            ).toBe(false)
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  [key]: 1,
+                },
+              })
+            ).toBe(false)
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  [key]: {},
+                },
+              })
+            ).toBe(false)
+            expect(
+              validators.isValidPaywallConfig({
+                ...validConfig,
+                callToAction: {
+                  [key]: [],
+                },
+              })
+            ).toBe(false)
+          }
+        )
+      })
+
+      it('locks is falsy', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: false,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: 0,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: '',
+          })
+        ).toBe(false)
+      })
+
+      it('icon is not a string', () => {
+        expect.assertions(2)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: [],
+          })
+        ).toBe(false)
+      })
+
+      it('icon is not a valid url', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon:
+              '"><script type="text/javascript>alert("XSS");</script><img src="http://example.com/img.jpg',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: 'notaURL',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: '/test.jpg',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: 'gerbils://eat.poo/fancy.jpg',
+          })
+        ).toBe(false)
+      })
+
+      it('locks is not an object', () => {
+        expect.assertions(3)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: 'null',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: [],
+          })
+        ).toBe(false)
+      })
+
+      it('locks has no locks', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: {},
+          })
+        ).toBe(false)
+      })
+
+      describe('locks', () => {
+        it('lock address is malformed', () => {
+          expect.assertions(3)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                notalock: {
+                  name: 'hahaha',
+                },
+              },
+            })
+          ).toBe(false)
+
+          const endsWithZ = `${lock.substring(0, lock.length - 1)}Z`
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [endsWithZ]: {
+                  name: 'hahaha I end in Z',
+                },
+              },
+            })
+          ).toBe(false)
+
+          const tooLong = `${lock}a`
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [tooLong]: {
+                  name: 'hahaha I am too long',
+                },
+              },
+            })
+          ).toBe(false)
+        })
+
+        it('lock is not an object', () => {
+          expect.assertions(4)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: false,
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: null,
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: 0,
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: '',
+              },
+            })
+          ).toBe(false)
+        })
+
+        it('lock has wrong number of properties', () => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: 'hi',
+                  whatthe: 'hey?',
+                },
+              },
+            })
+          ).toBe(false)
+        })
+
+        it('lock name is not a string', () => {
+          expect.assertions(4)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: {},
+                },
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: [],
+                },
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: null,
+                },
+              },
+            })
+          ).toBe(false)
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              locks: {
+                [lock]: {
+                  name: 0,
+                },
+              },
+            })
+          ).toBe(false)
+        })
+      })
+
+      describe('unlockUserAccounts', () => {
+        it('unlockUserAccounts is missing', () => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+            })
+          ).toBe(true)
+        })
+
+        it('unlockUserAccounts is true', () => {
+          expect.assertions(2)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: true,
+            })
+          ).toBe(true)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: 'true',
+            })
+          ).toBe(true)
+        })
+
+        it('unlockUserAccounts is false', () => {
+          expect.assertions(2)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: false,
+            })
+          ).toBe(true)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: 'false',
+            })
+          ).toBe(true)
+        })
+
+        it('unlockUserAccounts is not a boolean', () => {
+          expect.assertions(4)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: 'hello',
+            })
+          ).toBe(false)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: [],
+            })
+          ).toBe(false)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: 7,
+            })
+          ).toBe(false)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              unlockUserAccounts: {},
+            })
+          ).toBe(false)
+        })
+      })
+
+      describe('persistentCheckout', () => {
+        it("should accept or 'true' as value", () => {
+          expect.assertions(2)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              persistentCheckout: true,
+            })
+          ).toBe(true)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              persistentCheckout: 'true',
+            })
+          ).toBe(true)
+        })
+        it("should accept false or 'false' as value", () => {
+          expect.assertions(2)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              persistentCheckout: false,
+            })
+          ).toBe(true)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              persistentCheckout: 'false',
+            })
+          ).toBe(true)
+        })
+
+        it('should accept no value set', () => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+            })
+          ).toBe(true)
+        })
+
+        it('should reject other types', () => {
+          expect.assertions(4)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              persistentCheckout: '',
+            })
+          ).toBe(false)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              persistentCheckout: 3,
+            })
+          ).toBe(false)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              persistentCheckout: [],
+            })
+          ).toBe(false)
+
+          expect(
+            validators.isValidPaywallConfig({
+              ...validConfig,
+              persistentCheckout: {},
+            })
+          ).toBe(false)
+        })
+      })
+    })
+
+    describe('valid cases', () => {
+      it('is valid config', () => {
+        expect.assertions(9)
+
+        expect(validators.isValidPaywallConfig(validConfig)).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: false,
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: 'https://example.com/img.png',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: 'hi',
+            },
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: '//example.com/img.png',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: 'hi',
+              expired: 'hi',
+            },
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            callToAction: {
+              default: 'hi',
+              expired: 'hi',
+              pending: 'hi',
+            },
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            icon: 'ftp://example.com/img.png',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidPaywallConfig({
+            ...validConfig,
+            locks: {
+              [lock]: {},
+            },
+          })
+        ).toBe(true)
+      })
+    })
+
+    it('is valid when lock has no name', () => {
+      expect.assertions(1)
+
+      expect(
+        validators.isValidPaywallConfig({
+          ...validConfig,
+          locks: {
+            [lock]: {
+              whatthe: 'hey?',
+            },
+          },
+        })
+      ).toBe(true)
+    })
+
+    it('is valid when lock name is an empty string', () => {
+      expect.assertions(1)
+
+      expect(
+        validators.isValidPaywallConfig({
+          ...validConfig,
+          locks: {
+            [lock]: {
+              name: '',
+            },
+          },
+        })
+      ).toBe(true)
+    })
+
+    it('is valid when metadataInputs is present and valid', () => {
+      expect.assertions(1)
+
+      const metadataInputs = [
+        {
+          name: 'Name',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'Birthday',
+          type: 'date',
+          required: false,
+        },
+      ]
+
+      expect(
+        validators.isValidPaywallConfig({
+          ...validConfig,
+          metadataInputs,
+        })
+      ).toBeTruthy()
+    })
+  })
+
+  describe('isValidKey', () => {
+    const validKey = {
+      expiration: 1,
+      transactions: [],
+      status: 'none',
+      confirmations: 0,
+      owner: '0x1234567890123456789012345678901234567890',
+      lock: '0x0987654321098765432109876543210987654321',
+    }
+
+    describe('failures', () => {
+      it('should fail with invalid objects', () => {
+        expect.assertions(5)
+
+        expect(validators.isValidKey(false)).toBe(false)
+        expect(validators.isValidKey('hi')).toBe(false)
+        expect(validators.isValidKey(0)).toBe(false)
+        expect(validators.isValidKey([])).toBe(false)
+        expect(
+          validators.isValidKey({
+            expiration: 1,
+            transactions: [],
+            status: 'hi',
+            confirmations: 2,
+            notakey: 4,
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if expiration is invalid', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            expiration: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            expiration: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            expiration: '1',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            expiration: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if transactions is not an array', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            transactions: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            transactions: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            transactions: 'hi',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            transactions: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if status is not a string', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if status is not a known value', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            status: 'notvalid',
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if confirmations is invalid', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            confirmations: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            confirmations: '1',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            confirmations: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            confirmations: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if owner is not a valid ethereum address', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            owner: '0xIamnot a valid ethereum address',
+          })
+        ).toBe(false)
+      })
+
+      it('should fail if lock is not a valid ethereum address', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            lock: '0xIamnot a valid ethereum address',
+          })
+        ).toBe(false)
+      })
+    })
+
+    describe('valid keys', () => {
+      it('should accept a basic valid key', () => {
+        expect.assertions(1)
+
+        expect(validators.isValidKey(validKey)).toBe(true)
+      })
+
+      it('should accept a basic valid key with optional id', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidKey({
+            ...validKey,
+            id: 'id',
+          })
+        ).toBe(true)
+      })
+
+      describe('status', () => {
+        it.each([
+          'none',
+          'confirming',
+          'confirmed',
+          'expired',
+          'valid',
+          'submitted',
+          'pending',
+          'failed',
+        ])('should accept "%s" as a valid status', status => {
+          expect.assertions(1)
+
+          expect(
+            validators.isValidKey({
+              ...validKey,
+              status,
+            })
+          ).toBe(true)
+        })
+      })
+    })
+  })
+
+  describe('isValidLock', () => {
+    const validLock = {
+      address: '0x1234567890123456789009876543210987654321',
+      keyPrice: '123',
+      expirationDuration: 123,
+      key: {
+        expiration: 1,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+        owner: '0x1234567890123456789012345678901234567890',
+        lock: '0x0987654321098765432109876543210987654321',
+      },
+    }
+    describe('failures', () => {
+      it('should fail with invalid objects', () => {
+        expect.assertions(6)
+
+        expect(validators.isValidLock(false)).toBe(false)
+        expect(validators.isValidLock('hi')).toBe(false)
+        expect(validators.isValidLock(0)).toBe(false)
+        expect(validators.isValidLock([])).toBe(false)
+        expect(
+          validators.isValidLock({
+            address: 1,
+            keyPrice: [],
+            expirationDuration: 'hi',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            address: 1,
+            keyPrice: [],
+            expirationDuration: 'hi',
+            kery: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid name', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            name: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            name: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            name: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            name: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid lock address', () => {
+        expect.assertions(5)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: {},
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            address: 'not a valid lock address',
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid lock keyPrice', () => {
+        expect.assertions(5)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: 1,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: {},
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: '0.023.0',
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid lock expirationDuration', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            expirationDuration: null,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            expirationDuration: '1',
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            expirationDuration: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            expirationDuration: {},
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid lock key', () => {
+        expect.assertions(1)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            key: null,
+          })
+        ).toBe(false)
+      })
+
+      it('should fail on invalid lock currencyContractAddress', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: 9,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: undefined,
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: [],
+          })
+        ).toBe(false)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: {},
+          })
+        ).toBe(false)
+      })
+    })
+
+    describe('valid locks', () => {
+      it('should accept a basic valid lock', () => {
+        expect.assertions(1)
+
+        expect(validators.isValidLock(validLock)).toBe(true)
+      })
+
+      it('should accept a valid lock with optional fields', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            asOf: 1,
+            maxNumberOfKeys: -1,
+            outstandingKeys: 0,
+            balance: '0',
+            owner: '0x1234567890123456789012345678901234567890',
+            publicLockVersion: 4,
+            currencyContractAddress:
+              '0x9876543210987654321098765432109876543210',
+            some: 'random',
+            fields: 'we do not know about',
+          })
+        ).toBe(true)
+      })
+
+      it('should accept valid currency contract address', () => {
+        expect.assertions(2)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress:
+              '0x9876543210987654321098765432109876543210',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            currencyContractAddress: null,
+          })
+        ).toBe(true)
+      })
+
+      it('should accept valid key price', () => {
+        expect.assertions(4)
+
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: '0.1',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: '.1',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: '1',
+          })
+        ).toBe(true)
+        expect(
+          validators.isValidLock({
+            ...validLock,
+            keyPrice: '21.000',
+          })
+        ).toBe(true)
+      })
+    })
+  })
+
+  describe('isValidLocks', () => {
+    const validLock = {
+      address: '0x1234567890123456789009876543210987654321',
+      keyPrice: '123',
+      expirationDuration: 123,
+      key: {
+        expiration: 1,
+        transactions: [],
+        status: 'none',
+        confirmations: 0,
+        owner: '0x1234567890123456789012345678901234567890',
+        lock: '0x0987654321098765432109876543210987654321',
+      },
+    }
+    const invalidLock = {
+      ...validLock,
+      address: 'not a valid lock',
+    }
+
+    it('should fail on invalid locks', () => {
+      expect.assertions(3)
+
+      expect(validators.isValidLocks(null)).toBe(false)
+      expect(validators.isValidLocks('hi')).toBe(false)
+      expect(validators.isValidLocks([])).toBe(false)
+    })
+
+    it('should fail on any invalid locks', () => {
+      expect.assertions(2)
+
+      expect(
+        validators.isValidLocks({
+          [validLock.address]: validLock,
+          invalidLock,
+        })
+      ).toBe(false)
+      expect(
+        validators.isValidLocks({
+          [validLock.address]: invalidLock,
+          [validLock.address.replace('1', '2')]: invalidLock,
+        })
+      ).toBe(false)
+    })
+
+    it('should succeed if all locks are valid', () => {
+      expect.assertions(1)
+      const address = '0x0987654321098765432109876543210987654321'
+
+      expect(
+        validators.isValidLocks({
+          [validLock.address]: validLock,
+          [address]: {
+            ...validLock,
+            lock: '0x098765432109876543210987654321098765432a',
+            address,
+          },
+        })
+      ).toBe(true)
+    })
+  })
+
+  describe('isValidMetadataField', () => {
+    const name = 'field name'
+    const validType = 'date'
+    const invalidType = 'genome-sequence'
+
+    describe('failures', () => {
+      it('should be false if the name is missing', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            type: validType,
+            required: false,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the name is not a string', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name: 7,
+            type: validType,
+            required: true,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the type is missing', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            required: true,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the type is incorrect', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            type: invalidType,
+            required: true,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the required property is missing', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            type: validType,
+          })
+        ).toBeFalsy()
+      })
+
+      it('should be false if the required property is not a boolean', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            type: validType,
+            required: 7,
+          })
+        ).toBeFalsy()
+      })
+    })
+
+    describe('successes', () => {
+      it('should be true for a valid field input', () => {
+        expect.assertions(1)
+
+        expect(
+          validators.isValidMetadataField({
+            name,
+            type: validType,
+            required: true,
+          })
+        ).toBeTruthy()
+      })
+    })
+  })
+
+  describe('isValidMetadataArray', () => {
+    describe('failures', () => {
+      it('should be false if input is not an array', () => {
+        expect.assertions(1)
+
+        expect(validators.isValidMetadataArray(7)).toBeFalsy()
+      })
+
+      it('should be false if input contains invalid metadata fields', () => {
+        expect.assertions(1)
+
+        const fields = [
+          {
+            name: 'Jeff',
+            type: 'person',
+            required: 7,
+          },
+        ]
+
+        expect(validators.isValidMetadataArray(fields)).toBeFalsy()
+      })
+    })
+
+    describe('successes', () => {
+      it('should be true if all fields are valid', () => {
+        expect.assertions(1)
+
+        const fields = [
+          {
+            name: 'Name',
+            type: 'text',
+            required: true,
+          },
+          {
+            name: 'Email',
+            type: 'email',
+            required: true,
+          },
+          {
+            name: 'Birthday',
+            type: 'date',
+            required: false,
+          },
+        ]
+
+        expect(validators.isValidMetadataArray(fields)).toBeTruthy()
+      })
+    })
+  })
+})

--- a/unlock-app/src/__tests__/utils/getConfigFromSearch.test.ts
+++ b/unlock-app/src/__tests__/utils/getConfigFromSearch.test.ts
@@ -1,0 +1,75 @@
+import getConfigFromSearch from '../../utils/getConfigFromSearch'
+
+let originalConsole: any
+let error = jest.fn()
+
+const lock = '0x1234567890123456789012345678901234567890'
+const validConfig = {
+  callToAction: {
+    default: 'hi',
+    expired: 'there',
+    pending: 'pending',
+    confirmed: 'confirmed',
+  },
+  locks: {
+    [lock]: {
+      name: 'A Lock',
+    },
+  },
+  icon: 'http://image.com/image.tiff',
+}
+
+describe('getConfigFromSearch', () => {
+  beforeAll(() => {
+    originalConsole = global.console
+  })
+  beforeEach(() => {
+    error = jest.fn()
+    ;(global.console as any) = { error }
+  })
+  afterAll(() => {
+    global.console = originalConsole
+  })
+
+  it('should be undefined if there is no paywall config', () => {
+    expect.assertions(2)
+
+    expect(getConfigFromSearch({})).toBeUndefined()
+    expect(error).toHaveBeenCalledWith(
+      'no paywall config found in URL, continuing with undefined'
+    )
+  })
+
+  it('should be undefined if paywall config is malformed JSON', () => {
+    expect.assertions(2)
+
+    expect(getConfigFromSearch({ paywallConfig: '{' })).toBeUndefined()
+    expect(error).toHaveBeenCalledWith(
+      'paywall config in URL not valid JSON, continuing with undefined'
+    )
+  })
+
+  it('should be undefined if paywall config does not pass validation', () => {
+    expect.assertions(2)
+
+    expect(getConfigFromSearch({ paywallConfig: '{}' })).toBeUndefined()
+    expect(error).toHaveBeenCalledWith(
+      'paywall config in URL does not pass validation, continuing with undefined'
+    )
+  })
+
+  it('should return a paywall config otherwise', () => {
+    expect.assertions(2)
+
+    expect(
+      getConfigFromSearch({
+        paywallConfig: encodeURIComponent(JSON.stringify(validConfig)),
+      })
+    ).toEqual(
+      expect.objectContaining({
+        icon: 'http://image.com/image.tiff',
+      })
+    )
+    expect(error).not.toHaveBeenCalled()
+  })
+})

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -1,16 +1,24 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import Head from 'next/head'
+import queryString from 'query-string'
 import BrowserOnly from '../helpers/BrowserOnly'
 import Layout from '../interface/Layout'
 import Account from '../interface/Account'
 import { pageTitle } from '../../constants'
 import LogInSignUp from '../interface/LogInSignUp'
-import { Account as AccountType, Network } from '../../unlockTypes'
+import {
+  Account as AccountType,
+  Network,
+  Router,
+  PaywallConfig,
+} from '../../unlockTypes'
+import getConfigFromSearch from '../../utils/getConfigFromSearch'
 
 interface CheckoutContentProps {
   account: AccountType
   network: Network
+  config?: PaywallConfig
 }
 
 export const CheckoutContent = ({ account, network }: CheckoutContentProps) => {
@@ -35,12 +43,18 @@ export const CheckoutContent = ({ account, network }: CheckoutContentProps) => {
 interface ReduxState {
   account: AccountType
   network: Network
+  router: Router
 }
 
-export const mapStateToProps = ({ account, network }: ReduxState) => {
+export const mapStateToProps = ({ account, network, router }: ReduxState) => {
+  const search = queryString.parse(router.location.search)
+
+  const config = getConfigFromSearch(search)
+
   return {
     account,
     network,
+    config,
   }
 }
 

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -82,6 +82,7 @@ export interface PaywallCallToAction {
   expired: string
   pending: string
   confirmed: string
+  noWallet: string
 }
 
 export interface PaywallConfigLocks {
@@ -90,13 +91,6 @@ export interface PaywallConfigLocks {
 
 export interface PaywallConfigLock {
   name: string
-}
-
-// This interface describes an individual paywall's config
-export interface PaywallConfig {
-  icon: string
-  callToAction: PaywallCallToAction
-  locks: PaywallConfigLocks
 }
 
 export enum KeyStatus {
@@ -169,4 +163,20 @@ export interface KeyholdersByLock {
       }
     }[]
   }[]
+}
+
+export interface MetadataInput {
+  name: string
+  type: 'text' | 'date' | 'color' | 'email' | 'url'
+  required: boolean
+  public?: true // optional, all non-public fields are treated as protected
+}
+
+export interface PaywallConfig {
+  icon?: string
+  unlockUserAccounts?: true | 'true' | false
+  callToAction: PaywallCallToAction
+  locks: PaywallConfigLocks
+  metadataInputs?: MetadataInput[]
+  persistentCheckout?: boolean
 }

--- a/unlock-app/src/utils/checkoutValidators.js
+++ b/unlock-app/src/utils/checkoutValidators.js
@@ -1,0 +1,443 @@
+import isURL from 'validator/lib/isURL'
+import isDataURI from 'validator/lib/isDataURI'
+import isDecimal from 'validator/lib/isDecimal'
+
+import { ACCOUNT_REGEXP } from '../constants'
+
+/* eslint-disable no-console */
+
+// tests whether a field's value was not entered by the user
+export const isNotEmpty = val => val || val === 0
+
+// tests whether a number is non-negative and not a decimal number
+export const isPositiveInteger = val => {
+  const parsedInt = parseInt(val)
+  return !isNaN(parsedInt) && val == parsedInt && +val >= 0
+}
+
+// tests whether a number is a non-negative real number (decimals allowed)
+export const isPositiveNumber = val => {
+  const parsedFloat = parseFloat(val)
+  return !isNaN(parsedFloat) && +parsedFloat >= 0
+}
+
+export const isAccount = val => {
+  return val && typeof val === 'string' && val.match(ACCOUNT_REGEXP)
+}
+
+export const isAccountOrNull = val => {
+  return val === null || isAccount(val)
+}
+
+export const isValidIcon = icon => {
+  if (typeof icon !== 'string') {
+    console.error('The paywall config\'s "icon" property is not a string.')
+    return false
+  }
+  if (
+    icon &&
+    !isURL(icon, {
+      allow_underscores: true,
+      allow_protocol_relative_urls: true,
+      disallow_auth: true,
+    }) &&
+    !isDataURI(icon)
+  ) {
+    console.error('The paywall config\'s "icon" property is not a valid URL.')
+    return false
+  }
+  return true
+}
+
+export const isValidCTA = callToAction => {
+  const callsToAction = [
+    'default',
+    'expired',
+    'pending',
+    'confirmed',
+    'noWallet',
+  ]
+
+  const ctaKeys = Object.keys(callToAction)
+
+  if (ctaKeys.length > callsToAction.length) {
+    console.error(
+      'The paywall config\'s "callToAction" properties contain an unexpected entry.'
+    )
+    return false
+  }
+  if (ctaKeys.filter(key => !callsToAction.includes(key)).length) {
+    // TODO: log which key is bad, or remove this check
+    console.error(
+      'The paywall config\'s "callToAction" properties contain an unexpected entry.'
+    )
+    return false
+  }
+  if (ctaKeys.filter(key => typeof callToAction[key] !== 'string').length) {
+    console.error(
+      'The paywall config\'s "callToAction" properties contain an entry whose value is not a string.'
+    )
+    return false
+  }
+
+  return true
+}
+
+export const isValidConfigLock = (lock, configLocks) => {
+  if (!isAccount(lock)) return false
+  const thisLock = configLocks[lock]
+  if (!thisLock || typeof thisLock !== 'object') return false
+  if (!Object.keys(thisLock).length) return true
+  if (Object.keys(thisLock).length !== 1) return false
+  if (
+    typeof thisLock.name !== 'undefined' &&
+    typeof thisLock.name !== 'string'
+  ) {
+    // TODO: which of the above conditions did it fail on?
+    console.error(
+      `The paywall config's "locks" field contains a key "${lock}" which has an invalid value.`
+    )
+    return false
+  }
+  return true
+}
+
+export const isValidConfigLocks = configLocks => {
+  if (typeof configLocks !== 'object') {
+    console.error('The paywall configs\'s "locks" field is not an object.')
+    return false
+  }
+  const locks = Object.keys(configLocks)
+  if (!locks.length) return false
+  if (
+    locks.filter(lock => isValidConfigLock(lock, configLocks)).length !==
+    locks.length
+  ) {
+    // The logging of lock failures in `isValidConfigLock` should make
+    // it clear which lock caused this to fail.
+    return false
+  }
+
+  return true
+}
+
+/**
+ * For now, this assumes this structure:
+ *
+ * var unlockProtocolConfig = {
+ *   locks: {
+ *     '0xabc...': {
+ *   	   name: 'One Week',
+ *      },
+ *      '0xdef...': {
+ *        name: 'One Month',
+ *      },
+ *      '0xghi...': {
+ *        name: 'One Year',
+ *      },
+ *    },
+ *    icon: 'https://...',
+ *    callToAction: {
+ *	    default:
+ *        'Enjoy Forbes Online without any ads for as little as $2 a week. Pay with Ethereum in just two clicks.',
+ *      expired:
+ *        'your key has expired, please purchase a new one',
+ *      pending: 'Purchase pending...',
+ *      confirmed: 'Your content is unlocked!',
+ *      noWallet: 'Please, get a wallet!',
+ *   },
+ * }
+ *
+ * The fields in callToAction are all optional, and icon can be false for none
+ */
+export const isValidPaywallConfig = config => {
+  if (!config) {
+    console.error('No paywall config provided.')
+    return false
+  }
+  if (!isValidObject(config, ['callToAction', 'locks'])) {
+    console.error(
+      'The paywall config does not contain at least one of the required fields: "callToAction", "locks".'
+    )
+    return false
+  }
+
+  // Icon may not be specified
+  if (config.icon) {
+    if (!isValidIcon(config.icon)) {
+      return false
+    }
+  }
+
+  if (typeof config.callToAction !== 'object') {
+    console.error(
+      'The paywall config\'s "callToAction" property is not a valid object.'
+    )
+    return false
+  }
+  if (!isValidCTA(config.callToAction)) {
+    return false
+  }
+
+  // TODO: !locks should have been checked already in the isValidObject check above?
+  if (!config.locks) {
+    console.error('The paywall config\'s "locks" fields is not set.')
+    return false
+  }
+  if (!isValidConfigLocks(config.locks)) {
+    return false
+  }
+
+  if (
+    config.unlockUserAccounts &&
+    !(
+      typeof config.unlockUserAccounts === 'boolean' ||
+      config.unlockUserAccounts === 'true' ||
+      config.unlockUserAccounts === 'false'
+    )
+  ) {
+    console.error(
+      'The paywall config\'s "unlockUserAccounts" field has an invalid value.'
+    )
+    return false
+  }
+
+  // persistentCheckout can be undefined (not set), a boolean, or "true" or "false".
+  if (
+    typeof config.persistentCheckout !== 'undefined' &&
+    typeof config.persistentCheckout !== 'boolean' &&
+    ['true', 'false'].indexOf(config.persistentCheckout) === -1
+  ) {
+    console.error(
+      'The paywall config\'s "persistentCheckout" field has an invalid value.'
+    )
+    return false
+  }
+
+  if (config.metadataInputs) {
+    if (!isValidMetadataArray(config.metadataInputs)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * helper function to assert on a thing being an
+ * object with required and optional keys
+ *
+ * No assertion on the types of the values is done here
+ */
+function isValidObject(obj, validKeys) {
+  if (!obj || typeof obj !== 'object') return false
+  const keys = Object.keys(obj)
+
+  if (keys.length < validKeys.length) return false
+  if (validKeys.filter(key => !keys.includes(key)).length) return false
+  return true
+}
+
+function isValidKeyStatus(status) {
+  if (typeof status !== 'string') return false
+  if (
+    ![
+      'none',
+      'confirming',
+      'confirmed',
+      'expired',
+      'valid',
+      'submitted',
+      'pending',
+      'failed',
+      'stale',
+    ].includes(status)
+  ) {
+    return false
+  }
+  return true
+}
+
+/**
+ * validate a single key. This should match the type in unlockTypes.ts
+ */
+export const isValidKey = key => {
+  if (
+    !isValidObject(key, [
+      'expiration',
+      'transactions',
+      'status',
+      'confirmations',
+      'owner',
+      'lock',
+    ])
+  ) {
+    return false
+  }
+
+  if (
+    typeof key.expiration !== 'number' ||
+    !isPositiveInteger(key.expiration)
+  ) {
+    return false
+  }
+  if (!Array.isArray(key.transactions)) return false
+  if (!isValidKeyStatus(key.status)) return false
+  if (
+    typeof key.confirmations !== 'number' ||
+    !isPositiveInteger(key.confirmations)
+  ) {
+    return false
+  }
+  if (!isAccount(key.owner)) return false
+  if (!isAccount(key.lock)) return false
+  // NOTE: transactions are not used in the UI, and may be removed, so
+  // for now we do not validate them. If this ever changes, they must
+  // be validated
+  /*
+  if (
+    key.transactions.filter(transaction => !isValidTransaction(transaction))
+      .length
+  ) {
+    return false
+  }
+  */
+  return true
+}
+
+/**
+ * validate a single lock. This should match the type in unlockTypes.ts
+ */
+export const isValidLock = lock => {
+  if (
+    !isValidObject(lock, ['address', 'keyPrice', 'expirationDuration', 'key'])
+  ) {
+    return false
+  }
+
+  if (lock.hasOwnProperty('name') && typeof lock.name !== 'string') return false
+  if (
+    lock.hasOwnProperty('currencyContractAddress') &&
+    !isAccountOrNull(lock.currencyContractAddress)
+  ) {
+    return false
+  }
+  if (!isAccount(lock.address)) return false
+  if (typeof lock.keyPrice !== 'string' || !isDecimal(lock.keyPrice)) {
+    return false
+  }
+  if (
+    typeof lock.expirationDuration !== 'number' ||
+    !isPositiveInteger(lock.expirationDuration)
+  ) {
+    return false
+  }
+  if (!isValidKey(lock.key)) return false
+  return true
+}
+
+/**
+ * validate the list of locks returned from the data iframe
+ */
+export const isValidLocks = locks => {
+  if (!locks || typeof locks !== 'object' || Array.isArray(locks)) return false
+  const keys = Object.keys(locks)
+  if (keys.filter(key => !isAccount(key)).length) return false
+  const lockValues = Object.values(locks)
+  if (lockValues.filter(lock => !isValidLock(lock)).length) return false
+  return true
+}
+
+/**
+ * validate the list of keys returned from the data iframe
+ * TODO: consider if validation is actually required
+ */
+export const isValidKeys = () => {
+  return true
+}
+
+/**
+ * validate the list of transactions returned from the data iframe
+ * TODO: consider if validation is actually required
+ */
+export const isValidTransactions = () => {
+  return true
+}
+
+/**
+ * validate a balance as an object of currency: balance
+ */
+export const isValidBalance = balance => {
+  if (!balance || typeof balance !== 'object' || Array.isArray(balance)) {
+    return false
+  }
+  return Object.keys(balance).reduce((accumulator, currency) => {
+    return (
+      accumulator &&
+      isPositiveNumber(balance[currency]) &&
+      typeof balance[currency] === 'string'
+    )
+  }, true)
+}
+
+const allowedInputTypes = ['text', 'date', 'color', 'email', 'url']
+
+/**
+ * A valid metadata field looks like:
+ * {
+ *   name: 'field name', // any string
+ *   type: 'date', // any valid html input type
+ *   required: false, // a boolean
+ * }
+ */
+export const isValidMetadataField = field => {
+  const requiredKeys = ['name', 'type', 'required']
+  const hasRequiredProperties = isValidObject(field, requiredKeys)
+
+  if (!hasRequiredProperties) {
+    // TODO: more specificity in error messages
+    console.error(
+      'A field in the metadata fields in the paywall config is missing a required property.'
+    )
+    return false
+  }
+
+  const { name, type, required } = field
+
+  if (typeof name !== 'string') {
+    console.error(`Paywall metadata field error: ${name} is not a string.`)
+    return false
+  }
+
+  if (!allowedInputTypes.includes(type)) {
+    console.error(
+      `Paywall metadata field error: ${type} is not an allowed input type.`
+    )
+    return false
+  }
+
+  if (typeof required !== 'boolean') {
+    console.error(`Paywall metadata field error: ${required} is not a boolean.`)
+    return false
+  }
+
+  return true
+}
+
+export const isValidMetadataArray = fields => {
+  if (!Array.isArray(fields)) {
+    console.error('Paywall config metadata property is not an array.')
+    return false
+  }
+
+  // TODO: disallow multiple fields with the same name?
+  const validFields = fields.filter(isValidMetadataField)
+  if (validFields.length !== fields.length) {
+    console.error(
+      'Paywall config metadata contains an invalid field description.'
+    )
+    return false
+  }
+
+  return true
+}

--- a/unlock-app/src/utils/getConfigFromSearch.ts
+++ b/unlock-app/src/utils/getConfigFromSearch.ts
@@ -1,0 +1,35 @@
+import { PaywallConfig } from '../unlockTypes'
+import { isValidPaywallConfig } from './checkoutValidators'
+/* eslint-disable no-console */
+
+export default function getConfigFromSearch(
+  search: any
+): PaywallConfig | undefined {
+  if (typeof search.paywallConfig !== 'string') {
+    console.error('no paywall config found in URL, continuing with undefined')
+    return undefined
+  }
+
+  const rawConfig = search.paywallConfig
+  const decodedConfig = decodeURIComponent(rawConfig)
+
+  let parsedConfig: any
+
+  try {
+    parsedConfig = JSON.parse(decodedConfig)
+  } catch (e) {
+    console.error(
+      'paywall config in URL not valid JSON, continuing with undefined'
+    )
+    return undefined
+  }
+
+  if (isValidPaywallConfig(parsedConfig)) {
+    return parsedConfig as PaywallConfig
+  }
+
+  console.error(
+    'paywall config in URL does not pass validation, continuing with undefined'
+  )
+  return undefined
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR makes the `CheckoutContent` component parse the paywall config from a URL param if it is present. No visible change here yet, the prop is just available to the component for future use.

One surprisingly huge part of this PR was moving the associated validators over from the paywall subrepo.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
