### PR TITLE
Adding a top-level store for the checkout iframe

### DIFF
--- a/unlock-app/src/__tests__/hooks/useCheckoutStore.test.ts
+++ b/unlock-app/src/__tests__/hooks/useCheckoutStore.test.ts
@@ -1,0 +1,55 @@
+import { reducer } from '../../hooks/useCheckoutStore'
+import {
+  setConfig,
+  setShowingLogin,
+  setPurchasingLockAddress,
+} from '../../utils/checkoutActions'
+
+const newConfig = {
+  locks: {
+    '0xlockaddress': {
+      name: 'a lock',
+    },
+  },
+  callToAction: {
+    default: '',
+    expired: '',
+    pending: '',
+    confirmed: '',
+    noWallet: '',
+  },
+}
+
+describe('useCheckoutStore -- reducer', () => {
+  it('returns the state updated with a new config on setConfig', () => {
+    expect.assertions(1)
+
+    expect(reducer(undefined, setConfig(newConfig))).toEqual(
+      expect.objectContaining({
+        config: newConfig,
+      })
+    )
+  })
+
+  it('returns the state updated with the new login state on setShowingLogin', () => {
+    expect.assertions(1)
+
+    expect(reducer(undefined, setShowingLogin(true))).toEqual(
+      expect.objectContaining({
+        showingLogin: true,
+      })
+    )
+  })
+
+  it('returns the state updated with a new purchasing address on setPurchasingLockAddress', () => {
+    expect.assertions(1)
+
+    const newAddress = '0xthenewaddress'
+
+    expect(reducer(undefined, setPurchasingLockAddress(newAddress))).toEqual(
+      expect.objectContaining({
+        purchasingLockAddress: newAddress,
+      })
+    )
+  })
+})

