### PR TITLE
Use lock.address as key for looped renders on checkout

### DIFF
--- a/unlock-app/src/components/interface/checkout/FiatLocks.tsx
+++ b/unlock-app/src/components/interface/checkout/FiatLocks.tsx
@@ -44,6 +44,7 @@ export const FiatLocks = ({
     getTokenBalance,
     config
   )
+
   const fiatKeyPrices = useFiatKeyPrices(lockAddresses)
   const { keys } = useKeyOwnershipStatus(lockAddresses, accountAddress)
   const [showingPaymentForm, setShowingPaymentForm] = useState<
@@ -84,7 +85,7 @@ export const FiatLocks = ({
           const fiatPrice = `$${formattedPrice}`
           return (
             <FiatLock
-              key={lock.name}
+              key={lock.address}
               lock={lock}
               formattedKeyPrice={fiatPrice}
               activeKeys={activeKeys}
@@ -101,7 +102,7 @@ export const FiatLocks = ({
         return (
           <DisabledLock
             address={lock.address}
-            key={lock.name}
+            key={lock.address}
             name={lock.name}
             formattedKeyPrice={`${lock.keyPrice} ${lockTickerSymbol(lock)}`}
             formattedKeysAvailable={lockKeysAvailable(lock)}

--- a/unlock-app/src/components/interface/checkout/Locks.tsx
+++ b/unlock-app/src/components/interface/checkout/Locks.tsx
@@ -49,7 +49,7 @@ export const Locks = ({
     <div>
       {locks.map(lock => (
         <Lock
-          key={lock.name}
+          key={lock.address}
           lock={lock}
           emitTransactionInfo={emitTransactionInfo}
           balances={balances}

--- a/unlock-app/src/components/interface/checkout/NotLoggedInLocks.tsx
+++ b/unlock-app/src/components/interface/checkout/NotLoggedInLocks.tsx
@@ -37,7 +37,7 @@ export const NotLoggedInLocks = ({ lockAddresses, config }: LocksProps) => {
       {locks.map(lock => (
         <DisabledLock
           address={lock.address}
-          key={lock.name}
+          key={lock.address}
           name={lock.name}
           formattedKeyPrice={`${lock.keyPrice} ${lockTickerSymbol(lock)}`}
           formattedKeysAvailable={lockKeysAvailable(lock)}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

`lock.name` is not guaranteed to be unique, we should always use `lock.address` when iterating to render locks.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
