### PR TITLE
fix #7070: add locks in paywall status event

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,5 +1,5 @@
 {
-  "contributors": ["unlock-deployer", "smombartz", "hardlydifficult", "benwerd","nfurfaro","akeem","cnasc","cellog","julien51","renovate[bot]", "renovate-bot", "ImgBotApp", "NickCuso", "metjm", "dobrokhvalov", "vikmeup", "pi0neerpat"],
+  "contributors": ["unlock-deployer", "smombartz", "hardlydifficult", "benwerd","nfurfaro","akeem","cnasc","cellog","julien51","renovate[bot]", "renovate-bot", "ImgBotApp", "NickCuso", "metjm", "dobrokhvalov", "vikmeup", "pi0neerpat", "pwagner"],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. In order for us to review and merge your code, please contact us (easiest way is to [open an issue](https://github.com/unlock-protocol/unlock/issues)) to get yourself added."
 
 }

--- a/paywall/src/__tests__/paywall-script/Paywall.test.ts
+++ b/paywall/src/__tests__/paywall-script/Paywall.test.ts
@@ -25,8 +25,8 @@ const paywallConfig = {
   icon: 'http://com.com/image.tiff',
 }
 
-const testLock = Object.keys(paywallConfig.locks)[0];
-const now = new Date().toDateString();
+const testLock = Object.keys(paywallConfig.locks)[0]
+const now = new Date().toDateString()
 const savedTransactions = [
   {
     recipient: testLock,
@@ -230,11 +230,11 @@ describe('Paywall unlockPage', () => {
   it('should dispatch an event for lock status', async () => {
     expect.assertions(1)
     jest.spyOn(paywallScriptUtils, 'dispatchEvent')
-    paywall.unlockPage([ testLock ])
+    paywall.unlockPage([testLock])
     expect(paywallScriptUtils.dispatchEvent).toHaveBeenCalledWith(
       paywallScriptUtils.unlockEvents.status,
       {
-        locks: [ testLock ],
+        locks: [testLock],
         state: 'unlocked',
       }
     )

--- a/paywall/src/__tests__/paywall-script/Paywall.test.ts
+++ b/paywall/src/__tests__/paywall-script/Paywall.test.ts
@@ -1,3 +1,4 @@
+import 'jest-fetch-mock'
 import { Enabler } from '../../utils/enableInjectedProvider'
 import { Paywall } from '../../paywall-script/Paywall'
 import * as isUnlockedUtil from '../../utils/isUnlocked'
@@ -23,6 +24,21 @@ const paywallConfig = {
   },
   icon: 'http://com.com/image.tiff',
 }
+
+const testLock = Object.keys(paywallConfig.locks)[0];
+const now = new Date().toDateString();
+const savedTransactions = [
+  {
+    recipient: testLock,
+    transactionHash: '0xtransaction',
+    createdAt: now,
+    updatedAt: now,
+    chain: 0,
+    sender: '0xuser',
+    for: '0xfor',
+    data: '0xdata',
+  },
+]
 
 let paywall: Paywall
 
@@ -119,10 +135,12 @@ describe('Paywall object', () => {
     it('should call isUnlocked and unlockPage the page if it yields true', async () => {
       expect.assertions(2)
       jest.spyOn(isUnlockedUtil, 'isUnlocked').mockResolvedValueOnce(true)
-      paywall.userAccountAddress = '0xUser'
+      jest
+        .spyOn(optimisticUnlockingUtils, 'getTransactionsForUserAndLocks')
+        .mockImplementationOnce(() => Promise.resolve(savedTransactions))
 
       await paywall.checkKeysAndLock()
-      expect(paywall.unlockPage).toHaveBeenCalled()
+      expect(paywall.unlockPage).toHaveBeenCalledWith([testLock])
       expect(paywall.lockPage).not.toHaveBeenCalled()
     })
 
@@ -201,5 +219,24 @@ describe('Paywall object', () => {
       })
       expect(optimisticUnlockingUtils.willUnlock).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('Paywall unlockPage', () => {
+  beforeEach(() => {
+    paywall = new Paywall(paywallConfig, networkConfigs)
+  })
+
+  it('should dispatch an event for lock status', async () => {
+    expect.assertions(1)
+    jest.spyOn(paywallScriptUtils, 'dispatchEvent')
+    paywall.unlockPage([ testLock ])
+    expect(paywallScriptUtils.dispatchEvent).toHaveBeenCalledWith(
+      paywallScriptUtils.unlockEvents.status,
+      {
+        locks: [ testLock ],
+        state: 'unlocked',
+      }
+    )
   })
 })

--- a/paywall/src/paywall-script/Paywall.ts
+++ b/paywall/src/paywall-script/Paywall.ts
@@ -140,10 +140,14 @@ export class Paywall {
         locksmithUri,
       })
     ) {
-      const locks = await getUnlockedLocks(this.userAccountAddress, this.paywallConfig, {
-        readOnlyProvider,
-        locksmithUri,
-      });
+      const locks = await getUnlockedLocks(
+        this.userAccountAddress,
+        this.paywallConfig,
+        {
+          readOnlyProvider,
+          locksmithUri,
+        }
+      )
 
       return this.unlockPage(locks)
     }

--- a/paywall/src/paywall-script/Paywall.ts
+++ b/paywall/src/paywall-script/Paywall.ts
@@ -144,7 +144,7 @@ export class Paywall {
         readOnlyProvider,
         locksmithUri,
       });
-      console.log('getUnlockedLocks locks', locks);
+
       return this.unlockPage(locks)
     }
     return this.lockPage()

--- a/paywall/src/paywall-script/Paywall.ts
+++ b/paywall/src/paywall-script/Paywall.ts
@@ -5,6 +5,7 @@ import { dispatchEvent, unlockEvents, injectProviderInfo } from './utils'
 import { store, retrieve } from '../utils/localStorage'
 import { willUnlock } from '../utils/optimisticUnlocking'
 import { isUnlocked } from '../utils/isUnlocked'
+import { getUnlockedLocks } from '../utils/getUnlockedLocks'
 import {
   Enabler,
   getProvider,
@@ -139,7 +140,12 @@ export class Paywall {
         locksmithUri,
       })
     ) {
-      return this.unlockPage()
+      const locks = await getUnlockedLocks(this.userAccountAddress, this.paywallConfig, {
+        readOnlyProvider,
+        locksmithUri,
+      });
+      console.log('getUnlockedLocks locks', locks);
+      return this.unlockPage(locks)
     }
     return this.lockPage()
   }
@@ -182,7 +188,7 @@ export class Paywall {
         true // Optimistic if missing
       )
       if (optimistic) {
-        this.unlockPage()
+        this.unlockPage([lock])
       }
     }
   }
@@ -219,9 +225,10 @@ export class Paywall {
     })
   }
 