--- a/unlock-app/src/__tests__/utils/getConfigFromSearch.test.ts
+++ b/unlock-app/src/__tests__/utils/getConfigFromSearch.test.ts
@@ -35,9 +35,7 @@ describe('getConfigFromSearch', () => {
     expect.assertions(2)
 
     expect(getConfigFromSearch({})).toBeUndefined()
-    expect(error).toHaveBeenCalledWith(
-      'no paywall config found in URL, continuing with undefined'
-    )
+    expect(error).not.toHaveBeenCalled()
   })
 
   it('should be undefined if paywall config is malformed JSON', () => {

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import Head from 'next/head'
 import queryString from 'query-string'
@@ -16,6 +16,8 @@ import {
 } from '../../unlockTypes'
 import getConfigFromSearch from '../../utils/getConfigFromSearch'
 import { useCheckoutCommunication } from '../../hooks/useCheckoutCommunication'
+import { useCheckoutStore } from '../../hooks/useCheckoutStore'
+import { setConfig, setShowingLogin } from '../../utils/checkoutActions'
 
 interface CheckoutContentProps {
   account: AccountType
@@ -28,16 +30,18 @@ export const CheckoutContent = ({
   account,
   configFromSearch,
 }: CheckoutContentProps) => {
-  const [showingLogin, setShowingLogin] = useState(false)
-  const [configFromPostmate, setConfig] = useState<PaywallConfig | undefined>(
-    undefined
-  )
+  const { state, dispatch } = useCheckoutStore()
+  const { showingLogin, config } = state
 
   const {
     emitTransactionInfo,
     emitCloseModal,
     emitUserInfo,
-  } = useCheckoutCommunication({ setConfig })
+  } = useCheckoutCommunication({
+    setConfig: (config: PaywallConfig) => {
+      dispatch(setConfig(config))
+    },
+  })
 
   useEffect(() => {
     if (account && account.address) {
@@ -47,8 +51,11 @@ export const CheckoutContent = ({
     }
   }, [account])
 
-  // Config value from postmate always takes precedence over the one in the URL if it is present.
-  const config = configFromPostmate || configFromSearch
+  useEffect(() => {
+    if (!config && configFromSearch) {
+      dispatch(setConfig(configFromSearch))
+    }
+  }, [configFromSearch])
 
   const lockAddresses = config
     ? Object.keys(config.locks)
@@ -71,7 +78,7 @@ export const CheckoutContent = ({
               <NotLoggedInLocks lockAddresses={lockAddresses} />
               <input
                 type="button"
-                onClick={() => setShowingLogin(true)}
+                onClick={() => dispatch(setShowingLogin(true))}
                 value="Log in"
               />
             </>

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -16,7 +16,11 @@ import {
 } from '../../unlockTypes'
 import getConfigFromSearch from '../../utils/getConfigFromSearch'
 import { useCheckoutCommunication } from '../../hooks/useCheckoutCommunication'
-import { useCheckoutStore } from '../../hooks/useCheckoutStore'
+import {
+  useCheckoutStore,
+  CheckoutStoreProvider,
+} from '../../hooks/useCheckoutStore'
+
 import { setConfig, setShowingLogin } from '../../utils/checkoutActions'
 
 interface CheckoutContentProps {
@@ -26,7 +30,22 @@ interface CheckoutContentProps {
 
 const defaultLockAddresses: string[] = []
 
+// This component wraps CheckoutContentInner so that it has access to the store.
 export const CheckoutContent = ({
+  account,
+  configFromSearch,
+}: CheckoutContentProps) => {
+  return (
+    <CheckoutStoreProvider>
+      <CheckoutContentInner
+        account={account}
+        configFromSearch={configFromSearch}
+      />
+    </CheckoutStoreProvider>
+  )
+}
+
+export const CheckoutContentInner = ({
   account,
   configFromSearch,
 }: CheckoutContentProps) => {

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -10,11 +10,11 @@ import {
 import { usePurchaseKey } from '../../../hooks/usePurchaseKey'
 import * as LockVariations from './LockVariations'
 import { TransactionInfo } from '../../../hooks/useCheckoutCommunication'
+import { useCheckoutStore } from '../../../hooks/useCheckoutStore'
+import { setPurchasingLockAddress } from '../../../utils/checkoutActions'
 
 interface LockProps {
   lock: RawLock
-  purchasingLockAddress: string | null
-  setPurchasingLockAddress: (lockAddress: string) => void
   emitTransactionInfo: (info: TransactionInfo) => void
   balances: Balances
   activeKeys: KeyResult[]
@@ -23,22 +23,21 @@ interface LockProps {
 
 export const Lock = ({
   lock,
-  purchasingLockAddress,
-  setPurchasingLockAddress,
   emitTransactionInfo,
   balances,
   activeKeys,
   accountAddress,
 }: LockProps) => {
   const { purchaseKey, transactionHash } = usePurchaseKey(lock, accountAddress)
+  const { state, dispatch } = useCheckoutStore()
 
   const onClick = () => {
-    if (purchasingLockAddress) {
+    if (state.purchasingLockAddress) {
       // There is already a key purchase in progress (or completed) -- do not start another one
       return
     }
 
-    setPurchasingLockAddress(lock.address)
+    dispatch(setPurchasingLockAddress(lock.address))
     purchaseKey()
   }
 
@@ -63,7 +62,7 @@ export const Lock = ({
   const keyForThisLock = activeKeys.find(key => key.lock === lock.address)
 
   // This lock is being/has been purchased
-  if (purchasingLockAddress === lock.address || keyForThisLock) {
+  if (state.purchasingLockAddress === lock.address || keyForThisLock) {
     if (transactionHash || keyForThisLock) {
       return <LockVariations.ConfirmedLock {...props} />
     }
@@ -71,7 +70,7 @@ export const Lock = ({
   }
 
   // Some other lock is being/has been purchased
-  if (purchasingLockAddress || activeKeys.length) {
+  if (state.purchasingLockAddress || activeKeys.length) {
     return <LockVariations.DisabledLock {...props} />
   }
 

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Lock } from './Lock'
 import { LoadingLock } from './LockVariations'
 import { usePaywallLocks } from '../../../hooks/usePaywallLocks'
@@ -12,16 +12,11 @@ interface LocksProps {
   emitTransactionInfo: (info: TransactionInfo) => void
 }
 
-type PurchasingLockAddress = string | null
-
 export const Locks = ({
   lockAddresses,
   accountAddress,
   emitTransactionInfo,
 }: LocksProps) => {
-  const [purchasingLockAddress, setPurchasingLockAddress] = useState(
-    null as PurchasingLockAddress
-  )
   const { getTokenBalance, balances } = useGetTokenBalance(accountAddress)
   const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
   const { keys } = useKeyOwnershipStatus(lockAddresses, accountAddress)
@@ -45,8 +40,6 @@ export const Locks = ({
         <Lock
           key={lock.name}
           lock={lock}
-          purchasingLockAddress={purchasingLockAddress}
-          setPurchasingLockAddress={setPurchasingLockAddress}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={activeKeys}

--- a/unlock-app/src/hooks/useCheckoutStore.tsx
+++ b/unlock-app/src/hooks/useCheckoutStore.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable react/prop-types */
+import React, { createContext, useReducer, useContext } from 'react'
+import { PaywallConfig } from '../unlockTypes'
+import { Action } from '../utils/checkoutActions'
+
+interface State {
+  showingLogin: boolean
+  config: PaywallConfig | undefined
+  purchasingLockAddress: string | undefined
+}
+
+export const defaultState: State = {
+  showingLogin: false,
+  config: undefined,
+  purchasingLockAddress: undefined,
+}
+
+function assertNever(x: never): never {
+  throw new Error(`Unexpected object: ${x}`)
+}
+
+export function reducer(state = defaultState, action: Action): State {
+  switch (action.kind) {
+    case 'setConfig':
+      return { ...state, config: action.config }
+    case 'setShowingLogin':
+      return { ...state, showingLogin: action.value }
+    case 'setPurchasingLockAddress':
+      return { ...state, purchasingLockAddress: action.address }
+    default:
+      // Exhaustiveness check, will cause compile error if you forget to implement an action
+      return assertNever(action)
+  }
+}
+
+interface ContextValue {
+  state: State
+  dispatch: React.Dispatch<Action>
+}
+
+const CheckoutStoreContext = createContext<ContextValue | null>(null)
+
+export const CheckoutStoreProvider: React.FunctionComponent = ({
+  children,
+}) => {
+  const [state, dispatch] = useReducer(reducer, defaultState)
+  const value = { state, dispatch }
+
+  return (
+    <CheckoutStoreContext.Provider value={value}>
+      {children}
+    </CheckoutStoreContext.Provider>
+  )
+}
+
+// We cast the return result as ContextValue to do away with the
+// default null value. The store will always be available so long as the
+// consuming component is under a provider.
+export const useCheckoutStore = () =>
+  useContext(CheckoutStoreContext) as ContextValue

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -15,7 +15,6 @@ import { WalletServiceContext } from '../utils/withWalletService'
 import { Web3ServiceContext } from '../utils/withWeb3Service'
 import { StorageServiceContext } from '../utils/withStorageService'
 import { StorageService } from '../services/storageService'
-import { CheckoutStoreProvider } from '../hooks/useCheckoutStore'
 
 import FullScreenModal from '../components/interface/FullScreenModals'
 import GlobalErrorConsumer from '../components/interface/GlobalErrorConsumer'
@@ -156,11 +155,9 @@ The Unlock team
                 <Web3ServiceProvider value={web3Service}>
                   <WalletServiceProvider value={walletService}>
                     <ConfigProvider value={config}>
-                      <CheckoutStoreProvider>
-                        <GlobalErrorConsumer>
-                          <Component {...pageProps} />
-                        </GlobalErrorConsumer>
-                      </CheckoutStoreProvider>
+                      <GlobalErrorConsumer>
+                        <Component {...pageProps} />
+                      </GlobalErrorConsumer>
                     </ConfigProvider>
                   </WalletServiceProvider>
                 </Web3ServiceProvider>

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -15,6 +15,7 @@ import { WalletServiceContext } from '../utils/withWalletService'
 import { Web3ServiceContext } from '../utils/withWeb3Service'
 import { StorageServiceContext } from '../utils/withStorageService'
 import { StorageService } from '../services/storageService'
+import { CheckoutStoreProvider } from '../hooks/useCheckoutStore'
 
 import FullScreenModal from '../components/interface/FullScreenModals'
 import GlobalErrorConsumer from '../components/interface/GlobalErrorConsumer'
@@ -155,9 +156,11 @@ The Unlock team
                 <Web3ServiceProvider value={web3Service}>
                   <WalletServiceProvider value={walletService}>
                     <ConfigProvider value={config}>
-                      <GlobalErrorConsumer>
-                        <Component {...pageProps} />
-                      </GlobalErrorConsumer>
+                      <CheckoutStoreProvider>
+                        <GlobalErrorConsumer>
+                          <Component {...pageProps} />
+                        </GlobalErrorConsumer>
+                      </CheckoutStoreProvider>
                     </ConfigProvider>
                   </WalletServiceProvider>
                 </Web3ServiceProvider>

--- a/unlock-app/src/utils/checkoutActions.ts
+++ b/unlock-app/src/utils/checkoutActions.ts
@@ -1,0 +1,35 @@
+import { PaywallConfig } from '../unlockTypes'
+
+export type Action = SetConfig | SetShowingLogin | SetPurchasingLockAddress
+
+interface SetConfig {
+  kind: 'setConfig'
+  config: PaywallConfig
+}
+
+export const setConfig = (config: PaywallConfig): SetConfig => ({
+  kind: 'setConfig',
+  config,
+})
+
+interface SetShowingLogin {
+  kind: 'setShowingLogin'
+  value: boolean
+}
+
+export const setShowingLogin = (value: boolean): SetShowingLogin => ({
+  kind: 'setShowingLogin',
+  value,
+})
+
+interface SetPurchasingLockAddress {
+  kind: 'setPurchasingLockAddress'
+  address: string
+}
+
+export const setPurchasingLockAddress = (
+  address: string
+): SetPurchasingLockAddress => ({
+  kind: 'setPurchasingLockAddress',
+  address,
+})

--- a/unlock-app/src/utils/getConfigFromSearch.ts
+++ b/unlock-app/src/utils/getConfigFromSearch.ts
@@ -6,7 +6,6 @@ export default function getConfigFromSearch(
   search: any
 ): PaywallConfig | undefined {
   if (typeof search.paywallConfig !== 'string') {
-    console.error('no paywall config found in URL, continuing with undefined')
     return undefined
   }
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR introduces a top-level store for the checkout iframe. I'm keeping this separate from the existing Redux store because there shouldn't be any cross-pollination between them. The basic step was to find all instances of `useState` and replace them with updates dispatched to the store. This lays the foundation for easier switching between views without dumping all our state (important for metadata).

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
