### PR TITLE
bringing cluster up

### DIFF
--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -20,6 +20,10 @@ docker-compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE down
 # improvments we want. We already have a script to build images with build-image.sh which should
 # make that easy.
 
+# start unlock-app to make sure it's built by the time the tests run
+docker-compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE up --detach unlock-app
+docker-compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE up --detach unlock-provider-unlock-app
+docker-compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE up --detach paywall
 
 # Deploy the subgraph
 # TODO make the script idempotent so that it does not deploy twice!


### PR DESCRIPTION
# Description

It looks like we have a race condition and building the next application may sometimes take too much time for integration tests to run. We now bring these instances up earlier so that they're fully built and ready by the time integration tests run.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->