### PR TITLE
Oauth handler

### DIFF
--- a/locksmith/__tests__/controllers/authController.test.ts
+++ b/locksmith/__tests__/controllers/authController.test.ts
@@ -1,0 +1,130 @@
+import request from 'supertest'
+import { ethers } from 'ethers'
+
+const app = require('../../src/app')
+
+describe('Auth Endpoint', () => {
+  it('returns an error if redirect_uri is missing', async () => {
+    expect.assertions(1)
+    const response = await request(app)
+      .post('/api/oauth')
+      .set('Accept', 'json')
+      .send({
+        client_id: 'ouvre-boite.com',
+        grant_type: 'authorization_code',
+        code: 'code',
+      })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns an error if client_id is missing', async () => {
+    expect.assertions(1)
+    const response = await request(app)
+      .post('/api/oauth')
+      .set('Accept', 'json')
+      .send({
+        redirect_uri: 'https://ouvre-boite.com',
+        grant_type: 'authorization_code',
+        code: 'code',
+      })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns an error if grant_type is not authorization_code', async () => {
+    expect.assertions(1)
+    const response = await request(app)
+      .post('/api/oauth')
+      .set('Accept', 'json')
+      .send({
+        redirect_uri: 'https://ouvre-boite.com',
+        client_id: 'ouvre-boite.com',
+        grant_type: 'nope',
+        code: 'code',
+      })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns an error if code is missing', async () => {
+    expect.assertions(1)
+    const response = await request(app)
+      .post('/api/oauth')
+      .set('Accept', 'json')
+      .send({
+        redirect_uri: 'https://ouvre-boite.com',
+        client_id: 'ouvre-boite.com',
+        grant_type: 'authorization_code',
+      })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns an error if the redirect_uri does not match the client_id', async () => {
+    expect.assertions(1)
+    const response = await request(app)
+      .post('/api/oauth')
+      .set('Accept', 'json')
+      .send({
+        redirect_uri: 'https://ouvre-boite.com',
+        client_id: 'apple.com',
+        grant_type: 'authorization_code',
+        code: 'code',
+      })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns the user address from the hashed message', async () => {
+    expect.assertions(2)
+    const client_id = 'ouvre-boite.com'
+    const signer = ethers.Wallet.createRandom()
+    const address = await signer.getAddress()
+    const digest = `Connecting to ${client_id}`
+
+    // Get the signature
+    const signature = await signer.signMessage(digest)
+
+    const code = Buffer.from(
+      JSON.stringify({
+        d: digest,
+        s: signature,
+      })
+    ).toString('base64')
+
+    const response = await request(app)
+      .post('/api/oauth')
+      .set('Accept', 'json')
+      .send({
+        redirect_uri: `https://${client_id}`,
+        client_id: client_id,
+        grant_type: 'authorization_code',
+        code,
+      })
+
+    expect(response.status).toBe(200)
+    expect(response.body.me).toBe(address)
+  })
+
+  it('returns the right user address from the code that the front-end yield', async () => {
+    expect.assertions(2)
+    const client_id = 'ouvre-boite.com'
+
+    // This was generated in the front-end application, to make sure we keep compatibility
+    const code =
+      'eyJkIjoiQ29ubmVjdGluZyBteSBhY2Njb3VudCB0byBvdXZyZS1ib2l0ZS5jb20uIiwicyI6IjB4NjNjOTg3ZDdkMTk3M2E3ZmYyZDMyY2FlNjM3ZWFlNTFmNTBlNTdiMmIwYWRjNjk5NjdkZTA3MjAyYjMxNzIwNzNjNzdhYjZhYjZiZDJkZmJjM2E0ZDUyMDlmN2E2ZWYxNTcxNjljNDRmNTk5MDQ4NmY5YjkzZDUzMDNmM2E1M2ExYyJ9'
+
+    const response = await request(app)
+      .post('/api/oauth')
+      .set('Accept', 'json')
+      .send({
+        redirect_uri: `https://${client_id}`,
+        client_id: client_id,
+        grant_type: 'authorization_code',
+        code,
+      })
+    expect(response.status).toBe(200)
+    expect(response.body.me).toBe('0xDD8e2548da5A992A63aE5520C6bC92c37a2Bcc44')
+  })
+})

