### PR TITLE
Remove last use of lock.owner

### DIFF
--- a/unlock-app/src/__tests__/hooks/useLocks.test.js
+++ b/unlock-app/src/__tests__/hooks/useLocks.test.js
@@ -331,7 +331,7 @@ describe('useLocks', () => {
           expirationDuration: lock.expirationDuration,
           keyPrice: lock.keyPrice,
           maxNumberOfKeys: lock.maxNumberOfKeys,
-          owner: lock.owner,
+          owner: ownerAddress,
           name: lock.name,
           currencyContractAddress: lock.currencyContractAddress,
         },

--- a/unlock-app/src/hooks/useLocks.js
+++ b/unlock-app/src/hooks/useLocks.js
@@ -196,7 +196,7 @@ export const useLocks = owner => {
         expirationDuration: lock.expirationDuration,
         keyPrice: lock.keyPrice,
         maxNumberOfKeys: lock.maxNumberOfKeys,
-        owner: lock.owner,
+        owner,
         name: lock.name,
         currencyContractAddress: lock.currencyContractAddress,
       },


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

One use of lock.owner got away in my last PR. Now grepping for `lock.owner` in `unlock-app` returns nothing.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
