### PR TITLE
Pass account address to usePurchaseKey for correct purchase

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -28,6 +28,8 @@ const activeKeyForAnotherLock: KeyResult = {
   lock: '0xanotherlockaddress',
 }
 
+const accountAddress = '0xuser'
+
 describe('Checkout Lock', () => {
   describe('Lock', () => {
     let purchaseKey: () => void
@@ -56,6 +58,7 @@ describe('Checkout Lock', () => {
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={[]}
+          accountAddress={accountAddress}
         />
       )
 
@@ -78,6 +81,7 @@ describe('Checkout Lock', () => {
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={[]}
+          accountAddress={accountAddress}
         />
       )
 
@@ -105,6 +109,7 @@ describe('Checkout Lock', () => {
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={[]}
+          accountAddress={accountAddress}
         />
       )
 
@@ -122,6 +127,7 @@ describe('Checkout Lock', () => {
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={[]}
+          accountAddress={accountAddress}
         />
       )
 
@@ -139,6 +145,7 @@ describe('Checkout Lock', () => {
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={[activeKeyForAnotherLock]}
+          accountAddress={accountAddress}
         />
       )
 
@@ -156,6 +163,7 @@ describe('Checkout Lock', () => {
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={[]}
+          accountAddress={accountAddress}
         />
       )
 
@@ -180,6 +188,7 @@ describe('Checkout Lock', () => {
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={[]}
+          accountAddress={accountAddress}
         />
       )
 
@@ -197,6 +206,7 @@ describe('Checkout Lock', () => {
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={[activeKeyForThisLock]}
+          accountAddress={accountAddress}
         />
       )
 
@@ -221,6 +231,7 @@ describe('Checkout Lock', () => {
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={[]}
+          accountAddress={accountAddress}
         />
       )
 

--- a/unlock-app/src/__tests__/hooks/usePurchaseKey.test.ts
+++ b/unlock-app/src/__tests__/hooks/usePurchaseKey.test.ts
@@ -16,6 +16,8 @@ class MockWalletService extends EventEmitter {
 
 let mockWalletService: MockWalletService
 
+const accountAddress = '0xpurchaser'
+
 const lock = {
   asOf: 3196,
   name: 'ETH Lock',
@@ -47,7 +49,7 @@ describe('usePurchaseKey', () => {
   it('should return an object containing a function that will purchase a key', async () => {
     expect.assertions(1)
 
-    const { result } = renderHook(() => usePurchaseKey(lock))
+    const { result } = renderHook(() => usePurchaseKey(lock, accountAddress))
 
     await act(async () => {
       result.current.purchaseKey()
@@ -58,7 +60,7 @@ describe('usePurchaseKey', () => {
         erc20Address: lock.currencyContractAddress,
         keyPrice: lock.keyPrice,
         lockAddress: lock.address,
-        owner: lock.owner,
+        owner: accountAddress,
       },
       expect.any(Function)
     )
@@ -67,7 +69,7 @@ describe('usePurchaseKey', () => {
   it('should provide an error value if an error occurs', async () => {
     expect.assertions(2)
 
-    const { result } = renderHook(() => usePurchaseKey(lock))
+    const { result } = renderHook(() => usePurchaseKey(lock, accountAddress))
 
     mockWalletService.purchaseKey = jest.fn((_, callback: any) => {
       const error = new Error('failure')
@@ -86,7 +88,7 @@ describe('usePurchaseKey', () => {
   it('should provide a transaction hash when purchaseKey completes', async () => {
     expect.assertions(2)
 
-    const { result } = renderHook(() => usePurchaseKey(lock))
+    const { result } = renderHook(() => usePurchaseKey(lock, accountAddress))
 
     mockWalletService.purchaseKey = jest.fn((_, callback: any) => {
       const hash = '0xhash'

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -18,6 +18,7 @@ interface LockProps {
   emitTransactionInfo: (info: TransactionInfo) => void
   balances: Balances
   activeKeys: KeyResult[]
+  accountAddress: string
 }
 
 export const Lock = ({
@@ -27,8 +28,9 @@ export const Lock = ({
   emitTransactionInfo,
   balances,
   activeKeys,
+  accountAddress,
 }: LockProps) => {
-  const { purchaseKey, transactionHash } = usePurchaseKey(lock)
+  const { purchaseKey, transactionHash } = usePurchaseKey(lock, accountAddress)
 
   const onClick = () => {
     if (purchasingLockAddress) {

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -50,6 +50,7 @@ export const Locks = ({
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}
           activeKeys={activeKeys}
+          accountAddress={accountAddress}
         />
       ))}
     </div>

--- a/unlock-app/src/hooks/usePurchaseKey.ts
+++ b/unlock-app/src/hooks/usePurchaseKey.ts
@@ -6,7 +6,7 @@ import { WalletServiceContext } from '../utils/withWalletService'
 type TransactionHash = string | null
 type PurchaseError = Error | null
 
-export const usePurchaseKey = (lock: RawLock) => {
+export const usePurchaseKey = (lock: RawLock, accountAddress: string) => {
   const [transactionHash, setTransactionHash] = useState(
     null as TransactionHash
   )
@@ -18,7 +18,7 @@ export const usePurchaseKey = (lock: RawLock) => {
     walletService.purchaseKey(
       {
         lockAddress: lock.address,
-        owner: lock.owner!,
+        owner: accountAddress,
         keyPrice: lock.keyPrice,
         erc20Address: lock.currencyContractAddress,
       },


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR fixes a bug caused by passing the lock owner to `walletService.purchaseKey` rather than _the recipient_.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
