### PR TITLE
Adding a new require to transferFrom

### DIFF
--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -49,12 +49,15 @@ contract MixinPurchase is
 
     // Assign the key
     Key storage toKey = keyByOwner[_recipient];
+    uint idTo = toKey.tokenId;
     uint newTimeStamp;
 
-    if (toKey.tokenId == 0) {
+    if (idTo == 0) {
       // Assign a new tokenId (if a new owner or previously transferred)
       _assignNewTokenId(toKey);
-      _recordOwner(_recipient, toKey.tokenId);
+      // refresh the cached value
+      idTo = toKey.tokenId;
+      _recordOwner(_recipient, idTo);
       newTimeStamp = block.timestamp + expirationDuration;
       toKey.expirationTimestamp = newTimeStamp;
 
@@ -62,7 +65,7 @@ contract MixinPurchase is
       emit Transfer(
         address(0), // This is a creation.
         _recipient,
-        toKey.tokenId
+        idTo
       );
     } else if (toKey.expirationTimestamp >= block.timestamp) {
       // This is an existing owner trying to extend their key
@@ -77,7 +80,7 @@ contract MixinPurchase is
       toKey.expirationTimestamp = newTimeStamp;
 
       // reset the key Manager to 0x00
-      _resetKeyManagerOf(toKey.tokenId);
+      _resetKeyManagerOf(idTo);
 
       emit RenewKeyPurchase(_recipient, newTimeStamp);
     }

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -59,7 +59,7 @@ contract MixinTransfer is
     require(getHasValidKey(keyOwner), 'KEY_NOT_VALID');
     Key storage fromKey = keyByOwner[keyOwner];
     Key storage toKey = keyByOwner[_to];
-    uint iDTo = toKey.tokenId;
+    uint idTo = toKey.tokenId;
     uint time;
     // get the remaining time for the origin key
     uint timeRemaining = fromKey.expirationTimestamp - block.timestamp;
@@ -81,27 +81,27 @@ contract MixinTransfer is
       emit ExpireKey(_tokenId);
     }
 
-    if (iDTo == 0) {
+    if (idTo == 0) {
       _assignNewTokenId(toKey);
-      iDTo = toKey.tokenId;
-      _recordOwner(_to, iDTo);
+      idTo = toKey.tokenId;
+      _recordOwner(_to, idTo);
       emit Transfer(
         address(0), // This is a creation or time-sharing
         _to,
-        iDTo
+        idTo
       );
     } else if (toKey.expirationTimestamp <= block.timestamp) {
       // reset the key Manager for expired keys
-      _resetKeyManagerOf(iDTo);
+      _resetKeyManagerOf(idTo);
     }
 
     // add time to new key
-    _timeMachine(iDTo, time, true);
+    _timeMachine(idTo, time, true);
     // trigger event
     emit Transfer(
       keyOwner,
       _to,
-      iDTo
+      idTo
     );
 
     require(_checkOnERC721Received(keyOwner, _to, _tokenId, ''), 'NON_COMPLIANT_ERC721_RECEIVER');

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -124,16 +124,14 @@ contract MixinTransfer is
 
     Key storage fromKey = keyByOwner[_from];
     Key storage toKey = keyByOwner[_recipient];
-    uint idTo = toKey.tokenId;
 
     uint previousExpiration = toKey.expirationTimestamp;
     // subtract the fee from the senders key before the transfer
     _timeMachine(_tokenId, fee, false);
 
-    if (idTo == 0) {
+    if (toKey.tokenId == 0) {
       toKey.tokenId = _tokenId;
-      idTo = _tokenId;
-      _recordOwner(_recipient, idTo);
+      _recordOwner(_recipient, _tokenId);
     }
 
     if (previousExpiration <= block.timestamp) {
@@ -141,12 +139,11 @@ contract MixinTransfer is
       // An expired key is no longer a valid key, so the new tokenID is the sender's tokenID
       toKey.expirationTimestamp = fromKey.expirationTimestamp;
       toKey.tokenId = _tokenId;
-      idTo = _tokenId;
 
       // Reset the key Manager to the key owner
-      _resetKeyManagerOf(idTo);
+      _resetKeyManagerOf(_tokenId);
 
-      _recordOwner(_recipient, idTo);
+      _recordOwner(_recipient, _tokenId);
     } else {
       // The recipient has a non expired key. We just add them the corresponding remaining time
       // SafeSub is not required since the if confirms `previousExpiration - block.timestamp` cannot underflow
@@ -167,7 +164,7 @@ contract MixinTransfer is
     emit Transfer(
       _from,
       _recipient,
-      idTo
+      _tokenId
     );
   }
 

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -96,6 +96,25 @@ contract('Lock / erc721 / transferFrom', accounts => {
       assert.equal(keyExpiration.toFixed(), expirationTimestamp.toFixed())
     })
 
+    it('should abort if the params are not consistent', async () => {
+      const id = await locks.FIRST.getTokenIdFor.call(accountWithKey)
+      const mismatchedId = id + 1
+      // testing an id mismatch
+      await reverts(
+        locks.FIRST.transferFrom(accountWithKey, to, mismatchedId, {
+          from: accountWithKey,
+        }),
+        'ONLY_KEY_MANAGER_OR_APPROVED'
+      )
+      // testing a mismatched _from address
+      await reverts(
+        locks.FIRST.transferFrom(accountWithKeyApproved, to, id, {
+          from: accountWithKey,
+        }),
+        'TRANSFER_FROM: NOT_KEY_OWNER'
+      )
+    })
+
     describe('when the recipient already has an expired key', () => {
       it('should transfer the key validity without extending it', async () => {
         // First let's make sure from has a key!


### PR DESCRIPTION
# Description
TransferFrom takes 3 params: address _from, address _recipient, uint _tokenId
In the current implementation, it’s possible to call this function with a `_tokenId` which is different than the one actually owned by `_from` .
I’ve added a check to ensure that `_from` is the owner of `_tokenId`, as well as a new test for this.
I've also made some changes around caching tokenId values to lower gas costs a little.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
