### PR TITLE
Paywall script needs to initiate the handshake on loadCheckoutModal

### DIFF
--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -45,6 +45,8 @@ export class Paywall {
     const loadCheckoutModal = () => {
       if (this.iframe) {
         this.showIframe()
+      } else {
+        this.shakeHands()
       }
     }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR fixes a silly mistake I made when converting the paywall init script to a class. It wasn't actually calling the handshake, so the iframe would never load. It took me longer to find this than I care to admit, because I forgot to include a comment while stubbing out the methods.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
