### PR TITLE
Only check transactions made in last 24 hours for optimistc unlock

### DIFF
--- a/paywall/src/__tests__/utils/optimisticUnlocking.test.js
+++ b/paywall/src/__tests__/utils/optimisticUnlocking.test.js
@@ -10,6 +10,7 @@ const savedTransactions = [
   {
     recipient: lock,
     transactionHash: '0xtransactionHash',
+    createdAt: new Date().toDateString(),
   },
   {
     recipient: lock,
@@ -19,7 +20,7 @@ const savedTransactions = [
 
 describe('optimisticUnlocking', () => {
   it('should yield true if any transaction is optimistic', async () => {
-    expect.assertions(5)
+    expect.assertions(4)
     jest
       .spyOn(OptimisticUnlocking, 'getTransactionsForUserAndLocks')
       .mockImplementationOnce(() => {
@@ -39,20 +40,12 @@ describe('optimisticUnlocking', () => {
     expect(
       OptimisticUnlocking.getTransactionsForUserAndLocks
     ).toHaveBeenCalledWith(locksmithUri, user, locks)
-    expect(OptimisticUnlocking.willUnlock).toHaveBeenCalledTimes(
-      savedTransactions.length
-    )
+    expect(OptimisticUnlocking.willUnlock).toHaveBeenCalledTimes(1)
     expect(OptimisticUnlocking.willUnlock).toHaveBeenNthCalledWith(
       1,
       user,
       lock,
       '0xtransactionHash'
-    )
-    expect(OptimisticUnlocking.willUnlock).toHaveBeenNthCalledWith(
-      2,
-      user,
-      lock,
-      '0xtransactionHash2'
     )
   })
 })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR adds a simple filter to the optimistic unlocking in the new paywall; it only checks transactions created in the last 24 hours.

Fixes #6269 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
