### PR TITLE
Callback on transaction yields the transaction object as 3rd argument

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+# 0.8.6
+- Callback on transaction yields the transaction object as 3rd argument
+
 # 0.8.5
 - Corrected type definition so that callback is optional on purchaseKey
 

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/v0/createLock.js
+++ b/unlock-js/src/v0/createLock.js
@@ -25,7 +25,7 @@ export default async function(lock, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's update the lock to reflect that it is linked to this

--- a/unlock-js/src/v0/purchaseKey.js
+++ b/unlock-js/src/v0/purchaseKey.js
@@ -30,7 +30,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the transaction to go thru to return the token id

--- a/unlock-js/src/v0/updateKeyPrice.js
+++ b/unlock-js/src/v0/updateKeyPrice.js
@@ -21,7 +21,7 @@ export default async function({ lockAddress, keyPrice }, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the keyPrice to have been changed before we return it

--- a/unlock-js/src/v0/withdrawFromLock.js
+++ b/unlock-js/src/v0/withdrawFromLock.js
@@ -20,7 +20,7 @@ export default async function({ lockAddress }, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the funds to have been withdrawn

--- a/unlock-js/src/v01/createLock.js
+++ b/unlock-js/src/v01/createLock.js
@@ -31,7 +31,7 @@ export default async function(lock, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's update the lock to reflect that it is linked to this

--- a/unlock-js/src/v01/purchaseKey.js
+++ b/unlock-js/src/v01/purchaseKey.js
@@ -22,7 +22,7 @@ export default async function({ lockAddress, owner, keyPrice }, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the transaction to go thru to return the token id

--- a/unlock-js/src/v01/updateKeyPrice.js
+++ b/unlock-js/src/v01/updateKeyPrice.js
@@ -23,7 +23,7 @@ export default async function({ lockAddress, keyPrice }, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the keyPrice to have been changed before we return it

--- a/unlock-js/src/v01/withdrawFromLock.js
+++ b/unlock-js/src/v01/withdrawFromLock.js
@@ -19,7 +19,7 @@ export default async function({ lockAddress }, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the funds to have been withdrawn

--- a/unlock-js/src/v02/createLock.js
+++ b/unlock-js/src/v02/createLock.js
@@ -33,7 +33,7 @@ export default async function(lock, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's update the lock to reflect that it is linked to this

--- a/unlock-js/src/v02/purchaseKey.js
+++ b/unlock-js/src/v02/purchaseKey.js
@@ -25,7 +25,7 @@ export default async function({ lockAddress, owner, keyPrice }, callback) {
   const parser = lockContract.interface
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   const transferEvent = receipt.logs

--- a/unlock-js/src/v02/updateKeyPrice.js
+++ b/unlock-js/src/v02/updateKeyPrice.js
@@ -23,7 +23,7 @@ export default async function({ lockAddress, keyPrice }, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the keyPrice to have been changed before we return it

--- a/unlock-js/src/v02/withdrawFromLock.js
+++ b/unlock-js/src/v02/withdrawFromLock.js
@@ -20,7 +20,7 @@ export default async function({ lockAddress }, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the funds to have been withdrawn

--- a/unlock-js/src/v10/createLock.js
+++ b/unlock-js/src/v10/createLock.js
@@ -59,7 +59,7 @@ export default async function(lock, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's update the lock to reflect that it is linked to this

--- a/unlock-js/src/v10/purchaseKey.js
+++ b/unlock-js/src/v10/purchaseKey.js
@@ -70,7 +70,7 @@ export default async function(
   const receipt = await this.provider.waitForTransaction(hash)
   const parser = lockContract.interface
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   const transferEvent = receipt.logs

--- a/unlock-js/src/v10/updateKeyPrice.js
+++ b/unlock-js/src/v10/updateKeyPrice.js
@@ -44,7 +44,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the keyPrice to have been changed before we return it

--- a/unlock-js/src/v10/withdrawFromLock.js
+++ b/unlock-js/src/v10/withdrawFromLock.js
@@ -18,7 +18,7 @@ export default async function({ lockAddress }, callback) {
     TransactionTypes.WITHDRAWAL
   )
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
   // Let's now wait for the funds to have been withdrawn
   const receipt = await this.provider.waitForTransaction(hash)

--- a/unlock-js/src/v11/createLock.js
+++ b/unlock-js/src/v11/createLock.js
@@ -59,7 +59,7 @@ export default async function(lock, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's update the lock to reflect that it is linked to this

--- a/unlock-js/src/v11/purchaseKey.js
+++ b/unlock-js/src/v11/purchaseKey.js
@@ -68,7 +68,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the transaction to go thru to return the token id

--- a/unlock-js/src/v11/updateKeyPrice.js
+++ b/unlock-js/src/v11/updateKeyPrice.js
@@ -44,7 +44,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the keyPrice to have been changed before we return it

--- a/unlock-js/src/v11/withdrawFromLock.js
+++ b/unlock-js/src/v11/withdrawFromLock.js
@@ -28,7 +28,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the funds to have been withdrawn

--- a/unlock-js/src/v12/createLock.js
+++ b/unlock-js/src/v12/createLock.js
@@ -65,7 +65,7 @@ export default async function(lock, callback) {
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's update the lock to reflect that it is linked to this

--- a/unlock-js/src/v12/purchaseKey.js
+++ b/unlock-js/src/v12/purchaseKey.js
@@ -81,7 +81,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the transaction to go thru to return the token id

--- a/unlock-js/src/v12/updateKeyPrice.js
+++ b/unlock-js/src/v12/updateKeyPrice.js
@@ -44,7 +44,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the keyPrice to have been changed before we return it

--- a/unlock-js/src/v12/withdrawFromLock.js
+++ b/unlock-js/src/v12/withdrawFromLock.js
@@ -47,7 +47,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the funds to have been withdrawn

--- a/unlock-js/src/v13/createLock.js
+++ b/unlock-js/src/v13/createLock.js
@@ -59,7 +59,7 @@ export default async function(lock, callback) {
     TransactionTypes.LOCK_CREATION
   )
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's update the lock to reflect that it is linked to this

--- a/unlock-js/src/v13/purchaseKey.js
+++ b/unlock-js/src/v13/purchaseKey.js
@@ -81,7 +81,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the transaction to go thru to return the token id

--- a/unlock-js/src/v13/updateKeyPrice.js
+++ b/unlock-js/src/v13/updateKeyPrice.js
@@ -46,7 +46,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the keyPrice to have been changed before we return it

--- a/unlock-js/src/v13/withdrawFromLock.js
+++ b/unlock-js/src/v13/withdrawFromLock.js
@@ -47,7 +47,7 @@ export default async function(
   )
 
   if (callback) {
-    callback(null, hash)
+    callback(null, hash, await transactionPromise)
   }
 
   // Let's now wait for the funds to have been withdrawn


### PR DESCRIPTION
# Description

This is going to provide more details to the front end when we need to store transactions in locksmith.

There is probably a better way to DRY this up, but I think that's going to be part of getting rid of the `_handleMethodCall` thing.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

