### PR TITLE
Handle NO_SUCH_KEY in keyExpirationTimestampFor

### DIFF
--- a/paywall/src/__tests__/utils/keyExpirationTimestampFor.test.js
+++ b/paywall/src/__tests__/utils/keyExpirationTimestampFor.test.js
@@ -1,4 +1,6 @@
-import keyExpirationTimestampFor from '../../utils/keyExpirationTimestampFor'
+import keyExpirationTimestampFor, {
+  NO_SUCH_KEY,
+} from '../../utils/keyExpirationTimestampFor'
 
 const jsonRpcEndpoint = 'https://eth-mainnet.alchemyapi.io/jsonrpc/'
 const lockAddress = '0x75fa3aa7e999b9899010c5f05e52cd0543dab465'
@@ -43,6 +45,23 @@ describe('keyExpirationTimestampFor', () => {
       JSON.stringify({
         jsonrpc: '2.0',
         result: '0x',
+        id: 1773,
+      })
+    )
+    const expiration = await keyExpirationTimestampFor(
+      'https://eth-mainnet.alchemyapi.io/jsonrpc/DazqAi1xewCexIggwLSZVkXdnztC-w0u',
+      '0x75fa3aa7e999b9899010c5f05e52cd0543dab465',
+      'c0f32eba9a4192d93209e83e03b95be7f81036d7'
+    )
+    expect(expiration).toEqual(0)
+  })
+
+  it('should return zero when result is NO_SUCH_KEY', async () => {
+    expect.assertions(1)
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        result: NO_SUCH_KEY,
         id: 1773,
       })
     )

--- a/paywall/src/utils/keyExpirationTimestampFor.ts
+++ b/paywall/src/utils/keyExpirationTimestampFor.ts
@@ -1,3 +1,6 @@
+export const NO_SUCH_KEY =
+  '0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000134841535f4e455645525f4f574e45445f4b455900000000000000000000000000'
+
 export const keyExpirationTimestampFor = async (
   provider: string,
   lock: string,
@@ -23,6 +26,10 @@ export const keyExpirationTimestampFor = async (
 
   const body = await response.json()
   const result = body.result
+
+  if (result === NO_SUCH_KEY) {
+    return 0
+  }
   return parseInt(result, 16) || 0
 }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a previously unhandled case in the `keyExpirationTimestampFor` util that caused the paywall to unlock when a user had never purchased a key for a given lock. This issue was that the smart contract returns a huge number used as a magic value to indicate when a user has no key and has never had a key. We were parsing this into an expiration timestamp that was guaranteed to be far in the future and we treated it as a valid key.

With the addition of a check, we now return an expiration of 0 in this case.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
