### PR TITLE
Ensure config passed to checkout always contains provider info

### DIFF
--- a/paywall/src/__tests__/paywall-script/index.test.ts
+++ b/paywall/src/__tests__/paywall-script/index.test.ts
@@ -13,6 +13,8 @@ const paywallConfig = {
     expired: 'expired',
     pending: 'pending',
     confirmed: 'confirmed',
+    noWallet: 'noWallet',
+    metadata: 'metadata',
   },
   locks: {
     '0x1234567890123456789012345678901234567890': {
@@ -37,7 +39,10 @@ describe('Paywall init script', () => {
 
     expect(paywall.childCallBuffer).toHaveLength(1)
 
-    expect(paywall.childCallBuffer[0]).toEqual(['setConfig', paywallConfig])
+    // Constuctor will update config with provider info
+    const expectedConfig = paywallScriptUtils.injectProviderInfo(paywallConfig)
+
+    expect(paywall.childCallBuffer[0]).toEqual(['setConfig', expectedConfig])
   })
 
   describe('userInfo event', () => {

--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -4,6 +4,7 @@ import {
   setupUnlockProtocolVariable,
   dispatchEvent,
   unlockEvents,
+  injectProviderInfo,
 } from './utils'
 import { store, retrieve } from '../utils/localStorage'
 import { willUnlock } from '../utils/optimisticUnlocking'
@@ -59,6 +60,8 @@ export class Paywall {
   provider?: Enabler
 
   constructor(paywallConfig: any) {
+    this.provider = getProvider(window as Web3Window)
+
     const loadCheckoutModal = () => {
       if (this.iframe) {
         this.showIframe()
@@ -68,12 +71,12 @@ export class Paywall {
     }
 
     const resetConfig = (config: any) => {
-      this.paywallConfig = config
+      this.paywallConfig = injectProviderInfo(config, this.provider)
       this.checkKeysAndLock()
       if (this.setConfig) {
-        this.setConfig(config)
+        this.setConfig(this.paywallConfig)
       } else {
-        this.childCallBuffer.push(['setConfig', config])
+        this.childCallBuffer.push(['setConfig', this.paywallConfig])
       }
     }
 
@@ -93,8 +96,6 @@ export class Paywall {
       getUserAccountAddress,
       getState,
     })
-
-    this.provider = getProvider(window as Web3Window)
 
     // Always do this last!
     this.loadCache()

--- a/paywall/src/paywall-script/utils.ts
+++ b/paywall/src/paywall-script/utils.ts
@@ -1,3 +1,6 @@
+import { PaywallConfig } from 'src/unlockTypes'
+import { Enabler } from 'src/utils/enableInjectedProvider'
+
 /**
  * Dispatches events
  * @param eventName
@@ -79,4 +82,21 @@ export const setupUnlockProtocolVariable = (properties: {
     // eslint-disable-next-line no-console
     console.warn('WARNING: unlockProtocol already defined, cannot re-define it')
   }
+}
+
+export const injectProviderInfo = (
+  config: PaywallConfig,
+  provider?: Enabler
+) => {
+  const newConfig = { ...config }
+
+  // We want to inform the checkout iframe about the availability of a
+  // delegated provider. However, we will not overwrite an existing
+  // value in the config, in case the paywall owner has reason to
+  // force it one way or the other.
+  if (!newConfig.useDelegatedProvider) {
+    newConfig.useDelegatedProvider = !!provider
+  }
+
+  return newConfig
 }

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -90,6 +90,7 @@ export interface PaywallConfig {
   locks: PaywallConfigLocks
   metadataInputs?: MetadataInput[]
   persistentCheckout?: boolean
+  useDelegatedProvider?: boolean
 }
 
 export enum KeyStatus {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

As part of letting the checkout know when it should use a delegated provider, this PR makes the paywall script modify the paywall config based on the availability of a provider in the main window.

This code explicitly avoids overwriting the config value if it is already set; this will allow the person in control of the paywall to force it to use an injected provider or not; in most cases I think this would be used to disable the injected provider because enabling it when none is available can lead to a non-functional paywall.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
