### PR TITLE
allowing the use of ethers signers

### DIFF
--- a/unlock-js/CHANGELOG.md
+++ b/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+# 0.10.1
+
+- Support Ether providers and signers in WalletService
+
 # 0.10.0
 
 - adding support for grantKey function

--- a/unlock-js/package.json
+++ b/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/unlock-js/src/__tests__/helpers/walletServiceHelper.js
+++ b/unlock-js/src/__tests__/helpers/walletServiceHelper.js
@@ -8,6 +8,7 @@ import * as UnlockV13 from 'unlock-abi-1-3'
 import * as UnlockV7 from 'unlock-abi-7'
 import { ethers } from 'ethers'
 
+import { BigNumber } from 'ethers/utils'
 import utils from '../../utils'
 import { GAS_AMOUNTS } from '../../constants'
 
@@ -146,12 +147,14 @@ export const prepContract = ({
       blockHash: null,
       blockNumber: null,
       transactionIndex: 0,
+      chainId: 0,
       confirmations: 0,
       creates: null,
       networkId: 0,
       nonce: 0,
       value: utils.bigNumberify(encodedValue),
       gasLimit: utils.bigNumberify(testParams.gas),
+      gasPrice: expect.any(BigNumber),
       hash: transactionHash,
       wait: expect.any(Function),
     }

--- a/unlock-js/src/erc20.js
+++ b/unlock-js/src/erc20.js
@@ -1,6 +1,5 @@
 import { ethers } from 'ethers'
 import utils from './utils'
-import FastJsonRpcSigner from './FastJsonRpcSigner'
 import erc20abi from './erc20abi'
 
 // The SAI contract does not have the symbol method implemented correctly
@@ -86,15 +85,7 @@ export async function approveTransfer(
   provider,
   signer
 ) {
-  // Using the FastJsonRpcSigner so that we immediately return and not have the user wait for the approval transaction
-  // to succeed.
-  // TODO: add test to ensure that this is actually retuning instantly?
-  const fastSigner = new FastJsonRpcSigner(signer)
-  const contract = new ethers.Contract(
-    erc20ContractAddress,
-    erc20abi,
-    fastSigner
-  )
+  const contract = new ethers.Contract(erc20ContractAddress, erc20abi, signer)
   return contract.approve(lockContractAddress, value)
 }
 

--- a/unlock-js/src/unlockService.js
+++ b/unlock-js/src/unlockService.js
@@ -10,8 +10,6 @@ import v12 from './v12'
 import v13 from './v13'
 import v7 from './v7'
 
-import FastJsonRpcSigner from './FastJsonRpcSigner'
-
 // mute warnings from overloaded smart contract methods (https://github.com/ethers-io/ethers.js/issues/499)
 ethers.errors.setLogLevel('error')
 
@@ -170,10 +168,7 @@ export default class UnlockService extends EventEmitter {
   }
 
   async getWritableContract(address, contract) {
-    // TODO: replace this when v5 of ethers is out
-    // see https://github.com/ethers-io/ethers.js/issues/511
-    const signer = new FastJsonRpcSigner(this.signer)
-    return new ethers.Contract(address, contract.abi, signer)
+    return new ethers.Contract(address, contract.abi, this.signer)
   }
 
   async getLockContract(lockAddress) {


### PR DESCRIPTION
# Description

There are 3 distinct situations when initializing the walletService:
1. We pass a URL to a local node (ganache mostly?) which has at least one unlocked account.
2. We pass a web3 provider (context of web applications). For reasons, these providers need a litte tweaking so we use a _fast_ version of it for the provider (one which does not wait for the transaction to be mined to succeed)
3. We pass an ethers provider _and_ an ethers signer.

Here we are cleaning up the API to support the use case #3 which will let us get rid of the HDWallet at least in the context of locksmith.

Some tests will break because some providers decide of gasPrices...
I'll submit a follow up commit in this PR with fixes

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->