### PR TITLE
Adding the metadata collection flow to the new checkout

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/Lock.test.tsx
@@ -5,7 +5,11 @@ import { Lock } from '../../../../components/interface/checkout/Lock'
 import * as usePurchaseKey from '../../../../hooks/usePurchaseKey'
 import { TransactionInfo } from '../../../../hooks/useCheckoutCommunication'
 import * as CheckoutStoreModule from '../../../../hooks/useCheckoutStore'
-import { setPurchasingLockAddress } from '../../../../utils/checkoutActions'
+import {
+  setPurchasingLockAddress,
+  setDelayedPurchase,
+  setShowingMetadataForm,
+} from '../../../../utils/checkoutActions'
 
 const balances = {
   eth: '500.00',
@@ -77,6 +81,34 @@ describe('Checkout Lock', () => {
       expect(dispatch).toHaveBeenCalledWith(
         setPurchasingLockAddress('0xlockaddress')
       )
+    })
+
+    it('delays the purchase and shows metadata form when metadata is required', () => {
+      expect.assertions(2)
+
+      const { getByText } = rtl.render(
+        <Lock
+          lock={lock}
+          emitTransactionInfo={emitTransactionInfo}
+          balances={balances}
+          activeKeys={[]}
+          accountAddress={accountAddress}
+          metadataRequired
+        />
+      )
+
+      const validitySpan = getByText('Valid for')
+
+      rtl.fireEvent.click(validitySpan)
+
+      expect(dispatch).toHaveBeenNthCalledWith(
+        1,
+        setDelayedPurchase({
+          lockAddress: '0xlockaddress',
+          purchaseKey: expect.any(Function),
+        })
+      )
+      expect(dispatch).toHaveBeenNthCalledWith(2, setShowingMetadataForm(true))
     })
 
     it('does not purchase a key and set the purchasing address when there is already a purchase', () => {

--- a/unlock-app/src/__tests__/hooks/useCheckoutStore.test.ts
+++ b/unlock-app/src/__tests__/hooks/useCheckoutStore.test.ts
@@ -3,6 +3,9 @@ import {
   setConfig,
   setShowingLogin,
   setPurchasingLockAddress,
+  setTransactionHash,
+  setShowingMetadataForm,
+  setDelayedPurchase,
 } from '../../utils/checkoutActions'
 
 const newConfig = {
@@ -18,6 +21,11 @@ const newConfig = {
     confirmed: '',
     noWallet: '',
   },
+}
+
+const newDelayedPurchase = {
+  lockAddress: '0xalock',
+  purchaseKey: jest.fn(),
 }
 
 describe('useCheckoutStore -- reducer', () => {
@@ -49,6 +57,38 @@ describe('useCheckoutStore -- reducer', () => {
     expect(reducer(undefined, setPurchasingLockAddress(newAddress))).toEqual(
       expect.objectContaining({
         purchasingLockAddress: newAddress,
+      })
+    )
+  })
+
+  it('returns the state updated with a new transaction hash on setTransactionHash', () => {
+    expect.assertions(1)
+
+    const transactionHash = '0xthehash'
+
+    expect(reducer(undefined, setTransactionHash(transactionHash))).toEqual(
+      expect.objectContaining({
+        transactionHash,
+      })
+    )
+  })
+
+  it('returns the state updated with the new metadata form state on setShowingMetadataForm', () => {
+    expect.assertions(1)
+
+    expect(reducer(undefined, setShowingMetadataForm(true))).toEqual(
+      expect.objectContaining({
+        showingMetadataForm: true,
+      })
+    )
+  })
+
+  it('returns the state updated with a new delayed purchase on setDelayedPurchase', () => {
+    expect.assertions(1)
+
+    expect(reducer(undefined, setDelayedPurchase(newDelayedPurchase))).toEqual(
+      expect.objectContaining({
+        delayedPurchase: newDelayedPurchase,
       })
     )
   })

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -9,10 +9,12 @@ import { Locks } from '../interface/checkout/Locks'
 import { NotLoggedInLocks } from '../interface/checkout/NotLoggedInLocks'
 import CheckoutWrapper from '../interface/checkout/CheckoutWrapper'
 import CheckoutContainer from '../interface/checkout/CheckoutContainer'
+import { MetadataForm } from '../interface/checkout/MetadataForm'
 import {
   Account as AccountType,
   Router,
   PaywallConfig,
+  UserMetadata,
 } from '../../unlockTypes'
 import getConfigFromSearch from '../../utils/getConfigFromSearch'
 import { useCheckoutCommunication } from '../../hooks/useCheckoutCommunication'
@@ -21,7 +23,12 @@ import {
   CheckoutStoreProvider,
 } from '../../hooks/useCheckoutStore'
 
-import { setConfig, setShowingLogin } from '../../utils/checkoutActions'
+import {
+  setConfig,
+  setShowingLogin,
+  setShowingMetadataForm,
+} from '../../utils/checkoutActions'
+import { useSetUserMetadata } from '../../hooks/useSetUserMetadata'
 
 interface CheckoutContentProps {
   account: AccountType
@@ -50,7 +57,8 @@ export const CheckoutContentInner = ({
   configFromSearch,
 }: CheckoutContentProps) => {
   const { state, dispatch } = useCheckoutStore()
-  const { showingLogin, config } = state
+  const { setUserMetadata } = useSetUserMetadata()
+  const { showingLogin, config, showingMetadataForm, delayedPurchase } = state
 
   const {
     emitTransactionInfo,
@@ -81,6 +89,16 @@ export const CheckoutContentInner = ({
     : defaultLockAddresses
 
   const metadataRequired = config ? !!config.metadataInputs : false
+  const onMetadataSubmit = (metadata: UserMetadata) => {
+    setUserMetadata(
+      delayedPurchase!.lockAddress,
+      account!.address,
+      metadata,
+      delayedPurchase!.purchaseKey
+    )
+    dispatch(setShowingMetadataForm(false))
+  }
+
   return (
     <CheckoutContainer close={emitCloseModal}>
       <CheckoutWrapper allowClose hideCheckout={emitCloseModal}>
@@ -88,28 +106,38 @@ export const CheckoutContentInner = ({
           <title>{pageTitle('Checkout')}</title>
         </Head>
         <BrowserOnly>
-          {config && config.icon && (
-            <img alt="Publisher Icon" src={config.icon} />
-          )}
-          <p>{config ? config.callToAction.default : ''}</p>
-          {!account && showingLogin && <LogInSignUp login embedded />}
-          {!account && !showingLogin && (
-            <>
-              <NotLoggedInLocks lockAddresses={lockAddresses} />
-              <input
-                type="button"
-                onClick={() => dispatch(setShowingLogin(true))}
-                value="Log in"
-              />
-            </>
-          )}
-          {account && (
-            <Locks
-              accountAddress={account.address}
-              lockAddresses={lockAddresses}
-              emitTransactionInfo={emitTransactionInfo}
-              metadataRequired={metadataRequired}
+          {showingMetadataForm && (
+            <MetadataForm
+              fields={config!.metadataInputs!}
+              onSubmit={onMetadataSubmit}
             />
+          )}
+          {!showingMetadataForm && (
+            <>
+              {config && config.icon && (
+                <img alt="Publisher Icon" src={config.icon} />
+              )}
+              <p>{config ? config.callToAction.default : ''}</p>
+              {!account && showingLogin && <LogInSignUp login embedded />}
+              {!account && !showingLogin && (
+                <>
+                  <NotLoggedInLocks lockAddresses={lockAddresses} />
+                  <input
+                    type="button"
+                    onClick={() => dispatch(setShowingLogin(true))}
+                    value="Log in"
+                  />
+                </>
+              )}
+              {account && (
+                <Locks
+                  accountAddress={account.address}
+                  lockAddresses={lockAddresses}
+                  emitTransactionInfo={emitTransactionInfo}
+                  metadataRequired={metadataRequired}
+                />
+              )}
+            </>
           )}
         </BrowserOnly>
       </CheckoutWrapper>

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -80,6 +80,7 @@ export const CheckoutContentInner = ({
     ? Object.keys(config.locks)
     : defaultLockAddresses
 
+  const metadataRequired = config ? !!config.metadataInputs : false
   return (
     <CheckoutContainer close={emitCloseModal}>
       <CheckoutWrapper allowClose hideCheckout={emitCloseModal}>
@@ -107,6 +108,7 @@ export const CheckoutContentInner = ({
               accountAddress={account.address}
               lockAddresses={lockAddresses}
               emitTransactionInfo={emitTransactionInfo}
+              metadataRequired={metadataRequired}
             />
           )}
         </BrowserOnly>

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -19,6 +19,7 @@ interface LockProps {
   balances: Balances
   activeKeys: KeyResult[]
   accountAddress: string
+  metadataRequired?: boolean
 }
 
 export const Lock = ({

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -11,7 +11,11 @@ import { usePurchaseKey } from '../../../hooks/usePurchaseKey'
 import * as LockVariations from './LockVariations'
 import { TransactionInfo } from '../../../hooks/useCheckoutCommunication'
 import { useCheckoutStore } from '../../../hooks/useCheckoutStore'
-import { setPurchasingLockAddress } from '../../../utils/checkoutActions'
+import {
+  setPurchasingLockAddress,
+  setDelayedPurchase,
+  setShowingMetadataForm,
+} from '../../../utils/checkoutActions'
 
 interface LockProps {
   lock: RawLock
@@ -28,9 +32,15 @@ export const Lock = ({
   balances,
   activeKeys,
   accountAddress,
+  metadataRequired,
 }: LockProps) => {
   const { purchaseKey } = usePurchaseKey(emitTransactionInfo)
   const { state, dispatch } = useCheckoutStore()
+
+  const purchase = () => {
+    dispatch(setPurchasingLockAddress(lock.address))
+    purchaseKey(lock, accountAddress)
+  }
 
   const onClick = () => {
     if (state.purchasingLockAddress) {
@@ -38,8 +48,17 @@ export const Lock = ({
       return
     }
 
-    dispatch(setPurchasingLockAddress(lock.address))
-    purchaseKey(lock, accountAddress)
+    if (metadataRequired) {
+      dispatch(
+        setDelayedPurchase({
+          lockAddress: lock.address,
+          purchaseKey: purchase,
+        })
+      )
+      dispatch(setShowingMetadataForm(true))
+    } else {
+      purchase()
+    }
   }
 
   const props: LockVariations.LockProps = {

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -10,12 +10,14 @@ interface LocksProps {
   accountAddress: string
   lockAddresses: string[]
   emitTransactionInfo: (info: TransactionInfo) => void
+  metadataRequired?: boolean
 }
 
 export const Locks = ({
   lockAddresses,
   accountAddress,
   emitTransactionInfo,
+  metadataRequired,
 }: LocksProps) => {
   const { getTokenBalance, balances } = useGetTokenBalance(accountAddress)
   const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
@@ -44,6 +46,7 @@ export const Locks = ({
           balances={balances}
           activeKeys={activeKeys}
           accountAddress={accountAddress}
+          metadataRequired={metadataRequired}
         />
       ))}
     </div>

--- a/unlock-app/src/hooks/useCheckoutStore.tsx
+++ b/unlock-app/src/hooks/useCheckoutStore.tsx
@@ -1,20 +1,24 @@
 /* eslint-disable react/prop-types */
 import React, { createContext, useReducer, useContext } from 'react'
-import { PaywallConfig } from '../unlockTypes'
+import { PaywallConfig, DelayedPurchase } from '../unlockTypes'
 import { Action } from '../utils/checkoutActions'
 
 interface State {
   showingLogin: boolean
+  showingMetadataForm: boolean
   config: PaywallConfig | undefined
   purchasingLockAddress: string | undefined
   transactionHash: string | undefined
+  delayedPurchase: DelayedPurchase | undefined
 }
 
 export const defaultState: State = {
   showingLogin: false,
+  showingMetadataForm: false,
   config: undefined,
   purchasingLockAddress: undefined,
   transactionHash: undefined,
+  delayedPurchase: undefined,
 }
 
 function assertNever(x: never): never {
@@ -27,10 +31,14 @@ export function reducer(state = defaultState, action: Action): State {
       return { ...state, config: action.config }
     case 'setShowingLogin':
       return { ...state, showingLogin: action.value }
+    case 'setShowingMetadataForm':
+      return { ...state, showingMetadataForm: action.value }
     case 'setPurchasingLockAddress':
       return { ...state, purchasingLockAddress: action.address }
     case 'setTransactionHash':
       return { ...state, transactionHash: action.hash }
+    case 'setDelayedPurchase':
+      return { ...state, delayedPurchase: action.purchase }
     default:
       // Exhaustiveness check, will cause compile error if you forget to implement an action
       return assertNever(action)

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -212,3 +212,8 @@ export interface UserMetadata {
     [key: string]: string
   }
 }
+
+export interface DelayedPurchase {
+  lockAddress: string
+  purchaseKey: () => void
+}

--- a/unlock-app/src/utils/checkoutActions.ts
+++ b/unlock-app/src/utils/checkoutActions.ts
@@ -1,10 +1,12 @@
-import { PaywallConfig } from '../unlockTypes'
+import { PaywallConfig, DelayedPurchase } from '../unlockTypes'
 
 export type Action =
   | SetConfig
   | SetShowingLogin
   | SetPurchasingLockAddress
   | SetTransactionHash
+  | SetShowingMetadataForm
+  | SetDelayedPurchase
 
 interface SetConfig {
   kind: 'setConfig'
@@ -23,6 +25,18 @@ interface SetShowingLogin {
 
 export const setShowingLogin = (value: boolean): SetShowingLogin => ({
   kind: 'setShowingLogin',
+  value,
+})
+
+interface SetShowingMetadataForm {
+  kind: 'setShowingMetadataForm'
+  value: boolean
+}
+
+export const setShowingMetadataForm = (
+  value: boolean
+): SetShowingMetadataForm => ({
+  kind: 'setShowingMetadataForm',
   value,
 })
 
@@ -46,4 +60,16 @@ interface SetTransactionHash {
 export const setTransactionHash = (hash: string): SetTransactionHash => ({
   kind: 'setTransactionHash',
   hash,
+})
+
+interface SetDelayedPurchase {
+  kind: 'setDelayedPurchase'
+  purchase: DelayedPurchase
+}
+
+export const setDelayedPurchase = (
+  purchase: DelayedPurchase
+): SetDelayedPurchase => ({
+  kind: 'setDelayedPurchase',
+  purchase,
 })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

After a lot of refactoring, we're now at the point where the metadata collection flow works in the new unlock-app based checkout.

The basic idea behind this is that when metadata is required, we store a pending purchase in the state, and once the metadata has been submitted we execute the purchase.

There is more work to be done with styling on the form, but I think we can do that as a separate pass in the tasks I will create while running through the flow.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
