### PR TITLE
adding metadata call to action

### DIFF
--- a/paywall/src/__tests__/utils/callToAction.test.ts
+++ b/paywall/src/__tests__/utils/callToAction.test.ts
@@ -7,6 +7,7 @@ const ctas: PaywallCallToAction = {
   pending: 'The Pending CTA',
   expired: 'This key is past its sell-by date',
   noWallet: 'You do not have a wallet',
+  metadata: 'We need more info',
 }
 
 const onlyDefaultCta: any = {

--- a/paywall/src/hooks/usePaywallConfig.ts
+++ b/paywall/src/hooks/usePaywallConfig.ts
@@ -50,6 +50,8 @@ export const defaultValue: PaywallConfig = {
     expired: 'Your access has expired. Please purchase a new key to continue',
     pending: 'Purchase pending...',
     confirmed: 'Purchase confirmed, content unlocked!',
+    metadata:
+      'We need to collect some additional information for your purchase.',
     noWallet:
       'To buy a key you will need to use a crypto-enabled browser that has a wallet. Here are a few options.',
   },

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -64,6 +64,7 @@ export interface PaywallCallToAction {
   pending: string
   confirmed: string
   noWallet: string
+  metadata: string
 }
 
 export interface PaywallConfigLocks {

--- a/paywall/src/utils/validators.js
+++ b/paywall/src/utils/validators.js
@@ -56,6 +56,7 @@ export const isValidCTA = callToAction => {
     'pending',
     'confirmed',
     'noWallet',
+    'metadata',
   ]
 
   const ctaKeys = Object.keys(callToAction)
@@ -145,6 +146,7 @@ export const isValidConfigLocks = configLocks => {
  *      pending: 'Purchase pending...',
  *      confirmed: 'Your content is unlocked!',
  *      noWallet: 'Please, get a wallet!',
+ *      metadata: 'We need more info.',
  *   },
  * }
  *

--- a/unlock-app/src/__tests__/components/interface/checkout/CallToAction.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/CallToAction.test.tsx
@@ -8,6 +8,7 @@ import { PaywallCallToAction } from '../../../../unlockTypes'
 
 const callToAction = {
   noWallet: 'Hey, you need a wallet for this to work',
+  metadata: 'We need to collect some additional information for your purchase.',
 }
 
 describe('CallToAction', () => {
@@ -38,5 +39,18 @@ describe('CallToAction', () => {
     )
 
     getByText(callToAction.noWallet)
+  })
+
+  it('renders a message from the cta object when provided when in the metadata stare', () => {
+    expect.assertions(0)
+
+    const { getByText } = rtl.render(
+      <CallToAction
+        state="metadataForm"
+        callToAction={callToAction as PaywallCallToAction}
+      />
+    )
+
+    getByText(callToAction.metadata)
   })
 })

--- a/unlock-app/src/__tests__/components/interface/checkout/FiatLocks.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/checkout/FiatLocks.test.tsx
@@ -35,6 +35,7 @@ const paywallConfig: PaywallConfig = {
     pending: '',
     confirmed: '',
     noWallet: '',
+    metadata: '',
   },
 }
 

--- a/unlock-app/src/__tests__/hooks/usePaywallLocks.test.ts
+++ b/unlock-app/src/__tests__/hooks/usePaywallLocks.test.ts
@@ -33,6 +33,7 @@ const paywallConfig: PaywallConfig = {
     pending: '',
     confirmed: '',
     noWallet: '',
+    metadata: '',
   },
 }
 

