### PR TITLE
Remove shadow from the loading lock body on checkout page

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5342,7 +5342,7 @@ Object {
         </span>
       </div>
       <div
-        class="sc-pbxSd kQAkpQ"
+        class="sc-pbxSd kdlDET"
       >
         <span
           class="sc-pBzUF kXDysY"
@@ -5441,7 +5441,6 @@ Object {
   width: 100%;
   border-radius: 4px;
   border: 1px var(--lightgrey) solid;
-  box-shadow: 0px 0px 40px rgba(0,0,0,0.08);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5500,7 +5499,7 @@ Object {
       class="sc-pjstK bwTJOd"
     >
       <div
-        class="sc-pbxSd hAlLJB"
+        class="sc-pbxSd gyQAqr"
         loading="true"
       />
     </div>

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -54,6 +54,14 @@ export const lockBodyOpacity = ({ loading }: LockBodyProps) => {
   `
 }
 
+export const lockBodyShadow = ({ loading }: LockBodyProps) => {
+  if (loading) {
+    return ''
+  }
+
+  return 'box-shadow: 0px 0px 40px rgba(0, 0, 0, 0.08)'
+}
+
 export const Arrow = styled(Svg.Arrow)`
   width: 32px;
   fill: var(--darkgrey);
@@ -66,7 +74,7 @@ export const LockBody = styled.div`
   width: 100%;
   border-radius: 4px;
   ${(props: LockBodyProps) => lockBodyBorder(props)};
-  box-shadow: 0px 0px 40px rgba(0, 0, 0, 0.08);
+  ${(props: LockBodyProps) => lockBodyShadow(props)};
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Per a request from @smombartz, this PR removes the shadow around the lock body of the loading lock on the new checkout page.

Before:
<img width="255" alt="before" src="https://user-images.githubusercontent.com/9300702/74977179-3be3c880-53f8-11ea-8eaf-a331dc8b5fbb.png">

After:
<img width="255" alt="after" src="https://user-images.githubusercontent.com/9300702/74977192-40a87c80-53f8-11ea-8fc9-e998be99d5a5.png">

(slight difference in color between the shots due to the animated background)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
