### PR TITLE
Renovate: switch to Sundays to miss less updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     ":doNotPinPackage(node)"
   ],
   "timezone": "America/Los_Angeles",
-  "schedule": ["before 3am on monday"],
+  "schedule": ["on sunday"],
   "rebaseStalePrs": false,
   "minor": {
     "groupName": "minor and patch updates"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Renovate missed a lot of updates the past 2 weeks.  Looking at the logs, it seems to be failing with a network issue more often then not -- and it retries once per hour.  So instead of a 3 hour window Monday morning, maybe a 24 window over the weekend will work more reliably.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
