### PR TITLE
Paywall object takes an optional provider at construction

### DIFF
--- a/paywall/src/paywall-script/Paywall.ts
+++ b/paywall/src/paywall-script/Paywall.ts
@@ -77,9 +77,10 @@ export class Paywall {
 
   moduleConfig: ModuleConfig
 
-  constructor(paywallConfig: any, moduleConfig: ModuleConfig) {
+  constructor(paywallConfig: any, moduleConfig: ModuleConfig, provider?: any) {
     this.moduleConfig = moduleConfig
-    this.provider = getProvider(window as Web3Window)
+    // Use provider in parameter, fall back to injected provider in window (if any)
+    this.provider = provider || getProvider(window as Web3Window)
 
     const loadCheckoutModal = () => {
       if (this.iframe) {

--- a/paywall/src/paywall-script/Paywall.ts
+++ b/paywall/src/paywall-script/Paywall.ts
@@ -1,11 +1,6 @@
 import Postmate from 'postmate'
 import './iframe.css'
-import {
-  setupUnlockProtocolVariable,
-  dispatchEvent,
-  unlockEvents,
-  injectProviderInfo,
-} from './utils'
+import { dispatchEvent, unlockEvents, injectProviderInfo } from './utils'
 import { store, retrieve } from '../utils/localStorage'
 import { willUnlock } from '../utils/optimisticUnlocking'
 import { isUnlocked } from '../utils/isUnlocked'
@@ -82,43 +77,36 @@ export class Paywall {
     // Use provider in parameter, fall back to injected provider in window (if any)
     this.provider = provider || getProvider(window as Web3Window)
 
-    const loadCheckoutModal = () => {
-      if (this.iframe) {
-        this.showIframe()
-      } else {
-        this.shakeHands()
-      }
-    }
-
-    const resetConfig = (config: any) => {
-      this.paywallConfig = injectProviderInfo(config, this.provider)
-      this.checkKeysAndLock()
-      if (this.setConfig) {
-        this.setConfig(this.paywallConfig)
-      } else {
-        this.childCallBuffer.push(['setConfig', this.paywallConfig])
-      }
-    }
-
-    const getUserAccountAddress = () => {
-      return this.userAccountAddress
-    }
-
-    const getState = () => {
-      return this.lockStatus
-    }
-
-    resetConfig(paywallConfig)
-
-    setupUnlockProtocolVariable({
-      loadCheckoutModal,
-      resetConfig,
-      getUserAccountAddress,
-      getState,
-    })
+    this.resetConfig(paywallConfig)
 
     // Always do this last!
     this.loadCache()
+  }
+
+  loadCheckoutModal = () => {
+    if (this.iframe) {
+      this.showIframe()
+    } else {
+      this.shakeHands()
+    }
+  }
+
+  getUserAccountAddress = () => {
+    return this.userAccountAddress
+  }
+
+  resetConfig = (config: any) => {
+    this.paywallConfig = injectProviderInfo(config, this.provider)
+    this.checkKeysAndLock()
+    if (this.setConfig) {
+      this.setConfig(this.paywallConfig)
+    } else {
+      this.childCallBuffer.push(['setConfig', this.paywallConfig])
+    }
+  }
+
+  getState = () => {
+    return this.lockStatus
   }
 
   // Saves the user info in the cache

--- a/paywall/src/paywall-script/index.ts
+++ b/paywall/src/paywall-script/index.ts
@@ -1,4 +1,5 @@
 import { Paywall } from './Paywall'
+import { setupUnlockProtocolVariable } from './utils'
 
 declare let __ENVIRONMENT_VARIABLES__: any
 const moduleConfig: any = __ENVIRONMENT_VARIABLES__
@@ -7,5 +8,18 @@ const rawConfig = (window as any).unlockProtocolConfig
 if (!rawConfig) {
   console.error('Missing window.unlockProtocolConfig.')
 } else {
-  new Paywall(rawConfig, moduleConfig)
+  const paywall = new Paywall(rawConfig, moduleConfig)
+  const {
+    getState,
+    getUserAccountAddress,
+    loadCheckoutModal,
+    resetConfig,
+  } = paywall
+
+  setupUnlockProtocolVariable({
+    loadCheckoutModal,
+    resetConfig,
+    getUserAccountAddress,
+    getState,
+  })
 }

--- a/paywall/src/paywall-script/module.d.ts
+++ b/paywall/src/paywall-script/module.d.ts
@@ -11,5 +11,5 @@ export function isUnlocked(
 ): Promise<boolean>
 
 export class Paywall {
-  constructor(paywallConfig: any, moduleConfig: PaywallModuleConfig)
+  constructor(paywallConfig: any, moduleConfig: PaywallModuleConfig, provider?: any)
 }

--- a/paywall/src/paywall-script/package.json
+++ b/paywall/src/paywall-script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/paywall",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "module": "dist/module.js",
   "main": "dist/module.js",
   "types": "module.d.ts",


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

This small PR allows the Paywall object to take an optional parameter indicating a provider to use (such as from Web3Modal). In the absence of that provider, the paywall will use the injected provider from the window (if available).

This should be everything, but tomorrow I'm going to take some time to test thoroughly on a local environment and use that as an example of how to use this new feature with Web3Modal in a blog post.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #6397 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
