### PR TITLE
Updating permissions for approvals

### DIFF
--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -19,9 +19,7 @@ contract MixinApproval is
   // This is a mapping of addresses which have approved
   // the transfer of a key to another address where their key can be transferred
   // Note: the approver may actually NOT have a key... and there can only
-  // be a single approved beneficiary
-  // Note 2: for transfer, both addresses will be different
-  // Note 3: for sales (new keys on restricted locks), both addresses will be the same
+  // be a single approved address
   mapping (uint => address) private approved;
 
   // Keeping track of approved operators for a given Key manager.
@@ -79,7 +77,7 @@ contract MixinApproval is
     onlyIfAlive
   {
     require(_to != msg.sender, 'APPROVE_SELF');
-    ownerToOperatorApproved[msg.sender][_to] = _approved;
+    managerToOperatorApproved[msg.sender][_to] = _approved;
     emit ApprovalForAll(msg.sender, _to, _approved);
   }
 

--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -96,7 +96,7 @@ contract MixinApproval is
 
   /**
    * @dev Tells whether an operator is approved by a given keyManager
-   * @param _keyOwner owner address which you want to query the approval of
+   * @param _owner owner address which you want to query the approval of
    * @param _operator operator address which you want to query the approval of
    * @return bool whether the given operator is approved by the given owner
    */
@@ -108,7 +108,11 @@ contract MixinApproval is
   {
     uint tokenId = keyByOwner[_owner].tokenId;
     address keyManager = keyManagerOf[tokenId];
-    return managerToOperatorApproved[keyManager][_operator];
+    if(keyManager == address(0)) {
+      return managerToOperatorApproved[_owner][_operator];
+    } else {
+      return managerToOperatorApproved[keyManager][_operator];
+    }
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -24,10 +24,12 @@ contract MixinApproval is
   // Note 3: for sales (new keys on restricted locks), both addresses will be the same
   mapping (uint => address) private approved;
 
-  // Keeping track of approved operators for a Key owner.
-  // Since an owner can have up to 1 Key, this is similiar to above
-  // but the approval does not reset when a transfer occurs.
-  mapping (address => mapping (address => bool)) private ownerToOperatorApproved;
+  // Keeping track of approved operators for a given Key manager.
+  // This approves a given operator for all keys managed by the calling "keyManager"
+  // The caller may not currently be the keyManager for ANY keys.
+  // These approvals are never reset/revoked automatically, unlike "approved",
+  // which is reset on transfer.
+  mapping (address => mapping (address => bool)) private managerToOperatorApproved;
 
   // Ensure that the caller is the keyManager of the key
   // or that the caller has been approved

--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -95,18 +95,20 @@ contract MixinApproval is
   }
 
   /**
-   * @dev Tells whether an operator is approved by a given owner
+   * @dev Tells whether an operator is approved by a given keyManager
    * @param _keyOwner owner address which you want to query the approval of
    * @param _operator operator address which you want to query the approval of
    * @return bool whether the given operator is approved by the given owner
    */
   function isApprovedForAll(
-    address _keyOwner,
+    address _owner,
     address _operator
   ) public view
     returns (bool)
   {
-    return ownerToOperatorApproved[_keyOwner][_operator];
+    uint tokenId = keyByOwner[_owner].tokenId;
+    address keyManager = keyManagerOf[tokenId];
+    return managerToOperatorApproved[keyManager][_operator];
   }
 
   /**


### PR DESCRIPTION
# Description
This updates our approvals permissions, including renaming `ownerToOperatorApproved `to `managerToOperatorApproved`.
 It also fixes the way we look up approved operators in `isApprovedForAll` to be consistent with the changes to default keyManagers (where a keyManager of address(0) means the keyOwner is also the manager).
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #5557

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
