### PR TITLE
tokenId bug fix

### DIFF
--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -81,8 +81,9 @@ contract MixinTransfer is
       emit ExpireKey(_tokenId);
     }
 
-    if (toKey.tokenId == 0) {
+    if (iDTo == 0) {
       _assignNewTokenId(toKey);
+      iDTo = toKey.tokenId;
       _recordOwner(_to, iDTo);
       emit Transfer(
         address(0), // This is a creation or time-sharing

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -210,6 +210,16 @@ contract('Lock / shareKey', accounts => {
       )
     })
 
+    it('should correctly assign a new id to the new token', async () => {
+      let newId = await lock.getTokenIdFor.call(accountWithNoKey2)
+      // the tokenId of the new child key should be > the Parent key
+      assert(new BigNumber(newId).gt(new BigNumber(tokenId2)))
+    })
+
+    it('should not assign the recipient of the granted key as the owner of tokenId 0', async () => {
+      await reverts(lock.ownerOf.call(0), 'NO_SUCH_KEY')
+    })
+
     it('total time remaining is <= original time + fee', async () => {
       timestampAfterSharing = new BigNumber(
         (await web3.eth.getBlock('latest')).timestamp


### PR DESCRIPTION
# Description
I found a bug in the way tokenId's were getting mapped to a key owner when `shareKey` was used to share a key with a new owner(someone not currently owning a key).
- Basically, the new key's tokenId was incremented correctly, but the new owner was set as the owner of the key with a tokenId of `0`. This was caused by incorrect handling of a cached value `iDTo` which wasn't refreshed after the call to `_assignNewTokenId()`
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
