### PR TITLE
adding more events

### DIFF
--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -1,6 +1,10 @@
 import Postmate from 'postmate'
 import './iframe.css'
-import { setupUnlockProtocolVariable, dispatchEvent } from './utils'
+import {
+  setupUnlockProtocolVariable,
+  dispatchEvent,
+  unlockEvents,
+} from './utils'
 import { store, retrieve } from '../utils/localStorage'
 import { willUnlock } from '../utils/optimisticUnlocking'
 import { isUnlocked } from '../utils/isUnlocked'
@@ -145,6 +149,7 @@ export class Paywall {
 
   handleTransactionInfoEvent = async ({ hash, lock }: TransactionInfo) => {
     const { readOnlyProvider } = __ENVIRONMENT_VARIABLES__
+    dispatchEvent(unlockEvents.transactionSent, { hash, lock })
     const optimistic = await willUnlock(
       readOnlyProvider,
       this.userAccountAddress!,
@@ -159,6 +164,7 @@ export class Paywall {
 
   handleUserInfoEvent = async (info: UserInfo) => {
     this.userAccountAddress = info.address
+    dispatchEvent(unlockEvents.authenticated, info)
     this.cacheUserInfo(info)
     this.checkKeysAndLock()
   }
@@ -173,12 +179,16 @@ export class Paywall {
 
   lockPage = () => {
     this.lockStatus = 'locked'
-    dispatchEvent('locked')
+    dispatchEvent(unlockEvents.status, {
+      state: this.lockStatus,
+    })
   }
 
   unlockPage = () => {
     this.lockStatus = 'unlocked'
-    dispatchEvent('unlocked')
+    dispatchEvent(unlockEvents.status, {
+      state: this.lockStatus,
+    })
   }
 }
 

--- a/paywall/src/paywall-script/utils.ts
+++ b/paywall/src/paywall-script/utils.ts
@@ -1,20 +1,38 @@
-export const dispatchEvent = (detail: any) => {
+/**
+ * Dispatches events
+ * @param eventName
+ * @param params
+ */
+export const dispatchEvent = (eventName: string, params: any) => {
+  if (eventName === unlockEvents.status) {
+    // Supporting legacy unlockProtocol event
+    dispatchEvent('unlockProtocol', params.state)
+  }
   let event: any
   try {
-    event = new window.CustomEvent('unlockProtocol', { detail })
+    event = new window.CustomEvent(eventName, { detail: params })
   } catch (e) {
     // older browsers do events this clunky way.
     // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events#The_old-fashioned_way
     // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent#Parameters
     event = window.document.createEvent('customevent')
     event.initCustomEvent(
-      'unlockProtocol',
+      eventName,
       true /* canBubble */,
       true /* cancelable */,
-      detail
+      params
     )
   }
   window.dispatchEvent(event)
+}
+
+/**
+ * Mapping between events and their names
+ */
+export const unlockEvents = {
+  status: 'unlockProtocol.status',
+  authenticated: 'unlockProtocol.authenticated',
+  transactionSent: 'unlockProtocol.transactionSent',
 }
 
 export const setupUnlockProtocolVariable = (properties: {


### PR DESCRIPTION
# Description

In order to make our paywall API richer, we are trigger more than one single event.
For this we introduce the following events:
  * `unlockProtocol.status` (detail can be `locked` or `unlocked`)
  * `unlockProtocol.authenticated` (detail will be the user address)
  * `unlockProtocol.transactionSent` (detail will be an object with `hash` and `lock`)

Additionnaly, in order to remain backward compatible, the `unlockProtocol.status` will emit the legacy `unlockProtocol` event.

# Issues

Refs #6549

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->