### PR TITLE
Checkout lock can show when balance is insufficient

### DIFF
--- a/unlock-app/src/__tests__/hooks/usePaywallLocks.test.ts
+++ b/unlock-app/src/__tests__/hooks/usePaywallLocks.test.ts
@@ -39,7 +39,9 @@ describe('usePaywallLocks', () => {
   it('should default to an empty object and loading, then populate with locks and stop loading', async () => {
     expect.assertions(4)
     const lockAddresses = ['0xlock1', '0xlock2']
-    const { result, wait } = renderHook(() => usePaywallLocks(lockAddresses))
+    const { result, wait } = renderHook(() =>
+      usePaywallLocks(lockAddresses, jest.fn())
+    )
 
     expect(result.current.locks).toEqual([])
     expect(result.current.loading).toBeTruthy()
@@ -49,5 +51,27 @@ describe('usePaywallLocks', () => {
     })
     expect(result.current.locks).toHaveLength(2)
     expect(result.current.loading).toBeFalsy()
+  })
+
+  it('should query for ERC20 balance if needed', async () => {
+    expect.assertions(1)
+    mockWeb3Service.getLock = jest.fn(address => {
+      return Promise.resolve({
+        address,
+        currencyContractAddress: '0xerc20',
+        ...web3ServiceLock,
+      })
+    })
+    const getTokenBalance = jest.fn()
+    const lockAddresses = ['0xlock1']
+    const { result, wait } = renderHook(() =>
+      usePaywallLocks(lockAddresses, getTokenBalance)
+    )
+
+    await wait(() => {
+      return !result.current.loading
+    })
+
+    expect(getTokenBalance).toHaveBeenCalledWith('0xerc20')
   })
 })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5127,35 +5127,6 @@ Object {
   margin-right: 8px;
 }
 
