### PR TITLE
Updating cancellation permissions

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -258,7 +258,7 @@ contract IPublicLock is IERC721Enumerable {
   ) external view returns (uint);
 
   /**
-   * @dev Invoked by the lock owner to destroy the user's key and perform a refund and cancellation of the key
+   * @dev Invoked by the lock owner to expire the user's key and perform a refund and cancellation of the key
    * @param _keyOwner The key owner to whom we wish to send a refund to
    * @param amount The amount to refund the key-owner
    * @dev Throws if called by other than owner
@@ -270,13 +270,14 @@ contract IPublicLock is IERC721Enumerable {
   ) external;
 
    /**
-   * @dev Destroys the key managed by msg.sender and sends a refund
-   * based on the amount of time remaining.
+   * @dev allows the key manager to expire a given tokenId
+   * and send a refund to the keyOwner based on the amount of time remaining.
+   * @param _tokenId The id of the key to cancel.
    */
-  function cancelAndRefund(uint) external;
+  function cancelAndRefund(uint _tokenId) external;
 
   /**
-   * @dev Cancels a key managed by a different user and sends the funds to the msg.sender.
+   * @dev Cancels a key managed by a different user and sends the funds to the keyOwner.
    * @param _keyManager the key managed by this user will be canceled
    * @param _v _r _s getCancelAndRefundApprovalHash signed by the _keyManager
    * @param _tokenId The key to cancel

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -269,21 +269,24 @@ contract IPublicLock is IERC721Enumerable {
     uint amount
   ) external;
 
-  /**
-   * @notice Destroys the msg.sender's key and sends a refund based on the amount of time remaining.
+   /**
+   * @dev Destroys the key managed by msg.sender and sends a refund
+   * based on the amount of time remaining.
    */
   function cancelAndRefund(uint) external;
 
   /**
-   * @dev Cancels a key owned by a different user and sends the funds to the msg.sender.
-   * @param _keyOwner this user's key will be canceled
-   * @param _v _r _s getCancelAndRefundApprovalHash signed by the _keyOwner
+   * @dev Cancels a key managed by a different user and sends the funds to the msg.sender.
+   * @param _keyManager the key managed by this user will be canceled
+   * @param _v _r _s getCancelAndRefundApprovalHash signed by the _keyManager
+   * @param _tokenId The key to cancel
    */
   function cancelAndRefundFor(
-    address _keyOwner,
+    address _keyManager,
     uint8 _v,
     bytes32 _r,
-    bytes32 _s
+    bytes32 _s,
+    uint _tokenId
   ) external;
 
   /**
@@ -317,17 +320,17 @@ contract IPublicLock is IERC721Enumerable {
     address _keyOwner
   ) external view returns (uint refund);
 
-  function keyOwnerToNonce(address ) external view returns (uint256 );
+  function keyManagerToNonce(address ) external view returns (uint256 );
 
   /**
    * @notice returns the hash to sign in order to allow another user to cancel on your behalf.
    * @dev this can be computed in JS instead of read from the contract.
-   * @param _keyOwner The key owner's address (also the message signer)
+   * @param _keyManager The key manager's address (also the message signer)
    * @param _txSender The address cancelling cancel on behalf of the keyOwner
    * @return approvalHash The hash to sign
    */
   function getCancelAndRefundApprovalHash(
-    address _keyOwner,
+    address _keyManager,
     address _txSender
   ) external view returns (bytes32 approvalHash);
 

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -272,7 +272,7 @@ contract IPublicLock is IERC721Enumerable {
   /**
    * @notice Destroys the msg.sender's key and sends a refund based on the amount of time remaining.
    */
-  function cancelAndRefund() external;
+  function cancelAndRefund(uint) external;
 
   /**
    * @dev Cancels a key owned by a different user and sends the funds to the msg.sender.

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -75,6 +75,12 @@ contract MixinPurchase is
       // (relative to the size of a uint)
       newTimeStamp = block.timestamp + expirationDuration;
       toKey.expirationTimestamp = newTimeStamp;
+
+      // If the key owner is not already the key Manager, make it so
+      if(keyManagerOf[toKey.tokenId] != address(0)) {
+        keyManagerOf[toKey.tokenId] = address(0);
+        emit KeyManagerChanged(toKey.tokenId, address(0));
+      }
       emit RenewKeyPurchase(_recipient, newTimeStamp);
     }
 

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -60,14 +60,17 @@ contract MixinRefunds is
   }
 
   /**
-   * @dev Destroys the user's key and sends a refund based on the amount of time remaining.
+   * @dev Destroys the key and sends a refund based on the amount of time remaining.
+   * @param _tokenId The id of the key to cancel.
    */
-  function cancelAndRefund()
+  function cancelAndRefund(uint _tokenId)
     external
+    onlyKeyManager(_tokenId)
   {
-    uint refund = _getCancelAndRefundValue(msg.sender);
+    address keyOwner = ownerOf(_tokenId)
+    uint refund = _getCancelAndRefundValue(keyOwner);
 
-    _cancelAndRefund(msg.sender, refund);
+    _cancelAndRefund(keyOwner, refund);
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -67,7 +67,7 @@ contract MixinRefunds is
     external
     onlyKeyManager(_tokenId)
   {
-    address keyOwner = ownerOf(_tokenId)
+    address keyOwner = ownerOf(_tokenId);
     uint refund = _getCancelAndRefundValue(keyOwner);
 
     _cancelAndRefund(keyOwner, refund);

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -74,26 +74,29 @@ contract MixinRefunds is
   }
 
   /**
-   * @dev Cancels a key owned by a different user and sends the funds to the msg.sender.
-   * @param _keyOwner this user's key will be canceled
+   * @dev Cancels a key managed by a different user and sends the funds to the msg.sender.
+   * @param _keyManager the key managed by this user will be canceled
    * @param _v _r _s getCancelAndRefundApprovalHash signed by the _keyOwner
+   * @param _tokenId The key to cancel
    */
   function cancelAndRefundFor(
-    address _keyOwner,
+    address _keyManager,
     uint8 _v,
     bytes32 _r,
-    bytes32 _s
+    bytes32 _s,
+    uint _tokenId
   ) external
     consumeOffchainApproval(
-      getCancelAndRefundApprovalHash(_keyOwner, msg.sender),
-      _keyOwner,
+      getCancelAndRefundApprovalHash(_keyManager, msg.sender),
+      _keyManager,
       _v,
       _r,
       _s
     )
   {
-    uint refund = _getCancelAndRefundValue(_keyOwner);
-    _cancelAndRefund(_keyOwner, refund);
+    address keyOwner = ownerOf(_tokenId);
+    uint refund = _getCancelAndRefundValue(keyOwner);
+    _cancelAndRefund(keyOwner, refund);
   }
 
   /**
@@ -133,12 +136,12 @@ contract MixinRefunds is
   /**
    * @notice returns the hash to sign in order to allow another user to cancel on your behalf.
    * @dev this can be computed in JS instead of read from the contract.
-   * @param _keyOwner The key owner's address (also the message signer)
+   * @param _keyManager The key manager's address (also the message signer)
    * @param _txSender The address cancelling cancel on behalf of the keyOwner
    * @return approvalHash The hash to sign
    */
   function getCancelAndRefundApprovalHash(
-    address _keyOwner,
+    address _keyManager,
     address _txSender
   ) public view
     returns (bytes32 approvalHash)
@@ -150,7 +153,7 @@ contract MixinRefunds is
         // The specific function the signer is approving
         CANCEL_TYPEHASH,
         // Approval enables only one cancel call
-        keyOwnerToNonce[_keyOwner],
+        keyManagerToNonce[_keyManager],
         // Approval allows only one account to broadcast the tx
         _txSender
       )

--- a/smart-contracts/contracts/mixins/MixinSignatures.sol
+++ b/smart-contracts/contracts/mixins/MixinSignatures.sol
@@ -7,7 +7,7 @@ contract MixinSignatures
 {
   /// @notice emits anytime the nonce used for off-chain approvals changes.
   event NonceChanged(
-    address indexed keyOwner,
+    address indexed keyManager,
     uint nextAvailableNonce
   );
 
@@ -46,8 +46,8 @@ contract MixinSignatures
     uint _nextAvailableNonce
   ) external
   {
-    require(_nextAvailableNonce > keyOwnerToNonce[msg.sender], 'NONCE_ALREADY_USED');
-    keyOwnerToNonce[msg.sender] = _nextAvailableNonce;
+    require(_nextAvailableNonce > keyManagerToNonce[msg.sender], 'NONCE_ALREADY_USED');
+    keyManagerToNonce[msg.sender] = _nextAvailableNonce;
     emit NonceChanged(msg.sender, _nextAvailableNonce);
   }
 }

