### PR TITLE
Checkout keeps track of purchases in progress

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import * as rtl from '@testing-library/react'
+import {
+  lockKeysAvailable,
+  Lock,
+} from '../../../../components/interface/checkout/Lock'
+import * as usePurchaseKey from '../../../../hooks/usePurchaseKey'
+
+describe('Checkout Lock', () => {
+  describe('helpers', () => {
+    describe('lockKeysAvailable', () => {
+      it('returns Unlimited if it has unlimited keys', () => {
+        expect.assertions(1)
+        const lock = {
+          unlimitedKeys: true,
+          maxNumberOfKeys: -1,
+          outstandingKeys: 100,
+        }
+        expect(lockKeysAvailable(lock)).toEqual('Unlimited')
+      })
+
+      it('returns the difference between max and outstanding ottherwise', () => {
+        expect.assertions(1)
+        const lock = {
+          maxNumberOfKeys: 203,
+          outstandingKeys: 100,
+        }
+        expect(lockKeysAvailable(lock)).toEqual('103')
+      })
+    })
+  })
+
+  describe('Lock', () => {
+    let purchaseKey: () => void
+    let setPurchasingLockAddress: () => void
+    beforeEach(() => {
+      purchaseKey = jest.fn()
+      setPurchasingLockAddress = jest.fn()
+      jest
+        .spyOn(usePurchaseKey, 'usePurchaseKey')
+        .mockImplementation(_ => ({ purchaseKey, initiatedPurchase: false }))
+    })
+
+    it('purchases a key and sets the purchasing address on click', () => {
+      expect.assertions(2)
+
+      const lock = {
+        name: 'lock',
+        address: '0xlockaddress',
+        keyPrice: '4000000',
+        expirationDuration: 50,
+        currencyContractAddress: null,
+      }
+
+      const { getByText } = rtl.render(
+        <Lock
+          lock={lock}
+          purchasingLockAddress={null}
+          setPurchasingLockAddress={setPurchasingLockAddress}
+        />
+      )
+
+      const validitySpan = getByText('Valid for')
+
+      rtl.fireEvent.click(validitySpan)
+
+      expect(purchaseKey).toHaveBeenCalled()
+      expect(setPurchasingLockAddress).toHaveBeenCalledWith('0xlockaddress')
+    })
+
+    it('does not purchase a key and set the purchasing address when there is already a purchase', () => {
+      expect.assertions(2)
+
+      const lock = {
+        name: 'lock',
+        address: '0xlockaddress',
+        keyPrice: '4000000',
+        expirationDuration: 50,
+        currencyContractAddress: null,
+      }
+
+      const { getByText } = rtl.render(
+        <Lock
+          lock={lock}
+          purchasingLockAddress="0xneato"
+          setPurchasingLockAddress={setPurchasingLockAddress}
+        />
+      )
+
+      const validitySpan = getByText('Valid for')
+
+      rtl.fireEvent.click(validitySpan)
+
+      expect(purchaseKey).not.toHaveBeenCalled()
+      expect(setPurchasingLockAddress).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
@@ -18,12 +18,14 @@ interface WrapperStyleProps {
 const CheckoutWrapper: React.FunctionComponent<WrapperProps> = ({
   children,
   hideCheckout,
-  bgColor = 'var(--offwhite)',
   allowClose = true,
   icon,
 }: React.PropsWithChildren<WrapperProps>) => {
   return (
-    <Wrapper bgColor={bgColor} onClick={allowClose ? hideCheckout : () => {}}>
+    <Wrapper
+      bgColor="var(--offwhite)"
+      onClick={allowClose ? hideCheckout : () => {}}
+    >
       {allowClose ? (
         <CloseButton
           backgroundColor="var(--lightgrey)"

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -166,27 +166,54 @@ export const LoadingLock = () => {
 
 interface LockProps {
   lock: RawLock
+  purchasingLockAddress: string | null
+  setPurchasingLockAddress: (lockAddress: string) => void
 }
 
-const lockKeysAvailable = (lock: RawLock) => {
-  if ((lock as any).unlimitedKeys) {
+interface LockKeysAvailableLock {
+  unlimitedKeys?: boolean
+  maxNumberOfKeys?: number
+  outstandingKeys?: number
+}
+
+export const lockKeysAvailable = ({
+  unlimitedKeys,
+  maxNumberOfKeys,
+  outstandingKeys,
+}: LockKeysAvailableLock) => {
+  if (unlimitedKeys) {
     return 'Unlimited'
   }
 
   // maxNumberOfKeys and outstandingKeys are assumed to be defined
   // if they are ever not, a runtime error can occur
-  return (lock.maxNumberOfKeys! - lock.outstandingKeys!).toString()
+  return (maxNumberOfKeys! - outstandingKeys!).toString()
 }
 
-export const Lock = ({ lock }: LockProps) => {
+export const Lock = ({
+  lock,
+  purchasingLockAddress,
+  setPurchasingLockAddress,
+}: LockProps) => {
   const { purchaseKey } = usePurchaseKey(lock)
+
+  const onClick = () => {
+    if (purchasingLockAddress) {
+      // There is already a key purchase in progress (or completed) -- do not start another one
+      return
+    }
+
+    setPurchasingLockAddress(lock.address)
+    purchaseKey()
+  }
+
   return (
     <LockContainer>
       <InfoWrapper>
         <LockName>{lock.name}</LockName>
         <KeysAvailable>{lockKeysAvailable(lock)} Available</KeysAvailable>
       </InfoWrapper>
-      <LockBody onClick={purchaseKey}>
+      <LockBody onClick={onClick}>
         <LockPrice>{lock.keyPrice}</LockPrice>
         <TickerSymbol>{(lock as any).currencySymbol || 'ETH'}</TickerSymbol>
         <ValidityDuration>

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Lock, LoadingLock } from './Lock'
 import { usePaywallLocks } from '../../../hooks/usePaywallLocks'
 
@@ -7,7 +7,12 @@ interface LocksProps {
   lockAddresses: string[]
 }
 
+type PurchasingLockAddress = string | null
+
 export const Locks = ({ lockAddresses }: LocksProps) => {
+  const [purchasingLockAddress, setPurchasingLockAddress] = useState(
+    null as PurchasingLockAddress
+  )
   const { locks, loading } = usePaywallLocks(lockAddresses)
 
   if (loading) {
@@ -23,7 +28,12 @@ export const Locks = ({ lockAddresses }: LocksProps) => {
   return (
     <div>
       {locks.map(lock => (
-        <Lock lock={lock} key={lock.name} />
+        <Lock
+          key={lock.name}
+          lock={lock}
+          purchasingLockAddress={purchasingLockAddress}
+          setPurchasingLockAddress={setPurchasingLockAddress}
+        />
       ))}
     </div>
   )

--- a/unlock-app/src/stories/interface/checkout/Lock.stories.js
+++ b/unlock-app/src/stories/interface/checkout/Lock.stories.js
@@ -17,10 +17,18 @@ const lock = {
   address: '0xEE9FE39966DF737eECa5920ABa975c283784Faf8',
 }
 
+const setPurchasingLockAddress = () => {}
+
 storiesOf('Checkout Lock', module)
   .add('Loading', () => {
     return <LoadingLock />
   })
   .add('Active', () => {
-    return <Lock lock={lock} />
+    return (
+      <Lock
+        lock={lock}
+        purchasingLockAddress={null}
+        setPurchasingLockAddress={setPurchasingLockAddress}
+      />
+    )
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

One thing we need on the checkout is for the UI to react when a purchase begins. In particular, it should disable lock buttons once a purchase starts so that we don't have any duplicate purchases.

This PR adds that, and also takes the opportunity to remove some unneeded stuff from the CheckoutWrapper component.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
