### PR TITLE
Checkout now shows when locks have insufficient balance

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -7,6 +7,14 @@ const balances = {
   eth: '500.00',
 }
 
+const lock = {
+  name: 'lock',
+  address: '0xlockaddress',
+  keyPrice: '0.04',
+  expirationDuration: 50,
+  currencyContractAddress: null,
+}
+
 describe('Checkout Lock', () => {
   describe('Lock', () => {
     let purchaseKey: () => void
@@ -24,14 +32,6 @@ describe('Checkout Lock', () => {
 
     it('purchases a key and sets the purchasing address on click', () => {
       expect.assertions(2)
-
-      const lock = {
-        name: 'lock',
-        address: '0xlockaddress',
-        keyPrice: '4000000',
-        expirationDuration: 50,
-        currencyContractAddress: null,
-      }
 
       const { getByText } = rtl.render(
         <Lock
@@ -53,14 +53,6 @@ describe('Checkout Lock', () => {
     it('does not purchase a key and set the purchasing address when there is already a purchase', () => {
       expect.assertions(2)
 
-      const lock = {
-        name: 'lock',
-        address: '0xlockaddress',
-        keyPrice: '4000000',
-        expirationDuration: 50,
-        currencyContractAddress: null,
-      }
-
       const { getByText } = rtl.render(
         <Lock
           lock={lock}
@@ -78,16 +70,28 @@ describe('Checkout Lock', () => {
       expect(setPurchasingLockAddress).not.toHaveBeenCalled()
     })
 
-    it('renders a disabled lock when there is a purchase for a different lock', () => {
+    it('renders an insufficient balance lock when the user cannot afford a key', () => {
       expect.assertions(0)
 
-      const lock = {
-        name: 'lock',
-        address: '0xlockaddress',
-        keyPrice: '4000000',
-        expirationDuration: 50,
-        currencyContractAddress: null,
+      const insufficientBalanceLock = {
+        ...lock,
+        currencyContractAddress: '0xcurrency',
       }
+
+      const { getByTestId } = rtl.render(
+        <Lock
+          lock={insufficientBalanceLock}
+          purchasingLockAddress={null}
+          setPurchasingLockAddress={setPurchasingLockAddress}
+          balances={balances}
+        />
+      )
+
+      getByTestId('InsufficientBalanceLock')
+    })
+
+    it('renders a disabled lock when there is a purchase for a different lock', () => {
+      expect.assertions(0)
 
       const { getByTestId } = rtl.render(
         <Lock
@@ -103,14 +107,6 @@ describe('Checkout Lock', () => {
 
     it('renders a processing lock when there is a purchase without transaction hash for this lock', () => {
       expect.assertions(0)
-
-      const lock = {
-        name: 'lock',
-        address: '0xlockaddress',
-        keyPrice: '4000000',
-        expirationDuration: 50,
-        currencyContractAddress: null,
-      }
 
       const { getByTestId } = rtl.render(
         <Lock
@@ -135,14 +131,6 @@ describe('Checkout Lock', () => {
         error: null,
         transactionHash: '0xhash',
       }))
-
-      const lock = {
-        name: 'lock',
-        address: '0xlockaddress',
-        keyPrice: '4000000',
-        expirationDuration: 50,
-        currencyContractAddress: null,
-      }
 
       const { getByTestId } = rtl.render(
         <Lock

--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -1,66 +1,13 @@
 import React from 'react'
 import * as rtl from '@testing-library/react'
-import {
-  lockKeysAvailable,
-  lockTickerSymbol,
-  Lock,
-} from '../../../../components/interface/checkout/Lock'
+import { Lock } from '../../../../components/interface/checkout/Lock'
 import * as usePurchaseKey from '../../../../hooks/usePurchaseKey'
 
+const balances = {
+  eth: '500.00',
+}
+
 describe('Checkout Lock', () => {
-  describe('helpers', () => {
-    describe('lockKeysAvailable', () => {
-      it('returns Unlimited if it has unlimited keys', () => {
-        expect.assertions(1)
-        const lock = {
-          unlimitedKeys: true,
-          maxNumberOfKeys: -1,
-          outstandingKeys: 100,
-        }
-        expect(lockKeysAvailable(lock)).toEqual('Unlimited')
-      })
-
-      it('returns the difference between max and outstanding ottherwise', () => {
-        expect.assertions(1)
-        const lock = {
-          maxNumberOfKeys: 203,
-          outstandingKeys: 100,
-        }
-        expect(lockKeysAvailable(lock)).toEqual('103')
-      })
-    })
-
-    describe('lockTickerSymbol', () => {
-      it('returns ETH when it is an ETH lock', () => {
-        expect.assertions(1)
-        const lock = {
-          currencyContractAddress: null,
-        }
-
-        expect(lockTickerSymbol(lock)).toEqual('ETH')
-      })
-
-      it('returns DAI when it is a DAI lock', () => {
-        expect.assertions(1)
-        const lock = {
-          currencyContractAddress: '0xDAI',
-          currencySymbol: 'DAI',
-        }
-
-        expect(lockTickerSymbol(lock)).toEqual('DAI')
-      })
-
-      it('returns ERC20 when it is an unknown ERC20 lock', () => {
-        expect.assertions(1)
-        const lock = {
-          currencyContractAddress: '0xDAI',
-        }
-
-        expect(lockTickerSymbol(lock)).toEqual('ERC20')
-      })
-    })
-  })
-
   describe('Lock', () => {
     let purchaseKey: () => void
     let setPurchasingLockAddress: () => void
@@ -91,6 +38,7 @@ describe('Checkout Lock', () => {
           lock={lock}
           purchasingLockAddress={null}
           setPurchasingLockAddress={setPurchasingLockAddress}
+          balances={balances}
         />
       )
 
@@ -118,6 +66,7 @@ describe('Checkout Lock', () => {
           lock={lock}
           purchasingLockAddress="0xneato"
           setPurchasingLockAddress={setPurchasingLockAddress}
+          balances={balances}
         />
       )
 
@@ -145,6 +94,7 @@ describe('Checkout Lock', () => {
           lock={lock}
           purchasingLockAddress="0xneato"
           setPurchasingLockAddress={setPurchasingLockAddress}
+          balances={balances}
         />
       )
 
@@ -167,6 +117,7 @@ describe('Checkout Lock', () => {
           lock={lock}
           purchasingLockAddress="0xlockaddress"
           setPurchasingLockAddress={setPurchasingLockAddress}
+          balances={balances}
         />
       )
 
@@ -198,6 +149,7 @@ describe('Checkout Lock', () => {
           lock={lock}
           purchasingLockAddress="0xlockaddress"
           setPurchasingLockAddress={setPurchasingLockAddress}
+          balances={balances}
         />
       )
 

--- a/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
+++ b/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   lockKeysAvailable,
   lockTickerSymbol,
+  userCanAffordKey,
 } from '../../utils/checkoutLockUtils'
 
 describe('Checkout Lock Utils', () => {
@@ -52,6 +53,77 @@ describe('Checkout Lock Utils', () => {
       }
 
       expect(lockTickerSymbol(lock)).toEqual('ERC20')
+    })
+  })
+
+  describe('userCanAffordKey', () => {
+    const balances = {
+      eth: '50',
+      '0x123abc': '50',
+    }
+
+    it('returns true when the user has enough eth', () => {
+      expect.assertions(1)
+
+      const lock = {
+        keyPrice: '0.01',
+      }
+
+      expect(userCanAffordKey(lock, balances)).toBeTruthy()
+    })
+
+    it('returns true when the user has enough erc20', () => {
+      expect.assertions(1)
+
+      const lock = {
+        keyPrice: '0.01',
+        currencyContractAddress: '0x123abc',
+      }
+
+      expect(userCanAffordKey(lock, balances)).toBeTruthy()
+    })
+
+    it('returns false when the user has insufficient eth', () => {
+      expect.assertions(1)
+
+      const lock = {
+        keyPrice: '100',
+      }
+
+      expect(userCanAffordKey(lock, balances)).toBeFalsy()
+    })
+
+    it('returns false when the user has insufficient erc20', () => {
+      expect.assertions(1)
+
+      const lock = {
+        keyPrice: '100',
+        currencyContractAddress: '0x123abc',
+      }
+
+      expect(userCanAffordKey(lock, balances)).toBeFalsy()
+    })
+
+    it('returns false when the key price cannot be parsed', () => {
+      expect.assertions(1)
+
+      const lock = {
+        keyPrice: '100qq',
+        currencyContractAddress: '0x123abc',
+      }
+
+      expect(userCanAffordKey(lock, balances)).toBeFalsy()
+    })
+
+    it('returns false when the balance cannot be parsed', () => {
+      expect.assertions(1)
+
+      const lock = {
+        keyPrice: '100',
+        currencyContractAddress: '0xnotintheobject',
+      }
+
+      expect(userCanAffordKey(lock, balances)).toBeFalsy()
     })
   })
 })

--- a/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
+++ b/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
@@ -1,0 +1,57 @@
+import {
+  lockKeysAvailable,
+  lockTickerSymbol,
+} from '../../utils/checkoutLockUtils'
+
+describe('Checkout Lock Utils', () => {
+  describe('lockKeysAvailable', () => {
+    it('returns Unlimited if it has unlimited keys', () => {
+      expect.assertions(1)
+      const lock = {
+        unlimitedKeys: true,
+        maxNumberOfKeys: -1,
+        outstandingKeys: 100,
+      }
+      expect(lockKeysAvailable(lock)).toEqual('Unlimited')
+    })
+
+    it('returns the difference between max and outstanding ottherwise', () => {
+      expect.assertions(1)
+      const lock = {
+        maxNumberOfKeys: 203,
+        outstandingKeys: 100,
+      }
+      expect(lockKeysAvailable(lock)).toEqual('103')
+    })
+  })
+
+  describe('lockTickerSymbol', () => {
+    it('returns ETH when it is an ETH lock', () => {
+      expect.assertions(1)
+      const lock = {
+        currencyContractAddress: null,
+      }
+
+      expect(lockTickerSymbol(lock)).toEqual('ETH')
+    })
+
+    it('returns DAI when it is a DAI lock', () => {
+      expect.assertions(1)
+      const lock = {
+        currencyContractAddress: '0xDAI',
+        currencySymbol: 'DAI',
+      }
+
+      expect(lockTickerSymbol(lock)).toEqual('DAI')
+    })
+
+    it('returns ERC20 when it is an unknown ERC20 lock', () => {
+      expect.assertions(1)
+      const lock = {
+        currencyContractAddress: '0xDAI',
+      }
+
+      expect(lockTickerSymbol(lock)).toEqual('ERC20')
+    })
+  })
+})

--- a/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
+++ b/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
@@ -67,6 +67,7 @@ describe('Checkout Lock Utils', () => {
 
       const lock = {
         keyPrice: '0.01',
+        currencyContractAddress: null,
       }
 
       expect(userCanAffordKey(lock, balances)).toBeTruthy()
@@ -88,6 +89,7 @@ describe('Checkout Lock Utils', () => {
 
       const lock = {
         keyPrice: '100',
+        currencyContractAddress: null,
       }
 
       expect(userCanAffordKey(lock, balances)).toBeFalsy()

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -4,6 +4,7 @@ import { durationsAsTextFromSeconds } from '../../../utils/durations'
 import {
   lockKeysAvailable,
   lockTickerSymbol,
+  userCanAffordKey,
 } from '../../../utils/checkoutLockUtils'
 import { usePurchaseKey } from '../../../hooks/usePurchaseKey'
 import * as LockVariations from './LockVariations'
@@ -19,6 +20,7 @@ export const Lock = ({
   lock,
   purchasingLockAddress,
   setPurchasingLockAddress,
+  balances,
 }: LockProps) => {
   const { purchaseKey, transactionHash } = usePurchaseKey(lock)
 
@@ -40,6 +42,8 @@ export const Lock = ({
     name: lock.name,
   }
 
+  const canAfford = userCanAffordKey(lock, balances)
+
   // This lock is being/has been purchased
   if (purchasingLockAddress === lock.address) {
     if (transactionHash) {
@@ -54,5 +58,9 @@ export const Lock = ({
   }
 
   // No lock is being/has been purchased
-  return <LockVariations.PurchaseableLock {...props} />
+  if (canAfford) {
+    return <LockVariations.PurchaseableLock {...props} />
+  }
+
+  return <LockVariations.InsufficientBalanceLock {...props} />
 }

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
-import { RawLock } from '../../../unlockTypes'
+import { RawLock, Balances } from '../../../unlockTypes'
 import { durationsAsTextFromSeconds } from '../../../utils/durations'
+import {
+  lockKeysAvailable,
+  lockTickerSymbol,
+} from '../../../utils/checkoutLockUtils'
 import { usePurchaseKey } from '../../../hooks/usePurchaseKey'
 import * as LockVariations from './LockVariations'
 
@@ -8,39 +12,7 @@ interface LockProps {
   lock: RawLock
   purchasingLockAddress: string | null
   setPurchasingLockAddress: (lockAddress: string) => void
-}
-
-interface LockKeysAvailableLock {
-  unlimitedKeys?: boolean
-  maxNumberOfKeys?: number
-  outstandingKeys?: number
-}
-
-export const lockKeysAvailable = ({
-  unlimitedKeys,
-  maxNumberOfKeys,
-  outstandingKeys,
-}: LockKeysAvailableLock) => {
-  if (unlimitedKeys) {
-    return 'Unlimited'
-  }
-
-  // maxNumberOfKeys and outstandingKeys are assumed to be defined
-  // if they are ever not, a runtime error can occur
-  return (maxNumberOfKeys! - outstandingKeys!).toLocaleString()
-}
-
-interface LockTickerSymbolLock {
-  currencyContractAddress: string | null
-  currencySymbol?: string
-}
-
-export const lockTickerSymbol = (lock: LockTickerSymbolLock) => {
-  if (lock.currencyContractAddress) {
-    // TODO: if there is no symbol, we probably need something better than "ERC20"
-    return (lock as any).currencySymbol || 'ERC20'
-  }
-  return 'ETH'
+  balances: Balances
 }
 
 export const Lock = ({

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -15,7 +15,7 @@ export const Locks = ({ lockAddresses, accountAddress }: LocksProps) => {
   const [purchasingLockAddress, setPurchasingLockAddress] = useState(
     null as PurchasingLockAddress
   )
-  const { getTokenBalance } = useGetTokenBalance(accountAddress)
+  const { getTokenBalance, balances } = useGetTokenBalance(accountAddress)
   const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
 
   if (loading) {
@@ -36,6 +36,7 @@ export const Locks = ({ lockAddresses, accountAddress }: LocksProps) => {
           lock={lock}
           purchasingLockAddress={purchasingLockAddress}
           setPurchasingLockAddress={setPurchasingLockAddress}
+          balances={balances}
         />
       ))}
     </div>

--- a/unlock-app/src/utils/checkoutLockUtils.ts
+++ b/unlock-app/src/utils/checkoutLockUtils.ts
@@ -1,7 +1,10 @@
+import { Balances } from '../unlockTypes'
+
 // These interfaces patch over the sort of incomplete definition of
 // RawLock in unlockTypes. TODO: we should really tighten up our lock
 // type so that it at least includes as optional all possible
-// properties on a lock.
+// properties on a lock. These are all compatible with RawLock insofar
+// as they only extend it with properties that may be undefined.
 interface LockKeysAvailableLock {
   unlimitedKeys?: boolean
   maxNumberOfKeys?: number
@@ -11,6 +14,11 @@ interface LockKeysAvailableLock {
 interface LockTickerSymbolLock {
   currencyContractAddress: string | null
   currencySymbol?: string
+}
+
+interface LockPriceLock {
+  currencyContractAddress?: string
+  keyPrice: string
 }
 
 export const lockKeysAvailable = ({
@@ -33,4 +41,20 @@ export const lockTickerSymbol = (lock: LockTickerSymbolLock) => {
     return (lock as any).currencySymbol || 'ERC20'
   }
   return 'ETH'
+}
+
+export const userCanAffordKey = (
+  lock: LockPriceLock,
+  balances: Balances
+): boolean => {
+  const currency = lock.currencyContractAddress || 'eth'
+  const keyPrice = parseFloat(lock.keyPrice)
+  const balance = parseFloat(balances[currency])
+
+  if (typeof keyPrice !== 'number' || typeof balance !== 'number') {
+    // we could not parse one of these numbers, ipso facto we cannot afford a key
+    return false
+  }
+
+  return keyPrice <= balance
 }

--- a/unlock-app/src/utils/checkoutLockUtils.ts
+++ b/unlock-app/src/utils/checkoutLockUtils.ts
@@ -1,0 +1,36 @@
+// These interfaces patch over the sort of incomplete definition of
+// RawLock in unlockTypes. TODO: we should really tighten up our lock
+// type so that it at least includes as optional all possible
+// properties on a lock.
+interface LockKeysAvailableLock {
+  unlimitedKeys?: boolean
+  maxNumberOfKeys?: number
+  outstandingKeys?: number
+}
+
+interface LockTickerSymbolLock {
+  currencyContractAddress: string | null
+  currencySymbol?: string
+}
+
+export const lockKeysAvailable = ({
+  unlimitedKeys,
+  maxNumberOfKeys,
+  outstandingKeys,
+}: LockKeysAvailableLock) => {
+  if (unlimitedKeys) {
+    return 'Unlimited'
+  }
+
+  // maxNumberOfKeys and outstandingKeys are assumed to be defined
+  // if they are ever not, a runtime error can occur
+  return (maxNumberOfKeys! - outstandingKeys!).toLocaleString()
+}
+
+export const lockTickerSymbol = (lock: LockTickerSymbolLock) => {
+  if (lock.currencyContractAddress) {
+    // TODO: if there is no symbol, we probably need something better than "ERC20"
+    return (lock as any).currencySymbol || 'ERC20'
+  }
+  return 'ETH'
+}

--- a/unlock-app/src/utils/checkoutLockUtils.ts
+++ b/unlock-app/src/utils/checkoutLockUtils.ts
@@ -17,7 +17,7 @@ interface LockTickerSymbolLock {
 }
 
 interface LockPriceLock {
-  currencyContractAddress?: string
+  currencyContractAddress: string | null
   keyPrice: string
 }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Pretty simple PR, adding a UI state where the checkout shows that a user does not have sufficient balance to purchase a key.

<img width="264" alt="image" src="https://user-images.githubusercontent.com/9300702/75564087-7a413f00-5a19-11ea-8a4e-d082839865a0.png">

In the process of doing this, I extracted some utils from the `Lock` component and put them in their own file.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
