### PR TITLE
[WIP] Adding a keyManager for each key

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -381,6 +381,17 @@ contract IPublicLock is IERC721Enumerable {
     address _keyManager
   ) external;
 
+  /**
+  * @notice Update transfer and cancel rights for a given key
+  * @param _tokenId The id of the key to assign rights for
+  * @param _keyManager The address to assign the rights to for the given key
+  * */
+  //
+  function _updateKeyManagerOf(
+    uint _tokenId,
+    address _keyManager
+  ) external;
+
   /// @notice A descriptive name for a collection of NFTs in this contract
   function name() external view returns (string memory _name);
   ///===================================================================

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -390,7 +390,7 @@ contract IPublicLock is IERC721Enumerable {
   function _updateKeyManagerOf(
     uint _tokenId,
     address _keyManager
-  ) external;
+  ) internal;
 
   /// @notice A descriptive name for a collection of NFTs in this contract
   function name() external view returns (string memory _name);

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -382,15 +382,24 @@ contract IPublicLock is IERC721Enumerable {
   ) external;
 
   /**
+  * @notice Get the key manager for the given tokenId
+  * @param _tokenId The id of the key to assign rights for
+  * @return The address of the manager for the given key
+  */
+  function getKeyManagerOf(
+    uint _tokenId
+  ) external view
+    returns (address);
+
+  /**
   * @notice Update transfer and cancel rights for a given key
   * @param _tokenId The id of the key to assign rights for
   * @param _keyManager The address to assign the rights to for the given key
-  * */
-  //
-  function _updateKeyManagerOf(
+  */
+  function setKeyManagerOf(
     uint _tokenId,
     address _keyManager
-  ) internal;
+  ) external;
 
   /// @notice A descriptive name for a collection of NFTs in this contract
   function name() external view returns (string memory _name);

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -202,7 +202,8 @@ contract IPublicLock is IERC721Enumerable {
    */
   function grantKeys(
     address[] calldata _recipients,
-    uint[] calldata _expirationTimestamps
+    uint[] calldata _expirationTimestamps,
+    address[] calldata _keyManagers
   ) external;
 
   /**
@@ -376,7 +377,8 @@ contract IPublicLock is IERC721Enumerable {
   function shareKey(
     address _to,
     uint _tokenId,
-    uint _timeShared
+    uint _timeShared,
+    address _keyManager
   ) external;
 
   /// @notice A descriptive name for a collection of NFTs in this contract

--- a/smart-contracts/contracts/mixins/MixinGrantKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinGrantKeys.sol
@@ -38,7 +38,7 @@ contract MixinGrantKeys is
       _assignNewTokenId(toKey);
       _recordOwner(recipient, toKey.tokenId);
       // Assign the KeyManager
-      _setKeyManagerOf(toKey.tokenId, keyManager);
+      _setKeyManagerOf(toKey.tokenId, keyManager, false);
       toKey.expirationTimestamp = expirationTimestamp;
 
       // trigger event

--- a/smart-contracts/contracts/mixins/MixinGrantKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinGrantKeys.sol
@@ -21,7 +21,7 @@ contract MixinGrantKeys is
   function grantKeys(
     address[] calldata _recipients,
     uint[] calldata _expirationTimestamps,
-    address[] _keyManagers
+    address[] calldata _keyManagers
   ) external
     onlyKeyGranter
   {
@@ -38,7 +38,7 @@ contract MixinGrantKeys is
       _assignNewTokenId(toKey);
       _recordOwner(recipient, toKey.tokenId);
       // Assign the KeyManager
-      _setKeyManager(toKey.tokenId, keyManager);
+      _setKeyManagerOf(toKey.tokenId, keyManager);
       toKey.expirationTimestamp = expirationTimestamp;
 
       // trigger event

--- a/smart-contracts/contracts/mixins/MixinGrantKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinGrantKeys.sol
@@ -21,19 +21,14 @@ contract MixinGrantKeys is
   function grantKeys(
     address[] calldata _recipients,
     uint[] calldata _expirationTimestamps,
-    address _keyManager
+    address[] _keyManagers
   ) external
     onlyKeyGranter
   {
-    address keyManager;
-    if (_keyManager != address(0)) {
-      keyManager = _keyManager;
-    } else {
-      keyManager = msg.sender;
-    }
     for(uint i = 0; i < _recipients.length; i++) {
       address recipient = _recipients[i];
       uint expirationTimestamp = _expirationTimestamps[i];
+      address keyManager = _keyManagers[i];
 
       require(recipient != address(0), 'INVALID_ADDRESS');
 

--- a/smart-contracts/contracts/mixins/MixinGrantKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinGrantKeys.sol
@@ -20,10 +20,17 @@ contract MixinGrantKeys is
    */
   function grantKeys(
     address[] calldata _recipients,
-    uint[] calldata _expirationTimestamps
+    uint[] calldata _expirationTimestamps,
+    address _keyManager
   ) external
     onlyKeyGranter
   {
+    address keyManager;
+    if (_keyManager != address(0)) {
+      keyManager = _keyManager;
+    } else {
+      keyManager = msg.sender;
+    }
     for(uint i = 0; i < _recipients.length; i++) {
       address recipient = _recipients[i];
       uint expirationTimestamp = _expirationTimestamps[i];
@@ -35,6 +42,8 @@ contract MixinGrantKeys is
 
       _assignNewTokenId(toKey);
       _recordOwner(recipient, toKey.tokenId);
+      // Assign the KeyManager
+      _setKeyManager(toKey.tokenId, keyManager);
       toKey.expirationTimestamp = expirationTimestamp;
 
       // trigger event

--- a/smart-contracts/contracts/mixins/MixinGrantKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinGrantKeys.sol
@@ -37,9 +37,12 @@ contract MixinGrantKeys is
 
       _assignNewTokenId(toKey);
       _recordOwner(recipient, toKey.tokenId);
-      // Assign the KeyManager
-      keyManagerOf[toKey.tokenId] = keyManager;
-      emit KeyManagerChanged(toKey.tokenId, keyManager);
+      // Only assign the KeyManager for new keys
+      if(keyManagerOf[toKey.tokenId] == address(0)) {
+        keyManagerOf[toKey.tokenId] = keyManager;
+        emit KeyManagerChanged(toKey.tokenId, keyManager);
+      }
+
       toKey.expirationTimestamp = expirationTimestamp;
 
       // trigger event

--- a/smart-contracts/contracts/mixins/MixinGrantKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinGrantKeys.sol
@@ -38,7 +38,8 @@ contract MixinGrantKeys is
       _assignNewTokenId(toKey);
       _recordOwner(recipient, toKey.tokenId);
       // Assign the KeyManager
-      _setKeyManagerOf(toKey.tokenId, keyManager);
+      keyManagerOf[toKey.tokenId] = keyManager;
+      emit KeyManagerChanged(toKey.tokenId, keyManager);
       toKey.expirationTimestamp = expirationTimestamp;
 
       // trigger event

--- a/smart-contracts/contracts/mixins/MixinGrantKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinGrantKeys.sol
@@ -38,7 +38,7 @@ contract MixinGrantKeys is
       _assignNewTokenId(toKey);
       _recordOwner(recipient, toKey.tokenId);
       // Assign the KeyManager
-      _setKeyManagerOf(toKey.tokenId, keyManager, false);
+      _setKeyManagerOf(toKey.tokenId, keyManager);
       toKey.expirationTimestamp = expirationTimestamp;
 
       // trigger event

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -311,11 +311,14 @@ contract MixinKeys is
 
   function _setKeyManagerOf(
     uint _tokenId,
-    address _keyManager
+    address _keyManager,
+    bool _bypassAccessControl
   ) internal
     isKey(_tokenId)
   {
-    require(keyManagerOf[_tokenId] == msg.sender || isLockManager(msg.sender), 'SETKEYMANAGEROF_ACCESS_DENIED');
+    if(!_bypassAccessControl) {
+      require(keyManagerOf[_tokenId] == msg.sender || isLockManager(msg.sender), 'SETKEYMANAGEROF_ACCESS_DENIED');
+    }
     keyManagerOf[_tokenId] = _keyManager;
     emit KeyManagerChanged(_tokenId, _keyManager);
   }

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -309,6 +309,12 @@ contract MixinKeys is
     emit ExpirationChanged(_tokenId, _deltaT, _addTime);
   }
 
+  /**
+  * @notice Update transfer and cancel rights for a given key
+  * @param _tokenId The id of the key to assign rights for
+  * @param _keyManager The address to assign the rights to for the given key
+  * */
+  //
   function _updateKeyManagerOf(
     uint _tokenId,
     address _keyManager

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -96,6 +96,14 @@ contract MixinKeys is
     _;
   }
 
+  // Ensure that the caller is the keyManager for this key
+  modifier onlyKeyManager(
+    uint _tokenId
+  ) {
+    require(keyManagerOf[_tokenId] == msg.sender, 'NOT_MANAGER_OF_KEY');
+    _;
+  }
+
   /**
    * A function which lets the owner of the lock expire a users' key.
    */

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -315,8 +315,8 @@ contract MixinKeys is
   ) internal
     isKey(_tokenId)
   {
-    require(keyManagerOf[_tokenId] == msg.sender || isLockManager[msg.sender], 'SETKEYMANAGEROF_ACCESS_DENIED' )
+    require(keyManagerOf[_tokenId] == msg.sender || isLockManager(msg.sender), 'SETKEYMANAGEROF_ACCESS_DENIED');
     keyManagerOf[_tokenId] = _keyManager;
-    emit KeyManagerChanged(tokenId, _keyManager);
+    emit KeyManagerChanged(_tokenId, _keyManager);
   }
 }

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -33,6 +33,8 @@ contract MixinKeys is
     bool _timeAdded
   );
 
