### PR TITLE
Pull provider correctly in useProvider

### DIFF
--- a/unlock-app/src/__tests__/hooks/useProvider.test.ts
+++ b/unlock-app/src/__tests__/hooks/useProvider.test.ts
@@ -1,9 +1,23 @@
 import { renderHook } from '@testing-library/react-hooks'
 import * as Redux from 'react-redux'
+import React from 'react'
 import { useProvider } from '../../hooks/useProvider'
+import { ConfigContext } from '../../utils/withConfig'
 
-jest.spyOn(Redux, 'useSelector').mockImplementation(() => {
-  return {}
+jest.spyOn(Redux, 'useSelector').mockImplementation(selector => {
+  return selector({
+    provider: 'Unlock',
+  })
+})
+
+jest.spyOn(React, 'useContext').mockImplementation(context => {
+  if (context === ConfigContext) {
+    return {
+      providers: {
+        Unlock: {},
+      },
+    }
+  }
 })
 
 describe('useProvider', () => {

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -1,13 +1,24 @@
 import { useSelector } from 'react-redux'
+import { useContext } from 'react'
 import UnlockProvider from '../services/unlockProvider'
+import { ConfigContext } from '../utils/withConfig'
 
 type Provider = UnlockProvider | null
+
 interface State {
-  provider: Provider
+  provider: string
+}
+
+interface Config {
+  providers: {
+    [name: string]: Provider
+  }
 }
 
 export const useProvider = () => {
-  const provider = useSelector<State, Provider>(state => state.provider)
+  const config: Config = useContext(ConfigContext)
+  const providerName = useSelector<State, string>(state => state.provider)
+  const provider = config.providers[providerName]
 
   return { provider }
 }

--- a/unlock-app/src/hooks/useUserAccountsPurchaseKey.ts
+++ b/unlock-app/src/hooks/useUserAccountsPurchaseKey.ts
@@ -24,9 +24,11 @@ export const useUserAccountsPurchaseKey = (
   const purchaseKey = async (lock: RawLock, accountAddress: string) => {
     const { data, sig } = provider!.signKeyPurchaseRequestData({
       recipient: accountAddress,
-      lockAddress: lock.address,
+      lock: lock.address,
     })
+
     const transactionHash = await storageService.purchaseKey(data, btoa(sig))
+
     dispatch(setTransactionHash(transactionHash))
     emitTransactionInfo({
       hash: transactionHash,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

The previous iteration of `useProvider` actually just got the _name_ of the provider from the state. This PR updates it to use that name to get the _actual_ provider out of the config.

Additionally, this PR corrects a misnamed property in the purchase request typed data, which now allows user account purchases to proceed.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
