### PR TITLE
Fix `getApproved` reverts to match spec

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -473,7 +473,14 @@ contract IPublicLock
      */
     function transferFrom(address from, address to, uint256 tokenId) public;
     function approve(address to, uint256 tokenId) public;
-    function getApproved(uint256 tokenId) public view returns (address operator);
+
+    /**
+    * @notice Get the approved address for a single NFT
+    * @dev Throws if `_tokenId` is not a valid NFT.
+    * @param _tokenId The NFT to find the approved address for
+    * @return The approved address for this NFT, or the zero address if there is none
+    */
+    function getApproved(uint256 _tokenId) public view returns (address operator);
 
     function setApprovalForAll(address operator, bool _approved) public;
     function isApprovedForAll(address _owner, address operator) public view returns (bool);

--- a/smart-contracts/contracts/mixins/MixinApproval.sol
+++ b/smart-contracts/contracts/mixins/MixinApproval.sol
@@ -82,15 +82,18 @@ contract MixinApproval is
   }
 
   /**
-   * Will return the approved recipient for a key, if any.
+   * @notice Get the approved address for a single NFT
+   * @dev Throws if `_tokenId` is not a valid NFT.
+   * @param _tokenId The NFT to find the approved address for
+   * @return The approved address for this NFT, or the zero address if there is none
    */
   function getApproved(
     uint _tokenId
   ) public view
+    isKey(_tokenId)
     returns (address)
   {
     address approvedRecipient = approved[_tokenId];
-    require(approvedRecipient != address(0), 'NONE_APPROVED');
     return approvedRecipient;
   }
 

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -1,3 +1,4 @@
+const { constants } = require('hardlydifficult-ethereum-contracts')
 const { reverts } = require('truffle-assertions')
 const deployLocks = require('../../helpers/deployLocks')
 
@@ -112,7 +113,10 @@ contract('Lock / erc721 / approve', accounts => {
         })
 
         it('The zero address indicates there is no approved address', async () => {
-          await reverts(locks.FIRST.getApproved.call(ID), 'NONE_APPROVED')
+          assert.equal(
+            await locks.FIRST.getApproved.call(ID),
+            constants.ZERO_ADDRESS
+          )
         })
       })
     })

--- a/smart-contracts/test/Lock/erc721/getApproved.js
+++ b/smart-contracts/test/Lock/erc721/getApproved.js
@@ -5,27 +5,14 @@ const unlockContract = artifacts.require('Unlock.sol')
 const getProxy = require('../../helpers/proxy')
 
 let locks
-let ID
 
 contract('Lock / erc721 / getApproved', accounts => {
-  const keyPurchaser = accounts[3]
-
   before(async () => {
     this.unlock = await getProxy(unlockContract)
     locks = await deployLocks(this.unlock, accounts[0])
   })
 
-  before(async () => {
-    await locks.FIRST.purchase(0, keyPurchaser, web3.utils.padLeft(0, 40), [], {
-      value: web3.utils.toWei('0.01', 'ether'),
-      from: keyPurchaser,
-    })
-    ID = await locks.FIRST.getTokenIdFor.call(keyPurchaser)
-  })
-
-  describe('getApproved', () => {
-    it('should fail if no one was approved for a key', async () => {
-      await reverts(locks.FIRST.getApproved.call(ID), 'NONE_APPROVED')
-    })
+  it('should fail if the key does not exist', async () => {
+    await reverts(locks.FIRST.getApproved.call(42), 'NO_SUCH_KEY')
   })
 })

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -237,10 +237,7 @@ contract('Lock / erc721 / transferFrom', accounts => {
       })
 
       it('approval should be cleared after a transfer', async () => {
-        assert.equal(
-          await locks.FIRST.getApproved(accountApproved),
-          constants.ZERO_ADDRESS
-        )
+        assert.equal(await locks.FIRST.getApproved(ID), constants.ZERO_ADDRESS)
       })
     })
 

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -1,5 +1,6 @@
 const BigNumber = require('bignumber.js')
 
+const { constants } = require('hardlydifficult-ethereum-contracts')
 const { reverts } = require('truffle-assertions')
 const deployLocks = require('../../helpers/deployLocks')
 
@@ -236,7 +237,10 @@ contract('Lock / erc721 / transferFrom', accounts => {
       })
 
       it('approval should be cleared after a transfer', async () => {
-        await reverts(locks.FIRST.getApproved(accountApproved), 'NONE_APPROVED')
+        assert.equal(
+          await locks.FIRST.getApproved(accountApproved),
+          constants.ZERO_ADDRESS
+        )
       })
     })
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Switching requires on `getApproved` to match the ERC-721 spec. I also added the comment from the spec.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #6299
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
