### PR TITLE
Show the wallet suggestions when user is not logged in

### DIFF
--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -5,15 +5,13 @@ import Head from 'next/head'
 import queryString from 'query-string'
 import BrowserOnly from '../helpers/BrowserOnly'
 import { pageTitle } from '../../constants'
-import { CheckoutLoginSignup } from '../interface/checkout/CheckoutLoginSignup'
 import { Locks } from '../interface/checkout/Locks'
-import { NotLoggedInLocks } from '../interface/checkout/NotLoggedInLocks'
 import { FiatLocks } from '../interface/checkout/FiatLocks'
 import CheckoutWrapper from '../interface/checkout/CheckoutWrapper'
 import CheckoutContainer from '../interface/checkout/CheckoutContainer'
 import { MetadataForm } from '../interface/checkout/MetadataForm'
 import { CheckoutErrors } from '../interface/checkout/CheckoutErrors'
-import { LogInButton } from '../interface/checkout/LogInButton'
+import { NotLoggedIn } from '../interface/checkout/NotLoggedIn'
 import {
   Account as AccountType,
   Router,
@@ -135,16 +133,13 @@ export const CheckoutContentInner = ({
           )}
           {!showingMetadataForm && (
             <>
-              {!account && showingLogin && <CheckoutLoginSignup login />}
-              {!account && !showingLogin && (
-                <>
-                  <NotLoggedInLocks lockAddresses={lockAddresses} />
-                  {config && config.unlockUserAccounts && (
-                    <LogInButton
-                      onClick={() => dispatch(setShowingLogin(true))}
-                    />
-                  )}
-                </>
+              {config && !account && (
+                <NotLoggedIn
+                  showingLogin={showingLogin}
+                  showLogin={() => dispatch(setShowingLogin(true))}
+                  config={config}
+                  lockAddresses={lockAddresses}
+                />
               )}
               {account && !account.emailAddress && (
                 <Locks

--- a/unlock-app/src/components/interface/checkout/NotLoggedIn.tsx
+++ b/unlock-app/src/components/interface/checkout/NotLoggedIn.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { PaywallConfig } from '../../../unlockTypes'
+import { CheckoutLoginSignup } from './CheckoutLoginSignup'
+import { NotLoggedInLocks } from './NotLoggedInLocks'
+import { LogInButton } from './LogInButton'
+import { RecommendedWallets } from './RecommendWallets'
+
+interface NotLoggedInProps {
+  config: PaywallConfig
+  showingLogin: boolean
+  lockAddresses: string[]
+  showLogin: () => void
+}
+
+export const NotLoggedIn = ({
+  showingLogin,
+  config,
+  lockAddresses,
+  showLogin,
+}: NotLoggedInProps) => {
+  if (showingLogin) {
+    return <CheckoutLoginSignup login />
+  }
+
+  if (config.unlockUserAccounts) {
+    return (
+      <>
+        <NotLoggedInLocks lockAddresses={lockAddresses} />
+        <LogInButton onClick={showLogin} />
+      </>
+    )
+  }
+
+  return <RecommendedWallets />
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

<img width="488" alt="image" src="https://user-images.githubusercontent.com/9300702/78066736-7d568480-7363-11ea-8125-b9d076a242f1.png">

The one missing piece is showing the nowallet message from the config -- that will require a bigger shift so will be done in a follow up PR.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
