### PR TITLE
Paywall script lazy-loads and renders correctly

### DIFF
--- a/paywall/src/__tests__/paywall-script/utils.test.ts
+++ b/paywall/src/__tests__/paywall-script/utils.test.ts
@@ -1,0 +1,66 @@
+import {
+  dispatchEvent,
+  setupUnlockProtocolVariable,
+} from '../../paywall-script/utils'
+
+describe('Paywall script utils', () => {
+  describe('dispatchEvent', () => {
+    it('calls window.dispatchEvent with a CustomEvent when supported', () => {
+      expect.assertions(1)
+
+      // awkward implementation because it needs to be "newable"
+      const CustomEvent = jest.fn(function() {
+        return { event: 'custom' }
+      })
+      const windowDispatchEvent = jest.fn()
+      ;(global as any).CustomEvent = CustomEvent
+      ;(global as any).dispatchEvent = windowDispatchEvent
+      dispatchEvent('neato')
+
+      expect((global as any).dispatchEvent).toHaveBeenCalledWith({
+        event: 'custom',
+      })
+    })
+
+    it('calls window.dispatchEvent with a document.createEvent when falling back', () => {
+      expect.assertions(1)
+
+      const createEvent = jest.fn(() => ({
+        initCustomEvent: jest.fn(),
+      }))
+      const windowDispatchEvent = jest.fn()
+
+        // Need to delete this from the last test
+      ;(global as any).CustomEvent = undefined
+      ;(global as any).document.createEvent = createEvent
+      ;(global as any).dispatchEvent = windowDispatchEvent
+      dispatchEvent('neato')
+
+      expect((global as any).dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initCustomEvent: expect.any(Function),
+        })
+      )
+    })
+  })
+
+  describe('setupUnlockProtocolVariable', () => {
+    it('sets up a global variable containing the immutable properties passed in', () => {
+      expect.assertions(2)
+
+      const loadCheckoutModal = () => 'checkout'
+      const readANewspaper = () => 'reading...'
+      const thisIsANumber = 7
+
+      expect((global as any).unlockProtocol).not.toBeDefined()
+
+      setupUnlockProtocolVariable({
+        loadCheckoutModal,
+        readANewspaper,
+        thisIsANumber,
+      })
+
+      expect((global as any).unlockProtocol).toBeDefined()
+    })
+  })
+})

