### PR TITLE
adding route to update payment details with address

### DIFF
--- a/locksmith/__tests__/controllers/userController/paymentDetails.test.ts
+++ b/locksmith/__tests__/controllers/userController/paymentDetails.test.ts
@@ -8,13 +8,10 @@ beforeAll(() => {
 
   const { UserReference } = models
   const { User } = models
-
-  UserOperations.updatePaymentDetails = jest
-    .fn()
-    .mockReturnValueOnce(true)
-    .mockReturnValueOnce(false)
+  const { StripeCustomer } = models
 
   return Promise.all([
+    StripeCustomer.truncate({ cascade: true }),
     UserReference.truncate({ cascade: true }),
     User.truncate({ cascade: true }),
   ])
@@ -40,6 +37,12 @@ describe('payment details', () => {
   describe("when able to update the user's payment details", () => {
     it('returns 202', async () => {
       expect.assertions(1)
+
+      UserOperations.updatePaymentDetails = jest
+        .fn()
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false)
+
       const response = await request(app)
         .put('/users/user@example.com/paymentdetails')
         .set('Accept', /json/)
@@ -55,9 +58,34 @@ describe('payment details', () => {
       expect(response.statusCode).toBe(202)
     })
   })
+
+  describe("when able to update the user's payment details with an address", () => {
+    it('returns 202', async () => {
+      expect.assertions(1)
+
+      const publicKey = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+      const response = await request(app)
+        .put(`/users/${publicKey}/credit-cards`)
+        .set('Accept', /json/)
+        .send({
+          message: {
+            user: {
+              publicKey,
+              stripeTokenId: 'tok_visa',
+            },
+          },
+        })
+
+      expect(response.statusCode).toBe(202)
+    })
+  })
+
   describe("when unable to update the user's payment details", () => {
     it('returns 400', async () => {
       expect.assertions(1)
+
+      UserOperations.updatePaymentDetails = jest.fn().mockReturnValueOnce(false)
+
       const response = await request(app)
         .put('/users/user@example.com/paymentdetails')
         .set('Accept', /json/)
@@ -65,6 +93,27 @@ describe('payment details', () => {
           message: {
             user: {
               publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+              stripeTokenId: 'tok_INVALID',
+            },
+          },
+        })
+      expect(response.statusCode).toBe(400)
+    })
+  })
+
+  describe("when unable to update the user's payment details with the the public key", () => {
+    it('returns 400', async () => {
+      expect.assertions(1)
+      const publicKey = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+
+      // It should fail because we already have a record!
+      const response = await request(app)
+        .put(`/users/${publicKey}/credit-cards`)
+        .set('Accept', /json/)
+        .send({
+          message: {
+            user: {
+              publicKey,
               stripeTokenId: 'tok_INVALID',
             },
           },

--- a/locksmith/__tests__/operations/stripeOperations.test.js
+++ b/locksmith/__tests__/operations/stripeOperations.test.js
@@ -75,7 +75,7 @@ describe('lockOperations', () => {
       await saveStripeCustomerIdForAddress(publicKey, stripeCustomerId)
       expect(StripeCustomer.create).toHaveBeenCalledWith({
         publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
-        stripeCustomerId: 'cus_customerId',
+        StripeCustomerId: 'cus_customerId',
       })
     })
   })

--- a/locksmith/src/controllers/userController.ts
+++ b/locksmith/src/controllers/userController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express-serve-static-core' // eslint-disable-line no-unused-vars, import/no-unresolved
 import { DecoyUser } from '../utils/decoyUser'
 import { SignedRequest } from '../types' // eslint-disable-line no-unused-vars, import/no-unresolved
+import StripeOperations from '../operations/stripeOperations'
 
 import UserOperations = require('../operations/userOperations')
 
@@ -132,6 +133,41 @@ namespace UserController {
       return res.sendStatus(202)
     }
     return res.sendStatus(400)
+  }
+
+  export const updateAddressPaymentDetails = async (
+    req: Request,
+    res: Response
+  ): Promise<any> => {
+    const { ethereumAddress } = req.params
+    const token = req.body.message.user.stripeTokenId
+    const result = await StripeOperations.saveStripeCustomerIdForAddress(
+      ethereumAddress,
+      token
+    )
+
+    if (result) {
+      return res.sendStatus(202)
+    }
+    return res.sendStatus(400)
+  }
+
+  export const getAddressPaymentDetails = async (
+    req: Request,
+    res: Response
+  ): Promise<any> => {
+    const { ethereumAddress } = req.params
+    const stripeCustomerId = await StripeOperations.getStripeCustomerIdForAddress(
+      ethereumAddress
+    )
+    if (!stripeCustomerId) {
+      return res.json([])
+    }
+    const result = await UserOperations.getCardDetailsFromStripe(
+      stripeCustomerId
+    )
+
+    return res.json(result)
   }
 
   export const updatePasswordEncryptedPrivateKey = async (

--- a/locksmith/src/operations/stripeOperations.ts
+++ b/locksmith/src/operations/stripeOperations.ts
@@ -49,9 +49,17 @@ export const saveStripeCustomerIdForAddress = async (
   stripeCustomerId: string
 ) => {
   const normalizedEthereumAddress = Normalizer.ethereumAddress(publicKey)
+  try {
+    return await StripeCustomer.create({
+      publicKey: normalizedEthereumAddress,
+      StripeCustomerId: stripeCustomerId,
+    })
+  } catch (error) {
+    return false
+  }
+}
 
-  return await StripeCustomer.create({
-    publicKey: normalizedEthereumAddress,
-    stripeCustomerId: stripeCustomerId,
-  })
+export default {
+  saveStripeCustomerIdForAddress,
+  getStripeCustomerIdForAddress,
 }

--- a/locksmith/src/operations/userOperations.ts
+++ b/locksmith/src/operations/userOperations.ts
@@ -173,7 +173,9 @@ namespace UserOperations {
     return []
   }
 
-  const getCardDetailsFromStripe = async (customer_id: any): Promise<any[]> => {
+  export const getCardDetailsFromStripe = async (
+    customer_id: any
+  ): Promise<any[]> => {
     const stripe = new Stripe(config.stripeSecret)
 
     try {

--- a/locksmith/src/routes/user.ts
+++ b/locksmith/src/routes/user.ts
@@ -48,13 +48,23 @@ router.get(
   userController.retrieveRecoveryPhrase
 )
 
+router.get(
+  '/:ethereumAddress/credit-cards',
+  userController.getAddressPaymentDetails
+)
+// Deprecated: we are now using ethereumAddress to store credit cards
 router.get('/:emailAddress/cards', userController.cards)
+
 router.put('/:emailAddress', userController.updateUser)
-router.put('/:emailAddress/paymentdetails', userController.updatePaymentDetails)
 router.put(
   '/:emailAddress/passwordEncryptedPrivateKey',
   userController.updatePasswordEncryptedPrivateKey
 )
 router.post('/:ethereumAddress/eject', userController.eject)
-
+router.put(
+  '/:ethereumAddress/credit-cards',
+  userController.updateAddressPaymentDetails
+)
+// Deprecated
+router.put('/:emailAddress/paymentdetails', userController.updatePaymentDetails)
 module.exports = router


### PR DESCRIPTION
# Description

Since we will support credit card saving for all users, we're moving away from setting/retrieving them with an email address.
This PR adds the ability to add/list them via the ethereum address.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->