--- a/smart-contracts/contracts/mixins/MixinSignatures.sol
+++ b/smart-contracts/contracts/mixins/MixinSignatures.sol
@@ -12,13 +12,13 @@ contract MixinSignatures
   );
 
   // Stores a nonce per user to use for signed messages
-  mapping(address => uint) public keyOwnerToNonce;
+  mapping(address => uint) public keyManagerToNonce;
 
   /// @notice Validates an off-chain approval signature.
   /// @dev If valid the nonce is consumed, else revert.
   modifier consumeOffchainApproval(
     bytes32 _hash,
-    address _keyOwner,
+    address _keyManager,
     uint8 _v,
     bytes32 _r,
     bytes32 _s
@@ -30,10 +30,10 @@ contract MixinSignatures
         _v,
         _r,
         _s
-      ) == _keyOwner, 'INVALID_SIGNATURE'
+      ) == _keyManager, 'INVALID_SIGNATURE'
     );
-    keyOwnerToNonce[_keyOwner]++;
-    emit NonceChanged(_keyOwner, keyOwnerToNonce[_keyOwner]);
+    keyManagerToNonce[_keyManager]++;
+    emit NonceChanged(_keyManager, keyManagerToNonce[_keyManager]);
     _;
   }
 

--- a/smart-contracts/test/Lock/cancelAndRefundFor.js
+++ b/smart-contracts/test/Lock/cancelAndRefundFor.js
@@ -37,6 +37,7 @@ contract('Lock / cancelAndRefundFor', accounts => {
   const txSender = accounts[9]
   const keyPrice = new BigNumber(web3.utils.toWei('0.01', 'ether'))
   let lockOwner
+  let tokenId
 
   beforeEach(async () => {
     unlock = await getProxy(unlockContract)
@@ -54,7 +55,7 @@ contract('Lock / cancelAndRefundFor', accounts => {
   })
 
   it('can read the current nonce', async () => {
-    const nonce = new BigNumber(await lock.keyOwnerToNonce.call(keyOwners[0]))
+    const nonce = new BigNumber(await lock.keyManagerToNonce.call(keyOwners[0]))
     assert.equal(nonce.toFixed(), 0)
   })
 
@@ -81,11 +82,13 @@ contract('Lock / cancelAndRefundFor', accounts => {
         }),
         keyOwners[0]
       )
+      tokenId = await lock.getTokenIdFor.call(keyOwners[0])
       txObj = await lock.cancelAndRefundFor(
         keyOwners[0],
         signature.v,
         signature.r,
         signature.s,
+        tokenId,
         {
           from: txSender,
         }
@@ -108,7 +111,9 @@ contract('Lock / cancelAndRefundFor', accounts => {
     })
 
     it('can read the non-zero nonce', async () => {
-      const nonce = new BigNumber(await lock.keyOwnerToNonce.call(keyOwners[0]))
+      const nonce = new BigNumber(
+        await lock.keyManagerToNonce.call(keyOwners[0])
+      )
       assert.equal(nonce.toFixed(), 1)
     })
 
@@ -131,7 +136,7 @@ contract('Lock / cancelAndRefundFor', accounts => {
 
     it('emits NonceChanged', async () => {
       const e = txObj.receipt.logs.find(e => e.event === 'NonceChanged')
-      assert.equal(e.args.keyOwner, keyOwners[0])
+      assert.equal(e.args.keyManager, keyOwners[0])
       assert.equal(e.args.nextAvailableNonce, '1')
     })
   })
@@ -147,12 +152,14 @@ contract('Lock / cancelAndRefundFor', accounts => {
         keyOwners[1]
       )
       await lock.invalidateOffchainApproval('1', { from: keyOwners[1] })
+      tokenId = await lock.getTokenIdFor.call(keyOwners[1])
       await reverts(
         lock.cancelAndRefundFor(
           keyOwners[1],
           signature.v,
           signature.r,
           signature.s,
+          tokenId,
           {
             from: txSender,
           }
@@ -166,11 +173,13 @@ contract('Lock / cancelAndRefundFor', accounts => {
         await lock.getCancelAndRefundApprovalHash(keyOwners[2], txSender),
         keyOwners[2]
       )
+      tokenId = await lock.getTokenIdFor.call(keyOwners[2])
       await lock.cancelAndRefundFor(
         keyOwners[2],
         signature.v,
         signature.r,
         signature.s,
+        tokenId,
         {
           from: txSender,
         }
@@ -185,6 +194,7 @@ contract('Lock / cancelAndRefundFor', accounts => {
           signature.v,
           signature.r,
           signature.s,
+          tokenId,
           {
             from: txSender,
           }
@@ -202,12 +212,14 @@ contract('Lock / cancelAndRefundFor', accounts => {
         signature.r.substr(0, 4) +
         (signature.r[4] === '0' ? '1' : '0') +
         signature.r.substr(5)
+      tokenId = await lock.getTokenIdFor.call(keyOwners[3])
       await reverts(
         lock.cancelAndRefundFor(
           keyOwners[3],
           signature.v,
           signature.r,
           signature.s,
+          tokenId,
           {
             from: txSender,
           }
@@ -228,12 +240,14 @@ contract('Lock / cancelAndRefundFor', accounts => {
         await lock.getCancelAndRefundApprovalHash(keyOwners[3], txSender),
         keyOwners[3]
       )
+      tokenId = await lock.getTokenIdFor.call(keyOwners[3])
       await reverts(
         lock.cancelAndRefundFor(
           keyOwners[3],
           signature.v,
           signature.r,
           signature.s,
+          tokenId,
           {
             from: txSender,
           }
@@ -255,12 +269,14 @@ contract('Lock / cancelAndRefundFor', accounts => {
         await lock.getCancelAndRefundApprovalHash(keyOwners[3], txSender),
         keyOwners[3]
       )
+      tokenId = await lock.getTokenIdFor.call(keyOwners[3])
       await reverts(
         lock.cancelAndRefundFor(
           keyOwners[3],
           signature.v,
           signature.r,
           signature.s,
+          tokenId,
           {
             from: txSender,
           }

--- a/smart-contracts/test/Lock/disableLock.js
+++ b/smart-contracts/test/Lock/disableLock.js
@@ -96,7 +96,7 @@ contract('Lock / disableLock', accounts => {
     })
 
     it('Key owners can still cancel for a partial refund', async () => {
-      await lock.cancelAndRefund({
+      await lock.cancelAndRefund(ID, {
         from: keyOwner,
       })
     })

--- a/smart-contracts/test/Lock/erc20.js
+++ b/smart-contracts/test/Lock/erc20.js
@@ -123,7 +123,8 @@ contract('Lock / erc20', accounts => {
 
       it('when a key owner cancels a key, they are refunded in tokens', async () => {
         const balance = new BigNumber(await token.balanceOf(keyOwner))
-        await lock.cancelAndRefund({ from: keyOwner })
+        const ID = await lock.getTokenIdFor.call(keyOwner)
+        await lock.cancelAndRefund(ID, { from: keyOwner })
         assert(balance.lt(await token.balanceOf(keyOwner)))
       })
 

--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -43,7 +43,8 @@ contract('Lock / freeTrial', accounts => {
 
     describe('should cancel and provide a full refund when enough time remains', () => {
       beforeEach(async () => {
-        await lock.cancelAndRefund({
+        const ID = await lock.getTokenIdFor.call(keyOwners[0])
+        await lock.cancelAndRefund(ID, {
           from: keyOwners[0],
         })
       })
@@ -58,8 +59,9 @@ contract('Lock / freeTrial', accounts => {
 
     describe('should cancel and provide a partial refund after the trial expires', () => {
       beforeEach(async () => {
+        const ID = await lock.getTokenIdFor.call(keyOwners[0])
         await sleep(6000)
-        await lock.cancelAndRefund({
+        await lock.cancelAndRefund(ID, {
           from: keyOwners[0],
         })
       })

--- a/smart-contracts/test/Lock/invalidateOffchainApproval.js
+++ b/smart-contracts/test/Lock/invalidateOffchainApproval.js
@@ -21,7 +21,7 @@ contract('Lock / invalidateOffchainApproval', accounts => {
   })
 
   it('can read the current nonce', async () => {
-    const nonce = new BigNumber(await lock.keyOwnerToNonce.call(keyOwner))
+    const nonce = new BigNumber(await lock.keyManagerToNonce.call(keyOwner))
     assert.equal(nonce.toFixed(), 0)
   })
 
@@ -31,7 +31,7 @@ contract('Lock / invalidateOffchainApproval', accounts => {
     })
 
     it('can read the current nonce', async () => {
-      const nonce = new BigNumber(await lock.keyOwnerToNonce.call(keyOwner))
+      const nonce = new BigNumber(await lock.keyManagerToNonce.call(keyOwner))
       assert.equal(nonce.toFixed(), '1')
     })
   })
@@ -43,7 +43,7 @@ contract('Lock / invalidateOffchainApproval', accounts => {
     })
 
     it('can read the current nonce', async () => {
-      const nonce = new BigNumber(await lock.keyOwnerToNonce.call(keyOwner))
+      const nonce = new BigNumber(await lock.keyManagerToNonce.call(keyOwner))
       assert.equal(nonce.toFixed(), nonce)
     })
 

--- a/smart-contracts/test/Lock/onKeyCancelHook.js
+++ b/smart-contracts/test/Lock/onKeyCancelHook.js
@@ -26,7 +26,8 @@ contract('Lock / onKeyCancelHook', accounts => {
       from,
       value: keyPrice,
     })
-    await lock.cancelAndRefund({ from: to })
+    const ID = await lock.getTokenIdFor.call(to)
+    await lock.cancelAndRefund(ID, { from: to })
   })
 
   it('key cancels should log the hook event', async () => {


### PR DESCRIPTION
# Description
This makes the  changes required to add the `keyManager` to `cancelAndRefund` & `cancelAndRefundFor`. It also makes some modifications to make things work:
- `keyOwnerToNonce` becomes `keyManagerToNonce`
- `consumeOffchainApproval` was changed to compare the signer's address to the keyManager rather than the keyOwner.
- an extra param `uint _tokenId` was added to both `cancelAndRefund` & `cancelAndRefundFor`. without it, it would be impossible to lookup the keyOwner and calculate the refund.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #5557

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
