### PR TITLE
Show disabled locks on checkout when no account is available

### DIFF
--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -5,6 +5,7 @@ import queryString from 'query-string'
 import BrowserOnly from '../helpers/BrowserOnly'
 import { pageTitle } from '../../constants'
 import { Locks } from '../interface/checkout/Locks'
+import { NotLoggedInLocks } from '../interface/checkout/NotLoggedInLocks'
 import CheckoutWrapper from '../interface/checkout/CheckoutWrapper'
 import {
   Account as AccountType,
@@ -26,19 +27,24 @@ export const CheckoutContent = ({ account, config }: CheckoutContentProps) => {
     : defaultLockAddresses
 
   return (
-    <CheckoutWrapper allowClose hideCheckout={() => console.log('clicked')}>
+    <CheckoutWrapper allowClose hideCheckout={() => {}}>
       <Head>
         <title>{pageTitle('Checkout')}</title>
       </Head>
-      <p>{config ? config.callToAction.default : ''}</p>
-      {account && (
-        <BrowserOnly>
+      <BrowserOnly>
+        <p>{config ? config.callToAction.default : ''}</p>
+        {!account && (
+          <>
+            <NotLoggedInLocks lockAddresses={lockAddresses} />
+          </>
+        )}
+        {account && (
           <Locks
             accountAddress={account.address}
             lockAddresses={lockAddresses}
           />
-        </BrowserOnly>
-      )}
+        )}
+      </BrowserOnly>
     </CheckoutWrapper>
   )
 }

--- a/unlock-app/src/components/interface/checkout/NotLoggedInLocks.tsx
+++ b/unlock-app/src/components/interface/checkout/NotLoggedInLocks.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { DisabledLock, LoadingLock } from './LockVariations'
+import { usePaywallLocks } from '../../../hooks/usePaywallLocks'
+import {
+  lockKeysAvailable,
+  lockTickerSymbol,
+} from '../../../utils/checkoutLockUtils'
+import { durationsAsTextFromSeconds } from '../../../utils/durations'
+
+interface LocksProps {
+  lockAddresses: string[]
+}
+
+export const NotLoggedInLocks = ({ lockAddresses }: LocksProps) => {
+  // Dummy function -- we don't have an account address so we cannot get balance
+  const getTokenBalance = () => {}
+  const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
+
+  if (loading) {
+    return (
+      <div>
+        {lockAddresses.map(address => (
+          <LoadingLock key={address} />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {locks.map(lock => (
+        <DisabledLock
+          key={lock.name}
+          name={lock.name}
+          formattedKeyPrice={`${lock.keyPrice} ${lockTickerSymbol(lock)}`}
+          formattedKeysAvailable={lockKeysAvailable(lock)}
+          formattedDuration={durationsAsTextFromSeconds(
+            lock.expirationDuration
+          )}
+          onClick={() => {}}
+        />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR makes it so we can show a set of disabled locks on the checkout modal when no account is available (either web3 not connected, or user account not logged in).

<img width="396" alt="image" src="https://user-images.githubusercontent.com/9300702/75578756-6e15ab80-5a32-11ea-8df3-ec364605c8a8.png">

This approach can be improved in the future: as of right now it will re-fetch the locks when the account changes, but in in the interest of saving network calls we can persist the locks and simply fetch the user's balances for any ERC20 tokens the locks may be denominated in.

Next step will be to implement the LogIn/SignUp view with a link to do so when there is no account available.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
