### PR TITLE
usePurchaseKey now directly sets transaction hash in state

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -179,12 +179,11 @@ describe('Checkout Lock', () => {
       expect.assertions(0)
 
       state.purchasingLockAddress = '0xlockaddress'
+      state.transactionHash = '0xhash'
 
       jest.spyOn(usePurchaseKey, 'usePurchaseKey').mockImplementation(_ => ({
         purchaseKey,
-        initiatedPurchase: false,
         error: null,
-        transactionHash: '0xhash',
       }))
 
       const { getByTestId } = rtl.render(
@@ -214,32 +213,6 @@ describe('Checkout Lock', () => {
       )
 
       getByTestId('ConfirmedLock')
-    })
-
-    it('calls emitTransactionInfo when a purchase resolves to a transaction hash', () => {
-      expect.assertions(1)
-
-      jest.spyOn(usePurchaseKey, 'usePurchaseKey').mockImplementation(_ => ({
-        purchaseKey,
-        initiatedPurchase: false,
-        error: null,
-        transactionHash: '0xhash',
-      }))
-
-      rtl.render(
-        <Lock
-          lock={lock}
-          emitTransactionInfo={emitTransactionInfo}
-          balances={balances}
-          activeKeys={[]}
-          accountAddress={accountAddress}
-        />
-      )
-
-      expect(emitTransactionInfo).toHaveBeenCalledWith({
-        hash: '0xhash',
-        lock: lock.address,
-      })
     })
   })
 })

--- a/unlock-app/src/__tests__/hooks/usePurchaseKey.test.ts
+++ b/unlock-app/src/__tests__/hooks/usePurchaseKey.test.ts
@@ -6,6 +6,7 @@ import { StorageServiceContext } from '../../utils/withStorageService'
 import { ConfigContext } from '../../utils/withConfig'
 import { usePurchaseKey } from '../../hooks/usePurchaseKey'
 import { StorageService } from '../../services/storageService'
