### PR TITLE
Providing storage for Stripe connection details

### DIFF
--- a/locksmith/migrations/20200422185907-add_connected_account_id_to_authorized_lock.js
+++ b/locksmith/migrations/20200422185907-add_connected_account_id_to_authorized_lock.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const table = 'AuthorizedLocks'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(table, 'stripe_account_id', {
+      type: Sequelize.STRING,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn(table, 'stripe_account_id')
+  },
+}

--- a/locksmith/src/models/authorizedLock.ts
+++ b/locksmith/src/models/authorizedLock.ts
@@ -8,4 +8,7 @@ export class AuthorizedLock extends Model<AuthorizedLock> {
 
   @Column
   authorizedAt!: Date
+
+  @Column
+  stripe_account_id!: string
 }


### PR DESCRIPTION
# Description

Linking to https://stripe.com/docs/connect/standard-accounts for background information.  At the moment the details are being stored close to the lock associated to a token to be purchased. 

If/when the feature receives more structure it may make sense to shift the store the relationship to an entity that sits higher in the hierarchy 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
