### PR TITLE
Providing authentication around  requesting cards by email address

### DIFF
--- a/locksmith/__tests__/controllers/userController/cards.test.ts
+++ b/locksmith/__tests__/controllers/userController/cards.test.ts
@@ -1,0 +1,118 @@
+import request from 'supertest'
+
+import app = require('../../../src/app')
+import Base64 = require('../../../src/utils/base64')
+import ethJsUtil = require('ethereumjs-util')
+import models = require('../../../src/models')
+import sigUtil = require('eth-sig-util')
+import UserOperations = require('../../../src/operations/userOperations')
+
+const emailAddress = 'existing@example.com'
+
+function generateTypedData(message: any) {
+  return {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+        { name: 'salt', type: 'bytes32' },
+      ],
+      User: [{ name: 'publicKey', type: 'address' }],
+    },
+    domain: {
+      name: 'Unlock',
+      version: '1',
+    },
+    primaryType: 'User',
+    message,
+  }
+}
+
+beforeAll(async () => {
+  const userCreationDetails = {
+    emailAddress,
+    publicKey: '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a',
+    passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
+    recoveryPhrase: 'a recovery phrase',
+  }
+
+  await UserOperations.createUser(userCreationDetails)
+})
+
+afterAll(async () => {
+  const { User } = models
+  const { UserReference } = models
+
+  return Promise.all([
+    User.truncate({ cascade: true }),
+    UserReference.truncate({ cascade: true }),
+  ])
+})
+
+describe('when requesting cards', () => {
+  describe('when the request does not include a signature', () => {
+    it('returns a 401', async () => {
+      expect.assertions(1)
+
+      const response = await request(app).get(`/users/${emailAddress}/cards`)
+      expect(response.status).toBe(401)
+    })
+  })
+
+  describe('when the request includes a signature that does not match the public address', () => {
+    it('returns a 401', async () => {
+      expect.assertions(1)
+
+      const message = {
+        user: {
+          publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+        },
+      }
+
+      const privateKey = ethJsUtil.toBuffer(
+        '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
+      )
+
+      const typedData = generateTypedData(message)
+      const sig = sigUtil.signTypedData(privateKey, {
+        data: typedData,
+      })
+
+      const response = await request(app)
+        .get(`/users/${emailAddress}/cards`)
+        .set('Authorization', `Bearer ${Base64.encode(sig)}`)
+
+      expect(response.status).toBe(401)
+    })
+  })
+
+  describe('when a valid signature is provided', () => {
+    it('returns the request cards', async () => {
+      expect.assertions(1)
+
+      const message = {
+        user: {
+          publicKey: '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a',
+        },
+      }
+
+      const privateKey = ethJsUtil.toBuffer(
+        '0x08491b7e20566b728ce21a07c88b12ed8b785b3826df93a7baceb21ddacf8b61'
+      )
+
+      const typedData = generateTypedData(message)
+      const sig = sigUtil.personalSign(privateKey, {
+        data: JSON.stringify(typedData),
+      })
+
+      const response = await request(app)
+        .get(`/users/${emailAddress}/cards`)
+        .set('Authorization', `Bearer-Simple ${Base64.encode(sig)}`)
+        .query({ data: JSON.stringify(typedData) })
+
+      expect(response.status).toBe(200)
+    })
+  })
+})

--- a/locksmith/__tests__/controllers/userController/paymentDetails.test.ts
+++ b/locksmith/__tests__/controllers/userController/paymentDetails.test.ts
@@ -27,16 +27,6 @@ afterAll(() => {
 describe('payment details', () => {
   const request = require('supertest')
 
-  describe("retrieving a user's card details ", () => {
-    it("return the user's card details if available", async () => {
-      expect.assertions(1)
-      UserOperations.getCards = jest.fn()
-
-      await request(app).get('/users/user@example.com/cards')
-      expect(UserOperations.getCards).toHaveBeenCalledWith('user@example.com')
-    })
-  })
-
   describe("when able to update the user's payment details", () => {
     it('returns 202', async () => {
       expect.assertions(1)

--- a/locksmith/src/controllers/userController.ts
+++ b/locksmith/src/controllers/userController.ts
@@ -159,10 +159,18 @@ namespace UserController {
     return res.sendStatus(400)
   }
 
-  export const cards = async (req: Request, res: Response) => {
+  export const cards = async (req: SignedRequest, res: Response) => {
     const { emailAddress } = req.params
-    const result = await UserOperations.getCards(emailAddress)
-    return res.json(result)
+    const publicKey = await UserOperations.publicKeyByEmailAddress(emailAddress)
+
+    if (publicKey == null) {
+      return res.sendStatus(401)
+    } else if (publicKey != req.signee) {
+      return res.sendStatus(401)
+    } else {
+      const result = await UserOperations.getCards(emailAddress)
+      return res.json(result)
+    }
   }
 
   export const eject = async (req: SignedRequest, res: Response) => {

--- a/locksmith/src/operations/userOperations.ts
+++ b/locksmith/src/operations/userOperations.ts
@@ -70,6 +70,20 @@ namespace UserOperations {
     }
   }
 
+  export const publicKeyByEmailAddress = async (emailAddress: string) => {
+    try {
+      const user = await UserReference.findOne({
+        where: {
+          emailAddress: Normalizer.emailAddress(emailAddress),
+        },
+      })
+
+      return user ? user.publicKey : null
+    } catch (e) {
+      return null
+    }
+  }
+
   export const ejectionStatusByAddress = async (
     publicKey: string
   ): Promise<boolean> => {

--- a/locksmith/src/routes/user.ts
+++ b/locksmith/src/routes/user.ts
@@ -9,6 +9,7 @@ const passwordEncryptedPrivateKeyPathRegex = new RegExp(
   'i'
 )
 const userUpdatePathRegex = new RegExp('^/users/?$', 'i')
+const cardsPathRegex = '/:emailAddress/cards'
 const ejectionPathRegex = '/:ethereumAddress/eject'
 
 router.post(
@@ -34,6 +35,15 @@ router.put(
   signatureValidationMiddleware.generateProcessor({
     name: 'user',
     required: ['publicKey', 'passwordEncryptedPrivateKey'],
+    signee: 'publicKey',
+  })
+)
+
+router.get(
+  cardsPathRegex,
+  signatureValidationMiddleware.generateSignatureEvaluator({
+    name: 'user',
+    required: ['publicKey'],
     signee: 'publicKey',
   })
 )


### PR DESCRIPTION
# Description

In order to close an information hole, callers are now required to sign this get request. Invalid scenarios will receive a 401 error code in response.

There is a bit swirling around in here, since the initial request is a GET we have kept that the same and expecting the personal signed version of the payload attached as a query parameter to the request.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
