### PR TITLE
Show confirmed lock after purchase is initiated

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import * as rtl from '@testing-library/react'
 import {
   lockKeysAvailable,
+  lockTickerSymbol,
   Lock,
 } from '../../../../components/interface/checkout/Lock'
 import * as usePurchaseKey from '../../../../hooks/usePurchaseKey'
@@ -26,6 +27,36 @@ describe('Checkout Lock', () => {
           outstandingKeys: 100,
         }
         expect(lockKeysAvailable(lock)).toEqual('103')
+      })
+    })
+
+    describe('lockTickerSymbol', () => {
+      it('returns ETH when it is an ETH lock', () => {
+        expect.assertions(1)
+        const lock = {
+          currencyContractAddress: null,
+        }
+
+        expect(lockTickerSymbol(lock)).toEqual('ETH')
+      })
+
+      it('returns DAI when it is a DAI lock', () => {
+        expect.assertions(1)
+        const lock = {
+          currencyContractAddress: '0xDAI',
+          currencySymbol: 'DAI',
+        }
+
+        expect(lockTickerSymbol(lock)).toEqual('DAI')
+      })
+
+      it('returns ERC20 when it is an unknown ERC20 lock', () => {
+        expect.assertions(1)
+        const lock = {
+          currencyContractAddress: '0xDAI',
+        }
+
+        expect(lockTickerSymbol(lock)).toEqual('ERC20')
       })
     })
   })
