### PR TITLE
accepting an optional signer when connecting the provider

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,55 +1,72 @@
 # Changes
 
+# Next
+
+- adding ability to pass signer
+
 # 0.9.3
+
 - Exporting type definition for isLockManager
 
 # 0.9.2
+
 - Adding isLockManager function to web3Service
 
 # 0.9.1
+
 - Replaced owner with beneficiary for locks
 
 # 0.9
+
 - Adding support for v7 of PublicLock and Unlock smart contracts
 
 # 0.8.7
+
 - Updated typescript definitions
 
 # 0.8.6
+
 - Callback on transaction yields the transaction object as 3rd argument
 
 # 0.8.5
+
 - Corrected type definition so that callback is optional on purchaseKey
 
 # 0.8.4
+
 - Updated WalletService type to include callback for purchaseKey
 
 # 0.8.3
+
 - Updated Web3ServiceParams to include the network id, which is required
 
 # 0.8.2
+
 - Hardcoding the symbol for SAI
 
 # 0.8.1
+
 - Addition of setUserMetadata, which follows the same argument pattern
   as the other metadata methods
 
 # 0.8.0
+
 - BREAKING: getKeyMetadata now takes an object for non-callback
   params, now including an optional signature to retrieve protected metadata
 - BREAKING: setKeyMetadata takes an object for non-callback params to
   keep calling conventions consistent for the setter and the getter
 
 # 0.7.2
+
 - bumped gas limits
 - Adding script to initialize a template
 
 # 0.7.1
+
 - Code cleaned witth automated linting fixes
 - Adjusted lint config to ignore violations that could not be fixed auttomatically
 - Added setKeyMetadata and getKeyMetadata methods to WalletService
 - Update gas prices
-
 
 # 0.7.0
 

--- a/unlock-js/src/__tests__/unlockService.test.js
+++ b/unlock-js/src/__tests__/unlockService.test.js
@@ -30,7 +30,9 @@ describe('UnlockService', () => {
     unlockService = new UnlockService({
       unlockAddress,
     })
-    unlockService.provider = new ethersProviders.JsonRpcProvider(endpoint)
+    const provider = new ethersProviders.JsonRpcProvider(endpoint)
+    unlockService.signer = provider.getSigner()
+    unlockService.provider = provider
     await nock.resolveWhenAllNocksUsed()
   }
 

--- a/unlock-js/src/__tests__/v13/initializeTemplate.test.js
+++ b/unlock-js/src/__tests__/v13/initializeTemplate.test.js
@@ -14,10 +14,11 @@ const lockContract = {
 }
 const templateAddress = '0xtemplate'
 const accountAddress = '0xaccount'
+const signer = {
+  getAddress: jest.fn(() => Promise.resolve(accountAddress)),
+}
 const provider = {
-  getSigner: () => ({
-    getAddress: jest.fn(() => Promise.resolve(accountAddress)),
-  }),
+  getSigner: () => signer,
   waitForTransaction: jest.fn(() => Promise.resolve()),
 }
 
@@ -27,6 +28,7 @@ describe('v13', () => {
       unlockAddress: '0xunlockAddress',
     })
     walletService.provider = provider
+    walletService.signer = signer
     walletService.lockContractAbiVersion = jest.fn(() => {
       return v13
     })

--- a/unlock-js/src/__tests__/v7/initializeTemplate.test.js
+++ b/unlock-js/src/__tests__/v7/initializeTemplate.test.js
@@ -14,10 +14,11 @@ const lockContract = {
 }
 const templateAddress = '0xtemplate'
 const accountAddress = '0xaccount'
+const signer = {
+  getAddress: jest.fn(() => Promise.resolve(accountAddress)),
+}
 const provider = {
-  getSigner: () => ({
-    getAddress: jest.fn(() => Promise.resolve(accountAddress)),
-  }),
+  getSigner: () => signer,
   waitForTransaction: jest.fn(() => Promise.resolve()),
 }
 
@@ -27,6 +28,7 @@ describe('v7', () => {
       unlockAddress: '0xunlockAddress',
     })
     walletService.provider = provider
+    walletService.signer = signer
     walletService.lockContractAbiVersion = jest.fn(() => {
       return v7
     })

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -172,7 +172,7 @@ export default class UnlockService extends EventEmitter {
   async getWritableContract(address, contract) {
     // TODO: replace this when v5 of ethers is out
     // see https://github.com/ethers-io/ethers.js/issues/511
-    const signer = new FastJsonRpcSigner(this.provider.getSigner())
+    const signer = new FastJsonRpcSigner(this.signer)
     return new ethers.Contract(address, contract.abi, signer)
   }
 

--- a/unlock-js/src/v13/initializeTemplate.js
+++ b/unlock-js/src/v13/initializeTemplate.js
@@ -5,8 +5,7 @@ import { ZERO } from '../constants'
  * @param {PropTypes.contract} contract
  */
 export default async function({ templateAddress }, callback) {
-  const signer = this.provider.getSigner()
-  const owner = await signer.getAddress()
+  const owner = await this.signer.getAddress()
   const expirationDuration = 0
   const tokenAddress = ZERO
   const keyPrice = 0

--- a/unlock-js/src/v13/purchaseKey.js
+++ b/unlock-js/src/v13/purchaseKey.js
@@ -20,8 +20,7 @@ export default async function(
   const lockContract = await this.getLockContract(lockAddress)
 
   if (!owner) {
-    const signer = this.provider.getSigner()
-    owner = await signer.getAddress()
+    owner = await this.signer.getAddress()
   }
 
   // If erc20Address was not provided, get it

--- a/unlock-js/src/v7/initializeTemplate.js
+++ b/unlock-js/src/v7/initializeTemplate.js
@@ -5,8 +5,7 @@ import { ZERO } from '../constants'
  * @param {PropTypes.contract} contract
  */
 export default async function({ templateAddress }, callback) {
-  const signer = this.provider.getSigner()
-  const owner = await signer.getAddress()
+  const owner = await this.signer.getAddress()
   const expirationDuration = 0
   const tokenAddress = ZERO
   const keyPrice = 0

--- a/unlock-js/src/v7/purchaseKey.js
+++ b/unlock-js/src/v7/purchaseKey.js
@@ -20,8 +20,7 @@ export default async function(
   const lockContract = await this.getLockContract(lockAddress)
 
   if (!owner) {
-    const signer = this.provider.getSigner()
-    owner = await signer.getAddress()
+    owner = await this.signer.getAddress()
   }
 
   // If erc20Address was not provided, get it


### PR DESCRIPTION
# Description

This decouples the provider from the signer which should help us being a bit more flexible when using unlock-js without a web3Provider (as in locksmith!)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->