### PR TITLE
Making Locks component aware of user account prresence

### DIFF
--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -137,6 +137,7 @@ export const CheckoutContentInner = ({
                   lockAddresses={lockAddresses}
                   emitTransactionInfo={emitTransactionInfo}
                   metadataRequired={metadataRequired}
+                  usingUserAccounts={!!account.emailAddress}
                 />
               )}
             </>

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -11,6 +11,7 @@ interface LocksProps {
   lockAddresses: string[]
   emitTransactionInfo: (info: TransactionInfo) => void
   metadataRequired?: boolean
+  usingUserAccounts?: boolean
 }
 
 export const Locks = ({

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -39,6 +39,8 @@ export interface Transactions {
 export interface Account {
   address: string
   balance: string // TODO: Stricter balance type (enforce currency, precision)
+  // emailAddress will be present when a user account is being used, but not otherwise
+  emailAddress?: string
 }
 
 export interface Network {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This is a simple PR that just passes a prop to the `Locks` component indicating whether or not the current user is an Unlock user account.

This will be used to determine whether to show the fiat-priced locks or the crypto locks.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