-  unlockPage = () => {
+  unlockPage = (locks: string[] = []) => {
     this.lockStatus = 'unlocked'
     dispatchEvent(unlockEvents.status, {
+      locks,
       state: this.lockStatus,
     })
   }

--- a/paywall/src/utils/getUnlockedLocks.ts
+++ b/paywall/src/utils/getUnlockedLocks.ts
@@ -19,7 +19,7 @@ export const getUnlockedLocks = async (
   { readOnlyProvider, locksmithUri }: ModuleConfig
 ): Promise<string[]> => {
   const lockAddresses = Object.keys(paywallConfig.locks)
-  const timeStampsByLock: Record<string, number> = {};
+  const timeStampsByLock: Record<string, number> = {}
   lockAddresses.map(async (lockAddress) => {
     timeStampsByLock[lockAddress] = await keyExpirationTimestampFor(
       readOnlyProvider,
@@ -28,24 +28,27 @@ export const getUnlockedLocks = async (
     )
   })
 
-  const unlockedLocks = Object.keys(timeStampsByLock)
-    .filter((lockAddress) => timeStampsByLock[lockAddress] > new Date().getTime() / 1000)
+  const unlockedLocks = Object.keys(timeStampsByLock).filter(
+    (lockAddress) => timeStampsByLock[lockAddress] > new Date().getTime() / 1000
+  )
 
   if (!paywallConfig.pessimistic) {
     // Add optimistically unlocked lock addresses
     const additionalLocks = await optimisticLocks(
       readOnlyProvider,
       locksmithUri,
-      lockAddresses.filter((lockAddress) => unlockedLocks.indexOf(lockAddress) < 0),
+      lockAddresses.filter(
+        (lockAddress) => unlockedLocks.indexOf(lockAddress) < 0
+      ),
       userAccountAddress!
     )
 
     if (additionalLocks.length > 0) {
-      unlockedLocks.push(...additionalLocks);
+      unlockedLocks.push(...additionalLocks)
     }
   }
 
-  return unlockedLocks;
+  return unlockedLocks
 }
 export default {
   getUnlockedLocks,

--- a/paywall/src/utils/getUnlockedLocks.ts
+++ b/paywall/src/utils/getUnlockedLocks.ts
@@ -1,0 +1,52 @@
+import { keyExpirationTimestampFor } from './keyExpirationTimestampFor'
+import { optimisticLocks } from './optimisticUnlocking'
+import { PaywallConfig } from '../unlockTypes'
+
+interface ModuleConfig {
+  readOnlyProvider: string
+  locksmithUri: string
+}
+
+/**
+ * A function which, given a user account, a paywall config will return an array of lock addresses
+ * to indicate which locks the user has unlocked.
+ * It will first check for the existence of keys, and if no valid one has been found
+ * it will check for pending transactions which might be optimistic.
+ */
+export const getUnlockedLocks = async (
+  userAccountAddress: string,
+  paywallConfig: PaywallConfig,
+  { readOnlyProvider, locksmithUri }: ModuleConfig
+): Promise<string[]> => {
+  const lockAddresses = Object.keys(paywallConfig.locks)
+  const timeStampsByLock: Record<string, number> = {};
+  lockAddresses.map(async (lockAddress) => {
+    timeStampsByLock[lockAddress] = await keyExpirationTimestampFor(
+      readOnlyProvider,
+      lockAddress,
+      userAccountAddress!
+    )
+  })
+
+  const unlockedLocks = Object.keys(timeStampsByLock)
+    .filter((lockAddress) => timeStampsByLock[lockAddress] > new Date().getTime() / 1000)
+
+  if (!paywallConfig.pessimistic) {
+    // Add optimistically unlocked lock addresses
+    const additionalLocks = await optimisticLocks(
+      readOnlyProvider,
+      locksmithUri,
+      lockAddresses.filter((lockAddress) => unlockedLocks.indexOf(lockAddress) < 0),
+      userAccountAddress!
+    )
+
+    if (additionalLocks.length > 0) {
+      unlockedLocks.push(...additionalLocks);
+    }
+  }
+
+  return unlockedLocks;
+}
+export default {
+  getUnlockedLocks,
+}

--- a/paywall/src/utils/optimisticUnlocking.ts
+++ b/paywall/src/utils/optimisticUnlocking.ts
@@ -40,7 +40,7 @@ export const optimisticUnlocking = async (
         user,
         transaction.recipient,
         transaction.transactionHash,
-        false // Passimistic if missing
+        false // Pessimistic if missing
       )
     })
   )
