### PR TITLE
removing the tos flash

### DIFF
--- a/unlock-app/src/__tests__/hooks/useTermsOfService.test.js
+++ b/unlock-app/src/__tests__/hooks/useTermsOfService.test.js
@@ -4,39 +4,54 @@ import useTermsOfService, {
 } from '../../hooks/useTermsOfService'
 
 describe('useTermsOfService', () => {
-  beforeAll(() => {})
+  beforeAll(() => {
+    jest.resetAllMocks()
+  })
 
   it('should default to false if no value is set in localtorage', async () => {
     expect.assertions(1)
     const { result } = renderHook(() => useTermsOfService())
-    const termsAccepted = result.current[0]
+    const termsAccepted = result.current.termsAccepted
     expect(termsAccepted).toBe(false)
   })
 
   it('should return true if the correct value is set in localstorage', async () => {
     expect.assertions(1)
-    window.localStorage.setItem(localStorageKey, 'true')
+    localStorage.setItem(localStorageKey, 'true')
     const { result } = renderHook(() => useTermsOfService())
-    const termsAccepted = result.current[0]
+    const termsAccepted = result.current.termsAccepted
     expect(termsAccepted).toBe(true)
   })
 
   it('should return false if the value in localstorage is not correct', async () => {
     expect.assertions(1)
-    window.localStorage.setItem(localStorageKey, 'hello')
+    localStorage.setItem(localStorageKey, 'hello')
     const { result } = renderHook(() => useTermsOfService())
-    const termsAccepted = result.current[0]
+    const termsAccepted = result.current.termsAccepted
+    expect(termsAccepted).toBe(false)
+  })
+
+  it('should return false if localstorage could not be read', async () => {
+    expect.assertions(1)
+
+    // eslint-disable-next-line no-proto
+    jest.spyOn(localStorage.__proto__, 'getItem').mockImplementationOnce(() => {
+      throw new Error()
+    })
+
+    const { result } = renderHook(() => useTermsOfService())
+    const termsAccepted = result.current.termsAccepted
     expect(termsAccepted).toBe(false)
   })
 
   it('should set the value in localstorage', async () => {
     expect.assertions(1)
     const { result } = renderHook(() => useTermsOfService())
-    const acceptTerms = result.current[1]
+    const saveTermsAccepted = result.current.saveTermsAccepted
     act(() => {
-      acceptTerms()
+      saveTermsAccepted()
     })
-    const savedValue = window.localStorage.getItem(localStorageKey)
+    const savedValue = localStorage.getItem(localStorageKey)
     expect(savedValue).toBe('true')
   })
 })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5804,6 +5804,16 @@ Object {
   z-index: var(--alwaysontop);
 }
 
