### PR TITLE
ERC20Votes fix

### DIFF
--- a/smart-contracts/contracts/ERC20Patched.sol
+++ b/smart-contracts/contracts/ERC20Patched.sol
@@ -1,4 +1,4 @@
-// Sources flattened with hardhat v2.4.1 https://hardhat.org
+// Sources flattened with hardhat v2.5.0 https://hardhat.org
 pragma solidity ^0.8.0;
 
 // File @openzeppelin/contracts-ethereum-package/contracts/access/Roles.sol@v2.5.0
@@ -39,7 +39,7 @@ library Roles {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol@v4.3.0
 
 
 
@@ -100,7 +100,7 @@ interface IERC20PermitUpgradeable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol@v4.3.0
 
 
 
@@ -183,7 +183,7 @@ interface IERC20Upgradeable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol@v4.3.0
 
 
 
@@ -210,7 +210,7 @@ interface IERC20MetadataUpgradeable is IERC20Upgradeable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol@v4.3.0
 
 
 
@@ -258,11 +258,11 @@ abstract contract Initializable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol@v4.3.0
 
 
 
-/*
+/**
  * @dev Provides information about the current execution context, including the
  * sender of the transaction and its data. While these are generally available
  * via msg.sender and msg.data, they should not be accessed in such a direct
@@ -290,11 +290,7 @@ abstract contract ContextUpgradeable is Initializable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol@v4.2.0
-
-
-
-
+// File @openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol@v4.3.0
 
 
 /**
@@ -308,9 +304,10 @@ abstract contract ContextUpgradeable is Initializable {
  * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
  * to implement supply mechanisms].
  *
- * We have followed general OpenZeppelin guidelines: functions revert instead
- * of returning `false` on failure. This behavior is nonetheless conventional
- * and does not conflict with the expectations of ERC20 applications.
+ * We have followed general OpenZeppelin Contracts guidelines: functions revert
+ * instead returning `false` on failure. This behavior is nonetheless
+ * conventional and does not conflict with the expectations of ERC20
+ * applications.
  *
  * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
  * This allows applications to reconstruct the allowance for all accounts just
@@ -368,7 +365,7 @@ abstract contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20U
     /**
      * @dev Returns the number of decimals used to get its user representation.
      * For example, if `decimals` equals `2`, a balance of `505` tokens should
-     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     * be displayed to a user as `5.05` (`505 / 10 ** 2`).
      *
      * Tokens usually opt for a value of 18, imitating the relationship between
      * Ether and Wei. This is the value {ERC20} uses, unless this function is
@@ -651,9 +648,7 @@ abstract contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20U
 }
 
 
-// File @openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol@v4.2.0
-
-
+// File @openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol@v4.3.0
 
 /**
  * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
@@ -662,9 +657,31 @@ abstract contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20U
  * of the private keys of a given address.
  */
 library ECDSAUpgradeable {
+    enum RecoverError {
+        NoError,
+        InvalidSignature,
+        InvalidSignatureLength,
+        InvalidSignatureS,
+        InvalidSignatureV
+    }
+
+    function _throwError(RecoverError error) private pure {
+        if (error == RecoverError.NoError) {
+            return; // no error: do nothing
+        } else if (error == RecoverError.InvalidSignature) {
+            revert("ECDSA: invalid signature");
+        } else if (error == RecoverError.InvalidSignatureLength) {
+            revert("ECDSA: invalid signature length");
+        } else if (error == RecoverError.InvalidSignatureS) {
+            revert("ECDSA: invalid signature 's' value");
+        } else if (error == RecoverError.InvalidSignatureV) {
+            revert("ECDSA: invalid signature 'v' value");
+        }
+    }
+
     /**
      * @dev Returns the address that signed a hashed message (`hash`) with
-     * `signature`. This address can then be used for verification purposes.
+     * `signature` or error string. This address can then be used for verification purposes.
      *
      * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
      * this function rejects them by requiring the `s` value to be in the lower
@@ -679,8 +696,10 @@ library ECDSAUpgradeable {
      * Documentation for signature generation:
      * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]
      * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]
+     *
+     * _Available since v4.3._
      */
-    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
+    function tryRecover(bytes32 hash, bytes memory signature) internal pure returns (address, RecoverError) {
         // Check the signature length
         // - case 65: r,s,v signature (standard)
         // - case 64: r,vs signature (cf https://eips.ethereum.org/EIPS/eip-2098) _Available since v4.1._
@@ -695,7 +714,7 @@ library ECDSAUpgradeable {
                 s := mload(add(signature, 0x40))
                 v := byte(0, mload(add(signature, 0x60)))
             }
-            return recover(hash, v, r, s);
+            return tryRecover(hash, v, r, s);
         } else if (signature.length == 64) {
             bytes32 r;
             bytes32 vs;
@@ -705,16 +724,55 @@ library ECDSAUpgradeable {
                 r := mload(add(signature, 0x20))
                 vs := mload(add(signature, 0x40))
             }
-            return recover(hash, r, vs);
+            return tryRecover(hash, r, vs);
         } else {
-            revert("ECDSA: invalid signature length");
+            return (address(0), RecoverError.InvalidSignatureLength);
         }
     }
 
     /**
-     * @dev Overload of {ECDSA-recover} that receives the `r` and `vs` short-signature fields separately.
+     * @dev Returns the address that signed a hashed message (`hash`) with
+     * `signature`. This address can then be used for verification purposes.
+     *
+     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+     * this function rejects them by requiring the `s` value to be in the lower
+     * half order, and the `v` value to be either 27 or 28.
+     *
+     * IMPORTANT: `hash` _must_ be the result of a hash operation for the
+     * verification to be secure: it is possible to craft signatures that
+     * recover to arbitrary addresses for non-hashed data. A safe way to ensure
+     * this is by receiving a hash of the original message (which may otherwise
+     * be too long), and then calling {toEthSignedMessageHash} on it.
+     */
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
+        (address recovered, RecoverError error) = tryRecover(hash, signature);
+        _throwError(error);
+        return recovered;
+    }
+
+    /**
+     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.
      *
      * See https://eips.ethereum.org/EIPS/eip-2098[EIP-2098 short signatures]
+     *
+     * _Available since v4.3._
+     */
+    function tryRecover(
+        bytes32 hash,
+        bytes32 r,
+        bytes32 vs
+    ) internal pure returns (address, RecoverError) {
+        bytes32 s;
+        uint8 v;
+        assembly {
+            s := and(vs, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            v := add(shr(255, vs), 27)
+        }
+        return tryRecover(hash, v, r, s);
+    }
+
+    /**
+     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.
      *
      * _Available since v4.2._
      */
@@ -723,17 +781,51 @@ library ECDSAUpgradeable {
         bytes32 r,
         bytes32 vs
     ) internal pure returns (address) {
-        bytes32 s;
-        uint8 v;
-        assembly {
-            s := and(vs, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
-            v := add(shr(255, vs), 27)
-        }
-        return recover(hash, v, r, s);
+        (address recovered, RecoverError error) = tryRecover(hash, r, vs);
+        _throwError(error);
+        return recovered;
     }
 
     /**
-     * @dev Overload of {ECDSA-recover} that receives the `v`, `r` and `s` signature fields separately.
+     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,
+     * `r` and `s` signature fields separately.
+     *
+     * _Available since v4.3._
+     */
+    function tryRecover(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal pure returns (address, RecoverError) {
+        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (301): 0 < s < secp256k1n ÷ 2 + 1, and for v in (302): v ∈ {27, 28}. Most
+        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
+        //
+        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+        // these malleable signatures as well.
+        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            return (address(0), RecoverError.InvalidSignatureS);
+        }
+        if (v != 27 && v != 28) {
+            return (address(0), RecoverError.InvalidSignatureV);
+        }
+
+        // If the signature is valid (and not malleable), return the signer address
+        address signer = ecrecover(hash, v, r, s);
+        if (signer == address(0)) {
+            return (address(0), RecoverError.InvalidSignature);
+        }
+
+        return (signer, RecoverError.NoError);
+    }
+
+    /**
+     * @dev Overload of {ECDSA-recover} that receives the `v`,
+     * `r` and `s` signature fields separately.
      */
     function recover(
         bytes32 hash,
@@ -741,26 +833,9 @@ library ECDSAUpgradeable {
         bytes32 r,
         bytes32 s
     ) internal pure returns (address) {
-        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
-        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
-        // the valid range for s in (281): 0 < s < secp256k1n ÷ 2 + 1, and for v in (282): v ∈ {27, 28}. Most
-        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
-        //
-        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
-        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
-        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
-        // these malleable signatures as well.
-        require(
-            uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
-            "ECDSA: invalid signature 's' value"
-        );
-        require(v == 27 || v == 28, "ECDSA: invalid signature 'v' value");
-
-        // If the signature is valid (and not malleable), return the signer address
-        address signer = ecrecover(hash, v, r, s);
-        require(signer != address(0), "ECDSA: invalid signature");
-
-        return signer;
+        (address recovered, RecoverError error) = tryRecover(hash, v, r, s);
+        _throwError(error);
+        return recovered;
     }
 
     /**
@@ -792,7 +867,7 @@ library ECDSAUpgradeable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol@v4.3.0
 
 
 
@@ -904,7 +979,7 @@ abstract contract EIP712Upgradeable is Initializable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol@v4.3.0
 
 
 
@@ -948,7 +1023,7 @@ library CountersUpgradeable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol@v4.3.0
 
 
 
@@ -1042,7 +1117,7 @@ abstract contract ERC20PermitUpgradeable is Initializable, ERC20Upgradeable, IER
 }
 
 
-// File @openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol@v4.3.0
 
 
 
@@ -1069,8 +1144,8 @@ library MathUpgradeable {
      * zero.
      */
     function average(uint256 a, uint256 b) internal pure returns (uint256) {
-        // (a + b) / 2 can overflow, so we distribute.
-        return (a / 2) + (b / 2) + (((a % 2) + (b % 2)) / 2);
+        // (a + b) / 2 can overflow.
+        return (a & b) + (a ^ b) / 2;
     }
 
     /**
@@ -1086,7 +1161,7 @@ library MathUpgradeable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol@v4.3.0
 
 
 
@@ -1328,7 +1403,7 @@ library SafeCastUpgradeable {
 }
 
 
-// File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol@v4.2.0
+// File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol@v4.3.0
 
 
 
@@ -1438,10 +1513,10 @@ abstract contract ERC20VotesUpgradeable is Initializable, ERC20PermitUpgradeable
     function _checkpointsLookup(Checkpoint[] storage ckpts, uint256 blockNumber) private view returns (uint256) {
         // We run a binary search to look for the earliest checkpoint taken after `blockNumber`.
         //
-        // During the loop, the index of the wanted checkpoint remains in the range [low, high).
+        // During the loop, the index of the wanted checkpoint remains in the range [low-1, high).
         // With each iteration, either `low` or `high` is moved towards the middle of the range to maintain the invariant.
         // - If the middle checkpoint is after `blockNumber`, we look in [low, mid)
-        // - If the middle checkpoint is before `blockNumber`, we look in [mid+1, high)
+        // - If the middle checkpoint is before or equal to `blockNumber`, we look in [mid+1, high)
         // Once we reach a single value (when low == high), we've found the right checkpoint at the index high-1, if not
         // out of bounds (in which case we're looking too far in the past and the result is 0).
         // Note that if the latest checkpoint available is exactly for `blockNumber`, we end up with an index that is
@@ -1591,61 +1666,9 @@ abstract contract ERC20VotesUpgradeable is Initializable, ERC20PermitUpgradeable
 }
 
 
-// File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesCompUpgradeable.sol@v4.2.0
+// File scripts/udt-flatten/ERC20Patched.template.sol
 
 
-
-
-/**
- * @dev Extension of ERC20 to support Compound's voting and delegation. This version exactly matches Compound's
- * interface, with the drawback of only supporting supply up to (2^96^ - 1).
- *
- * NOTE: You should use this contract if you need exact compatibility with COMP (for example in order to use your token
- * with Governor Alpha or Bravo) and if you are sure the supply cap of 2^96^ is enough for you. Otherwise, use the
- * {ERC20Votes} variant of this module.
- *
- * This extensions keeps a history (checkpoints) of each account's vote power. Vote power can be delegated either
- * by calling the {delegate} function directly, or by providing a signature to be used with {delegateBySig}. Voting
- * power can be queried through the public accessors {getCurrentVotes} and {getPriorVotes}.
- *
- * By default, token balance does not account for voting power. This makes transfers cheaper. The downside is that it
- * requires users to delegate to themselves in order to activate checkpoints and have their voting power tracked.
- * Enabling self-delegation can easily be done by overriding the {delegates} function. Keep in mind however that this
- * will significantly increase the base gas cost of transfers.
- *
- * _Available since v4.2._
- */
-abstract contract ERC20VotesCompUpgradeable is Initializable, ERC20VotesUpgradeable {
-    function __ERC20VotesComp_init_unchained() internal initializer {
-    }
-    /**
-     * @dev Comp version of the {getVotes} accessor, with `uint96` return type.
-     */
-    function getCurrentVotes(address account) external view returns (uint96) {
-        return SafeCastUpgradeable.toUint96(getVotes(account));
-    }
-
-    /**
-     * @dev Comp version of the {getPastVotes} accessor, with `uint96` return type.
-     */
-    function getPriorVotes(address account, uint256 blockNumber) external view returns (uint96) {
-        return SafeCastUpgradeable.toUint96(getPastVotes(account, blockNumber));
-    }
-
-    /**
-     * @dev Maximum token supply. Reduced to `type(uint96).max` (2^96^ - 1) to fit COMP interface.
-     */
-    function _maxSupply() internal view virtual override returns (uint224) {
-        return type(uint96).max;
-    }
-    uint256[50] private __gap;
-}
-
-
-// File scripts/udt-upgrade/ERC20Patched.template.sol
-
-
-// import '@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol';
 
 abstract contract MinterRoleUpgradeable is Initializable, ContextUpgradeable {
     using Roles for Roles.Role;

--- a/smart-contracts/contracts/UnlockDiscountTokenV2.sol
+++ b/smart-contracts/contracts/UnlockDiscountTokenV2.sol
@@ -10,7 +10,7 @@ import './ERC20Patched.sol';
 contract UnlockDiscountTokenV2 is
 ERC20MintableUpgradeable,
 ERC20DetailedUpgradeable,
-ERC20VotesCompUpgradeable
+ERC20VotesUpgradeable
 {
  /**
   * @notice A one-time call to configure the token.

--- a/smart-contracts/scripts/README.md
+++ b/smart-contracts/scripts/README.md
@@ -22,12 +22,12 @@ The upgrade requires a few changes, namely
 4. manually correct the issues in the generated file.  Corrections are saved as `contracts/ERC20Patched.ref`)
 1. generate a patch containing the changes 
 ```
-diff -u contracts/ERC20Patched.ref contracts/ERC20Patched.generated.sol > genV2/ERC20Patched.patch
+diff -u contracts/ERC20Patched.ref contracts/ERC20Patched.generated.sol > scripts/udt-flatten/ERC20Patched.patch
 ```
 6. create a script that replay steps 1-3 and apply the patch to generate the new version of the contract
 
 ```sh
-sh udt-flatten-v2.sh
+sh scripts/udt-flatten-v2.sh
 ```
 
 ## Upgrading `.openzeppelin` files

--- a/smart-contracts/scripts/udt-flatten/ERC20Patched.patch
+++ b/smart-contracts/scripts/udt-flatten/ERC20Patched.patch
@@ -1,261 +1,257 @@
---- contracts/ERC20Patched.ref	2021-07-08 16:58:54.000000000 +0200
-+++ contracts/ERC20Patched.generated.sol	2021-07-08 16:58:58.000000000 +0200
-@@ -1,8 +1,9 @@
- // Sources flattened with hardhat v2.4.1 https://hardhat.org
--pragma solidity ^0.8.0;
+--- contracts/ERC20Patched.generated.sol	2021-08-20 13:23:27.000000000 +0200
++++ contracts/ERC20Patched.sol	2021-08-20 13:28:21.000000000 +0200
+@@ -1,9 +1,8 @@
+ // Sources flattened with hardhat v2.5.0 https://hardhat.org
++pragma solidity ^0.8.0;
  
  // File @openzeppelin/contracts-ethereum-package/contracts/access/Roles.sol@v2.5.0
  
-+pragma solidity ^0.5.0;
-+
+-pragma solidity ^0.5.0;
+-
  /**
   * @title Roles
   * @dev Library for managing addresses assigned to a Role.
-@@ -42,6 +43,7 @@
- // File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol@v4.2.0
+@@ -43,7 +42,6 @@
+ // File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  /**
   * @dev Interface of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
-@@ -103,6 +105,7 @@
- // File @openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol@v4.2.0
+@@ -105,7 +103,6 @@
+ // File @openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  /**
   * @dev Interface of the ERC20 standard as defined in the EIP.
-@@ -186,6 +189,7 @@
- // File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol@v4.2.0
+@@ -189,7 +186,6 @@
+ // File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  /**
   * @dev Interface for the optional metadata functions from the ERC20 standard.
-@@ -213,6 +217,7 @@
- // File @openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol@v4.2.0
+@@ -217,7 +213,6 @@
+ // File @openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  /**
   * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
-@@ -230,29 +235,29 @@
+@@ -235,29 +230,29 @@
      /**
       * @dev Indicates that the contract has been initialized.
       */
--    bool private initialized;
-+    bool private _initialized;
+-    bool private _initialized;
++    bool private initialized;
  
      /**
       * @dev Indicates that the contract is in the process of being initialized.
       */
--    bool private initializing;
-+    bool private _initializing;
+-    bool private _initializing;
++    bool private initializing;
  
      /**
       * @dev Modifier to protect an initializer function from being invoked twice.
       */
      modifier initializer() {
--        require(initializing || !initialized, "Initializable: contract is already initialized");
-+        require(_initializing || !_initialized, "Initializable: contract is already initialized");
+-        require(_initializing || !_initialized, "Initializable: contract is already initialized");
++        require(initializing || !initialized, "Initializable: contract is already initialized");
  
--        bool isTopLevelCall = !initializing;
-+        bool isTopLevelCall = !_initializing;
+-        bool isTopLevelCall = !_initializing;
++        bool isTopLevelCall = !initializing;
          if (isTopLevelCall) {
--            initializing = true;
--            initialized = true;
-+            _initializing = true;
-+            _initialized = true;
+-            _initializing = true;
+-            _initialized = true;
++            initializing = true;
++            initialized = true;
          }
  
          _;
  
          if (isTopLevelCall) {
--            initializing = false;
-+            _initializing = false;
+-            _initializing = false;
++            initializing = false;
          }
      }
  }
-@@ -261,6 +266,7 @@
- // File @openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol@v4.2.0
+@@ -266,7 +261,6 @@
+ // File @openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
- /*
+ /**
   * @dev Provides information about the current execution context, including the
-@@ -286,13 +292,14 @@
+@@ -292,18 +286,13 @@
      function _msgData() internal view virtual returns (bytes calldata) {
          return msg.data;
      }
--    uint256[50] private ______gap;
-+    uint256[50] private __gap;
+-    uint256[50] private __gap;
++    uint256[50] private ______gap;
  }
  
  
- // File @openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol@v4.2.0
+ // File @openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
- 
- 
- 
-@@ -321,15 +328,15 @@
+-pragma solidity ^0.8.0;
+-
+-
+-
+-
+ /**
+  * @dev Implementation of the {IERC20} interface.
+  *
+@@ -329,15 +318,15 @@
   * functions have been added to mitigate the well-known issues around setting
   * allowances. See {IERC20-approve}.
   */
--abstract contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable, IERC20MetadataUpgradeable {
-+contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable, IERC20MetadataUpgradeable {
+-contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable, IERC20MetadataUpgradeable {
++abstract contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable, IERC20MetadataUpgradeable {
      mapping(address => uint256) private _balances;
  
      mapping(address => mapping(address => uint256)) private _allowances;
  
      uint256 private _totalSupply;
  
--    // string private _name;
--    // string private _symbol;
-+    string private _name;
-+    string private _symbol;
+-    string private _name;
+-    string private _symbol;
++    // string private _name;
++    // string private _symbol;
  
      /**
       * @dev Sets the values for {name} and {symbol}.
-@@ -346,24 +353,24 @@
+@@ -354,24 +343,24 @@
      }
  
      function __ERC20_init_unchained(string memory name_, string memory symbol_) internal initializer {
--        // _name = name_;
--        // _symbol = symbol_;
-+        _name = name_;
-+        _symbol = symbol_;
+-        _name = name_;
+-        _symbol = symbol_;
++        // _name = name_;
++        // _symbol = symbol_;
      }
  
      /**
       * @dev Returns the name of the token.
       */
--    // function name() public view virtual override returns (string memory) {
--    //     return _name;
--    // }
-+    function name() public view virtual override returns (string memory) {
-+        return _name;
-+    }
+-    function name() public view virtual override returns (string memory) {
+-        return _name;
+-    }
++    // function name() public view virtual override returns (string memory) {
++    //     return _name;
++    // }
  
      /**
       * @dev Returns the symbol of the token, usually a shorter version of the
       * name.
       */
--    // function symbol() public view virtual override returns (string memory) {
--    //     return _symbol;
--    // }
-+    function symbol() public view virtual override returns (string memory) {
-+        return _symbol;
-+    }
+-    function symbol() public view virtual override returns (string memory) {
+-        return _symbol;
+-    }
++    // function symbol() public view virtual override returns (string memory) {
++    //     return _symbol;
++    // }
  
      /**
       * @dev Returns the number of decimals used to get its user representation.
-@@ -647,13 +654,14 @@
+@@ -655,15 +644,12 @@
          address to,
          uint256 amount
      ) internal virtual {}
--    uint256[50] private ______gap;
-+    uint256[45] private __gap;
+-    uint256[45] private __gap;
++    uint256[50] private ______gap;
  }
  
  
- // File @openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol@v4.2.0
+ // File @openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol@v4.3.0
  
- 
-+pragma solidity ^0.8.0;
- 
+-
+-pragma solidity ^0.8.0;
+-
  /**
   * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
-@@ -795,6 +803,7 @@
- // File @openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol@v4.2.0
+  *
+@@ -884,7 +870,6 @@
+ // File @openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  
  /**
-@@ -907,6 +916,7 @@
- // File @openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol@v4.2.0
+@@ -997,7 +982,6 @@
+ // File @openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  /**
   * @title Counters
-@@ -951,6 +961,7 @@
- // File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol@v4.2.0
+@@ -1042,7 +1026,6 @@
+ // File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  
  
-@@ -1045,6 +1056,7 @@
- // File @openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol@v4.2.0
+@@ -1137,7 +1120,6 @@
+ // File @openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  /**
   * @dev Standard math utilities missing in the Solidity language.
-@@ -1089,6 +1101,7 @@
- // File @openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol@v4.2.0
+@@ -1182,7 +1164,6 @@
+ // File @openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  /**
   * @dev Wrappers over Solidity's uintXX/intXX casting operators with added overflow
-@@ -1331,6 +1344,7 @@
- // File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol@v4.2.0
+@@ -1425,7 +1406,6 @@
+ // File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol@v4.3.0
  
  
-+pragma solidity ^0.8.0;
+-pragma solidity ^0.8.0;
  
  
  
-@@ -1594,6 +1608,7 @@
- // File @openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesCompUpgradeable.sol@v4.2.0
+@@ -1688,10 +1668,9 @@
+ 
+ // File scripts/udt-flatten/ERC20Patched.template.sol
+ 
+-pragma solidity ^0.8.0;
  
  
-+pragma solidity ^0.8.0;
- 
- 
- /**
-@@ -1644,10 +1659,11 @@
- 
- // File scripts/udt-upgrade/ERC20Patched.template.sol
- 
-+pragma solidity ^0.8.0;
- 
- // import '@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol';
- 
--abstract contract MinterRoleUpgradeable is Initializable, ContextUpgradeable {
-+contract MinterRoleUpgradeable is Initializable, ContextUpgradeable {
+-contract MinterRoleUpgradeable is Initializable, ContextUpgradeable {
++abstract contract MinterRoleUpgradeable is Initializable, ContextUpgradeable {
      using Roles for Roles.Role;
  
      event MinterAdded(address indexed account);
-@@ -1691,7 +1707,7 @@
+@@ -1735,7 +1714,7 @@
      uint256[50] private ______gap;
  }
  
--abstract contract ERC20DetailedUpgradeable is Initializable, IERC20Upgradeable {
-+abstract contract ERC20DetailedUpgradeable is Initializable, ERC20VotesUpgradeable {
+-abstract contract ERC20DetailedUpgradeable is Initializable, ERC20VotesUpgradeable {
++abstract contract ERC20DetailedUpgradeable is Initializable, IERC20Upgradeable {
      string private _name;
      string private _symbol;
      uint8 private _decimals;
-@@ -1717,7 +1733,7 @@
+@@ -1761,7 +1740,7 @@
      uint256[50] private ______gap;
  }
  
--abstract contract ERC20MintableUpgradeable is Initializable, ERC20Upgradeable, MinterRoleUpgradeable {
-+abstract contract ERC20MintableUpgradeable is Initializable, ERC20VotesUpgradeable, MinterRoleUpgradeable {
+-abstract contract ERC20MintableUpgradeable is Initializable, ERC20VotesUpgradeable, MinterRoleUpgradeable {
++abstract contract ERC20MintableUpgradeable is Initializable, ERC20Upgradeable, MinterRoleUpgradeable {
      function initialize(address sender) public virtual override initializer {
          MinterRoleUpgradeable.initialize(sender);
      }

--- a/smart-contracts/scripts/udt-flatten/ERC20Patched.template.sol
+++ b/smart-contracts/scripts/udt-flatten/ERC20Patched.template.sol
@@ -1,8 +1,7 @@
 pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts-ethereum-package/contracts/access/Roles.sol';
-// import '@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol';
-import '@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesCompUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol';
 
 contract MinterRoleUpgradeable is Initializable, ContextUpgradeable {
     using Roles for Roles.Role;

--- a/smart-contracts/test/UnlockDiscountToken/governance.js
+++ b/smart-contracts/test/UnlockDiscountToken/governance.js
@@ -66,13 +66,6 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
         assert(supply.eq(await udt.balanceOf(holder)))
       })
     })
-    it('minting restriction', async () => {
-      const amount = new BN('2').pow(new BN('96'))
-      await expectRevert(
-        udt.mint(minter, amount, { from: minter }),
-        'ERC20Votes: total supply risks overflowing votes'
-      )
-    })
   })
 
   describe('Delegation', () => {
@@ -92,12 +85,13 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
         newBalance: supply,
       })
 
-      assert(supply.eq(await udt.getCurrentVotes(holder)))
+      expect(await udt.delegates(holder)).to.be.equal(holder);
+      assert(supply.eq(await udt.getVotes(holder)))
       assert(
-        new BN(0).eq(await udt.getPriorVotes(holder, receipt.blockNumber - 1))
+        new BN(0).eq(await udt.getPastVotes(holder, receipt.blockNumber - 1))
       )
       await time.advanceBlock()
-      assert(supply.eq(await udt.getPriorVotes(holder, receipt.blockNumber)))
+      assert(supply.eq(await udt.getPastVotes(holder, receipt.blockNumber)))
     })
     it('delegation without balance', async () => {
       expect(await udt.delegates(holder)).to.be.equal(ZERO_ADDRESS)
@@ -143,22 +137,22 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
 
         expect(await udt.delegates(holder)).to.be.equal(holderDelegatee)
 
-        expect(await udt.getCurrentVotes(holder)).to.be.bignumber.equal('0')
+        expect(await udt.getVotes(holder)).to.be.bignumber.equal('0')
         expect(
-          await udt.getCurrentVotes(holderDelegatee)
+          await udt.getVotes(holderDelegatee)
         ).to.be.bignumber.equal(supply)
         expect(
-          await udt.getPriorVotes(holder, receipt.blockNumber - 1)
+          await udt.getPastVotes(holder, receipt.blockNumber - 1)
         ).to.be.bignumber.equal(supply)
         expect(
-          await udt.getPriorVotes(holderDelegatee, receipt.blockNumber - 1)
+          await udt.getPastVotes(holderDelegatee, receipt.blockNumber - 1)
         ).to.be.bignumber.equal('0')
         await time.advanceBlock()
         expect(
-          await udt.getPriorVotes(holder, receipt.blockNumber)
+          await udt.getPastVotes(holder, receipt.blockNumber)
         ).to.be.bignumber.equal('0')
         expect(
-          await udt.getPriorVotes(holderDelegatee, receipt.blockNumber)
+          await udt.getPastVotes(holderDelegatee, receipt.blockNumber)
         ).to.be.bignumber.equal(supply)
       })
     })
@@ -256,21 +250,21 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
     })
 
     afterEach(async () => {
-      expect(await udt.getCurrentVotes(holder)).to.be.bignumber.equal(
+      expect(await udt.getVotes(holder)).to.be.bignumber.equal(
         holderVotes
       )
-      expect(await udt.getCurrentVotes(recipient)).to.be.bignumber.equal(
+      expect(await udt.getVotes(recipient)).to.be.bignumber.equal(
         recipientVotes
       )
 
-      // need to advance 2 blocks to see the effect of a transfer on "getPriorVotes"
+      // need to advance 2 blocks to see the effect of a transfer on "getPastVotes"
       const blockNumber = await time.latestBlock()
       await time.advanceBlock()
       expect(
-        await udt.getPriorVotes(holder, blockNumber)
+        await udt.getPastVotes(holder, blockNumber)
       ).to.be.bignumber.equal(holderVotes)
       expect(
-        await udt.getPriorVotes(recipient, blockNumber)
+        await udt.getPastVotes(recipient, blockNumber)
       ).to.be.bignumber.equal(recipientVotes)
     })
   })
@@ -324,16 +318,16 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
 
         await time.advanceBlock()
         expect(
-          await udt.getPriorVotes(other1, t1.receipt.blockNumber)
+          await udt.getPastVotes(other1, t1.receipt.blockNumber)
         ).to.be.bignumber.equal('100')
         expect(
-          await udt.getPriorVotes(other1, t2.receipt.blockNumber)
+          await udt.getPastVotes(other1, t2.receipt.blockNumber)
         ).to.be.bignumber.equal('90')
         expect(
-          await udt.getPriorVotes(other1, t3.receipt.blockNumber)
+          await udt.getPastVotes(other1, t3.receipt.blockNumber)
         ).to.be.bignumber.equal('80')
         expect(
-          await udt.getPriorVotes(other1, t4.receipt.blockNumber)
+          await udt.getPastVotes(other1, t4.receipt.blockNumber)
         ).to.be.bignumber.equal('100')
       })
 
@@ -363,16 +357,16 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
       })
     })
 
-    describe('getPriorVotes', () => {
+    describe('getPastVotes', () => {
       it('reverts if block number >= current block', async () => {
         await expectRevert(
-          udt.getPriorVotes(other1, 5e10),
+          udt.getPastVotes(other1, 5e10),
           'ERC20Votes: block not yet mined'
         )
       })
 
       it('returns 0 if there are no checkpoints', async () => {
-        expect(await udt.getPriorVotes(other1, 0)).to.be.bignumber.equal('0')
+        expect(await udt.getPastVotes(other1, 0)).to.be.bignumber.equal('0')
       })
 
       it('returns the latest block if >= last checkpoint block', async () => {
@@ -381,10 +375,10 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
         await time.advanceBlock()
 
         expect(
-          await udt.getPriorVotes(other1, t1.receipt.blockNumber)
+          await udt.getPastVotes(other1, t1.receipt.blockNumber)
         ).to.be.bignumber.equal('10000000000000000000000000')
         expect(
-          await udt.getPriorVotes(other1, t1.receipt.blockNumber + 1)
+          await udt.getPastVotes(other1, t1.receipt.blockNumber + 1)
         ).to.be.bignumber.equal('10000000000000000000000000')
       })
 
@@ -395,10 +389,10 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
         await time.advanceBlock()
 
         expect(
-          await udt.getPriorVotes(other1, t1.receipt.blockNumber - 1)
+          await udt.getPastVotes(other1, t1.receipt.blockNumber - 1)
         ).to.be.bignumber.equal('0')
         expect(
-          await udt.getPriorVotes(other1, t1.receipt.blockNumber + 1)
+          await udt.getPastVotes(other1, t1.receipt.blockNumber + 1)
         ).to.be.bignumber.equal('10000000000000000000000000')
       })
 
@@ -417,31 +411,31 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
         await time.advanceBlock()
 
         expect(
-          await udt.getPriorVotes(other1, t1.receipt.blockNumber - 1)
+          await udt.getPastVotes(other1, t1.receipt.blockNumber - 1)
         ).to.be.bignumber.equal('0')
         expect(
-          await udt.getPriorVotes(other1, t1.receipt.blockNumber)
+          await udt.getPastVotes(other1, t1.receipt.blockNumber)
         ).to.be.bignumber.equal('10000000000000000000000000')
         expect(
-          await udt.getPriorVotes(other1, t1.receipt.blockNumber + 1)
+          await udt.getPastVotes(other1, t1.receipt.blockNumber + 1)
         ).to.be.bignumber.equal('10000000000000000000000000')
         expect(
-          await udt.getPriorVotes(other1, t2.receipt.blockNumber)
+          await udt.getPastVotes(other1, t2.receipt.blockNumber)
         ).to.be.bignumber.equal('9999999999999999999999990')
         expect(
-          await udt.getPriorVotes(other1, t2.receipt.blockNumber + 1)
+          await udt.getPastVotes(other1, t2.receipt.blockNumber + 1)
         ).to.be.bignumber.equal('9999999999999999999999990')
         expect(
-          await udt.getPriorVotes(other1, t3.receipt.blockNumber)
+          await udt.getPastVotes(other1, t3.receipt.blockNumber)
         ).to.be.bignumber.equal('9999999999999999999999980')
         expect(
-          await udt.getPriorVotes(other1, t3.receipt.blockNumber + 1)
+          await udt.getPastVotes(other1, t3.receipt.blockNumber + 1)
         ).to.be.bignumber.equal('9999999999999999999999980')
         expect(
-          await udt.getPriorVotes(other1, t4.receipt.blockNumber)
+          await udt.getPastVotes(other1, t4.receipt.blockNumber)
         ).to.be.bignumber.equal('10000000000000000000000000')
         expect(
-          await udt.getPriorVotes(other1, t4.receipt.blockNumber + 1)
+          await udt.getPastVotes(other1, t4.receipt.blockNumber + 1)
         ).to.be.bignumber.equal('10000000000000000000000000')
       })
     })

--- a/smart-contracts/test/UnlockDiscountToken/governance.js
+++ b/smart-contracts/test/UnlockDiscountToken/governance.js
@@ -85,7 +85,7 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
         newBalance: supply,
       })
 
-      expect(await udt.delegates(holder)).to.be.equal(holder);
+      expect(await udt.delegates(holder)).to.be.equal(holder)
       assert(supply.eq(await udt.getVotes(holder)))
       assert(
         new BN(0).eq(await udt.getPastVotes(holder, receipt.blockNumber - 1))
@@ -138,9 +138,9 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
         expect(await udt.delegates(holder)).to.be.equal(holderDelegatee)
 
         expect(await udt.getVotes(holder)).to.be.bignumber.equal('0')
-        expect(
-          await udt.getVotes(holderDelegatee)
-        ).to.be.bignumber.equal(supply)
+        expect(await udt.getVotes(holderDelegatee)).to.be.bignumber.equal(
+          supply
+        )
         expect(
           await udt.getPastVotes(holder, receipt.blockNumber - 1)
         ).to.be.bignumber.equal(supply)
@@ -250,9 +250,7 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
     })
 
     afterEach(async () => {
-      expect(await udt.getVotes(holder)).to.be.bignumber.equal(
-        holderVotes
-      )
+      expect(await udt.getVotes(holder)).to.be.bignumber.equal(holderVotes)
       expect(await udt.getVotes(recipient)).to.be.bignumber.equal(
         recipientVotes
       )
@@ -260,9 +258,9 @@ contract('UDT ERC20VotesComp extension', (accounts) => {
       // need to advance 2 blocks to see the effect of a transfer on "getPastVotes"
       const blockNumber = await time.latestBlock()
       await time.advanceBlock()
-      expect(
-        await udt.getPastVotes(holder, blockNumber)
-      ).to.be.bignumber.equal(holderVotes)
+      expect(await udt.getPastVotes(holder, blockNumber)).to.be.bignumber.equal(
+        holderVotes
+      )
       expect(
         await udt.getPastVotes(recipient, blockNumber)
       ).to.be.bignumber.equal(recipientVotes)

--- a/smart-contracts/test/UnlockDiscountToken/upgrades.mainnet.js
+++ b/smart-contracts/test/UnlockDiscountToken/upgrades.mainnet.js
@@ -399,13 +399,13 @@ contract('UnlockDiscountToken (on mainnet)', async () => {
         assert.equal(previousBalance, '0')
         assert(newBalance.eq(supply))
 
-        assert(supply.eq(await udt.getCurrentVotes(recipient.address)))
+        assert(supply.eq(await udt.getVotes(recipient.address)))
         assert(
-          (await udt.getPriorVotes(recipient.address, blockNumber - 1)).eq(0)
+          (await udt.getPastVotes(recipient.address, blockNumber - 1)).eq(0)
         )
         await time.advanceBlock()
         assert(
-          supply.eq(await udt.getPriorVotes(recipient.address, blockNumber))
+          supply.eq(await udt.getPastVotes(recipient.address, blockNumber))
         )
       })
     })


### PR DESCRIPTION
# Description

Replace `ERC20VotesComp` extension used by UDT for Governor contract compliance by native Open Zeppelin `ERC20Votes` extension. 

Both are very similar, but the `Comp` one has some supply size limitations that we better avoid.

> **ERC20VotesComp**
>
> import "@openzeppelin/contracts/token/ERC20/extensions/ERC20VotesComp.sol";
>
> Extension of ERC20 to support Compound’s voting and delegation. This version exactly matches Compound’s interface, with the drawback of only supporting supply up to (2^96 - 1).

from https://docs.openzeppelin.com/contracts/4.x/api/token/erc20#ERC20VotesComp

*NOTE*: it turns out that we were effectively already using  `ERC20Votes` in our contract (import) so this is mostly about to cleaning up and removing mentions of the `Comp` extension, adapting vocabulary in tests and upgrading to newer OZ version of the lib.

# Issues

relates to #7424 and #7422

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
