### PR TITLE
Bugfix for purchase()

### DIFF
--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -67,7 +67,7 @@ contract MixinPurchase is
         _recipient,
         idTo
       );
-    } else if (toKey.expirationTimestamp >= block.timestamp) {
+    } else if (toKey.expirationTimestamp > block.timestamp) {
       // This is an existing owner trying to extend their key
       newTimeStamp = toKey.expirationTimestamp.add(expirationDuration);
       toKey.expirationTimestamp = newTimeStamp;


### PR DESCRIPTION
# Description
in purchase , the way we were checking if a purchase was an extensiion of an existing key was with this:
`} else if (toKey.expirationTimestamp >= block.timestamp) {`
The test was failing sometimes because it was expiring the key (setting `toKey.expirationTimestamp = block.timestamp` and then repurchasing, sometimes in the same block. Running all tests now before I push the fix, which is to change to using:
`} else if (toKey.expirationTimestamp > block.timestamp) {`

The changes to the tests was to eliminate that as the source of the error. They are not strictly necessary, but I think they're still an improvement.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #6204
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