@@ -93,6 +124,50 @@ describe('Checkout Lock', () => {
 
       expect(purchaseKey).not.toHaveBeenCalled()
       expect(setPurchasingLockAddress).not.toHaveBeenCalled()
+    })
+
+    it('renders a disabled lock when there is a purchase for a different lock', () => {
+      expect.assertions(0)
+
+      const lock = {
+        name: 'lock',
+        address: '0xlockaddress',
+        keyPrice: '4000000',
+        expirationDuration: 50,
+        currencyContractAddress: null,
+      }
+
+      const { getByTestId } = rtl.render(
+        <Lock
+          lock={lock}
+          purchasingLockAddress="0xneato"
+          setPurchasingLockAddress={setPurchasingLockAddress}
+        />
+      )
+
+      getByTestId('DisabledLock')
+    })
+
+    it('renders a confirmed lock when there is a purchase for this lock', () => {
+      expect.assertions(0)
+
+      const lock = {
+        name: 'lock',
+        address: '0xlockaddress',
+        keyPrice: '4000000',
+        expirationDuration: 50,
+        currencyContractAddress: null,
+      }
+
+      const { getByTestId } = rtl.render(
+        <Lock
+          lock={lock}
+          purchasingLockAddress="0xlockaddress"
+          setPurchasingLockAddress={setPurchasingLockAddress}
+        />
+      )
+
+      getByTestId('ConfirmedLock')
     })
   })
 })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -43618,6 +43618,7 @@ Object {
       <div>
         <div
           class="c0"
+          data-testid="LoadingLock"
         >
           <div
             class="c1"
@@ -43625,6 +43626,7 @@ Object {
         </div>
         <div
           class="c2"
+          data-testid="DisabledLock"
         >
           <div
             class="c3"
@@ -43668,6 +43670,7 @@ Object {
         </div>
         <div
           class="c2"
+          data-testid="SoldOutLock"
         >
           <div
             class="c3"
@@ -43716,6 +43719,7 @@ Object {
         </div>
         <div
           class="c2"
+          data-testid="InsufficientBalanceLock"
         >
           <div
             class="c3"
@@ -43770,6 +43774,7 @@ Object {
         </div>
         <div
           class="c0"
+          data-testid="PurchaseableLock"
         >
           <div
             class="c3"
@@ -43819,6 +43824,7 @@ Object {
         </div>
         <div
           class="c0"
+          data-testid="ProcessingLock"
         >
           <div
             class="c3"
@@ -43898,6 +43904,7 @@ Object {
         </div>
         <div
           class="c0"
+          data-testid="ConfirmedLock"
         >
           <div
             class="c3"
@@ -43956,6 +43963,7 @@ Object {
     <div>
       <div
         class="sc-pRtAn frZgaC"
+        data-testid="LoadingLock"
       >
         <div
           class="sc-prorn sc-qYIQh jXTxcM"
@@ -43963,6 +43971,7 @@ Object {
       </div>
       <div
         class="sc-pRtAn sc-pZOBi ddXFBD"
+        data-testid="DisabledLock"
       >
         <div
           class="sc-qQYBZ kTPjys"
@@ -44006,6 +44015,7 @@ Object {
       </div>
       <div
         class="sc-pRtAn sc-pZOBi ddXFBD"
+        data-testid="SoldOutLock"
       >
         <div
           class="sc-qQYBZ kTPjys"
@@ -44054,6 +44064,7 @@ Object {
       </div>
       <div
         class="sc-pRtAn sc-pZOBi ddXFBD"
+        data-testid="InsufficientBalanceLock"
       >
         <div
           class="sc-qQYBZ kTPjys"
@@ -44108,6 +44119,7 @@ Object {
       </div>
       <div
         class="sc-pRtAn frZgaC"
+        data-testid="PurchaseableLock"
       >
         <div
           class="sc-qQYBZ kTPjys"
@@ -44157,6 +44169,7 @@ Object {
       </div>
       <div
         class="sc-pRtAn frZgaC"
+        data-testid="ProcessingLock"
       >
         <div
           class="sc-qQYBZ kTPjys"
@@ -44236,6 +44249,7 @@ Object {
       </div>
       <div
         class="sc-pRtAn frZgaC"
+        data-testid="ConfirmedLock"
       >
         <div
           class="sc-qQYBZ kTPjys"

--- a/unlock-app/src/components/interface/checkout/LockVariations.tsx
+++ b/unlock-app/src/components/interface/checkout/LockVariations.tsx
@@ -166,7 +166,7 @@ export const ValidityDuration = styled.div`
   }
 `
 
-interface LockProps {
+export interface LockProps {
   name: string
   formattedKeyPrice: string
   formattedDuration: string
@@ -176,7 +176,7 @@ interface LockProps {
 
 export const LoadingLock = () => {
   return (
-    <LockContainer>
+    <LockContainer data-testid="LoadingLock">
       <LoadingLockBody />
     </LockContainer>
   )
@@ -188,7 +188,7 @@ export const SoldOutLock = ({
   formattedKeyPrice,
 }: LockProps) => {
   return (
-    <DisabledLockContainer>
+    <DisabledLockContainer data-testid="SoldOutLock">
       <InfoWrapper>
         <LockName>{name}</LockName>
         <SoldOut>Sold Out</SoldOut>
@@ -213,7 +213,7 @@ export const InsufficientBalanceLock = ({
   formattedKeysAvailable,
 }: LockProps) => {
   return (
-    <DisabledLockContainer>
+    <DisabledLockContainer data-testid="InsufficientBalanceLock">
       <InfoWrapper>
         <LockName>{name}</LockName>
         <KeysAvailable>{formattedKeysAvailable} Available</KeysAvailable>
@@ -240,7 +240,7 @@ export const DisabledLock = ({
   formattedKeyPrice,
 }: LockProps) => {
   return (
-    <DisabledLockContainer>
+    <DisabledLockContainer data-testid="DisabledLock">
       <InfoWrapper>
         <LockName>{name}</LockName>
       </InfoWrapper>
@@ -265,7 +265,7 @@ export const PurchaseableLock = ({
   onClick,
 }: LockProps) => {
   return (
-    <LockContainer>
+    <LockContainer data-testid="PurchaseableLock">
       <InfoWrapper>
         <LockName>{name}</LockName>
         <KeysAvailable>{formattedKeysAvailable} Available</KeysAvailable>
@@ -289,7 +289,7 @@ export const ProcessingLock = ({
   formattedKeyPrice,
 }: LockProps) => {
   return (
-    <LockContainer>
+    <LockContainer data-testid="ProcessingLock">
       <InfoWrapper>
         <LockName>{name}</LockName>
         <Processing>Processing</Processing>
@@ -314,7 +314,7 @@ export const ConfirmedLock = ({
   formattedKeysAvailable,
 }: LockProps) => {
   return (
-    <LockContainer>
+    <LockContainer data-testid="ConfirmedLock">
       <InfoWrapper>
         <LockName>{name}</LockName>
         <KeysAvailable>{formattedKeysAvailable} Available</KeysAvailable>

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Lock } from './Lock'
 import { LoadingLock } from './LockVariations'
 import { usePaywallLocks } from '../../../hooks/usePaywallLocks'
+import { useGetTokenBalance } from '../../../hooks/useGetTokenBalance'
 
 interface LocksProps {
   accountAddress: string
@@ -10,11 +11,12 @@ interface LocksProps {
 
 type PurchasingLockAddress = string | null
 
-export const Locks = ({ lockAddresses }: LocksProps) => {
+export const Locks = ({ lockAddresses, accountAddress }: LocksProps) => {
   const [purchasingLockAddress, setPurchasingLockAddress] = useState(
     null as PurchasingLockAddress
   )
-  const { locks, loading } = usePaywallLocks(lockAddresses)
+  const { getTokenBalance } = useGetTokenBalance(accountAddress)
+  const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
 
   if (loading) {
     return (


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
The checkout page now shows the "confirmed" lock after a purchase is initiated. At some point in the future we will replace this with a transition from the "processing" lock to the "confirmed" one. It also disables any other locks on the page to avoid causing multiple purchases.

TODO: this should be robust in the face of canceled purchases, the `usePurchaseKey` hook will have to be updated to provide more information.

<img width="335" alt="image" src="https://user-images.githubusercontent.com/9300702/75387552-84482e00-58b1-11ea-8ae3-13e31681103d.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
