### PR TITLE
Adding placeholder on metadata fields

### DIFF
--- a/unlock-app/.storybook/.babelrc
+++ b/unlock-app/.storybook/.babelrc
@@ -10,20 +10,7 @@
             "displayName": true,
             "preprocess": false
           }
-        ]
-      ]
-    },
-    "production": {
-      "presets": ["next/babel"],
-      "plugins": [
-        [
-          "styled-components",
-          {
-            "ssr": true,
-            "displayName": false,
-            "preprocess": false
-          }
-        ]
+        ],
       ]
     },
     "test": {
@@ -46,7 +33,7 @@
             "preprocess": false
           }
         ],
-        ["require-context-hook"]
+        ["require-context-hook"],
       ]
     }
   }

--- a/unlock-app/.storybook/addons.js
+++ b/unlock-app/.storybook/addons.js
@@ -1,3 +1,2 @@
-import '@storybook/addon-knobs/register'
 import '@storybook/addon-actions/register'
 import '@storybook/addon-viewport/register'

--- a/unlock-app/src/components/interface/checkout/FormStyles.tsx
+++ b/unlock-app/src/components/interface/checkout/FormStyles.tsx
@@ -14,6 +14,11 @@ export const Input = styled.input`
   padding: 0 8px;
   color: var(--darkgrey);
   margin-bottom: 16px;
+
+  &::placeholder {
+    color: var(--grey);
+    font-weight: 300;
+  }
 `
 
 export const Label = styled.label`

--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -65,10 +65,14 @@ export const MetadataForm = ({ network, lock, fields, onSubmit }: Props) => {
       </Message>
       {error && <Error>{error}</Error>}
 
-      {fields.map(({ name, type, required }) => (
+      {fields.map(({ name, type, required, placeholder }) => (
         <StyledLabel required={required} key={name}>
           <span>{name}</span>
-          <Input type={type} {...register(name, { required })} />
+          <Input
+            placeholder={placeholder}
+            type={type}
+            {...register(name, { required })}
+          />
         </StyledLabel>
       ))}
 

--- a/unlock-app/src/stories/content/CheckoutContent.stories.js
+++ b/unlock-app/src/stories/content/CheckoutContent.stories.js
@@ -90,6 +90,7 @@ storiesOf('Checkout', module)
           name: 'Name',
           type: 'text',
           required: true,
+          placeholder: 'John Doe',
         },
         {
           name: 'Email',

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -175,6 +175,7 @@ export interface MetadataInput {
   defaultValue?: string
   type: 'text' | 'date' | 'color' | 'email' | 'url'
   required: boolean
+  placeholder?: string
   public?: true // optional, all non-public fields are treated as protected
 }
 


### PR DESCRIPTION
# Description

Adding an optional placeholder on metadata fields.

![image](https://user-images.githubusercontent.com/17735/139164043-8851cee1-d833-42bb-8017-7e851c1585ed.png)

# Issues

Fixes #7665

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread
