### PR TITLE
Communication via cookies

### DIFF
--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -74,6 +74,7 @@
     "styled-components": "5.0.1",
     "ts-jest": "25.2.1",
     "typescript": "3.8.3",
+    "universal-cookie": "4.0.3",
     "validator": "12.2.0"
   },
   "devDependencies": {

--- a/unlock-app/src/__tests__/hooks/useCheckoutCommunication.test.ts
+++ b/unlock-app/src/__tests__/hooks/useCheckoutCommunication.test.ts
@@ -5,16 +5,24 @@ import {
   CheckoutEvents,
 } from '../../hooks/useCheckoutCommunication'
 
-let emit = jest.fn()
+const mockCookies = {
+  set: jest.fn(),
+}
 
+jest.mock('universal-cookie', () => {
+  return () => mockCookies
+})
+
+let emit = jest.fn()
 describe('useCheckoutCommunication', () => {
   beforeEach(() => {
     emit = jest.fn()
     jest.spyOn(Postmate, 'Model').mockResolvedValue({ emit })
+    mockCookies.set = jest.fn()
   })
 
   it('emits a userInfo event when emitUserInfo is called', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     const { result, wait } = renderHook(() => useCheckoutCommunication())
 
@@ -24,10 +32,14 @@ describe('useCheckoutCommunication', () => {
     result.current.emitUserInfo(userInfo)
 
     expect(emit).toHaveBeenCalledWith(CheckoutEvents.userInfo, userInfo)
+    expect(mockCookies.set).toHaveBeenCalledWith(
+      '__unlockCookie__checkout.userInfo__',
+      userInfo
+    )
   })
 
   it('emits a closeModal event when emitCloseModal is called', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     const { result, wait } = renderHook(() => useCheckoutCommunication())
 
@@ -40,10 +52,14 @@ describe('useCheckoutCommunication', () => {
     // isn't one. This has no impact on real code, since only the
     // event name is important in this case.
     expect(emit).toHaveBeenCalledWith(CheckoutEvents.closeModal, undefined)
+    expect(mockCookies.set).toHaveBeenCalledWith(
+      '__unlockCookie__checkout.closeModal__',
+      undefined
+    )
   })
 
   it('emits a transactionInfo event when emitTransactionInfo is called', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     const { result, wait } = renderHook(() => useCheckoutCommunication())
 
@@ -54,6 +70,10 @@ describe('useCheckoutCommunication', () => {
 
     expect(emit).toHaveBeenCalledWith(
       CheckoutEvents.transactionInfo,
+      transactionInfo
+    )
+    expect(mockCookies.set).toHaveBeenCalledWith(
+      '__unlockCookie__checkout.transactionInfo__',
       transactionInfo
     )
   })

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import Cookies from 'universal-cookie'
 import { usePostmateParent } from './usePostmateParent'
 
 export interface UserInfo {
@@ -29,12 +30,15 @@ interface BufferedEvent {
 // buffer. After that, once the handle to the parent is available, all
 // the buffered events are emitted and future events are emitted
 // directly.
+// Communication also happens thru setting a cookie
+// Which is useful in the context of proxying where the checkout window is
+// not displayed in an iframe but as the main window.
 export const useCheckoutCommunication = (model?: any) => {
   const [buffer, setBuffer] = useState([] as BufferedEvent[])
   const parent = usePostmateParent(model)
-
   const pushOrEmit = (kind: CheckoutEvents, payload?: Payload) => {
-    // Set the cookie too!
+    const cookies = new Cookies()
+    cookies.set(`__unlockCookie__${kind}__`, payload)
     if (!parent) {
       setBuffer([...buffer, { kind, payload }])
     } else {

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -34,6 +34,7 @@ export const useCheckoutCommunication = (model?: any) => {
   const parent = usePostmateParent(model)
 
   const pushOrEmit = (kind: CheckoutEvents, payload?: Payload) => {
+    // Set the cookie too!
     if (!parent) {
       setBuffer([...buffer, { kind, payload }])
     } else {

--- a/unlock-app/yarn.lock
+++ b/unlock-app/yarn.lock
@@ -3422,6 +3422,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/decompress@*":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/decompress/-/decompress-4.2.3.tgz#98eed48af80001038aa05690b2094915f296fe65"
@@ -3581,6 +3586,11 @@
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@types/npmlog/-/npmlog-4.1.2.tgz#d070fe6a6b78755d1092a3dc492d34c3d8f871c4"
   integrity sha512-4QQmOF5KlwfxJ5IGXFIudkeLCdMABz03RcUXu+LCb24zmln8QW6aDjuGl4d4XPVLf2j+FnjelHTP7dvceAFbhA==
+
+"@types/object-assign@^4.0.30":
+  version "4.0.30"
+  resolved "https://registry.yarnpkg.com/@types/object-assign/-/object-assign-4.0.30.tgz#8949371d5a99f4381ee0f1df0a9b7a187e07e652"
+  integrity sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI=
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -17317,6 +17327,16 @@ unique-string@^2.0.0:
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+universal-cookie@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.3.tgz#c2fa59127260e6ad21ef3e0cdd66ad453cbc41f6"
+  integrity sha512-YbEHRs7bYOBTIWedTR9koVEe2mXrq+xdjTJZcoKJK/pQaE6ni28ak2AKXFpevb+X6w3iU5SXzWDiJkmpDRb9qw==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    "@types/object-assign" "^4.0.30"
+    cookie "^0.4.0"
+    object-assign "^4.1.1"
 
 universal-user-agent@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Description

In the context of a proxy based approach, we cannot use postMessage communications... but we can use cookies!

I am not yet 100% sure this is the right appoach. Maybe we can just *inject* a window listener at the proxy level which would perform the actions the user intends?

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->