### PR TITLE
adding the ability to only show non expired keys to graphql query

### DIFF
--- a/unlock-app/src/queries/keyholdersByLock.js
+++ b/unlock-app/src/queries/keyholdersByLock.js
@@ -2,9 +2,9 @@ import { gql } from 'apollo-boost'
 
 export default function keyholdersByLockQuery() {
   return gql`
-    query Lock($addresses: [String!]) {
+    query Lock($addresses: [String!], $expiresAfter: BigInt! = 0) {
       locks(where: { address_in: $addresses }) {
-        keys {
+        keys(where: { expiration_gt: $expiresAfter }) {
           owner {
             address
           }


### PR DESCRIPTION
# Description

Both Forbes and Ethereal asked to only see the non-expired keys by default.
This first PR adds the ability to request keys which are set to expire _after_ a certain date.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread