### PR TITLE
changing the init process of the mailbox

### DIFF
--- a/paywall/src/__tests__/data-iframe/Mailbox/setConfig.test.ts
+++ b/paywall/src/__tests__/data-iframe/Mailbox/setConfig.test.ts
@@ -1,4 +1,5 @@
 import { IframePostOfficeWindow } from '../../../windowTypes'
+
 import {
   ConstantsType,
   FetchWindow,
@@ -113,7 +114,6 @@ describe('Mailbox - setConfig', () => {
 
       expect(testingMailbox().configuration).toEqual(expectedConfiguration)
     })
-
     describe('caching', () => {
       beforeEach(() => {
         setupDefaults()
@@ -129,14 +129,6 @@ describe('Mailbox - setConfig', () => {
         expect(
           mailbox.getBlockchainDataFromLocalStorageCache
         ).toHaveBeenCalled()
-      })
-
-      it('should begin listening for storage events', () => {
-        expect.assertions(1)
-
-        mailbox.setConfig(configuration)
-
-        expect(mailbox.setupStorageListener).toHaveBeenCalled()
       })
     })
   })


### PR DESCRIPTION
# Description

This is the last but one change to support multiple configs in the paywall.
This removes the configuration setting from the mailbox constructor and moves it into the `init` method.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->