### PR TITLE
Render call to action based on state with defaults

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/CallToAction.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/CallToAction.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import * as rtl from '@testing-library/react'
+import {
+  CallToAction,
+  defaultCallToAction,
+} from '../../../../components/interface/checkout/CallToAction'
+import { PaywallCallToAction } from '../../../../unlockTypes'
+
+const callToAction = {
+  noWallet: 'Hey, you need a wallet for this to work',
+}
+
+describe('CallToAction', () => {
+  it('renders a loading message while the state is loading', () => {
+    expect.assertions(0)
+
+    const { getByText } = rtl.render(<CallToAction state="loading" />)
+
+    getByText('Loading...')
+  })
+
+  it('renders a message from the defaults when no cta object is provided', () => {
+    expect.assertions(0)
+
+    const { getByText } = rtl.render(<CallToAction state="notLoggedIn" />)
+
+    getByText(defaultCallToAction.noWallet)
+  })
+
+  it('renders a message from the cta object when provided', () => {
+    expect.assertions(0)
+
+    const { getByText } = rtl.render(
+      <CallToAction
+        state="notLoggedIn"
+        callToAction={callToAction as PaywallCallToAction}
+      />
+    )
+
+    getByText(callToAction.noWallet)
+  })
+})

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -102,7 +102,7 @@ export const CheckoutContentInner = ({
     )
     send('metadataSubmitted')
   }
