### PR TITLE
adding isLockManager method

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+# 0.9.2
+- Adding isLockManager function to web3Service
+
 # 0.9.1
 - Replaced owner with beneficiary for locks
 

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/integration/walletServiceIntegration.test.js
+++ b/unlock-js/src/__tests__/integration/walletServiceIntegration.test.js
@@ -30,7 +30,7 @@ let accounts
 
 // Tests
 describe('Wallet Service Integration', () => {
-  const versions = ['v0'] // ['v0', 'v01', 'v02', 'v10', 'v11', 'v12', 'v13', 'v7']
+  const versions = ['v0', 'v01', 'v02', 'v10', 'v11', 'v12', 'v13', 'v7']
   describe.each(versions)('%s', versionName => {
     let walletService
     let web3Service

--- a/unlock-js/src/__tests__/integration/walletServiceIntegration.test.js
+++ b/unlock-js/src/__tests__/integration/walletServiceIntegration.test.js
@@ -30,7 +30,7 @@ let accounts
 
 // Tests
 describe('Wallet Service Integration', () => {
-  const versions = ['v0', 'v01', 'v02', 'v10', 'v11', 'v12', 'v13', 'v7']
+  const versions = ['v0'] // ['v0', 'v01', 'v02', 'v10', 'v11', 'v12', 'v13', 'v7']
   describe.each(versions)('%s', versionName => {
     let walletService
     let web3Service
@@ -173,6 +173,15 @@ describe('Wallet Service Integration', () => {
           expect(lock.currencyContractAddress).toEqual(
             lockParams.currencyContractAddress
           )
+        })
+
+        it('should have set the creator as a lock manager', async () => {
+          expect.assertions(1)
+          const isLockManager = await web3Service.isLockManager(
+            lockAddress,
+            accounts[0]
+          )
+          expect(isLockManager).toBe(true)
         })
 
         it('should have deployed a lock to the right beneficiary', () => {

--- a/unlock-js/src/__tests__/v0/isLockManager.test.js
+++ b/unlock-js/src/__tests__/v0/isLockManager.test.js
@@ -1,0 +1,51 @@
+import v0 from '../../v0'
+
+import Web3Service from '../../web3Service'
+import { getTestLockContract } from '../helpers/contracts'
+import { getTestProvider } from '../helpers/provider'
+
+const provider = getTestProvider({})
+
+const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
+const owner = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+
+const lockContract = getTestLockContract({
+  lockAddress,
+  abi: v0.PublicLock.abi,
+  provider,
+})
+
+let web3Service
+
+describe('v0', () => {
+  describe('isLockManager', () => {
+    beforeEach(() => {
+      web3Service = new Web3Service({
+        readOnlyProvider: '',
+        network: 1984,
+      })
+
+      web3Service.lockContractAbiVersion = jest.fn(() => Promise.resolve(v0))
+      web3Service.getLockContract = jest.fn(() => Promise.resolve(lockContract))
+      lockContract.owner = jest.fn(() => {
+        return owner
+      })
+    })
+
+    it('should return true if the user is the owner', async () => {
+      expect.assertions(2)
+      const isLockManager = await web3Service.isLockManager(lockAddress, owner)
+      expect(isLockManager).toBe(true)
+      expect(lockContract.owner).toHaveBeenCalledWith()
+    })
+
+    it('should return false if the user is not the owner', async () => {
+      expect.assertions(1)
+      const isLockManager = await web3Service.isLockManager(
+        lockAddress,
+        '0xSomeoneElse'
+      )
+      expect(isLockManager).toBe(false)
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v01/isLockManager.test.js
+++ b/unlock-js/src/__tests__/v01/isLockManager.test.js
@@ -1,0 +1,51 @@
+import v01 from '../../v01'
+
+import Web3Service from '../../web3Service'
+import { getTestLockContract } from '../helpers/contracts'
+import { getTestProvider } from '../helpers/provider'
+
+const provider = getTestProvider({})
+
+const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
+const owner = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+
+const lockContract = getTestLockContract({
+  lockAddress,
+  abi: v01.PublicLock.abi,
+  provider,
+})
+
+let web3Service
+
+describe('v01', () => {
+  describe('isLockManager', () => {
+    beforeEach(() => {
+      web3Service = new Web3Service({
+        readOnlyProvider: '',
+        network: 1984,
+      })
+
+      web3Service.lockContractAbiVersion = jest.fn(() => Promise.resolve(v01))
+      web3Service.getLockContract = jest.fn(() => Promise.resolve(lockContract))
+      lockContract.owner = jest.fn(() => {
+        return owner
+      })
+    })
+
+    it('should return true if the user is the owner', async () => {
+      expect.assertions(2)
+      const isLockManager = await web3Service.isLockManager(lockAddress, owner)
+      expect(isLockManager).toBe(true)
+      expect(lockContract.owner).toHaveBeenCalledWith()
+    })
+
+    it('should return false if the user is not the owner', async () => {
+      expect.assertions(1)
+      const isLockManager = await web3Service.isLockManager(
+        lockAddress,
+        '0xSomeoneElse'
+      )
+      expect(isLockManager).toBe(false)
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v02/isLockManager.test.js
+++ b/unlock-js/src/__tests__/v02/isLockManager.test.js
@@ -1,0 +1,51 @@
+import v02 from '../../v02'
+
+import Web3Service from '../../web3Service'
+import { getTestLockContract } from '../helpers/contracts'
+import { getTestProvider } from '../helpers/provider'
+
+const provider = getTestProvider({})
+
+const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
+const owner = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+
+const lockContract = getTestLockContract({
+  lockAddress,
+  abi: v02.PublicLock.abi,
+  provider,
+})
+
+let web3Service
+
+describe('v02', () => {
+  describe('isLockManager', () => {
+    beforeEach(() => {
+      web3Service = new Web3Service({
+        readOnlyProvider: '',
+        network: 1984,
+      })
+
+      web3Service.lockContractAbiVersion = jest.fn(() => Promise.resolve(v02))
+      web3Service.getLockContract = jest.fn(() => Promise.resolve(lockContract))
+      lockContract.owner = jest.fn(() => {
+        return owner
+      })
+    })
+
+    it('should return true if the user is the owner', async () => {
+      expect.assertions(2)
+      const isLockManager = await web3Service.isLockManager(lockAddress, owner)
+      expect(isLockManager).toBe(true)
+      expect(lockContract.owner).toHaveBeenCalledWith()
+    })
+
+    it('should return false if the user is not the owner', async () => {
+      expect.assertions(1)
+      const isLockManager = await web3Service.isLockManager(
+        lockAddress,
+        '0xSomeoneElse'
+      )
+      expect(isLockManager).toBe(false)
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v10/isLockManager.test.js
+++ b/unlock-js/src/__tests__/v10/isLockManager.test.js
@@ -1,0 +1,51 @@
+import v10 from '../../v10'
+
+import Web3Service from '../../web3Service'
+import { getTestLockContract } from '../helpers/contracts'
+import { getTestProvider } from '../helpers/provider'
+
+const provider = getTestProvider({})
+
+const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
+const owner = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+
+const lockContract = getTestLockContract({
+  lockAddress,
+  abi: v10.PublicLock.abi,
+  provider,
+})
+
+let web3Service
+
+describe('v10', () => {
+  describe('isLockManager', () => {
+    beforeEach(() => {
+      web3Service = new Web3Service({
+        readOnlyProvider: '',
+        network: 1984,
+      })
+
+      web3Service.lockContractAbiVersion = jest.fn(() => Promise.resolve(v10))
+      web3Service.getLockContract = jest.fn(() => Promise.resolve(lockContract))
+      lockContract.owner = jest.fn(() => {
+        return owner
+      })
+    })
+
+    it('should return true if the user is the owner', async () => {
+      expect.assertions(2)
+      const isLockManager = await web3Service.isLockManager(lockAddress, owner)
+      expect(isLockManager).toBe(true)
+      expect(lockContract.owner).toHaveBeenCalledWith()
+    })
+
+    it('should return false if the user is not the owner', async () => {
+      expect.assertions(1)
+      const isLockManager = await web3Service.isLockManager(
+        lockAddress,
+        '0xSomeoneElse'
+      )
+      expect(isLockManager).toBe(false)
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v11/isLockManager.test.js
+++ b/unlock-js/src/__tests__/v11/isLockManager.test.js
@@ -1,0 +1,51 @@
+import v11 from '../../v11'
+
+import Web3Service from '../../web3Service'
+import { getTestLockContract } from '../helpers/contracts'
+import { getTestProvider } from '../helpers/provider'
+
+const provider = getTestProvider({})
+
+const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
+const owner = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+
+const lockContract = getTestLockContract({
+  lockAddress,
+  abi: v11.PublicLock.abi,
+  provider,
+})
+
+let web3Service
+
+describe('v11', () => {
+  describe('isLockManager', () => {
+    beforeEach(() => {
+      web3Service = new Web3Service({
+        readOnlyProvider: '',
+        network: 1984,
+      })
+
+      web3Service.lockContractAbiVersion = jest.fn(() => Promise.resolve(v11))
+      web3Service.getLockContract = jest.fn(() => Promise.resolve(lockContract))
+      lockContract.owner = jest.fn(() => {
+        return owner
+      })
+    })
+
+    it('should return true if the user is the owner', async () => {
+      expect.assertions(2)
+      const isLockManager = await web3Service.isLockManager(lockAddress, owner)
+      expect(isLockManager).toBe(true)
+      expect(lockContract.owner).toHaveBeenCalledWith()
+    })
+
+    it('should return false if the user is not the owner', async () => {
+      expect.assertions(1)
+      const isLockManager = await web3Service.isLockManager(
+        lockAddress,
+        '0xSomeoneElse'
+      )
+      expect(isLockManager).toBe(false)
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v12/isLockManager.test.js
+++ b/unlock-js/src/__tests__/v12/isLockManager.test.js
@@ -1,0 +1,51 @@
+import v12 from '../../v12'
+
+import Web3Service from '../../web3Service'
+import { getTestLockContract } from '../helpers/contracts'
+import { getTestProvider } from '../helpers/provider'
+
+const provider = getTestProvider({})
+
+const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
+const owner = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+
+const lockContract = getTestLockContract({
+  lockAddress,
+  abi: v12.PublicLock.abi,
+  provider,
+})
+
+let web3Service
+
+describe('v12', () => {
+  describe('isLockManager', () => {
+    beforeEach(() => {
+      web3Service = new Web3Service({
+        readOnlyProvider: '',
+        network: 1984,
+      })
+
+      web3Service.lockContractAbiVersion = jest.fn(() => Promise.resolve(v12))
+      web3Service.getLockContract = jest.fn(() => Promise.resolve(lockContract))
+      lockContract.owner = jest.fn(() => {
+        return owner
+      })
+    })
+
+    it('should return true if the user is the owner', async () => {
+      expect.assertions(2)
+      const isLockManager = await web3Service.isLockManager(lockAddress, owner)
+      expect(isLockManager).toBe(true)
+      expect(lockContract.owner).toHaveBeenCalledWith()
+    })
+
+    it('should return false if the user is not the owner', async () => {
+      expect.assertions(1)
+      const isLockManager = await web3Service.isLockManager(
+        lockAddress,
+        '0xSomeoneElse'
+      )
+      expect(isLockManager).toBe(false)
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v13/isLockManager.test.js
+++ b/unlock-js/src/__tests__/v13/isLockManager.test.js
@@ -1,0 +1,51 @@
+import v13 from '../../v13'
+
+import Web3Service from '../../web3Service'
+import { getTestLockContract } from '../helpers/contracts'
+import { getTestProvider } from '../helpers/provider'
+
+const provider = getTestProvider({})
+
+const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
+const owner = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+
+const lockContract = getTestLockContract({
+  lockAddress,
+  abi: v13.PublicLock.abi,
+  provider,
+})
+
+let web3Service
+
+describe('v13', () => {
+  describe('isLockManager', () => {
+    beforeEach(() => {
+      web3Service = new Web3Service({
+        readOnlyProvider: '',
+        network: 1984,
+      })
+
+      web3Service.lockContractAbiVersion = jest.fn(() => Promise.resolve(v13))
+      web3Service.getLockContract = jest.fn(() => Promise.resolve(lockContract))
+      lockContract.owner = jest.fn(() => {
+        return owner
+      })
+    })
+
+    it('should return true if the user is the owner', async () => {
+      expect.assertions(2)
+      const isLockManager = await web3Service.isLockManager(lockAddress, owner)
+      expect(isLockManager).toBe(true)
+      expect(lockContract.owner).toHaveBeenCalledWith()
+    })
+
+    it('should return false if the user is not the owner', async () => {
+      expect.assertions(1)
+      const isLockManager = await web3Service.isLockManager(
+        lockAddress,
+        '0xSomeoneElse'
+      )
+      expect(isLockManager).toBe(false)
+    })
+  })
+})

--- a/unlock-js/src/__tests__/v7/isLockManager.test.js
+++ b/unlock-js/src/__tests__/v7/isLockManager.test.js
@@ -1,0 +1,59 @@
+import v7 from '../../v7'
+
+import Web3Service from '../../web3Service'
+import { getTestLockContract } from '../helpers/contracts'
+import { getTestProvider } from '../helpers/provider'
+
+const provider = getTestProvider({})
+
+const lockAddress = '0xc43efe2c7116cb94d563b5a9d68f260ccc44256f'
+const manager = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+
+const lockContract = getTestLockContract({
+  lockAddress,
+  abi: v7.PublicLock.abi,
+  provider,
+})
+
+let web3Service
+
+describe('v7', () => {
+  describe('isLockManager', () => {
+    beforeEach(() => {
+      web3Service = new Web3Service({
+        readOnlyProvider: '',
+        network: 1984,
+      })
+
+      web3Service.lockContractAbiVersion = jest.fn(() => Promise.resolve(v7))
+      web3Service.getLockContract = jest.fn(() => Promise.resolve(lockContract))
+    })
+
+    it('should return true if the user is a manager', async () => {
+      expect.assertions(2)
+      lockContract.isLockManager = jest.fn(() => {
+        return true
+      })
+
+      const isLockManager = await web3Service.isLockManager(
+        lockAddress,
+        manager
+      )
+      expect(isLockManager).toBe(true)
+      expect(lockContract.isLockManager).toHaveBeenCalledWith(manager)
+    })
+
+    it('should return false if the user is not a manager', async () => {
+      expect.assertions(1)
+      lockContract.isLockManager = jest.fn(() => {
+        return false
+      })
+
+      const isLockManager = await web3Service.isLockManager(
+        lockAddress,
+        '0xSomeoneElse'
+      )
+      expect(isLockManager).toBe(false)
+    })
+  })
+})

--- a/unlock-js/src/v0/index.js
+++ b/unlock-js/src/v0/index.js
@@ -5,6 +5,7 @@ import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 import configureUnlock from './configureUnlock'
+import isLockManager from './isLockManager'
 
 const version = 'v0'
 const { Unlock } = abis.v0
@@ -12,6 +13,7 @@ const { PublicLock } = abis.v0
 export default {
   createLock,
   configureUnlock,
+  isLockManager,
   getLock,
   purchaseKey,
   updateKeyPrice,

--- a/unlock-js/src/v0/isLockManager.js
+++ b/unlock-js/src/v0/isLockManager.js
@@ -1,0 +1,13 @@
+/**
+ * Yields true if the user is a lock manager
+ * In this version, only the lock owner is a manager
+ * @param {string} lockAddres address of the lock
+ * @param {string} userAddress address of the user
+ */
+export default async function(lockAddres, userAddress) {
+  const lockContract = await this.getLockContract(lockAddres)
+
+  const owner = await lockContract.owner()
+
+  return owner.toLowerCase() === userAddress.toLowerCase()
+}

--- a/unlock-js/src/v01/index.js
+++ b/unlock-js/src/v01/index.js
@@ -5,6 +5,7 @@ import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 import configureUnlock from './configureUnlock'
+import isLockManager from './isLockManager'
 
 export default {
   createLock,
@@ -13,6 +14,7 @@ export default {
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
+  isLockManager,
   version: 'v01',
   Unlock: abis.v01.Unlock,
   PublicLock: abis.v01.PublicLock,

--- a/unlock-js/src/v01/isLockManager.js
+++ b/unlock-js/src/v01/isLockManager.js
@@ -1,0 +1,13 @@
+/**
+ * Yields true if the user is a lock manager
+ * In this version, only the lock owner is a manager
+ * @param {string} lockAddres address of the lock
+ * @param {string} userAddress address of the user
+ */
+export default async function(lockAddres, userAddress) {
+  const lockContract = await this.getLockContract(lockAddres)
+
+  const owner = await lockContract.owner()
+
+  return owner.toLowerCase() === userAddress.toLowerCase()
+}

--- a/unlock-js/src/v02/index.js
+++ b/unlock-js/src/v02/index.js
@@ -5,6 +5,7 @@ import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 import configureUnlock from './configureUnlock'
+import isLockManager from './isLockManager'
 
 export default {
   createLock,
@@ -13,6 +14,7 @@ export default {
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
+  isLockManager,
   version: 'v02',
   Unlock: abis.v02.Unlock,
   PublicLock: abis.v02.PublicLock,

--- a/unlock-js/src/v02/isLockManager.js
+++ b/unlock-js/src/v02/isLockManager.js
@@ -1,0 +1,13 @@
+/**
+ * Yields true if the user is a lock manager
+ * In this version, only the lock owner is a manager
+ * @param {string} lockAddres address of the lock
+ * @param {string} userAddress address of the user
+ */
+export default async function(lockAddres, userAddress) {
+  const lockContract = await this.getLockContract(lockAddres)
+
+  const owner = await lockContract.owner()
+
+  return owner.toLowerCase() === userAddress.toLowerCase()
+}

--- a/unlock-js/src/v10/index.js
+++ b/unlock-js/src/v10/index.js
@@ -5,6 +5,7 @@ import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 import configureUnlock from './configureUnlock'
+import isLockManager from './isLockManager'
 
 export default {
   createLock,
@@ -13,6 +14,7 @@ export default {
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
+  isLockManager,
   version: 'v10',
   Unlock: abis.v10.Unlock,
   PublicLock: abis.v10.PublicLock,

--- a/unlock-js/src/v10/isLockManager.js
+++ b/unlock-js/src/v10/isLockManager.js
@@ -1,0 +1,13 @@
+/**
+ * Yields true if the user is a lock manager
+ * In this version, only the lock owner is a manager
+ * @param {string} lockAddres address of the lock
+ * @param {string} userAddress address of the user
+ */
+export default async function(lockAddres, userAddress) {
+  const lockContract = await this.getLockContract(lockAddres)
+
+  const owner = await lockContract.owner()
+
+  return owner.toLowerCase() === userAddress.toLowerCase()
+}

--- a/unlock-js/src/v11/index.js
+++ b/unlock-js/src/v11/index.js
@@ -5,6 +5,7 @@ import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 import configureUnlock from './configureUnlock'
+import isLockManager from './isLockManager'
 
 export default {
   createLock,
@@ -13,6 +14,7 @@ export default {
   purchaseKey,
   updateKeyPrice,
   withdrawFromLock,
+  isLockManager,
   version: 'v11',
   Unlock: abis.v11.Unlock,
   PublicLock: abis.v11.PublicLock,

--- a/unlock-js/src/v11/isLockManager.js
+++ b/unlock-js/src/v11/isLockManager.js
@@ -1,0 +1,13 @@
+/**
+ * Yields true if the user is a lock manager
+ * In this version, only the lock owner is a manager
+ * @param {string} lockAddres address of the lock
+ * @param {string} userAddress address of the user
+ */
+export default async function(lockAddres, userAddress) {
+  const lockContract = await this.getLockContract(lockAddres)
+
+  const owner = await lockContract.owner()
+
+  return owner.toLowerCase() === userAddress.toLowerCase()
+}

--- a/unlock-js/src/v12/index.js
+++ b/unlock-js/src/v12/index.js
@@ -5,6 +5,7 @@ import purchaseKey from './purchaseKey'
 import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 import configureUnlock from './configureUnlock'
+import isLockManager from './isLockManager'
 
 export default {
   version: 'v12',
@@ -16,4 +17,5 @@ export default {
   purchaseKey,
   withdrawFromLock,
   configureUnlock,
+  isLockManager,
 }

--- a/unlock-js/src/v12/isLockManager.js
+++ b/unlock-js/src/v12/isLockManager.js
@@ -1,0 +1,13 @@
+/**
+ * Yields true if the user is a lock manager
+ * In this version, only the lock owner is a manager
+ * @param {string} lockAddres address of the lock
+ * @param {string} userAddress address of the user
+ */
+export default async function(lockAddres, userAddress) {
+  const lockContract = await this.getLockContract(lockAddres)
+
+  const owner = await lockContract.owner()
+
+  return owner.toLowerCase() === userAddress.toLowerCase()
+}

--- a/unlock-js/src/v13/index.js
+++ b/unlock-js/src/v13/index.js
@@ -6,6 +6,7 @@ import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 import initializeTemplate from './initializeTemplate'
 import configureUnlock from './configureUnlock'
+import isLockManager from './isLockManager'
 
 export default {
   version: 'v13',
@@ -18,4 +19,5 @@ export default {
   purchaseKey,
   withdrawFromLock,
   configureUnlock,
+  isLockManager,
 }

--- a/unlock-js/src/v13/isLockManager.js
+++ b/unlock-js/src/v13/isLockManager.js
@@ -1,0 +1,13 @@
+/**
+ * Yields true if the user is a lock manager
+ * In this version, only the lock owner is a manager
+ * @param {string} lockAddres address of the lock
+ * @param {string} userAddress address of the user
+ */
+export default async function(lockAddres, userAddress) {
+  const lockContract = await this.getLockContract(lockAddres)
+
+  const owner = await lockContract.owner()
+
+  return owner.toLowerCase() === userAddress.toLowerCase()
+}

--- a/unlock-js/src/v7/index.js
+++ b/unlock-js/src/v7/index.js
@@ -6,6 +6,7 @@ import updateKeyPrice from './updateKeyPrice'
 import withdrawFromLock from './withdrawFromLock'
 import initializeTemplate from './initializeTemplate'
 import configureUnlock from './configureUnlock'
+import isLockManager from './isLockManager'
 
 export default {
   version: 'v7',
@@ -18,4 +19,5 @@ export default {
   purchaseKey,
   withdrawFromLock,
   configureUnlock,
+  isLockManager,
 }

--- a/unlock-js/src/v7/isLockManager.js
+++ b/unlock-js/src/v7/isLockManager.js
@@ -1,0 +1,11 @@
+/**
+ * Yields true if the user is a lock manager
+ * In this version, only the lock owner is a manager
+ * @param {string} lockAddres address of the lock
+ * @param {string} userAddress address of the user
+ */
+export default async function(lockAddres, userAddress) {
+  const lockContract = await this.getLockContract(lockAddres)
+
+  return lockContract.isLockManager(userAddress)
+}

--- a/unlock-js/src/web3Service.js
+++ b/unlock-js/src/web3Service.js
@@ -617,6 +617,16 @@ export default class Web3Service extends UnlockService {
   }
 
   /**
+   * Refresh the lock's data.
+   * We use the block version
+   * @return Promise<Lock>
+   */
+  async isLockManager(lock, manager) {
+    const version = await this.lockContractAbiVersion(lock)
+    return version.isLockManager.bind(this)(lock, manager)
+  }
+
+  /**
    * Returns the key to the lock by the account.
    * @param {PropTypes.string} lock
    * @param {PropTypes.string} owner


### PR DESCRIPTION
# Description

Since v7 does not have lock ownwers any more, we are adding a function to check if an address is the lock manager.
This will mostly be used in locksmith which relies on a user being a lock owner before allowing them to do some changes or accessing some data.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->