### PR TITLE
Locks get transaction hash when a key purchase goes through

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -67,9 +67,12 @@ describe('Checkout Lock', () => {
     beforeEach(() => {
       purchaseKey = jest.fn()
       setPurchasingLockAddress = jest.fn()
-      jest
-        .spyOn(usePurchaseKey, 'usePurchaseKey')
-        .mockImplementation(_ => ({ purchaseKey, initiatedPurchase: false }))
+      jest.spyOn(usePurchaseKey, 'usePurchaseKey').mockImplementation(_ => ({
+        purchaseKey,
+        initiatedPurchase: false,
+        error: null,
+        transactionHash: null,
+      }))
     })
 
     it('purchases a key and sets the purchasing address on click', () => {
@@ -148,8 +151,39 @@ describe('Checkout Lock', () => {
       getByTestId('DisabledLock')
     })
 
-    it('renders a confirmed lock when there is a purchase for this lock', () => {
+    it('renders a processing lock when there is a purchase without transaction hash for this lock', () => {
       expect.assertions(0)
+
+      const lock = {
+        name: 'lock',
+        address: '0xlockaddress',
+        keyPrice: '4000000',
+        expirationDuration: 50,
+        currencyContractAddress: null,
+      }
+
+      const { getByTestId } = rtl.render(
+        <Lock
+          lock={lock}
+          purchasingLockAddress="0xlockaddress"
+          setPurchasingLockAddress={setPurchasingLockAddress}
+        />
+      )
+
+      getByTestId('ProcessingLock')
+    })
+
+    it('renders a confirmed lock when there is a purchase with transaction hash for this lock', () => {
+      expect.assertions(0)
+
+      purchaseKey = jest.fn()
+      setPurchasingLockAddress = jest.fn()
+      jest.spyOn(usePurchaseKey, 'usePurchaseKey').mockImplementation(_ => ({
+        purchaseKey,
+        initiatedPurchase: false,
+        error: null,
+        transactionHash: '0xhash',
+      }))
 
       const lock = {
         name: 'lock',

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -48,7 +48,7 @@ export const Lock = ({
   purchasingLockAddress,
   setPurchasingLockAddress,
 }: LockProps) => {
-  const { purchaseKey } = usePurchaseKey(lock)
+  const { purchaseKey, transactionHash } = usePurchaseKey(lock)
 
   const onClick = () => {
     if (purchasingLockAddress) {
@@ -68,12 +68,19 @@ export const Lock = ({
     name: lock.name,
   }
 
-  if (purchasingLockAddress) {
-    if (purchasingLockAddress === lock.address) {
+  // This lock is being/has been purchased
+  if (purchasingLockAddress === lock.address) {
+    if (transactionHash) {
       return <LockVariations.ConfirmedLock {...props} />
     }
+    return <LockVariations.ProcessingLock {...props} />
+  }
+
+  // Some other lock is being/has been purchased
+  if (purchasingLockAddress) {
     return <LockVariations.DisabledLock {...props} />
   }
 
+  // No lock is being/has been purchased
   return <LockVariations.PurchaseableLock {...props} />
 }

--- a/unlock-app/src/hooks/usePurchaseKey.ts
+++ b/unlock-app/src/hooks/usePurchaseKey.ts
@@ -3,19 +3,34 @@ import { WalletService } from '@unlock-protocol/unlock-js'
 import { RawLock } from '../unlockTypes'
 import { WalletServiceContext } from '../utils/withWalletService'
 
+type TransactionHash = string | null
+type PurchaseError = Error | null
+
 export const usePurchaseKey = (lock: RawLock) => {
-  const [initiatedPurchase, setInitiatedPurchase] = useState(false)
+  const [transactionHash, setTransactionHash] = useState(
+    null as TransactionHash
+  )
+  const [error, setError] = useState(null as PurchaseError)
+
   const walletService: WalletService = useContext(WalletServiceContext)
 
   const purchaseKey = () => {
-    setInitiatedPurchase(true)
-    walletService.purchaseKey({
-      lockAddress: lock.address,
-      owner: lock.owner!,
-      keyPrice: lock.keyPrice,
-      erc20Address: lock.currencyContractAddress,
-    })
+    walletService.purchaseKey(
+      {
+        lockAddress: lock.address,
+        owner: lock.owner!,
+        keyPrice: lock.keyPrice,
+        erc20Address: lock.currencyContractAddress,
+      },
+      (error, hash) => {
+        if (error) {
+          setError(error)
+        } else {
+          setTransactionHash(hash)
+        }
+      }
+    )
   }
 
-  return { purchaseKey, initiatedPurchase }
+  return { purchaseKey, error, transactionHash }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR updates `usePurchaseKey` to get the transaction hash from the callback, and exposes it to the lock component. In the future we will message this hash up to the containing application, but for now we just use it to indicate a "processing" state before we get the hash.

Start:
<img width="264" alt="image" src="https://user-images.githubusercontent.com/9300702/75485383-9b058800-5978-11ea-9ff3-9f4e9dc14cc7.png">

Click "ETH Lock": (grayed out because wallet check overlay is in place)
<img width="264" alt="image" src="https://user-images.githubusercontent.com/9300702/75485454-b7092980-5978-11ea-84d9-11e0991cc069.png">

Finish: (after confirming purchase in metamask; hash is present so we show the confirmed lock)
<img width="264" alt="image" src="https://user-images.githubusercontent.com/9300702/75485528-d30ccb00-5978-11ea-8da9-0804cfbddbfc.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
