### PR TITLE
adding a query to list locks by manager

### DIFF
--- a/unlock-app/src/__tests__/hooks/useLocks.test.js
+++ b/unlock-app/src/__tests__/hooks/useLocks.test.js
@@ -82,7 +82,7 @@ describe('useLocks', () => {
     )
     mockStorageService.storeTransaction = jest.fn(() => {})
 
-    mockGraphService.locksByOwner = jest.fn(() => Promise.resolve(graphLocks))
+    mockGraphService.locksByManager = jest.fn(() => Promise.resolve(graphLocks))
   })
 
   it('should default to loading and an empty list', async () => {
@@ -117,7 +117,7 @@ describe('useLocks', () => {
     const { loading, locks } = result.current
     expect(loading).toBe(false)
     expect(locks.length).toBe(2)
-    expect(mockGraphService.locksByOwner).toHaveBeenCalledWith(ownerAddress)
+    expect(mockGraphService.locksByManager).toHaveBeenCalledWith(ownerAddress)
   })
 
   describe('pending trasanctions', () => {

--- a/unlock-app/src/__tests__/services/graphService.test.js
+++ b/unlock-app/src/__tests__/services/graphService.test.js
@@ -2,7 +2,7 @@ import ApolloClient from 'apollo-boost'
 import { utils } from 'ethers'
 
 import GraphService from '../../services/graphService'
-import locksByOwner from '../../queries/locksByOwner'
+import locksByManager from '../../queries/locksByManager'
 
 jest.mock('apollo-boost')
 jest.mock('ethers')
@@ -15,16 +15,20 @@ describe('GraphService', () => {
     graphService = new GraphService(graphEndpoint)
   })
 
-  describe('locksByOwner', () => {
+  describe('locksByManager', () => {
     const owner = '0xowner'
-    it('should use the locksByOwner query to return the list of locks', async () => {
+    it('should use the locksByManager query to return the list of locks', async () => {
       expect.assertions(5)
-      const locks = [
+      const lockManagers = [
         {
-          address: '0xlock1',
+          lock: {
+            address: '0xlock1',
+          },
         },
         {
-          address: '0xlock2',
+          lock: {
+            address: '0xlock2',
+          },
         },
       ]
 
@@ -33,7 +37,7 @@ describe('GraphService', () => {
       apolloClientMock.query = jest.fn(() => {
         return Promise.resolve({
           data: {
-            locks,
+            lockManagers,
           },
         })
       })
@@ -42,17 +46,17 @@ describe('GraphService', () => {
         return address
       })
 
-      const ownerLocks = await graphService.locksByOwner(owner)
+      const ownerLocks = await graphService.locksByManager(owner)
 
       expect(utils.getAddress).toHaveBeenCalledTimes(2)
       expect(apolloClientMock.query).toHaveBeenCalledWith({
-        query: locksByOwner(),
+        query: locksByManager(),
         variables: {
           owner,
         },
       })
       expect(graphService.client.query).toHaveBeenCalledTimes(1)
-      expect(ownerLocks).toEqual(locks)
+      expect(ownerLocks).toEqual(lockManagers.map(manager => manager.lock))
     })
   })
 })

--- a/unlock-app/src/hooks/useLocks.js
+++ b/unlock-app/src/hooks/useLocks.js
@@ -82,7 +82,7 @@ export const useLocks = owner => {
     // The locks from the subgraph miss some important things, such as balance,
     // ERC20 info.. etc so we need to retrieve them from unlock-js too.
     // TODO: add these missing fields to the graph!
-    const locks = await graphService.locksByOwner(owner)
+    const locks = await graphService.locksByManager(owner)
 
     const lockPromises = locks.map(async (lock, index) => {
       addToLocks({

--- a/unlock-app/src/queries/locksByManager.js
+++ b/unlock-app/src/queries/locksByManager.js
@@ -1,0 +1,29 @@
+import { gql } from 'apollo-boost'
+
+export default function locksByManagerQuery() {
+  return gql`
+    query Locks($owner: String!) {
+      lockManagers(where: { address: $owner }) {
+        lock(orderBy: creationBlock, orderDirection: desc) {
+          id
+          address
+          name
+          expirationDuration
+          totalSupply
+          maxNumberOfKeys
+          owner
+          creationBlock
+        }
+      }
+    }
+  `
+}
+
+// query Locks($owner: String!) {
+//   locks(
+//     where: { manager: $owner }
+//     orderBy: creationBlock
+//     orderDirection: desc
+//   ) {
+//   }
+// }

--- a/unlock-app/src/services/graphService.ts
+++ b/unlock-app/src/services/graphService.ts
@@ -1,7 +1,6 @@
 import ApolloClient from 'apollo-boost'
 import { utils } from 'ethers'
-import locksByOwner from '../queries/locksByOwner'
-import { Lock } from '../unlockTypes'
+import locksByManager from '../queries/locksByManager'
 
 export default class GraphService {
   public client: any
@@ -12,8 +11,8 @@ export default class GraphService {
     })
   }
 
-  locksByOwner = async (owner: string) => {
-    const query = locksByOwner()
+  locksByManager = async (owner: string) => {
+    const query = locksByManager()
     const result = await this.client.query({
       query,
       variables: {
@@ -26,10 +25,10 @@ export default class GraphService {
     // the Graph returns lower cased addresses.
     // To make sure we stay consistent with the rest of the app
     // We use checksumed addresses.
-    return result.data.locks.map((lock: Lock) => {
+    return result.data.lockManagers.map((manager: any) => {
       return {
-        ...lock,
-        address: utils.getAddress(lock.address),
+        ...manager.lock,
+        address: utils.getAddress(manager.lock.address),
       }
     })
   }


### PR DESCRIPTION
# Description

On the dashboard, rather than list locks by owner, we now list them by lock manager.

Fixes: #6487

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->