### PR TITLE
Fix local packages linkage in docker prod build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,15 +125,19 @@ WORKDIR /app
 COPY --from=build --chown=node /home/unlock/$BUILD_DIR/package.json package.json
 COPY --from=build --chown=node /home/unlock/$BUILD_DIR/yarn.lock yarn.lock
 
-# delete dev deps to prevent yarn from fetching them
+# delete dev deps (prevents yarn from fetching them)
+# add link: protocol workaround for yarn local links to work
 RUN apk add --no-cache --virtual .build-deps coreutils jq  \
-    && jq 'del(.devDependencies)' package.json > package.json.tmp \
+    && jq 'del(.devDependencies) | (.dependencies |= (with_entries(if .key == "@unlock-protocol/networks" then .key = "link:./packages/networks" else . end)))' package.json > package.json.tmp \
     && mv package.json.tmp package.json \ 
     && apk del .build-deps \
     && chown node:node package.json
 
+
+# get local packages builds
+COPY --from=build --chown=node /home/unlock/packages packages
+
 # prod install 
-# NOTE: this required that all shared packages have been published to npm
 USER node
 ENV NODE_ENV production
 RUN yarn install --production --non-interactive --pure-lockfile

--- a/scripts/heroku.sh
+++ b/scripts/heroku.sh
@@ -15,7 +15,7 @@ then
 fi
 
 # build image
-docker build --rm=false -t registry.heroku.com/$HEROKU_APP_NAME/web --build-arg BUILD_DIR=$SERVICE .
+docker build --rm=false --progress=plain -t registry.heroku.com/$HEROKU_APP_NAME/web --build-arg BUILD_DIR=$SERVICE .
 
 # push image to Heroku registry
 docker login -username=$HEROKU_EMAIL --password=$HEROKU_API_KEY registry.heroku.com


### PR DESCRIPTION
# Description

Use local `link:` protocol to prevent yarn from fetching local packages and throwing 

```
#42 1.509 error An unexpected error occurred: "https://registry.yarnpkg.com/@unlock-protocol%2fnetworks: Not found".
```

https://app.circleci.com/pipelines/github/unlock-protocol/unlock/18145/workflows/3d49ce55-bb70-4cf9-8574-914aa0f48a5b/jobs/252263


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Relates to https://github.com/yarnpkg/yarn/issues/2611 and https://github.com/yarnpkg/yarn/issues/5083

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->
