### PR TITLE
adding the pessimistic option

### DIFF
--- a/paywall/src/__tests__/paywall-script/index.test.ts
+++ b/paywall/src/__tests__/paywall-script/index.test.ts
@@ -181,5 +181,26 @@ describe('Paywall init script', () => {
         }
       )
     })
+
+    it('should not try to optimistically unlock if the config has a pessimistic field', async () => {
+      expect.assertions(1)
+      const pessimisticConfig = {
+        ...paywallConfig,
+        pessimistic: true,
+      }
+      const paywall = new Paywall(pessimisticConfig)
+
+      jest
+        .spyOn(optimisticUnlockingUtils, 'willUnlock')
+        .mockResolvedValueOnce(true)
+
+      paywall.lockPage = jest.fn()
+
+      await paywall.handleTransactionInfoEvent({
+        hash: '0xhash',
+        lock: '0xlock',
+      })
+      expect(optimisticUnlockingUtils.willUnlock).not.toHaveBeenCalled()
+    })
   })
 })

--- a/paywall/src/__tests__/utils/isUnlocked.test.js
+++ b/paywall/src/__tests__/utils/isUnlocked.test.js
@@ -64,6 +64,32 @@ describe('isUnlocked', () => {
         .spyOn(timeStampUtil, 'keyExpirationTimestampFor')
         .mockResolvedValue(pastTime)
     })
+
+    describe('when the config is pessimistic', () => {
+      it('should return false even if the user has a pending transaction', async () => {
+        expect.assertions(2)
+        const spy = jest
+          .spyOn(optimisticUtil, 'optimisticUnlocking')
+          .mockResolvedValue(true)
+
+        const pesimisticConfig = {
+          ...paywallConfig,
+          pessimistic: true,
+        }
+
+        const unlocked = await isUnlocked(
+          userAccountAddress,
+          pesimisticConfig,
+          {
+            readOnlyProvider,
+            locksmithUri,
+          }
+        )
+        expect(unlocked).toBe(false)
+        expect(spy).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when the user has a pending transaction for which we should be optimistic', () => {
       it('should return true', async () => {
         expect.assertions(2)

--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -179,15 +179,17 @@ export class Paywall {
   handleTransactionInfoEvent = async ({ hash, lock }: TransactionInfo) => {
     const { readOnlyProvider } = __ENVIRONMENT_VARIABLES__
     dispatchEvent(unlockEvents.transactionSent, { hash, lock })
-    const optimistic = await willUnlock(
-      readOnlyProvider,
-      this.userAccountAddress!,
-      lock,
-      hash,
-      true // Optimistic if missing
-    )
-    if (optimistic) {
-      this.unlockPage()
+    if (!this.paywallConfig.pessimistic) {
+      const optimistic = await willUnlock(
+        readOnlyProvider,
+        this.userAccountAddress!,
+        lock,
+        hash,
+        true // Optimistic if missing
+      )
+      if (optimistic) {
+        this.unlockPage()
+      }
     }
   }
 

--- a/paywall/src/unlockTypes.ts
+++ b/paywall/src/unlockTypes.ts
@@ -84,6 +84,7 @@ export interface MetadataInput {
 
 // This interface describes an individual paywall's config
 export interface PaywallConfig {
+  pessimistic?: boolean
   icon?: string
   unlockUserAccounts?: true | 'true' | false
   callToAction: PaywallCallToAction

--- a/paywall/src/utils/isUnlocked.ts
+++ b/paywall/src/utils/isUnlocked.ts
@@ -34,15 +34,17 @@ export const isUnlocked = async (
     return true
   }
 
-  // If not key exists on chain, let's see if we can be optimistic before locking the page.
-  const optimistic = await optimisticUnlocking(
-    readOnlyProvider,
-    locksmithUri,
-    Object.keys(paywallConfig.locks),
-    userAccountAddress!
-  )
-  if (optimistic) {
-    return true
+  if (!paywallConfig.pessimistic) {
+    // If not key exists on chain, let's see if we can be optimistic before locking the page.
+    const optimistic = await optimisticUnlocking(
+      readOnlyProvider,
+      locksmithUri,
+      Object.keys(paywallConfig.locks),
+      userAccountAddress!
+    )
+    if (optimistic) {
+      return true
+    }
   }
 
   // If no key exists, or no transaction exists which could be optimistic, we lock


### PR DESCRIPTION
# Description

Sometimes, a creator might not want to provide optimistic unlocking to their users.
This introduces a new paywall configuration option to skip optimistic unlocking.

# Issues

Fixes #6549


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->