### PR TITLE
Hoist logo, call to action, errors to always be visible on checkout

### DIFF
--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -119,6 +119,14 @@ export const CheckoutContentInner = ({
           <title>{pageTitle('Checkout')}</title>
         </Head>
         <BrowserOnly>
+          {config && config.icon && (
+            <PaywallLogo alt="Publisher Icon" src={config.icon} />
+          )}
+          <p>{config ? config.callToAction.default : ''}</p>
+          <CheckoutErrors
+            errors={errors}
+            resetError={(e: UnlockError) => reduxDispatch(resetError(e))}
+          />
           {showingMetadataForm && (
             <MetadataForm
               fields={config!.metadataInputs!}
@@ -127,14 +135,6 @@ export const CheckoutContentInner = ({
           )}
           {!showingMetadataForm && (
             <>
-              {config && config.icon && (
-                <PaywallLogo alt="Publisher Icon" src={config.icon} />
-              )}
-              <p>{config ? config.callToAction.default : ''}</p>
-              <CheckoutErrors
-                errors={errors}
-                resetError={(e: UnlockError) => reduxDispatch(resetError(e))}
-              />
               {!account && showingLogin && <CheckoutLoginSignup login />}
               {!account && !showingLogin && (
                 <>


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR shuffles around some components in `<CheckoutContent>` so that the icon (if available), call to action, and errors (if present) are always visible on the checkout modal.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
