### PR TITLE
Add a nonce to KeyPurchaser creation

### DIFF
--- a/smart-contract-extensions/contracts/KeyPurchaserFactory.sol
+++ b/smart-contract-extensions/contracts/KeyPurchaserFactory.sol
@@ -38,11 +38,12 @@ contract KeyPurchaserFactory
     uint _maxKeyPrice,
     uint _renewWindow,
     uint _renewMinFrequency,
-    uint _msgSenderReward
+    uint _msgSenderReward,
+    uint _nonce
   ) private pure
     returns (bytes32)
   {
-    return keccak256(abi.encodePacked(address(_lock), _maxKeyPrice, _renewWindow, _renewMinFrequency, _msgSenderReward));
+    return keccak256(abi.encodePacked(address(_lock), _maxKeyPrice, _renewWindow, _renewMinFrequency, _msgSenderReward, _nonce));
   }
 
   /**
@@ -54,11 +55,12 @@ contract KeyPurchaserFactory
     uint _maxKeyPrice,
     uint _renewWindow,
     uint _renewMinFrequency,
-    uint _msgSenderReward
+    uint _msgSenderReward,
+    uint _nonce
   ) external view
     returns (address)
   {
-    bytes32 salt = _getClone2Salt(_lock, _maxKeyPrice, _renewWindow, _renewMinFrequency, _msgSenderReward);
+    bytes32 salt = _getClone2Salt(_lock, _maxKeyPrice, _renewWindow, _renewMinFrequency, _msgSenderReward, _nonce);
     return keyPurchaserTemplate.getClone2Address(salt);
   }
 
@@ -70,10 +72,11 @@ contract KeyPurchaserFactory
     uint _maxKeyPrice,
     uint _renewWindow,
     uint _renewMinFrequency,
-    uint _msgSenderReward
+    uint _msgSenderReward,
+    uint _nonce
   ) public
   {
-    bytes32 salt = _getClone2Salt(_lock, _maxKeyPrice, _renewWindow, _renewMinFrequency, _msgSenderReward);
+    bytes32 salt = _getClone2Salt(_lock, _maxKeyPrice, _renewWindow, _renewMinFrequency, _msgSenderReward, _nonce);
     address purchaser = keyPurchaserTemplate.createClone2(salt);
 
     KeyPurchaser(purchaser).initialize(_lock, _maxKeyPrice, _renewWindow, _renewMinFrequency, _msgSenderReward);

--- a/smart-contract-extensions/contracts/KeyPurchaserFactory.sol
+++ b/smart-contract-extensions/contracts/KeyPurchaserFactory.sol
@@ -66,6 +66,9 @@ contract KeyPurchaserFactory
 
   /**
    * @notice Deploys a new KeyPurchaser for a lock and stores the address for reference.
+   * @param _nonce Allows a KeyPurchaser to be redeployed with a different address in case the original
+   * was incorrectly stopped. Typically this should be set to 0.
+   * @dev See KeyPurchaser for a description of the other params.
    */
   function deployKeyPurchaser(
     IPublicLockV7 _lock,

--- a/smart-contract-extensions/test/keyPurchaserFactory.js
+++ b/smart-contract-extensions/test/keyPurchaserFactory.js
@@ -38,6 +38,7 @@ contract('keyPurchaserFactory', accounts => {
         42,
         99,
         1,
+        0,
         {
           from: lockCreator,
         }
@@ -72,7 +73,8 @@ contract('keyPurchaserFactory', accounts => {
         maxPurchasePrice,
         renewWindow,
         renewMinFrequency,
-        msgSenderReward
+        msgSenderReward,
+        0
       )
       assert.equal(expectedAddress, purchaser.address)
     })
@@ -101,6 +103,7 @@ contract('keyPurchaserFactory', accounts => {
             50,
             99 + i,
             0,
+            0,
             {
               from: lockCreator,
             }
@@ -112,6 +115,21 @@ contract('keyPurchaserFactory', accounts => {
         const purchasers = await factory.getKeyPurchasers(lock.address)
         assert.equal(purchasers.length, purchaserCount)
         assert.equal(purchasers[0], purchaser.address) // sanity check
+      })
+    })
+
+    describe('with a different nonce', () => {
+      beforeEach(async () => {
+        await factory.deployKeyPurchaser(lock.address, keyPrice, 50, 99, 0, 1, {
+          from: lockCreator,
+        })
+      })
+
+      it('can read the purchasers', async () => {
+        const purchasers = await factory.getKeyPurchasers(lock.address)
+        assert.equal(purchasers.length, 2)
+        assert.equal(purchasers[0], purchaser.address) // sanity check
+        assert.notEqual(purchasers[1], purchaser.address) // sanity check
       })
     })
   })


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Adding a nonce to the KeyPurchaser creation allows us to redeploy the contract using the same configuration but with a new address if the original was incorrectly stopped.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
