### PR TITLE
updated useLocks to retrieve past transactions and create locks

### DIFF
--- a/unlock-app/src/__tests__/hooks/useLocks.test.js
+++ b/unlock-app/src/__tests__/hooks/useLocks.test.js
@@ -1,14 +1,28 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook, act } from '@testing-library/react-hooks'
 import React from 'react'
+import * as redux from 'react-redux'
+import { EventEmitter } from 'events'
+import { StorageServiceContext } from '../../utils/withStorageService'
+import { Web3ServiceContext } from '../../utils/withWeb3Service'
+import { WalletServiceContext } from '../../utils/withWalletService'
+
 import useLocks from '../../hooks/useLocks'
 import { UNLIMITED_KEYS_COUNT } from '../../constants'
 
-const mockWeb3Service = {
-  getLock: jest.fn(() => Promise.resolve({})),
+import configure from '../../config'
+
+const config = configure()
+class MockWeb3Service extends EventEmitter {
+  constructor() {
+    super()
+  }
 }
-const mockGraphService = {
-  locksByOwner: jest.fn(() => Promise.resolve(graphLocks)),
-}
+
+let mockWeb3Service
+
+const mockWalletService = {}
+const mockStorageService = {}
+const mockGraphService = {}
 
 jest.mock('../../services/graphService', () => {
   return () => {
@@ -19,11 +33,55 @@ jest.mock('../../services/graphService', () => {
 const ownerAddress = '0xlockOwner'
 
 let graphLocks = []
+let pastTransactions = {}
+const web3ServiceLock = {
+  name: 'My Lock',
+}
+
+const networkName = 1984
 
 describe('useLocks', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.spyOn(React, 'useContext').mockImplementation(() => mockWeb3Service)
+
+    jest.spyOn(React, 'useContext').mockImplementation(context => {
+      if (context === Web3ServiceContext) {
+        return mockWeb3Service
+      }
+      if (context === WalletServiceContext) {
+        return mockWalletService
+      }
+      if (context === StorageServiceContext) {
+        return mockStorageService
+      }
+    })
+    jest.spyOn(redux, 'useSelector').mockImplementation(() => ({
+      name: networkName,
+    }))
+
+    mockWeb3Service = new MockWeb3Service()
+    mockWeb3Service.getLock = jest.fn(address => {
+      return Promise.resolve({
+        address,
+        ...web3ServiceLock,
+      })
+    })
+    mockWeb3Service.generateLockAddress = jest.fn(() =>
+      Promise.resolve('0xnewLockAddress')
+    )
+
+    mockWalletService.connect = jest.fn(() => {})
+    mockWalletService.createLock = jest.fn(() => {})
+
+    pastTransactions = {}
+    mockStorageService.getRecentTransactionsHashesSentBy = jest.fn(() =>
+      Promise.resolve({
+        hashes: Object.keys(pastTransactions),
+      })
+    )
+    mockStorageService.storeTransaction = jest.fn(() => {})
+
+    mockGraphService.locksByOwner = jest.fn(() => Promise.resolve(graphLocks))
   })
 
   it('should default to loading and an empty list', async () => {
@@ -31,11 +89,11 @@ describe('useLocks', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useLocks(ownerAddress)
     )
-    const [loading, locks] = result.current
+    const { loading, locks } = result.current
     expect(loading).toBe(true)
     expect(locks.length).toBe(0)
     await waitForNextUpdate()
-    const [loadingAfter, locksAfter] = result.current
+    const { loading: loadingAfter, locks: locksAfter } = result.current
     expect(loadingAfter).toBe(false)
     expect(locksAfter.length).toBe(0)
   })
@@ -54,11 +112,53 @@ describe('useLocks', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useLocks(ownerAddress)
     )
-    await waitForNextUpdate()
-    const [loading, locks] = result.current
+    await waitForNextUpdate() // Set the locks
+    await waitForNextUpdate() // Set the waiting
+    const { loading, locks } = result.current
     expect(loading).toBe(false)
     expect(locks.length).toBe(2)
     expect(mockGraphService.locksByOwner).toHaveBeenCalledWith(ownerAddress)
+  })
+
+  it('retrieve the list of recent transactions as they may include lock creations', async () => {
+    expect.assertions(5)
+    graphLocks = []
+    pastTransactions = {
+      '0xt1': {
+        lock: '0x123',
+      },
+      '0xt2': {
+        lock: '0x456',
+      },
+    }
+    mockStorageService.getRecentTransactionsHashesSentBy = jest.fn(() =>
+      Promise.resolve({
+        hashes: Object.keys(pastTransactions),
+      })
+    )
+
+    mockWeb3Service.getTransaction = jest.fn(hash => {
+      mockWeb3Service.emit('transaction.updated', hash, {
+        lock: pastTransactions[hash].lock,
+      })
+    })
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useLocks(ownerAddress)
+    )
+    await waitForNextUpdate()
+    const { loading, locks } = result.current
+    expect(loading).toBe(false)
+    expect(locks.length).toBe(2)
+    expect(
+      mockStorageService.getRecentTransactionsHashesSentBy
+    ).toHaveBeenCalledWith(ownerAddress)
+    expect(mockWeb3Service.getTransaction).toHaveBeenCalledTimes(
+      Object.keys(pastTransactions).length
+    )
+    expect(mockWeb3Service.getLock).toHaveBeenCalledTimes(
+      Object.keys(pastTransactions).length
+    )
   })
 
   it('retrieve the locks details', async () => {
@@ -71,18 +171,13 @@ describe('useLocks', () => {
         address: '0x456',
       },
     ]
-    const web3ServiceLock = {
-      name: 'My Lock',
-    }
-    mockWeb3Service.getLock = jest.fn(() => {
-      return Promise.resolve(web3ServiceLock)
-    })
 
     const { result, waitForNextUpdate } = renderHook(() =>
       useLocks(ownerAddress)
     )
-    await waitForNextUpdate()
-    const [loading, locks] = result.current
+    await waitForNextUpdate() // set the locks
+    await waitForNextUpdate() // sets loading as false
+    const { loading, locks } = result.current
     expect(loading).toBe(false)
     expect(locks.length).toBe(2)
     expect(mockWeb3Service.getLock).toHaveBeenCalledWith(graphLocks[0].address)
@@ -108,13 +203,137 @@ describe('useLocks', () => {
       useLocks(ownerAddress)
     )
     await waitForNextUpdate()
-    const [loading, locks] = result.current
+    const { loading, locks } = result.current
     expect(loading).toBe(false)
     expect(locks.length).toBe(1)
     expect(locks[0]).toEqual({
       ...web3ServiceLock,
       address: graphLocks[0].address,
       unlimitedKeys: true,
+    })
+  })
+
+  it('merges locks when the same is yieded by the graph and past transactions', async () => {
+    expect.assertions(2)
+    graphLocks = [
+      {
+        address: '0x123',
+      },
+    ]
+    pastTransactions = {
+      '0xt1': {
+        lock: '0x123',
+      },
+      '0xt3': {}, // This transaction does not create a lock
+    }
+
+    mockStorageService.getRecentTransactionsHashesSentBy = jest.fn(() =>
+      Promise.resolve({
+        hashes: Object.keys(pastTransactions),
+      })
+    )
+
+    mockWeb3Service.getTransaction = jest.fn(hash => {
+      mockWeb3Service.emit('transaction.updated', hash, {
+        lock: pastTransactions[hash].lock,
+      })
+    })
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useLocks(ownerAddress)
+    )
+    await waitForNextUpdate() // First render when lock is loaded through The Graph
+    await waitForNextUpdate() // Second render when the lock is loaded through past transactions
+    const { loading, locks } = result.current
+    expect(loading).toBe(false)
+    expect(locks.length).toBe(1)
+  })
+
+  describe('addLock', () => {
+    let result
+    const lock = {
+      name: 'New lock',
+      expirationDuration: 100,
+      keyPrice: '1.0',
+      maxNumberOfKeys: 1000,
+      owner: ownerAddress,
+    }
+    const lockCreationTransasctionHash = '0xnewLockTransactionHash'
+
+    beforeEach(async () => {
+      const rendered = renderHook(() => useLocks(ownerAddress))
+      await rendered.waitForNextUpdate()
+      result = rendered.result
+      // NOTE: There's a gotcha with updates. renderHook mutates the value of current when updates happen so you cannot destructure its values as the assignment will make a copy locking into the value at that time.
+      // https://react-hooks-testing-library.com/usage/basic-hooks
+      mockWalletService.createLock = jest.fn((lock, callback) => {
+        return callback(null, lockCreationTransasctionHash)
+      })
+    })
+
+    it('should generate the lock address', async done => {
+      expect.assertions(1)
+      await act(async () => {
+        await result.current.addLock(lock, done)
+      })
+      expect(mockWeb3Service.generateLockAddress).toHaveBeenCalledWith(
+        ownerAddress,
+        lock
+      )
+    })
+
+    it('should create the lock', async done => {
+      expect.assertions(1)
+      await act(async () => {
+        await result.current.addLock(lock, done)
+      })
+      expect(mockWalletService.createLock).toHaveBeenCalledWith(
+        {
+          expirationDuration: lock.expirationDuration,
+          keyPrice: lock.keyPrice,
+          maxNumberOfKeys: lock.maxNumberOfKeys,
+          owner: lock.owner,
+          name: lock.name,
+          currencyContractAddress: lock.currencyContractAddress,
+        },
+        expect.any(Function)
+      )
+    })
+
+    it('should store the new transaction', async done => {
+      expect.assertions(1)
+      await act(async () => {
+        await result.current.addLock(lock, done)
+      })
+
+      expect(mockStorageService.storeTransaction).toHaveBeenCalledWith(
+        lockCreationTransasctionHash,
+        ownerAddress,
+        config.unlockAddress,
+        networkName
+      )
+    })
+
+    it('should return the lock as part of the locks state', async done => {
+      expect.assertions(1)
+      const locksLength = result.current.locks.length
+      await act(async () => {
+        await result.current.addLock(lock, done)
+      })
+      expect(result.current.locks.length).toEqual(locksLength + 1)
+    })
+
+    it('should update the error when there was an error to create the lock', async () => {
+      expect.assertions(1)
+      const errorMessage = 'An error occured'
+      await act(async () => {
+        mockWalletService.createLock = jest.fn((lock, callback) => {
+          callback(new Error(errorMessage))
+          return Promise.resolve({})
+        })
+        await result.current.addLock(lock, () => {})
+      })
+      expect(result.current.error.message).toEqual('An error occured')
     })
   })
 })

