### PR TITLE
Storing stripe details in their own table and retrieving them from there

### DIFF
--- a/locksmith/__tests__/operations/stripeOperations.test.js
+++ b/locksmith/__tests__/operations/stripeOperations.test.js
@@ -1,0 +1,82 @@
+import {
+  getStripeCustomerIdForAddress,
+  saveStripeCustomerIdForAddress,
+} from '../../src/operations/stripeOperations'
+
+const Sequelize = require('sequelize')
+
+const { Op } = Sequelize
+
+const models = require('../../src/models')
+
+let { UserReference, StripeCustomer } = models
+
+beforeEach(() => {
+  // resetting for before each test
+  UserReference = models.UserReference
+  StripeCustomer = models.StripeCustomer
+})
+
+describe('lockOperations', () => {
+  describe('getStripeCustomerIdForAddress', () => {
+    it('should get the data from StripeCustomer if it exists', async () => {
+      expect.assertions(2)
+      const stripeCustomerId = 'cus_customerId'
+
+      StripeCustomer.findOne = jest.fn(() =>
+        Promise.resolve({ StripeCustomerId: stripeCustomerId })
+      )
+      const publicKey = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
+      const result = await getStripeCustomerIdForAddress(publicKey)
+      expect(StripeCustomer.findOne).toHaveBeenCalledWith({
+        where: {
+          publicKey: { [Op.eq]: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2' },
+        },
+      })
+      expect(result).toEqual(stripeCustomerId)
+    })
+
+    it('should get the data from the userReference table if the StripeCustomer record does not exist', async () => {
+      expect.assertions(3)
+      const stripeCustomerId = 'cus_customerId'
+      StripeCustomer.findOne = jest.fn(() => Promise.resolve(null))
+      UserReference.findOne = jest.fn(() =>
+        Promise.resolve({ stripe_customer_id: stripeCustomerId })
+      )
+      const publicKey = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
+      const result = await getStripeCustomerIdForAddress(publicKey)
+      expect(StripeCustomer.findOne).toHaveBeenCalled()
+      expect(UserReference.findOne).toHaveBeenCalledWith({
+        where: {
+          publicKey: { [Op.eq]: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2' },
+        },
+      })
+      expect(result).toEqual(stripeCustomerId)
+    })
+
+    it('should return null if the customer id does not exist in any of StripeCustomer and UserReference', async () => {
+      expect.assertions(3)
+      StripeCustomer.findOne = jest.fn(() => Promise.resolve(null))
+      UserReference.findOne = jest.fn(() => Promise.resolve(null))
+      const publicKey = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
+      const result = await getStripeCustomerIdForAddress(publicKey)
+      expect(StripeCustomer.findOne).toHaveBeenCalled()
+      expect(UserReference.findOne).toHaveBeenCalled()
+      expect(result).toEqual(null)
+    })
+  })
+
+  describe('saveStripeCustomerIdForAddress', () => {
+    it('should store a stripeCustomer, normalized', async () => {
+      expect.assertions(1)
+      StripeCustomer.create = jest.fn(() => {})
+      const publicKey = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
+      const stripeCustomerId = 'cus_customerId'
+      await saveStripeCustomerIdForAddress(publicKey, stripeCustomerId)
+      expect(StripeCustomer.create).toHaveBeenCalledWith({
+        publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+        stripeCustomerId: 'cus_customerId',
+      })
+    })
+  })
+})

--- a/locksmith/__tests__/operations/userOperations.test.ts
+++ b/locksmith/__tests__/operations/userOperations.test.ts
@@ -220,9 +220,10 @@ describe('Updating encrypted private key', () => {
 describe("Retrieving a user's cards", () => {
   describe('when the user has credit cards', () => {
     beforeAll(() => {
-      UserReference.findOne = jest.fn().mockImplementationOnce(() => {
+      UserReference.findOne = jest.fn().mockImplementation(() => {
         return {
           stripe_customer_id: 'cus_AsampleID',
+          publicKey: '0xpublicKey',
         }
       })
     })

--- a/locksmith/src/models/index.ts
+++ b/locksmith/src/models/index.ts
@@ -11,6 +11,7 @@ import { LockMetadata } from './lockMetadata'
 import { KeyMetadata } from './keyMetadata'
 import { ParsedBlockForLockCreation } from './parsedBlockForLockCreation'
 import { UserTokenMetadata } from './usertokenmetadata'
+import { StripeCustomer } from './stripeCustomer'
 
 const config = require('../../config/config')
 
@@ -29,6 +30,7 @@ sequelize.addModels([
   KeyMetadata,
   ParsedBlockForLockCreation,
   UserTokenMetadata,
+  StripeCustomer,
 ])
 
 User.removeAttribute('id')
@@ -36,6 +38,7 @@ Lock.removeAttribute('id')
 Block.removeAttribute('id')
 Transaction.removeAttribute('id')
 LockMetadata.removeAttribute('id')
+StripeCustomer.removeAttribute('id')
 
 export * from './user'
 export * from './userReference'
@@ -46,3 +49,4 @@ export * from './transaction'
 export * from './authorizedLock'
 export * from './eventLink'
 export * from './usertokenmetadata'
+export * from './stripeCustomer'

--- a/locksmith/src/models/stripeCustomer.ts
+++ b/locksmith/src/models/stripeCustomer.ts
@@ -7,5 +7,5 @@ export class StripeCustomer extends Model<StripeCustomer> {
   publicKey!: string
 
   @Column
-  stripeCustomerId!: string
+  StripeCustomerId!: string
 }

--- a/locksmith/src/models/userReference.ts
+++ b/locksmith/src/models/userReference.ts
@@ -14,5 +14,5 @@ export class UserReference extends Model<UserReference> {
   publicKey!: string
 
   @Column
-  stripe_customer_id!: string
+  stripe_customer_id!: string // TODO: deprecated!
 }

--- a/locksmith/src/operations/stripeOperations.ts
+++ b/locksmith/src/operations/stripeOperations.ts
@@ -1,0 +1,57 @@
+import { ethereumAddress } from '../types' // eslint-disable-line import/named, no-unused-vars
+import * as Normalizer from '../utils/normalizer'
+import { UserReference } from '../models/userReference'
+
+import { StripeCustomer } from '../models/stripeCustomer'
+
+const Sequelize = require('sequelize')
+
+const { Op } = Sequelize
+
+/**
+ * Method, which, given a publicKey, returns the stripe token id
+ * This does a double look up as we changed how stripe token ids are stored (used to be in UserReferences and are now in their own table)
+ * @param publicKey
+ */
+export const getStripeCustomerIdForAddress = async (
+  publicKey: ethereumAddress
+) => {
+  const normalizedEthereumAddress = Normalizer.ethereumAddress(publicKey)
+
+  // First, let's try in the StripeCustomer
+  const stripeCustomer = await StripeCustomer.findOne({
+    where: { publicKey: { [Op.eq]: normalizedEthereumAddress } },
+  })
+
+  if (stripeCustomer && stripeCustomer.StripeCustomerId) {
+    return stripeCustomer.StripeCustomerId
+  }
+
+  // Otherwise, check UserReference
+  // Note: this is deprecated. At some point we should finish the migration
+  // and delete that row!
+  const userReference = await UserReference.findOne({
+    where: { publicKey: { [Op.eq]: normalizedEthereumAddress } },
+  })
+  if (!userReference) {
+    return null
+  }
+  return userReference.stripe_customer_id
+}
+
+/**
+ * Method whichs saves a stripe customer id!
+ * @param publicKey
+ * @param stripeCustomerId
+ */
+export const saveStripeCustomerIdForAddress = async (
+  publicKey: ethereumAddress,
+  stripeCustomerId: string
+) => {
+  const normalizedEthereumAddress = Normalizer.ethereumAddress(publicKey)
+
+  return await StripeCustomer.create({
+    publicKey: normalizedEthereumAddress,
+    stripeCustomerId: stripeCustomerId,
+  })
+}

--- a/locksmith/src/operations/userOperations.ts
+++ b/locksmith/src/operations/userOperations.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe'
 import { ethereumAddress, UserCreationInput } from '../types' // eslint-disable-line no-unused-vars, import/named
 import * as Normalizer from '../utils/normalizer'
 import { PaymentProcessor } from '../payment/paymentProcessor'
+import { getStripeCustomerIdForAddress } from './stripeOperations'
 // eslint-disable-line no-unused-vars
 import RecoveryPhrase = require('../utils/recoveryPhrase')
 
@@ -162,9 +163,12 @@ namespace UserOperations {
     const user = await UserReference.findOne({
       where: { emailAddress: Normalizer.emailAddress(emailAddress) },
     })
-
-    if (user) {
-      return getCardDetailsFromStripe(user.stripe_customer_id)
+    if (user && user.publicKey) {
+      const customerId = await getStripeCustomerIdForAddress(user.publicKey)
+      if (customerId) {
+        return getCardDetailsFromStripe(customerId)
+      }
+      return []
     }
     return []
   }


### PR DESCRIPTION
# Description

This will allow us to support retrieving and storing stripe details for crypto users, as well as eventually let them purchase keys through credit cards.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread