### PR TITLE
showing insufficient funds when the key price in eth is exactly the user balance because they would need to pay for gas

### DIFF
--- a/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
+++ b/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
@@ -84,11 +84,33 @@ describe('Checkout Lock Utils', () => {
       expect(userCanAffordKey(lock, balances)).toBeTruthy()
     })
 
+    it('returns true when the user has exactly the right amount of erc20', () => {
+      expect.assertions(1)
+
+      const lock = {
+        keyPrice: balances['0x123abc'],
+        currencyContractAddress: '0x123abc',
+      }
+
+      expect(userCanAffordKey(lock, balances)).toBeTruthy()
+    })
+
     it('returns false when the user has insufficient eth', () => {
       expect.assertions(1)
 
       const lock = {
         keyPrice: '100',
+        currencyContractAddress: null,
+      }
+
+      expect(userCanAffordKey(lock, balances)).toBeFalsy()
+    })
+
+    it('returns false when the user has exactly the right amount of eth', () => {
+      expect.assertions(1)
+
+      const lock = {
+        keyPrice: balances.eth,
         currencyContractAddress: null,
       }
 

--- a/unlock-app/src/utils/checkoutLockUtils.ts
+++ b/unlock-app/src/utils/checkoutLockUtils.ts
@@ -56,5 +56,12 @@ export const userCanAffordKey = (
     return false
   }
 
+  // For eth need some gas so if the balance is exactly the same as key price
+  // this would fail
+  if (currency === 'eth') {
+    return keyPrice < balance
+  }
+
+  // TODO: take balance of eth into account for gas (it's tricky!)
   return keyPrice <= balance
 }


### PR DESCRIPTION
# Description

For eth locks, we need to take into account gas.
This is especially annoying on 0eth lock which do not show as "insufficient funds" even though they are :(
This is kind of weird and I hope we quickly work our way to some kind of meta-transaction to let the lock owner 'refund' the person paying for gas.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->