-
+  console.log(current)
   return (
     <CheckoutContainer close={emitCloseModal}>
       <CheckoutWrapper allowClose={allowClose} hideCheckout={emitCloseModal}>

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -8,13 +8,14 @@ import { UnlockError } from '../../utils/Error'
 import BrowserOnly from '../helpers/BrowserOnly'
 import { pageTitle } from '../../constants'
 import { useCheckoutCommunication } from '../../hooks/useCheckoutCommunication'
-import { checkoutMachine } from '../../stateMachines/checkout'
+import { checkoutMachine, CheckoutState } from '../../stateMachines/checkout'
 import CheckoutWrapper from '../interface/checkout/CheckoutWrapper'
 import CheckoutContainer from '../interface/checkout/CheckoutContainer'
 import { CheckoutErrors } from '../interface/checkout/CheckoutErrors'
 import { NotLoggedIn } from '../interface/checkout/NotLoggedIn'
 import { Locks } from '../interface/checkout/Locks'
 import { FiatLocks } from '../interface/checkout/FiatLocks'
+import { CallToAction } from '../interface/checkout/CallToAction'
 import Loading from '../interface/Loading'
 import { resetError } from '../../actions/error'
 import {
@@ -112,16 +113,21 @@ export const CheckoutContentInner = ({
           {paywallConfig && paywallConfig.icon && (
             <PaywallLogo alt="Publisher Icon" src={paywallConfig.icon} />
           )}
-          <p>{paywallConfig ? paywallConfig.callToAction.default : ''}</p>
+          {paywallConfig && (
+            <CallToAction
+              state={current.value}
+              callToAction={paywallConfig.callToAction}
+            />
+          )}
           <CheckoutErrors
             errors={errors}
             resetError={(e: UnlockError) => reduxDispatch(resetError(e))}
           />
-          {current.matches('loading') && <Loading />}
-          {current.matches('notLoggedIn') && (
+          {current.matches(CheckoutState.loading) && <Loading />}
+          {current.matches(CheckoutState.notLoggedIn) && (
             <NotLoggedIn config={config!} lockAddresses={lockAddresses} />
           )}
-          {current.matches('locks') && (
+          {current.matches(CheckoutState.locks) && (
             <Locks
               accountAddress={account.address}
               lockAddresses={lockAddresses}
@@ -130,7 +136,7 @@ export const CheckoutContentInner = ({
               showMetadataForm={() => send('collectMetadata')}
             />
           )}
-          {current.matches('fiatLocks') && (
+          {current.matches(CheckoutState.fiatLocks) && (
             <FiatLocks
               accountAddress={account.address}
               lockAddresses={lockAddresses}
@@ -140,7 +146,7 @@ export const CheckoutContentInner = ({
               showMetadataForm={() => send('collectMetadata')}
             />
           )}
-          {current.matches('metadataForm') && (
+          {current.matches(CheckoutState.metadataForm) && (
             <MetadataForm
               fields={config!.metadataInputs!}
               onSubmit={onMetadataSubmit}

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -102,7 +102,7 @@ export const CheckoutContentInner = ({
     )
     send('metadataSubmitted')
   }
-  console.log(current)
+
   return (
     <CheckoutContainer close={emitCloseModal}>
       <CheckoutWrapper allowClose={allowClose} hideCheckout={emitCloseModal}>

--- a/unlock-app/src/components/interface/checkout/CallToAction.tsx
+++ b/unlock-app/src/components/interface/checkout/CallToAction.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { PaywallCallToAction } from '../../../unlockTypes'
+import { CheckoutState } from '../../../stateMachines/checkout'
+
+export const defaultCallToAction: PaywallCallToAction = {
+  default:
+    'You have reached your limit of free articles. Please purchase access',
+  expired: 'Your access has expired. Please purchase a new key to continue',
+  pending: 'Purchase pending...',
+  confirmed: 'Purchase confirmed, content unlocked!',
+  noWallet:
+    'To buy a key you will need to use a crypto-enabled browser that has a wallet. Here are a few options.',
+}
+
+// TODO: Handle expired/pending/confirmed cases
+export const stateToCTAKey: {
+  [state in CheckoutState]: keyof PaywallCallToAction
+} = {
+  [CheckoutState.loading]: 'default',
+  [CheckoutState.fiatLocks]: 'default',
+  [CheckoutState.locks]: 'default',
+  [CheckoutState.metadataForm]: 'default',
+  [CheckoutState.notLoggedIn]: 'noWallet',
+}
+
+export const CallToAction = (
+  state: any,
+  callToAction?: PaywallCallToAction
+) => {
+  const key = stateToCTAKey[state as keyof typeof CheckoutState]
+  const message =
+    (callToAction && callToAction[key]) || defaultCallToAction[key]
+  return <p>{message}</p>
+}

--- a/unlock-app/src/components/interface/checkout/CallToAction.tsx
+++ b/unlock-app/src/components/interface/checkout/CallToAction.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'styled-components'
 import { PaywallCallToAction } from '../../../unlockTypes'
 import { CheckoutState } from '../../../stateMachines/checkout'
 
@@ -23,12 +24,21 @@ export const stateToCTAKey: {
   [CheckoutState.notLoggedIn]: 'noWallet',
 }
 
-export const CallToAction = (
-  state: any,
+interface CallToActionProps {
+  state: any
   callToAction?: PaywallCallToAction
-) => {
+}
+
+export const CallToAction = ({ state, callToAction }: CallToActionProps) => {
+  if (state === CheckoutState.loading) {
+    return <Message>Loading...</Message>
+  }
   const key = stateToCTAKey[state as keyof typeof CheckoutState]
   const message =
     (callToAction && callToAction[key]) || defaultCallToAction[key]
-  return <p>{message}</p>
+  return <Message>{message}</Message>
 }
+
+const Message = styled.p`
+  width: 100%;
+`

--- a/unlock-app/src/stateMachines/checkout.ts
+++ b/unlock-app/src/stateMachines/checkout.ts
@@ -1,12 +1,20 @@
 import { Machine } from 'xstate'
 
+export enum CheckoutState {
+  loading = 'loading',
+  metadataForm = 'metadataForm',
+  notLoggedIn = 'notLoggedIn',
+  locks = 'locks',
+  fiatLocks = 'fiatLocks',
+}
+
 interface CheckoutStateSchema {
   states: {
-    loading: {}
-    metadataForm: {}
-    notLoggedIn: {}
-    locks: {}
-    fiatLocks: {}
+    [CheckoutState.loading]: {}
+    [CheckoutState.metadataForm]: {}
+    [CheckoutState.notLoggedIn]: {}
+    [CheckoutState.locks]: {}
+    [CheckoutState.fiatLocks]: {}
   }
 }
 
@@ -21,31 +29,31 @@ export const checkoutMachine = Machine<CheckoutStateSchema, CheckoutEvent>({
   id: 'checkout',
   initial: 'loading',
   states: {
-    loading: {
+    [CheckoutState.loading]: {
       on: {
         gotConfigAndUserAccount: 'fiatLocks',
         gotConfigAndAccount: 'locks',
         gotConfig: 'notLoggedIn',
       },
     },
-    metadataForm: {
+    [CheckoutState.metadataForm]: {
       on: {
         metadataSubmitted: 'locks',
       },
     },
-    notLoggedIn: {
+    [CheckoutState.notLoggedIn]: {
       on: {
         gotConfigAndUserAccount: 'fiatLocks',
         gotConfigAndAccount: 'locks',
       },
     },
-    locks: {
+    [CheckoutState.locks]: {
       on: {
         gotConfigAndUserAccount: 'fiatLocks',
         collectMetadata: 'metadataForm',
       },
     },
-    fiatLocks: {
+    [CheckoutState.fiatLocks]: {
       on: {
         collectMetadata: 'metadataForm',
         gotConfigAndAccount: 'locks',


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR uses the new state machine infrastructure to choose which call to action to render. Additionally, it provides defaults for when a call to action has not been defined.

Right now it doesn't handle every possible call to action. For that we'll want to define new states so that `locks` can transition to `locks/pending` and so on.

<img width="447" alt="image" src="https://user-images.githubusercontent.com/9300702/78575439-5a135580-77f9-11ea-9c68-32f0ddf4f400.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
