### PR TITLE
Exposing the  baseTokenURI  storage field on the Lock contract

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -174,11 +174,6 @@ contract IPublicLock
     external view
     returns(string memory);
 
-  // Allows anoyone to get the baseTokenURI for this Lock.
-  function getBaseTokenURI()
-   external view
-   returns(string memory);
-
     /**
    * Allows a Lock manager to update the baseTokenURI for this Lock.
    * @dev Throws if called by other than a Lock manager

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -391,7 +391,6 @@ contract IPublicLock
 
   function keyManagerOf(uint) external view returns (address );
 
-
   ///===================================================================
 
   /**

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -391,6 +391,9 @@ contract IPublicLock
 
   function keyManagerOf(uint) external view returns (address );
 
+  function baseTokenURI() external view returns (string memory );
+
+
   ///===================================================================
 
   /**

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -174,6 +174,11 @@ contract IPublicLock
     external view
     returns(string memory);
 
+  // Allows anoyone to get the baseTokenURI for this Lock.
+  function getBaseTokenURI()
+   external view
+   returns(string memory);
+
     /**
    * Allows a Lock manager to update the baseTokenURI for this Lock.
    * @dev Throws if called by other than a Lock manager
@@ -390,8 +395,6 @@ contract IPublicLock
   function unlockProtocol() external view returns (address );
 
   function keyManagerOf(uint) external view returns (address );
-
-  function baseTokenURI() external view returns (string memory );
 
 
   ///===================================================================

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -91,7 +91,11 @@ contract MixinLockMetadata is
    view
    returns(string memory)
   {
-    return baseTokenURI;
+    if(bytes(baseTokenURI).length == 0) {
+      return unlockProtocol.globalBaseTokenURI();
+    } else {
+      return baseTokenURI;
+    }
   }
 
   /**
@@ -106,32 +110,42 @@ contract MixinLockMetadata is
   }
 
   /**  @notice A distinct Uniform Resource Identifier (URI) for a given asset.
-   * @dev Throws if `_tokenId` is not a valid NFT. URIs are defined in RFC
-   *  3986. The URI may point to a JSON file that conforms to the "ERC721
-   *  Metadata JSON Schema".
+   * @param _tokenId The iD of the token  for which we want to retrieve the URI.
+   * If 0 is passed here, we just return the appropriate baseTokenURI.
+   * @dev  URIs are defined in RFC 3986. The URI may point to a JSON file
+   * that conforms to the "ERC721 Metadata JSON Schema".
    * https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
    */
   function tokenURI(
     uint256 _tokenId
   ) external
     view
-    isKey(_tokenId)
     returns(string memory)
   {
     string memory URI;
+    string memory tokenId;
+    string memory lockAddress = address(this).address2Str();
+    string memory seperator;
+
+    if(_tokenId != 0) {
+      tokenId = _tokenId.uint2Str();
+    } else {
+      tokenId = '';
+    }
+
     if(bytes(baseTokenURI).length == 0) {
       URI = unlockProtocol.globalBaseTokenURI();
-      return URI.strConcat(
-        address(this).address2Str(),
-        '/',
-        _tokenId.uint2Str()
-      );
+      seperator = '/';
     } else {
-      return baseTokenURI.strConcat(
-        '',
-        '/',
-        _tokenId.uint2Str()
-      );
+      URI = baseTokenURI;
+      seperator = '';
+      lockAddress = '';
     }
+
+    return URI.strConcat(
+        lockAddress,
+        seperator,
+        tokenId
+      );
   }
 }

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -127,8 +127,7 @@ contract MixinLockMetadata is
         _tokenId.uint2Str()
       );
     } else {
-      URI = baseTokenURI;
-      return URI.strConcat(
+      return baseTokenURI.strConcat(
         '',
         '/',
         _tokenId.uint2Str()

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -122,17 +122,17 @@ contract MixinLockMetadata is
     if(bytes(baseTokenURI).length == 0) {
       URI = unlockProtocol.globalBaseTokenURI();
       return URI.strConcat(
-      address(this).address2Str(),
-      '/',
-      _tokenId.uint2Str()
-    );
+        address(this).address2Str(),
+        '/',
+        _tokenId.uint2Str()
+      );
     } else {
       URI = baseTokenURI;
       return URI.strConcat(
-      '',
-      '/',
-      _tokenId.uint2Str()
-    );
+        '',
+        '/',
+        _tokenId.uint2Str()
+      );
     }
   }
 }

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -100,6 +100,8 @@ contract MixinLockMetadata is
   /**  @notice A distinct Uniform Resource Identifier (URI) for a given asset.
    * @param _tokenId The iD of the token  for which we want to retrieve the URI.
    * If 0 is passed here, we just return the appropriate baseTokenURI.
+   * If a custom URI has been set we don't return the lock address.
+   * It may be included in the custom baseTokenURI if needed.
    * @dev  URIs are defined in RFC 3986. The URI may point to a JSON file
    * that conforms to the "ERC721 Metadata JSON Schema".
    * https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -86,18 +86,6 @@ contract MixinLockMetadata is
     }
   }
 
-  function getBaseTokenURI()
-   external
-   view
-   returns(string memory)
-  {
-    if(bytes(baseTokenURI).length == 0) {
-      return unlockProtocol.globalBaseTokenURI();
-    } else {
-      return baseTokenURI;
-    }
-  }
-
   /**
    * Allows the Lock owner to update the baseTokenURI for this Lock.
    */

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -31,7 +31,7 @@ contract MixinLockMetadata is
   string private lockSymbol;
 
   // the base Token URI for this Lock. If not set by lock owner, the global URI stored in Unlock is used.
-  string public baseTokenURI;
+  string private baseTokenURI;
 
   event NewLockSymbol(
     string symbol
@@ -86,6 +86,14 @@ contract MixinLockMetadata is
     }
   }
 
+  function getBaseTokenURI()
+   external
+   view
+   returns(string memory)
+  {
+    return baseTokenURI;
+  }
+
   /**
    * Allows the Lock owner to update the baseTokenURI for this Lock.
    */
@@ -113,14 +121,18 @@ contract MixinLockMetadata is
     string memory URI;
     if(bytes(baseTokenURI).length == 0) {
       URI = unlockProtocol.globalBaseTokenURI();
-    } else {
-      URI = baseTokenURI;
-    }
-
-    return URI.strConcat(
+      return URI.strConcat(
       address(this).address2Str(),
       '/',
       _tokenId.uint2Str()
     );
+    } else {
+      URI = baseTokenURI;
+      return URI.strConcat(
+      '',
+      '/',
+      _tokenId.uint2Str()
+    );
+    }
   }
 }

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -31,7 +31,7 @@ contract MixinLockMetadata is
   string private lockSymbol;
 
   // the base Token URI for this Lock. If not set by lock owner, the global URI stored in Unlock is used.
-  string private baseTokenURI;
+  string public baseTokenURI;
 
   event NewLockSymbol(
     string symbol

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -100,7 +100,8 @@ contract('Lock / erc721 / tokenURI', accounts => {
       assert.equal(uri, 'https:/customBaseTokenURI.com/api/key/' + '1')
     })
 
-    it('should let anyone get the baseTokenURI for a lock', async () => {
+    it('should let anyone get the baseTokenURI for a lock by passing tokenId 0', async () => {
+      // here we pass 0 as the tokenId to get the baseTokenURI
       baseTokenURI = await lock.tokenURI.call(0)
       // should be the same as the previously set URI
       assert.equal(baseTokenURI, 'https:/customBaseTokenURI.com/api/key/')

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -10,7 +10,6 @@ let txObj
 let event
 let baseTokenURI
 let uri
-let lowerCaseAddress
 
 // Helper function to deal with the lock returning the address part of the URI in lowercase.
 function stringShifter(str) {
@@ -95,13 +94,11 @@ contract('Lock / erc721 / tokenURI', accounts => {
         value: web3.utils.toWei('0.01', 'ether'),
       })
       uri = await lock.tokenURI.call(1)
-      const lockAddressStr = lock.address.toString()
-      lowerCaseAddress = stringShifter(lockAddressStr)
-      assert.equal(uri, `https:/newURI.com/api/key/${lowerCaseAddress}` + '/1')
+      assert.equal(uri, 'https:/newURI.com/api/key/' + '/1')
     })
 
     it('should let anyone get the baseTokenURI for a lock', async () => {
-      baseTokenURI = await lock.baseTokenURI.call()
+      baseTokenURI = await lock.getBaseTokenURI.call()
       // should be the same as the previously set URI
       assert.equal(baseTokenURI, 'https:/newURI.com/api/key/')
     })
@@ -110,9 +107,11 @@ contract('Lock / erc721 / tokenURI', accounts => {
       await lock.setBaseTokenURI('', {
         from: accounts[0],
       })
-      baseTokenURI = await lock.baseTokenURI.call()
+      baseTokenURI = await lock.getBaseTokenURI.call()
       assert.equal(baseTokenURI, '')
       uri = await lock.tokenURI.call(1)
+      const lockAddressStr = lock.address.toString()
+      const lowerCaseAddress = stringShifter(lockAddressStr)
       assert.equal(
         uri,
         `https://newTokenURI.com/api/key/${lowerCaseAddress}` + '/1'

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -107,5 +107,11 @@ contract('Lock / erc721 / tokenURI', accounts => {
         'MixinLockManager: caller does not have the LockManager role'
       )
     })
+
+    it('should let anyone get the baseTokenURI for a lock', async () => {
+      const URI = await lock.baseTokenURI.call()
+      // should be the same as the previously set URI
+      assert.equal(URI, 'https:/newURI.com/api/key/')
+    })
   })
 })


### PR DESCRIPTION
# Description
This is a refactoring of our existing `tokenURI` function in `PublicLock.sol`, motivated by the need to be able to get the custom `baseTokenURI` even when no keys have been sold yet, which was previously impossible to do. the refactored version of the function handles all possible combinations of 2 primary conditions:
1.) Is the `tokenId` 0 or not?
  - passing 0 will now return the baseTokenID (custom or global)

2.) Has a custom `baseTokenURI` been set?
  - if NO, the `globalBaseTokenURI` + the lock address is returned.
  - if YES, the `baseTokenURI` is returned, without the lock address (the address is redundant as a differentiator when a custom URI has been set).

This also moves us in the right direction regarding issue 5836 (Do not revert read-only calls)


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
