### PR TITLE
Basic optimistic unlocking

### DIFF
--- a/paywall/src/__tests__/utils/optimisticUnlocking.test.js
+++ b/paywall/src/__tests__/utils/optimisticUnlocking.test.js
@@ -1,0 +1,88 @@
+import * as OptimisticUnlocking from '../../utils/optimisticUnlocking'
+
+const user = '0xuser'
+const lock = '0xlock'
+const locks = [lock, '0xanother']
+const transaction = '0xtransaction'
+const locksmithUri = 'https://locksmith.unlock-protocol.com'
+
+const savedTransactions = [
+  {
+    recipient: lock,
+    transactionHash: '0xtransactionHash',
+  },
+  {
+    recipient: lock,
+    transactionHash: '0xtransactionHash2',
+  },
+]
+
+describe('optimisticUnlocking', () => {
+  it('should yield true if any transaction is optimistic', async () => {
+    expect.assertions(5)
+    jest
+      .spyOn(OptimisticUnlocking, 'getTransactionsForUserAndLocks')
+      .mockImplementationOnce(() => {
+        return savedTransactions
+      })
+
+    jest.spyOn(OptimisticUnlocking, 'willUnlock').mockImplementationOnce(() => {
+      return true
+    })
+
+    const optimistic = await OptimisticUnlocking.optimisticUnlocking(
+      locksmithUri,
+      locks,
+      user
+    )
+    expect(optimistic).toBe(true)
+    expect(
+      OptimisticUnlocking.getTransactionsForUserAndLocks
+    ).toHaveBeenCalledWith(locksmithUri, user, locks)
+    expect(OptimisticUnlocking.willUnlock).toHaveBeenCalledTimes(
+      savedTransactions.length
+    )
+    expect(OptimisticUnlocking.willUnlock).toHaveBeenNthCalledWith(
+      1,
+      user,
+      lock,
+      '0xtransactionHash'
+    )
+    expect(OptimisticUnlocking.willUnlock).toHaveBeenNthCalledWith(
+      2,
+      user,
+      lock,
+      '0xtransactionHash2'
+    )
+  })
+})
+
+describe('getTransactionsForUserAndLocks', () => {
+  it('should yield the relevant transactions for that user', async () => {
+    expect.assertions(3)
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        transactions: savedTransactions,
+      })
+    )
+    const transactions = await OptimisticUnlocking.getTransactionsForUserAndLocks(
+      locksmithUri,
+      user,
+      locks
+    )
+    expect(transactions).toEqual(savedTransactions)
+    expect(fetch.mock.calls.length).toEqual(1)
+    expect(fetch.mock.calls[0][0]).toEqual(
+      `${locksmithUri}/transactions?for=0xuser&recipient[]=0xlock&recipient[]=0xanother`
+    )
+  })
+})
+
+describe('willUnlock', () => {
+  it('should return true', async () => {
+    expect.assertions(1)
+    expect(await OptimisticUnlocking.willUnlock(user, lock, transaction)).toBe(
+      true
+    )
+  })
+})

--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -3,10 +3,12 @@ import './iframe.css'
 import { setupUnlockProtocolVariable, dispatchEvent } from './utils'
 import { keyExpirationTimestampFor } from '../utils/keyExpirationTimestampFor'
 import { store, retrieve } from '../utils/localStorage'
+import { optimisticUnlocking, willUnlock } from '../utils/optimisticUnlocking'
 
 declare let __ENVIRONMENT_VARIABLES__: {
   unlockAppUrl: string
   readOnlyProvider: string
+  locksmithUri: string
 }
 export const checkoutIframeClassName = 'unlock-protocol-checkout'
 