-.c4 {
-  height: 48px;
-  width: 100%;
-  border-radius: 4px;
-  border: 1px var(--white) solid;
-  box-shadow: 0px 0px 40px rgba(0,0,0,0.08);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: var(--white);
-  cursor: pointer;
-}
-
-.c4:hover {
-  border: 1px solid var(--blue);
-}
-
-.c4:hover .c8 {
-  fill: var(--blue);
-}
-
 .c0 {
   width: 240px;
   height: 72px;
@@ -5257,6 +5228,35 @@ Object {
   width: 100%;
 }
 
+.c4 {
+  height: 48px;
+  width: 100%;
+  border-radius: 4px;
+  border: 1px var(--white) solid;
+  box-shadow: 0px 0px 40px rgba(0,0,0,0.08);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: var(--white);
+  cursor: pointer;
+}
+
+.c4:hover {
+  border: 1px solid var(--blue);
+}
+
+.c4:hover .c8 {
+  fill: var(--blue);
+}
+
 <div>
       <link
         href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
@@ -5324,38 +5324,368 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-pjstK bwTJOd"
+      class="sc-pbxSd nDHyO"
     >
       <div
-        class="sc-qYIQh kMzNWR"
+        class="sc-qQMSE eJZUqy"
       >
         <span
-          class="sc-prorn lnozAw"
+          class="sc-pjstK vopgb"
         >
           ETH Lock
         </span>
         <span
-          class="sc-qQMSE jigpIh"
+          class="sc-prorn ghBwTr"
         >
           Unlimited
            Available
         </span>
       </div>
       <div
-        class="sc-pbxSd kdlDET"
+        class="sc-pRtAn kJBdYp"
       >
         <span
-          class="sc-pBzUF kXDysY"
+          class="sc-qYIQh hmXhDL"
         >
           0.01
         </span>
         <span
-          class="sc-pJUVA hTiwUC"
+          class="sc-pBzUF iykWKN"
         >
           ETH
         </span>
         <div
-          class="sc-pRtAn dLrkMV"
+          class="sc-pJUVA loGuSw"
+        >
+          <span>
+            Valid for
+          </span>
+          <br />
+          <span>
+            5 minutes
+          </span>
+        </div>
+        <svg
+          class="sc-oTBUA hFpCpo"
+          viewBox="0 0 24 24"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M17.5 12a.5.5 0 01-.175.38l-3.5 3a.5.5 0 11-.65-.76l2.473-2.12H7a.5.5 0 010-1h8.648l-2.473-2.12a.5.5 0 11.65-.76l3.5 3a.5.5 0 01.175.38z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Checkout Lock Insufficient Balance 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c11 {
+  width: 32px;
+  fill: var(--darkgrey);
+  margin-left: auto;
+  margin-right: 8px;
+}
+
+.c0 {
+  width: 240px;
+  height: 72px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  margin-top: 17px;
+}
+
+.c2 {
+  font-size: 13px;
+  color: var(--grey);
+  font-family: IBM Plex Sans;
+  font-style: normal;
+  font-weight: normal;
+}
+
+.c3 {
+  font-size: 9px;
+  color: var(--grey);
+  font-family: IBM Plex Sans;
+  font-style: normal;
+  font-weight: normal;
+}
+
+.c1 {
+  height: 24px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  color: var(--darkgrey);
+  font-family: IBM Plex Mono;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 20px;
+  margin-left: 12px;
+  text-align: right;
+  width: 65px;
+}
+
+.c8 {
+  color: var(--darkgrey);
+  font-family: IBM Plex Mono;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 20px;
+  text-align: right;
+  width: 42px;
+}
+
+.c9 {
+  font-family: IBM Plex Sans;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 9px;
+  line-height: 10px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: right;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin: 0 auto;
+}
+
+.c9 > span {
+  width: 100%;
+}
+
+.c4 {
+  height: 48px;
+  width: 100%;
+  border-radius: 4px;
+  border: 1px var(--white) solid;
+  box-shadow: 0px 0px 40px rgba(0,0,0,0.08);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: var(--white);
+  cursor: pointer;
+}
+
+.c4:hover {
+  border: 1px solid var(--blue);
+}
+
+.c4:hover .c10 {
+  fill: var(--blue);
+}
+
+.c4 .c10 {
+  visibility: hidden;
+}
+
+.c4 .c5,
+.c4 .c7 {
+  color: var(--red);
+}
+
+.c4:hover {
+  border: 1px var(--white) solid;
+  cursor: not-allowed;
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <span
+            class="c2"
+          >
+            ETH Lock
+          </span>
+          <span
+            class="c3"
+          >
+            Unlimited
+             Available
+          </span>
+        </div>
+        <div
+          class="c4"
+        >
+          <span
+            class="c5 c6"
+          >
+            0.01
+          </span>
+          <span
+            class="c7 c8"
+          >
+            ETH
+          </span>
+          <div
+            class="c9"
+          >
+            <span>
+              Valid for
+            </span>
+            <br />
+            <span>
+              5 minutes
+            </span>
+          </div>
+          <svg
+            class="c10 c11"
+            viewBox="0 0 24 24"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M17.5 12a.5.5 0 01-.175.38l-3.5 3a.5.5 0 11-.65-.76l2.473-2.12H7a.5.5 0 010-1h8.648l-2.473-2.12a.5.5 0 11.65-.76l3.5 3a.5.5 0 01.175.38z"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-pbxSd nDHyO"
+    >
+      <div
+        class="sc-qQMSE eJZUqy"
+      >
+        <span
+          class="sc-pjstK vopgb"
+        >
+          ETH Lock
+        </span>
+        <span
+          class="sc-prorn ghBwTr"
+        >
+          Unlimited
+           Available
+        </span>
+      </div>
+      <div
+        class="sc-pRtAn faNRxl"
+      >
+        <span
+          class="sc-qYIQh hmXhDL"
+        >
+          0.01
+        </span>
+        <span
+          class="sc-pBzUF iykWKN"
+        >
+          ETH
+        </span>
+        <div
+          class="sc-pJUVA loGuSw"
         >
           <span>
             Valid for
@@ -5436,7 +5766,24 @@ exports[`Storyshots Checkout Lock Loading 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c1 {
+    .c0 {
+  width: 240px;
+  height: 72px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  margin-top: 17px;
+}
+
+.c1 {
   height: 48px;
   width: 100%;
   border-radius: 4px;
@@ -5458,21 +5805,18 @@ Object {
   animation: gfABjo 2s linear infinite;
 }
 
-.c0 {
-  width: 240px;
-  height: 72px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  margin-top: 17px;
+.c1 .sc-oTBUA {
+  visibility: hidden;
+}
+
+.c1 .sc-qYIQh,
+.c1 .sc-pBzUF {
+  color: var(--red);
+}
+
+.c1:hover {
+  border: 1px var(--white) solid;
+  cursor: not-allowed;
 }
 
 <div>
@@ -5496,10 +5840,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-pjstK bwTJOd"
+      class="sc-pbxSd nDHyO"
     >
       <div
-        class="sc-pbxSd gyQAqr"
+        class="sc-pRtAn ijHGyJ"
         loading="true"
       />
     </div>

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5324,38 +5324,38 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-pbxSd nDHyO"
+      class="sc-pbxSd eqkMjK"
     >
       <div
-        class="sc-qQMSE eJZUqy"
+        class="sc-qQMSE gubPLK"
       >
         <span
-          class="sc-pjstK vopgb"
+          class="sc-pjstK kAEfjf"
         >
           ETH Lock
         </span>
         <span
-          class="sc-prorn ghBwTr"
+          class="sc-prorn iHoddj"
         >
           Unlimited
            Available
         </span>
       </div>
       <div
-        class="sc-pRtAn kJBdYp"
+        class="sc-pRtAn dFACop"
       >
         <span
-          class="sc-qYIQh hmXhDL"
+          class="sc-qYIQh gTyRBn"
         >
           0.01
         </span>
         <span
-          class="sc-pBzUF iykWKN"
+          class="sc-pBzUF dWerlR"
         >
           ETH
         </span>
         <div
-          class="sc-pJUVA loGuSw"
+          class="sc-pJUVA dNIpAo"
         >
           <span>
             Valid for
@@ -5654,38 +5654,38 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-pbxSd nDHyO"
+      class="sc-pbxSd eqkMjK"
     >
       <div
-        class="sc-qQMSE eJZUqy"
+        class="sc-qQMSE gubPLK"
       >
         <span
-          class="sc-pjstK vopgb"
+          class="sc-pjstK kAEfjf"
         >
           ETH Lock
         </span>
         <span
-          class="sc-prorn ghBwTr"
+          class="sc-prorn iHoddj"
         >
           Unlimited
            Available
         </span>
       </div>
       <div
-        class="sc-pRtAn faNRxl"
+        class="sc-pRtAn fzbPsV"
       >
         <span
-          class="sc-qYIQh hmXhDL"
+          class="sc-qYIQh gTyRBn"
         >
           0.01
         </span>
         <span
-          class="sc-pBzUF iykWKN"
+          class="sc-pBzUF dWerlR"
         >
           ETH
         </span>
         <div
-          class="sc-pJUVA loGuSw"
+          class="sc-pJUVA dNIpAo"
         >
           <span>
             Valid for
@@ -5840,10 +5840,10 @@ Object {
       rel="stylesheet"
     />
     <div
-      class="sc-pbxSd nDHyO"
+      class="sc-pbxSd eqkMjK"
     >
       <div
-        class="sc-pRtAn ijHGyJ"
+        class="sc-pRtAn cNgtLp"
         loading="true"
       />
     </div>

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5327,7 +5327,7 @@ Object {
       class="sc-pbxSd eqkMjK"
     >
       <div
-        class="sc-qQMSE gubPLK"
+        class="sc-qYIQh kMzNWR"
       >
         <span
           class="sc-pjstK kAEfjf"
@@ -5342,20 +5342,20 @@ Object {
         </span>
       </div>
       <div
-        class="sc-pRtAn dFACop"
+        class="sc-pZOBi dNwGwy"
       >
         <span
-          class="sc-qYIQh gTyRBn"
+          class="sc-pBzUF kXDysY"
         >
           0.01
         </span>
         <span
-          class="sc-pBzUF dWerlR"
+          class="sc-pJUVA hTiwUC"
         >
           ETH
         </span>
         <div
-          class="sc-pJUVA dNIpAo"
+          class="sc-pRtAn dLrkMV"
         >
           <span>
             Valid for
@@ -5474,6 +5474,7 @@ Object {
   font-family: IBM Plex Sans;
   font-style: normal;
   font-weight: normal;
+  color: var(--red);
 }
 
 .c1 {
@@ -5563,6 +5564,7 @@ Object {
   align-items: center;
   background-color: var(--white);
   cursor: pointer;
+  opacity: 0.5;
 }
 
 .c4:hover {
@@ -5604,10 +5606,9 @@ Object {
             ETH Lock
           </span>
           <span
-            class="c3"
+            class="sc-prorn c3"
           >
-            Unlimited
-             Available
+            Insufficient Funds
           </span>
         </div>
         <div
@@ -5657,7 +5658,7 @@ Object {
       class="sc-pbxSd eqkMjK"
     >
       <div
-        class="sc-qQMSE gubPLK"
+        class="sc-qYIQh kMzNWR"
       >
         <span
           class="sc-pjstK kAEfjf"
@@ -5665,27 +5666,26 @@ Object {
           ETH Lock
         </span>
         <span
-          class="sc-prorn iHoddj"
+          class="sc-prorn sc-qQMSE fudlIn"
         >
-          Unlimited
-           Available
+          Insufficient Funds
         </span>
       </div>
       <div
-        class="sc-pRtAn fzbPsV"
+        class="sc-pZOBi cDuuth"
       >
         <span
-          class="sc-qYIQh gTyRBn"
+          class="sc-pBzUF kXDysY"
         >
           0.01
         </span>
         <span
-          class="sc-pBzUF dWerlR"
+          class="sc-pJUVA hTiwUC"
         >
           ETH
         </span>
         <div
-          class="sc-pJUVA dNIpAo"
+          class="sc-pRtAn dLrkMV"
         >
           <span>
             Valid for
@@ -5809,8 +5809,8 @@ Object {
   visibility: hidden;
 }
 
-.c1 .sc-qYIQh,
-.c1 .sc-pBzUF {
+.c1 .sc-pBzUF,
+.c1 .sc-pJUVA {
   color: var(--red);
 }
 
@@ -5843,7 +5843,7 @@ Object {
       class="sc-pbxSd eqkMjK"
     >
       <div
-        class="sc-pRtAn cNgtLp"
+        class="sc-pZOBi fvTzW"
         loading="true"
       />
     </div>
@@ -61411,14 +61411,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-pQEbo fHHJUQ"
+      class="sc-pYA-dN bkYJiK"
     >
       <div
-        class="sc-pYA-dN icvhJr"
+        class="sc-oUcyK frlsSP"
         color="--green"
       >
         <div
-          class="sc-psQdR vNcgI"
+          class="sc-qPlga kMFShP"
         >
           <svg
             viewBox="0 0 24 24"
@@ -61434,57 +61434,57 @@ Object {
           </svg>
         </div>
         <h1
-          class="sc-oUcyK gvYHzG"
+          class="sc-pbYBj foGBlG"
         >
           Valid Key
         </h1>
         <h2
-          class="sc-pbYBj kPbXAq"
+          class="sc-pkUbs bmDCxi"
         >
           Until 
           Jun 24th, 2020
         </h2>
       </div>
       <div
-        class="sc-qPlga cuusPX"
+        class="sc-qXhiz llHUTy"
       >
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Lock Name
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           Week in Ethereum News
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Token Id
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           53
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Owner Address
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           0x33ab07dF7f09e793dDD1E9A25b079989a557119A
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Time Since signed
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           20 minutes ago
         </div>
@@ -61750,14 +61750,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-pQEbo fHHJUQ"
+      class="sc-pYA-dN bkYJiK"
     >
       <div
-        class="sc-pYA-dN icvhJr"
+        class="sc-oUcyK frlsSP"
         color="--green"
       >
         <div
-          class="sc-psQdR vNcgI"
+          class="sc-qPlga kMFShP"
         >
           <svg
             viewBox="0 0 24 24"
@@ -61773,62 +61773,62 @@ Object {
           </svg>
         </div>
         <h1
-          class="sc-oUcyK gvYHzG"
+          class="sc-pbYBj foGBlG"
         >
           Valid Key
         </h1>
         <h2
-          class="sc-pbYBj kPbXAq"
+          class="sc-pkUbs bmDCxi"
         >
           Until 
           Jun 24th, 2020
         </h2>
       </div>
       <div
-        class="sc-qPlga cuusPX"
+        class="sc-qXhiz llHUTy"
       >
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Lock Name
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           Week in Ethereum News
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Token Id
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           53
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Owner Address
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           0x33ab07dF7f09e793dDD1E9A25b079989a557119A
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Time Since signed
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           20 minutes ago
         </div>
         <button
-          class="sc-fznBtT sc-qXhiz yIftG"
+          class="sc-fznBtT sc-pzYib cWkUVA"
         >
           Mark as Checked-In
         </button>
@@ -62065,14 +62065,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-pQEbo fHHJUQ"
+      class="sc-pYA-dN bkYJiK"
     >
       <div
-        class="sc-pYA-dN icvhJr"
+        class="sc-oUcyK frlsSP"
         color="--green"
       >
         <div
-          class="sc-psQdR vNcgI"
+          class="sc-qPlga kMFShP"
         >
           <svg
             viewBox="0 0 24 24"
@@ -62088,57 +62088,57 @@ Object {
           </svg>
         </div>
         <h1
-          class="sc-oUcyK gvYHzG"
+          class="sc-pbYBj foGBlG"
         >
           Valid Key
         </h1>
         <h2
-          class="sc-pbYBj kPbXAq"
+          class="sc-pkUbs bmDCxi"
         >
           Until 
           Jun 24th, 2020
         </h2>
       </div>
       <div
-        class="sc-qPlga cuusPX"
+        class="sc-qXhiz llHUTy"
       >
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Lock Name
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           Week in Ethereum News
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Token Id
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           53
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Owner Address
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           0x33ab07dF7f09e793dDD1E9A25b079989a557119A
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Time Since signed
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           20 minutes ago
         </div>
@@ -62391,14 +62391,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-pQEbo fHHJUQ"
+      class="sc-pYA-dN bkYJiK"
     >
       <div
-        class="sc-pYA-dN hHhpOn"
+        class="sc-oUcyK kZgVQb"
         color="--yellow"
       >
         <div
-          class="sc-psQdR vNcgI"
+          class="sc-qPlga kMFShP"
         >
           <svg
             viewBox="0 0 24 24"
@@ -62414,18 +62414,18 @@ Object {
           </svg>
         </div>
         <h1
-          class="sc-oUcyK gvYHzG"
+          class="sc-pbYBj foGBlG"
         >
           Valid Key
         </h1>
         <h2
-          class="sc-pbYBj kPbXAq"
+          class="sc-pkUbs bmDCxi"
         >
           Until 
           Jun 24th, 2020
         </h2>
         <h2
-          class="sc-pkUbs ffihxy"
+          class="sc-psQdR gRoepd"
         >
           Checked-in 
           1 minute
@@ -62433,45 +62433,45 @@ Object {
         </h2>
       </div>
       <div
-        class="sc-qPlga cuusPX"
+        class="sc-qXhiz llHUTy"
       >
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Lock Name
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           Week in Ethereum News
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Token Id
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           53
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Owner Address
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           0x33ab07dF7f09e793dDD1E9A25b079989a557119A
         </div>
         <div
-          class="sc-pzYib cqnJTo"
+          class="sc-pItiW iSTDmj"
         >
           Time Since signed
         </div>
         <div
-          class="sc-pItiW hQzYEK"
+          class="sc-pQSRh blNJIV"
         >
           20 minutes ago
         </div>
@@ -62616,14 +62616,14 @@ Object {
       rel="stylesheet"
     />
     <section
-      class="sc-pQEbo fHHJUQ"
+      class="sc-pYA-dN bkYJiK"
     >
       <div
-        class="sc-pYA-dN bmFggf"
+        class="sc-oUcyK dWVgxT"
         color="--red"
       >
         <div
-          class="sc-psQdR vNcgI"
+          class="sc-qPlga kMFShP"
         >
           <svg
             viewBox="0 0 24 24"
@@ -62639,7 +62639,7 @@ Object {
           </svg>
         </div>
         <h1
-          class="sc-oUcyK gvYHzG"
+          class="sc-pbYBj foGBlG"
         >
           Key Invalid
         </h1>

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -6,7 +6,7 @@ import BrowserOnly from '../helpers/BrowserOnly'
 import Layout from '../interface/Layout'
 import Account from '../interface/Account'
 import { pageTitle } from '../../constants'
-import { Lock, LoadingLock } from '../interface/checkout/Lock'
+import { Locks } from '../interface/checkout/Locks'
 import {
   Account as AccountType,
   Network,
@@ -14,7 +14,6 @@ import {
   PaywallConfig,
 } from '../../unlockTypes'
 import getConfigFromSearch from '../../utils/getConfigFromSearch'
-import { usePaywallLocks } from '../../hooks/usePaywallLocks'
 
 interface CheckoutContentProps {
   account: AccountType
@@ -33,8 +32,6 @@ export const CheckoutContent = ({
     ? Object.keys(config.locks)
     : defaultLockAddresses
 
-  const { locks, loading } = usePaywallLocks(lockAddresses)
-
   return (
     <Layout title="Checkout">
       <Head>
@@ -43,20 +40,10 @@ export const CheckoutContent = ({
       {account && (
         <BrowserOnly>
           <Account network={network} account={account} />
-          {loading && (
-            <div>
-              {lockAddresses.map(address => (
-                <LoadingLock key={address} />
-              ))}
-            </div>
-          )}
-          {locks && (
-            <div>
-              {locks.map(lock => (
-                <Lock lock={lock} key={lock.name} />
-              ))}
-            </div>
-          )}
+          <Locks
+            accountAddress={account.address}
+            lockAddresses={lockAddresses}
+          />
         </BrowserOnly>
       )}
     </Layout>

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -45,9 +45,9 @@ export const fadeInOut = keyframes`
   100% { opacity: 1; }
 `
 
-export const lockBodyOpacity = ({ loading }: LockBodyProps) => {
+export const lockBodyOpacity = ({ loading, canAfford }: LockBodyProps) => {
   if (!loading) {
-    return ''
+    return canAfford ? '' : 'opacity: 0.5;'
   }
 
   return css`
@@ -93,6 +93,10 @@ export const KeysAvailable = styled.span`
   font-family: IBM Plex Sans;
   font-style: normal;
   font-weight: normal;
+`
+
+export const CannotBuy = styled(KeysAvailable)`
+  color: var(--red);
 `
 
 export const InfoWrapper = styled.div`
@@ -221,7 +225,10 @@ export const Lock = ({ lock, balances }: LockProps) => {
     <LockContainer>
       <InfoWrapper>
         <LockName>{lock.name}</LockName>
-        <KeysAvailable>{lockKeysAvailable(lock)} Available</KeysAvailable>
+        {!canAfford && <CannotBuy>Insufficient Funds</CannotBuy>}
+        {canAfford && (
+          <KeysAvailable>{lockKeysAvailable(lock)} Available</KeysAvailable>
+        )}
       </InfoWrapper>
       <LockBody onClick={purchaseKey} canAfford={canAfford}>
         <LockPrice>{lock.keyPrice}</LockPrice>

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Lock, LoadingLock } from './Lock'
+import { usePaywallLocks } from '../../../hooks/usePaywallLocks'
+import { useGetTokenBalance } from '../../../hooks/useGetTokenBalance'
+
+interface LocksProps {
+  accountAddress: string
+  lockAddresses: string[]
+}
+
+export const Locks = ({ accountAddress, lockAddresses }: LocksProps) => {
+  const { balances, getTokenBalance } = useGetTokenBalance(accountAddress)
+  const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
+
+  if (loading) {
+    return (
+      <div>
+        {lockAddresses.map(address => (
+          <LoadingLock key={address} />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {locks.map(lock => (
+        <Lock lock={lock} balances={balances} key={lock.name} />
+      ))}
+    </div>
+  )
+}

--- a/unlock-app/src/hooks/useGetTokenBalance.ts
+++ b/unlock-app/src/hooks/useGetTokenBalance.ts
@@ -1,11 +1,7 @@
 import { useReducer, useContext, useEffect } from 'react'
 import { Web3Service } from '@unlock-protocol/unlock-js'
+import { Balances } from '../unlockTypes'
 import { Web3ServiceContext } from '../utils/withWeb3Service'
-
-interface Balances {
-  eth: string
-  [contractAddress: string]: string
-}
 
 interface BalanceUpdate {
   // `eth` or the currency contract address

--- a/unlock-app/src/hooks/usePaywallLocks.ts
+++ b/unlock-app/src/hooks/usePaywallLocks.ts
@@ -3,7 +3,10 @@ import { Web3Service } from '@unlock-protocol/unlock-js'
 import { Web3ServiceContext } from '../utils/withWeb3Service'
 import { RawLock } from '../unlockTypes'
 
-export const usePaywallLocks = (lockAddresses: string[]) => {
+export const usePaywallLocks = (
+  lockAddresses: string[],
+  getTokenBalance: (contractAddress: string) => void
+) => {
   const web3Service: Web3Service = useContext(Web3ServiceContext)
 
   const [loading, setLoading] = useState(true)
@@ -17,8 +20,14 @@ export const usePaywallLocks = (lockAddresses: string[]) => {
     })
 
     const locks = await Promise.all(lockPromises)
-    // getLock doesn't always return the lock address apparently
-    locks.forEach((lock, index) => (lock.address = lockAddresses[index]))
+    locks.forEach((lock, index) => {
+      if (lock.currencyContractAddress) {
+        getTokenBalance(lock.currencyContractAddress)
+      }
+
+      // getLock doesn't always return the lock address apparently
+      lock.address = lockAddresses[index]
+    })
     setLoading(false)
     setLocks(locks)
   }

--- a/unlock-app/src/stories/interface/checkout/Lock.stories.js
+++ b/unlock-app/src/stories/interface/checkout/Lock.stories.js
@@ -21,6 +21,9 @@ storiesOf('Checkout Lock', module)
   .add('Loading', () => {
     return <LoadingLock />
   })
+  .add('Insufficient Balance', () => {
+    return <Lock lock={lock} balances={{}} />
+  })
   .add('Active', () => {
-    return <Lock lock={lock} />
+    return <Lock lock={lock} balances={{ eth: '1' }} />
   })

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -193,3 +193,8 @@ export interface RawLock {
   balance?: string
   owner?: string
 }
+
+export interface Balances {
+  eth: string
+  [contractAddress: string]: string
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR allows the new checkout UI to show when a lock is too expensive for a user per @smombartz's design. Part of doing this involved shuffling some pieces around to avoid errors with the hooks.

**Edit**
In response to @akeem's concerns, I've gone beyond the figma and made it a bit more clear that the user cannot interact with the lock when they don't have enough money.

_Normal_:
<img width="256" alt="image" src="https://user-images.githubusercontent.com/9300702/75169070-ea885180-56f5-11ea-98d9-ba180bd95dcf.png">

_Insufficient Funds_:
<img width="256" alt="image" src="https://user-images.githubusercontent.com/9300702/75169095-f7a54080-56f5-11ea-8399-66326b68d226.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
