### PR TITLE
caching user info

### DIFF
--- a/paywall/src/__tests__/paywall-script/index.test.ts
+++ b/paywall/src/__tests__/paywall-script/index.test.ts
@@ -16,9 +16,12 @@ const paywallConfig = {
   icon: 'http://com.com/image.tiff',
 }
 
-const paywall = new Paywall(paywallConfig)
+let paywall: Paywall
 
 describe('Paywall init script', () => {
+  beforeEach(() => {
+    paywall = new Paywall(paywallConfig)
+  })
   it('is constructed with one call in the buffer to set the config', () => {
     expect.assertions(2)
 
@@ -28,30 +31,46 @@ describe('Paywall init script', () => {
   })
 
   describe('userInfo event', () => {
+    it('caches the user key info and checks the status', async () => {
+      expect.assertions(3)
+
+      paywall.cacheUserInfo = jest.fn()
+      paywall.checkKeysAndLock = jest.fn()
+
+      await paywall.handleUserInfoEvent({ address: '0xtheaddress' })
+      expect(paywall.cacheUserInfo).toHaveBeenCalledWith({
+        address: '0xtheaddress',
+      })
+      expect(paywall.checkKeysAndLock).toHaveBeenCalledWith()
+      expect(paywall.userAccountAddress).toBe('0xtheaddress')
+    })
+  })
+
+  describe('checkKeysAndLock', () => {
     it('unlocks the page if some key expiration timestamp is in the future', async () => {
       expect.assertions(1)
-
+      paywall.userAccountAddress = '0xtheaddress'
       paywall.unlockPage = jest.fn()
       const futureTime = new Date().getTime() / 1000 + 50000
       jest
         .spyOn(timeStampUtil, 'keyExpirationTimestampFor')
         .mockResolvedValue(futureTime)
 
-      await paywall.handleUserInfoEvent({ address: '0xtheaddress' })
+      await paywall.checkKeysAndLock()
 
       expect(paywall.unlockPage).toHaveBeenCalled()
     })
 
     it('does not unlock the page if all key expiration timestamps are in the past', async () => {
       expect.assertions(1)
-
+      paywall.userAccountAddress = '0xtheaddress'
       paywall.unlockPage = jest.fn()
       const futureTime = new Date().getTime() / 1000 - 50000
       jest
         .spyOn(timeStampUtil, 'keyExpirationTimestampFor')
         .mockResolvedValue(futureTime)
 
-      await paywall.handleUserInfoEvent({ address: '0xtheaddress' })
+      await paywall.checkKeysAndLock()
 
       expect(paywall.unlockPage).not.toHaveBeenCalled()
     })

--- a/paywall/src/utils/localStorage.js
+++ b/paywall/src/utils/localStorage.js
@@ -24,3 +24,18 @@ export default function localStorageAvailable(window) {
     )
   }
 }
+
+export function store(key, value) {
+  if (localStorageAvailable(window)) {
+    window.localStorage.setItem(key, JSON.stringify(value))
+  } else {
+    // Fail silently!
+  }
+}
+
+export function retrieve(key) {
+  if (localStorageAvailable(window)) {
+    return JSON.parse(window.localStorage.getItem(key))
+  }
+  return undefined
+}


### PR DESCRIPTION
# Description

This is the first step to speed up the experience so that once a user has "connected" and checked out, their address is cached for faster lookup of the state!

# Issues

Refs #6196

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->