### PR TITLE
Integrating price threshold check within the service endpoint

### DIFF
--- a/locksmith/__tests__/utils/priceRange.test.ts
+++ b/locksmith/__tests__/utils/priceRange.test.ts
@@ -5,13 +5,17 @@ describe('PriceRange', () => {
     describe('when the requested price is within the acceptable range', () => {
       it('returns true', () => {
         expect.assertions(1)
-        expect(PriceRange.within(5, 5)).toBe(true)
+        expect(PriceRange.within({ requestPrice: 5, currentPrice: 5 })).toBe(
+          true
+        )
       })
     })
     describe('when the requested price is outside of the acceptable range', () => {
       it('returns false', () => {
         expect.assertions(1)
-        expect(PriceRange.within(5, 100)).toBe(false)
+        expect(PriceRange.within({ requestPrice: 5, currentPrice: 100 })).toBe(
+          false
+        )
       })
     })
   })

--- a/locksmith/src/controllers/purchaseController.ts
+++ b/locksmith/src/controllers/purchaseController.ts
@@ -2,6 +2,8 @@ import { Response } from 'express-serve-static-core' // eslint-disable-line no-u
 import { SignedRequest, ethereumAddress } from '../types' // eslint-disable-line no-unused-vars, import/no-unresolved, import/named
 import AuthorizedLockOperations from '../operations/authorizedLockOperations'
 import PaymentProcessor from '../payment/paymentProcessor'
+import * as PriceRange from '../utils/priceRange'
+import KeyPricer from '../utils/keyPricer'
 
 const config = require('../../config/config')
 
@@ -44,12 +46,28 @@ namespace PurchaseController {
     res: Response
   ): Promise<any> => {
     const { expiry } = req.body.message.purchaseRequest
+    const { lock } = req.body.message.purchaseRequest
+    const requestedPurchaseAmount = req.body.message.purchaseRequest.USDAmount
 
     if (expired(expiry)) {
       return res.sendStatus(412)
     }
 
-    return res.sendStatus(200)
+    const currentPrice = new KeyPricer(
+      config.web3ProviderHost,
+      config.unlockContractAddress
+    ).keyPriceUSD(lock)
+
+    const validRequestPrice = PriceRange.within({
+      requestPrice: requestedPurchaseAmount,
+      currentPrice,
+    })
+
+    if (validRequestPrice) {
+      return res.sendStatus(200)
+    } else {
+      return res.sendStatus(417)
+    }
   }
 
   const expired = (expiry: number): Boolean => {

--- a/locksmith/src/utils/keyPricer.ts
+++ b/locksmith/src/utils/keyPricer.ts
@@ -17,6 +17,13 @@ export default class KeyPricer {
     })
   }
 
+  // eslint-disable-next-line no-unused-vars
+  keyPriceUSD(_lockAddress: string): number {
+    // this is a stub to be implemented in a following
+    // commit
+    return 0
+  }
+
   async keyPrice(lockAddress: string): Promise<number> {
     const lock = await this.readOnlyEthereumService.getLock(lockAddress)
     return Math.round(Number(lock.keyPrice) * 100)

--- a/locksmith/src/utils/priceRange.ts
+++ b/locksmith/src/utils/priceRange.ts
@@ -1,8 +1,15 @@
 const THRESHOLD = 0.03
 
-export function within(requestedPrice: number, current: number): boolean {
-  const range = generateRange(current, THRESHOLD)
-  return requestedPrice >= range.lower && requestedPrice <= range.upper
+interface WithinParams {
+  requestPrice: number
+  currentPrice: number
+}
+
+export function within(params: WithinParams): boolean {
+  const range = generateRange(params.currentPrice, THRESHOLD)
+  return (
+    params.requestPrice >= range.lower && params.requestPrice <= range.upper
+  )
 }
 
 function generateRange(value: number, percentage: number): any {


### PR DESCRIPTION
# Description

As part of allowing keys to be granted, we are checking if the purchase amount is within our expected range. We've updated the price range library to remove ambiguity for callers.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