+.c17 {
+  display: grid;
+  justify-items: center;
+}
+
+.c17 svg {
+  fill: var(--lightgrey);
+  width: 60px;
+}
+
 .c0 {
   display: grid;
   grid-template-columns: 1fr minmax(280px,4fr) 1fr;
@@ -5874,16 +5884,6 @@ Object {
 .c15 {
   margin: 0px;
   font-size: 16px;
-}
-
-.c17 {
-  display: grid;
-  justify-items: center;
-}
-
-.c17 svg {
-  fill: var(--lightgrey);
-  width: 60px;
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
@@ -34079,6 +34079,16 @@ Object {
   z-index: var(--alwaysontop);
 }
 
+.c28 {
+  display: grid;
+  justify-items: center;
+}
+
+.c28 svg {
+  fill: var(--lightgrey);
+  width: 60px;
+}
+
 .c0 {
   display: grid;
   grid-template-columns: 1fr minmax(280px,4fr) 1fr;
@@ -34149,16 +34159,6 @@ Object {
 .c20 {
   margin: 0px;
   font-size: 16px;
-}
-
-.c28 {
-  display: grid;
-  justify-items: center;
-}
-
-.c28 svg {
-  fill: var(--lightgrey);
-  width: 60px;
 }
 
 .c26 {
@@ -36909,6 +36909,16 @@ Object {
   z-index: var(--alwaysontop);
 }
 
+.c28 {
+  display: grid;
+  justify-items: center;
+}
+
+.c28 svg {
+  fill: var(--lightgrey);
+  width: 60px;
+}
+
 .c0 {
   display: grid;
   grid-template-columns: 1fr minmax(280px,4fr) 1fr;
@@ -36979,16 +36989,6 @@ Object {
 .c20 {
   margin: 0px;
   font-size: 16px;
-}
-
-.c28 {
-  display: grid;
-  justify-items: center;
-}
-
-.c28 svg {
-  fill: var(--lightgrey);
-  width: 60px;
 }
 
 .c26 {
@@ -38611,6 +38611,16 @@ Object {
   z-index: var(--alwaysontop);
 }
 
+.c28 {
+  display: grid;
+  justify-items: center;
+}
+
+.c28 svg {
+  fill: var(--lightgrey);
+  width: 60px;
+}
+
 .c0 {
   display: grid;
   grid-template-columns: 1fr minmax(280px,4fr) 1fr;
@@ -38681,16 +38691,6 @@ Object {
 .c20 {
   margin: 0px;
   font-size: 16px;
-}
-
-.c28 {
-  display: grid;
-  justify-items: center;
-}
-
-.c28 svg {
-  fill: var(--lightgrey);
-  width: 60px;
 }
 
 .c26 {
@@ -40313,6 +40313,16 @@ Object {
   z-index: var(--alwaysontop);
 }
 
+.c28 {
+  display: grid;
+  justify-items: center;
+}
+
+.c28 svg {
+  fill: var(--lightgrey);
+  width: 60px;
+}
+
 .c0 {
   display: grid;
   grid-template-columns: 1fr minmax(280px,4fr) 1fr;
@@ -40383,16 +40393,6 @@ Object {
 .c20 {
   margin: 0px;
   font-size: 16px;
-}
-
-.c28 {
-  display: grid;
-  justify-items: center;
-}
-
-.c28 svg {
-  fill: var(--lightgrey);
-  width: 60px;
 }
 
 .c26 {
@@ -51712,6 +51712,16 @@ Object {
   z-index: var(--alwaysontop);
 }
 
+.c23 {
+  display: grid;
+  justify-items: center;
+}
+
+.c23 svg {
+  fill: var(--lightgrey);
+  width: 60px;
+}
+
 .c0 {
   display: grid;
   grid-template-columns: 1fr minmax(280px,4fr) 1fr;
@@ -51782,16 +51792,6 @@ Object {
 .c18 {
   margin: 0px;
   font-size: 16px;
-}
-
-.c23 {
-  display: grid;
-  justify-items: center;
-}
-
-.c23 svg {
-  fill: var(--lightgrey);
-  width: 60px;
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {

--- a/unlock-app/src/components/interface/Layout.js
+++ b/unlock-app/src/components/interface/Layout.js
@@ -11,9 +11,13 @@ import { MessageBox } from './modal-templates/styles'
 import { ActionButton } from './buttons/ActionButton'
 import withConfig from '../../utils/withConfig'
 import useTermsOfService from '../../hooks/useTermsOfService'
+import Loading from './Loading'
 
 export default function Layout({ forContent, title, children }) {
-  const [tosAccepted, setTosAccepted] = useTermsOfService()
+  const { termsAccepted, saveTermsAccepted, termsLoading } = useTermsOfService()
+  if (termsLoading) {
+    return <Loading />
+  }
   return (
     <Container>
       <Left>
@@ -27,7 +31,7 @@ export default function Layout({ forContent, title, children }) {
       </Left>
       <Content>
         <Header forContent={forContent} title={title} />
-        {!tosAccepted && <Terms setTosAccepted={setTosAccepted} />}
+        {!termsAccepted && <Terms setTermsAccepted={saveTermsAccepted} />}
         {children}
         {forContent && <Footer />}
       </Content>
@@ -48,7 +52,7 @@ Layout.defaultProps = {
   forContent: false,
 }
 
-const Terms = withConfig(({ setTosAccepted, config }) => {
+const Terms = withConfig(({ setTermsAccepted, config }) => {
   return (
     <styles.Greyout>
       <TermsModal>
@@ -67,7 +71,9 @@ const Terms = withConfig(({ setTosAccepted, config }) => {
           </Link>
           .
         </Message>
-        <TosButton onClick={() => setTosAccepted(true)}>I agree</TosButton>
+        <TermsButton onClick={() => setTermsAccepted(true)}>
+          I agree
+        </TermsButton>
       </TermsModal>
     </styles.Greyout>
   )
@@ -95,7 +101,7 @@ const TermsModal = styled(MessageBox)`
   `}
 `
 
-const TosButton = styled(ActionButton)`
+const TermsButton = styled(ActionButton)`
   padding: 10px;
 `
 

--- a/unlock-app/src/hooks/useTermsOfService.js
+++ b/unlock-app/src/hooks/useTermsOfService.js
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 export const localStorageKey = 'terms-of-service'
 
@@ -7,24 +7,34 @@ export const localStorageKey = 'terms-of-service'
  * @param {*} address
  */
 export const useTermsOfService = () => {
-  const [tosAccepted, setTosAccepted] = useState(() => {
+  const [termsLoading, setTermsLoading] = useState(true)
+  const [termsAccepted, setTermsAccepted] = useState(false)
+
+  const readFromLocalStorage = () => {
     try {
-      return window.localStorage.getItem(localStorageKey) === 'true'
+      setTermsAccepted(window.localStorage.getItem(localStorageKey) === 'true')
+      setTermsLoading(false)
     } catch (error) {
       // No localstorage, assume false!
-      return false
+      setTermsAccepted(false)
+      setTermsLoading(false)
     }
-  })
+  }
 
-  const saveTosAccepted = () => {
-    setTosAccepted(true)
+  useEffect(() => {
+    readFromLocalStorage()
+  }, [])
+
+  const saveTermsAccepted = () => {
+    setTermsAccepted(true)
     try {
-      window.localStorage.setItem(localStorageKey, true)
+      window.localStorage.setItem(localStorageKey, 'true')
     } catch (error) {
       // Could not store in localstorage.
     }
   }
-  return [tosAccepted, saveTosAccepted]
+
+  return { termsAccepted, saveTermsAccepted, termsLoading }
 }
 
 export default useTermsOfService


### PR DESCRIPTION
# Description

By only showing it once we have a clear value from localStorage we avoid the annoying flash.
I also renamed variables for consistency with our style guide.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->