--- a/paywall/src/components/content/NewDemoContent.tsx
+++ b/paywall/src/components/content/NewDemoContent.tsx
@@ -51,6 +51,7 @@ export default function NewDemoContent() {
     url.searchParams.get('unlockUserAccounts') === 'true'
   const useMetadataInputs: boolean =
     url.searchParams.get('metadataInputs') === 'true'
+  const useNewCheckout: boolean = url.searchParams.get('newCheckout') === 'true'
 
   window.unlockProtocolConfig = {
     persistentCheckout: false,
@@ -90,11 +91,13 @@ export default function NewDemoContent() {
     window.unlockProtocol && window.unlockProtocol.loadCheckoutModal()
   }
 
+  const scriptVersion = useNewCheckout ? '2.0' : '1.0'
+
   return (
     <>
       <Head>
         <title>{pageTitle('Demo')}</title>
-        <script src="/static/unlock.1.0.min.js" />
+        <script src={`/static/unlock.${scriptVersion}.min.js`} />
       </Head>
       <DemoComponent locked={locked} checkout={checkout} />
     </>

--- a/paywall/src/paywall-script/iframe.css
+++ b/paywall/src/paywall-script/iframe.css
@@ -1,0 +1,15 @@
+.unlock-protocol-checkout {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  border: 0;
+  z-index: -2147483647;
+}
+
+.unlock-protocol-checkout.show {
+  display: block;
+  z-index: 2147483647;
+}

--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -1,6 +1,9 @@
 import Postmate from 'postmate'
+import './iframe.css'
+import { setupUnlockProtocolVariable, dispatchEvent } from './utils'
 
 declare let __ENVIRONMENT_VARIABLES__: { unlockAppUrl: string }
+const checkoutIframeClassName = 'unlock-protocol-checkout'
 
 /**
  * These type definitions come from `useCheckoutCommunication` in
@@ -27,21 +30,39 @@ const { unlockAppUrl } = __ENVIRONMENT_VARIABLES__
 const rawConfig = (window as any).unlockProtocolConfig
 const encodedConfig = encodeURIComponent(JSON.stringify(rawConfig))
 
-const handshake = new Postmate({
-  url: `${unlockAppUrl}/checkout?paywallConfig=${encodedConfig}`,
-  classListArray: ['unlock-protocol-checkout'],
-})
+let iframe: Element | undefined
 
-handshake.then(child => {
-  child.on(CheckoutEvents.closeModal, () => {
-    console.log('Close the modal when we receive this event.')
+let loadCheckoutModal = () => {
+  if (iframe) {
+    iframe.classList.add('show')
+  } else {
+    shakeHands()
+  }
+}
+
+dispatchEvent('locked')
+
+async function shakeHands() {
+  const handshake = new Postmate({
+    url: `${unlockAppUrl}/checkout?paywallConfig=${encodedConfig}`,
+    classListArray: [checkoutIframeClassName, 'show'],
   })
 
-  child.on(CheckoutEvents.userInfo, (info: UserInfo) => {
-    console.log(`got user address: ${info.address}`)
-  })
+  handshake.then(child => {
+    iframe = document.getElementsByClassName(checkoutIframeClassName)[0]
 
-  child.on(CheckoutEvents.transactionInfo, (info: TransactionInfo) => {
-    console.log(`got transaction hash: ${info.hash}`)
+    child.on(CheckoutEvents.closeModal, () => {
+      iframe!.classList.remove('show')
+    })
+
+    child.on(CheckoutEvents.userInfo, (info: UserInfo) => {
+      console.log(`got user address: ${info.address}`)
+    })
+
+    child.on(CheckoutEvents.transactionInfo, (info: TransactionInfo) => {
+      console.log(`got transaction hash: ${info.hash}`)
+    })
   })
-})
+}
+
+setupUnlockProtocolVariable({ loadCheckoutModal })

--- a/paywall/src/paywall-script/utils.ts
+++ b/paywall/src/paywall-script/utils.ts
@@ -1,0 +1,64 @@
+export const dispatchEvent = (detail: any) => {
+  let event: any
+  try {
+    event = new window.CustomEvent('unlockProtocol', { detail })
+  } catch (e) {
+    // older browsers do events this clunky way.
+    // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events#The_old-fashioned_way
+    // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent#Parameters
+    event = window.document.createEvent('customevent')
+    event.initCustomEvent(
+      'unlockProtocol',
+      true /* canBubble */,
+      true /* cancelable */,
+      detail
+    )
+  }
+  window.dispatchEvent(event)
+}
+
+export const setupUnlockProtocolVariable = (properties: {
+  [name: string]: any
+}) => {
+  const unlockProtocol: Object = {}
+
+  const immutable = {
+    writable: false,
+    configurable: false,
+    enumerable: false,
+  }
+
+  const immutableProperties = Object.keys(properties).map(name => {
+    return {
+      [name]: {
+        value: properties[name],
+        ...immutable,
+      },
+    }
+  })
+
+  Object.defineProperties(
+    unlockProtocol,
+    Object.assign({}, ...immutableProperties)
+  )
+
+  const freeze: (obj: any) => void = Object.freeze || Object
+
+  // if freeze is available, prevents adding or
+  // removing the object prototype properties
+  // (value, get, set, enumerable, writable, configurable)
+  // TODO: consider whether this is actually necessary
+  freeze(unlockProtocol)
+
+  try {
+    Object.defineProperties(window, {
+      unlockProtocol: {
+        value: unlockProtocol,
+        ...immutable,
+      },
+    })
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('WARNING: unlockProtocol already defined, cannot re-define it')
+  }
+}

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -8,6 +8,7 @@ import LogInSignUp from '../interface/LogInSignUp'
 import { Locks } from '../interface/checkout/Locks'
 import { NotLoggedInLocks } from '../interface/checkout/NotLoggedInLocks'
 import CheckoutWrapper from '../interface/checkout/CheckoutWrapper'
