### PR TITLE
Introducing the ability to have a hard coded glbal paywall configuration

### DIFF
--- a/unlock-app/src/__tests__/utils/getConfigFromDom.test.js
+++ b/unlock-app/src/__tests__/utils/getConfigFromDom.test.js
@@ -1,0 +1,49 @@
+import getConfigFromDom from '../../utils/getConfigFromDom'
+
+const lock = '0x1234567890123456789012345678901234567890'
+const validConfig = {
+  callToAction: {
+    default: 'hi',
+    expired: 'there',
+    pending: 'pending',
+    confirmed: 'confirmed',
+  },
+  locks: {
+    [lock]: {
+      name: 'A Lock',
+    },
+  },
+  icon: 'http://image.com/image.tiff',
+}
+
+describe('getConfigFromDom', () => {
+  afterEach(() => {
+    delete global.__unlockPaywalConfig__
+  })
+
+  it('should be undefined if there is no paywall config', () => {
+    expect.assertions(1)
+
+    expect(getConfigFromDom()).toBeUndefined()
+  })
+
+  it('should be undefined if paywall config does not pass validation', () => {
+    expect.assertions(1)
+
+    global.__unlockPaywalConfig__ = { not: 'a valid config' }
+
+    expect(getConfigFromDom()).toBeUndefined()
+  })
+
+  it('should return a paywall config otherwise', () => {
+    expect.assertions(1)
+
+    global.__unlockPaywalConfig__ = validConfig
+
+    expect(getConfigFromDom()).toEqual(
+      expect.objectContaining({
+        icon: 'http://image.com/image.tiff',
+      })
+    )
+  })
+})

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -19,6 +19,7 @@ import {
   UserMetadata,
 } from '../../unlockTypes'
 import getConfigFromSearch from '../../utils/getConfigFromSearch'
+import getConfigFromDom from '../../utils/getConfigFromDom'
 import { useCheckoutCommunication } from '../../hooks/useCheckoutCommunication'
 import {
   useCheckoutStore,
@@ -34,7 +35,7 @@ import { useSetUserMetadata } from '../../hooks/useSetUserMetadata'
 
 interface CheckoutContentProps {
   account: AccountType
-  configFromSearch?: PaywallConfig
+  defaultConfig?: PaywallConfig
 }
 
 const defaultLockAddresses: string[] = []
@@ -42,21 +43,18 @@ const defaultLockAddresses: string[] = []
 // This component wraps CheckoutContentInner so that it has access to the store.
 export const CheckoutContent = ({
   account,
-  configFromSearch,
+  defaultConfig,
 }: CheckoutContentProps) => {
   return (
     <CheckoutStoreProvider>
-      <CheckoutContentInner
-        account={account}
-        configFromSearch={configFromSearch}
-      />
+      <CheckoutContentInner account={account} defaultConfig={defaultConfig} />
     </CheckoutStoreProvider>
   )
 }
 
 export const CheckoutContentInner = ({
   account,
-  configFromSearch,
+  defaultConfig,
 }: CheckoutContentProps) => {
   const { state, dispatch } = useCheckoutStore()
   const { setUserMetadata } = useSetUserMetadata()
@@ -81,10 +79,10 @@ export const CheckoutContentInner = ({
   }, [account])
 
   useEffect(() => {
-    if (!config && configFromSearch) {
-      dispatch(setConfig(configFromSearch))
+    if (!config && defaultConfig) {
+      dispatch(setConfig(defaultConfig))
     }
-  }, [configFromSearch])
+  }, [defaultConfig])
 
   const lockAddresses = config
     ? Object.keys(config.locks)
@@ -159,10 +157,11 @@ export const mapStateToProps = ({ account, router }: ReduxState) => {
   const search = queryString.parse(router.location.search)
 
   const configFromSearch = getConfigFromSearch(search)
+  const configFromDom = getConfigFromDom()
 
   return {
     account,
-    configFromSearch,
+    defaultConfig: configFromSearch || configFromDom,
   }
 }
 

--- a/unlock-app/src/utils/getConfigFromDom.ts
+++ b/unlock-app/src/utils/getConfigFromDom.ts
@@ -1,0 +1,24 @@
+import { PaywallConfig } from '../unlockTypes'
+import { isValidPaywallConfig } from './checkoutValidators'
+/* eslint-disable no-console */
+
+export interface WindowWithPaywallConfig {
+  __unlockPaywalConfig__?: PaywallConfig
+}
+
+export default function getConfigFromDom(): PaywallConfig | undefined {
+  if (!window || !(window as WindowWithPaywallConfig).__unlockPaywalConfig__) {
+    return undefined
+  }
+
+  if (
+    !isValidPaywallConfig(
+      (window as WindowWithPaywallConfig).__unlockPaywalConfig__
+    )
+  ) {
+    return undefined
+  }
+
+  return (window as WindowWithPaywallConfig)
+    .__unlockPaywalConfig__ as PaywallConfig
+}


### PR DESCRIPTION
# Description

As I was experimenting with Cloudflare, I found that our current checkout approach was lacking in one specific use case: it requires to be set-up by the front end at "runtime".

With the Cloudflare worker approach (or any proxy approach rely), we may want to "render" the checkout, without the ability to pass the configuration via a query string, or via post message.

This PR adds the ability to use a a global `__unlockPaywalConfig__` variable.
The Cloudflare worker will be able to _inject_ this in the markup letting the checkout config run.

This is fairly experimental work, so I am not documenting this yet.

Another PR will add the ability to set a cookie to store the user information.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

s# ------------------------ >8 ------------------------
# Do not modify or remove the line above.
# Everything below it will be ignored.

Requesting a pull to unlock-protocol:master from unlock-protocol:julien-unlockAppQueryString

Write a message for this pull request. The first block
of text is the title and the rest is the description.