### PR TITLE
Use UserAccountLocks in CheckoutContent

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/UserAccountLocks.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/UserAccountLocks.test.tsx
@@ -15,7 +15,7 @@ const lock = {
 
 const prices = {
   [lock.address]: {
-    usd: '12.33',
+    usd: '1233',
   },
 }
 

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -7,6 +7,7 @@ import { pageTitle } from '../../constants'
 import LogInSignUp from '../interface/LogInSignUp'
 import { Locks } from '../interface/checkout/Locks'
 import { NotLoggedInLocks } from '../interface/checkout/NotLoggedInLocks'
+import { UserAccountLocks } from '../interface/checkout/UserAccountLocks'
 import CheckoutWrapper from '../interface/checkout/CheckoutWrapper'
 import CheckoutContainer from '../interface/checkout/CheckoutContainer'
 import { MetadataForm } from '../interface/checkout/MetadataForm'
@@ -130,14 +131,16 @@ export const CheckoutContentInner = ({
                   )}
                 </>
               )}
-              {account && (
+              {account && !account.emailAddress && (
                 <Locks
                   accountAddress={account.address}
                   lockAddresses={lockAddresses}
                   emitTransactionInfo={emitTransactionInfo}
                   metadataRequired={metadataRequired}
-                  usingUserAccounts={!!account.emailAddress}
                 />
+              )}
+              {account && account.emailAddress && (
+                <UserAccountLocks lockAddresses={lockAddresses} />
               )}
             </>
           )}

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -11,7 +11,6 @@ interface LocksProps {
   lockAddresses: string[]
   emitTransactionInfo: (info: TransactionInfo) => void
   metadataRequired?: boolean
-  usingUserAccounts?: boolean
 }
 
 export const Locks = ({

--- a/unlock-app/src/components/interface/checkout/UserAccountLocks.tsx
+++ b/unlock-app/src/components/interface/checkout/UserAccountLocks.tsx
@@ -15,6 +15,7 @@ interface LocksProps {
 
 export const renderLock = (lock: RawLock, prices: KeyPrices) => {
   if (prices[lock.address]) {
+    // prices returned from locksmith are in cents
     const basePrice = parseInt(prices[lock.address].usd)
     const formattedPrice = (basePrice / 100).toFixed(2)
     const fiatPrice = `$${formattedPrice}`

--- a/unlock-app/src/components/interface/checkout/UserAccountLocks.tsx
+++ b/unlock-app/src/components/interface/checkout/UserAccountLocks.tsx
@@ -15,7 +15,9 @@ interface LocksProps {
 
 export const renderLock = (lock: RawLock, prices: KeyPrices) => {
   if (prices[lock.address]) {
-    const fiatPrice = `$${prices[lock.address].usd}`
+    const basePrice = parseInt(prices[lock.address].usd)
+    const formattedPrice = (basePrice / 100).toFixed(2)
+    const fiatPrice = `$${formattedPrice}`
     return (
       <DisabledLock
         key={lock.name}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR integrates the new UserAccountLocks component in the checkout page so that users will see fiat prices on locks that have been approved for credit card purchase.

Before login
<img width="439" alt="image" src="https://user-images.githubusercontent.com/9300702/77098834-5f933200-69e9-11ea-9d1d-14d5826b5cfe.png">

After login
<img width="410" alt="image" src="https://user-images.githubusercontent.com/9300702/77099138-d5979900-69e9-11ea-8c67-f64ce91bb94c.png">

Fiat locks are always disabled at the moment, but the next step is to implement a purchasable lock.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
