### PR TITLE
Paywall config can be set through postmate model

### DIFF
--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -40,12 +40,18 @@ let loadCheckoutModal = () => {
   }
 }
 
+let setConfig: (config: any) => void | undefined
+
 const childCallBuffer: [string, any?][] = []
 
 // This definition is just a buffer until the child is available, it
 // will be replaced when the child is initialized.
 let resetConfig = (config: any) => {
-  childCallBuffer.push(['setConfig', config])
+  if (setConfig) {
+    setConfig(config)
+  } else {
+    childCallBuffer.push(['setConfig', config])
+  }
 }
 
 dispatchEvent('locked')
@@ -79,7 +85,7 @@ async function shakeHands() {
     childCallBuffer.forEach(bufferedCall => child.call(...bufferedCall))
 
     // replace the buffered version of resetConfig with the real one
-    resetConfig = (config: any) => {
+    setConfig = (config: any) => {
       child.call('setConfig', config)
     }
   })

--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -46,6 +46,7 @@ async function shakeHands() {
   const handshake = new Postmate({
     url: `${unlockAppUrl}/checkout?paywallConfig=${encodedConfig}`,
     classListArray: [checkoutIframeClassName, 'show'],
+    model: { config: rawConfig },
   })
 
   handshake.then(child => {
@@ -55,12 +56,16 @@ async function shakeHands() {
       iframe!.classList.remove('show')
     })
 
+    // TODO: use account address to know if user already has a key
+    // Lock list may have to wait for a go/no-go from the key check to
+    // prevent duplicate purchase.
     child.on(CheckoutEvents.userInfo, (info: UserInfo) => {
       console.log(`got user address: ${info.address}`)
     })
 
-    child.on(CheckoutEvents.transactionInfo, (info: TransactionInfo) => {
-      console.log(`got transaction hash: ${info.hash}`)
+    // TODO: pass transaction hash to a function that will monitor it?
+    child.on(CheckoutEvents.transactionInfo, (_: TransactionInfo) => {
+      dispatchEvent('unlocked')
     })
   })
 }

--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -28,7 +28,6 @@ export enum CheckoutEvents {
 
 const { unlockAppUrl } = __ENVIRONMENT_VARIABLES__
 const rawConfig = (window as any).unlockProtocolConfig
-const encodedConfig = encodeURIComponent(JSON.stringify(rawConfig))
 
 let iframe: Element | undefined
 
@@ -58,7 +57,7 @@ dispatchEvent('locked')
 
 async function shakeHands() {
   const handshake = new Postmate({
-    url: `${unlockAppUrl}/checkout?paywallConfig=${encodedConfig}`,
+    url: `${unlockAppUrl}/checkout`,
     classListArray: [checkoutIframeClassName, 'show'],
   })
 
@@ -88,6 +87,8 @@ async function shakeHands() {
     setConfig = (config: any) => {
       child.call('setConfig', config)
     }
+
+    setConfig(rawConfig)
   })
 }
 

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -19,19 +19,19 @@ import { useCheckoutCommunication } from '../../hooks/useCheckoutCommunication'
 
 interface CheckoutContentProps {
   account: AccountType
-  config?: PaywallConfig
+  configFromSearch?: PaywallConfig
 }
 
 const defaultLockAddresses: string[] = []
 
-export const CheckoutContent = ({ account, config }: CheckoutContentProps) => {
-  const lockAddresses = config
-    ? Object.keys(config.locks)
-    : defaultLockAddresses
-
+export const CheckoutContent = ({
+  account,
+  configFromSearch,
+}: CheckoutContentProps) => {
   const [showingLogin, setShowingLogin] = useState(false)
-  const [aConfig, setConfig] = useState<PaywallConfig | undefined>(undefined)
-  console.log({ aConfig })
+  const [configFromPostmate, setConfig] = useState<PaywallConfig | undefined>(
+    undefined
+  )
 
   const {
     emitTransactionInfo,
@@ -46,6 +46,13 @@ export const CheckoutContent = ({ account, config }: CheckoutContentProps) => {
       })
     }
   }, [account])
+
+  // Config value from postmate always takes precedence over the one in the URL if it is present.
+  const config = configFromPostmate || configFromSearch
+
+  const lockAddresses = config
+    ? Object.keys(config.locks)
+    : defaultLockAddresses
 
   return (
     <CheckoutContainer close={emitCloseModal}>
@@ -90,11 +97,11 @@ interface ReduxState {
 export const mapStateToProps = ({ account, router }: ReduxState) => {
   const search = queryString.parse(router.location.search)
 
-  const config = getConfigFromSearch(search)
+  const configFromSearch = getConfigFromSearch(search)
 
   return {
     account,
-    config,
+    configFromSearch,
   }
 }
 

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -30,12 +30,14 @@ export const CheckoutContent = ({ account, config }: CheckoutContentProps) => {
     : defaultLockAddresses
 
   const [showingLogin, setShowingLogin] = useState(false)
+  const [aConfig, setConfig] = useState<PaywallConfig | undefined>(undefined)
+  console.log({ aConfig })
 
   const {
     emitTransactionInfo,
     emitCloseModal,
     emitUserInfo,
-  } = useCheckoutCommunication()
+  } = useCheckoutCommunication({ setConfig })
 
   useEffect(() => {
     if (account && account.address) {

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -28,9 +28,9 @@ interface BufferedEvent {
 // buffer. After that, once the handle to the parent is available, all
 // the buffered events are emitted and future events are emitted
 // directly.
-export const useCheckoutCommunication = () => {
+export const useCheckoutCommunication = (model?: any) => {
   const [buffer, setBuffer] = useState([] as BufferedEvent[])
-  const parent = usePostmateParent()
+  const parent = usePostmateParent(model)
 
   const pushOrEmit = (kind: CheckoutEvents, payload?: Payload) => {
     if (!parent) {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR tweaks the new paywall script a bit so that it can set the paywall config through the child model.

For simplicity, the paywall script _always_ sets the config this way, though the checkout page will accept either the URL param or the postmate call. (In the presence of both, the one from postmate takes precedence).

At this point the paywall init script has grown enough that it's probably worth moving it to a more structured style so that it doesn't hinder readability. I definitely want to pull out a few pieces for more unit testing.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