@@ -22,6 +24,7 @@ export interface UserInfo {
 
 export interface TransactionInfo {
   hash: string
+  lock: string
 }
 
 export enum CheckoutEvents {
@@ -83,6 +86,10 @@ export class Paywall {
     this.checkKeysAndLock()
   }
 
+  // This function is in charge of assessing if we should unlock the page
+  // First we check the chain, and if any valid key exists, then we unlock
+  // If no valid key exists we check pending transactions to assess them
+  // optimistically.
   checkKeysAndLock = async () => {
     const { readOnlyProvider } = __ENVIRONMENT_VARIABLES__
 
@@ -97,11 +104,24 @@ export class Paywall {
       })
     )
 
+    // If any key is valid, we unlock the page
     if (timeStamps.some(val => val > new Date().getTime() / 1000)) {
-      this.unlockPage()
-    } else {
-      this.lockPage()
+      return this.unlockPage()
     }
+
+    // If not key exists on chain, let's see if we can be optimistic before locking the page.
+    const { locksmithUri } = __ENVIRONMENT_VARIABLES__
+    const optimistic = await optimisticUnlocking(
+      locksmithUri,
+      Object.keys(this.paywallConfig.locks),
+      this.userAccountAddress!
+    )
+    if (optimistic) {
+      return this.unlockPage()
+    }
+
+    // If no key exists, or no transaction exists which could be optimistic, we lock
+    this.lockPage()
   }
 
   shakeHands = async () => {
@@ -117,7 +137,7 @@ export class Paywall {
     child.on(CheckoutEvents.userInfo, this.handleUserInfoEvent)
 
     // transactionInfo event also carries transaction hash.
-    child.on(CheckoutEvents.transactionInfo, this.unlockPage)
+    child.on(CheckoutEvents.transactionInfo, this.handleTransactionInfoEvent)
 
     // flush the buffer of child calls from before the iframe was ready
     this.childCallBuffer.forEach(bufferedCall => child.call(...bufferedCall))
@@ -125,6 +145,13 @@ export class Paywall {
     this.setConfig = (config: any) => {
       child.call('setConfig', config)
       this.checkKeysAndLock()
+    }
+  }
+
+  handleTransactionInfoEvent = async ({ hash, lock }: TransactionInfo) => {
+    const optimistic = await willUnlock(this.userAccountAddress!, lock, hash)
+    if (optimistic) {
+      this.unlockPage()
     }
   }
 

--- a/paywall/src/utils/optimisticUnlocking.ts
+++ b/paywall/src/utils/optimisticUnlocking.ts
@@ -1,0 +1,73 @@
+/**
+ * Yields true if we should be optimistic for user and the locks
+ * @param locks
+ * @param user
+ */
+export const optimisticUnlocking = async (
+  locksmithUri: string,
+  locks: string[],
+  user: string
+) => {
+  const userTransactions = await getTransactionsForUserAndLocks(
+    locksmithUri,
+    user,
+    locks
+  )
+  const unlocked = await Promise.all(
+    userTransactions.map((transaction: any) => {
+      return willUnlock(
+        user,
+        transaction.recipient,
+        transaction.transactionHash
+      )
+    })
+  )
+
+  const reducer = (accumulator: any, currentValue: any) =>
+    currentValue || !!accumulator
+
+  return unlocked.reduce(reducer, false)
+}
+
+/**
+ * This method will query the backend to ensure that a transaction will succeed in generating a key for that user.
+ * @param user
+ * @param lock
+ * @param transactionHash
+ */
+export const willUnlock = async (
+  user: string,
+  lock: string,
+  transactionHash: string
+) => {
+  if (user && lock && transactionHash) {
+    // TODO: implement!
+    return true
+  }
+  return false
+}
+
+/**
+ * Returns all transactions from a user to a lock
+ * @param locksmithUri
+ * @param user
+ * @param locks
+ */
+export const getTransactionsForUserAndLocks = async (
+  locksmithUri: string,
+  user: string,
+  locks: string[]
+) => {
+  const filterLocks = locks
+    .map(
+      (lockAddress: string) => `recipient[]=${encodeURIComponent(lockAddress)}`
+    )
+    .join('&')
+
+  const url = `${locksmithUri}/transactions?for=${user}&${filterLocks}`
+  const response = await fetch(url)
+  const body = await response.json()
+  return body.transactions
+}
+
+export default optimisticUnlocking

--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -238,6 +238,7 @@ describe('Checkout Lock', () => {
 
       expect(emitTransactionInfo).toHaveBeenCalledWith({
         hash: '0xhash',
+        lock: lock.address,
       })
     })
   })

--- a/unlock-app/src/__tests__/hooks/useCheckoutCommunication.test.ts
+++ b/unlock-app/src/__tests__/hooks/useCheckoutCommunication.test.ts
@@ -49,7 +49,7 @@ describe('useCheckoutCommunication', () => {
 
     await wait(() => result.current.ready)
 
-    const transactionInfo = { hash: '0xmyhash' }
+    const transactionInfo = { hash: '0xmyhash', lock: '0xmylock' }
     result.current.emitTransactionInfo(transactionInfo)
 
     expect(emit).toHaveBeenCalledWith(
@@ -66,7 +66,7 @@ describe('useCheckoutCommunication', () => {
     const userInfo = { address: '0xmyaddress' }
     act(() => result.current.emitUserInfo(userInfo))
 
-    const transactionInfo = { hash: '0xmyhash' }
+    const transactionInfo = { hash: '0xmyhash', lock: '0xmylock' }
     act(() => result.current.emitTransactionInfo(transactionInfo))
 
     act(() => result.current.emitCloseModal())

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -44,6 +44,7 @@ export const Lock = ({
   useEffect(() => {
     if (transactionHash) {
       emitTransactionInfo({
+        lock: lock.address,
         hash: transactionHash,
       })
     }

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -7,6 +7,7 @@ export interface UserInfo {
 
 export interface TransactionInfo {
   hash: string
+  lock?: string
 }
 
 export enum CheckoutEvents {


### PR DESCRIPTION
# Description

This pull-request adds optimistic unlocking.
When the paywall script is loaded:
* if the user does not have a key, we fetch past transactions from locksmith and check if any transaction would result in a key, and unlock in that case
* then a transaction is sent back from the checkout iframe, we check if this transaction would result in a key and unlock in that case.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->