### PR TITLE
Update WalletService type with callback for purchaseKey

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+# 0.8.4
+- Updated WalletService type to include callback for purchaseKey
+
 # 0.8.3
 - Updated Web3ServiceParams to include the network id, which is required
 

--- a/unlock-js/index.d.ts
+++ b/unlock-js/index.d.ts
@@ -97,7 +97,9 @@ export class WalletService extends EventEmitter {
   provider?: any;
   connect: (provider: Web3Provider) => Promise<void>;
   getAccount: () => Promise<string | false>;
-  purchaseKey: (params: PurchaseKeyParams) => Promise<string>;
+  // callback is never called with an error and is always called with
+  // a hash -- this may change in the future.
+  purchaseKey: (params: PurchaseKeyParams, callback: (error: Error | null, hash: string | null) => void) => Promise<string>;
   setKeyMetadata: (params: SetKeyMetadataParams, callback: any) => void;
   setUserMetadata: (params: SetUserMetadataParams, callback: any) => void;
   getKeyMetadata: (params: GetKeyMetadataParams, callback: any) => void;

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

The type didn't expose the callback, but we need it for the `usePurchaseKey` hook to be able to expose the transaction hash.


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
