### PR TITLE
Requesting lock information now returns the existing base token data

### DIFF
--- a/locksmith/__tests__/controllers/lockController.test.js
+++ b/locksmith/__tests__/controllers/lockController.test.js
@@ -80,15 +80,6 @@ describe('lockController', () => {
         expect(response.statusCode).toBe(200)
       })
     })
-
-    describe('when the lock details are unavailable', () => {
-      test('it should returns an appropriate error code', async () => {
-        expect.assertions(1)
-        const response = await request(app).get('/lock/0xdeadbeef')
-
-        expect(response.statusCode).toBe(404)
-      })
-    })
   })
 
   describe('setting lock details', () => {

--- a/locksmith/src/controllers/lockController.js
+++ b/locksmith/src/controllers/lockController.js
@@ -24,10 +24,6 @@ const lockSave = async (req, res) => {
 
 const lockGet = async (req, res) => {
   logger.logLockDetailsRequest(req.params.lockAddress)
-  const lock = await getLockByAddress(req.params.lockAddress)
-  if (!lock) {
-    return res.sendStatus(404)
-  }
   // Serve lock metadata!
   const baseTokenData = await getBaseTokenData(
     req.params.lockAddress,


### PR DESCRIPTION
# Description

Updating the lock endpoint point functionality to reflect the new behavior

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #6563

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
