### PR TITLE
Don't shadow `_owner`

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -49,7 +49,7 @@ contract PublicLock is
   MixinRefunds
 {
   function initialize(
-    address _owner,
+    address _lockOwner,
     uint _expirationDuration,
     address _tokenAddress,
     uint _keyPrice,
@@ -58,15 +58,15 @@ contract PublicLock is
   ) public
     initializer()
   {
-    Ownable.initialize(_owner);
+    Ownable.initialize(_lockOwner);
     MixinFunds._initializeMixinFunds(_tokenAddress);
     MixinDisable._initializeMixinDisable();
-    MixinLockCore._initializeMixinLockCore(_owner, _expirationDuration, _keyPrice, _maxNumberOfKeys);
+    MixinLockCore._initializeMixinLockCore(_lockOwner, _expirationDuration, _keyPrice, _maxNumberOfKeys);
     MixinLockMetadata._initializeMixinLockMetadata(_lockName);
     MixinERC721Enumerable._initializeMixinERC721Enumerable();
     MixinRefunds._initializeMixinRefunds();
-    MixinLockManagerRole._initializeMixinLockManagerRole(_owner);
-    MixinKeyGranterRole._initializeMixinKeyGranterRole(_owner);
+    MixinLockManagerRole._initializeMixinLockManagerRole(_lockOwner);
+    MixinKeyGranterRole._initializeMixinKeyGranterRole(_lockOwner);
     // registering the interface for erc721 with ERC165.sol using
     // the ID specified in the standard: https://eips.ethereum.org/EIPS/eip-721
     _registerInterface(0x80ac58cd);

--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -106,13 +106,13 @@ contract Unlock is
 
   // Use initialize instead of a constructor to support proxies (for upgradeability via zos).
   function initialize(
-    address _owner
+    address _unlockOwner
   )
     public
     initializer()
   {
     // We must manually initialize Ownable.sol
-    Ownable.initialize(_owner);
+    Ownable.initialize(_unlockOwner);
   }
 
   /**

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -16,7 +16,7 @@ contract IPublicLock is IERC721Enumerable {
   /// Functions
 
   function initialize(
-    address _owner,
+    address _lockOwner,
     uint _expirationDuration,
     address _tokenAddress,
     uint _keyPrice,
@@ -88,16 +88,16 @@ contract IPublicLock is IERC721Enumerable {
    * A function which lets the owner of the lock expire a users' key.
    * @dev Throws if called by other than lock owner
    * @dev Throws if key owner does not have a valid key
-   * @param _owner The address of the key owner
+   * @param _keyOwner The address of the key owner
    */
-  function expireKeyFor( address _owner ) external;
+  function expireKeyFor( address _keyOwner ) external;
 
     /**
    * Checks if the user has a non-expired key.
-   * @param _owner The address of the key owner
+   * @param _user The address of the key owner
    */
   function getHasValidKey(
-    address _owner
+    address _user
   ) external view returns (bool);
 
   /**
@@ -124,20 +124,20 @@ contract IPublicLock is IERC721Enumerable {
   /**
    * Checks if the given address owns the given tokenId.
    * @param _tokenId The tokenId of the key to check
-   * @param _owner The potential key owners address
+   * @param _keyOwner The potential key owners address
    */
   function isKeyOwner(
     uint _tokenId,
-    address _owner
+    address _keyOwner
   ) external view returns (bool);
 
   /**
   * @dev Returns the key's ExpirationTimestamp field for a given owner.
-  * @param _owner address of the user for whom we search the key
+  * @param _keyOwner address of the user for whom we search the key
   * @dev Throws if owner has never owned a key for this lock
   */
   function keyExpirationTimestampFor(
-    address _owner
+    address _keyOwner
   ) external view returns (uint timestamp);
 
   /**
@@ -238,13 +238,13 @@ contract IPublicLock is IERC721Enumerable {
    * Determines how much of a fee a key owner would need to pay in order to
    * transfer the key to another account.  This is pro-rated so the fee goes down
    * overtime.
-   * @dev Throws if _owner does not have a valid key
-   * @param _owner The owner of the key check the transfer fee for.
+   * @dev Throws if _keyOwner does not have a valid key
+   * @param _keyOwner The owner of the key check the transfer fee for.
    * @param _time The amount of time to calculate the fee for.
    * @return The transfer fee in seconds.
    */
   function getTransferFee(
-    address _owner,
+    address _keyOwner,
     uint _time
   ) external view returns (uint);
 
@@ -299,13 +299,13 @@ contract IPublicLock is IERC721Enumerable {
 
   /**
    * @dev Determines how much of a refund a key owner would receive if they issued
-   * @param _owner The key owner to get the refund value for.
+   * @param _keyOwner The key owner to get the refund value for.
    * a cancelAndRefund block.timestamp.
    * Note that due to the time required to mine a tx, the actual refund amount will be lower
    * than what the user reads from this call.
    */
   function getCancelAndRefundValueFor(
-    address _owner
+    address _keyOwner
   ) external view returns (uint refund);
 
   function keyOwnerToNonce(address ) external view returns (uint256 );

--- a/smart-contracts/contracts/interfaces/IUnlock.sol
+++ b/smart-contracts/contracts/interfaces/IUnlock.sol
@@ -9,7 +9,7 @@ pragma solidity 0.5.16;
 interface IUnlock {
 
   // Use initialize instead of a constructor to support proxies (for upgradeability via zos).
-  function initialize(address _owner) external;
+  function initialize(address _unlockOwner) external;
 
   /**
   * @dev Create lock

--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -94,17 +94,17 @@ contract MixinApproval is
 
   /**
    * @dev Tells whether an operator is approved by a given owner
-   * @param _owner owner address which you want to query the approval of
+   * @param _keyOwner owner address which you want to query the approval of
    * @param _operator operator address which you want to query the approval of
    * @return bool whether the given operator is approved by the given owner
    */
   function isApprovedForAll(
-    address _owner,
+    address _keyOwner,
     address _operator
   ) public view
     returns (bool)
   {
-    return ownerToOperatorApproved[_owner][_operator];
+    return ownerToOperatorApproved[_keyOwner][_operator];
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinERC721Enumerable.sol
+++ b/smart-contracts/contracts/mixins/MixinERC721Enumerable.sol
@@ -42,19 +42,19 @@ contract MixinERC721Enumerable is
   }
 
   /// @notice Enumerate NFTs assigned to an owner
-  /// @dev Throws if `_index` >= `balanceOf(_owner)` or if
-  ///  `_owner` is the zero address, representing invalid NFTs.
-  /// @param _owner An address where we are interested in NFTs owned by them
-  /// @param _index A counter less than `balanceOf(_owner)`
-  /// @return The token identifier for the `_index`th NFT assigned to `_owner`,
+  /// @dev Throws if `_index` >= `balanceOf(_keyOwner)` or if
+  ///  `_keyOwner` is the zero address, representing invalid NFTs.
+  /// @param _keyOwner An address where we are interested in NFTs owned by them
+  /// @param _index A counter less than `balanceOf(_keyOwner)`
+  /// @return The token identifier for the `_index`th NFT assigned to `_keyOwner`,
   ///   (sort order not specified)
   function tokenOfOwnerByIndex(
-    address _owner,
+    address _keyOwner,
     uint256 _index
   ) public view
     returns (uint256)
   {
     require(_index == 0, 'ONLY_ONE_KEY_PER_OWNER');
-    return getTokenIdFor(_owner);
+    return getTokenIdFor(_keyOwner);
   }
 }

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -51,20 +51,20 @@ contract MixinKeys is
 
   // Ensures that an owner owns or has owned a key in the past
   modifier ownsOrHasOwnedKey(
-    address _owner
+    address _keyOwner
   ) {
     require(
-      keyByOwner[_owner].expirationTimestamp > 0, 'HAS_NEVER_OWNED_KEY'
+      keyByOwner[_keyOwner].expirationTimestamp > 0, 'HAS_NEVER_OWNED_KEY'
     );
     _;
   }
 
   // Ensures that an owner has a valid key
   modifier hasValidKey(
-    address _owner
+    address _user
   ) {
     require(
-      getHasValidKey(_owner), 'KEY_NOT_VALID'
+      getHasValidKey(_user), 'KEY_NOT_VALID'
     );
     _;
   }
@@ -93,43 +93,43 @@ contract MixinKeys is
    * A function which lets the owner of the lock expire a users' key.
    */
   function expireKeyFor(
-    address _owner
+    address _keyOwner
   )
     public
     onlyOwner
-    hasValidKey(_owner)
+    hasValidKey(_keyOwner)
   {
-    Key storage key = keyByOwner[_owner];
+    Key storage key = keyByOwner[_keyOwner];
     key.expirationTimestamp = block.timestamp; // Effectively expiring the key
     emit ExpireKey(key.tokenId);
   }
 
   /**
    * In the specific case of a Lock, each owner can own only at most 1 key.
-   * @return The number of NFTs owned by `_owner`, either 0 or 1.
+   * @return The number of NFTs owned by `_keyOwner`, either 0 or 1.
   */
   function balanceOf(
-    address _owner
+    address _keyOwner
   )
     public
     view
     returns (uint)
   {
-    require(_owner != address(0), 'INVALID_ADDRESS');
-    return getHasValidKey(_owner) ? 1 : 0;
+    require(_keyOwner != address(0), 'INVALID_ADDRESS');
+    return getHasValidKey(_keyOwner) ? 1 : 0;
   }
 
   /**
    * Checks if the user has a non-expired key.
    */
   function getHasValidKey(
-    address _owner
+    address _keyOwner
   )
     public
     view
     returns (bool)
   {
-    return keyByOwner[_owner].expirationTimestamp > block.timestamp;
+    return keyByOwner[_keyOwner].expirationTimestamp > block.timestamp;
   }
 
   /**
@@ -186,25 +186,25 @@ contract MixinKeys is
    */
   function isKeyOwner(
     uint _tokenId,
-    address _owner
+    address _keyOwner
   ) public view
     returns (bool)
   {
-    return _ownerOf[_tokenId] == _owner;
+    return _ownerOf[_tokenId] == _keyOwner;
   }
 
   /**
   * @dev Returns the key's ExpirationTimestamp field for a given owner.
-  * @param _owner address of the user for whom we search the key
+  * @param _keyOwner address of the user for whom we search the key
   */
   function keyExpirationTimestampFor(
-    address _owner
+    address _keyOwner
   )
     public view
-    ownsOrHasOwnedKey(_owner)
+    ownsOrHasOwnedKey(_keyOwner)
     returns (uint timestamp)
   {
-    return keyByOwner[_owner].expirationTimestamp;
+    return keyByOwner[_keyOwner].expirationTimestamp;
   }
 
   /**
@@ -249,15 +249,15 @@ contract MixinKeys is
    * Records the owner of a given tokenId
    */
   function _recordOwner(
-    address _owner,
+    address _keyOwner,
     uint _tokenId
   ) internal
   {
-    if (_ownerOf[_tokenId] != _owner) {
+    if (_ownerOf[_tokenId] != _keyOwner) {
       // TODO: this may include duplicate entries
-      owners.push(_owner);
+      owners.push(_keyOwner);
       // We register the owner of the tokenID
-      _ownerOf[_tokenId] = _owner;
+      _ownerOf[_tokenId] = _keyOwner;
     }
   }
 

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -119,12 +119,12 @@ contract MixinRefunds is
    * than what the user reads from this call.
    */
   function getCancelAndRefundValueFor(
-    address _owner
+    address _keyOwner
   )
     external view
     returns (uint refund)
   {
-    return _getCancelAndRefundValue(_owner);
+    return _getCancelAndRefundValue(_keyOwner);
   }
 
   /**
@@ -180,16 +180,16 @@ contract MixinRefunds is
   /**
    * @dev Determines how much of a refund a key owner would receive if they issued
    * a cancelAndRefund now.
-   * @param _owner The owner of the key check the refund value for.
+   * @param _keyOwner The owner of the key check the refund value for.
    */
   function _getCancelAndRefundValue(
-    address _owner
+    address _keyOwner
   )
     private view
-    hasValidKey(_owner)
+    hasValidKey(_keyOwner)
     returns (uint refund)
   {
-    Key storage key = keyByOwner[_owner];
+    Key storage key = keyByOwner[_keyOwner];
     // Math: safeSub is not required since `hasValidKey` confirms timeRemaining is positive
     uint timeRemaining = key.expirationTimestamp - block.timestamp;
     if(timeRemaining + freeTrialLength >= expirationDuration) {

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -222,17 +222,17 @@ contract MixinTransfer is
    * Determines how much of a fee a key owner would need to pay in order to
    * transfer the key to another account.  This is pro-rated so the fee goes down
    * overtime.
-   * @param _owner The owner of the key check the transfer fee for.
+   * @param _keyOwner The owner of the key check the transfer fee for.
    */
   function getTransferFee(
-    address _owner,
+    address _keyOwner,
     uint _time
   )
     public view
-    hasValidKey(_owner)
+    hasValidKey(_keyOwner)
     returns (uint)
   {
-    Key storage key = keyByOwner[_owner];
+    Key storage key = keyByOwner[_keyOwner];
     uint timeToTransfer;
     uint fee;
     // Math: safeSub is not required since `hasValidKey` confirms timeToTransfer is positive


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

The most common issue reported by MythX is that we are shadowing `_owner` from OZ Ownable.sol

This renames variables to prevent that error on next run.

This likely conflicts with some of your recent changes @nfurfaro .. no problem sitting on this and then rebasing after your PR.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
