### PR TITLE
Update storybook config to not reference removed package

### DIFF
--- a/unlock-app/.storybook/.babelrc
+++ b/unlock-app/.storybook/.babelrc
@@ -1,7 +1,7 @@
 {
   "env": {
     "development": {
-      "presets": ["next/babel", "@zeit/next-typescript/babel"],
+      "presets": ["next/babel"],
       "plugins": [
         [
           "styled-components",
@@ -14,7 +14,7 @@
       ]
     },
     "production": {
-      "presets": ["next/babel", "@zeit/next-typescript/babel"],
+      "presets": ["next/babel"],
       "plugins": [
         [
           "styled-components",
@@ -35,7 +35,6 @@
               "modules": "commonjs"
             }
           },
-          "@zeit/next-typescript/babel"
         ]
       ],
       "plugins": [

--- a/unlock-app/.storybook/config.js
+++ b/unlock-app/.storybook/config.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { configure, addDecorator, addParameters } from '@storybook/react'
+import { configure, addDecorator } from '@storybook/react'
 import GlobalStyle from '../src/theme/globalStyle'
 import Fonts from '../src/theme/fonts'
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

In the upgrade of unlock-app to next v9, we forgot to remove one of the deprecated packages from the storybook webpack config, which prevented the storybook from running. This PR prunes the config into a working state.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
