### PR TITLE
moving normalizeConfig to its own util file

### DIFF
--- a/paywall/src/__tests__/unlock.js/startup.test.ts
+++ b/paywall/src/__tests__/unlock.js/startup.test.ts
@@ -1,4 +1,4 @@
-import { startup, normalizeConfig } from '../../unlock.js/startup'
+import { startup } from '../../unlock.js/startup'
 import FakeWindow from '../test-helpers/fakeWindowHelpers'
 import StartupConstants from '../../unlock.js/startupTypes'
 import { PaywallConfig } from '../../unlockTypes'
@@ -7,49 +7,6 @@ import { UnlockWindow } from '../../windowTypes'
 import { checkoutHandlerInit } from '../../unlock.js/postMessageHub'
 
 describe('unlock.js startup', () => {
-  describe('normalizeConfig', () => {
-    type badConfigs = [string, any][]
-    it.each(<badConfigs>[
-      ['false', false],
-      ['no locks', {}],
-      ['locks is not an object', { locks: 5 }],
-      ['locks is empty', { locks: {} }],
-    ])('should return invalid config (%s) as-is', (_, badConfig) => {
-      expect.assertions(1)
-
-      expect(normalizeConfig(badConfig)).toBe(badConfig)
-    })
-
-    it('should normalize the lock addresses to lower-case', () => {
-      expect.assertions(1)
-
-      const config: PaywallConfig = {
-        locks: {
-          ABC: { name: 'hi' },
-          def: { name: 'there' },
-          AbQ: { name: 'foo' },
-        },
-        callToAction: {
-          default: 'hi',
-          expired: 'there',
-          pending: 'pending',
-          confirmed: 'confirmed',
-          noWallet: 'no wallet',
-        },
-      }
-      const normalizedConfig = {
-        ...config,
-        locks: {
-          abc: { name: 'hi' },
-          def: { name: 'there' },
-          abq: { name: 'foo' },
-        },
-      }
-
-      expect(normalizeConfig(config)).toEqual(normalizedConfig)
-    })
-  })
-
   describe('startup', () => {
     let fakeWindow: FakeWindow
     const config: PaywallConfig = {

--- a/paywall/src/__tests__/utils/config.test.ts
+++ b/paywall/src/__tests__/utils/config.test.ts
@@ -1,0 +1,46 @@
+import { PaywallConfig } from '../../unlockTypes'
+
+import { normalizeConfig } from '../../utils/config'
+
+describe('normalizeConfig', () => {
+  type badConfigs = [string, any][]
+  it.each(<badConfigs>[
+    ['false', false],
+    ['no locks', {}],
+    ['locks is not an object', { locks: 5 }],
+    ['locks is empty', { locks: {} }],
+  ])('should return invalid config (%s) as-is', (_, badConfig) => {
+    expect.assertions(1)
+
+    expect(normalizeConfig(badConfig)).toBe(badConfig)
+  })
+
+  it('should normalize the lock addresses to lower-case', () => {
+    expect.assertions(1)
+
+    const config: PaywallConfig = {
+      locks: {
+        ABC: { name: 'hi' },
+        def: { name: 'there' },
+        AbQ: { name: 'foo' },
+      },
+      callToAction: {
+        default: 'hi',
+        expired: 'there',
+        pending: 'pending',
+        confirmed: 'confirmed',
+        noWallet: 'no wallet',
+      },
+    }
+    const normalizedConfig = {
+      ...config,
+      locks: {
+        abc: { name: 'hi' },
+        def: { name: 'there' },
+        abq: { name: 'foo' },
+      },
+    }
+
+    expect(normalizeConfig(config)).toEqual(normalizedConfig)
+  })
+})

--- a/paywall/src/unlock.js/startup.ts
+++ b/paywall/src/unlock.js/startup.ts
@@ -6,32 +6,7 @@ import StartupConstants from './startupTypes'
 import { walletStatus } from '../utils/wallet'
 import { checkoutHandlerInit } from './postMessageHub'
 import { PostMessages } from '../messageTypes'
-
-/**
- * convert all of the lock addresses to lower-case so they are normalized across the app
- */
-export function normalizeConfig(unlockConfig: any) {
-  if (
-    !unlockConfig ||
-    !unlockConfig.locks ||
-    typeof unlockConfig.locks !== 'object'
-  )
-    return unlockConfig
-  const lockAddresses = Object.keys(unlockConfig.locks)
-  if (!lockAddresses.length) {
-    return unlockConfig
-  }
-  const normalizedConfig = {
-    ...unlockConfig,
-    locks: lockAddresses.reduce((allLocks, address) => {
-      return {
-        ...allLocks,
-        [address.toLowerCase()]: unlockConfig.locks[address],
-      }
-    }, {}),
-  }
-  return normalizedConfig
-}
+import { normalizeConfig } from '../utils/config'
 
 // Temporary helper to dispatch locked event when we fail early
 function dispatchEvent(detail: any, window: any) {

--- a/paywall/src/utils/config.ts
+++ b/paywall/src/utils/config.ts
@@ -1,0 +1,25 @@
+/**
+ * convert all of the lock addresses to lower-case so they are normalized across the app
+ */
+export function normalizeConfig(unlockConfig: any) {
+  if (
+    !unlockConfig ||
+    !unlockConfig.locks ||
+    typeof unlockConfig.locks !== 'object'
+  )
+    return unlockConfig
+  const lockAddresses = Object.keys(unlockConfig.locks)
+  if (!lockAddresses.length) {
+    return unlockConfig
+  }
+  const normalizedConfig = {
+    ...unlockConfig,
+    locks: lockAddresses.reduce((allLocks, address) => {
+      return {
+        ...allLocks,
+        [address.toLowerCase()]: unlockConfig.locks[address],
+      }
+    }, {}),
+  }
+  return normalizedConfig
+}


### PR DESCRIPTION
# Description


This is the first PR of several in an effort to split #6049 so that we do not miss anything important.
This `normalizeConfig` will be used when calling `resetConfig`!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->