### PR TITLE
Refactoring provider handling

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/FiatLock.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/FiatLock.test.tsx
@@ -69,6 +69,7 @@ describe('FiatLock', () => {
           sig: 'sig',
         })),
       } as any,
+      loading: true,
     }))
   })
 

--- a/unlock-app/src/__tests__/config.test.js
+++ b/unlock-app/src/__tests__/config.test.js
@@ -33,7 +33,6 @@ describe('config', () => {
       window.top = window
 
       const config = configure(
-        global,
         {
           unlockEnv: 'dev',
           httpProvider: '127.0.0.1',
@@ -52,7 +51,6 @@ describe('config', () => {
       }
 
       const config = configure(
-        global,
         {
           unlockEnv: 'dev',
           httpProvider: '127.0.0.1',
@@ -66,7 +64,6 @@ describe('config', () => {
     it('should return true when an exception is thrown', () => {
       expect.assertions(1)
       const config = configure(
-        global,
         {
           unlockEnv: 'dev',
           httpProvider: '127.0.0.1',
@@ -79,7 +76,7 @@ describe('config', () => {
   })
 
   describe('dev', () => {
-    let config = configure(global, {
+    const config = configure({
       unlockEnv: 'dev',
       httpProvider: '127.0.0.1',
     })
@@ -93,32 +90,8 @@ describe('config', () => {
     })
 
     it('should have the right keys in dev', () => {
-      expect.assertions(2)
-      expect(config.requiredNetwork).toEqual('Dev')
-      expect(config.providers).toHaveProperty('Unlock')
-    })
-
-    it('should have the right keys in dev when there is a web3 provider', () => {
       expect.assertions(1)
-      config = configure(
-        {
-          web3: {
-            currentProvider: {
-              isMetaMask: true,
-            },
-          },
-        },
-        {
-          unlockEnv: 'dev',
-          httpProvider: '127.0.0.1',
-        }
-      )
-      expect(config.providers).toMatchObject({
-        Unlock: expect.any(Object),
-        Metamask: {
-          isMetaMask: true,
-        },
-      })
+      expect(config.requiredNetwork).toEqual('Dev')
     })
 
     it('should contain the right URLs for chain explorers', () => {
@@ -129,19 +102,10 @@ describe('config', () => {
   })
 
   describe('staging', () => {
-    const config = configure(
-      {
-        web3: {
-          currentProvider: {
-            isMetaMask: true,
-          },
-        },
-      },
-      {
-        unlockEnv: 'staging',
-        httpProvider: '127.0.0.1',
-      }
-    )
+    const config = configure({
+      unlockEnv: 'staging',
+      httpProvider: '127.0.0.1',
+    })
 
     it('should require rinkeby', () => {
       expect.assertions(4)
@@ -152,13 +116,8 @@ describe('config', () => {
     })
 
     it('should have the right keys ', () => {
-      expect.assertions(2)
+      expect.assertions(1)
       expect(config.requiredNetwork).toEqual('Rinkeby')
-      expect(config.providers).toMatchObject({
-        Metamask: {
-          isMetaMask: true,
-        },
-      })
     })
 
     it('should contain the right URLs for chain explorers', () => {
@@ -171,7 +130,7 @@ describe('config', () => {
   })
 
   describe('production', () => {
-    const config = configure(global, {
+    const config = configure({
       unlockEnv: 'prod',
       httpProvider: '127.0.0.1',
     })
@@ -185,10 +144,8 @@ describe('config', () => {
     })
 
     it('should have the right keys in production', () => {
-      expect.assertions(2)
+      expect.assertions(1)
       expect(config.requiredNetwork).toEqual('Mainnet')
-      // No web3 provider, but Unlock provider is always there
-      expect(config.providers).toHaveProperty('Unlock')
     })
 
     it('should contain the right URLs for chain explorers', () => {

--- a/unlock-app/src/__tests__/hooks/useProvider.test.ts
+++ b/unlock-app/src/__tests__/hooks/useProvider.test.ts
@@ -1,8 +1,32 @@
 import { renderHook } from '@testing-library/react-hooks'
 import * as Redux from 'react-redux'
 import React from 'react'
-import { useProvider } from '../../hooks/useProvider'
+import { useProvider, EthereumWindow } from '../../hooks/useProvider'
 import { ConfigContext } from '../../utils/withConfig'
+
+let mockDispatch = jest.fn()
+
+const mockConfig = {
+  env: 'test',
+  httpProvider: 'localhost',
+}
+
+let mockWeb3Provider: any = null
+
+const mockWeb3ProviderContext = {
+  getWeb3Provider: jest.fn(),
+  setWeb3Provider: jest.fn(),
+}
+
+jest.mock('react-redux', () => {
+  const ActualReactRedux = require.requireActual('react-redux')
+  return {
+    ...ActualReactRedux,
+    useDispatch: () => {
+      return mockDispatch
+    },
+  }
+})
 
 jest.spyOn(Redux, 'useSelector').mockImplementation(selector => {
   return selector({
@@ -12,22 +36,103 @@ jest.spyOn(Redux, 'useSelector').mockImplementation(selector => {
 
 jest.spyOn(React, 'useContext').mockImplementation(context => {
   if (context === ConfigContext) {
-    return {
-      providers: {
-        Unlock: {},
-      },
-    }
+    return mockConfig
   }
+  return mockWeb3ProviderContext
 })
 
 describe('useProvider', () => {
-  it('returns a provider', () => {
-    expect.assertions(1)
+  beforeEach(() => {
+    mockDispatch = jest.fn()
+    mockWeb3Provider = null
+    mockWeb3ProviderContext.setWeb3Provider = jest.fn(web3Provider => {
+      mockWeb3Provider = web3Provider
+    })
+    mockWeb3ProviderContext.getWeb3Provider = jest.fn(() => mockWeb3Provider)
+  })
 
-    const { result } = renderHook(() => useProvider())
+  describe('in the test environment', () => {
+    it('should use the provider from the local node', async () => {
+      expect.assertions(2)
 
-    expect(result.current).toEqual({
-      provider: expect.any(Object),
+      const { result, wait } = renderHook(() => useProvider())
+
+      await wait(() => !result.current.loading)
+      expect(mockWeb3ProviderContext.setWeb3Provider).toHaveBeenCalledWith(
+        `http://${mockConfig.httpProvider}:8545`
+      )
+      expect(result.current).toEqual({
+        provider: `http://${mockConfig.httpProvider}:8545`,
+        loading: false,
+      })
+    })
+  })
+
+  describe('when not using the test environment', () => {
+    beforeEach(() => {
+      mockConfig.env = 'dev'
+    })
+
+    it('returns no provider if none is set in the window', async () => {
+      expect.assertions(1)
+
+      const { result, wait } = renderHook(() => useProvider())
+
+      await wait(() => !result.current.loading)
+
+      expect(result.current).toEqual({
+        provider: null,
+        loading: false,
+      })
+    })
+
+    it('returns a provider if web3 is defined on the window', async () => {
+      expect.assertions(2)
+      const web3Provider = {}
+
+      const ethereumWindow = (window as unknown) as EthereumWindow
+
+      ethereumWindow.web3 = {
+        currentProvider: web3Provider,
+      }
+
+      const { result, wait } = renderHook(() => useProvider())
+
+      await wait(() => !result.current.loading)
+      expect(mockWeb3ProviderContext.setWeb3Provider).toHaveBeenCalledWith(
+        web3Provider
+      )
+      expect(result.current).toEqual({
+        provider: web3Provider,
+        loading: false,
+      })
+    })
+
+    describe('when window.ethereum is defined', () => {
+      it('should enable the provider and yield it', async () => {
+        expect.assertions(4)
+        const web3Provider = {}
+
+        const ethereumWindow = (window as unknown) as EthereumWindow
+
+        ethereumWindow.ethereum = {
+          enable: jest.fn(() => Promise.resolve([])),
+          currentProvider: web3Provider,
+        }
+
+        const { result, wait } = renderHook(() => useProvider())
+
+        await wait(() => !result.current.loading)
+        expect(mockWeb3ProviderContext.setWeb3Provider).toHaveBeenCalledWith(
+          ethereumWindow.ethereum
+        )
+        expect(mockDispatch).toHaveBeenCalledTimes(3)
+        expect(ethereumWindow.ethereum.enable).toHaveBeenCalled()
+        expect(result.current).toEqual({
+          provider: ethereumWindow.ethereum,
+          loading: false,
+        })
+      })
     })
   })
 })

--- a/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
+++ b/unlock-app/src/__tests__/middlewares/providerMiddleware.test.ts
@@ -2,10 +2,9 @@ import providerMiddleware, {
   changePassword,
   initializeUnlockProvider,
 } from '../../middlewares/providerMiddleware'
-import { SET_PROVIDER, providerReady } from '../../actions/provider'
+
 import { setError } from '../../actions/error'
-import { FATAL_MISSING_PROVIDER } from '../../errors'
-import { Application, LogIn } from '../../utils/Error'
+import { LogIn } from '../../utils/Error'
 import {
   GOT_ENCRYPTED_PRIVATE_KEY_PAYLOAD,
   SIGN_USER_DATA,
@@ -21,63 +20,34 @@ import { EncryptedPrivateKey } from '../../unlockTypes'
 jest.mock('../../utils/accounts')
 
 const config = {
-  providers: {
-    UNLOCK: {
+  readOnlyProvider: '',
+  requiredNetworkId: '',
+}
+
+let dispatch: () => any
+
+let mockProvider = {
+  isUnlock: true,
+  signUserData: jest.fn(() => ({ data: {}, sig: {} })),
+  signPaymentData: jest.fn(() => ({ data: {}, sig: {} })),
+  signKeyPurchaseRequestData: jest.fn(() => ({ data: {}, sig: {} })),
+  generateSignedEjectionRequest: jest.fn(() => ({ data: {}, sig: {} })),
+}
+
+const getProvider = jest.fn(() => {
+  return mockProvider
+})
+const setProvider = jest.fn(() => {})
+
+describe('provider middleware', () => {
+  beforeEach(() => {
+    mockProvider = {
       isUnlock: true,
       signUserData: jest.fn(() => ({ data: {}, sig: {} })),
       signPaymentData: jest.fn(() => ({ data: {}, sig: {} })),
       signKeyPurchaseRequestData: jest.fn(() => ({ data: {}, sig: {} })),
       generateSignedEjectionRequest: jest.fn(() => ({ data: {}, sig: {} })),
-    },
-    NUNLOCK: {
-      enable: jest.fn(() => new Promise(resolve => resolve(true))),
-    },
-    METAMASQUE: {
-      enable: jest.fn(() => new Promise(resolve => resolve(true))),
-    },
-    NOENABLE: {},
-  },
-}
-
-const getState = () => ({
-  provider: 'NUNLOCK',
-})
-
-const metamasqueAction = {
-  type: SET_PROVIDER,
-  provider: 'METAMASQUE',
-}
-
-const erroneousAction = {
-  type: SET_PROVIDER,
-  provider: 'HONLOCK',
-}
-
-const sameAction = {
-  type: SET_PROVIDER,
-  provider: 'NUNLOCK',
-}
-
-const unlockAction = {
-  type: SET_PROVIDER,
-  provider: 'UNLOCK',
-}
-
-const noEnableAction = {
-  type: SET_PROVIDER,
-  provider: 'NOENABLE',
-}
-
-let dispatch: () => any
-
-describe('provider middleware', () => {
-  beforeEach(() => {
-    config.providers.NUNLOCK.enable = jest.fn(
-      () => new Promise(resolve => resolve(true))
-    )
-    config.providers.METAMASQUE.enable = jest.fn(
-      () => new Promise(resolve => resolve(true))
-    )
+    }
     dispatch = jest.fn()
   })
 
@@ -113,92 +83,18 @@ describe('provider middleware', () => {
     })
   })
 
-  describe('SET_PROVIDER', () => {
-    it('should initialize the provider when provider is different from one in state', done => {
-      expect.assertions(2)
-      const next = () => {
-        expect(config.providers.METAMASQUE.enable).toHaveBeenCalled()
-        expect(config.providers.NUNLOCK.enable).not.toHaveBeenCalled()
-        done()
-      }
-
-      providerMiddleware(config)({ getState, dispatch })(next)(metamasqueAction)
-    })
-
-    it('should set an error and return if there is no matching provider', done => {
-      expect.assertions(3)
-      const next = () => {
-        expect(config.providers.NUNLOCK.enable).not.toHaveBeenCalled()
-        expect(config.providers.METAMASQUE.enable).not.toHaveBeenCalled()
-        expect(dispatch).toHaveBeenCalledWith(
-          setError(Application.Fatal(FATAL_MISSING_PROVIDER))
-        )
-        done()
-      }
-
-      providerMiddleware(config)({ getState, dispatch })(next)(erroneousAction)
-    })
-
-    it('should set an error and return if the call to enable fails', done => {
-      expect.assertions(2)
-      config.providers.METAMASQUE.enable = jest.fn(() => {
-        // eslint-disable-next-line promise/param-names
-        return new Promise((_, reject) => {
-          reject('The front fell off.')
-        })
-      })
-
-      const next = () => {
-        expect(config.providers.METAMASQUE.enable).toHaveBeenCalled()
-        expect(config.providers.NUNLOCK.enable).not.toHaveBeenCalled()
-        done()
-      }
-
-      providerMiddleware(config)({ getState, dispatch })(next)(metamasqueAction)
-    })
-
-    it('should do nothing if provider is the same as in state', done => {
-      expect.assertions(3)
-      const next = () => {
-        expect(config.providers.METAMASQUE.enable).not.toHaveBeenCalled()
-        expect(config.providers.NUNLOCK.enable).not.toHaveBeenCalled()
-        expect(dispatch).not.toHaveBeenCalled()
-        done()
-      }
-
-      providerMiddleware(config)({ getState, dispatch })(next)(sameAction)
-    })
-
-    it('should do nothing if using unlockProvider', done => {
-      expect.assertions(3)
-      const next = () => {
-        expect(config.providers.METAMASQUE.enable).not.toHaveBeenCalled()
-        expect(config.providers.NUNLOCK.enable).not.toHaveBeenCalled()
-        expect(dispatch).not.toHaveBeenCalled()
-        done()
-      }
-
-      providerMiddleware(config)({ getState, dispatch })(next)(unlockAction)
-    })
-
-    it('should simply dispatch providerReady if provider does not have enable method', () => {
-      expect.assertions(1)
-      const next = () => {
-        expect(dispatch).toHaveBeenCalledWith(providerReady())
-      }
-
-      providerMiddleware(config)({ getState, dispatch })(next)(noEnableAction)
-    })
-  })
-
   describe('SIGN_USER_DATA', () => {
     it('should call UnlockProvider', () => {
       expect.assertions(1)
       const next = () => {
-        expect(config.providers.UNLOCK.signUserData).toHaveBeenCalled()
+        expect(mockProvider.signUserData).toHaveBeenCalled()
       }
 
-      providerMiddleware(config)({
+      providerMiddleware(
+        config,
+        getProvider,
+        setProvider
+      )({
         getState: () => ({ provider: 'UNLOCK' }),
         dispatch,
       })(next)({
@@ -212,12 +108,16 @@ describe('provider middleware', () => {
     it('should call UnlockProvider', () => {
       expect.assertions(1)
       const next = () => {
-        expect(config.providers.UNLOCK.signPaymentData).toHaveBeenCalledWith(
+        expect(mockProvider.signPaymentData).toHaveBeenCalledWith(
           'tok_1EPsocIsiZS2oQBMRXzw21xh'
         )
       }
 
-      providerMiddleware(config)({
+      providerMiddleware(
+        config,
+        getProvider,
+        setProvider
+      )({
         getState: () => ({ provider: 'UNLOCK' }),
         dispatch,
       })(next)({
@@ -235,12 +135,16 @@ describe('provider middleware', () => {
         lock: '0x321cba',
       }
       const next = () => {
-        expect(
-          config.providers.UNLOCK.signKeyPurchaseRequestData
-        ).toHaveBeenCalledWith(data)
+        expect(mockProvider.signKeyPurchaseRequestData).toHaveBeenCalledWith(
+          data
+        )
       }
 
-      providerMiddleware(config)({
+      providerMiddleware(
+        config,
+        getProvider,
+        setProvider
+      )({
         getState: () => ({ provider: 'UNLOCK' }),
         dispatch,
       })(next)({
@@ -256,11 +160,15 @@ describe('provider middleware', () => {
 
       const next = () => {
         expect(
-          config.providers.UNLOCK.generateSignedEjectionRequest
+          mockProvider.generateSignedEjectionRequest
         ).toHaveBeenCalledWith()
       }
 
-      providerMiddleware(config)({
+      providerMiddleware(
+        config,
+        getProvider,
+        setProvider
+      )({
         getState: () => ({ provider: 'UNLOCK' }),
         dispatch,
       })(next)({

--- a/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
+++ b/unlock-app/src/__tests__/middlewares/walletMiddleware.test.js
@@ -35,6 +35,8 @@ let state = {}
 const transaction = {}
 const network = {}
 
+const mockProvider = {}
+
 /**
  * This is a "fake" middleware caller
  * Taken from https://redux.js.org/recipes/writing-tests#middleware
@@ -46,7 +48,13 @@ const create = (dispatchImplementation = () => true) => {
   }
   const next = jest.fn()
 
-  const handler = walletMiddleware(mockConfig, mockWalletService)(store)
+  const getProvider = () => mockProvider
+
+  const handler = walletMiddleware(
+    mockConfig,
+    mockWalletService,
+    getProvider
+  )(store)
 
   const invoke = action => handler(next)(action)
 
@@ -449,10 +457,9 @@ describe('Wallet middleware', () => {
     const { next, invoke } = create()
     const action = { type: PROVIDER_READY }
     mockWalletService.connect = jest.fn()
+    const mockProvider = {}
     invoke(action)
-    expect(mockWalletService.connect).toHaveBeenCalledWith(
-      mockConfig.providers[state.provider]
-    )
+    expect(mockWalletService.connect).toHaveBeenCalledWith(mockProvider)
     expect(next).toHaveBeenCalledWith(action)
   })
 

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -32080,6 +32080,46 @@ Object {
   z-index: var(--alwaysontop);
 }
 
+.c20 {
+  display: grid;
+  row-gap: 16px;
+  -webkit-column-gap: 32px;
+  column-gap: 32px;
+  border: solid 1px var(--lightgrey);
+  grid-template-columns: 72px;
+  grid-auto-flow: column;
+  border-radius: 4px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 32px;
+  padding-bottom: 40px;
+}
+
+.c21 {
+  width: 72px;
+}
+
+.c22 {
+  display: grid;
+  grid-gap: 16px;
+}
+
+.c22 > h1 {
+  font-weight: bold;
+  color: var(--red);
+  margin: 0px;
+  padding: 0px;
+}
+
+.c22 > p {
+  margin: 0px;
+  padding: 0px;
+  font-size: 16px;
+  color: var(--dimgrey);
+}
+
 .c0 {
   display: grid;
   grid-template-columns: 1fr minmax(280px,4fr) 1fr;
@@ -32210,6 +32250,14 @@ Object {
   }
 }
 
+@media (max-width:500px) {
+  .c20 {
+    grid-template-columns: 1fr;
+    grid-auto-flow: row;
+    padding: 16px;
+  }
+}
+
 @media only screen and (min-width:0px) and (max-width:736px) {
   .c0 {
     display: -webkit-box;
@@ -32240,7 +32288,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c20 {
+  .c23 {
     display: none;
   }
 }
@@ -32480,9 +32528,34 @@ Object {
               </button>
             </div>
           </div>
+          <section
+            class="c20"
+          >
+            <img
+              class="c21"
+              src="/static/images/illustrations/wallet.svg"
+            />
+            <div
+              class="c22"
+            >
+              <h1>
+                Wallet missing
+              </h1>
+              <p>
+                It looks like you’re using an incompatible browser or are missing a crypto wallet. If you’re using Chrome or Firefox you can install
+                 
+                <a
+                  href="https://metamask.io/"
+                >
+                  Metamask
+                </a>
+                .
+              </p>
+            </div>
+          </section>
         </div>
         <div
-          class="c20"
+          class="c23"
         />
       </div>
     </div>
@@ -32722,6 +32795,31 @@ Object {
             </button>
           </div>
         </div>
+        <section
+          class="sc-fzqKxP bqmVrm"
+        >
+          <img
+            class="sc-pANHa eMPpXq"
+            src="/static/images/illustrations/wallet.svg"
+          />
+          <div
+            class="sc-pIJJz doBmDm"
+          >
+            <h1>
+              Wallet missing
+            </h1>
+            <p>
+              It looks like you’re using an incompatible browser or are missing a crypto wallet. If you’re using Chrome or Firefox you can install
+               
+              <a
+                href="https://metamask.io/"
+              >
+                Metamask
+              </a>
+              .
+            </p>
+          </div>
+        </section>
       </div>
       <div
         class="hm3mhg-4 fEldZt"
@@ -33132,6 +33230,46 @@ Object {
   z-index: var(--alwaysontop);
 }
 
+.c24 {
+  display: grid;
+  row-gap: 16px;
+  -webkit-column-gap: 32px;
+  column-gap: 32px;
+  border: solid 1px var(--lightgrey);
+  grid-template-columns: 72px;
+  grid-auto-flow: column;
+  border-radius: 4px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 32px;
+  padding-bottom: 40px;
+}
+
+.c25 {
+  width: 72px;
+}
+
+.c26 {
+  display: grid;
+  grid-gap: 16px;
+}
+
+.c26 > h1 {
+  font-weight: bold;
+  color: var(--red);
+  margin: 0px;
+  padding: 0px;
+}
+
+.c26 > p {
+  margin: 0px;
+  padding: 0px;
+  font-size: 16px;
+  color: var(--dimgrey);
+}
+
 .c3 {
   display: grid;
   grid-template-columns: 1fr minmax(280px,4fr) 1fr;
@@ -33262,6 +33400,14 @@ Object {
   }
 }
 
+@media (max-width:500px) {
+  .c24 {
+    grid-template-columns: 1fr;
+    grid-auto-flow: row;
+    padding: 16px;
+  }
+}
+
 @media only screen and (min-width:0px) and (max-width:736px) {
   .c3 {
     display: -webkit-box;
@@ -33292,7 +33438,7 @@ Object {
 }
 
 @media only screen and (min-width:0px) and (max-width:736px) {
-  .c24 {
+  .c27 {
     display: none;
   }
 }
@@ -33596,9 +33742,34 @@ Object {
               </button>
             </div>
           </div>
+          <section
+            class="c24"
+          >
+            <img
+              class="c25"
+              src="/static/images/illustrations/wallet.svg"
+            />
+            <div
+              class="c26"
+            >
+              <h1>
+                Wallet missing
+              </h1>
+              <p>
+                It looks like you’re using an incompatible browser or are missing a crypto wallet. If you’re using Chrome or Firefox you can install
+                 
+                <a
+                  href="https://metamask.io/"
+                >
+                  Metamask
+                </a>
+                .
+              </p>
+            </div>
+          </section>
         </div>
         <div
-          class="c24"
+          class="c27"
         />
       </div>
     </div>
@@ -33902,6 +34073,31 @@ Object {
             </button>
           </div>
         </div>
+        <section
+          class="sc-fzqKxP bqmVrm"
+        >
+          <img
+            class="sc-pANHa eMPpXq"
+            src="/static/images/illustrations/wallet.svg"
+          />
+          <div
+            class="sc-pIJJz doBmDm"
+          >
+            <h1>
+              Wallet missing
+            </h1>
+            <p>
+              It looks like you’re using an incompatible browser or are missing a crypto wallet. If you’re using Chrome or Firefox you can install
+               
+              <a
+                href="https://metamask.io/"
+              >
+                Metamask
+              </a>
+              .
+            </p>
+          </div>
+        </section>
       </div>
       <div
         class="hm3mhg-4 fEldZt"

--- a/unlock-app/src/components/content/DashboardContent.js
+++ b/unlock-app/src/components/content/DashboardContent.js
@@ -16,6 +16,10 @@ import {
 } from '../interface/buttons/ActionButton'
 import { showForm, hideForm } from '../../actions/lockFormVisibility'
 import { Phone } from '../../theme/media'
+import { useProvider } from '../../hooks/useProvider'
+import { FATAL_MISSING_PROVIDER } from '../../errors'
+import Error from '../../utils/Error'
+import { mapErrorToComponent } from '../creator/FatalError'
 
 export const DashboardContent = ({
   account,
@@ -24,6 +28,7 @@ export const DashboardContent = ({
   showForm,
   hideForm,
 }) => {
+  const { provider } = useProvider()
   const toggleForm = () => {
     formIsVisible ? hideForm() : showForm()
   }
@@ -32,6 +37,8 @@ export const DashboardContent = ({
       <Head>
         <title>{pageTitle('Dashboard')}</title>
       </Head>
+      {!provider &&
+        mapErrorToComponent(Error.Application.Fatal(FATAL_MISSING_PROVIDER))}
       {account && (
         <BrowserOnly>
           <AccountWrapper>

--- a/unlock-app/src/components/interface/Layout.js
+++ b/unlock-app/src/components/interface/Layout.js
@@ -11,14 +11,17 @@ import { MessageBox } from './modal-templates/styles'
 import { ActionButton } from './buttons/ActionButton'
 import withConfig from '../../utils/withConfig'
 import useTermsOfService from '../../hooks/useTermsOfService'
+import { useProvider } from '../../hooks/useProvider'
 import Loading from './Loading'
 import GlobalErrorConsumer from './GlobalErrorConsumer'
 
 export default function Layout({ forContent, title, children }) {
   const { termsAccepted, saveTermsAccepted, termsLoading } = useTermsOfService()
-  if (termsLoading) {
+  const { loading: providerLoading } = useProvider()
+  if (termsLoading || providerLoading) {
     return <Loading />
   }
+
   return (
     <Container>
       <Left>

--- a/unlock-app/src/config.js
+++ b/unlock-app/src/config.js
@@ -1,7 +1,4 @@
-import { getCurrentProvider } from '@unlock-protocol/unlock-js'
-
 import getConfig from 'next/config'
-import UnlockProvider from './services/unlockProvider'
 import { ETHEREUM_NETWORKS_NAMES } from './constants'
 
 // cribbed from https://stackoverflow.com/questions/326069/how-to-identify-if-a-webpage-is-being-loaded-inside-an-iframe-or-directly-into-t
@@ -22,7 +19,6 @@ export function inIframe(window) {
  * @param {*} environment (in the JS sense: `window` most likely)
  */
 export default function configure(
-  environment = global,
   runtimeConfig = getConfig().publicRuntimeConfig,
   useWindow = global.window
 ) {
@@ -36,7 +32,6 @@ export default function configure(
   let googleDiscoveryDocs
   let googleScopes
 
-  const providers = {}
   let isRequiredNetwork = () => false
   let requiredNetwork = 'Dev'
   let requiredNetworkId = 1984
@@ -78,15 +73,8 @@ export default function configure(
   const readOnlyProviderUrl =
     runtimeConfig.readOnlyProvider || `http://${httpProvider}:8545`
 
-  // If there is an existing web3 injected provider, we also add this one to the list of possible providers
-  if (typeof environment.web3 !== 'undefined') {
-    providers[getCurrentProvider(environment)] =
-      environment.web3.currentProvider
-  }
-
   if (env === 'test') {
     // In test, we fake the HTTP provider
-    providers.HTTP = `http://${httpProvider}:8545`
     blockTime = 1000 // in mseconds.
     supportedProviders = ['HTTP']
     services.storage = {
@@ -208,8 +196,6 @@ export default function configure(
     readOnlyProvider = readOnlyProviderUrl
   }
 
-  providers.Unlock = new UnlockProvider({ readOnlyProvider, requiredNetworkId })
-
   return {
     base64WedlocksPublicKey,
     blockTime,
@@ -217,7 +203,7 @@ export default function configure(
     isServer,
     isInIframe,
     env,
-    providers,
+    httpProvider,
     isRequiredNetwork,
     readOnlyProvider,
     requiredNetworkId,

--- a/unlock-app/src/createUnlockStore.js
+++ b/unlock-app/src/createUnlockStore.js
@@ -6,8 +6,6 @@ import {
   initialRouterState,
 } from 'connected-next-router'
 
-import configure from './config'
-
 // Reducers
 
 import loadingReducer, {
@@ -55,8 +53,6 @@ import pageStatusReducer, {
 import signatureReducer, {
   initialState as defaultSignatureState,
 } from './reducers/signatureReducer'
-
-const config = configure()
 
 export const createUnlockStore = (
   defaultState = {},
@@ -107,7 +103,7 @@ export const createUnlockStore = (
     cart: defaultCartState,
     pageIsLocked: defaultPageStatus,
     signature: defaultSignatureState,
-    provider: Object.keys(config.providers)[0],
+    provider: null, // This will be set in the UI!
     ...defaultState,
   }
 

--- a/unlock-app/src/hooks/useLocks.js
+++ b/unlock-app/src/hooks/useLocks.js
@@ -59,11 +59,6 @@ export const useLocks = owner => {
   // TODO: move to context
   const graphService = new GraphService(subgraphURI)
 
-  // Connect to the provider.
-  // TODO: this should probably be moved upstream
-  // It is noop if already called somewhere else
-  walletService.connect(config.providers[Object.keys(config.providers)[0]])
-
   /**
    * Helper function: retrieves a lock object at the address
    */

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -1,24 +1,84 @@
-import { useSelector } from 'react-redux'
-import { useContext } from 'react'
-import UnlockProvider from '../services/unlockProvider'
+import React from 'react'
+import { useDispatch } from 'react-redux'
+import { providerReady } from '../actions/provider'
+import { waitForWallet, dismissWalletCheck } from '../actions/fullScreenModals'
+import { FATAL_NOT_ENABLED_IN_PROVIDER } from '../errors'
+import { setError } from '../actions/error'
+
+import { Application } from '../utils/Error'
+
 import { ConfigContext } from '../utils/withConfig'
 
-type Provider = UnlockProvider | null
+export const Web3ProviderContext = React.createContext({
+  getWeb3Provider: () => {},
+  setWeb3Provider: () => {},
+})
 
-interface State {
-  provider: string
+export interface EthereumWindow extends Window {
+  web3: any
+  ethereum: any
+}
+interface Web3ProviderContextType {
+  getWeb3Provider: any
+  setWeb3Provider: any
 }
 
 interface Config {
-  providers: {
-    [name: string]: Provider
-  }
+  env: string
+  httpProvider: string
 }
 
 export const useProvider = () => {
-  const config: Config = useContext(ConfigContext)
-  const providerName = useSelector<State, string>(state => state.provider)
-  const provider = config.providers[providerName]
+  const config: Config = React.useContext(ConfigContext)
+  const { getWeb3Provider, setWeb3Provider } = React.useContext<
+    Web3ProviderContextType
+  >(Web3ProviderContext)
 
-  return { provider }
+  const dispatch = useDispatch()
+
+  const [loading, setLoading] = React.useState(true)
+
+  /**
+   * Function which is called when the App component is rendered.
+   */
+  const initializeProvider = async () => {
+    if (config.env === 'test') {
+      // We set the provider to be the provided by the local ganache
+      setWeb3Provider(`http://${config.httpProvider}:8545`)
+      dispatch(providerReady())
+      setLoading(false)
+      return
+    }
+
+    const ethereumWindow = (window as unknown) as EthereumWindow
+
+    // If there is an injected provider
+    if (ethereumWindow.ethereum) {
+      dispatch(waitForWallet())
+      try {
+        // Request account access if needed
+        await ethereumWindow.ethereum.enable()
+        setWeb3Provider(ethereumWindow.ethereum)
+        dispatch(providerReady())
+      } catch (error) {
+        dispatch(setError(Application.Fatal(FATAL_NOT_ENABLED_IN_PROVIDER)))
+      }
+      dispatch(dismissWalletCheck())
+    } else if (ethereumWindow.web3) {
+      // Legacy web3 wallet/browser (should we keep supporting?)
+      setWeb3Provider(ethereumWindow.web3.currentProvider)
+      dispatch(providerReady())
+    } else {
+      // Hum. No provider!
+      // TODO: Let's let the user pick one up from the UI (including the unlock provider!)
+    }
+    setLoading(false)
+  }
+
+  React.useEffect(() => {
+    // Try to initalize the provider
+    initializeProvider()
+  }, [])
+
+  return { provider: getWeb3Provider(), loading }
 }

--- a/unlock-app/src/middlewares/walletMiddleware.js
+++ b/unlock-app/src/middlewares/walletMiddleware.js
@@ -31,7 +31,7 @@ import { SIGN_DATA, signedData } from '../actions/signature'
 // This middleware listen to redux events and invokes the walletService API.
 // It also listen to events from walletService and dispatches corresponding actions
 
-const walletMiddleware = (config, walletService) => {
+const walletMiddleware = (config, walletService, getProvider) => {
   return ({ getState, dispatch }) => {
     /**
      * Helper function which ensures that the walletService is ready
@@ -184,7 +184,7 @@ const walletMiddleware = (config, walletService) => {
     return function(next) {
       return function(action) {
         if (action.type === PROVIDER_READY) {
-          walletService.connect(config.providers[getState().provider])
+          walletService.connect(getProvider())
         } else if (action.type === CREATE_LOCK && action.lock.address) {
           ensureReadyBefore(() => {
             walletService.createLock({

--- a/unlock-app/src/pages/_app.js
+++ b/unlock-app/src/pages/_app.js
@@ -16,6 +16,8 @@ import { Web3ServiceContext } from '../utils/withWeb3Service'
 import { StorageServiceContext } from '../utils/withStorageService'
 import { StorageService } from '../services/storageService'
 
+import { Web3ProviderContext } from '../hooks/useProvider'
+
 import FullScreenModal from '../components/interface/FullScreenModals'
 
 // Middlewares
@@ -50,10 +52,10 @@ const storageService = new StorageService(config.services.storage.host)
 
 function getOrCreateStore(initialState, path) {
   const middlewares = [
-    providerMiddleware(config),
+    providerMiddleware(config, getWeb3Provider, setWeb3Provider),
     web3Middleware(web3Service),
     currencyConversionMiddleware(config),
-    walletMiddleware(config, walletService),
+    walletMiddleware(config, walletService, getWeb3Provider),
     wedlocksMiddleware(config),
     storageMiddleware(storageService),
   ]
@@ -89,6 +91,17 @@ const ConfigProvider = ConfigContext.Provider
 const WalletServiceProvider = WalletServiceContext.Provider
 const Web3ServiceProvider = Web3ServiceContext.Provider
 const StorageServiceProvider = StorageServiceContext.Provider
+const Web3ProviderContextProvider = Web3ProviderContext.Provider
+
+// web3 provider
+let web3Provider = null
+const setWeb3Provider = provider => {
+  web3Provider = provider
+}
+
+const getWeb3Provider = () => {
+  return web3Provider
+}
 
 class UnlockApp extends App {
   static async getInitialProps({ Component, ctx }) {
@@ -150,15 +163,19 @@ The Unlock team
           <Provider store={store}>
             <FullScreenModal />
             <ConnectedRouter>
-              <StorageServiceProvider value={storageService}>
-                <Web3ServiceProvider value={web3Service}>
-                  <WalletServiceProvider value={walletService}>
-                    <ConfigProvider value={config}>
-                      <Component {...pageProps} />
-                    </ConfigProvider>
-                  </WalletServiceProvider>
-                </Web3ServiceProvider>
-              </StorageServiceProvider>
+              <Web3ProviderContextProvider
+                value={{ getWeb3Provider, setWeb3Provider }}
+              >
+                <StorageServiceProvider value={storageService}>
+                  <Web3ServiceProvider value={web3Service}>
+                    <WalletServiceProvider value={walletService}>
+                      <ConfigProvider value={config}>
+                        <Component {...pageProps} />
+                      </ConfigProvider>
+                    </WalletServiceProvider>
+                  </Web3ServiceProvider>
+                </StorageServiceProvider>
+              </Web3ProviderContextProvider>
             </ConnectedRouter>
           </Provider>
         </Container>


### PR DESCRIPTION
# Description

This is a first draft of our effort to refactor the handling of the web3 provider.
We are moving the logic away from the "configuration" and into the app state itself.
The provider is then passed down to any component which may need it through re-using an existing hook as well as to the middleware through an accessor function.

There is more work to do but this opens the door to supporting WalletConnect.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread