### PR TITLE
Adding configuration for Unlock CI vi Github Actions

### DIFF
--- a/.github/workflows/unlock.yml
+++ b/.github/workflows/unlock.yml
@@ -1,0 +1,221 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Unlock Subprojects
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  smart-contract-extensions:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    env:
+      CI: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: cd smart-contract-extensions && yarn
+      - run: cd smart-contract-extensions && yarn build
+      - run: cd smart-contract-extensions && yarn ganache &
+      - run: cd smart-contract-extensions && yarn test
+
+  smart-contracts:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+    
+    env:
+      CI: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: cd smart-contracts && yarn
+      - run: cd smart-contracts && yarn build
+      - run: cd smart-contracts && yarn ganache &
+      - run: cd smart-contracts && yarn test
+
+  unlock-app:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: cd unlock-app && yarn
+      - run: cd unlock-app && yarn test
+        env:
+          CI: true
+
+  paywall:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: cd paywall && yarn
+      - run: cd paywall && yarn test
+        env:
+          CI: true
+
+  wedlocks:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: cd wedlocks && yarn
+      - run: cd wedlocks && yarn test
+        env:
+          CI: true
+
+  newsletter:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: cd newsletter && yarn
+      - run: cd newsletter && yarn test
+        env:
+          CI: true
+
+  unlock-protocol-com:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: cd unlock-protocol.com && yarn
+      - run: cd unlock-protocol.com && yarn test
+        env:
+          CI: true
+
+  nudge:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: cd nudge && yarn
+      - run: cd nudge && yarn test
+        env:
+          CI: true
+
+  locksmith:
+    runs-on: ubuntu-latest
+    container: node:10.18-jessie
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: cd locksmith && yarn
+      - name: Run test
+        run: cd locksmith && yarn test
+        env:
+          POSTGRES_HOST: postgres
+          DB_HOSTNAME: postgres
+          DB_PASSWORD: postgres
+          DB_USERNAME: postgres
+          DB_NAME: postgres
+          WEB3_PROVIDER_HOST: http://0.0.0.0:8545
+          POSTGRES_PORT: 5432
+
+  integration-test:
+    needs: [
+        unlock-app,
+        paywall,
+        wedlocks,
+        newsletter,
+        unlock-protocol-com,
+        nudge,
+        # smart-contract-extensions,
+        # smart-contracts,
+        locksmith,
+      ]
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Get Integration Test dependencies
+        run: cd tests && yarn


### PR DESCRIPTION
# Description

This draft PR is here to capture some of the learning around attempting to cut Unlock's CI over to Github Actions.

Generally speaking, github actions is easy to start with the general use case of: 
check out code -> execute -> proceed.

This has been illustrated with the running of the sub projects of the monorepo. 

As things become more complex the lack of visibility becomes a point of contention.  At the time of writing, unlockjs included an integration test suite that requires an instance of ganache to complete. The behavior of this setup differs from running in a development environment, without the ability to probe the environmental factors we are lead to debug via deployment which is an extremely slow feedback loop.

We encountered a few issues relative to our setup that make it difficult to proceed without adjustments. At the moment we have a few scripts in place to generalize the CI process from the underlying service for portability.  Unfortunately Github Actions does not support all of these assumptions.

* [Unlimited Storage to Build](https://github.community/t5/GitHub-Actions/BUG-Strange-quot-No-space-left-on-device-quot-IOExceptions-on/td-p/46101)
* [Support for Docker Layer Caching](https://github.community/t5/GitHub-Actions/Docker-layer-caching/td-p/41432)
* [Docker Images available across jobs](https://github.community/t5/GitHub-Actions/What-s-the-recommended-way-to-pass-a-Docker-image-to-the-next/td-p/41565)

These items in addition to the lack of visibility into the system upon error make it extremely difficult to debug issues with successfully running integration tests in the environment. A lot of this is magnified by there being a large amount of config in place for the integration tests.

