### PR TITLE
some rpc providers require the JSON mimetype to be passed

### DIFF
--- a/paywall/src/paywall-script/package.json
+++ b/paywall/src/paywall-script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/paywall",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "module": "dist/module.js",
   "main": "dist/module.js",
   "types": "module.d.ts",

--- a/paywall/src/utils/getTransaction.ts
+++ b/paywall/src/utils/getTransaction.ts
@@ -16,6 +16,9 @@ export const getTransaction = async (
 
   const response = await fetch(provider, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify(rpcRequest),
   })
 

--- a/paywall/src/utils/keyExpirationTimestampFor.ts
+++ b/paywall/src/utils/keyExpirationTimestampFor.ts
@@ -18,6 +18,9 @@ export const keyExpirationTimestampFor = async (
 
   const response = await fetch(provider, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify(rpcRequest),
   })
 


### PR DESCRIPTION
# Description

The Cloudflare RPC provider is picky and requires the HTTP header with `Content-Type` to be passed...


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->