### PR TITLE
isolated isUnlocked logic in its own file

### DIFF
--- a/paywall/src/__tests__/utils/isUnlocked.test.js
+++ b/paywall/src/__tests__/utils/isUnlocked.test.js
@@ -1,0 +1,99 @@
+import { isUnlocked } from '../../utils/isUnlocked'
+import * as optimisticUtil from '../../utils/optimisticUnlocking'
+import * as timeStampUtil from '../../utils/keyExpirationTimestampFor'
+
+const {
+  readOnlyProvider,
+  locksmithUri,
+} = __ENVIRONMENT_VARIABLES__ /* eslint no-undef: 0 */
+
+const userAccountAddress = '0xUser'
+const paywallConfig = {
+  callToAction: {
+    default: 'default',
+    expired: 'expired',
+    pending: 'pending',
+    confirmed: 'confirmed',
+  },
+  locks: {
+    '0x1234567890123456789012345678901234567890': {
+      name: 'A Lock',
+    },
+    '0x7C5af12cFcbAAd7893351B41a6DF251d67fD310D': {
+      name: 'Another Lock',
+    },
+  },
+  icon: 'http://com.com/image.tiff',
+}
+
+describe('isUnlocked', () => {
+  describe('when the user has a valid key to any of the locks', () => {
+    it('should check each locks', async () => {
+      expect.assertions(4)
+      const futureTime = new Date().getTime() / 1000 + 50000
+      const spy = jest
+        .spyOn(timeStampUtil, 'keyExpirationTimestampFor')
+        .mockResolvedValue(futureTime)
+
+      const unlocked = await isUnlocked(userAccountAddress, paywallConfig)
+      expect(unlocked).toBe(true)
+
+      expect(spy).toHaveBeenCalledTimes(2)
+      expect(spy).toHaveBeenNthCalledWith(
+        1,
+        readOnlyProvider,
+        Object.keys(paywallConfig.locks)[0],
+        userAccountAddress
+      )
+      expect(spy).toHaveBeenNthCalledWith(
+        2,
+        readOnlyProvider,
+        Object.keys(paywallConfig.locks)[1],
+        userAccountAddress
+      )
+    })
+  })
+
+  describe('when the user does not have a valid key to any of the locks', () => {
+    beforeEach(() => {
+      const pastTime = new Date().getTime() / 1000 - 50000
+      jest
+        .spyOn(timeStampUtil, 'keyExpirationTimestampFor')
+        .mockResolvedValue(pastTime)
+    })
+    describe('when the user has a pending transaction for which we should be optimistic', () => {
+      it('should return true', async () => {
+        expect.assertions(2)
+        const spy = jest
+          .spyOn(optimisticUtil, 'optimisticUnlocking')
+          .mockResolvedValue(true)
+
+        const unlocked = await isUnlocked(userAccountAddress, paywallConfig)
+        expect(unlocked).toBe(true)
+        expect(spy).toHaveBeenCalledWith(
+          readOnlyProvider,
+          locksmithUri,
+          Object.keys(paywallConfig.locks),
+          userAccountAddress
+        )
+      })
+    })
+    describe('when the user does not have an optimistic pending transaction', () => {
+      it('should return false', async () => {
+        expect.assertions(2)
+        const spy = jest
+          .spyOn(optimisticUtil, 'optimisticUnlocking')
+          .mockResolvedValue(false)
+
+        const unlocked = await isUnlocked(userAccountAddress, paywallConfig)
+        expect(unlocked).toBe(false)
+        expect(spy).toHaveBeenCalledWith(
+          readOnlyProvider,
+          locksmithUri,
+          Object.keys(paywallConfig.locks),
+          userAccountAddress
+        )
+      })
+    })
+  })
+})

--- a/paywall/src/utils/isUnlocked.ts
+++ b/paywall/src/utils/isUnlocked.ts
@@ -1,0 +1,53 @@
+import { keyExpirationTimestampFor } from './keyExpirationTimestampFor'
+import { optimisticUnlocking } from './optimisticUnlocking'
+
+declare let __ENVIRONMENT_VARIABLES__: {
+  readOnlyProvider: string
+  locksmithUri: string
+}
+
+/**
+ * A function which, given a user account, a paywall config will return a boolean
+ * to indicate whether the user has Unlocked any of the locks.
+ * It will first check for the existence of keys, and if no valid one has been found
+ * it will check for pending transactions which might be optimistic.
+ */
+export const isUnlocked = async (
+  userAccountAddress: string,
+  paywallConfig: any
+): Promise<boolean> => {
+  const { readOnlyProvider, locksmithUri } = __ENVIRONMENT_VARIABLES__
+
+  const lockAddresses = Object.keys(paywallConfig.locks)
+  const timeStamps = await Promise.all(
+    lockAddresses.map(lockAddress => {
+      return keyExpirationTimestampFor(
+        readOnlyProvider,
+        lockAddress,
+        userAccountAddress!
+      )
+    })
+  )
+
+  // If any key is valid, we unlock the page
+  if (timeStamps.some(val => val > new Date().getTime() / 1000)) {
+    return true
+  }
+
+  // If not key exists on chain, let's see if we can be optimistic before locking the page.
+  const optimistic = await optimisticUnlocking(
+    readOnlyProvider,
+    locksmithUri,
+    Object.keys(paywallConfig.locks),
+    userAccountAddress!
+  )
+  if (optimistic) {
+    return true
+  }
+
+  // If no key exists, or no transaction exists which could be optimistic, we lock
+  return false
+}
+export default {
+  isUnlocked,
+}


### PR DESCRIPTION
# Description

Isolating the logic to "retrieve" the state of a paywall (locked or unlocked).
This is the first step to "modularize" the paywall!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread