### PR TITLE
Replace some uses of lock.owner with current user address

### DIFF
--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -530,7 +530,7 @@ describe('Wallet middleware', () => {
           keyPrice: lock.keyPrice,
           maxNumberOfKeys: lock.maxNumberOfKeys,
           name: lock.name,
-          owner: lock.owner,
+          owner: account.address,
         })
 
         expect(next).toHaveBeenCalledWith(action)

--- a/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/web3Middleware.test.js
@@ -322,7 +322,7 @@ describe('Lock middleware', () => {
 
       invoke(action)
       expect(mockWeb3Service.generateLockAddress).toHaveBeenCalledWith(
-        lock.owner,
+        account.address,
         lock
       )
       expect(next).toHaveBeenCalledWith(action)

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -191,7 +191,7 @@ const walletMiddleware = (config, walletService) => {
               expirationDuration: action.lock.expirationDuration,
               keyPrice: action.lock.keyPrice,
               maxNumberOfKeys: action.lock.maxNumberOfKeys,
-              owner: action.lock.owner,
+              owner: getState().account.address,
               name: action.lock.name,
               currencyContractAddress: action.lock.currencyContractAddress,
             })

--- a/unlock-app/src/middlewares/web3Middleware.js
+++ b/unlock-app/src/middlewares/web3Middleware.js
@@ -88,7 +88,7 @@ const web3Middleware = web3Service => {
 
         if (action.type === CREATE_LOCK && !action.lock.address) {
           web3Service
-            .generateLockAddress(action.lock.owner, action.lock)
+            .generateLockAddress(getState().account.address, action.lock)
             .then(address => {
               action.lock.address = address
               dispatch(createLock(action.lock))


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This small PR replaces some uses of the deprecated `lock.owner` with the current user's account address.

Follow up PRs will use `isLockManager` where needed.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
