### PR TITLE
useProvider doesn't reinitialize when there is already a provider

### DIFF
--- a/unlock-app/src/__tests__/hooks/useProvider.test.ts
+++ b/unlock-app/src/__tests__/hooks/useProvider.test.ts
@@ -134,5 +134,29 @@ describe('useProvider', () => {
         })
       })
     })
+
+    describe('when the context already has a provider', () => {
+      it('should stop loading and use the existing provider', async () => {
+        expect.assertions(2)
+
+        const provider = {
+          enable: jest.fn(() => Promise.resolve([])),
+          currentProvider: {},
+        }
+
+        mockWeb3ProviderContext.getWeb3Provider = jest.fn(() => provider)
+
+        mockWeb3ProviderContext.setWeb3Provider = jest.fn()
+
+        const { result, wait } = renderHook(() => useProvider())
+
+        await wait(() => !result.current.loading)
+        expect(mockWeb3ProviderContext.setWeb3Provider).not.toHaveBeenCalled()
+        expect(result.current).toEqual({
+          provider,
+          loading: false,
+        })
+      })
+    })
   })
 })

--- a/unlock-app/src/__tests__/hooks/useProvider.test.ts
+++ b/unlock-app/src/__tests__/hooks/useProvider.test.ts
@@ -146,14 +146,34 @@ describe('useProvider', () => {
 
         mockWeb3ProviderContext.getWeb3Provider = jest.fn(() => provider)
 
-        mockWeb3ProviderContext.setWeb3Provider = jest.fn()
-
         const { result, wait } = renderHook(() => useProvider())
 
         await wait(() => !result.current.loading)
         expect(mockWeb3ProviderContext.setWeb3Provider).not.toHaveBeenCalled()
         expect(result.current).toEqual({
           provider,
+          loading: false,
+        })
+      })
+    })
+
+    describe('when a provider adapter is passed in', () => {
+      it('sets provider to the adapter', async () => {
+        expect.assertions(2)
+
+        const providerAdapter = {
+          enable: jest.fn(() => Promise.resolve([])),
+          currentProvider: {},
+        }
+
+        const { result, wait } = renderHook(() => useProvider(providerAdapter))
+
+        await wait(() => !result.current.loading)
+        expect(mockWeb3ProviderContext.setWeb3Provider).toHaveBeenCalledWith(
+          providerAdapter
+        )
+        expect(result.current).toEqual({
+          provider: providerAdapter,
           loading: false,
         })
       })

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -53,7 +53,7 @@ export const useProvider = (providerAdapter?: any) => {
     const ethereumWindow = (window as unknown) as EthereumWindow
 
     if (providerAdapter) {
-      // If we are using a provider in the "main window" via the paywall script
+      // If we are using an "explicit" provider (rather than one which was "injected").
       setWeb3Provider(providerAdapter)
     } else if (ethereumWindow.ethereum) {
       // If there is an injected provider

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -76,8 +76,14 @@ export const useProvider = () => {
   }
 
   React.useEffect(() => {
-    // Try to initalize the provider
-    initializeProvider()
+    const provider = getWeb3Provider()
+    if (provider) {
+      // The context already has a provider, we're ready to work
+      setLoading(false)
+    } else {
+      // Try to initalize the provider if there isn't one already
+      initializeProvider()
+    }
   }, [])
 
   return { provider: getWeb3Provider(), loading }

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -28,7 +28,7 @@ interface Config {
   httpProvider: string
 }
 
-export const useProvider = () => {
+export const useProvider = (providerAdapter?: any) => {
   const config: Config = React.useContext(ConfigContext)
   const { getWeb3Provider, setWeb3Provider } = React.useContext<
     Web3ProviderContextType
@@ -52,8 +52,11 @@ export const useProvider = () => {
 
     const ethereumWindow = (window as unknown) as EthereumWindow
 
-    // If there is an injected provider
-    if (ethereumWindow.ethereum) {
+    if (providerAdapter) {
+      // If we are using a provider in the "main window" via the paywall script
+      setWeb3Provider(providerAdapter)
+    } else if (ethereumWindow.ethereum) {
+      // If there is an injected provider
       dispatch(waitForWallet())
       try {
         // Request account access if needed


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This PR is a step toward allowing a provider hosted on the "main window" of the paywall (for example, web3modal) to be used from within the checkout.

1. useProvider does not reinitialize if a provider has already been set
2. useProvider will take an optional param which is the provider to use if none has already been set

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
