### PR TITLE
Add cleaner remote method call implementation

### DIFF
--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -24,7 +24,18 @@ export const CheckoutContent = ({
   errors,
 }: CheckoutContentProps) => {
   const checkoutCommunication = useCheckoutCommunication()
-  if (checkoutCommunication.insideIframe && !checkoutCommunication.config) {
+
+  // We need to delay render until we have a config at least, and
+  // further if we haven't yet set up the adapter for delegated web3
+  // calls
+  const noConfig =
+    checkoutCommunication.insideIframe && !checkoutCommunication.config
+  const noProviderAdapter =
+    checkoutCommunication.config &&
+    checkoutCommunication.config.useDelegatedProvider &&
+    !checkoutCommunication.providerAdapter
+
+  if (noConfig || noProviderAdapter) {
     return <></>
   }
 

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -11,7 +11,6 @@ import {
 import getConfigFromSearch from '../../utils/getConfigFromSearch'
 import { CheckoutStoreProvider } from '../../hooks/useCheckoutStore'
 import { useCheckoutCommunication } from '../../hooks/useCheckoutCommunication'
-import { useProvider } from '../../hooks/useProvider'
 
 interface CheckoutContentProps {
   account: AccountType
@@ -25,8 +24,7 @@ export const CheckoutContent = ({
   errors,
 }: CheckoutContentProps) => {
   const checkoutCommunication = useCheckoutCommunication()
-  const { loading } = useProvider()
-  if (loading) {
+  if (checkoutCommunication.insideIframe && !checkoutCommunication.config) {
     return <></>
   }
 

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../../hooks/useCheckoutCommunication'
 import { useSetUserMetadata } from '../../../hooks/useSetUserMetadata'
 import { useCheckoutStore } from '../../../hooks/useCheckoutStore'
+import { useProvider } from '../../../hooks/useProvider'
 
 interface CheckoutProps {
   account: AccountType
@@ -38,6 +39,7 @@ interface CheckoutProps {
   emitTransactionInfo: (info: TransactionInfo) => void
   emitUserInfo: (info: UserInfo) => void
   config?: PaywallConfig
+  providerAdapter: any
 }
 
 export const Checkout = ({
@@ -48,7 +50,10 @@ export const Checkout = ({
   emitTransactionInfo,
   emitUserInfo,
   config,
+  providerAdapter,
 }: CheckoutProps) => {
+  // solely called for side effect of initializing with provider
+  useProvider(providerAdapter)
   const reduxDispatch = useDispatch()
   const [current, send] = useMachine(checkoutMachine)
   const { setUserMetadata } = useSetUserMetadata()

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -49,14 +49,6 @@ export type AsyncSendable = {
   send?: (request: any, callback: (error: any, response: any) => void) => void
 }
 
-export const getNextId = (function() {
-  let currentId = 0
-  return function() {
-    currentId++
-    return currentId
-  }
-})()
-
 // Callbacks from method calls that have been sent to the parent
 // iframe are held here, once the parent iframe has resolved the call
 // it will trigger the callback and remove it from the table.

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -63,22 +63,25 @@ const waitingMethodCalls: {
 // the buffered events are emitted and future events are emitted
 // directly.
 export const useCheckoutCommunication = () => {
-  let providerAdapter: AsyncSendable | undefined
+  const [providerAdapter, setProviderAdapter] = useState<
+    AsyncSendable | undefined
+  >(undefined)
   const [buffer, setBuffer] = useState([] as BufferedEvent[])
   const [config, setConfig] = useState<PaywallConfig | undefined>(undefined)
   const parent = usePostmateParent({
     setConfig: (config: PaywallConfig) => {
       if (config.useDelegatedProvider) {
-        providerAdapter = {
+        setProviderAdapter({
           send: (request: MethodCall, callback) => {
             waitingMethodCalls[request.id] = callback
             emitMethodCall(request)
           },
-        }
+        })
       }
       setConfig(config)
     },
     resolveMethodCall: (result: MethodCallResult) => {
+      console.log({ result })
       const callback = waitingMethodCalls[result.id]
       if (!callback) {
         console.error(

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -124,7 +124,7 @@ export const useCheckoutCommunication = () => {
   // If the page is not inside an iframe, window and window.top will be identical
   const insideIframe = window.top !== window
 
-  if (config && config.useDelegatedProvider) {
+  if (config && config.useDelegatedProvider && !providerAdapter) {
     setProviderAdapter({
       sendAsync: (request: MethodCall, callback) => {
         waitingMethodCalls[request.id] = (error: any, response: any) => {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This is a slightly cleaner swing at an implementation for the checkout to make remote method calls against a provider in the host window.

Basically, when the provider receives a method call, it:

- Stores the callback for the method call in a table keyed by request id
- Sends a message to the parent iframe containing the method call

When the parent iframe has the result of the method call, it passes it back down (not implemented on paywall script side yet):
- Calls `resolveMethodCall` on the child iframe with the result, which:
  - pulls the relevant callback from the table
  - deletes the callback from the table
  - applies the callback to the result

This needs testing, and to do it properly we'll need to implement both ends of this. There is some remaining mystery about the method call format, because they don't always come in the format implied by the type signatures from `ethers`.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
