### PR TITLE
Initialize the public lock template when it's set

### DIFF
--- a/smart-contracts/contracts/interfaces/IUnlock.sol
+++ b/smart-contracts/contracts/interfaces/IUnlock.sol
@@ -83,11 +83,18 @@ interface IUnlock {
    *  Should throw if called by other than owner.
    */
   function configUnlock(
-    address _publicLockAddress,
     string calldata _symbol,
     string calldata _URI
   )
     external;
+
+  /**
+   * @notice Upgrade the PublicLock template used for future calls to `createLock`.
+   * @dev This will initialize the template and revokeOwnership.
+   */
+  function setLockTemplate(
+    address _publicLockAddress
+  ) external;
 
   // Allows the owner to change the value tracking variables as needed.
   function resetTrackedValue(

--- a/smart-contracts/migrations/3_create_proxy.js
+++ b/smart-contracts/migrations/3_create_proxy.js
@@ -1,5 +1,6 @@
 // Load zos scripts and truffle wrapper function
 const { scripts, ConfigManager } = require('@openzeppelin/cli')
+const { constants } = require('hardlydifficult-ethereum-contracts')
 
 const { create } = scripts
 const PublicLock = artifacts.require('PublicLock')
@@ -23,8 +24,8 @@ async function deploy(options, accounts) {
   // Deploy lock template
   const lockTemplate = await PublicLock.new()
   await unlockContract.methods
-    .configUnlock(lockTemplate.address, '', '')
-    .send({ from: unlockOwner })
+    .setLockTemplate(lockTemplate.address)
+    .send({ from: unlockOwner, gas: constants.MAX_GAS })
 }
 
 module.exports = async (deployer, networkName, accounts) => {
@@ -34,7 +35,7 @@ module.exports = async (deployer, networkName, accounts) => {
     network: networkName,
     from: proxyAdmin,
   })
-  txParams.gas = 4000000
+  txParams.gas = constants.MAX_GAS
   const options = { network, txParams }
   await deploy(options, accounts)
 }

--- a/smart-contracts/test/Lock/erc721/tokenSymbol.js
+++ b/smart-contracts/test/Lock/erc721/tokenSymbol.js
@@ -25,7 +25,6 @@ contract('Lock / erc721 / tokenSymbol', accounts => {
     describe('set the global symbol', () => {
       beforeEach(async () => {
         txObj = await unlock.configUnlock(
-          await unlock.publicLockAddress(),
           'KEY',
           await unlock.globalBaseTokenURI(),
           {
@@ -53,14 +52,9 @@ contract('Lock / erc721 / tokenSymbol', accounts => {
 
     it('should fail if someone other than the owner tries to set the symbol', async () => {
       await reverts(
-        unlock.configUnlock(
-          await unlock.publicLockAddress(),
-          'BTC',
-          await unlock.globalBaseTokenURI(),
-          {
-            from: accounts[1],
-          }
-        )
+        unlock.configUnlock('BTC', await unlock.globalBaseTokenURI(), {
+          from: accounts[1],
+        })
       )
     })
   })

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -41,7 +41,6 @@ contract('Lock / erc721 / tokenURI', accounts => {
     describe('set global base URI', () => {
       beforeEach(async () => {
         txObj = await unlock.configUnlock(
-          await unlock.publicLockAddress(),
           await unlock.globalTokenSymbol(),
           'https://newTokenURI.com/api/key',
           {
@@ -73,7 +72,6 @@ contract('Lock / erc721 / tokenURI', accounts => {
     it('should fail if someone other than the owner tries to set the URI', async () => {
       await reverts(
         unlock.configUnlock(
-          await unlock.publicLockAddress(),
           await unlock.globalTokenSymbol(),
           'https://fakeURI.com',
           {

--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -24,7 +24,7 @@ contract('Lock / timeMachine', accounts => {
   before(async () => {
     let salt = 42
     unlock = await getProxy(unlockContract)
-    await unlock.configUnlock((await TimeMachineMock.new()).address, '', '')
+    await unlock.setLockTemplate((await TimeMachineMock.new()).address)
     let tx = await unlock.createLock(
       new BigNumber(60 * 60 * 24 * 30), // 30 days
       web3.utils.padLeft(0, 40),

--- a/smart-contracts/test/Unlock/behaviors/UnlockProxy.js
+++ b/smart-contracts/test/Unlock/behaviors/UnlockProxy.js
@@ -1,5 +1,6 @@
 const Zos = require('@openzeppelin/cli')
 const { ZWeb3, Contracts } = require('@openzeppelin/upgrades')
+const { constants } = require('hardlydifficult-ethereum-contracts')
 
 const TestHelper = Zos.TestHelper
 const shared = require('./shared')
@@ -23,15 +24,10 @@ contract('Unlock / UnlockProxy', accounts => {
     })
     this.unlock = await Unlock.at(this.proxy.address)
     const lock = await PublicLock.new()
-    await this.unlock.methods
-      .configUnlock(
-        lock.address,
-        await this.unlock.methods.globalTokenSymbol().call(),
-        await this.unlock.methods.globalBaseTokenURI().call()
-      )
-      .send({
-        from: this.unlockOwner,
-      })
+    await this.unlock.methods.setLockTemplate(lock.address).send({
+      from: this.unlockOwner,
+      gas: constants.MAX_GAS,
+    })
   })
 
   describe('should function as a proxy', () => {

--- a/smart-contracts/test/Unlock/setLockTemplate.js
+++ b/smart-contracts/test/Unlock/setLockTemplate.js
@@ -1,0 +1,58 @@
+const { reverts } = require('truffle-assertions')
+
+const unlockContract = artifacts.require('Unlock.sol')
+const PublicLock = artifacts.require('PublicLock')
+const getProxy = require('../helpers/proxy')
+
+let unlock
+let lockTemplate
+let unlockOwner
+
+contract('Lock / setLockTemplate', accounts => {
+  beforeEach(async () => {
+    unlock = await getProxy(unlockContract)
+    lockTemplate = await PublicLock.new()
+    unlockOwner = accounts[0]
+  })
+
+  describe('configuring the Unlock contract', () => {
+    it('should let the owner configure the Unlock contract', async () => {
+      await unlock.setLockTemplate(lockTemplate.address, {
+        from: unlockOwner,
+      })
+    })
+
+    it('should revert if the template was already initialized', async () => {
+      await lockTemplate.initialize(
+        accounts[0],
+        0,
+        web3.utils.padLeft(0, 40),
+        0,
+        0,
+        ''
+      )
+      await reverts(
+        unlock.setLockTemplate(lockTemplate.address, {
+          from: unlockOwner,
+        })
+      )
+    })
+
+    it('should revert if called by other than the owner', async () => {
+      await reverts(
+        unlock.setLockTemplate(lockTemplate.address, {
+          from: accounts[7],
+        }),
+        'Ownable: caller is not the owner'
+      )
+    })
+
+    it('should revert if the lock template address is not a contract', async () => {
+      await reverts(
+        unlock.setLockTemplate(accounts[7], {
+          from: unlockOwner,
+        })
+      )
+    })
+  })
+})

--- a/smart-contracts/test/Unlock/unlockConfig.js
+++ b/smart-contracts/test/Unlock/unlockConfig.js
@@ -1,17 +1,14 @@
 const { reverts } = require('truffle-assertions')
 
 const unlockContract = artifacts.require('Unlock.sol')
-const PublicLock = artifacts.require('PublicLock')
 const getProxy = require('../helpers/proxy')
 
 let unlock
-let lockTemplate
 let unlockOwner
 
 contract('Lock / configUnlock', accounts => {
   before(async () => {
     unlock = await getProxy(unlockContract)
-    lockTemplate = await PublicLock.new()
     unlockOwner = accounts[0]
   })
 

--- a/smart-contracts/test/Unlock/unlockConfig.js
+++ b/smart-contracts/test/Unlock/unlockConfig.js
@@ -17,26 +17,17 @@ contract('Lock / configUnlock', accounts => {
 
   describe('configuring the Unlock contract', () => {
     it('should let the owner configure the Unlock contract', async () => {
-      await unlock.configUnlock(lockTemplate.address, '', '', {
+      await unlock.configUnlock('', '', {
         from: unlockOwner,
       })
     })
 
     it('should revert if called by other than the owner', async () => {
       await reverts(
-        unlock.configUnlock(lockTemplate.address, '', '', {
+        unlock.configUnlock('', '', {
           from: accounts[7],
         }),
         'Ownable: caller is not the owner'
-      )
-    })
-
-    it('should revert if the lock template address is not a contract', async () => {
-      await reverts(
-        unlock.configUnlock(accounts[7], '', '', {
-          from: unlockOwner,
-        }),
-        'NOT_A_CONTRACT'
       )
     })
   })

--- a/smart-contracts/test/Unlock/upgrades.js
+++ b/smart-contracts/test/Unlock/upgrades.js
@@ -101,16 +101,20 @@ contract('Unlock / upgrades', accounts => {
                 gas: constants.MAX_GAS,
               })
 
-            await unlock.methods
-              .configUnlock(
-                lockTemplate._address,
-                await unlock.methods.globalTokenSymbol().call(),
-                await unlock.methods.globalBaseTokenURI().call()
-              )
-              .send({
+            if (versionNumber >= 7) {
+              // Version 7 moved setLockTemplate to its own function
+              await unlock.methods.setLockTemplate(lockTemplate._address).send({
                 from: unlockOwner,
                 gas: constants.MAX_GAS,
               })
+            } else {
+              await unlock.methods
+                .configUnlock(lockTemplate._address, '', '')
+                .send({
+                  from: unlockOwner,
+                  gas: constants.MAX_GAS,
+                })
+            }
           }
         })
 
@@ -234,16 +238,12 @@ contract('Unlock / upgrades', accounts => {
                 await project.upgradeProxy(proxy.address, UnlockLatest)
                 unlock = await UnlockLatest.at(proxy.address)
 
-                const lock = await PublicLockLatest.new({
+                const lockTemplate = await PublicLockLatest.new({
                   from: unlockOwner,
                   gas: constants.MAX_GAS,
                 })
                 await unlock.methods
-                  .configUnlock(
-                    lock.address,
-                    await unlock.methods.globalTokenSymbol().call(),
-                    await unlock.methods.globalBaseTokenURI().call()
-                  )
+                  .setLockTemplate(lockTemplate.address)
                   .send({
                     from: unlockOwner,
                     gas: constants.MAX_GAS,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Updates Unlock.sol to initialize and renounceOwnership on the public lock.  This way we know that no one else has already claimed the template.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
