### PR TITLE
Fix occasional test fail due to timestamp

### DIFF
--- a/smart-contracts/test/Lock/grantKeys.js
+++ b/smart-contracts/test/Lock/grantKeys.js
@@ -15,9 +15,10 @@ let tx
 contract('Lock / grantKeys', accounts => {
   const lockOwner = accounts[1]
   const keyOwner = accounts[2]
-  const validExpirationTimestamp = Math.round(Date.now() / 1000 + 600)
+  let validExpirationTimestamp
 
   before(async () => {
+    validExpirationTimestamp = Math.round(Date.now() / 1000 + 600)
     unlock = await getProxy(unlockContract)
     locks = await deployLocks(unlock, lockOwner)
     lock = locks.FIRST
@@ -47,9 +48,10 @@ contract('Lock / grantKeys', accounts => {
     })
 
     describe('can grant a key extension for an existing user', () => {
-      const extendedExpiration = validExpirationTimestamp + 100
+      let extendedExpiration
 
       before(async () => {
+        extendedExpiration = validExpirationTimestamp + 100
         tx = await lock.grantKeys([keyOwner], [extendedExpiration], {
           from: lockOwner,
         })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Sometimes the test pass fails due to this timestamp being expired by the test actually runs.  This is because it uses the date when the JS parsed, vs the date when that specific test begins.  As a result when running the full suite, 10 mins may have already passed.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
