### PR TITLE
purchaseKey callback is optional (allows automatic update)

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changes
 
 # 0.8.5
-- Indicated that callback is optional on purchaseKey
+- Corrected type definition so that callback is optional on purchaseKey
 
 # 0.8.4
 - Updated WalletService type to include callback for purchaseKey

--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+# 0.8.5
+- Indicated that callback is optional on purchaseKey
+
 # 0.8.4
 - Updated WalletService type to include callback for purchaseKey
 

--- a/unlock-js/index.d.ts
+++ b/unlock-js/index.d.ts
@@ -99,7 +99,7 @@ export class WalletService extends EventEmitter {
   getAccount: () => Promise<string | false>;
   // callback is never called with an error and is always called with
   // a hash -- this may change in the future.
-  purchaseKey: (params: PurchaseKeyParams, callback: (error: Error | null, hash: string | null) => void) => Promise<string>;
+  purchaseKey: (params: PurchaseKeyParams, callback?: (error: Error | null, hash: string | null) => void) => Promise<string>;
   setKeyMetadata: (params: SetKeyMetadataParams, callback: any) => void;
   setUserMetadata: (params: SetUserMetadataParams, callback: any) => void;
   getKeyMetadata: (params: GetKeyMetadataParams, callback: any) => void;

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

When the renovate PR went in for `unlock-js` it caused a few breakages, because the `purchaseKey` callback is supposed to be optional, but wasn't marked that way in the typedefs. This PR corrects the type definition to be aligned with the code.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
