### PR TITLE
Add approveBeneficiary

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -76,6 +76,15 @@ contract IPublicLock
   ) external;
 
   /**
+   * @notice An ERC-20 style approval, allowing the spender to transfer funds directly from this lock.
+   */
+  function approveBeneficiary(
+    address _spender,
+    uint _amount
+  ) external
+    returns (bool);
+
+  /**
    * A function which lets a Lock manager of the lock to change the price for future purchases.
    * @dev Throws if called by other than a Lock manager
    * @dev Throws if lock has been disabled

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -196,4 +196,17 @@ contract MixinLockCore is
   {
     return _totalSupply;
   }
+
+  /**
+   * @notice An ERC-20 style approval, allowing the spender to transfer funds directly from this lock.
+   */
+  function approveBeneficiary(
+    address _spender,
+    uint _amount
+  ) public
+    onlyLockManagerOrBeneficiary
+    returns (bool)
+  {
+    return IERC20(tokenAddress).approve(_spender, _amount);
+  }
 }

--- a/smart-contracts/test/Lock/approveBeneficiary.js
+++ b/smart-contracts/test/Lock/approveBeneficiary.js
@@ -1,0 +1,74 @@
+const { reverts } = require('truffle-assertions')
+const { tokens } = require('hardlydifficult-eth')
+const deployLocks = require('../helpers/deployLocks')
+
+const unlockContract = artifacts.require('Unlock.sol')
+const getProxy = require('../helpers/proxy')
+
+let unlock
+let locks
+
+contract('Lock / approveBeneficiary', (accounts) => {
+  const [daiOwner, beneficiary, keyOwner, spender, other] = accounts
+
+  before(async () => {
+    unlock = await getProxy(unlockContract)
+  })
+
+  describe('ETH', () => {
+    before(async () => {
+      locks = await deployLocks(unlock, beneficiary)
+    })
+
+    it('fails to approve if the lock is priced in ETH', async () => {
+      await reverts(
+        locks.OWNED.approveBeneficiary(accounts[0], 1, { from: beneficiary })
+      )
+    })
+  })
+
+  describe('ERC20', () => {
+    let token
+
+    before(async () => {
+      token = await tokens.dai.deploy(web3, daiOwner)
+      await token.mint(keyOwner, web3.utils.toWei('100', 'ether'), {
+        from: daiOwner,
+      })
+      locks = await deployLocks(unlock, beneficiary, token.address)
+
+      await token.approve(locks.ERC20.address, await locks.ERC20.keyPrice(), {
+        from: keyOwner,
+      })
+      await locks.ERC20.purchase(
+        await locks.ERC20.keyPrice(),
+        keyOwner,
+        web3.utils.padLeft(0, 40),
+        [],
+        {
+          from: keyOwner,
+        }
+      )
+
+      await locks.ERC20.approveBeneficiary(spender, 1, { from: beneficiary })
+    })
+
+    it('approve fails if called from the wrong account', async () => {
+      await reverts(
+        locks.OWNED.approveBeneficiary(accounts[0], 1, { from: other }),
+        'ONLY_LOCK_MANAGER_OR_BENEFICIARY'
+      )
+    })
+
+    it('has allowance', async () => {
+      const actual = await token.allowance(locks.ERC20.address, spender)
+      assert.equal(actual.toString(), 1)
+    })
+
+    it('can transferFrom', async () => {
+      await token.transferFrom(locks.ERC20.address, other, 1, {
+        from: spender,
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

Allows the beneficiary or a lock manager to approve another account to spend ERC-20 funds held by the lock.

Note: this will not enable direct interactions with most other contracts. Typically a contract assumes permission to call `transferFrom` by the `msg.sender`. To support that use case, a couple options come to mind:
  - Add proxy support, allowing the beneficiary or lock manager to call the Lock contract with arbitrary call information that could be used to interact with another contract.
  - Or launch an independent contract that verifies permission (maybe with a signature or by confirming the msg.sender is a lock manager); it then calls transferFrom to collect funds from the lock; approves spending by the target contract; and then calls the target contract. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #6742
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
