### PR TITLE
Add useGetTokenBalance hook

### DIFF
--- a/unlock-app/src/__tests__/hooks/useGetTokenBalance.test.ts
+++ b/unlock-app/src/__tests__/hooks/useGetTokenBalance.test.ts
@@ -1,0 +1,94 @@
+import { renderHook } from '@testing-library/react-hooks'
+import React from 'react'
+import { EventEmitter } from 'events'
+import { Web3ServiceContext } from '../../utils/withWeb3Service'
+
+import { useGetTokenBalance } from '../../hooks/useGetTokenBalance'
+
+class MockWeb3Service extends EventEmitter {
+  constructor() {
+    super()
+  }
+}
+
+const balances = {
+  '0x1': '5',
+  '0x2': '0.05',
+  eth: '12.506',
+}
+const accountAddress = '0xuser'
+
+let mockWeb3Service: any
+
+describe('useGetTokenBalance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(React, 'useContext').mockImplementation(context => {
+      if (context === Web3ServiceContext) {
+        return mockWeb3Service
+      }
+    })
+
+    mockWeb3Service = new MockWeb3Service()
+    mockWeb3Service.getTokenBalance = jest.fn(
+      (contractAddress: '0x1' | '0x2', _: string) => {
+        return Promise.resolve(balances[contractAddress])
+      }
+    )
+    mockWeb3Service.refreshAccountBalance = jest.fn(
+      (_: { address: string }) => {
+        return Promise.resolve(balances.eth)
+      }
+    )
+  })
+
+  it('should default to zero eth balance, then update with current balance', async () => {
+    expect.assertions(2)
+    const { result, wait } = renderHook(() =>
+      useGetTokenBalance(accountAddress)
+    )
+
+    expect(result.current.balances).toEqual({
+      eth: '0',
+    })
+
+    await wait(() => {
+      return result.current.balances.eth !== '0'
+    })
+
+    expect(result.current.balances).toEqual({
+      eth: '12.506',
+    })
+  })
+
+  it('should be able to query for additional token balances and update the existing table', async () => {
+    expect.assertions(3)
+    const { result, wait } = renderHook(() =>
+      useGetTokenBalance(accountAddress)
+    )
+
+    expect(result.current.balances).toEqual({
+      eth: '0',
+    })
+
+    result.current.getTokenBalance('0x1')
+
+    await wait(() => {
+      return !!result.current.balances['0x1']
+    })
+
+    expect(result.current.balances).toEqual({
+      eth: '12.506',
+      '0x1': '5',
+    })
+
+    result.current.getTokenBalance('0x2')
+
+    await wait(() => {
+      return !!result.current.balances['0x2']
+    })
+
+    expect(result.current.balances).toEqual(balances)
+  })
+})

--- a/unlock-app/src/hooks/useGetTokenBalance.ts
+++ b/unlock-app/src/hooks/useGetTokenBalance.ts
@@ -1,0 +1,52 @@
+import { useReducer, useContext, useEffect } from 'react'
+import { Web3Service } from '@unlock-protocol/unlock-js'
+import { Web3ServiceContext } from '../utils/withWeb3Service'
+
+interface Balances {
+  eth: string
+  [contractAddress: string]: string
+}
+
+interface BalanceUpdate {
+  // `eth` or the currency contract address
+  kind: string
+  value: string
+}
+
+const defaultBalances: Balances = {
+  eth: '0',
+}
+
+const balanceReducer = (balances: Balances, update: BalanceUpdate) => {
+  return {
+    ...balances,
+    [update.kind]: update.value,
+  }
+}
+
+export const useGetTokenBalance = (accountAddress: string) => {
+  const web3Service: Web3Service = useContext(Web3ServiceContext)
+  const [balances, updateBalance] = useReducer(balanceReducer, defaultBalances)
+
+  async function getTokenBalance(contractAddress: string) {
+    const value = await web3Service.getTokenBalance(
+      contractAddress,
+      accountAddress
+    )
+    updateBalance({ kind: contractAddress, value })
+  }
+
+  async function getEthBalance() {
+    const value = await web3Service.refreshAccountBalance({
+      address: accountAddress,
+    })
+    updateBalance({ kind: 'eth', value })
+  }
+
+  // Always get eth balance to begin with
+  useEffect(() => {
+    getEthBalance()
+  }, [])
+
+  return { balances, getTokenBalance }
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR introduces a hook in `unlock-app` to get token balances. The intent is that it will be called at the top-level of the checkout component. The `balances` object it returns will be passed down to consuming components that require knowledge of the user's balance, and the `getTokenBalance` function it exposes will be passed in to the `usePaywallLocks` hook so that when we are made aware of a lock denominated in an ERC20 token, we can fetch the balance immediately.

This workflow is a little awkward, but given the current architecture of all involved components feels like the smoothest and easiest-to-upgrade path to me.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
