### PR TITLE
Remove revert if never owned key

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -134,7 +134,7 @@ contract IPublicLock is IERC721Enumerable {
   /**
   * @dev Returns the key's ExpirationTimestamp field for a given owner.
   * @param _keyOwner address of the user for whom we search the key
-  * @dev Throws if owner has never owned a key for this lock
+  * @dev Returns 0 if the owner has never owned a key for this lock
   */
   function keyExpirationTimestampFor(
     address _keyOwner

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -199,7 +199,7 @@ contract MixinKeys is
   * @dev Returns 0 if the owner has never owned a key for this lock
   */
   function keyExpirationTimestampFor(
-    address _owner
+    address _keyOwner
   ) public view
     returns (uint)
   {

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -196,13 +196,12 @@ contract MixinKeys is
   /**
   * @dev Returns the key's ExpirationTimestamp field for a given owner.
   * @param _keyOwner address of the user for whom we search the key
+  * @dev Returns 0 if the owner has never owned a key for this lock
   */
   function keyExpirationTimestampFor(
-    address _keyOwner
-  )
-    public view
-    ownsOrHasOwnedKey(_keyOwner)
-    returns (uint timestamp)
+    address _owner
+  ) public view
+    returns (uint)
   {
     return keyByOwner[_keyOwner].expirationTimestamp;
   }

--- a/smart-contracts/test/Lock/disableTransfers.js
+++ b/smart-contracts/test/Lock/disableTransfers.js
@@ -47,11 +47,11 @@ contract('Lock / disableTransfers', accounts => {
         // check owner still has a key
         assert.equal(await lock.getHasValidKey.call(keyOwner), true)
         // check recipient never received a key
-        await reverts(
-          lock.keyExpirationTimestampFor.call(accountWithNoKey, {
+        assert.equal(
+          await lock.keyExpirationTimestampFor.call(accountWithNoKey, {
             from: accountWithNoKey,
           }),
-          'HAS_NEVER_OWNED_KEY'
+          0
         )
       })
     })
@@ -70,11 +70,11 @@ contract('Lock / disableTransfers', accounts => {
         // check owner still has a key
         assert.equal(await lock.getHasValidKey.call(keyOwner), true)
         // check recipient never received a key
-        await reverts(
-          lock.keyExpirationTimestampFor.call(accountWithNoKey, {
+        assert.equal(
+          await lock.keyExpirationTimestampFor.call(accountWithNoKey, {
             from: accountWithNoKey,
           }),
-          'HAS_NEVER_OWNED_KEY'
+          0
         )
       })
     })

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -24,9 +24,9 @@ contract('Lock / purchaseFor', accounts => {
         'NOT_ENOUGH_FUNDS'
       )
       // Making sure we do not have a key set!
-      await reverts(
-        locks.FIRST.keyExpirationTimestampFor.call(accounts[0]),
-        'HAS_NEVER_OWNED_KEY'
+      assert.equal(
+        await locks.FIRST.keyExpirationTimestampFor.call(accounts[0]),
+        0
       )
     })
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Reverting read-only calls is often unexpected. This removes the revert for `keyExpirationTimestampFor` - it seems fine to just return 0 instead.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #5836

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