--- a/unlock-app/src/hooks/useLocks.js
+++ b/unlock-app/src/hooks/useLocks.js
@@ -1,6 +1,10 @@
-import { useState, useEffect, useContext } from 'react'
+import { useState, useEffect, useContext, useReducer } from 'react'
+import { useSelector } from 'react-redux'
+import { TransactionType } from '../unlockTypes'
 import { UNLIMITED_KEYS_COUNT } from '../constants'
+import { StorageServiceContext } from '../utils/withStorageService'
 import { Web3ServiceContext } from '../utils/withWeb3Service'
+import { WalletServiceContext } from '../utils/withWalletService'
 
 import GraphService from '../services/graphService'
 import configure from '../config'
@@ -16,13 +20,47 @@ const config = configure()
  */
 export const useLocks = owner => {
   // Let's retrieve the locks!
-  const [loading, setLoading] = useState(true)
-  const [locks, setLocks] = useState([])
+  const network = useSelector(state => state.network)
   const web3Service = useContext(Web3ServiceContext)
+  const walletService = useContext(WalletServiceContext)
+  const storageService = useContext(StorageServiceContext)
+  const [error, setError] = useState(undefined)
+  const [loading, setLoading] = useState(true)
+
+  // We use a reducer so we can easily add locks as they are retrieved
+  const [locks, addToLocks] = useReducer((locks, lock) => {
+    let l = locks.find(element => element.address === lock.address)
+    if (!l) {
+      // New lock, add it
+      return [lock, ...locks]
+    }
+    // The lock already exists. we merge
+    l = {
+      ...l,
+      ...lock,
+    }
+    return locks
+  }, [])
 
   // TODO Load thru context
-  const { subgraphURI } = config
+  const { subgraphURI, unlockAddress } = config
+  // TODO: move to context
   const graphService = new GraphService(subgraphURI)
+
+  // Connect to the provider.
+  // TODO: this should probably be moved upstream
+  // It is noop if already called somewhere else
+  walletService.connect(config.providers[Object.keys(config.providers)[0]])
+
+  /**
+   * Helper function: retrieves a lock object at the address
+   */
+  const getLockAtAddress = async address => {
+    const lock = await web3Service.getLock(address)
+    lock.unlimitedKeys = lock.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
+    lock.address = address
+    return lock
+  }
 
   /**
    * Retrieves the locks for a user
@@ -36,29 +74,101 @@ export const useLocks = owner => {
     )
 
     const lockPromises = lockAddresses.map(async (address, index) => {
-      // HACK: We delay each lock by 300ms to avoid rate limits...
+      // HACK: We delay each lock retrieval by 300ms to avoid rate limits...
       await new Promise(resolve => {
         setTimeout(() => {
           resolve()
         }, 300 * index)
       })
-
-      const lock = await web3Service.getLock(address)
-      lock.unlimitedKeys = lock.maxNumberOfKeys === UNLIMITED_KEYS_COUNT
-      lock.address = address
-      return lock
+      addToLocks(await getLockAtAddress(address))
     })
-
-    const locks = await Promise.all(lockPromises)
-    setLocks(locks)
+    await Promise.all(lockPromises)
     setLoading(false)
   }
 
+  /**
+   * Let's also retrieve past transactions for this user which locksmith keeps track of just in case one of them is a lock creation!
+   */
+  const retrieveLockCreationTransactions = async () => {
+    const { hashes } = await storageService.getRecentTransactionsHashesSentBy(
+      owner
+    )
+
+    // For each transaction, we will get a 'transaction.updated' event
+    // TODO: change API for unlockJS to yield promises rather than events
+    web3Service.on('transaction.updated', async (transactionHash, update) => {
+      if (update.lock) {
+        const lock = await getLockAtAddress(update.lock)
+        addToLocks(lock)
+      }
+    })
+
+    // For each of the hashes, let's retrieve the transaction
+    hashes.forEach(hash => {
+      web3Service.getTransaction(hash)
+    })
+  }
+
+  /**
+   * Retrieves the locks when initialized
+   * Both by retrieving them from the graph and by retrieving pending transactions
+   */
   useEffect(() => {
     retrieveLocks()
+    retrieveLockCreationTransactions()
   }, [owner])
 
-  return [loading, locks]
+  /**
+   * Function to create a lock to be added to the list of locks
+   * @param {*} lock
+   */
+  const addLock = async (lock, callback) => {
+    // New locks have the following properties
+    lock.outstandingKeys = 0
+    lock.balance = '0'
+    // First get the address
+    const address = await web3Service.generateLockAddress(owner, lock)
+    lock.address = address
+
+    // Second, create the lock
+    return walletService.createLock(
+      {
+        expirationDuration: lock.expirationDuration,
+        keyPrice: lock.keyPrice,
+        maxNumberOfKeys: lock.maxNumberOfKeys,
+        owner: lock.owner,
+        name: lock.name,
+        currencyContractAddress: lock.currencyContractAddress,
+      },
+      (createLockError, transactionHash) => {
+        if (createLockError) {
+          setError(createLockError)
+          callback(createLockError)
+        } else {
+          // Third, set it!
+          lock.creationTransaction = {
+            confirmations: 0,
+            createdAt: new Date().getTime(),
+            hash: transactionHash,
+            lock: lock.address,
+            type: TransactionType.LOCK_CREATION,
+          }
+          // Store the hash!
+          storageService.storeTransaction(
+            transactionHash,
+            owner,
+            unlockAddress,
+            network.name
+          )
+
+          addToLocks(lock)
+          callback(null, lock)
+        }
+      }
+    )
+  }
+
+  return { error, loading, locks, addLock }
 }
 
 export default useLocks


### PR DESCRIPTION
# Description

This Pull Request adds the ability to retrieve pas transactions for users to identify pending locks.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->