### PR TITLE
names in the config will override default lock name

### DIFF
--- a/scripts/local-docker-integration-tests.sh
+++ b/scripts/local-docker-integration-tests.sh
@@ -16,6 +16,8 @@ EXTRA_ARGS=$*
 # prior to attempting to run the tests. This line is critical!
 docker-compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE down
 
+exit
+
 # re-build the images. This will use local docker cache
 # and because we source the script, it will inherit our environment variables
 # NOTE: we cannot using the build-image.sh script or docker-compose-build.sh scripts

--- a/unlock-app/src/__tests__/components/interface/checkout/FiatLocks.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/FiatLocks.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import * as rtl from '@testing-library/react'
 import { FiatLocks } from '../../../../components/interface/checkout/FiatLocks'
 import doNothing from '../../../../utils/doNothing'
+import { PaywallConfig } from '../../../../unlockTypes'
 
 const lock = {
   name: 'a test lock',
@@ -18,6 +19,24 @@ const emitTransactionInfo = jest.fn()
 let usePaywallLocksMock: any
 let useCardsMock: any
 const useFiatKeyPricesMock: any = {}
+
+const paywallConfig: PaywallConfig = {
+  locks: {
+    '0xlock1': {
+      name: 'Lock name override',
+    },
+    '0xlock2': {
+      name: '2nd Lock',
+    },
+  },
+  callToAction: {
+    default: 'You need a membership',
+    expired: '',
+    pending: '',
+    confirmed: '',
+    noWallet: '',
+  },
+}
 
 jest.mock('../../../../hooks/usePaywallLocks', () => {
   return {
@@ -58,6 +77,7 @@ describe('FiatLocks', () => {
           emitTransactionInfo={emitTransactionInfo}
           metadataRequired={false}
           showMetadataForm={doNothing}
+          config={paywallConfig}
         />
       )
 
@@ -77,6 +97,7 @@ describe('FiatLocks', () => {
           emitTransactionInfo={emitTransactionInfo}
           metadataRequired={false}
           showMetadataForm={doNothing}
+          config={paywallConfig}
         />
       )
 
@@ -96,6 +117,7 @@ describe('FiatLocks', () => {
           emitTransactionInfo={emitTransactionInfo}
           metadataRequired={false}
           showMetadataForm={doNothing}
+          config={paywallConfig}
         />
       )
 

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -143,6 +143,7 @@ export const CheckoutContentInner = ({
               emitTransactionInfo={emitTransactionInfo}
               metadataRequired={metadataRequired}
               showMetadataForm={() => send('collectMetadata')}
+              config={paywallConfig!}
             />
           )}
           {current.matches(CheckoutState.fiatLocks) && (
@@ -152,6 +153,7 @@ export const CheckoutContentInner = ({
               emitTransactionInfo={emitTransactionInfo}
               metadataRequired={metadataRequired}
               showMetadataForm={() => send('collectMetadata')}
+              config={paywallConfig!}
             />
           )}
           {current.matches(CheckoutState.metadataForm) && (

--- a/unlock-app/src/components/interface/checkout/FiatLocks.tsx
+++ b/unlock-app/src/components/interface/checkout/FiatLocks.tsx
@@ -12,6 +12,7 @@ import {
 import { durationsAsTextFromSeconds } from '../../../utils/durations'
 import { PaymentDetails } from './PaymentDetails'
 import { useCards } from '../../../hooks/useCards'
+import { PaywallConfig } from '../../../unlockTypes'
 
 interface LocksProps {
   lockAddresses: string[]
@@ -19,6 +20,7 @@ interface LocksProps {
   emitTransactionInfo: (info: TransactionInfo) => void
   metadataRequired: boolean
   showMetadataForm: () => void
+  config: PaywallConfig
 }
 
 interface PaymentFormState {
@@ -32,11 +34,16 @@ export const FiatLocks = ({
   emitTransactionInfo,
   metadataRequired,
   showMetadataForm,
+  config,
 }: LocksProps) => {
   const { cards, loading: cardsLoading, saveCard } = useCards(accountAddress)
   // Dummy function -- we don't have an account address so we cannot get balance
   const getTokenBalance = () => {}
-  const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
+  const { locks, loading } = usePaywallLocks(
+    lockAddresses,
+    getTokenBalance,
+    config
+  )
   const fiatKeyPrices = useFiatKeyPrices(lockAddresses)
   const { keys } = useKeyOwnershipStatus(lockAddresses, accountAddress)
   const [showingPaymentForm, setShowingPaymentForm] = useState<

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -5,6 +5,7 @@ import { usePaywallLocks } from '../../../hooks/usePaywallLocks'
 import { useGetTokenBalance } from '../../../hooks/useGetTokenBalance'
 import { TransactionInfo } from '../../../hooks/useCheckoutCommunication'
 import { useKeyOwnershipStatus } from '../../../hooks/useKeyOwnershipStatus'
+import { PaywallConfig } from '../../../unlockTypes'
 
 interface LocksProps {
   accountAddress: string
@@ -12,6 +13,7 @@ interface LocksProps {
   emitTransactionInfo: (info: TransactionInfo) => void
   metadataRequired?: boolean
   showMetadataForm: () => void
+  config: PaywallConfig
 }
 
 export const Locks = ({
@@ -20,9 +22,14 @@ export const Locks = ({
   emitTransactionInfo,
   metadataRequired,
   showMetadataForm,
+  config,
 }: LocksProps) => {
   const { getTokenBalance, balances } = useGetTokenBalance(accountAddress)
-  const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
+  const { locks, loading } = usePaywallLocks(
+    lockAddresses,
+    getTokenBalance,
+    config
+  )
   const { keys } = useKeyOwnershipStatus(lockAddresses, accountAddress)
 
   const now = new Date().getTime() / 1000

--- a/unlock-app/src/components/interface/checkout/NotLoggedIn.tsx
+++ b/unlock-app/src/components/interface/checkout/NotLoggedIn.tsx
@@ -19,7 +19,7 @@ export const NotLoggedIn = ({ config, lockAddresses }: NotLoggedInProps) => {
   if (config.unlockUserAccounts) {
     return (
       <>
-        <NotLoggedInLocks lockAddresses={lockAddresses} />
+        <NotLoggedInLocks config={config} lockAddresses={lockAddresses} />
         <LogInButton onClick={() => setShowingLogin(true)} />
       </>
     )

--- a/unlock-app/src/components/interface/checkout/NotLoggedInLocks.tsx
+++ b/unlock-app/src/components/interface/checkout/NotLoggedInLocks.tsx
@@ -6,15 +6,21 @@ import {
   lockTickerSymbol,
 } from '../../../utils/checkoutLockUtils'
 import { durationsAsTextFromSeconds } from '../../../utils/durations'
+import { PaywallConfig } from '../../../unlockTypes'
 
 interface LocksProps {
   lockAddresses: string[]
+  config: PaywallConfig
 }
 
-export const NotLoggedInLocks = ({ lockAddresses }: LocksProps) => {
+export const NotLoggedInLocks = ({ lockAddresses, config }: LocksProps) => {
   // Dummy function -- we don't have an account address so we cannot get balance
   const getTokenBalance = () => {}
-  const { locks, loading } = usePaywallLocks(lockAddresses, getTokenBalance)
+  const { locks, loading } = usePaywallLocks(
+    lockAddresses,
+    getTokenBalance,
+    config
+  )
 
   if (loading) {
     return (

--- a/unlock-app/src/hooks/usePaywallLocks.ts
+++ b/unlock-app/src/hooks/usePaywallLocks.ts
@@ -1,11 +1,12 @@
 import { useContext, useState, useEffect } from 'react'
 import { Web3Service } from '@unlock-protocol/unlock-js'
 import { Web3ServiceContext } from '../utils/withWeb3Service'
-import { RawLock } from '../unlockTypes'
+import { RawLock, PaywallConfig } from '../unlockTypes'
 
 export const usePaywallLocks = (
   lockAddresses: string[],
-  getTokenBalance: (contractAddress: string) => void
+  getTokenBalance: (contractAddress: string) => void,
+  config: PaywallConfig
 ) => {
   const web3Service: Web3Service = useContext(Web3ServiceContext)
 
@@ -30,7 +31,11 @@ export const usePaywallLocks = (
       }
 
       // getLock doesn't always return the lock address apparently
+      // We keep consistency from the config
       lock.address = lockAddresses[index]
+      if (config.locks[lock.address].name) {
+        lock.name = config.locks[lock.address].name
+      }
     })
     setLoading(false)
     setLocks(locks)


### PR DESCRIPTION
# Description

This was reported by an early of the new paywall :)
We now make sure to overide the name of the lock with the config.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->