### PR TITLE
use the config's persistentCheckout to prevent the checkout modal to be closed

### DIFF
--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -110,9 +110,11 @@ export const CheckoutContentInner = ({
     dispatch(setShowingMetadataForm(false))
   }
 
+  const allowClose = !(!config || config.persistentCheckout)
+
   return (
     <CheckoutContainer close={emitCloseModal}>
-      <CheckoutWrapper allowClose hideCheckout={emitCloseModal}>
+      <CheckoutWrapper allowClose={allowClose} hideCheckout={emitCloseModal}>
         <Head>
           <title>{pageTitle('Checkout')}</title>
         </Head>

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import styled from 'styled-components'
 import { connect, useDispatch } from 'react-redux'
 import Head from 'next/head'
 import queryString from 'query-string'
@@ -125,7 +126,7 @@ export const CheckoutContentInner = ({
           {!showingMetadataForm && (
             <>
               {config && config.icon && (
-                <img alt="Publisher Icon" src={config.icon} />
+                <PaywallLogo alt="Publisher Icon" src={config.icon} />
               )}
               <p>{config ? config.callToAction.default : ''}</p>
               <CheckoutErrors
@@ -185,3 +186,8 @@ export const mapStateToProps = ({ account, router, errors }: ReduxState) => {
 }
 
 export default connect(mapStateToProps)(CheckoutContent)
+
+const PaywallLogo = styled.img`
+  max-width: 200px;
+  align-self: start;
+`


### PR DESCRIPTION
# Description

the cloudflare worker checkout should not be "closable" .
All of the code was already in place (yay!) but for the piece which loads it from the config.
To avoid a flash, when no config is set, it is marked as not closable.


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->