### PR TITLE
Using saveCard from the useCards hook

### DIFF
--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -7793,7 +7793,7 @@ Object {
               disabled=""
               type="submit"
             >
-              Submit
+              Purchase
             </button>
           </form>
           <footer
@@ -9203,7 +9203,7 @@ Object {
             disabled=""
             type="submit"
           >
-            Submit
+            Purchase
           </button>
         </form>
         <footer

--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -18,14 +18,14 @@ interface PaymentSettings {
 }
 
 export const PaymentSettings = ({ address }: PaymentSettings) => {
-  const { cards, loading, deleteCard } = useCards(address)
+  const { cards, loading, saveCard, deleteCard } = useCards(address)
   if (loading) {
     return <Loading />
   }
   if (cards.length > 0) {
     return <PaymentMethods cards={cards} deleteCard={deleteCard} />
   }
-  return <PaymentDetails />
+  return <PaymentDetails saveCard={(token: string) => saveCard(token)} />
 }
 
 interface SettingsContentProps {

--- a/unlock-app/src/components/interface/checkout/FiatLocks.tsx
+++ b/unlock-app/src/components/interface/checkout/FiatLocks.tsx
@@ -33,8 +33,7 @@ export const FiatLocks = ({
   metadataRequired,
   showMetadataForm,
 }: LocksProps) => {
-  const { cards, loading: cardsLoading } = useCards(accountAddress)
-
+  const { cards, loading: cardsLoading, saveCard } = useCards(accountAddress)
   // Dummy function -- we don't have an account address so we cannot get balance
   const getTokenBalance = () => {}
   const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
@@ -43,7 +42,6 @@ export const FiatLocks = ({
   const [showingPaymentForm, setShowingPaymentForm] = useState<
     PaymentFormState
   >({ visible: false })
-
   const needToCollectPaymentDetails = cards.length === 0
 
   const now = new Date().getTime() / 1000
@@ -62,6 +60,7 @@ export const FiatLocks = ({
   if (showingPaymentForm.visible) {
     return (
       <PaymentDetails
+        saveCard={token => saveCard(token)}
         setShowingPaymentForm={setShowingPaymentForm}
         invokePurchase={showingPaymentForm.invokePurchase!}
       />


### PR DESCRIPTION
# Description

We use the hook to save cards for users.
The next steps on this front:
- let users with a crypto wallet save a card on `/settings`
- let users with a crypto wallet checkout through credit card in the paywall


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread