### PR TITLE
Copy some checkout components into unlock-app

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/CheckoutWrapper.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/CheckoutWrapper.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import * as rtl from '@testing-library/react'
+import CheckoutWrapper from '../../../../components/interface/checkout/CheckoutWrapper'
+
+describe('CheckoutWrapper', () => {
+  it('renders the footer', () => {
+    expect.assertions(1)
+
+    const hideCheckout = jest.fn()
+    const allowClose = false
+
+    const { container } = rtl.render(
+      <CheckoutWrapper hideCheckout={hideCheckout} allowClose={allowClose} />
+    )
+
+    // the close button is also an a tag, but it doesn't render when allowClose is false
+    expect(container.getElementsByTagName('a')).toHaveLength(1)
+  })
+
+  it('does not have a close button when allowClose is false', () => {
+    expect.assertions(1)
+
+    const hideCheckout = jest.fn()
+    const allowClose = false
+
+    const { queryByTitle } = rtl.render(
+      <CheckoutWrapper hideCheckout={hideCheckout} allowClose={allowClose} />
+    )
+
+    expect(queryByTitle('Close')).toBeNull()
+  })
+
+  it('calls hideCheckout on click when allowClose is true', () => {
+    expect.assertions(2)
+
+    const hideCheckout = jest.fn()
+    const allowClose = true
+
+    const { getByTitle } = rtl.render(
+      <CheckoutWrapper hideCheckout={hideCheckout} allowClose={allowClose} />
+    )
+
+    const button = getByTitle('Close')
+
+    expect(hideCheckout).not.toHaveBeenCalled()
+
+    rtl.fireEvent.click(button)
+
+    expect(hideCheckout).toHaveBeenCalled()
+  })
+})

--- a/unlock-app/src/components/interface/checkout/CheckoutStyles.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutStyles.tsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components'
+import React from 'react'
+
+import { WordMarkLogo } from '../Logo'
+
+export const CheckoutFooter = () => (
+  <FooterWrapper>
+    <span>Powered by</span>
+    <a
+      href="https://unlock-protocol.com"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <WordMark alt="Unlock" />
+    </a>
+  </FooterWrapper>
+)
+
+const FooterWrapper = styled.footer`
+  margin-top: 50px;
+  font-size: 12px;
+  text-align: center;
+
+  div {
+    margin: 8px;
+    vertical-align: middle;
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+  }
+`
+
+const WordMark = styled(WordMarkLogo)`
+  width: 48px;
+  margin-bottom: -1px;
+  margin-left: 4px;
+`

--- a/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import styled from 'styled-components'
+import Close from '../buttons/layout/Close'
+import Media from '../../../theme/media'
+import { CheckoutFooter } from './CheckoutStyles'
+
+interface WrapperProps {
+  children: any
+  hideCheckout: (...args: any[]) => any
+  allowClose: boolean
+  bgColor?: string
+  onClick?: (event: any) => void
+  icon?: string
+}
+
+interface WrapperStyleProps {
+  bgColor: string
+}
+
+const CheckoutWrapper = ({
+  children,
+  hideCheckout,
+  bgColor = 'var(--offwhite)',
+  onClick = () => {},
+  allowClose = true,
+  icon,
+}: WrapperProps) => {
+  return (
+    <Wrapper bgColor={bgColor} onClick={allowClose ? onClick : () => {}}>
+      {allowClose ? (
+        <CloseButton
+          backgroundColor="var(--lightgrey)"
+          fillColor="var(--grey)"
+          onClick={hideCheckout}
+        />
+      ) : (
+        ''
+      )}
+      <header>
+        <Title>{icon && <Logo src={icon} />}</Title>
+      </header>
+      {children}
+      <CheckoutFooter />
+    </Wrapper>
+  )
+}
+
+export default CheckoutWrapper
+
+const CloseButton = styled(Close).attrs(() => ({
+  className: 'closeButton',
+}))`
+  position: absolute;
+  top: 24px;
+  right: 24px;
+`
+
+const Wrapper = styled.section`
+  padding: 10px 40px;
+  display: flex;
+  flex-direction: column;
+  background-color: ${(props: WrapperStyleProps) => props.bgColor};
+  color: var(--darkgrey);
+  border-radius: 4px;
+  position: relative;
+  ${Media.nophone`
+width: 600px;
+`}
+  ${Media.phone`
+width: 100%;
+`}
+`
+
+const Title = styled.h1`
+  font-size: 40px;
+  font-weight: 200;
+  vertical-align: middle;
+`
+
+const Logo = styled.img`
+  max-height: 47px;
+  max-width: 200px;
+`

--- a/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
@@ -5,11 +5,9 @@ import Media from '../../../theme/media'
 import { CheckoutFooter } from './CheckoutStyles'
 
 interface WrapperProps {
-  children: any
   hideCheckout: (...args: any[]) => any
   allowClose: boolean
   bgColor?: string
-  onClick?: (event: any) => void
   icon?: string
 }
 
@@ -17,16 +15,15 @@ interface WrapperStyleProps {
   bgColor: string
 }
 
-const CheckoutWrapper = ({
+const CheckoutWrapper: React.FunctionComponent<WrapperProps> = ({
   children,
   hideCheckout,
   bgColor = 'var(--offwhite)',
-  onClick = () => {},
   allowClose = true,
   icon,
-}: WrapperProps) => {
+}: React.PropsWithChildren<WrapperProps>) => {
   return (
-    <Wrapper bgColor={bgColor} onClick={allowClose ? onClick : () => {}}>
+    <Wrapper bgColor={bgColor} onClick={allowClose ? hideCheckout : () => {}}>
       {allowClose ? (
         <CloseButton
           backgroundColor="var(--lightgrey)"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Went down an annoying rabbit hole of trying to repurpose Paywall components for use in the new checkout and didn't meet with much success. Was able to salvage these 2, however, which will be modified as needed.

No visible change at the moment, but the `CheckoutWrapper` will replace the usual `Layout` component we use, since we'll be iframing into the checkout page. Brought this in as a separate component from what we use on the account iframe because there will be differences in how they are managed and we don't want to break the existing account flow (and the paywall version is more consistent with our future design direction)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
