### PR TITLE
Applying the keyManager-modifiers

### DIFF
--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -56,7 +56,7 @@ contract MixinApproval is
   )
     public
     onlyIfAlive
-    onlyKeyOwnerOrApproved(_tokenId)
+    onlyKeyManagerOrApproved(_tokenId)
   {
     require(msg.sender != _approved, 'APPROVE_SELF');
 

--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -29,20 +29,6 @@ contract MixinApproval is
   // but the approval does not reset when a transfer occurs.
   mapping (address => mapping (address => bool)) private ownerToOperatorApproved;
 
-  // Ensure that the caller has a key
-  // or that the caller has been approved
-  // for ownership of that key
-  modifier onlyKeyOwnerOrApproved(
-    uint _tokenId
-  ) {
-    require(
-      isKeyOwner(_tokenId, msg.sender) ||
-        _isApproved(_tokenId, msg.sender) ||
-        isApprovedForAll(_ownerOf[_tokenId], msg.sender),
-      'ONLY_KEY_OWNER_OR_APPROVED');
-    _;
-  }
-
   // Ensure that the caller is the keyManager of the key
   // or that the caller has been approved
   // for ownership of that key

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -51,7 +51,7 @@ contract MixinTransfer is
     uint _timeShared
   ) public
     onlyIfAlive
-    onlyKeyOwnerOrApproved(_tokenId)
+    onlyKeyManagerOrApproved(_tokenId)
   {
     require(transferFeeBasisPoints < BASIS_POINTS_DEN, 'KEY_TRANSFERS_DISABLED');
     require(_to != address(0), 'INVALID_ADDRESS');
@@ -111,7 +111,7 @@ contract MixinTransfer is
     public
     onlyIfAlive
     hasValidKey(_from)
-    onlyKeyOwnerOrApproved(_tokenId)
+    onlyKeyManagerOrApproved(_tokenId)
   {
     require(transferFeeBasisPoints < BASIS_POINTS_DEN, 'KEY_TRANSFERS_DISABLED');
     require(_recipient != address(0), 'INVALID_ADDRESS');

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -20,7 +20,7 @@ contract('Lock / erc721 / approve', accounts => {
         locks.FIRST.approve(accounts[2], 42, {
           from: accounts[1],
         }),
-        'ONLY_KEY_OWNER_OR_APPROVED'
+        'ONLY_KEY_MANAGER_OR_APPROVED'
       )
     })
   })
@@ -46,7 +46,7 @@ contract('Lock / erc721 / approve', accounts => {
           locks.FIRST.approve(accounts[2], ID, {
             from: accounts[2],
           }),
-          'ONLY_KEY_OWNER_OR_APPROVED'
+          'ONLY_KEY_MANAGER_OR_APPROVED'
         )
       })
     })

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -53,7 +53,7 @@ contract('Lock / shareKey', accounts => {
           lock.shareKey(accounts[7], 11, 1000, {
             from: accountWithNoKey1,
           }),
-          'ONLY_KEY_OWNER_OR_APPROVED'
+          'ONLY_KEY_MANAGER_OR_APPROVED'
         )
       })
 
@@ -67,7 +67,7 @@ contract('Lock / shareKey', accounts => {
               from: accounts[6],
             }
           ),
-          'ONLY_KEY_OWNER_OR_APPROVED'
+          'ONLY_KEY_MANAGER_OR_APPROVED'
         )
       })
 


### PR DESCRIPTION
# Description
Part 3 in the keyManager permissions PR's.
- This applies the 2 new modifiers `onlyKeyManager` & `onlyKeyManagerOrApproved`
- I've now removed the deprecated `onlyKeyOwnerOrApproved`.
- This didn't involed many other changes, as by default the keyManager right now is always the key Owner. This will change when I modify the `keyManager` assignment in the relevant functions.
- for reference, this is the source of truth on permissions:
https://docs.google.com/document/d/11bP7OjY2ei_NO1pzYOoTlrvQ1_9AtqXfmtgwZUYMwY0/edit?pli=1#
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #5557

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
