### PR TITLE
Using useCards and using ethereum address route to get cards

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/FiatLocks.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/FiatLocks.test.tsx
@@ -16,6 +16,7 @@ const accountAddress = '0xaccount'
 const emitTransactionInfo = jest.fn()
 
 let usePaywallLocksMock: any
+let useCardsMock: any
 const useFiatKeyPricesMock: any = {}
 
 jest.mock('../../../../hooks/usePaywallLocks', () => {
@@ -36,19 +37,25 @@ jest.mock('../../../../hooks/useFiatKeyPrices', () => {
   }
 })
 
+jest.mock('../../../../hooks/useCards', () => {
+  return {
+    useCards: jest.fn(() => useCardsMock),
+  }
+})
+
 describe('FiatLocks', () => {
   describe('component', () => {
     it('shows loading locks while loading', () => {
       expect.assertions(0)
 
       usePaywallLocksMock = { loading: true }
+      useCardsMock = { loading: false, cards: [] }
 
       const { getByTestId } = rtl.render(
         <FiatLocks
           lockAddresses={['0xlock']}
           accountAddress={accountAddress}
           emitTransactionInfo={emitTransactionInfo}
-          cards={[]}
           metadataRequired={false}
           showMetadataForm={doNothing}
         />
@@ -57,17 +64,36 @@ describe('FiatLocks', () => {
       getByTestId('LoadingLock')
     })
 
-    it('shows live locks when usePaywallLocks resolves', () => {
+    it('shows loading locks while cards are loading', () => {
       expect.assertions(0)
 
-      usePaywallLocksMock = { loading: false, locks: [lock] }
+      usePaywallLocksMock = { loading: false }
+      useCardsMock = { loading: true, cards: [] }
 
       const { getByTestId } = rtl.render(
         <FiatLocks
           lockAddresses={['0xlock']}
           accountAddress={accountAddress}
           emitTransactionInfo={emitTransactionInfo}
-          cards={[]}
+          metadataRequired={false}
+          showMetadataForm={doNothing}
+        />
+      )
+
+      getByTestId('LoadingLock')
+    })
+
+    it('shows live locks when usePaywallLocks useCards resolves', () => {
+      expect.assertions(0)
+
+      usePaywallLocksMock = { loading: false, locks: [lock] }
+      useCardsMock = { loading: false, cards: [] }
+
+      const { getByTestId } = rtl.render(
+        <FiatLocks
+          lockAddresses={['0xlock']}
+          accountAddress={accountAddress}
+          emitTransactionInfo={emitTransactionInfo}
           metadataRequired={false}
           showMetadataForm={doNothing}
         />

--- a/unlock-app/src/__tests__/hooks/useCards.test.ts
+++ b/unlock-app/src/__tests__/hooks/useCards.test.ts
@@ -57,7 +57,7 @@ describe('useCards', () => {
       json: () => Promise.resolve([]),
     } as any)
 
-    const { result, wait } = renderHook(() => useCards(account))
+    const { result, wait } = renderHook(() => useCards(account.address))
 
     await wait(() => !!result.current.cards)
 
@@ -72,7 +72,7 @@ describe('useCards', () => {
 
     fetch.mockRejectedValue(new Error('fail'))
 
-    const { result, wait } = renderHook(() => useCards(account))
+    const { result, wait } = renderHook(() => useCards(account.address))
 
     await wait(() => !!result.current.error)
 

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -144,7 +144,6 @@ export const CheckoutContentInner = ({
               accountAddress={account.address}
               lockAddresses={lockAddresses}
               emitTransactionInfo={emitTransactionInfo}
-              cards={account.cards || []}
               metadataRequired={metadataRequired}
               showMetadataForm={() => send('collectMetadata')}
             />

--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -13,13 +13,26 @@ import { useCards } from '../../hooks/useCards'
 import { Account } from '../../unlockTypes'
 import Loading from '../interface/Loading'
 
+interface PaymentSettings {
+  address: string
+}
+
+export const PaymentSettings = ({ address }: PaymentSettings) => {
+  const { cards, loading } = useCards(address)
+  if (loading) {
+    return <Loading />
+  }
+  if (cards.length > 0) {
+    return <PaymentMethods cards={cards} />
+  }
+  return <PaymentDetails />
+}
+
 interface SettingsContentProps {
   account: Account | undefined
 }
 
 export const SettingsContent = ({ account }: SettingsContentProps) => {
-  const { cards } = useCards(account)
-
   return (
     <Layout title="Account Settings">
       <Head>
@@ -29,9 +42,7 @@ export const SettingsContent = ({ account }: SettingsContentProps) => {
       {account && account.emailAddress && (
         <>
           <AccountInfo />
-          {!cards && <Loading />}
-          {cards && cards.length > 0 && <PaymentMethods cards={cards} />}
-          {cards && cards.length === 0 && <PaymentDetails />}
+          <PaymentSettings address={account.address} />
           <EjectAccount />
         </>
       )}

--- a/unlock-app/src/components/interface/checkout/FiatLocks.tsx
+++ b/unlock-app/src/components/interface/checkout/FiatLocks.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { Card } from '@stripe/stripe-js'
 import { FiatLock } from './FiatLock'
 import { DisabledLock, LoadingLock } from './LockVariations'
 import { usePaywallLocks } from '../../../hooks/usePaywallLocks'
@@ -12,12 +11,12 @@ import {
 } from '../../../utils/checkoutLockUtils'
 import { durationsAsTextFromSeconds } from '../../../utils/durations'
 import { PaymentDetails } from './PaymentDetails'
+import { useCards } from '../../../hooks/useCards'
 
 interface LocksProps {
   lockAddresses: string[]
   accountAddress: string
   emitTransactionInfo: (info: TransactionInfo) => void
-  cards: Card[]
   metadataRequired: boolean
   showMetadataForm: () => void
 }
@@ -31,10 +30,11 @@ export const FiatLocks = ({
   lockAddresses,
   accountAddress,
   emitTransactionInfo,
-  cards,
   metadataRequired,
   showMetadataForm,
 }: LocksProps) => {
+  const { cards, loading: cardsLoading } = useCards(accountAddress)
+
   // Dummy function -- we don't have an account address so we cannot get balance
   const getTokenBalance = () => {}
   const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
@@ -49,7 +49,7 @@ export const FiatLocks = ({
   const now = new Date().getTime() / 1000
   const activeKeys = keys.filter(key => key.expiration > now)
 
-  if (loading) {
+  if (loading || cardsLoading) {
     return (
       <div>
         {lockAddresses.map(address => (


### PR DESCRIPTION
# Description

This PR actually introduces 2 small changes:
1. we use the new locksmith route based on the ethereum address to retrieve cards
2. We use the useCards hook in the fiat locks


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->