### PR TITLE
not requiring a user anymore to store a card.

### DIFF
--- a/locksmith/__tests__/payment/paymentProcessor.test.ts
+++ b/locksmith/__tests__/payment/paymentProcessor.test.ts
@@ -129,18 +129,6 @@ describe('PaymentProcessor', () => {
         expect(user).toBe(true)
       })
     })
-
-    describe('when the user can not be created', () => {
-      it('returns false', async () => {
-        expect.assertions(1)
-        const user = await paymentProcessor.updateUserPaymentDetails(
-          'tok_unknown',
-          '0xb76ef2e0d0edcce723b3fdd4307db6c5f0dda1b8'
-        )
-
-        expect(user).toBe(false)
-      })
-    })
   })
 
   describe('chargeUser', () => {


### PR DESCRIPTION
# Description

We do not require the existence of a user account to store a stripe customer id.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->