--- a/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
+++ b/unlock-app/src/__tests__/storybook/__snapshots__/storyshots.test.js.snap
@@ -7255,9 +7255,6 @@ Object {
             
           </a>
           <form>
-            <p>
-              We need to collect some additional information for your purchase.
-            </p>
             <label
               class="sc-psCJM c4"
               required=""
@@ -7347,9 +7344,6 @@ Object {
           
         </a>
         <form>
-          <p>
-            We need to collect some additional information for your purchase.
-          </p>
           <label
             class="sc-psCJM sc-pHIBf jLkhMY"
             required=""
@@ -7650,9 +7644,6 @@ Object {
             
           </a>
           <form>
-            <p>
-              We need to collect some additional information for your purchase.
-            </p>
             <label
               class="sc-psCJM c4"
               required=""
@@ -7755,9 +7746,6 @@ Object {
           
         </a>
         <form>
-          <p>
-            We need to collect some additional information for your purchase.
-          </p>
           <label
             class="sc-psCJM sc-pHIBf jLkhMY"
             required=""

--- a/unlock-app/src/components/content/DemoContent.jsx
+++ b/unlock-app/src/components/content/DemoContent.jsx
@@ -51,7 +51,18 @@ const usePaywall = () => {
       locks: {
         [url.searchParams.get('lock')]: {},
       },
-      callToAction: {},
+      callToAction: {
+        default: 'This content is locked. You need to unlock it!',
+        expired:
+          'Your previous membership has now expired.. You need to get a new membership!',
+        pending:
+          'Thanks for your trust. The transaction is now being processed.',
+        confirmed: 'Thanks for being a member!',
+        metadata:
+          'We need to collect some additional information for your purchase.',
+        noWallet:
+          'You need to use a crypto-wallet in order to unlock this content.',
+      },
     }
 
     // Remove localStorage (on the demo we do not want to store any accoun)

--- a/unlock-app/src/components/interface/checkout/CallToAction.tsx
+++ b/unlock-app/src/components/interface/checkout/CallToAction.tsx
@@ -8,6 +8,7 @@ export const defaultCallToAction: PaywallCallToAction = {
     'You have reached your limit of free articles. Please purchase access',
   expired: 'Your access has expired. Please purchase a new key to continue',
   pending: 'Purchase pending...',
+  metadata: 'We need to collect some additional information for your purchase.',
   confirmed: 'Purchase confirmed, content unlocked!',
   noWallet:
     'To buy a key you will need to use a crypto-enabled browser that has a wallet. Here are a few options.',
@@ -20,7 +21,7 @@ export const stateToCTAKey: {
   [CheckoutState.loading]: 'default',
   [CheckoutState.fiatLocks]: 'default',
   [CheckoutState.locks]: 'default',
-  [CheckoutState.metadataForm]: 'default',
+  [CheckoutState.metadataForm]: 'metadata',
   [CheckoutState.notLoggedIn]: 'noWallet',
 }
 

--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -42,7 +42,6 @@ export const MetadataForm = ({ fields, onSubmit }: Props) => {
 
   return (
     <form onSubmit={handleSubmit(wrappedOnSubmit)}>
-      <p>We need to collect some additional information for your purchase.</p>
       {fields.map(({ name, type, required }) => (
         <StyledLabel required={required} key={name}>
           <span>{name}</span>

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -88,6 +88,7 @@ export interface PaywallCallToAction {
   pending: string
   confirmed: string
   noWallet: string
+  metadata: string
 }
 
 export interface PaywallConfigLocks {

--- a/unlock-app/src/utils/checkoutValidators.js
+++ b/unlock-app/src/utils/checkoutValidators.js
@@ -63,6 +63,7 @@ export const isValidCTA = callToAction => {
     'pending',
     'confirmed',
     'noWallet',
+    'metadata',
   ]
 
   const ctaKeys = Object.keys(callToAction)
@@ -152,6 +153,7 @@ export const isValidConfigLocks = configLocks => {
  *      pending: 'Purchase pending...',
  *      confirmed: 'Your content is unlocked!',
  *      noWallet: 'Please, get a wallet!',
+ *      metadata: 'Fill this form!',
  *   },
  * }
  *


### PR DESCRIPTION
# Description

We now allow for a `metadata` field on the `callToAction` value in the paywall config.
This solves #6445

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->