### PR TITLE
Add config for running tenderly debugger

### DIFF
--- a/smart-contract-extensions/package.json
+++ b/smart-contract-extensions/package.json
@@ -6,6 +6,7 @@
     "build": "yarn compile",
     "compile": "truffle compile",
     "test": "truffle test",
+    "debug": "truffle test --network tenderly",
     "lint": "solium -d ./contracts/ && eslint .",
     "lintFix": "solium -d ./contracts/ --fix && eslint . --fix",
     "coverage": "truffle run coverage && cat coverage/lcov.info | coveralls",

--- a/smart-contract-extensions/truffle-config.js
+++ b/smart-contract-extensions/truffle-config.js
@@ -8,6 +8,12 @@ module.exports = {
       port: 8545,
       network_id: '*',
     },
+    tenderly: {
+      host: '127.0.0.1',
+      port: 9545,
+      network_id: '*',
+      gasPrice: 0,
+    },
   },
   compilers: {
     solc: {

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -74,6 +74,7 @@
   },
   "scripts": {
     "test": "cross-env NODE_ENV=test truffle test --network development",
+    "debug": "cross-env NODE_ENV=test truffle test --network tenderly",
     "lint": "solium -d ./contracts/ && eslint .",
     "lintFix": "solium -d ./contracts/ --fix && eslint . --fix",
     "dev": "yarn lint && yarn build && yarn test",
@@ -82,8 +83,7 @@
     "ganache": "ganache-cli --mnemonic \"hello unlock save the web\"",
     "zos": "openzeppelin",
     "flatten": "(truffle-flattener contracts/PublicLock.sol > build/PublicLock-Flattened.sol) && (echo Wrote file: build/PublicLock-Flattened.sol)",
-    "verify": "truffle run verify",
-    "debug": "truffle debug"
+    "verify": "truffle run verify"
   },
   "author": "",
   "license": "ISC"

--- a/smart-contracts/truffle-config.js
+++ b/smart-contracts/truffle-config.js
@@ -95,6 +95,12 @@ module.exports = {
       port: 8545,
       network_id: '*', // Match any network id
     },
+    tenderly: {
+      host: '127.0.0.1',
+      port: 9545,
+      network_id: '*',
+      gasPrice: 0,
+    },
     rinkeby: {
       provider: rinkebyProvider,
       network_id: '4', // Network Id for Rinkeby


### PR DESCRIPTION
# Description
This lets us use tenderly's debugging locally. in order for it to work, you must:
- install tenderly-cli (homebrew or curl)
- start ganache
- in another terminal, run `tenderly proxy`
- run `npx truffle migrate --network tenderly`
- run tests with `yarn debug` (basically truffle test with --network changed to "tenderly")

https://github.com/Tenderly/tenderly-cli#proxy-debugging
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
