### PR TITLE
Standing up ganache ci for integration tests

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -6,6 +6,14 @@ services:
     expose:
       - 8545
     command: ['-h=0.0.0.0', '-m=hello unlock save the web', '-i=1984']
+  ganache-standup:    
+    build:
+      context: ./development
+      dockerfile: ganache.dockerfile
+    env_file: ./integration.env
+    entrypoint: ['node', '/standup/prepare-ganache-for-unlock.js']
+    depends_on:
+      - ganache-integration     
   ganache-integration:
     env_file: ./integration.env
     restart: always

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -15,6 +15,8 @@ docker-compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE up subgraph_deplo
 # Deploy the smart contract
 docker-compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE build ganache-integration
 
+docker-compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE up ganache-standup
+
 # And then run the integration tests
 COMMAND="yarn run ci"
 docker-compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE run -v /tmp/screenshots:/screenshots $EXTRA_ARGS integration-tests bash -c "$COMMAND"


### PR DESCRIPTION
# Description

A fix for a regression that stopped integration tests from running. As part of the integration test scripts, we now run the populate script to ensure that the environment is ready for testing.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
