### PR TITLE
SettingsContent retrieves cards with a hook

### DIFF
--- a/unlock-app/src/__tests__/components/content/SettingsContent.test.tsx
+++ b/unlock-app/src/__tests__/components/content/SettingsContent.test.tsx
@@ -21,7 +21,7 @@ describe('SettingsContent', () => {
       const { getByText } = rtl.render(
         <Provider store={store}>
           <ConfigContext.Provider value={config}>
-            <SettingsContent account={null} cards={[]} />
+            <SettingsContent account={undefined} />
           </ConfigContext.Provider>
         </Provider>
       )
@@ -33,7 +33,7 @@ describe('SettingsContent', () => {
       const { getByText } = rtl.render(
         <Provider store={store}>
           <ConfigContext.Provider value={config}>
-            <SettingsContent account={{}} cards={[]} />
+            <SettingsContent account={{ address: '', balance: '' }} />
           </ConfigContext.Provider>
         </Provider>
       )
@@ -44,7 +44,7 @@ describe('SettingsContent', () => {
   })
 
   describe('mapStateToProps', () => {
-    it('with default state it should return null account and empty cards list', () => {
+    it('with default state it should return undefined account', () => {
       expect.assertions(1)
 
       expect(
@@ -52,8 +52,7 @@ describe('SettingsContent', () => {
           account: null,
         })
       ).toEqual({
-        account: null,
-        cards: [],
+        account: undefined,
       })
     })
   })

--- a/unlock-app/src/__tests__/hooks/useCards.test.ts
+++ b/unlock-app/src/__tests__/hooks/useCards.test.ts
@@ -1,0 +1,81 @@
+import React from 'react'
+import { EventEmitter } from 'events'
+import { renderHook } from '@testing-library/react-hooks'
+import fetch from 'jest-fetch-mock'
+import { WalletServiceContext } from '../../utils/withWalletService'
+import { ConfigContext } from '../../utils/withConfig'
+import { useCards } from '../../hooks/useCards'
+
+class MockWalletService extends EventEmitter {
+  constructor() {
+    super()
+  }
+}
+
+let mockWalletService: any
+
+const locksmithHost = 'https://locksmith'
+const userAddress = '0xuser'
+const emailAddress = 'ted@nelson.xanadu'
+
+const account = {
+  address: userAddress,
+  emailAddress,
+  balance: '5',
+}
+
+describe('useCards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    fetch.resetMocks()
+
+    jest.spyOn(React, 'useContext').mockImplementation(context => {
+      if (context === WalletServiceContext) {
+        return mockWalletService
+      }
+      if (context === ConfigContext) {
+        return {
+          services: {
+            storage: {
+              host: locksmithHost,
+            },
+          },
+        }
+      }
+    })
+
+    mockWalletService = new MockWalletService()
+    mockWalletService.unformattedSignTypedData = jest
+      .fn()
+      .mockResolvedValue('a signature')
+  })
+
+  it('should call WalletService.unformattedSignTypedData with the correct values', async () => {
+    expect.assertions(1)
+
+    fetch.mockResolvedValue({
+      json: () => Promise.resolve([]),
+    } as any)
+
+    const { result, wait } = renderHook(() => useCards(account))
+
+    await wait(() => !!result.current.cards)
+
+    expect(mockWalletService.unformattedSignTypedData).toHaveBeenCalledWith(
+      account.address,
+      expect.any(Object)
+    )
+  })
+
+  it('should return an error when the fetch fails', async () => {
+    expect.assertions(1)
+
+    fetch.mockRejectedValue(new Error('fail'))
+
+    const { result, wait } = renderHook(() => useCards(account))
+
+    await wait(() => !!result.current.error)
+
+    expect(result.current.error!.message).toEqual('fail')
+  })
+})

--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import Head from 'next/head'
-import { Card } from '@stripe/stripe-js'
 import Layout from '../interface/Layout'
 import { pageTitle } from '../../constants'
 import Errors from '../interface/Errors'
@@ -10,15 +9,17 @@ import { PaymentDetails } from '../interface/user-account/PaymentDetails'
 import PaymentMethods from '../interface/user-account/PaymentMethods'
 import EjectAccount from '../interface/user-account/EjectAccount'
 import LogInSignUp from '../interface/LogInSignUp'
+import { useCards } from '../../hooks/useCards'
+import { Account } from '../../unlockTypes'
+import Loading from '../interface/Loading'
 
 interface SettingsContentProps {
-  account: {
-    emailAddress?: string
-  } | null
-  cards: Card[]
+  account: Account | undefined
 }
 
-export const SettingsContent = ({ cards, account }: SettingsContentProps) => {
+export const SettingsContent = ({ account }: SettingsContentProps) => {
+  const { cards } = useCards(account)
+
   return (
     <Layout title="Account Settings">
       <Head>
@@ -28,8 +29,9 @@ export const SettingsContent = ({ cards, account }: SettingsContentProps) => {
       {account && account.emailAddress && (
         <>
           <AccountInfo />
-          {cards.length > 0 && <PaymentMethods cards={cards} />}
-          {cards.length === 0 && <PaymentDetails />}
+          {!cards && <Loading />}
+          {cards && cards.length > 0 && <PaymentMethods cards={cards} />}
+          {cards && cards.length === 0 && <PaymentDetails />}
           <EjectAccount />
         </>
       )}
@@ -45,21 +47,12 @@ export const SettingsContent = ({ cards, account }: SettingsContentProps) => {
 }
 
 interface ReduxState {
-  account: {
-    cards?: Card[]
-    emailAddress?: string
-  } | null
+  account: Account | null
 }
 
 export const mapStateToProps = ({ account }: ReduxState) => {
-  let cards: Card[] = []
-  if (account && account.cards) {
-    cards = account.cards
-  }
-
   return {
-    account,
-    cards,
+    account: account || undefined,
   }
 }
 

--- a/unlock-app/src/hooks/useCards.ts
+++ b/unlock-app/src/hooks/useCards.ts
@@ -1,0 +1,90 @@
+import { useContext, useEffect, useState } from 'react'
+import { WalletService } from '@unlock-protocol/unlock-js'
+import { Card } from '@stripe/stripe-js'
+import { WalletServiceContext } from '../utils/withWalletService'
+import { ConfigContext } from '../utils/withConfig'
+import { Account } from '../unlockTypes'
+
+interface Config {
+  services: {
+    storage: {
+      host: string
+    }
+  }
+}
+
+export const genAuthorizationHeader = (token: string) => {
+  return { Authorization: ` Bearer ${token}` }
+}
+
+// Taken from locksmith's userController/cards.test.ts
+export function generateTypedData(publicKey: string) {
+  return {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+        { name: 'salt', type: 'bytes32' },
+      ],
+      User: [{ name: 'publicKey', type: 'address' }],
+    },
+    domain: {
+      name: 'Unlock',
+      version: '1',
+    },
+    primaryType: 'User',
+    message: {
+      user: {
+        publicKey,
+      },
+    },
+  }
+}
+
+export const useCards = (account?: Account) => {
+  const walletService: WalletService = useContext(WalletServiceContext)
+  const config: Config = useContext(ConfigContext)
+  const [cards, setCards] = useState<Card[] | undefined>(undefined)
+  const [error, setError] = useState<Error | undefined>(undefined)
+
+  const getSignature = async (account: Account) => {
+    const typedData = generateTypedData(account.address)
+    const signature = await (walletService as any).unformattedSignTypedData(
+      account.address,
+      typedData
+    )
+    return signature
+  }
+
+  const getCards = async (account: Account) => {
+    const signature = await getSignature(account)
+    const token = Buffer.from(signature).toString('base64')
+    const opts = {
+      method: 'GET',
+      headers: genAuthorizationHeader(token),
+    }
+
+    try {
+      const response = await fetch(
+        `${config.services.storage.host}/users/${encodeURIComponent(
+          account.emailAddress!
+        )}/cards`,
+        opts
+      )
+      const json = await response.json()
+      setCards(json)
+    } catch (e) {
+      setError(e)
+    }
+  }
+
+  useEffect(() => {
+    if (account && account.emailAddress) {
+      getCards(account)
+    }
+  }, [JSON.stringify(account)])
+
+  return { cards, error }
+}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->
This PR adds a `useCards` hook to retrieve cards from locksmith. It passes along an authentication payload.

It also uses this hook in place of Redux in `SettingsContent`
# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #6408 (won't be resolved until we've removed all uses of the storageService method)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