+  event KeyManagerChanged(uint indexed _tokenId, address indexed _newManager);
+
   // Keys
   // Each owner can have at most exactly one key
   // TODO: could we use public here? (this could be confusing though because it getter will
@@ -48,6 +50,11 @@ contract MixinKeys is
   // Addresses of owners are also stored in an array.
   // Addresses are never removed by design to avoid abuses around referals
   address[] public owners;
+
+  // A given key has both an owner and a manager.
+  // The owner and manager may be the same address
+  // Each key can have at most 1 keyManager, but may have no manager.
+  mapping (uint => address) internal keyManagerOf;
 
   // Ensures that an owner owns or has owned a key in the past
   modifier ownsOrHasOwnedKey(
@@ -292,5 +299,16 @@ contract MixinKeys is
       key.expirationTimestamp = formerTimestamp.sub(_deltaT);
     }
     emit ExpirationChanged(_tokenId, _deltaT, _addTime);
+  }
+
+  function _setKeyManagerOf(
+    uint _tokenId,
+    address _keyManager
+  ) internal
+    isKey(_tokenId)
+  {
+    require(keyManagerOf[_tokenId] == msg.sender || isLockManager[msg.sender], 'SETKEYMANAGEROF_ACCESS_DENIED' )
+    keyManagerOf[_tokenId] = _keyManager;
+    emit KeyManagerChanged(tokenId, _keyManager);
   }
 }

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -244,6 +244,35 @@ contract MixinKeys is
   }
 
   /**
+  * @notice Get the key manager for the given tokenId
+  * @return The address of the manager for the given key
+  */
+  function getKeyManagerOf(
+    uint _tokenId
+  ) public view
+    returns (address)
+  {
+    return keyManagerOf[_tokenId];
+  }
+
+  /**
+  * @notice Update transfer and cancel rights for a given key
+  * @param _tokenId The id of the key to assign rights for
+  * @param _keyManager The address to assign the rights to for the given key
+  * */
+  //
+  function setKeyManagerOf(
+    uint _tokenId,
+    address _keyManager
+  ) public
+    isKey(_tokenId)
+  {
+    require( (msg.sender == keyManagerOf[_tokenId]) || (isLockManager(msg.sender) == true), 'SETKEYMANAGEROF_ACCESS_DENIED');
+    keyManagerOf[_tokenId] = _keyManager;
+    emit KeyManagerChanged(_tokenId, _keyManager);
+  }
+
+  /**
    * Assigns the key a new tokenId (from totalSupply) if it does not already have
    * one assigned.
    */
