### PR TITLE
Paywall script unlocks page if user is found to already own a key

### DIFF
--- a/paywall/src/__tests__/paywall-script/index.test.ts
+++ b/paywall/src/__tests__/paywall-script/index.test.ts
@@ -1,4 +1,5 @@
 import { Paywall } from '../../paywall-script/index'
+import * as timeStampUtil from '../../utils/keyExpirationTimestampFor'
 
 const paywallConfig = {
   callToAction: {
@@ -24,5 +25,35 @@ describe('Paywall init script', () => {
     expect(paywall.childCallBuffer).toHaveLength(1)
 
     expect(paywall.childCallBuffer[0]).toEqual(['setConfig', paywallConfig])
+  })
+
+  describe('userInfo event', () => {
+    it('unlocks the page if some key expiration timestamp is in the future', async () => {
+      expect.assertions(1)
+
+      paywall.unlockPage = jest.fn()
+      const futureTime = new Date().getTime() / 1000 + 50000
+      jest
+        .spyOn(timeStampUtil, 'keyExpirationTimestampFor')
+        .mockResolvedValue(futureTime)
+
+      await paywall.handleUserInfoEvent({ address: '0xtheaddress' })
+
+      expect(paywall.unlockPage).toHaveBeenCalled()
+    })
+
+    it('does not unlock the page if all key expiration timestamps are in the past', async () => {
+      expect.assertions(1)
+
+      paywall.unlockPage = jest.fn()
+      const futureTime = new Date().getTime() / 1000 - 50000
+      jest
+        .spyOn(timeStampUtil, 'keyExpirationTimestampFor')
+        .mockResolvedValue(futureTime)
+
+      await paywall.handleUserInfoEvent({ address: '0xtheaddress' })
+
+      expect(paywall.unlockPage).not.toHaveBeenCalled()
+    })
   })
 })

--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -103,6 +103,7 @@ export class Paywall {
     )
 
     if (timeStamps.some(val => val > new Date().getTime() / 1000)) {
+      // TODO: communicate to checkout iframe that there is already a valid key
       this.unlockPage()
     }
   }

--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -1,8 +1,12 @@
 import Postmate from 'postmate'
 import './iframe.css'
 import { setupUnlockProtocolVariable, dispatchEvent } from './utils'
+import { keyExpirationTimestampFor } from '../utils/keyExpirationTimestampFor'
 
-declare let __ENVIRONMENT_VARIABLES__: { unlockAppUrl: string }
+declare let __ENVIRONMENT_VARIABLES__: {
+  unlockAppUrl: string
+  readOnlyProvider: string
+}
 export const checkoutIframeClassName = 'unlock-protocol-checkout'
 
 /**
@@ -29,6 +33,8 @@ export enum CheckoutEvents {
 export class Paywall {
   childCallBuffer: [string, any?][] = []
 
+  paywallConfig: any
+
   userAccountAddress?: string
 
   iframe?: Element
@@ -43,6 +49,7 @@ export class Paywall {
     }
 
     const resetConfig = (config: any) => {
+      this.paywallConfig = config
       if (this.setConfig) {
         this.setConfig(config)
       } else {
@@ -67,9 +74,7 @@ export class Paywall {
     this.iframe = document.getElementsByClassName(checkoutIframeClassName)[0]
 
     child.on(CheckoutEvents.closeModal, this.hideIframe)
-    child.on(CheckoutEvents.userInfo, (info: UserInfo) => {
-      this.userAccountAddress = info.address
-    })
+    child.on(CheckoutEvents.userInfo, this.handleUserInfoEvent)
 
     // transactionInfo event also carries transaction hash.
     child.on(CheckoutEvents.transactionInfo, this.unlockPage)
@@ -79,6 +84,26 @@ export class Paywall {
 
     this.setConfig = (config: any) => {
       child.call('setConfig', config)
+    }
+  }
+
+  handleUserInfoEvent = async (info: UserInfo) => {
+    const { readOnlyProvider } = __ENVIRONMENT_VARIABLES__
+    this.userAccountAddress = info.address
+
+    const lockAddresses = Object.keys(this.paywallConfig.locks)
+    const timeStamps = await Promise.all(
+      lockAddresses.map(lockAddress => {
+        return keyExpirationTimestampFor(
+          readOnlyProvider,
+          lockAddress,
+          this.userAccountAddress!
+        )
+      })
+    )
+
+    if (timeStamps.some(val => val > new Date().getTime() / 1000)) {
+      this.unlockPage()
     }
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR updates the paywall init script to unlock the page on receiving an account address if that address already owns a key with an expiration date in the future. There will have to be some more work around this -- the checkout iframe needs to know which key that is so it can show the one that is already purchased and disable any extra purchases. I'll take care of that in a future PR.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
