### PR TITLE
useCheckoutCommunication now buffers received events

### DIFF
--- a/unlock-app/src/__tests__/hooks/useCheckoutCommunication.test.ts
+++ b/unlock-app/src/__tests__/hooks/useCheckoutCommunication.test.ts
@@ -1,5 +1,5 @@
 import Postmate from 'postmate'
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook, act } from '@testing-library/react-hooks'
 import {
   useCheckoutCommunication,
   CheckoutEvents,
@@ -35,7 +35,11 @@ describe('useCheckoutCommunication', () => {
 
     result.current.emitCloseModal()
 
-    expect(emit).toHaveBeenCalledWith(CheckoutEvents.closeModal)
+    // the `undefined` in this call is an artifact of the buffer
+    // implementation, which always calls with a payload even if there
+    // isn't one. This has no impact on real code, since only the
+    // event name is important in this case.
+    expect(emit).toHaveBeenCalledWith(CheckoutEvents.closeModal, undefined)
   })
 
   it('emits a transactionInfo event when emitTransactionInfo is called', async () => {
@@ -51,6 +55,40 @@ describe('useCheckoutCommunication', () => {
     expect(emit).toHaveBeenCalledWith(
       CheckoutEvents.transactionInfo,
       transactionInfo
+    )
+  })
+
+  it('buffers an arbitrary number of events before the emitter is ready', async () => {
+    expect.assertions(4)
+
+    const { result, wait } = renderHook(() => useCheckoutCommunication())
+
+    const userInfo = { address: '0xmyaddress' }
+    act(() => result.current.emitUserInfo(userInfo))
+
+    const transactionInfo = { hash: '0xmyhash' }
+    act(() => result.current.emitTransactionInfo(transactionInfo))
+
+    act(() => result.current.emitCloseModal())
+
+    // events have gone into the buffer, but have not been emitted
+    expect(emit).not.toHaveBeenCalled()
+
+    await wait(() => result.current.ready)
+
+    // Once the emitter is ready, the buffer is flushed in the order events were received
+    expect(emit).toHaveBeenNthCalledWith(1, CheckoutEvents.userInfo, userInfo)
+
+    expect(emit).toHaveBeenNthCalledWith(
+      2,
+      CheckoutEvents.transactionInfo,
+      transactionInfo
+    )
+
+    expect(emit).toHaveBeenNthCalledWith(
+      3,
+      CheckoutEvents.closeModal,
+      undefined
     )
   })
 })

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -34,11 +34,10 @@ export const CheckoutContent = ({ account, config }: CheckoutContentProps) => {
     emitTransactionInfo,
     emitCloseModal,
     emitUserInfo,
-    ready,
   } = useCheckoutCommunication()
 
   useEffect(() => {
-    if (ready && account && account.address) {
+    if (account && account.address) {
       emitUserInfo({
         address: account.address,
       })

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -66,5 +66,8 @@ export const useCheckoutCommunication = () => {
     emitUserInfo,
     emitCloseModal,
     emitTransactionInfo,
+    // `ready` is primarily provided as an aid for testing the buffer
+    // implementation.
+    ready: !!parent,
   }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR makes `useCheckoutCommunication` a bit more robust with the addition of a buffer for events. Now end-users of the hook do not need to check whether the emitter is ready, they can just fire off events.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