@@ -307,22 +336,5 @@ contract MixinKeys is
       key.expirationTimestamp = formerTimestamp.sub(_deltaT);
     }
     emit ExpirationChanged(_tokenId, _deltaT, _addTime);
-  }
-
-  /**
-  * @notice Update transfer and cancel rights for a given key
-  * @param _tokenId The id of the key to assign rights for
-  * @param _keyManager The address to assign the rights to for the given key
-  * */
-  //
-  function _updateKeyManagerOf(
-    uint _tokenId,
-    address _keyManager
-  ) internal
-    isKey(_tokenId)
-  {
-    require(keyManagerOf[_tokenId] == msg.sender || isLockManager(msg.sender), 'SETKEYMANAGEROF_ACCESS_DENIED');
-    keyManagerOf[_tokenId] = _keyManager;
-    emit KeyManagerChanged(_tokenId, _keyManager);
   }
 }

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -311,14 +311,11 @@ contract MixinKeys is
 
   function _setKeyManagerOf(
     uint _tokenId,
-    address _keyManager,
-    bool _bypassAccessControl
+    address _keyManager
   ) internal
     isKey(_tokenId)
   {
-    if(!_bypassAccessControl) {
-      require(keyManagerOf[_tokenId] == msg.sender || isLockManager(msg.sender), 'SETKEYMANAGEROF_ACCESS_DENIED');
-    }
+    require(keyManagerOf[_tokenId] == msg.sender || isLockManager(msg.sender), 'SETKEYMANAGEROF_ACCESS_DENIED');
     keyManagerOf[_tokenId] = _keyManager;
     emit KeyManagerChanged(_tokenId, _keyManager);
   }

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -267,7 +267,7 @@ contract MixinKeys is
   ) public
     isKey(_tokenId)
   {
-    require( (msg.sender == keyManagerOf[_tokenId]) || (isLockManager(msg.sender) == true), 'SETKEYMANAGEROF_ACCESS_DENIED');
+    require((msg.sender == keyManagerOf[_tokenId]) || (isLockManager(msg.sender) == true), 'SETKEYMANAGEROF_ACCESS_DENIED');
     keyManagerOf[_tokenId] = _keyManager;
     emit KeyManagerChanged(_tokenId, _keyManager);
   }

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -309,7 +309,7 @@ contract MixinKeys is
     emit ExpirationChanged(_tokenId, _deltaT, _addTime);
   }
 