--- a/locksmith/src/controllers/authController.ts
+++ b/locksmith/src/controllers/authController.ts
@@ -4,9 +4,13 @@ import logger from '../logger'
 
 namespace AuthController {
   export const authorize = async (
-    request: SignedRequest,
-    response: Response
-  ): Promise<any> => {}
+    req: SignedRequest,
+    res: Response
+  ): Promise<any> => {
+    console.log(req.body)
+    logger.info('I was here')
+    return res.send('Cool')
+  }
 }
 
 export = AuthController

--- a/locksmith/src/controllers/authController.ts
+++ b/locksmith/src/controllers/authController.ts
@@ -1,0 +1,12 @@
+import { Response } from 'express-serve-static-core' // eslint-disable-line no-unused-vars, import/no-unresolved
+import { SignedRequest } from '../types'
+import logger from '../logger'
+
+namespace AuthController {
+  export const authorize = async (
+    request: SignedRequest,
+    response: Response
+  ): Promise<any> => {}
+}
+
+export = AuthController

--- a/locksmith/src/controllers/authController.ts
+++ b/locksmith/src/controllers/authController.ts
@@ -1,5 +1,7 @@
 import { Response } from 'express-serve-static-core' // eslint-disable-line no-unused-vars, import/no-unresolved
+import { ethers, utils } from 'ethers'
 import { SignedRequest } from '../types'
+
 import logger from '../logger'
 
 namespace AuthController {
@@ -7,9 +9,40 @@ namespace AuthController {
     req: SignedRequest,
     res: Response
   ): Promise<any> => {
-    console.log(req.body)
-    logger.info('I was here')
-    return res.send('Cool')
+    const { redirect_uri, client_id, grant_type, code } = req.body
+
+    if (
+      !redirect_uri ||
+      !client_id ||
+      grant_type !== 'authorization_code' ||
+      !code
+    ) {
+      return res.status(400).json({
+        error: 'invalid_request',
+      })
+    }
+
+    const redirectUrl = new URL(redirect_uri)
+    if (redirectUrl.host !== client_id) {
+      return res.status(400).json({
+        error: 'invalid_request',
+      })
+    }
+
+    // TODO: add timestamp to avoid replay attack
+    try {
+      const decoded = utils.base64.decode(code)
+      const message = JSON.parse(ethers.utils.toUtf8String(decoded))
+      const recoveredAddress = ethers.utils.verifyMessage(message.d, message.s)
+
+      // What is interesting is that this will always yield an address...
+      // but maybe not the correct one!
+      return res.json({
+        me: recoveredAddress,
+      })
+    } catch (error: any) {
+      logger.error('Error verifying auth signature', { code })
+    }
   }
 }
 

--- a/locksmith/src/routes/auth.ts
+++ b/locksmith/src/routes/auth.ts
@@ -1,0 +1,7 @@
+import express from 'express'
+
+const router = express.Router({ mergeParams: true })
+const authController = require('../controllers/authController')
+
+router.post('/', authController.authorize)
+module.exports = router

--- a/locksmith/src/routes/index.ts
+++ b/locksmith/src/routes/index.ts
@@ -36,7 +36,7 @@ router.use('/claim', claimRouter)
 router.use('/price', priceRouter)
 router.use('/api/key/:chain([0-9]{1,6})/', metadataRouter)
 router.use('/api/key', metadataRouter)
