### PR TITLE
showing an error message if the paywall config is missing

### DIFF
--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -183,4 +183,8 @@ export class Paywall {
 }
 
 const rawConfig = (window as any).unlockProtocolConfig
-new Paywall(rawConfig)
+if (!rawConfig) {
+  console.error('Missing window.unlockProtocolConfig.')
+} else {
+  new Paywall(rawConfig)
+}


### PR DESCRIPTION
# Description

Some users (like us!) may end up seeing the paywall script loaded without a config.
We should not run the paywall script.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->