### PR TITLE
Replace uses of raw paywall config in CheckoutContent

### DIFF
--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -125,7 +125,10 @@ export const CheckoutContentInner = ({
           />
           {current.matches(CheckoutState.loading) && <Loading />}
           {current.matches(CheckoutState.notLoggedIn) && (
-            <NotLoggedIn config={config!} lockAddresses={lockAddresses} />
+            <NotLoggedIn
+              config={paywallConfig!}
+              lockAddresses={lockAddresses}
+            />
           )}
           {current.matches(CheckoutState.locks) && (
             <Locks
@@ -148,7 +151,7 @@ export const CheckoutContentInner = ({
           )}
           {current.matches(CheckoutState.metadataForm) && (
             <MetadataForm
-              fields={config!.metadataInputs!}
+              fields={paywallConfig!.metadataInputs!}
               onSubmit={onMetadataSubmit}
             />
           )}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

`<CheckoutContent>` uses the paywall configuration object to determine what to render. It can receive this config in two ways: as a search param in the url (typically used in testing, when there is no parent page): `configFromSearch`, or as a message coming from the host page (when embedded into a page via the paywall script): `config`. 

Because the underlying code shouldn't care about how it receives the config, we choose which config to use (precedent going to the config that gets messaged into the page by the paywall) and store it in a variable called `paywallConfig`. However, there was an oversight where some child components referred to the raw `config` variable, which isn't present when running the checkout as a standalone page. This allowed us to enter an unrepresentable state and caused runtime errors.

This PR cleans up `<CheckoutContent>` so that all child components use the `paywallConfig` variable.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
