### PR TITLE
Improved handling of fatal errors on checkout

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/CheckoutErrors.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/CheckoutErrors.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import * as rtl from '@testing-library/react'
-import { CheckoutErrors } from '../../../../components/interface/checkout/CheckoutErrors'
+import {
+  CheckoutErrors,
+  genericError,
+} from '../../../../components/interface/checkout/CheckoutErrors'
 import { UnlockError } from '../../../../utils/Error'
 
 const fatalError: UnlockError = {
@@ -35,7 +38,7 @@ describe('Checkout Errors', () => {
       <CheckoutErrors errors={errors} resetError={resetError} />
     )
 
-    getByText(fatalError.message)
+    getByText(genericError)
     getByText(warningError.message)
     getByText(diagnosticError.message)
   })
@@ -47,9 +50,9 @@ describe('Checkout Errors', () => {
       <CheckoutErrors errors={errors} resetError={resetError} />
     )
 
-    const fatal = getByText(fatalError.message)
-    rtl.fireEvent.click(fatal)
+    const warning = getByText(warningError.message)
+    rtl.fireEvent.click(warning)
 
-    expect(resetError).toHaveBeenCalledWith(fatalError)
+    expect(resetError).toHaveBeenCalledWith(warningError)
   })
 })

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -5683,7 +5683,7 @@ Object {
           <div
             class="sc-qQMSE c4"
           >
-            Could not log in
+            This is a generic error because something just broke but we’re not sure what.
           </div>
           <div
             class="sc-qQMSE c5"
@@ -5753,7 +5753,7 @@ Object {
         <div
           class="sc-qQMSE sc-qYIQh cLHLvH"
         >
-          Could not log in
+          This is a generic error because something just broke but we’re not sure what.
         </div>
         <div
           class="sc-qQMSE sc-pBzUF dMsCIa"
@@ -5764,6 +5764,307 @@ Object {
           class="sc-qQMSE sc-pJUVA cCVntF"
         >
           That is not a great password
+        </div>
+        <footer
+          class="sc-pZOBi eVvhyX"
+        >
+          <span>
+            Powered by
+          </span>
+          <a
+            href="https://unlock-protocol.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <svg
+              alt="Unlock"
+              class="cenpj1-1 sc-oTNDV jckmCG"
+              viewBox="0 0 1200 256"
+            >
+              <path
+                d="M449.94 230.054h53.04V0h-53.04zM215.102 15.976h-55.596v55.608H70.68V15.976H15.083v55.608H0v26.42h15.083v41.626c0 52.081 45.052 94.578 100.33 94.578 54.956 0 99.689-42.497 99.689-94.578V98.004h14.964v-26.42h-14.964zM159.506 139.63c0 24.603-19.49 44.732-44.094 44.732A44.864 44.864 0 0170.68 139.63V98.004h88.826zm189.15-72.53c-19.17 0-37.703 8.626-48.247 24.282h-.639l-3.195-19.81h-46.65v158.482h53.04v-82.436c0-18.213 14.06-32.91 30.994-32.91 17.573 0 31.312 14.697 31.312 32.271v83.075h53.04v-88.187c0-42.177-26.839-74.768-69.654-74.768zm680.878 77.322l65.181-72.85h-65.5l-51.124 59.43h-.959V0h-53.04v230.054h53.04v-72.212h.96l52.72 72.212h66.78zM613.208 67.1c-49.525 0-90.423 37.703-90.423 83.714s40.898 83.395 90.423 83.395 90.424-37.384 90.424-83.395-40.898-83.714-90.424-83.714zm0 120.778c-20.13 0-37.064-16.934-37.064-37.064s16.935-37.064 37.064-37.064 37.384 16.934 37.384 37.064-17.254 37.064-37.384 37.064zm201.61-74.448c15.657 0 28.438 8.947 33.231 21.408h53.998c-5.431-37.064-41.537-67.738-86.27-67.738-49.845 0-91.063 37.703-91.063 83.714s41.218 83.395 91.064 83.395c43.773 0 81.157-29.396 86.27-68.058h-53.999c-5.752 13.1-17.574 21.408-33.23 21.408a36.955 36.955 0 01-36.744-36.745c0-20.13 16.295-37.384 36.744-37.384z"
+              />
+            </svg>
+          </a>
+        </footer>
+      </section>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Storyshots Checkout Errors With wrong network error 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c2 {
+  background-color: var(--lightgrey);
+  cursor: pointer;
+  border-radius: 50%;
+  height: 24px;
+  width: 24px;
+  display: inline-block;
+  padding: 0;
+  border: 0;
+  line-height: '15px';
+}
+
+.c2 > svg {
+  fill: var(--grey);
+  height: 24px;
+  width: 24px;
+}
+
+.c2:hover {
+  background-color: var(--link);
+}
+
+.c2:hover > svg {
+  fill: white;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c4 {
+  width: 100%;
+  border-radius: 4px;
+  padding: 12px 8px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  border: thin var(--sharpred) solid;
+  background-color: #f24c1533;
+}
+
+.c0 {
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  left: 0;
+  top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  margin-top: 32px;
+  margin-bottom: 6px;
+  font-size: 12px;
+  text-align: center;
+  color: var(--grey);
+}
+
+.c5 div {
+  margin: 8px;
+  vertical-align: middle;
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+}
+
+.c6 {
+  fill: var(--brand);
+  width: 48px;
+  margin-bottom: -1px;
+  margin-left: 4px;
+}
+
+.c3 {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.c1 {
+  padding: 24px 40px 10px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: var(--offwhite);
+  color: var(--darkgrey);
+  border-radius: 4px;
+  position: relative;
+  box-shadow: 0px 0px 60px rgba(0,0,0,0.25);
+}
+
+@media only screen and (min-width:736px) {
+  .c1 {
+    width: 380px;
+  }
+}
+
+@media only screen and (min-width:0px) and (max-width:736px) {
+  .c1 {
+    width: 100%;
+  }
+}
+
+<div>
+      <link
+        href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+        rel="stylesheet"
+      />
+      <div
+        class="c0"
+      >
+        <section
+          class="c1"
+        >
+          <a
+            class="c2 c3 closeButton"
+            target="_self"
+          >
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <title>
+                Close
+              </title>
+              <path
+                clip-rule="evenodd"
+                d="M8.237 7.177a.75.75 0 10-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 101.06 1.06L12 13.061l3.763 3.762a.75.75 0 101.06-1.06L13.061 12l3.762-3.763a.75.75 0 00-1.06-1.06L12 10.939 8.237 7.177z"
+                fill-rule="evenodd"
+              />
+            </svg>
+            
+          </a>
+          <div
+            class="sc-qQMSE c4"
+          >
+            You're currently on the Storynet network, but you need to be on the Winston network for the app to function.
+          </div>
+          <footer
+            class="c5"
+          >
+            <span>
+              Powered by
+            </span>
+            <a
+              href="https://unlock-protocol.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <svg
+                alt="Unlock"
+                class="cenpj1-1 c6"
+                viewBox="0 0 1200 256"
+              >
+                <path
+                  d="M449.94 230.054h53.04V0h-53.04zM215.102 15.976h-55.596v55.608H70.68V15.976H15.083v55.608H0v26.42h15.083v41.626c0 52.081 45.052 94.578 100.33 94.578 54.956 0 99.689-42.497 99.689-94.578V98.004h14.964v-26.42h-14.964zM159.506 139.63c0 24.603-19.49 44.732-44.094 44.732A44.864 44.864 0 0170.68 139.63V98.004h88.826zm189.15-72.53c-19.17 0-37.703 8.626-48.247 24.282h-.639l-3.195-19.81h-46.65v158.482h53.04v-82.436c0-18.213 14.06-32.91 30.994-32.91 17.573 0 31.312 14.697 31.312 32.271v83.075h53.04v-88.187c0-42.177-26.839-74.768-69.654-74.768zm680.878 77.322l65.181-72.85h-65.5l-51.124 59.43h-.959V0h-53.04v230.054h53.04v-72.212h.96l52.72 72.212h66.78zM613.208 67.1c-49.525 0-90.423 37.703-90.423 83.714s40.898 83.395 90.423 83.395 90.424-37.384 90.424-83.395-40.898-83.714-90.424-83.714zm0 120.778c-20.13 0-37.064-16.934-37.064-37.064s16.935-37.064 37.064-37.064 37.384 16.934 37.384 37.064-17.254 37.064-37.384 37.064zm201.61-74.448c15.657 0 28.438 8.947 33.231 21.408h53.998c-5.431-37.064-41.537-67.738-86.27-67.738-49.845 0-91.063 37.703-91.063 83.714s41.218 83.395 91.064 83.395c43.773 0 81.157-29.396 86.27-68.058h-53.999c-5.752 13.1-17.574 21.408-33.23 21.408a36.955 36.955 0 01-36.744-36.745c0-20.13 16.295-37.384 36.744-37.384z"
+                />
+              </svg>
+            </a>
+          </footer>
+        </section>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <link
+      href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,400,500,700|IBM+Plex+Sans:300,400,500,700|IBM+Plex+Serif:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+    <div
+      class="sc-pRtAn kcNtRY"
+    >
+      <section
+        class="sc-pjHjD hzPMMB"
+      >
+        <a
+          class="sc-850ddk-0 jqtNoT sc-pciEQ jVrIJM closeButton"
+          target="_self"
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <title>
+              Close
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M8.237 7.177a.75.75 0 10-1.06 1.06L10.939 12l-3.762 3.763a.75.75 0 101.06 1.06L12 13.061l3.763 3.762a.75.75 0 101.06-1.06L13.061 12l3.762-3.763a.75.75 0 00-1.06-1.06L12 10.939 8.237 7.177z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          
+        </a>
+        <div
+          class="sc-qQMSE sc-qYIQh cLHLvH"
+        >
+          You're currently on the Storynet network, but you need to be on the Winston network for the app to function.
         </div>
         <footer
           class="sc-pZOBi eVvhyX"

--- a/unlock-app/src/components/interface/checkout/CheckoutErrors.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutErrors.tsx
@@ -1,10 +1,35 @@
 import React from 'react'
 import styled from 'styled-components'
 import { UnlockError } from '../../../utils/Error'
+import { ETHEREUM_NETWORKS_NAMES } from '../../../constants'
 
 interface CheckoutErrorsProps {
   errors: UnlockError[]
   resetError: (error: UnlockError) => void
+}
+
+const fatalErrorMessages: { [key: string]: string } = {
+  FATAL_NON_DEPLOYED_CONTRACT:
+    'The Unlock contract has not been deployed at the configured address.',
+  FATAL_NOT_ENABLED_IN_PROVIDER:
+    'You did not approve Unlock in your web3 wallet.',
+}
+
+export const genericError =
+  'This is a generic error because something just broke but we’re not sure what.'
+
+const getMessage = (error: UnlockError) => {
+  if (error.message === 'FATAL_WRONG_NETWORK') {
+    const { currentNetwork, requiredNetworkId } = (error as any).data
+    const requiredNetwork = ETHEREUM_NETWORKS_NAMES[requiredNetworkId][0]
+    return `You're currently on the ${currentNetwork} network, but you need to be on the ${requiredNetwork} network for the app to function.`
+  }
+
+  if (error.level === 'Fatal') {
+    return fatalErrorMessages[error.message] || genericError
+  }
+
+  return error.message
 }
 
 export const CheckoutErrors = ({ errors, resetError }: CheckoutErrorsProps) => {
@@ -20,7 +45,7 @@ export const CheckoutErrors = ({ errors, resetError }: CheckoutErrorsProps) => {
         const onClick = () => resetError(error)
         return (
           <Component key={error.message} onClick={onClick}>
-            {error.message}
+            {getMessage(error)}
           </Component>
         )
       })}

--- a/unlock-app/src/stories/interface/checkout/CheckoutErrors.stories.js
+++ b/unlock-app/src/stories/interface/checkout/CheckoutErrors.stories.js
@@ -23,6 +23,16 @@ const diagnosticError = {
   message: 'That is not a great password',
 }
 
+const wrongNetworkError = {
+  level: 'Fatal',
+  kind: 'Storage',
+  message: 'FATAL_WRONG_NETWORK',
+  data: {
+    currentNetwork: 'Storynet',
+    requiredNetworkId: 1984,
+  },
+}
+
 storiesOf('Checkout Errors', module)
   .addDecorator(getStory => {
     return (
@@ -42,5 +52,10 @@ storiesOf('Checkout Errors', module)
         resetError={doNothing}
         errors={[fatalError, warningError, diagnosticError]}
       />
+    )
+  })
+  .add('With wrong network error', () => {
+    return (
+      <CheckoutErrors resetError={doNothing} errors={[wrongNetworkError]} />
     )
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Prior to this, fatal errors would be rendered just as the message provided in the object. However, our fatal errors all have non-descriptive messages like `FATAL_WRONG_NETWORK`. This PR takes some inspiration from the GlobalErrorConsumer and intercepts the fatal errors to replace their messages with something more helpful.

![image](https://user-images.githubusercontent.com/9300702/78160684-4c815880-7412-11ea-945f-3bba57870d8d.png)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
