### PR TITLE
Edit updateBeneficiary permissions to allow both LockManagers and the Beneficiary

### DIFF
--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -164,8 +164,8 @@ contract MixinLockCore is
   function updateBeneficiary(
     address _beneficiary
   ) external
-    onlyLockManager
   {
+    require(msg.sender == beneficiary || isLockManager(msg.sender), 'ONLY_BENEFICIARY_OR_LOCKMANAGER');
     require(_beneficiary != address(0), 'INVALID_ADDRESS');
     beneficiary = _beneficiary;
   }

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -164,8 +164,8 @@ contract MixinLockCore is
   function updateBeneficiary(
     address _beneficiary
   ) external
+    onlyLockManager
   {
-    require(msg.sender == beneficiary, 'ONLY_BENEFICIARY');
     require(_beneficiary != address(0), 'INVALID_ADDRESS');
     beneficiary = _beneficiary;
   }

--- a/smart-contracts/test/Lock/permissions/beneficiary.js
+++ b/smart-contracts/test/Lock/permissions/beneficiary.js
@@ -36,18 +36,17 @@ contract('Permissions / Beneficiary', accounts => {
       assert.equal(currentBenficiary, newBeneficiary)
     })
 
-    it('should not allow the current beneficiary to update the beneficiary', async () => {
+    it('should allow Beneficiary to update the beneficiary', async () => {
       currentBenficiary = await lock.beneficiary.call()
-      await reverts(
-        lock.updateBeneficiary(accounts[5], { from: currentBenficiary }),
-        'MixinLockManager: caller does not have the LockManager role'
-      )
+      await lock.updateBeneficiary(accounts[8], { from: currentBenficiary })
+      currentBenficiary = await lock.beneficiary.call()
+      assert.equal(currentBenficiary, accounts[8])
     })
 
     it('should not allow anyone else to update the beneficiary', async () => {
       await reverts(
         lock.updateBeneficiary(accounts[5], { from: notAuthorised }),
-        'MixinLockManager: caller does not have the LockManager role'
+        'ONLY_BENEFICIARY_OR_LOCKMANAGER'
       )
     })
   })

--- a/smart-contracts/test/Lock/permissions/beneficiary.js
+++ b/smart-contracts/test/Lock/permissions/beneficiary.js
@@ -1,0 +1,54 @@
+const { reverts } = require('truffle-assertions')
+const deployLocks = require('../../helpers/deployLocks')
+const getProxy = require('../../helpers/proxy')
+
+const unlockContract = artifacts.require('../Unlock.sol')
+
+let unlock
+let locks
+let lock
+let lockCreator
+let notAuthorised
+let currentBenficiary
+let newBeneficiary
+
+contract('Permissions / Beneficiary', accounts => {
+  lockCreator = accounts[0]
+  notAuthorised = accounts[9]
+  newBeneficiary = accounts[1]
+
+  before(async () => {
+    unlock = await getProxy(unlockContract)
+    locks = await deployLocks(unlock, lockCreator)
+    lock = locks.FIRST
+  })
+
+  describe('default permissions on a new lock', () => {
+    it('should make the lock creator the beneficiary as well', async () => {
+      const defaultBeneficiary = await lock.beneficiary.call()
+      assert.equal(defaultBeneficiary, lockCreator)
+    })
+  })
+  describe('modifying permissions on an existing lock', () => {
+    it('should allow a lockManager to update the beneficiary', async () => {
+      await lock.updateBeneficiary(newBeneficiary, { from: lockCreator })
+      currentBenficiary = await lock.beneficiary.call()
+      assert.equal(currentBenficiary, newBeneficiary)
+    })
+
+    it('should not allow the current beneficiary to update the beneficiary', async () => {
+      currentBenficiary = await lock.beneficiary.call()
+      await reverts(
+        lock.updateBeneficiary(accounts[5], { from: currentBenficiary }),
+        'MixinLockManager: caller does not have the LockManager role'
+      )
+    })
+
+    it('should not allow anyone else to update the beneficiary', async () => {
+      await reverts(
+        lock.updateBeneficiary(accounts[5], { from: notAuthorised }),
+        'MixinLockManager: caller does not have the LockManager role'
+      )
+    })
+  })
+})

--- a/smart-contracts/test/Lock/permissions/keyGranter.js
+++ b/smart-contracts/test/Lock/permissions/keyGranter.js
@@ -12,7 +12,7 @@ let lockCreator
 let notAuthorised
 let newKeyGranter
 
-contract('Lock / updateKeyPricing', accounts => {
+contract('Permissions / KeyGranter', accounts => {
   lockCreator = accounts[0]
   notAuthorised = accounts[9]
   newKeyGranter = accounts[1]

--- a/smart-contracts/test/Lock/withdraw.js
+++ b/smart-contracts/test/Lock/withdraw.js
@@ -138,12 +138,6 @@ contract('Lock / withdraw', accounts => {
 
       await lock.updateBeneficiary(beneficiary, { from: owner })
     })
-    it('the owner can no longer update the beneficiary', async () => {
-      await reverts(
-        lock.updateBeneficiary(owner, { from: owner }),
-        'ONLY_BENEFICIARY'
-      )
-    })
 
     it('can withdraw from beneficiary account', async () => {
       await lock.withdraw(tokenAddress, 42, {


### PR DESCRIPTION
# Description
This is undoing a change made recently, while also migrating to using lockManager instead of owner. It also adds a new test file under the `test/Lock/permissions` directory
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #5952 
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