+import * as Store from '../../hooks/useCheckoutStore'
 
 class MockWalletService extends EventEmitter {
   purchaseKey: jest.Mock<any, any>
@@ -37,6 +38,8 @@ const lock = {
 
 let mockStorageService: StorageService
 let mockConfig: any
+let emitTransactionInfo: jest.Mock<any, any>
+let dispatch: jest.Mock<any, any>
 
 describe('usePurchaseKey', () => {
   beforeEach(() => {
@@ -46,6 +49,10 @@ describe('usePurchaseKey', () => {
     mockConfig = {
       requiredNetworkId: 1337,
     }
+
+    dispatch = jest.fn()
+    emitTransactionInfo = jest.fn()
+
     jest.spyOn(React, 'useContext').mockImplementation(context => {
       if (context === WalletServiceContext) {
         return mockWalletService
@@ -58,16 +65,21 @@ describe('usePurchaseKey', () => {
       }
     })
 
+    jest.spyOn(Store, 'useCheckoutStore').mockImplementation(() => ({
+      state: Store.defaultState,
+      dispatch,
+    }))
+
     mockWalletService = new MockWalletService()
   })
 
   it('should return an object containing a function that will purchase a key', async () => {
     expect.assertions(1)
 
-    const { result } = renderHook(() => usePurchaseKey(lock, accountAddress))
+    const { result } = renderHook(() => usePurchaseKey(emitTransactionInfo))
 
     await act(async () => {
-      result.current.purchaseKey()
+      result.current.purchaseKey(lock, accountAddress)
     })
 
     expect(mockWalletService.purchaseKey).toHaveBeenCalledWith(
@@ -84,7 +96,7 @@ describe('usePurchaseKey', () => {
   it('should provide an error value if an error occurs', async () => {
     expect.assertions(2)
 
-    const { result } = renderHook(() => usePurchaseKey(lock, accountAddress))
+    const { result } = renderHook(() => usePurchaseKey(emitTransactionInfo))
 
     mockWalletService.purchaseKey = jest.fn((_, callback: any) => {
       const error = new Error('failure')
@@ -94,37 +106,66 @@ describe('usePurchaseKey', () => {
     expect(result.current.error).toBeNull()
 
     await act(async () => {
-      result.current.purchaseKey()
+      result.current.purchaseKey(lock, accountAddress)
     })
 
     expect(result.current.error?.message).toEqual('failure')
   })
 
-  it('should provide a transaction hash when purchaseKey completes', async () => {
+  it('should dispatch a transaction hash when purchaseKey completes', async () => {
     expect.assertions(2)
 
-    const { result } = renderHook(() => usePurchaseKey(lock, accountAddress))
+    const { result } = renderHook(() => usePurchaseKey(emitTransactionInfo))
     const transaction = {
       data: '0xdata',
     }
+    const hash = '0xhash'
+
     mockWalletService.purchaseKey = jest.fn((_, callback: any) => {
-      const hash = '0xhash'
       callback(null, hash, transaction)
     })
 
-    expect(result.current.transactionHash).toBeNull()
+    expect(dispatch).not.toHaveBeenCalled()
 
     await act(async () => {
-      result.current.purchaseKey()
+      result.current.purchaseKey(lock, accountAddress)
     })
 
-    expect(result.current.transactionHash).toEqual('0xhash')
+    expect(dispatch).toHaveBeenCalledWith({
+      hash,
+      kind: 'setTransactionHash',
+    })
+  })
+
+  it('should emit transaction information when purchaseKey completes', async () => {
+    expect.assertions(2)
+
+    const { result } = renderHook(() => usePurchaseKey(emitTransactionInfo))
+    const transaction = {
+      data: '0xdata',
+    }
+    const hash = '0xhash'
+
+    mockWalletService.purchaseKey = jest.fn((_, callback: any) => {
+      callback(null, hash, transaction)
+    })
+
+    expect(emitTransactionInfo).not.toHaveBeenCalled()
+
+    await act(async () => {
+      result.current.purchaseKey(lock, accountAddress)
+    })
+
+    expect(emitTransactionInfo).toHaveBeenCalledWith({
+      hash,
+      lock: lock.address,
+    })
   })
 
   it('should save the transaction', async () => {
-    expect.assertions(2)
+    expect.assertions(1)
 
-    const { result } = renderHook(() => usePurchaseKey(lock, accountAddress))
+    const { result } = renderHook(() => usePurchaseKey(emitTransactionInfo))
     const transaction = {
       hash: '0xhash',
       data: '0xdata',
@@ -133,12 +174,10 @@ describe('usePurchaseKey', () => {
       callback(null, transaction.hash, transaction)
     })
 
-    expect(result.current.transactionHash).toBeNull()
-
     mockStorageService.storeTransaction = jest.fn(() => Promise.resolve())
 
     await act(async () => {
-      result.current.purchaseKey()
+      result.current.purchaseKey(lock, accountAddress)
     })
 
     expect(mockStorageService.storeTransaction).toHaveBeenCalledWith(

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { KeyResult } from '@unlock-protocol/unlock-js'
 import { RawLock, Balances } from '../../../unlockTypes'
 import { durationsAsTextFromSeconds } from '../../../utils/durations'
@@ -28,7 +28,7 @@ export const Lock = ({
   activeKeys,
   accountAddress,
 }: LockProps) => {
-  const { purchaseKey, transactionHash } = usePurchaseKey(lock, accountAddress)
+  const { purchaseKey } = usePurchaseKey(emitTransactionInfo)
   const { state, dispatch } = useCheckoutStore()
 
   const onClick = () => {
@@ -38,17 +38,8 @@ export const Lock = ({
     }
 
     dispatch(setPurchasingLockAddress(lock.address))
-    purchaseKey()
+    purchaseKey(lock, accountAddress)
   }
-
-  useEffect(() => {
-    if (transactionHash) {
-      emitTransactionInfo({
-        lock: lock.address,
-        hash: transactionHash,
-      })
-    }
-  }, [transactionHash])
 
   const props: LockVariations.LockProps = {
     onClick,
@@ -64,7 +55,7 @@ export const Lock = ({
 
   // This lock is being/has been purchased
   if (state.purchasingLockAddress === lock.address || keyForThisLock) {
-    if (transactionHash || keyForThisLock) {
+    if (state.transactionHash || keyForThisLock) {
       return <LockVariations.ConfirmedLock {...props} />
     }
     return <LockVariations.ProcessingLock {...props} />

--- a/unlock-app/src/hooks/useCheckoutStore.tsx
+++ b/unlock-app/src/hooks/useCheckoutStore.tsx
@@ -7,12 +7,14 @@ interface State {
   showingLogin: boolean
   config: PaywallConfig | undefined
   purchasingLockAddress: string | undefined
+  transactionHash: string | undefined
 }
 
 export const defaultState: State = {
   showingLogin: false,
   config: undefined,
   purchasingLockAddress: undefined,
+  transactionHash: undefined,
 }
 
 function assertNever(x: never): never {
@@ -27,6 +29,8 @@ export function reducer(state = defaultState, action: Action): State {
       return { ...state, showingLogin: action.value }
     case 'setPurchasingLockAddress':
       return { ...state, purchasingLockAddress: action.address }
+    case 'setTransactionHash':
+      return { ...state, transactionHash: action.hash }
     default:
       // Exhaustiveness check, will cause compile error if you forget to implement an action
       return assertNever(action)
@@ -38,7 +42,7 @@ interface ContextValue {
   dispatch: React.Dispatch<Action>
 }
 
-const CheckoutStoreContext = createContext<ContextValue | null>(null)
+export const CheckoutStoreContext = createContext<ContextValue | null>(null)
 
 export const CheckoutStoreProvider: React.FunctionComponent = ({
   children,

--- a/unlock-app/src/utils/checkoutActions.ts
+++ b/unlock-app/src/utils/checkoutActions.ts
@@ -1,6 +1,10 @@
 import { PaywallConfig } from '../unlockTypes'
 
-export type Action = SetConfig | SetShowingLogin | SetPurchasingLockAddress
+export type Action =
+  | SetConfig
+  | SetShowingLogin
+  | SetPurchasingLockAddress
+  | SetTransactionHash
 
 interface SetConfig {
   kind: 'setConfig'
@@ -32,4 +36,14 @@ export const setPurchasingLockAddress = (
 ): SetPurchasingLockAddress => ({
   kind: 'setPurchasingLockAddress',
   address,
+})
+
+interface SetTransactionHash {
+  kind: 'setTransactionHash'
+  hash: string
+}
+
+export const setTransactionHash = (hash: string): SetTransactionHash => ({
+  kind: 'setTransactionHash',
+  hash,
 })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

In support of the metadata form PR, so that the UI can update correctly, we need to track the transaction hash in the app-level state, not in a return value from the hook. This PR changes `usePurchaseKey` and its one consumer around to ensure that it does so.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