-router.use('/api/key', metadataRouter)
+router.use('/health', healthCheckRouter)
 router.use('/api/oauth', authRouter)
 
 router.use('/', (_, res) => {

--- a/locksmith/src/routes/index.ts
+++ b/locksmith/src/routes/index.ts
@@ -7,6 +7,7 @@ const purchaseRouter = require('./purchase')
 const claimRouter = require('./claim')
 const priceRouter = require('./price')
 const metadataRouter = require('./metadata')
+const authRouter = require('./auth')
 const healthCheckRouter = require('./health')
 const config = require('../../config/config')
 
@@ -35,7 +36,8 @@ router.use('/claim', claimRouter)
 router.use('/price', priceRouter)
 router.use('/api/key/:chain([0-9]{1,6})/', metadataRouter)
 router.use('/api/key', metadataRouter)
-router.use('/health', healthCheckRouter)
+router.use('/api/key', metadataRouter)
+router.use('/api/oauth', authRouter)
 
 router.use('/', (_, res) => {
   res.send('<a href="https://unlock-protocol.com/">Unlock Protocol</a>')

--- a/unlock-app/src/components/content/CheckoutContent.tsx
+++ b/unlock-app/src/components/content/CheckoutContent.tsx
@@ -15,7 +15,6 @@ interface CheckoutContentProps {
 export const CheckoutContent = ({ query }: CheckoutContentProps) => {
   const checkoutCommunication = useCheckoutCommunication()
   const configFromSearch = getConfigFromSearch(query)
-  const redirectUri = query.redirectUri
   const config = useContext(ConfigContext)
   const [locks, setLocks] = useState({})
   // We need to delay render until we have a config at least, and
@@ -33,6 +32,7 @@ export const CheckoutContent = ({ query }: CheckoutContentProps) => {
       [lock.address]: lock,
     })
   }
+
   if (noProviderAdapter) {
     return <Loading />
   }
@@ -57,7 +57,7 @@ export const CheckoutContent = ({ query }: CheckoutContentProps) => {
         web3Provider={
           checkoutCommunication.providerAdapter || selectProvider(config)
         }
-        redirectUri={redirectUri || paywallConfig?.redirectUri}
+        redirectUri={oAuthConfig?.redirectUri || paywallConfig?.redirectUri}
         oAuthConfig={oAuthConfig}
         defaultState={defaultState}
         paywallConfig={paywallConfig} // last to avoid override by ...checkoutCommunication

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -104,10 +104,6 @@ export const Checkout = ({
   const [existingKeys, setHasKey] = useReducer(keysReducer, {})
   const [selectedLock, selectLock] = useState<any>(null)
   const [savedMetadata, setSavedMetadata] = useState<any>(false)
-  // state change
-  useEffect(() => {
-    setState(defaultState)
-  }, [defaultState])
 
   // state change
   useEffect(() => {
@@ -180,7 +176,9 @@ export const Checkout = ({
       }
       if (queryParams) {
         for (const key in queryParams) {
-          redirectUrl.searchParams.append(key, queryParams[key])
+          if (queryParams[key] !== undefined && queryParams[key] !== null) {
+            redirectUrl.searchParams.append(key, queryParams[key])
+          }
         }
       }
       window.location.href = redirectUrl.toString()

--- a/unlock-app/src/components/interface/checkout/OauthConnect.tsx
+++ b/unlock-app/src/components/interface/checkout/OauthConnect.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react'
+import { utils } from 'ethers'
 import { OAuthConfig } from '../../../unlockTypes'
 import LoginPrompt from '../LoginPrompt'
 import { AuthenticationContext } from '../Authenticate'
@@ -26,19 +27,26 @@ export const OAuthConnect = ({
   const [showLogin, setShowLogin] = useState(false)
   const { clientId } = oAuthConfig
   // What if the user has no account?
+
+  // TODO: add a timestamp to digest for increased security
+  const digest = `Connecting my acccount to ${clientId}.`
+
   const onProvider = async (provider: any) => {
-    const result = await authenticate(
-      provider,
-      `Connecting my acccount to ${clientId}.`
-    )
+    const result = await authenticate(provider, digest)
     // Here we need to wait for the parent coponent to re-render because authenticate sets a bunch of things!
     if (result) {
       setShowLogin(false)
       console.log(
         'Actually do not redirect just yet if there are memberships to purchase!'
       )
+
+      const code = JSON.stringify({
+        d: digest,
+        s: result.signedMessage,
+      })
+
       closeModal(true, redirectUri, {
-        code: result.signedMessage,
+        code: btoa(code),
         state: oAuthConfig.state,
       })
     }

--- a/unlock-app/src/components/interface/checkout/OauthConnect.tsx
+++ b/unlock-app/src/components/interface/checkout/OauthConnect.tsx
@@ -13,7 +13,6 @@ interface OAuthConnectProps {
 
 export const OAuthConnect = ({
   oAuthConfig,
-
   redirectUri,
   closeModal,
 }: OAuthConnectProps) => {
@@ -35,9 +34,6 @@ export const OAuthConnect = ({
     // Here we need to wait for the parent coponent to re-render because authenticate sets a bunch of things!
     if (result) {
       setShowLogin(false)
-      console.log(
-        'Redirect back! Make sure to include code (signed message) and state too!'
-      )
       console.log(
         'Actually do not redirect just yet if there are memberships to purchase!'
       )

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -1,4 +1,4 @@
-import { ethers, utils } from 'ethers'
+import { ethers } from 'ethers'
 import { useState, useContext } from 'react'
 import { WalletService } from '@unlock-protocol/unlock-js'
 import ProviderContext from '../contexts/ProviderContext'
@@ -46,10 +46,12 @@ export const useProvider = (config: any) => {
       const _account = await _walletService.getAccount()
       let _signedMessage
       if (messageToSign) {
-        _signedMessage = utils.base64.encode(
-          // @ts-expect-error
-          await _walletService.signMessage(messageToSign, 'personal_sign')
+        // @ts-expect-error
+        _signedMessage = await _walletService.signMessage(
+          messageToSign,
+          'personal_sign'
         )
+
         setSignedMessage(_signedMessage)
       }
       setWalletService(_walletService)

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -232,4 +232,5 @@ export interface OAuthConfig {
   clientId: string
   responseType: string
   state: string
+  redirectUri: string
 }

--- a/unlock-app/src/utils/getOAuthFromSearch.ts
+++ b/unlock-app/src/utils/getOAuthFromSearch.ts
@@ -3,14 +3,14 @@ import { OAuthConfig } from '../unlockTypes'
 export default function getConfigFromSearch(
   search: any
 ): OAuthConfig | undefined {
-  const { clientId, redirectUri, responseType, code, state } = search
-  if (!clientId) {
+  const { client_id, redirect_uri, response_type, code, state } = search
+  if (!client_id) {
     // No client id, no OAuth
     return undefined
   }
 
-  const redirectUrl = new URL(redirectUri)
-  if (redirectUrl.host !== clientId) {
+  const redirectUrl = new URL(redirect_uri)
+  if (redirectUrl.host !== client_id) {
     console.error(
       "We require clientId to match the redirectUri's host for privacy reasons"
     )
@@ -18,8 +18,9 @@ export default function getConfigFromSearch(
   }
 
   return {
-    clientId,
-    responseType,
+    redirectUri: redirect_uri,
+    clientId: client_id,
+    responseType: response_type,
     state,
   }
 }


### PR DESCRIPTION
# Description

We want to add an OAuth endpoint to enable implementing application to easily offer their users to "connect with Unlock".
The OAuth flow includes 2 steps:
1. Getting a code from the front-end
2. Accessing the user's address by redeeming the code with a backend service.

This PR introduces this flow.
We are leveraging the existing checkout UI in `unlock-app` to let the user share their address with a 3rd party service and then we're introducing the locksmith API call to retrieve the user's address.

This is a first iteration and more iterations will come later as we add improvements to the flow.

Ref: #7433

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread


![image](https://user-images.githubusercontent.com/17735/132537226-47e92433-8243-4ac5-a9b6-38861f9db201.png)


