### PR TITLE
updated getRecentTransactionsHashesSentBy to retrieve past transactions and create locks

### DIFF
--- a/unlock-app/src/__tests__/services/storageService.test.js
+++ b/unlock-app/src/__tests__/services/storageService.test.js
@@ -155,6 +155,49 @@ describe('StorageService', () => {
         done()
       })
     })
+
+    it('should return a promise of hashes', async () => {
+      expect.assertions(2)
+      const sender = '0xabc'
+      axios.get.mockReturnValue({
+        data: {
+          transactions: [
+            {
+              transactionHash: '0x123',
+              sender: '0xabc',
+              recipient: '0xcde',
+              chain: 1984,
+            },
+            {
+              transactionHash: '0x456',
+              sender: '0xabc',
+              recipient: '0xfgh',
+              chain: 1984,
+            },
+          ],
+        },
+      })
+
+      const {
+        hashes,
+        senderAddress,
+      } = await storageService.getRecentTransactionsHashesSentBy(sender)
+      expect(senderAddress).toEqual(sender)
+      expect(hashes).toEqual([
+        {
+          hash: '0x123',
+          from: '0xabc',
+          to: '0xcde',
+          network: 1984,
+        },
+        {
+          hash: '0x456',
+          from: '0xabc',
+          to: '0xfgh',
+          network: 1984,
+        },
+      ])
+    })
   })
 
   describe('storeTransaction', () => {

--- a/unlock-app/src/services/storageService.js
+++ b/unlock-app/src/services/storageService.js
@@ -96,8 +96,10 @@ export class StorageService extends EventEmitter {
         }))
       }
       this.emit(success.getTransactionHashesSentBy, { senderAddress, hashes })
+      return { senderAddress, hashes }
     } catch (error) {
       this.emit(failure.getTransactionHashesSentBy, error)
+      return {} // TODO: consider if thos should be an error
     }
   }
 


### PR DESCRIPTION
# Description

This is making the useLocks hook much easier.
At some point we can/should get rid of the event emitter approach completely.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->