### PR TITLE
Get token balance while fetching locks

### DIFF
--- a/unlock-app/src/hooks/useGetTokenBalance.ts
+++ b/unlock-app/src/hooks/useGetTokenBalance.ts
@@ -1,11 +1,7 @@
 import { useReducer, useContext, useEffect } from 'react'
 import { Web3Service } from '@unlock-protocol/unlock-js'
 import { Web3ServiceContext } from '../utils/withWeb3Service'
-
-interface Balances {
-  eth: string
-  [contractAddress: string]: string
-}
+import { Balances } from '../unlockTypes'
 
 interface BalanceUpdate {
   // `eth` or the currency contract address

--- a/unlock-app/src/hooks/usePaywallLocks.ts
+++ b/unlock-app/src/hooks/usePaywallLocks.ts
@@ -3,7 +3,10 @@ import { Web3Service } from '@unlock-protocol/unlock-js'
 import { Web3ServiceContext } from '../utils/withWeb3Service'
 import { RawLock } from '../unlockTypes'
 
-export const usePaywallLocks = (lockAddresses: string[]) => {
+export const usePaywallLocks = (
+  lockAddresses: string[],
+  getTokenBalance: (contractAddress: string) => void
+) => {
   const web3Service: Web3Service = useContext(Web3ServiceContext)
 
   const [loading, setLoading] = useState(true)
@@ -17,8 +20,18 @@ export const usePaywallLocks = (lockAddresses: string[]) => {
     })
 
     const locks = await Promise.all(lockPromises)
-    // getLock doesn't always return the lock address apparently
-    locks.forEach((lock, index) => (lock.address = lockAddresses[index]))
+
+    locks.forEach((lock, index) => {
+      if (lock.currencyContractAddress) {
+        // This is the easiest place to determine which tokens we need
+        // to query for the user's balance of. The values are tracked
+        // in the useGetTokenBalance hook.
+        getTokenBalance(lock.currencyContractAddress)
+      }
+
+      // getLock doesn't always return the lock address apparently
+      lock.address = lockAddresses[index]
+    })
     setLoading(false)
     setLocks(locks)
   }

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -193,3 +193,8 @@ export interface RawLock {
   balance?: string
   owner?: string
 }
+
+export interface Balances {
+  eth: string
+  [contractAddress: string]: string
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Split off from #6031. When we get lock information, if a given lock is denominated in an ERC20 token, we query for and store the user's balance of that token.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
