### PR TITLE
does not unlock optimistically transactions which have been mined

### DIFF
--- a/paywall/src/__tests__/paywall-script/index.test.ts
+++ b/paywall/src/__tests__/paywall-script/index.test.ts
@@ -2,6 +2,10 @@ import { Paywall } from '../../paywall-script/index'
 import * as timeStampUtil from '../../utils/keyExpirationTimestampFor'
 import * as optimisticUnlockingUtils from '../../utils/optimisticUnlocking'
 
+declare let __ENVIRONMENT_VARIABLES__: any
+// eslint-disable-next-line no-undef
+const { readOnlyProvider } = __ENVIRONMENT_VARIABLES__
+
 const paywallConfig = {
   callToAction: {
     default: 'default',
@@ -108,6 +112,7 @@ describe('Paywall init script', () => {
       jest
         .spyOn(optimisticUnlockingUtils, 'willUnlock')
         .mockResolvedValueOnce(true)
+
       paywall.unlockPage = jest.fn()
 
       await paywall.handleTransactionInfoEvent({
@@ -115,9 +120,11 @@ describe('Paywall init script', () => {
         lock: '0xlock',
       })
       expect(optimisticUnlockingUtils.willUnlock).toHaveBeenCalledWith(
+        readOnlyProvider,
         undefined,
         '0xlock',
-        '0xhash'
+        '0xhash',
+        true
       )
       expect(paywall.unlockPage).toHaveBeenCalled()
     })

--- a/paywall/src/__tests__/utils/getTransactionState.js
+++ b/paywall/src/__tests__/utils/getTransactionState.js
@@ -1,0 +1,46 @@
+import { getTransaction } from '../../utils/getTransaction'
+
+const jsonRpcEndpoint = 'https://eth-mainnet.alchemyapi.io/jsonrpc/'
+const transactionHash =
+  '0x85425ab32389a05426ca92934305b500f6a97aa102be99f9b7a65e65853773aa'
+const rpcTransaction = {
+  blockNumber: '0x5e7300',
+}
+
+describe('getTransaction', () => {
+  it('should make the right request', async () => {
+    expect.assertions(6)
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        result: rpcTransaction,
+        id: 1773,
+      })
+    )
+    const expiration = await getTransaction(jsonRpcEndpoint, transactionHash)
+    expect(expiration).toEqual(rpcTransaction)
+    expect(fetch.mock.calls.length).toEqual(1)
+    expect(fetch.mock.calls[0][0]).toEqual(jsonRpcEndpoint)
+    expect(fetch.mock.calls[0][1].method).toEqual('POST')
+    const body = JSON.parse(fetch.mock.calls[0][1].body)
+    expect(body).toMatchObject({
+      jsonrpc: '2.0',
+      method: 'eth_getTransactionByHash',
+    })
+    const params = body.params
+    expect(params[0]).toEqual(transactionHash)
+  })
+
+  it('should return null if the transaction does not exist', async () => {
+    expect.assertions(1)
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        result: null,
+        id: 1773,
+      })
+    )
+    const expiration = await getTransaction(jsonRpcEndpoint, transactionHash)
+    expect(expiration).toEqual(null)
+  })
+})

--- a/paywall/src/utils/getTransaction.ts
+++ b/paywall/src/utils/getTransaction.ts
@@ -1,0 +1,26 @@
+/**
+ * Gets a transaction from the RPC endpoint
+ * @param provider
+ * @param transactionHash
+ */
+export const getTransaction = async (
+  provider: string,
+  transactionHash: string
+) => {
+  const rpcRequest = {
+    method: 'eth_getTransactionByHash',
+    params: [transactionHash],
+    id: 1337, // Not used here
+    jsonrpc: '2.0',
+  }
+
+  const response = await fetch(provider, {
+    method: 'POST',
+    body: JSON.stringify(rpcRequest),
+  })
+
+  const body = await response.json()
+  return body.result
+}
+
+export default getTransaction


### PR DESCRIPTION
# Description

We will now only be optimitic for transactions which have not been mined yet.
Once the transaction has been minedm, we should not consider is likely to yield a key.

# Issues

Fixes #6313

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->