### PR TITLE
Extracting a resetKeyManager() function

### DIFF
--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -252,7 +252,7 @@ contract MixinKeys is
    * on transfer, sharing and purchase.
    * @param _tokenId The key to reset
    */
-  function resetKeyManager(
+  function _resetKeyManagerOf(
     uint _tokenId
   ) internal
   {

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -248,6 +248,21 @@ contract MixinKeys is
   }
 
   /**
+   * @notice This is used internally for resetting expired keys
+   * on transfer, sharing and purchase.
+   * @param _tokenId The key to reset
+   */
+  function resetKeyManager(
+    uint _tokenId
+  ) internal
+  {
+    if(keyManagerOf[_tokenId] != address(0)) {
+      keyManagerOf[_tokenId] = address(0);
+      emit KeyManagerChanged(_tokenId, address(0));
+    }
+  }
+
+  /**
   * Returns true if _keyManager is the manager of the key
   * identified by _tokenId
    */

--- a/smart-contracts/contracts/mocks/ResetKeyManagerMock.sol
+++ b/smart-contracts/contracts/mocks/ResetKeyManagerMock.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+
+import '../PublicLock.sol';
+
+contract ResetKeyManagerMock is
+  PublicLock
+{
+  function resetKeyManagerOf(
+    uint _tokenId
+  ) public
+  {
+    _resetKeyManagerOf(_tokenId);
+  }
+
+}

--- a/smart-contracts/test/Lock/permissions/resetKeyManager.js
+++ b/smart-contracts/test/Lock/permissions/resetKeyManager.js
@@ -1,0 +1,54 @@
+const BigNumber = require('bignumber.js')
+const { constants } = require('hardlydifficult-ethereum-contracts')
+const getProxy = require('../../helpers/proxy')
+
+const unlockContract = artifacts.require('Unlock.sol')
+const KeyManagerMock = artifacts.require('ResetKeyManagerMock')
+
+let unlock
+let lock
+let lockCreator
+let lockAddress
+
+contract('Permissions / resetKeyManager', accounts => {
+  lockCreator = accounts[0]
+  let keyManager
+  let iD
+  const keyPrice = new BigNumber(web3.utils.toWei('0.01', 'ether'))
+  const salt = 42
+
+  before(async () => {
+    unlock = await getProxy(unlockContract)
+    await unlock.setLockTemplate((await KeyManagerMock.new()).address)
+    let tx = await unlock.createLock(
+      new BigNumber(60 * 60 * 24 * 30), // 30 days
+      web3.utils.padLeft(0, 40),
+      new BigNumber(web3.utils.toWei('0.01', 'ether')),
+      11,
+      'KeyManagerMockLock',
+      `0x${salt.toString(16)}`,
+      { from: lockCreator }
+    )
+    lockAddress = tx.logs[1].args.newLockAddress
+    lock = await KeyManagerMock.at(lockAddress)
+    await lock.purchase(0, accounts[1], web3.utils.padLeft(0, 40), [], {
+      value: keyPrice.toFixed(),
+      from: accounts[1],
+    })
+  })
+
+  describe('resetting the key manager internally', () => {
+    before(async () => {
+      iD = await lock.getTokenIdFor(accounts[1])
+      await lock.setKeyManagerOf(iD, accounts[9], { from: accounts[1] })
+      keyManager = await lock.keyManagerOf.call(iD)
+      assert.equal(keyManager, accounts[9])
+      await lock.resetKeyManagerOf(iD)
+    })
+
+    it('should reset to the default KeyManager of 0x00', async () => {
+      keyManager = await lock.keyManagerOf.call(iD)
+      assert.equal(keyManager, constants.ZERO_ADDRESS)
+    })
+  })
+})


### PR DESCRIPTION
# Description
As part of the changes introduced with the `keyManager` title, this bit of logic is reused in at least 3 different places (`purchase`, `transferFrom` & `shareKey`.
Extracting to an internal function helps to keep the code a little more concise and readable, while not affecting gas costs negatively. (tested purchase function with & w/o this new internal function). 
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