@@ -49,6 +49,45 @@ export const optimisticUnlocking = async (
     currentValue || !!accumulator
 
   return unlocked.reduce(reducer, false)
+}
+
+/**
+ * Yields an array of optimistically unlocking locks
+ * @param locks
+ * @param user
+ */
+ export const optimisticLocks = async (
+  provider: string,
+  locksmithUri: string,
+  locks: string[],
+  user: string
+) => {
+  const userTransactions = await getTransactionsForUserAndLocks(
+    locksmithUri,
+    user,
+    locks
+  )
+
+  const recentTransactions = userTransactions.filter((tx) =>
+    withinLast24Hours(tx.createdAt)
+  )
+
+  const unlocked: string[] = [];
+  recentTransactions.map((transaction) => {
+    const lockIsOptimistc = willUnlock(
+      provider,
+      user,
+      transaction.recipient,
+      transaction.transactionHash,
+      false // Pessimistic if missing
+    )
+
+    if(lockIsOptimistc) {
+      unlocked.push(transaction.recipient)
+    }
+  })
+
+  return unlocked
 }
 
 /**

--- a/paywall/src/utils/optimisticUnlocking.ts
+++ b/paywall/src/utils/optimisticUnlocking.ts
@@ -56,7 +56,7 @@ export const optimisticUnlocking = async (
  * @param locks
  * @param user
  */
- export const optimisticLocks = async (
+export const optimisticLocks = async (
   provider: string,
   locksmithUri: string,
   locks: string[],
@@ -72,7 +72,7 @@ export const optimisticUnlocking = async (
     withinLast24Hours(tx.createdAt)
   )
 
-  const unlocked: string[] = [];
+  const unlocked: string[] = []
   recentTransactions.map((transaction) => {
     const lockIsOptimistc = willUnlock(
       provider,
@@ -82,7 +82,7 @@ export const optimisticUnlocking = async (
       false // Pessimistic if missing
     )
 
-    if(lockIsOptimistc) {
+    if (lockIsOptimistc) {
       unlocked.push(transaction.recipient)
     }
   })


### PR DESCRIPTION
# Description

Add locks to paywall message in status event.

# Issues

Fixes #7070 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

