### PR TITLE
Checkout component knows when a user already has a key

### DIFF
--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -103,7 +103,6 @@ export class Paywall {
     )
 
     if (timeStamps.some(val => val > new Date().getTime() / 1000)) {
-      // TODO: communicate to checkout iframe that there is already a valid key
       this.unlockPage()
     }
   }

--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -121,7 +121,7 @@ describe('Checkout Lock', () => {
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
-          activeKeys={[activeKeyForAnotherLock]}
+          activeKeys={[]}
         />
       )
 
@@ -134,11 +134,11 @@ describe('Checkout Lock', () => {
       const { getByTestId } = rtl.render(
         <Lock
           lock={lock}
-          purchasingLockAddress="0xneato"
+          purchasingLockAddress={null}
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
-          activeKeys={[]}
+          activeKeys={[activeKeyForAnotherLock]}
         />
       )
 

--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import * as rtl from '@testing-library/react'
+import { KeyResult } from '@unlock-protocol/unlock-js'
 import { Lock } from '../../../../components/interface/checkout/Lock'
 import * as usePurchaseKey from '../../../../hooks/usePurchaseKey'
 import { TransactionInfo } from '../../../../hooks/useCheckoutCommunication'
@@ -14,6 +15,17 @@ const lock = {
   keyPrice: '0.04',
   expirationDuration: 50,
   currencyContractAddress: null,
+}
+
+const activeKeyForThisLock: KeyResult = {
+  lock: '0xlockaddress',
+  owner: '0xme',
+  expiration: 512345555,
+}
+
+const activeKeyForAnotherLock: KeyResult = {
+  ...activeKeyForThisLock,
+  lock: '0xanotherlockaddress',
 }
 
 describe('Checkout Lock', () => {
@@ -43,6 +55,7 @@ describe('Checkout Lock', () => {
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
+          activeKeys={[]}
         />
       )
 
@@ -64,6 +77,7 @@ describe('Checkout Lock', () => {
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
+          activeKeys={[]}
         />
       )
 
@@ -90,6 +104,7 @@ describe('Checkout Lock', () => {
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
+          activeKeys={[]}
         />
       )
 
@@ -106,6 +121,24 @@ describe('Checkout Lock', () => {
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
+          activeKeys={[activeKeyForAnotherLock]}
+        />
+      )
+
+      getByTestId('DisabledLock')
+    })
+
+    it('renders a disabled lock when there is an active key for a different lock', () => {
+      expect.assertions(0)
+
+      const { getByTestId } = rtl.render(
+        <Lock
+          lock={lock}
+          purchasingLockAddress="0xneato"
+          setPurchasingLockAddress={setPurchasingLockAddress}
+          emitTransactionInfo={emitTransactionInfo}
+          balances={balances}
+          activeKeys={[]}
         />
       )
 
@@ -122,6 +155,7 @@ describe('Checkout Lock', () => {
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
+          activeKeys={[]}
         />
       )
 
@@ -145,6 +179,24 @@ describe('Checkout Lock', () => {
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
+          activeKeys={[]}
+        />
+      )
+
+      getByTestId('ConfirmedLock')
+    })
+
+    it('renders a confirmed lock when there is an active key for this lock', () => {
+      expect.assertions(0)
+
+      const { getByTestId } = rtl.render(
+        <Lock
+          lock={lock}
+          purchasingLockAddress="0xlockaddress"
+          setPurchasingLockAddress={setPurchasingLockAddress}
+          emitTransactionInfo={emitTransactionInfo}
+          balances={balances}
+          activeKeys={[activeKeyForThisLock]}
         />
       )
 
@@ -168,6 +220,7 @@ describe('Checkout Lock', () => {
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
+          activeKeys={[]}
         />
       )
 

--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -192,7 +192,7 @@ describe('Checkout Lock', () => {
       const { getByTestId } = rtl.render(
         <Lock
           lock={lock}
-          purchasingLockAddress="0xlockaddress"
+          purchasingLockAddress={null}
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}

--- a/unlock-app/src/__tests__/hooks/useKeyOwnershipStatus.test.ts
+++ b/unlock-app/src/__tests__/hooks/useKeyOwnershipStatus.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react-hooks'
+import React from 'react'
+import { EventEmitter } from 'events'
+import { Web3ServiceContext } from '../../utils/withWeb3Service'
+
+import { useKeyOwnershipStatus } from '../../hooks/useKeyOwnershipStatus'
+
+class MockWeb3Service extends EventEmitter {
+  constructor() {
+    super()
+  }
+}
+
+let mockWeb3Service: any
+
+const lockAddresses = ['0xlock1', '0xlock2']
+const accountAddress = '0xmyaccount'
+
+describe('usePaywallLocks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(React, 'useContext').mockImplementation(context => {
+      if (context === Web3ServiceContext) {
+        return mockWeb3Service
+      }
+    })
+
+    mockWeb3Service = new MockWeb3Service()
+    mockWeb3Service.getKeyByLockForOwner = jest.fn(() => {
+      return Promise.resolve(1337)
+    })
+  })
+
+  it('should default to undefined and loading, then become an array with keys and stop loading', async () => {
+    expect.assertions(4)
+    const { result, wait } = renderHook(() =>
+      useKeyOwnershipStatus(lockAddresses, accountAddress)
+    )
+
+    expect(result.current.keys).toEqual([])
+    expect(result.current.loading).toBeTruthy()
+
+    await wait(() => {
+      return !result.current.loading
+    })
+    expect(result.current.keys).toHaveLength(2)
+    expect(result.current.loading).toBeFalsy()
+  })
+})

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { KeyResult } from '@unlock-protocol/unlock-js'
 import { RawLock, Balances } from '../../../unlockTypes'
 import { durationsAsTextFromSeconds } from '../../../utils/durations'
 import {
@@ -16,6 +17,7 @@ interface LockProps {
   setPurchasingLockAddress: (lockAddress: string) => void
   emitTransactionInfo: (info: TransactionInfo) => void
   balances: Balances
+  activeKeys: KeyResult[]
 }
 
 export const Lock = ({
@@ -24,6 +26,7 @@ export const Lock = ({
   setPurchasingLockAddress,
   emitTransactionInfo,
   balances,
+  activeKeys,
 }: LockProps) => {
   const { purchaseKey, transactionHash } = usePurchaseKey(lock)
 
@@ -55,16 +58,18 @@ export const Lock = ({
 
   const canAfford = userCanAffordKey(lock, balances)
 
+  const keyForThisLock = activeKeys.find(key => key.lock === lock.address)
+
   // This lock is being/has been purchased
-  if (purchasingLockAddress === lock.address) {
-    if (transactionHash) {
+  if (purchasingLockAddress === lock.address || keyForThisLock) {
+    if (transactionHash || keyForThisLock) {
       return <LockVariations.ConfirmedLock {...props} />
     }
     return <LockVariations.ProcessingLock {...props} />
   }
 
   // Some other lock is being/has been purchased
-  if (purchasingLockAddress) {
+  if (purchasingLockAddress || activeKeys.length) {
     return <LockVariations.DisabledLock {...props} />
   }
 

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -4,7 +4,7 @@ import { LoadingLock } from './LockVariations'
 import { usePaywallLocks } from '../../../hooks/usePaywallLocks'
 import { useGetTokenBalance } from '../../../hooks/useGetTokenBalance'
 import { TransactionInfo } from '../../../hooks/useCheckoutCommunication'
-import { useKeyOwnershipStatus } from '../../../hooks/useGetKeyForLockByOwner'
+import { useKeyOwnershipStatus } from '../../../hooks/useKeyOwnershipStatus'
 
 interface LocksProps {
   accountAddress: string
@@ -24,15 +24,10 @@ export const Locks = ({
   )
   const { getTokenBalance, balances } = useGetTokenBalance(accountAddress)
   const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
-  const { keys, loading: keysLoading } = useKeyOwnershipStatus(
-    lockAddresses,
-    accountAddress
-  )
+  const { keys } = useKeyOwnershipStatus(lockAddresses, accountAddress)
 
   const now = new Date().getTime() / 1000
-  const activeKeys = keysLoading
-    ? []
-    : keys!.filter(key => key.expiration > now)
+  const activeKeys = keys.filter(key => key.expiration > now)
 
   if (loading) {
     return (

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -4,6 +4,7 @@ import { LoadingLock } from './LockVariations'
 import { usePaywallLocks } from '../../../hooks/usePaywallLocks'
 import { useGetTokenBalance } from '../../../hooks/useGetTokenBalance'
 import { TransactionInfo } from '../../../hooks/useCheckoutCommunication'
+import { useKeyOwnershipStatus } from '../../../hooks/useGetKeyForLockByOwner'
 
 interface LocksProps {
   accountAddress: string
@@ -23,6 +24,15 @@ export const Locks = ({
   )
   const { getTokenBalance, balances } = useGetTokenBalance(accountAddress)
   const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
+  const { keys, loading: keysLoading } = useKeyOwnershipStatus(
+    lockAddresses,
+    accountAddress
+  )
+
+  const now = new Date().getTime() / 1000
+  const activeKeys = keysLoading
+    ? []
+    : keys!.filter(key => key.expiration > now)
 
   if (loading) {
     return (
@@ -44,6 +54,7 @@ export const Locks = ({
           setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
+          activeKeys={activeKeys}
         />
       ))}
     </div>

--- a/unlock-app/src/hooks/useGetKeyForLockByOwner.ts
+++ b/unlock-app/src/hooks/useGetKeyForLockByOwner.ts
@@ -1,0 +1,31 @@
+import { useContext, useState, useEffect } from 'react'
+import { Web3Service, KeyResult } from '@unlock-protocol/unlock-js'
+import { Web3ServiceContext } from '../utils/withWeb3Service'
+
+export const useKeyOwnershipStatus = (
+  lockAddresses: string[],
+  accountAddress: string
+) => {
+  const [keys, setKeys] = useState<KeyResult[] | undefined>(undefined)
+  const [loading, setLoading] = useState(true)
+
+  const web3Service: Web3Service = useContext(Web3ServiceContext)
+
+  const getKeyStatuses = async () => {
+    setLoading(true)
+    const keyResults = await Promise.all(
+      lockAddresses.map(lockAddress => {
+        return web3Service.getKeyByLockForOwner(lockAddress, accountAddress)
+      })
+    )
+
+    setKeys(keyResults)
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    getKeyStatuses()
+  }, [lockAddresses, accountAddress])
+
+  return { keys, loading }
+}

--- a/unlock-app/src/hooks/useKeyOwnershipStatus.ts
+++ b/unlock-app/src/hooks/useKeyOwnershipStatus.ts
@@ -6,7 +6,7 @@ export const useKeyOwnershipStatus = (
   lockAddresses: string[],
   accountAddress: string
 ) => {
-  const [keys, setKeys] = useState<KeyResult[] | undefined>(undefined)
+  const [keys, setKeys] = useState<KeyResult[]>([])
   const [loading, setLoading] = useState(true)
 
   const web3Service: Web3Service = useContext(Web3ServiceContext)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR is the mirror image of the last one on the paywall script side. In short, it queries Web3Service for keys associated with the locks on the paywall. If it returns any valid ones, they are reflected in the UI (and other key purchases are disabled).

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
