### PR TITLE
build-checkout task includes new paywall script

### DIFF
--- a/paywall/package.json
+++ b/paywall/package.json
@@ -13,7 +13,7 @@
     "test": "cross-env UNLOCK_ENV=test jest --env=jsdom",
     "lint": "eslint --ext .tsx,.ts,.js src/",
     "svg-2-components": "./node_modules/@svgr/cli/bin/svgr --title-prop --no-dimensions --template src/components/interface/svg/template.js --no-dimensions -d src/components/interface/svg/ src/static/images/svg/",
-    "build-checkout": "yarn build-unlock.1.0.js && yarn build-data-iframe.1.0.js",
+    "build-checkout": "yarn build-unlock.1.0.js && yarn build-data-iframe.1.0.js && yarn build-unlock.2.0.js",
     "watch-checkout": "webpack --watch --config unlock.2.0.js.webpack.config.js",
     "build-unlock.1.0.js": "webpack --config unlock.1.0.js.webpack.config.js",
     "build-unlock.2.0.js": "webpack --config unlock.2.0.js.webpack.config.js",


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds the new paywall script's `webpack` job to the `build-checkout` task in the paywall. If I understand correctly, this will deposit the `unlock.2.0.min.js` script into the static directory when it deploys to netlify.

Before we merge this I want to verify on the draft URL that it works.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
