### PR TITLE
Reseting the paywall status when config is changed

### DIFF
--- a/paywall/src/__tests__/unlock.js/MainWindowHandler/setupUnlockProtocolVariable.test.ts
+++ b/paywall/src/__tests__/unlock.js/MainWindowHandler/setupUnlockProtocolVariable.test.ts
@@ -114,7 +114,7 @@ describe('MainWindowHandler - setupUnlockProtocolVariable', () => {
     })
 
     it('should send the normalized config when invoked', () => {
-      expect.assertions(3)
+      expect.assertions(4)
 
       const handler = getMainWindowHandler()
       handler.setupUnlockProtocolVariable()
@@ -133,8 +133,11 @@ describe('MainWindowHandler - setupUnlockProtocolVariable', () => {
         locks: {},
       }
 
+      handler.lockStatus = PostMessages.LOCKED
+
       fullWindow().unlockProtocol.resetConfig(newConfig)
 
+      expect(handler.lockStatus).toBe(undefined)
       expect(accountsSpy).toHaveBeenLastCalledWith(
         PostMessages.CONFIG,
         newConfig

--- a/paywall/src/unlock.js/MainWindowHandler.ts
+++ b/paywall/src/unlock.js/MainWindowHandler.ts
@@ -34,7 +34,7 @@ export default class MainWindowHandler {
 
   private showingAccountsIframe: boolean = false
 
-  private lockStatus: LockStatus = undefined
+  public lockStatus: LockStatus = undefined
 
   private blockchainData: BlockchainData = {
     locks: {},
@@ -75,6 +75,7 @@ export default class MainWindowHandler {
     }[message]
 
     // Only update if there's actually a change
+    // Or when the config was changed!
     if (this.lockStatus !== message) {
       this.dispatchEvent(message)
       this.setCachedLockedState(isLocked)
@@ -149,6 +150,7 @@ export default class MainWindowHandler {
     const getState = () => this.lockStatus
     const blockchainData = () => this.blockchainData
     const resetConfig = (config: PaywallConfig) => {
+      this.lockStatus = undefined
       const nornalizedConfig = normalizeConfig(config)
       this.iframes.accounts.postMessage(PostMessages.CONFIG, nornalizedConfig)
       this.iframes.checkout.postMessage(PostMessages.CONFIG, nornalizedConfig)


### PR DESCRIPTION
# Description

Up until now we do not emit the same event twice (locked/unlocked), but in the context of a config change I think it's better to trigger the same event.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread