### PR TITLE
adding a way to delete a card

### DIFF
--- a/locksmith/__tests__/controllers/userController/cards.test.ts
+++ b/locksmith/__tests__/controllers/userController/cards.test.ts
@@ -6,6 +6,7 @@ import ethJsUtil = require('ethereumjs-util')
 import models = require('../../../src/models')
 import sigUtil = require('eth-sig-util')
 import UserOperations = require('../../../src/operations/userOperations')
+import StripeOperations = require('../../../src/operations/stripeOperations')
 
 const { UserReference } = models
 const { User } = models
@@ -250,6 +251,126 @@ describe('when updating cards', () => {
         .put(`/users/${publicKey}/credit-cards`)
         .set('Authorization', `Bearer-Simple ${Base64.encode(sig)}`)
         .send(typedData)
+      expect(response.status).toBe(400)
+    })
+  })
+})
+
+describe('when deleting cards', () => {
+  describe('when there is no signature', () => {
+    it('returns 401', async () => {
+      expect.assertions(1)
+
+      const publicKey = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+
+      const message = {
+        user: {
+          publicKey,
+        },
+      }
+
+      const typedData = generateTypedData(message)
+
+      const response = await request(app)
+        .delete(`/users/${publicKey}/credit-cards`)
+        .send(typedData)
+
+      expect(response.status).toBe(401)
+    })
+  })
+
+  describe('when the signature does not match the user', () => {
+    it('returns 401', async () => {
+      expect.assertions(1)
+
+      expect.assertions(1)
+
+      const publicKey = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
+
+      const message = {
+        user: {
+          publicKey: '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a',
+        },
+      }
+
+      const privateKey = ethJsUtil.toBuffer(
+        '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
+      )
+
+      const typedData = generateTypedData(message)
+      const sig = sigUtil.personalSign(privateKey, {
+        data: JSON.stringify(typedData),
+      })
+
+      const response = await request(app)
+        .delete(`/users/${publicKey}/credit-cards`)
+        .set('Authorization', `Bearer-Simple ${Base64.encode(sig)}`)
+        .send(typedData)
+
+      expect(response.status).toBe(401)
+    })
+  })
+
+  describe("when able to delete the user's payment details with an address", () => {
+    it('returns 202', async () => {
+      expect.assertions(1)
+
+      const message = {
+        user: {
+          publicKey: '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a',
+        },
+      }
+
+      const privateKey = ethJsUtil.toBuffer(
+        '0x08491b7e20566b728ce21a07c88b12ed8b785b3826df93a7baceb21ddacf8b61'
+      )
+
+      jest
+        .spyOn(StripeOperations, 'deletePaymentDetailsForAddress')
+        .mockReturnValueOnce(Promise.resolve(true))
+
+      const typedData = generateTypedData(message)
+      const sig = sigUtil.personalSign(privateKey, {
+        data: JSON.stringify(typedData),
+      })
+
+      const response = await request(app)
+        .delete(`/users/${publicKey}/credit-cards`)
+        .set('Authorization', `Bearer-Simple ${Base64.encode(sig)}`)
+        .query({ data: JSON.stringify(typedData) })
+
+      expect(response.status).toBe(202)
+    })
+  })
+
+  describe("when unable to delete the user's payment details with the the public key", () => {
+    it('returns 400', async () => {
+      expect.assertions(1)
+
+      const message = {
+        user: {
+          publicKey: '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a',
+        },
+      }
+
+      const privateKey = ethJsUtil.toBuffer(
+        '0x08491b7e20566b728ce21a07c88b12ed8b785b3826df93a7baceb21ddacf8b61'
+      )
+
+      jest
+        .spyOn(StripeOperations, 'deletePaymentDetailsForAddress')
+        .mockReturnValueOnce(Promise.resolve(false))
+
+      const typedData = generateTypedData(message)
+      const sig = sigUtil.personalSign(privateKey, {
+        data: JSON.stringify(typedData),
+      })
+
+      const response = await request(app)
+        .delete(`/users/${publicKey}/credit-cards`)
+        .set('Authorization', `Bearer-Simple ${Base64.encode(sig)}`)
+        .query({ data: JSON.stringify(typedData) })
+
       expect(response.status).toBe(400)
     })
   })

--- a/locksmith/__tests__/operations/stripeOperations.test.js
+++ b/locksmith/__tests__/operations/stripeOperations.test.js
@@ -1,6 +1,7 @@
 import {
   getStripeCustomerIdForAddress,
   saveStripeCustomerIdForAddress,
+  deletePaymentDetailsForAddress,
 } from '../../src/operations/stripeOperations'
 
 const Sequelize = require('sequelize')
@@ -63,6 +64,54 @@ describe('lockOperations', () => {
       expect(StripeCustomer.findOne).toHaveBeenCalled()
       expect(UserReference.findOne).toHaveBeenCalled()
       expect(result).toEqual(null)
+    })
+  })
+
+  describe('deletePaymentDetailsForAddress', () => {
+    beforeEach(() => {
+      StripeCustomer.destroy = jest.fn(() => Promise.resolve(0))
+      UserReference.update = jest.fn(() => Promise.resolve([0]))
+    })
+
+    it('should delete data from StripeCustomer if it exists', async () => {
+      expect.assertions(2)
+
+      StripeCustomer.destroy = jest.fn(() => Promise.resolve(1))
+      const publicKey = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
+      const result = await deletePaymentDetailsForAddress(publicKey)
+      expect(StripeCustomer.destroy).toHaveBeenCalledWith({
+        where: {
+          publicKey: { [Op.eq]: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2' },
+        },
+      })
+      expect(result).toEqual(true)
+    })
+
+    it('should delete data from UserReference and StripeCustomer if it exists', async () => {
+      expect.assertions(2)
+      UserReference.update = jest.fn(() => Promise.resolve([1, 1]))
+      const publicKey = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
+      const result = await deletePaymentDetailsForAddress(publicKey)
+      expect(UserReference.update).toHaveBeenCalledWith(
+        {
+          stripe_customer_id: null,
+        },
+        {
+          where: {
+            publicKey: {
+              [Op.eq]: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+            },
+          },
+        }
+      )
+      expect(result).toEqual(true)
+    })
+
+    it('false if the data does not exist on any', async () => {
+      expect.assertions(1)
+      const publicKey = '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2'
+      const result = await deletePaymentDetailsForAddress(publicKey)
+      expect(result).toEqual(false)
     })
   })
 

--- a/locksmith/src/controllers/userController.ts
+++ b/locksmith/src/controllers/userController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express-serve-static-core' // eslint-disable-line no-unused-vars, import/no-unresolved
 import { DecoyUser } from '../utils/decoyUser'
 import { SignedRequest } from '../types' // eslint-disable-line no-unused-vars, import/no-unresolved
-import StripeOperations from '../operations/stripeOperations'
+import * as StripeOperations from '../operations/stripeOperations'
 import * as Normalizer from '../utils/normalizer'
 
 import UserOperations = require('../operations/userOperations')
@@ -187,6 +187,31 @@ namespace UserController {
     )
 
     return res.json(result)
+  }
+
+  export const deleteAddressPaymentDetails = async (
+    req: SignedRequest,
+    res: Response
+  ): Promise<any> => {
+    const { ethereumAddress } = req.params
+
+    if (!ethereumAddress || !req.signee) {
+      return res.sendStatus(401)
+    } else if (
+      Normalizer.ethereumAddress(ethereumAddress) !==
+      Normalizer.ethereumAddress(req.signee)
+    ) {
+      return res.sendStatus(401)
+    }
+
+    const result = await StripeOperations.deletePaymentDetailsForAddress(
+      ethereumAddress
+    )
+
+    if (result) {
+      return res.sendStatus(202)
+    }
+    return res.sendStatus(400)
   }
 
   export const updatePasswordEncryptedPrivateKey = async (

--- a/locksmith/src/operations/stripeOperations.ts
+++ b/locksmith/src/operations/stripeOperations.ts
@@ -59,7 +59,35 @@ export const saveStripeCustomerIdForAddress = async (
   }
 }
 
+/**
+ * Method which delets the stripe customer id for an address
+ */
+export const deletePaymentDetailsForAddress = async (
+  publicKey: ethereumAddress
+) => {
+  const normalizedEthereumAddress = Normalizer.ethereumAddress(publicKey)
+
+  // First, let's delete the StripeCustomer
+  const deletedStripeCustomer = await StripeCustomer.destroy({
+    where: { publicKey: { [Op.eq]: normalizedEthereumAddress } },
+  })
+
+  // Then, update UserReference
+  // TODO: deprecate when all stripe_customer_id UserReferences have been moved to use StripeCustomer
+  const [updatedUserReference] = await UserReference.update(
+    {
+      stripe_customer_id: null,
+    },
+    {
+      where: { publicKey: { [Op.eq]: normalizedEthereumAddress } },
+    }
+  )
+
+  return deletedStripeCustomer > 0 || updatedUserReference > 0
+}
+
 export default {
-  saveStripeCustomerIdForAddress,
+  deletePaymentDetailsForAddress,
   getStripeCustomerIdForAddress,
+  saveStripeCustomerIdForAddress,
 }

--- a/locksmith/src/routes/user.ts
+++ b/locksmith/src/routes/user.ts
@@ -48,6 +48,15 @@ router.get(
   })
 )
 
+router.delete(
+  cardsPathRegex,
+  signatureValidationMiddleware.generateSignatureEvaluator({
+    name: 'user',
+    required: ['publicKey'],
+    signee: 'publicKey',
+  })
+)
+
 router.put(
   cardsPathRegex,
   signatureValidationMiddleware.generateProcessor({
@@ -83,6 +92,10 @@ router.post('/:ethereumAddress/eject', userController.eject)
 router.put(
   '/:ethereumAddress/credit-cards',
   userController.updateAddressPaymentDetails
+)
+router.delete(
+  '/:ethereumAddress/credit-cards',
+  userController.deleteAddressPaymentDetails
 )
 // Deprecated
 router.put('/:emailAddress/paymentdetails', userController.updatePaymentDetails)


### PR DESCRIPTION
# Description

While working on the credit card UI I found that it would be important to have a way to remove payment info.
Rather than rely on Stripe, we remove the customer id info. This guarantees we can no longer use the card.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->