### PR TITLE
Discount codes: support multiple locks and switch to LockRoles

### DIFF
--- a/smart-contract-extensions/contracts/hooks/DiscountCodeHook.sol
+++ b/smart-contract-extensions/contracts/hooks/DiscountCodeHook.sol
@@ -16,7 +16,7 @@ contract DiscountCodeHook is ILockKeyPurchaseHookV7, LockRoles
 {
   using SafeMath for uint;
 
-  event AddCode(address lock, address codeAddress, uint discountBasisPoints);
+  event AddCode(address indexed lock, address codeAddress, uint discountBasisPoints);
 
   /**
    * @notice The code expressed as an address where the private key is

--- a/smart-contract-extensions/contracts/hooks/DiscountCodeHook.sol
+++ b/smart-contract-extensions/contracts/hooks/DiscountCodeHook.sol
@@ -52,7 +52,7 @@ contract DiscountCodeHook is ILockKeyPurchaseHookV7, LockRoles
    * @param _recipient the account which will be granted a key
    * @param _signature the signature created from the code's private key, signing
    * the message `"\x19Ethereum Signed Message:\n32" + keccak256(_recipient)`.
-   * This is passed throw the lock by setting the `_data` field on purchase.
+   * This is passed through the lock by setting the `_data` field on purchase.
    */
   function keyPurchasePrice(
     address /*from*/,

--- a/smart-contract-extensions/contracts/hooks/DiscountCodeHook.sol
+++ b/smart-contract-extensions/contracts/hooks/DiscountCodeHook.sol
@@ -5,11 +5,14 @@ import '@openzeppelin/contracts/cryptography/ECDSA.sol';
 import '@openzeppelin/contracts/access/roles/WhitelistAdminRole.sol';
 import 'unlock-abi-7/ILockKeyPurchaseHookV7.sol';
 import 'unlock-abi-7/IPublicLockV7.sol';
+import '../mixins/LockRoles.sol';
+
 
 /**
  * @notice Used with a Lock to offer discounts if the user enters a code.
+ * @dev One instance of this contract may be used for all v7 locks.
  */
-contract DiscountCodeHook is ILockKeyPurchaseHookV7, WhitelistAdminRole
+contract DiscountCodeHook is ILockKeyPurchaseHookV7, LockRoles
 {
   using SafeMath for uint;
 
@@ -18,23 +21,24 @@ contract DiscountCodeHook is ILockKeyPurchaseHookV7, WhitelistAdminRole
    * keccak256(abi.encode(code, lock.address)).
    * The discount is in basis points, so 1000 == 10%
    */
-  mapping(address => uint) public codeAddressToDiscountBasisPoints;
+  mapping(address => mapping(address => uint)) public lockToCodeAddressToDiscountBasisPoints;
 
   /**
-   * @notice Allows an admin to add or remove discount codes.
+   * @notice Allows a lock manager to add or remove discount codes.
    * @dev To remove a code, just set the discount to 0.
    */
   function addCodes(
+    IPublicLockV7 _lock,
     address[] calldata _codeAddresses,
     uint[] calldata _discountBasisPoints
   ) external
-    onlyWhitelistAdmin()
+    onlyLockManager(_lock)
   {
     for(uint i = 0; i < _codeAddresses.length; i++)
     {
       address codeAddress = _codeAddresses[i];
       require(codeAddress != address(0), 'INVALID_CODE');
-      codeAddressToDiscountBasisPoints[codeAddress] = _discountBasisPoints[i];
+      lockToCodeAddressToDiscountBasisPoints[address(_lock)][codeAddress] = _discountBasisPoints[i];
     }
   }
 
@@ -42,19 +46,21 @@ contract DiscountCodeHook is ILockKeyPurchaseHookV7, WhitelistAdminRole
    * @notice Returns the price per key after considering the code entered.
    * If the code is missing or incorrect, the lock's normal keyPrice will be used.
    * @param _recipient the account which will be granted a key
-   * @param _data arbitrary data populated by the front-end which initiated the sale
+   * @param _signature the signature created from the code's private key, signing
+   * the message `"\x19Ethereum Signed Message:\n32" + keccak256(_recipient)`.
+   * This is passed throw the lock by setting the `_data` field on purchase.
    */
   function keyPurchasePrice(
     address /*from*/,
     address _recipient,
     address /*referrer*/,
-    bytes calldata _data
+    bytes calldata _signature
   ) external view
     returns (uint minKeyPrice)
   {
-    bytes32 secretHash = ECDSA.toEthSignedMessageHash(keccak256(abi.encode(_recipient)));
-    address codeAddress = ECDSA.recover(secretHash, _data);
-    uint discountBP = codeAddressToDiscountBasisPoints[codeAddress];
+    bytes32 secretMessage = ECDSA.toEthSignedMessageHash(keccak256(abi.encode(_recipient)));
+    address codeAddress = ECDSA.recover(secretMessage, _signature);
+    uint discountBP = lockToCodeAddressToDiscountBasisPoints[msg.sender][codeAddress];
     minKeyPrice = IPublicLockV7(msg.sender).keyPrice();
     if(discountBP > 0)
     {

--- a/smart-contract-extensions/contracts/hooks/DiscountCodeHook.sol
+++ b/smart-contract-extensions/contracts/hooks/DiscountCodeHook.sol
@@ -16,6 +16,8 @@ contract DiscountCodeHook is ILockKeyPurchaseHookV7, LockRoles
 {
   using SafeMath for uint;
 
+  event AddCode(address lock, address codeAddress, uint discountBasisPoints);
+
   /**
    * @notice The code expressed as an address where the private key is
    * keccak256(abi.encode(code, lock.address)).
@@ -38,7 +40,9 @@ contract DiscountCodeHook is ILockKeyPurchaseHookV7, LockRoles
     {
       address codeAddress = _codeAddresses[i];
       require(codeAddress != address(0), 'INVALID_CODE');
-      lockToCodeAddressToDiscountBasisPoints[address(_lock)][codeAddress] = _discountBasisPoints[i];
+      uint discountBasisPoints = _discountBasisPoints[i];
+      lockToCodeAddressToDiscountBasisPoints[address(_lock)][codeAddress] = discountBasisPoints;
+      emit AddCode(address(_lock), codeAddress, discountBasisPoints);
     }
   }
 


### PR DESCRIPTION

# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

One discount code contract can now support any number of locks, so we can have one for the entire ecosystem.

Switched to LockRoles so that a separate permission scheme is no longer necessary.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
