### PR TITLE
Adding the usePurchaseKey hook

### DIFF
--- a/unlock-app/src/__tests__/hooks/usePurchaseKey.test.ts
+++ b/unlock-app/src/__tests__/hooks/usePurchaseKey.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import React from 'react'
+import { EventEmitter } from 'events'
+import { WalletServiceContext } from '../../utils/withWalletService'
+
+import { usePurchaseKey } from '../../hooks/usePurchaseKey'
+
+class MockWalletService extends EventEmitter {
+  purchaseKey: jest.Mock<any, any>
+
+  constructor() {
+    super()
+    this.purchaseKey = jest.fn().mockResolvedValue(true)
+  }
+}
+
+let mockWalletService: MockWalletService
+
+const lock = {
+  asOf: 3196,
+  name: 'ETH Lock',
+  maxNumberOfKeys: -1,
+  owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+  expirationDuration: 300,
+  keyPrice: '0.01',
+  publicLockVersion: 6,
+  balance: '0.03',
+  outstandingKeys: 1,
+  currencyContractAddress: null,
+  unlimitedKeys: true,
+  address: '0xEE9FE39966DF737eECa5920ABa975c283784Faf8',
+}
+
+describe('usePaywallLocks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(React, 'useContext').mockImplementation(context => {
+      if (context === WalletServiceContext) {
+        return mockWalletService
+      }
+    })
+
+    mockWalletService = new MockWalletService()
+  })
+
+  it('should return an object containing a function that will purchase a key', async () => {
+    expect.assertions(1)
+
+    const { result } = renderHook(() => usePurchaseKey(lock))
+
+    await act(async () => {
+      result.current.purchaseKey()
+    })
+
+    expect(mockWalletService.purchaseKey).toHaveBeenCalledWith({
+      erc20Address: lock.currencyContractAddress,
+      keyPrice: lock.keyPrice,
+      lockAddress: lock.address,
+      owner: lock.owner,
+    })
+  })
+
+  it('should indicate whether the transaction has initiated or not', async () => {
+    expect.assertions(2)
+
+    const { result } = renderHook(() => usePurchaseKey(lock))
+
+    expect(result.current.initiatedPurchase).toBeFalsy()
+
+    await act(async () => {
+      result.current.purchaseKey()
+    })
+
+    expect(result.current.initiatedPurchase).toBeTruthy()
+  })
+})

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5271,12 +5271,12 @@ Object {
           <span
             class="c2"
           >
-            Corporate
+            ETH Lock
           </span>
           <span
             class="c3"
           >
-            1,500
+            Unlimited
              Available
           </span>
         </div>
@@ -5286,7 +5286,7 @@ Object {
           <span
             class="c5"
           >
-            12345
+            0.01
           </span>
           <span
             class="c6"
@@ -5301,7 +5301,7 @@ Object {
             </span>
             <br />
             <span>
-              10 Months
+              5 minutes
             </span>
           </div>
           <svg
@@ -5332,12 +5332,12 @@ Object {
         <span
           class="sc-prorn lnozAw"
         >
-          Corporate
+          ETH Lock
         </span>
         <span
           class="sc-qQMSE jigpIh"
         >
-          1,500
+          Unlimited
            Available
         </span>
       </div>
@@ -5347,7 +5347,7 @@ Object {
         <span
           class="sc-pBzUF kXDysY"
         >
-          12345
+          0.01
         </span>
         <span
           class="sc-pJUVA hTiwUC"
@@ -5362,7 +5362,7 @@ Object {
           </span>
           <br />
           <span>
-            10 Months
+            5 minutes
           </span>
         </div>
         <svg

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -12,10 +12,8 @@ import {
   Network,
   Router,
   PaywallConfig,
-  RawLock,
 } from '../../unlockTypes'
 import getConfigFromSearch from '../../utils/getConfigFromSearch'
-import { durationsAsTextFromSeconds } from '../../utils/durations'
 import { usePaywallLocks } from '../../hooks/usePaywallLocks'
 
 interface CheckoutContentProps {
@@ -26,16 +24,6 @@ interface CheckoutContentProps {
 
 const defaultLockAddresses: string[] = []
 
-const lockKeysAvailable = (lock: RawLock) => {
-  if ((lock as any).unlimitedKeys) {
-    return 'Unlimited'
-  }
-
-  // maxNumberOfKeys and outstandingKeys are assumed to be defined
-  // if they are ever not, a runtime error can occur
-  return (lock.maxNumberOfKeys! - lock.outstandingKeys!).toString()
-}
-
 export const CheckoutContent = ({
   account,
   network,
@@ -45,7 +33,7 @@ export const CheckoutContent = ({
     ? Object.keys(config.locks)
     : defaultLockAddresses
   const { locks, loading } = usePaywallLocks(lockAddresses)
-
+  console.log({ locks })
   return (
     <Layout title="Checkout">
       <Head>
@@ -64,16 +52,7 @@ export const CheckoutContent = ({
           {locks && (
             <div>
               {locks.map(lock => (
-                <Lock
-                  name={lock.name}
-                  keysAvailable={lockKeysAvailable(lock)}
-                  key={lock.name}
-                  price={lock.keyPrice}
-                  symbol={(lock as any).currencySymbol || 'ETH'}
-                  validityDuration={durationsAsTextFromSeconds(
-                    lock.expirationDuration
-                  )}
-                />
+                <Lock lock={lock} key={lock.name} />
               ))}
             </div>
           )}

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -32,8 +32,9 @@ export const CheckoutContent = ({
   const lockAddresses = config
     ? Object.keys(config.locks)
     : defaultLockAddresses
+
   const { locks, loading } = usePaywallLocks(lockAddresses)
-  console.log({ locks })
+
   return (
     <Layout title="Checkout">
       <Head>

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import styled, { keyframes, css } from 'styled-components'
 import Svg from '../svg'
+import { RawLock } from '../../../unlockTypes'
+import { durationsAsTextFromSeconds } from '../../../utils/durations'
+import { usePurchaseKey } from '../../../hooks/usePurchaseKey'
 
 interface LockBodyProps {
   loading?: 'true'
@@ -154,33 +157,34 @@ export const LoadingLock = () => {
 }
 
 interface LockProps {
-  name: string
-  keysAvailable: string
-  price: string
-  symbol: string
-  validityDuration: string
+  lock: RawLock
 }
 
-export const Lock = ({
-  name,
-  keysAvailable,
-  price,
-  symbol,
-  validityDuration,
-}: LockProps) => {
+const lockKeysAvailable = (lock: RawLock) => {
+  if ((lock as any).unlimitedKeys) {
+    return 'Unlimited'
+  }
+
+  // maxNumberOfKeys and outstandingKeys are assumed to be defined
+  // if they are ever not, a runtime error can occur
+  return (lock.maxNumberOfKeys! - lock.outstandingKeys!).toString()
+}
+
+export const Lock = ({ lock }: LockProps) => {
+  const { purchaseKey } = usePurchaseKey(lock)
   return (
     <LockContainer>
       <InfoWrapper>
-        <LockName>{name}</LockName>
-        <KeysAvailable>{keysAvailable} Available</KeysAvailable>
+        <LockName>{lock.name}</LockName>
+        <KeysAvailable>{lockKeysAvailable(lock)} Available</KeysAvailable>
       </InfoWrapper>
-      <LockBody>
-        <LockPrice>{price}</LockPrice>
-        <TickerSymbol>{symbol}</TickerSymbol>
+      <LockBody onClick={purchaseKey}>
+        <LockPrice>{lock.keyPrice}</LockPrice>
+        <TickerSymbol>{(lock as any).currencySymbol || 'ETH'}</TickerSymbol>
         <ValidityDuration>
           <span>Valid for</span>
           <br />
-          <span>{validityDuration}</span>
+          <span>{durationsAsTextFromSeconds(lock.expirationDuration)}</span>
         </ValidityDuration>
         <Arrow />
       </LockBody>

--- a/unlock-app/src/hooks/usePaywallLocks.ts
+++ b/unlock-app/src/hooks/usePaywallLocks.ts
@@ -17,6 +17,8 @@ export const usePaywallLocks = (lockAddresses: string[]) => {
     })
 
     const locks = await Promise.all(lockPromises)
+    // getLock doesn't always return the lock address apparently
+    locks.forEach((lock, index) => (lock.address = lockAddresses[index]))
     setLoading(false)
     setLocks(locks)
   }

--- a/unlock-app/src/hooks/usePurchaseKey.ts
+++ b/unlock-app/src/hooks/usePurchaseKey.ts
@@ -1,0 +1,21 @@
+import { useState, useContext } from 'react'
+import { WalletService } from '@unlock-protocol/unlock-js'
+import { RawLock } from '../unlockTypes'
+import { WalletServiceContext } from '../utils/withWalletService'
+
+export const usePurchaseKey = (lock: RawLock) => {
+  const [initiatedPurchase, setInitiatedPurchase] = useState(false)
+  const walletService: WalletService = useContext(WalletServiceContext)
+
+  const purchaseKey = () => {
+    setInitiatedPurchase(true)
+    walletService.purchaseKey({
+      lockAddress: lock.address,
+      owner: lock.owner!,
+      keyPrice: lock.keyPrice,
+      erc20Address: lock.currencyContractAddress,
+    })
+  }
+
+  return { purchaseKey, initiatedPurchase }
+}

--- a/unlock-app/src/stories/interface/checkout/Lock.stories.js
+++ b/unlock-app/src/stories/interface/checkout/Lock.stories.js
@@ -2,18 +2,25 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Lock, LoadingLock } from '../../../components/interface/checkout/Lock'
 
+const lock = {
+  asOf: 3196,
+  name: 'ETH Lock',
+  maxNumberOfKeys: -1,
+  owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+  expirationDuration: 300,
+  keyPrice: '0.01',
+  publicLockVersion: 6,
+  balance: '0.03',
+  outstandingKeys: 1,
+  currencyContractAddress: null,
+  unlimitedKeys: true,
+  address: '0xEE9FE39966DF737eECa5920ABa975c283784Faf8',
+}
+
 storiesOf('Checkout Lock', module)
   .add('Loading', () => {
     return <LoadingLock />
   })
   .add('Active', () => {
-    return (
-      <Lock
-        name="Corporate"
-        keysAvailable="1,500"
-        price="12345"
-        symbol="ETH"
-        validityDuration="10 Months"
-      />
-    )
+    return <Lock lock={lock} />
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a hook wrapping the `purchaseKey` method of `WalletService`. Additionally, it integrates it into the `Lock` component we use on the checkout page, so it's now possible to buy a key from this page by clicking the lock.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
