### PR TITLE
adding grantKey to walletService

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Next
 
+- adding support for grantKey function
 - adding ability to pass signer
 
 # 0.9.3

--- a/unlock-js/src/transactionTypes.js
+++ b/unlock-js/src/transactionTypes.js
@@ -4,6 +4,7 @@ const TransactionType = {
   WITHDRAWAL: 'WITHDRAWAL',
   UPDATE_KEY_PRICE: 'UPDATE_KEY_PRICE',
   FAILED_TO_CREATE_LOCK: 'FAILED_TO_CREATE_LOCK',
+  GRANT_KEY: 'GRANT_KEY',
 }
 
 export default TransactionType


### PR DESCRIPTION
# Description

This adds the ability to grant key.
The v0 smart contracts do not support this...

I will now write some unit tests to complete this.
And maybe I'll split it in small PRs.

# Issues

Fixes #6518

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread