### PR TITLE
Remove redundant checks in safeTransferFrom

### DIFF
--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -196,9 +196,6 @@ contract MixinTransfer is
     bytes memory _data
   )
     public
-    onlyIfAlive
-    onlyKeyOwnerOrApproved(_tokenId)
-    hasValidKey(_ownerOf[_tokenId])
   {
     transferFrom(_from, _to, _tokenId);
     require(_checkOnERC721Received(_from, _to, _tokenId, _data), 'NON_COMPLIANT_ERC721_RECEIVER');


### PR DESCRIPTION
# Description
Calling  either `safeTransferFrom` function eventually calls `transferFrom` where we check these same conditions. This removes the redundant checks.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #5964
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