-  function _setKeyManagerOf(
+  function _updateKeyManagerOf(
     uint _tokenId,
     address _keyManager
   ) internal

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -56,7 +56,9 @@ contract MixinPurchase is
       _assignNewTokenId(toKey);
       _recordOwner(_recipient, toKey.tokenId);
       // Give the new key owner the right to manage their key
-      _setKeyManagerOf(toKey.tokenId, _recipient);
+      keyManagerOf[toKey.tokenId] = _recipient;
+      emit KeyManagerChanged(toKey.tokenId, _recipient);
+
       newTimeStamp = block.timestamp + expirationDuration;
       toKey.expirationTimestamp = newTimeStamp;
 

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -56,7 +56,7 @@ contract MixinPurchase is
       _assignNewTokenId(toKey);
       _recordOwner(_recipient, toKey.tokenId);
       // Give the new key owner the right to manage their key
-      _setKeyManagerOf(toKey.tokenId, _recipient);
+      _setKeyManagerOf(toKey.tokenId, _recipient, true);
       newTimeStamp = block.timestamp + expirationDuration;
       toKey.expirationTimestamp = newTimeStamp;
 

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -55,6 +55,8 @@ contract MixinPurchase is
       // Assign a new tokenId (if a new owner or previously transferred)
       _assignNewTokenId(toKey);
       _recordOwner(_recipient, toKey.tokenId);
+      // Give the new key owner the right to manage their key
+      _setKeyManagerOf(toKey.tokenId, _recipient);
       newTimeStamp = block.timestamp + expirationDuration;
       toKey.expirationTimestamp = newTimeStamp;
 

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -56,7 +56,7 @@ contract MixinPurchase is
       _assignNewTokenId(toKey);
       _recordOwner(_recipient, toKey.tokenId);
       // Give the new key owner the right to manage their key
-      _setKeyManagerOf(toKey.tokenId, _recipient, true);
+      _setKeyManagerOf(toKey.tokenId, _recipient);
       newTimeStamp = block.timestamp + expirationDuration;
       toKey.expirationTimestamp = newTimeStamp;
 

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -88,7 +88,7 @@ contract MixinTransfer is
       iDTo = toKey.tokenId;
       _recordOwner(_to, iDTo);
       // Assign the KeyManager
-      _setKeyManagerOf(toKey.tokenId, _keyManager, false);
+      _setKeyManagerOf(toKey.tokenId, _keyManager);
       emit Transfer(
         address(0), // This is a creation or time-sharing
         _to,
@@ -133,7 +133,7 @@ contract MixinTransfer is
     if (toKey.tokenId == 0) {
       toKey.tokenId = fromKey.tokenId;
       _recordOwner(_recipient, toKey.tokenId);
-      _setKeyManagerOf(toKey.tokenId, _recipient, false);
+      _setKeyManagerOf(toKey.tokenId, _recipient);
     }
 
     if (previousExpiration <= block.timestamp) {

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -52,8 +52,8 @@ contract MixinTransfer is
     address _keyManager
   ) public
     onlyIfAlive
-    onlyKeyManager(_tokenId)
     onlyKeyOwnerOrApproved(_tokenId)
+    onlyKeyManager(_tokenId)
   {
     require(transferFeeBasisPoints < BASIS_POINTS_DEN, 'KEY_TRANSFERS_DISABLED');
     require(_to != address(0), 'INVALID_ADDRESS');

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -88,7 +88,8 @@ contract MixinTransfer is
       iDTo = toKey.tokenId;
       _recordOwner(_to, iDTo);
       // Assign the KeyManager
-      _setKeyManagerOf(toKey.tokenId, _keyManager);
+      keyManagerOf[toKey.tokenId] = _keyManager;
+      emit KeyManagerChanged(toKey.tokenId, _keyManager);
       emit Transfer(
         address(0), // This is a creation or time-sharing
         _to,
@@ -133,7 +134,8 @@ contract MixinTransfer is
     if (toKey.tokenId == 0) {
       toKey.tokenId = fromKey.tokenId;
       _recordOwner(_recipient, toKey.tokenId);
-      _setKeyManagerOf(toKey.tokenId, _recipient);
+      keyManagerOf[toKey.tokenId] = _recipient;
+      emit KeyManagerChanged(toKey.tokenId, _recipient);
     }
 
     if (previousExpiration <= block.timestamp) {

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -133,7 +133,7 @@ contract MixinTransfer is
     if (toKey.tokenId == 0) {
       toKey.tokenId = fromKey.tokenId;
       _recordOwner(_recipient, toKey.tokenId);
-      _setKeyManagerOf(toKey.tokenId, _recipient)
+      _setKeyManagerOf(toKey.tokenId, _recipient);
     }
 
     if (previousExpiration <= block.timestamp) {

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -48,9 +48,11 @@ contract MixinTransfer is
   function shareKey(
     address _to,
     uint _tokenId,
-    uint _timeShared
+    uint _timeShared,
+    address _keyManager
   ) public
     onlyIfAlive
+    onlyKeyManager(_tokenId)
     onlyKeyOwnerOrApproved(_tokenId)
   {
     require(transferFeeBasisPoints < BASIS_POINTS_DEN, 'KEY_TRANSFERS_DISABLED');
@@ -85,6 +87,12 @@ contract MixinTransfer is
       _assignNewTokenId(toKey);
       iDTo = toKey.tokenId;
       _recordOwner(_to, iDTo);
+      // Assign the KeyManager
+      if (_keyManager != address(0)) {
+        _setKeyManagerOf(toKey.tokenId, _keyManager);
+      } else {
+        _setKeyManagerOf(toKey.tokenId, keyManagerOf[fromKey.tokenId]);
+      }
       emit Transfer(
         address(0), // This is a creation or time-sharing
         _to,

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -88,7 +88,7 @@ contract MixinTransfer is
       iDTo = toKey.tokenId;
       _recordOwner(_to, iDTo);
       // Assign the KeyManager
-      _setKeyManagerOf(toKey.tokenId, _keyManager);
+      _setKeyManagerOf(toKey.tokenId, _keyManager, false);
       emit Transfer(
         address(0), // This is a creation or time-sharing
         _to,
@@ -133,7 +133,7 @@ contract MixinTransfer is
     if (toKey.tokenId == 0) {
       toKey.tokenId = fromKey.tokenId;
       _recordOwner(_recipient, toKey.tokenId);
-      _setKeyManagerOf(toKey.tokenId, _recipient);
+      _setKeyManagerOf(toKey.tokenId, _recipient, false);
     }
 
     if (previousExpiration <= block.timestamp) {

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -110,6 +110,7 @@ contract MixinTransfer is
   )
     public
     onlyIfAlive
+    onlyKeyManager(_tokenId)
     hasValidKey(_from)
     onlyKeyOwnerOrApproved(_tokenId)
   {
@@ -128,6 +129,7 @@ contract MixinTransfer is
     if (toKey.tokenId == 0) {
       toKey.tokenId = fromKey.tokenId;
       _recordOwner(_recipient, toKey.tokenId);
+      _setKeyManagerOf(toKey.tokenId, _recipient)
     }
 
     if (previousExpiration <= block.timestamp) {

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -88,11 +88,7 @@ contract MixinTransfer is
       iDTo = toKey.tokenId;
       _recordOwner(_to, iDTo);
       // Assign the KeyManager
-      if (_keyManager != address(0)) {
-        _setKeyManagerOf(toKey.tokenId, _keyManager);
-      } else {
-        _setKeyManagerOf(toKey.tokenId, keyManagerOf[fromKey.tokenId]);
-      }
+      _setKeyManagerOf(toKey.tokenId, _keyManager);
       emit Transfer(
         address(0), // This is a creation or time-sharing
         _to,

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -115,9 +115,9 @@ contract MixinTransfer is
   )
     public
     onlyIfAlive
-    onlyKeyManager(_tokenId)
     hasValidKey(_from)
     onlyKeyOwnerOrApproved(_tokenId)
+    onlyKeyManager(_tokenId)
   {
     require(transferFeeBasisPoints < BASIS_POINTS_DEN, 'KEY_TRANSFERS_DISABLED');
     require(_recipient != address(0), 'INVALID_ADDRESS');

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -59,7 +59,9 @@ contract('Lock / cancelAndRefund', accounts => {
   })
 
   it('the amount of refund should be less than the original keyPrice when expiration is very far in the future', async () => {
-    await lock.grantKeys([accounts[5]], [999999999999], { from: accounts[0] })
+    await lock.grantKeys([accounts[5]], [999999999999], [accounts[0]], {
+      from: accounts[0],
+    })
     const estimatedRefund = new BigNumber(
       await lock.getCancelAndRefundValueFor.call(accounts[5])
     )
@@ -67,7 +69,7 @@ contract('Lock / cancelAndRefund', accounts => {
   })
 
   it('the estimated refund for a free Key should be 0', async () => {
-    await locks.FREE.grantKeys([accounts[5]], [999999999999], {
+    await locks.FREE.grantKeys([accounts[5]], [999999999999], [accounts[0]], {
       from: accounts[0],
     })
     const estimatedRefund = new BigNumber(
@@ -144,7 +146,7 @@ contract('Lock / cancelAndRefund', accounts => {
   })
 
   it('can cancel a free key', async () => {
-    await locks.FREE.grantKeys([accounts[1]], [999999999999], {
+    await locks.FREE.grantKeys([accounts[1]], [999999999999], [accounts[0]], {
       from: accounts[0],
     })
     const txObj = await locks.FREE.cancelAndRefund({

--- a/smart-contracts/test/Lock/disableTransfers.js
+++ b/smart-contracts/test/Lock/disableTransfers.js
@@ -63,7 +63,7 @@ contract('Lock / disableTransfers', accounts => {
         assert.equal(await lock.getHasValidKey.call(keyOwner), true)
         // try to share it
         await reverts(
-          lock.shareKey(accountWithNoKey, tokenId, oneDay, {
+          lock.shareKey(accountWithNoKey, tokenId, oneDay, keyOwner, {
             from: keyOwner,
           }),
           'KEY_TRANSFERS_DISABLED'

--- a/smart-contracts/test/Lock/erc721/approveForAll.js
+++ b/smart-contracts/test/Lock/erc721/approveForAll.js
@@ -7,7 +7,7 @@ const getProxy = require('../../helpers/proxy')
 
 let unlock
 let lock
-let ID
+let iD
 
 contract('Lock / erc721 / approveForAll', accounts => {
   before(async () => {
@@ -26,7 +26,7 @@ contract('Lock / erc721 / approveForAll', accounts => {
         value: Units.convert('0.01', 'eth', 'wei'),
         from: owner,
       })
-      ID = await lock.getTokenIdFor.call(owner)
+      iD = await lock.getTokenIdFor.call(owner)
     })
 
     it('isApprovedForAll defaults to false', async () => {
@@ -51,6 +51,7 @@ contract('Lock / erc721 / approveForAll', accounts => {
           from: owner,
         })
         event = result.logs[0]
+        await lock.setKeyManagerOf(iD, approvedUser)
       })
 
       it('isApprovedForAll is true', async () => {
@@ -70,20 +71,20 @@ contract('Lock / erc721 / approveForAll', accounts => {
       it('an authorized operator may set the approved address for an NFT', async () => {
         let newApprovedUser = accounts[8]
 
-        await lock.approve(newApprovedUser, ID, {
+        await lock.approve(newApprovedUser, iD, {
           from: approvedUser,
         })
 
-        assert.equal(await lock.getApproved.call(ID), newApprovedUser)
+        assert.equal(await lock.getApproved.call(iD), newApprovedUser)
       })
 
       it('should allow the approved user to transferFrom', async () => {
-        await lock.transferFrom(owner, accounts[3], ID, {
+        await lock.transferFrom(owner, accounts[3], iD, {
           from: approvedUser,
         })
 
         // Transfer it back to the original owner for other tests
-        await lock.transferFrom(accounts[3], owner, ID, {
+        await lock.transferFrom(accounts[3], owner, iD, {
           from: accounts[3],
         })
       })

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -206,6 +206,7 @@ contract('Lock / erc721 / transferFrom', accounts => {
         await locks.FIRST.approve(accountApproved, ID, {
           from: accountWithKeyApproved,
         })
+        await locks.FIRST.setKeyManagerOf(ID, accountApproved)
         await locks.FIRST.transferFrom(
           accountWithKeyApproved,
           accountApproved,

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -51,7 +51,7 @@ contract('Lock / owners', accounts => {
     assert.equal(numberOfOwners.toFixed(), 4)
   })
 
-  it('should allow for access to an individual key owner', async () => {
+  it('should allow for access to an indiviDual key owner', async () => {
     const owners = await Promise.all([
       lock.owners.call(0),
       lock.owners.call(1),
@@ -62,17 +62,18 @@ contract('Lock / owners', accounts => {
     assert.deepEqual(owners.sort(), accounts.slice(1, 5).sort())
   })
 
-  it('should fail to access to an individual key owner when out of bounds', async () => {
+  it('should fail to access to an indiviDual key owner when out of bounds', async () => {
     await truffleAssert.fails(lock.owners.call(6), 'revert')
   })
 
   describe('after a transfer to a new address', () => {
     let numberOfOwners
+    let iD
 
     before(async () => {
       numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
-      let ID = await lock.getTokenIdFor.call(accounts[1])
-      await lock.transferFrom(accounts[1], accounts[5], ID, {
+      iD = await lock.getTokenIdFor.call(accounts[1])
+      await lock.transferFrom(accounts[1], accounts[5], iD, {
         from: accounts[1],
       })
     })
@@ -89,7 +90,7 @@ contract('Lock / owners', accounts => {
 
     it('should fail if I transfer from the same account again', async () => {
       await reverts(
-        lock.transferFrom(accounts[1], accounts[5], accounts[1], {
+        lock.transferFrom(accounts[1], accounts[5], iD, {
           from: accounts[1],
         }),
         'KEY_NOT_VALID'
@@ -102,8 +103,8 @@ contract('Lock / owners', accounts => {
 
     before(async () => {
       numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
-      let ID = await lock.getTokenIdFor.call(accounts[2])
-      await lock.transferFrom(accounts[2], accounts[3], ID, {
+      let iD = await lock.getTokenIdFor.call(accounts[2])
+      await lock.transferFrom(accounts[2], accounts[3], iD, {
         from: accounts[2],
       })
     })

--- a/smart-contracts/test/Lock/permissions/keyManager.js
+++ b/smart-contracts/test/Lock/permissions/keyManager.js
@@ -1,15 +1,22 @@
 const { reverts } = require('truffle-assertions')
+const BigNumber = require('bignumber.js')
+const Units = require('ethereumjs-units')
 const deployLocks = require('../../helpers/deployLocks')
 const getProxy = require('../../helpers/proxy')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 
+let unlock
+let locks
+let lock
 let lockCreator
-const LockManager = lockCreator
-const KeyGranter = lockCreator
 
 contract('Permissions / KeyManager', accounts => {
   lockCreator = accounts[0]
+  const LockManager = lockCreator
+  const KeyGranter = lockCreator
+  const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
+  const keyPrice = new BigNumber(Units.convert(0.01, 'eth', 'wei'))
 
   before(async () => {
     unlock = await getProxy(unlockContract)
@@ -17,9 +24,21 @@ contract('Permissions / KeyManager', accounts => {
     lock = locks.FIRST
   })
 
+  before(async () => {
+    const purchases = keyOwners.map(account => {
+      return lock.purchase(0, account, web3.utils.padLeft(0, 40), [], {
+        value: keyPrice.toFixed(),
+        from: account,
+      })
+    })
+    await Promise.all(purchases)
+  })
+
   describe('Key Purchases', () => {
     // KM == KeyManager
-    it('should set KM == keyOwner for new purchases', async () => {})
+    it('should set KM == keyOwner for new purchases', async () => {
+      // await
+    })
     it('should not change KM when topping-up valid keys', async () => {})
     it('should not change KM when re-newing expired keys', async () => {})
   })

--- a/smart-contracts/test/Lock/permissions/keyManager.js
+++ b/smart-contracts/test/Lock/permissions/keyManager.js
@@ -4,12 +4,24 @@ const getProxy = require('../../helpers/proxy')
 
 const unlockContract = artifacts.require('../Unlock.sol')
 
+let lockCreator
+const LockManager = lockCreator
+const KeyGranter = lockCreator
+
 contract('Permissions / KeyManager', accounts => {
+  lockCreator = accounts[0]
+
+  before(async () => {
+    unlock = await getProxy(unlockContract)
+    locks = await deployLocks(unlock, lockCreator)
+    lock = locks.FIRST
+  })
+
   describe('Key Purchases', () => {
     // KM == KeyManager
     it('should set KM == keyOwner for new purchases', async () => {})
-    it('should not change KM when re-newing expired keys', async () => {})
     it('should not change KM when topping-up valid keys', async () => {})
+    it('should not change KM when re-newing expired keys', async () => {})
   })
   describe('Key Transfers', () => {
     it('should set KM == keyOwner for new recipients', async () => {})
@@ -22,5 +34,10 @@ contract('Permissions / KeyManager', accounts => {
   describe('Key Granting', () => {
     it('should let KeyGranter set an arbitrary KM for granted key', async () => {})
     it('should let KeyGranter set no KM for granted key', async () => {})
+  })
+
+  describe('updating the key manager', () => {
+    it('should allow the current keyManager to set a new KM', async () => {})
+    it('should allow a LockManager to set a new KM', async () => {})
   })
 })

--- a/smart-contracts/test/Lock/permissions/keyManager.js
+++ b/smart-contracts/test/Lock/permissions/keyManager.js
@@ -1,0 +1,26 @@
+const { reverts } = require('truffle-assertions')
+const deployLocks = require('../../helpers/deployLocks')
+const getProxy = require('../../helpers/proxy')
+
+const unlockContract = artifacts.require('../Unlock.sol')
+
+contract('Permissions / KeyManager', accounts => {
+  describe('Key Purchases', () => {
+    // KM == KeyManager
+    it('should set KM == keyOwner for new purchases', async () => {})
+    it('should not change KM when re-newing expired keys', async () => {})
+    it('should not change KM when topping-up valid keys', async () => {})
+  })
+  describe('Key Transfers', () => {
+    it('should set KM == keyOwner for new recipients', async () => {})
+    it('should not change KM for existing key owners', async () => {})
+  })
+  describe('Key Sharing', () => {
+    it('should let key sharer set an arbitrary KM for Child key', async () => {})
+    it('should let key sharer set no KM for Child key', async () => {})
+  })
+  describe('Key Granting', () => {
+    it('should let KeyGranter set an arbitrary KM for granted key', async () => {})
+    it('should let KeyGranter set no KM for granted key', async () => {})
+  })
+})

--- a/smart-contracts/test/Lock/permissions/keyManager.js
+++ b/smart-contracts/test/Lock/permissions/keyManager.js
@@ -16,8 +16,12 @@ contract('Permissions / KeyManager', accounts => {
   const lockManager = lockCreator
   const keyGranter = lockCreator
   const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
-  const [keyOwner1, keyOwner2, keyOwner3, keyOwner4] = keyOwners
+  const [keyOwner1, keyOwner2, keyOwner3, evilKeyOwner] = keyOwners
   const keyPrice = new BigNumber(Units.convert(0.01, 'eth', 'wei'))
+  const oneDay = new BigNumber(60 * 60 * 24)
+  let iD
+  let keyManager
+  let keyManagerBefore
 
   before(async () => {
     unlock = await getProxy(unlockContract)
@@ -36,10 +40,8 @@ contract('Permissions / KeyManager', accounts => {
   })
 
   describe('Key Purchases', () => {
-    let keyManager
-    let keyManagerBefore
     let keyOwner
-    let iD
+
     // KM == KeyManager
     it('should set KM == keyOwner for new purchases', async () => {
       iD = await lock.getTokenIdFor(keyOwner1)
@@ -56,7 +58,7 @@ contract('Permissions / KeyManager', accounts => {
       keyManager = await lock.getKeyManagerOf.call(iD)
       assert.equal(keyManagerBefore, keyManager)
     })
-    it('should not change KM when re-newing expired keys', async () => {
+    it('should not change KM when renewing expired keys', async () => {
       keyManagerBefore = await lock.getKeyManagerOf.call(iD)
       await lock.expireKeyFor(keyOwner1, { from: lockManager })
       await lock.purchase(0, keyOwner1, web3.utils.padLeft(0, 40), [], {
@@ -68,12 +70,57 @@ contract('Permissions / KeyManager', accounts => {
     })
   })
   describe('Key Transfers', () => {
-    it('should set KM == keyOwner for new recipients', async () => {})
-    it('should not change KM for existing key owners', async () => {})
+    it('should set KM == keyOwner for new recipients', async () => {
+      await lock.transferFrom(keyOwner1, accounts[9], iD, {
+        from: keyOwner1,
+      })
+      keyManager = await lock.getKeyManagerOf.call(iD)
+      assert.equal(keyManager, accounts[9])
+    })
+    it('should not change KM for existing key owners', async () => {
+      let iD9 = await lock.getTokenIdFor(accounts[9])
+      iD = await lock.getTokenIdFor(keyOwner2)
+      keyManagerBefore = await lock.getKeyManagerOf.call(iD)
+      await lock.transferFrom(accounts[9], keyOwner2, iD9, {
+        from: accounts[9],
+      })
+      keyManager = await lock.getKeyManagerOf.call(iD)
+      assert.equal(keyManagerBefore, keyManager)
+    })
   })
   describe('Key Sharing', () => {
-    it('should let key sharer set an arbitrary KM for Child key', async () => {})
-    it('should let key sharer set no KM for Child key', async () => {})
+    const ZERO_ADDRESS = web3.utils.padLeft(0, 40)
+    it('should let key sharer set an arbitrary KM for Child key', async () => {
+      iD = await lock.getTokenIdFor(keyOwner3)
+      await lock.shareKey(accounts[8], iD, oneDay, accounts[7], {
+        from: keyOwner3,
+      })
+      iD = await lock.getTokenIdFor(accounts[8])
+      keyManager = await lock.getKeyManagerOf(iD)
+      assert.equal(keyManager, accounts[7])
+    })
+    it('should let key sharer set no KM for Child key', async () => {
+      iD = await lock.getTokenIdFor(keyOwner3)
+      await lock.shareKey(accounts[6], iD, oneDay, ZERO_ADDRESS, {
+        from: keyOwner3,
+      })
+      iD = await lock.getTokenIdFor(accounts[6])
+      keyManager = await lock.getKeyManagerOf(iD)
+      assert.equal(keyManager, ZERO_ADDRESS)
+    })
+
+    // prevent key sharer from taking control of an existing key simply by sharing a small abount of time with it and setting self as KM !
+    it('does not allow the key sharer to update the KM for Child key', async () => {
+      let hasKey = await lock.getHasValidKey(accounts[6])
+      assert.equal(hasKey, true)
+      iD = await lock.getTokenIdFor(evilKeyOwner)
+      await lock.shareKey(accounts[6], iD, oneDay, evilKeyOwner, {
+        from: evilKeyOwner,
+      })
+      iD = await lock.getTokenIdFor(accounts[6])
+      keyManager = await lock.getKeyManagerOf(iD)
+      assert.notEqual(keyManager, evilKeyOwner)
+    })
   })
   describe('Key Granting', () => {
     it('should let KeyGranter set an arbitrary KM for granted key', async () => {})

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -66,9 +66,9 @@ contract('Lock / purchaseFor', accounts => {
           value: Units.convert('0.01', 'eth', 'wei'),
         }
       )
-      assert.equal(tx.logs[0].event, 'Transfer')
-      assert.equal(tx.logs[0].args.from, 0)
-      assert.equal(tx.logs[0].args.to, accounts[2])
+      assert.equal(tx.logs[1].event, 'Transfer')
+      assert.equal(tx.logs[1].args.from, 0)
+      assert.equal(tx.logs[1].args.to, accounts[2])
       // Verify that RenewKeyPurchase does not emit on a first key purchase
       const includes = tx.logs.filter(l => l.event === 'RenewKeyPurchase')
       assert.equal(includes.length, 0)
@@ -234,9 +234,9 @@ contract('Lock / purchaseFor', accounts => {
         web3.utils.padLeft(0, 40),
         []
       )
-      assert.equal(tx.logs[0].event, 'Transfer')
-      assert.equal(tx.logs[0].args.from, 0)
-      assert.equal(tx.logs[0].args.to, accounts[2])
+      assert.equal(tx.logs[1].event, 'Transfer')
+      assert.equal(tx.logs[1].args.from, 0)
+      assert.equal(tx.logs[1].args.to, accounts[2])
     })
 
     describe('can re-purchase an expired key', () => {

--- a/smart-contracts/test/Lock/purchaseForFrom.js
+++ b/smart-contracts/test/Lock/purchaseForFrom.js
@@ -37,9 +37,9 @@ contract('Lock / purchaseForFrom', accounts => {
     it('can purchaseForFrom a free key', async () => {
       await locks.FREE.purchase(0, accounts[0], web3.utils.padLeft(0, 40), [])
       const tx = await locks.FREE.purchase(0, accounts[2], accounts[0], [])
-      assert.equal(tx.logs[0].event, 'Transfer')
-      assert.equal(tx.logs[0].args.from, 0)
-      assert.equal(tx.logs[0].args.to, accounts[2])
+      assert.equal(tx.logs[1].event, 'Transfer')
+      assert.equal(tx.logs[1].args.from, 0)
+      assert.equal(tx.logs[1].args.to, accounts[2])
     })
   })
 })

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -19,10 +19,10 @@ contract('Lock / shareKey', accounts => {
   let lock
   let tokenId1
   let tokenId2
-  let event
   let event1
   let event2
   let event3
+  let event4
   let tx1
   let tx2
 
@@ -181,16 +181,14 @@ contract('Lock / shareKey', accounts => {
           from: keyManager,
         }
       )
-      console.log(tx2.logs)
-      event = tx2.logs[0].event // ExpirationChanged
-      event1 = tx2.logs[1].event // KeyManagerChanged
+      event1 = tx2.logs[0].event // ExpirationChanged
       event2 = tx2.logs[2].event // Transfer
       event3 = tx2.logs[3].event // ExpirationChanged
       event4 = tx2.logs[4].event // Transfer
     })
 
     it('should emit the ExpirationChanged event twice', async () => {
-      assert.equal(event, 'ExpirationChanged')
+      assert.equal(event1, 'ExpirationChanged')
       assert.equal(tx2.logs[0].args._timeAdded, false)
       assert.equal(event3, 'ExpirationChanged')
       assert.equal(tx2.logs[3].args._timeAdded, true)


### PR DESCRIPTION
# Description
This was a fairly large task with many changes. The most notable of them are:

- In order to `approve` someone to transfer or share your key for you, you must also make them the keyManager for your key.
- Both `shareKey` and `grantKeys` now have an extra parameter (`_keyManager` & `_keyManagers[]` respectively)
- new event added: `KeyManagerChanged`
- new modifier added: `onlyKeyManager`
- new functions added: `setKeyManagerOf(...)` & `getKeyManagerOf(...)`
- new mapping: `mapping (uint => address) internal keyManagerOf;`
- 1 new test file: `permissions/keyManager.js`
- modifications to a bunch of test files, mostly around adding the extra params to function calls, and updating the log indexes when reading emitted events.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #5557 
Fixes #5753
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