+import CheckoutContainer from '../interface/checkout/CheckoutContainer'
 import {
   Account as AccountType,
   Router,
@@ -45,35 +46,37 @@ export const CheckoutContent = ({ account, config }: CheckoutContentProps) => {
   }, [account])
 
   return (
-    <CheckoutWrapper allowClose hideCheckout={emitCloseModal}>
-      <Head>
-        <title>{pageTitle('Checkout')}</title>
-      </Head>
-      <BrowserOnly>
-        {config && config.icon && (
-          <img alt="Publisher Icon" src={config.icon} />
-        )}
-        <p>{config ? config.callToAction.default : ''}</p>
-        {!account && showingLogin && <LogInSignUp login embedded />}
-        {!account && !showingLogin && (
-          <>
-            <NotLoggedInLocks lockAddresses={lockAddresses} />
-            <input
-              type="button"
-              onClick={() => setShowingLogin(true)}
-              value="Log in"
+    <CheckoutContainer close={emitCloseModal}>
+      <CheckoutWrapper allowClose hideCheckout={emitCloseModal}>
+        <Head>
+          <title>{pageTitle('Checkout')}</title>
+        </Head>
+        <BrowserOnly>
+          {config && config.icon && (
+            <img alt="Publisher Icon" src={config.icon} />
+          )}
+          <p>{config ? config.callToAction.default : ''}</p>
+          {!account && showingLogin && <LogInSignUp login embedded />}
+          {!account && !showingLogin && (
+            <>
+              <NotLoggedInLocks lockAddresses={lockAddresses} />
+              <input
+                type="button"
+                onClick={() => setShowingLogin(true)}
+                value="Log in"
+              />
+            </>
+          )}
+          {account && (
+            <Locks
+              accountAddress={account.address}
+              lockAddresses={lockAddresses}
+              emitTransactionInfo={emitTransactionInfo}
             />
-          </>
-        )}
-        {account && (
-          <Locks
-            accountAddress={account.address}
-            lockAddresses={lockAddresses}
-            emitTransactionInfo={emitTransactionInfo}
-          />
-        )}
-      </BrowserOnly>
-    </CheckoutWrapper>
+          )}
+        </BrowserOnly>
+      </CheckoutWrapper>
+    </CheckoutContainer>
   )
 }
 

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -8,6 +8,7 @@ import LogInSignUp from '../interface/LogInSignUp'
 import { Locks } from '../interface/checkout/Locks'
 import { NotLoggedInLocks } from '../interface/checkout/NotLoggedInLocks'
 import CheckoutWrapper from '../interface/checkout/CheckoutWrapper'
+import { Greyout } from '../interface/modal-templates/styles'
 import {
   Account as AccountType,
   Router,
@@ -45,35 +46,37 @@ export const CheckoutContent = ({ account, config }: CheckoutContentProps) => {
   }, [account])
 
   return (
-    <CheckoutWrapper allowClose hideCheckout={emitCloseModal}>
-      <Head>
-        <title>{pageTitle('Checkout')}</title>
-      </Head>
-      <BrowserOnly>
-        {config && config.icon && (
-          <img alt="Publisher Icon" src={config.icon} />
-        )}
-        <p>{config ? config.callToAction.default : ''}</p>
-        {!account && showingLogin && <LogInSignUp login embedded />}
-        {!account && !showingLogin && (
-          <>
-            <NotLoggedInLocks lockAddresses={lockAddresses} />
-            <input
-              type="button"
-              onClick={() => setShowingLogin(true)}
-              value="Log in"
+    <Greyout>
+      <CheckoutWrapper allowClose hideCheckout={emitCloseModal}>
+        <Head>
+          <title>{pageTitle('Checkout')}</title>
+        </Head>
+        <BrowserOnly>
+          {config && config.icon && (
+            <img alt="Publisher Icon" src={config.icon} />
+          )}
+          <p>{config ? config.callToAction.default : ''}</p>
+          {!account && showingLogin && <LogInSignUp login embedded />}
+          {!account && !showingLogin && (
+            <>
+              <NotLoggedInLocks lockAddresses={lockAddresses} />
+              <input
+                type="button"
+                onClick={() => setShowingLogin(true)}
+                value="Log in"
+              />
+            </>
+          )}
+          {account && (
+            <Locks
+              accountAddress={account.address}
+              lockAddresses={lockAddresses}
+              emitTransactionInfo={emitTransactionInfo}
             />
-          </>
-        )}
-        {account && (
-          <Locks
-            accountAddress={account.address}
-            lockAddresses={lockAddresses}
-            emitTransactionInfo={emitTransactionInfo}
-          />
-        )}
-      </BrowserOnly>
-    </CheckoutWrapper>
+          )}
+        </BrowserOnly>
+      </CheckoutWrapper>
+    </Greyout>
   )
 }
 

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -8,7 +8,6 @@ import LogInSignUp from '../interface/LogInSignUp'
 import { Locks } from '../interface/checkout/Locks'
 import { NotLoggedInLocks } from '../interface/checkout/NotLoggedInLocks'
 import CheckoutWrapper from '../interface/checkout/CheckoutWrapper'
