### PR TITLE
Bugfix on NotLoggedInLocks, hide login when accounts unavailable

### DIFF
--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -122,11 +122,13 @@ export const CheckoutContentInner = ({
               {!account && !showingLogin && (
                 <>
                   <NotLoggedInLocks lockAddresses={lockAddresses} />
-                  <input
-                    type="button"
-                    onClick={() => dispatch(setShowingLogin(true))}
-                    value="Log in"
-                  />
+                  {config && config.unlockUserAccounts && (
+                    <input
+                      type="button"
+                      onClick={() => dispatch(setShowingLogin(true))}
+                      value="Log in"
+                    />
+                  )}
                 </>
               )}
               {account && (

--- a/unlock-app/src/hooks/usePaywallLocks.ts
+++ b/unlock-app/src/hooks/usePaywallLocks.ts
@@ -38,7 +38,7 @@ export const usePaywallLocks = (
 
   useEffect(() => {
     getLocks()
-  }, [])
+  }, [lockAddresses])
 
   return { locks, loading }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR contains a bugfix on the `useEffect` in `usePaywallLocks` that prevented the component from rerendering once it got new lock addresses. Additionally, this PR hides the login button on the checkout if `unlockUserAccounts` is not set in the paywall config.

The end result is that we show a list of disabled locks when a user's account is not available, prompting them to login if user accounts are an option.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Refs #6199 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
