### PR TITLE
Adding keyManager modifiers

### DIFF
--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -43,6 +43,22 @@ contract MixinApproval is
     _;
   }
 
+  // Ensure that the caller is the keyManager of the key
+  // or that the caller has been approved
+  // for ownership of that key
+  modifier onlyKeyManagerOrApproved(
+    uint _tokenId
+  )
+  {
+    require(
+      isKeyManager(_tokenId, msg.sender) ||
+      _isApproved(_tokenId, msg.sender) ||
+      isApprovedForAll(_ownerOf[_tokenId], msg.sender),
+      'ONLY_KEY_MANAGER_OR_APPROVED'
+    );
+    _;
+  }
+
   /**
    * This approves _approved to get ownership of _tokenId.
    * Note: that since this is used for both purchase and transfer approvals

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -101,10 +101,7 @@ contract MixinKeys is
   modifier onlyKeyManager(
     uint _tokenId
   ) {
-    require(
-      keyManagerOf[_tokenId] == msg.sender ||
-      (keyManagerOf[_tokenId] == address(0) && isKeyOwner(_tokenId, msg.sender)), 'ONLY_KEY_MANAGER'
-    );
+    require(isKeyManager(_tokenId, msg.sender), 'ONLY_KEY_MANAGER');
     _;
   }
 
@@ -234,8 +231,7 @@ contract MixinKeys is
   * @param _tokenId The id of the key to assign rights for
   * @param _keyManager The address with the manager's rights for the given key.
   * Setting _keyManager to address(0) means the keyOwner is also the keyManager
-  * */
-  //
+   */
   function setKeyManagerOf(
     uint _tokenId,
     address _keyManager
@@ -243,12 +239,30 @@ contract MixinKeys is
     isKey(_tokenId)
   {
     require(
-      keyManagerOf[_tokenId] == msg.sender ||
-      isLockManager(msg.sender) ||
-      keyManagerOf[_tokenId] == address(0) && isKeyOwner(_tokenId, msg.sender), 'UNAUTHORIZED_KEY_MANAGER_UPDATE'
+      isKeyManager(_tokenId, msg.sender) ||
+      isLockManager(msg.sender),
+      'UNAUTHORIZED_KEY_MANAGER_UPDATE'
     );
     keyManagerOf[_tokenId] = _keyManager;
     emit KeyManagerChanged(_tokenId, _keyManager);
+  }
+
+  /**
+  * Returns true if _keyManager is the manager of the key
+  * identified by _tokenId
+   */
+  function isKeyManager(
+    uint _tokenId,
+    address _keyManager
+  ) internal view
+    returns (bool)
+  {
+    if(keyManagerOf[_tokenId] == msg.sender ||
+      (keyManagerOf[_tokenId] == address(0) && isKeyOwner(_tokenId, msg.sender))) {
+        return true;
+      } else {
+        return false;
+      }
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -259,10 +259,10 @@ contract MixinKeys is
   {
     if(keyManagerOf[_tokenId] == msg.sender ||
       (keyManagerOf[_tokenId] == address(0) && isKeyOwner(_tokenId, msg.sender))) {
-        return true;
-      } else {
-        return false;
-      }
+      return true;
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -97,6 +97,17 @@ contract MixinKeys is
     _;
   }
 
+  // Ensure that the caller is the keyManager for this key
+  modifier onlyKeyManager(
+    uint _tokenId
+  ) {
+    require(
+      keyManagerOf[_tokenId] == msg.sender ||
+      (keyManagerOf[_tokenId] == address(0) && isKeyOwner(_tokenId, msg.sender)), 'ONLY_KEY_MANAGER'
+    );
+    _;
+  }
+
   /**
    * In the specific case of a Lock, each owner can own only at most 1 key.
    * @return The number of NFTs owned by `_keyOwner`, either 0 or 1.


### PR DESCRIPTION
# Description
Part 2 of the keyManager PR's.
- This adds 2 modifiers, and an internal function `isKeyManager`. 
- The modifiers are not applied to any functions yet, but will be in the next PR.
- the current modifier `onlyKeyOwnerOrApproved` will be removed in the next PR.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #5557

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