-import { Greyout } from '../interface/modal-templates/styles'
 import {
   Account as AccountType,
   Router,
@@ -46,37 +45,35 @@ export const CheckoutContent = ({ account, config }: CheckoutContentProps) => {
   }, [account])
 
   return (
-    <Greyout>
-      <CheckoutWrapper allowClose hideCheckout={emitCloseModal}>
-        <Head>
-          <title>{pageTitle('Checkout')}</title>
-        </Head>
-        <BrowserOnly>
-          {config && config.icon && (
-            <img alt="Publisher Icon" src={config.icon} />
-          )}
-          <p>{config ? config.callToAction.default : ''}</p>
-          {!account && showingLogin && <LogInSignUp login embedded />}
-          {!account && !showingLogin && (
-            <>
-              <NotLoggedInLocks lockAddresses={lockAddresses} />
-              <input
-                type="button"
-                onClick={() => setShowingLogin(true)}
-                value="Log in"
-              />
-            </>
-          )}
-          {account && (
-            <Locks
-              accountAddress={account.address}
-              lockAddresses={lockAddresses}
-              emitTransactionInfo={emitTransactionInfo}
+    <CheckoutWrapper allowClose hideCheckout={emitCloseModal}>
+      <Head>
+        <title>{pageTitle('Checkout')}</title>
+      </Head>
+      <BrowserOnly>
+        {config && config.icon && (
+          <img alt="Publisher Icon" src={config.icon} />
+        )}
+        <p>{config ? config.callToAction.default : ''}</p>
+        {!account && showingLogin && <LogInSignUp login embedded />}
+        {!account && !showingLogin && (
+          <>
+            <NotLoggedInLocks lockAddresses={lockAddresses} />
+            <input
+              type="button"
+              onClick={() => setShowingLogin(true)}
+              value="Log in"
             />
-          )}
-        </BrowserOnly>
-      </CheckoutWrapper>
-    </Greyout>
+          </>
+        )}
+        {account && (
+          <Locks
+            accountAddress={account.address}
+            lockAddresses={lockAddresses}
+            emitTransactionInfo={emitTransactionInfo}
+          />
+        )}
+      </BrowserOnly>
+    </CheckoutWrapper>
   )
 }
 

--- a/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import styled from 'styled-components'
+
+interface Props {
+  close: () => void
+}
+
+export const CheckoutContainer: React.FunctionComponent<Props> = ({
+  close,
+  children,
+}: React.PropsWithChildren<Props>) => {
+  return <Container onClick={close}>{children}</Container>
+}
+
+export const Container = styled.div`
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  left: 0;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`
+
+export default CheckoutContainer

--- a/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
@@ -22,10 +22,7 @@ const CheckoutWrapper: React.FunctionComponent<WrapperProps> = ({
   icon,
 }: React.PropsWithChildren<WrapperProps>) => {
   return (
-    <Wrapper
-      bgColor="var(--offwhite)"
-      onClick={allowClose ? hideCheckout : () => {}}
-    >
+    <Wrapper bgColor="var(--offwhite)">
       {allowClose ? (
         <CloseButton
           backgroundColor="var(--lightgrey)"

--- a/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
@@ -22,7 +22,13 @@ const CheckoutWrapper: React.FunctionComponent<WrapperProps> = ({
   icon,
 }: React.PropsWithChildren<WrapperProps>) => {
   return (
-    <Wrapper bgColor="var(--offwhite)">
+    <Wrapper
+      bgColor="var(--offwhite)"
+      onClick={e => {
+        e.stopPropagation()
+        e.nativeEvent.stopImmediatePropagation()
+      }}
+    >
       {allowClose ? (
         <CloseButton
           backgroundColor="var(--lightgrey)"

--- a/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
@@ -66,6 +66,7 @@ const Wrapper = styled.section`
   color: var(--darkgrey);
   border-radius: 4px;
   position: relative;
+  box-shadow: 0px 0px 60px rgba(0, 0, 0, 0.25);
   ${Media.nophone`
 width: 380px;
 `}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR hooks up the paywall communication a little more. Now, the `loadCheckoutModal` function is available, and it will load the iframe on the first click, and on subsequent clicks simply show the iframe that is already there.

This PR also adds some CSS and sets up the `NewDemoContent` page to use the new script when a query param is passed, which will allow us to more easily test this locally.

<img width="1514" alt="image" src="https://user-images.githubusercontent.com/9300702/76234114-a1f58b80-61ff-11ea-9615-24c118e00903.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
