### PR TITLE
explicitly enabling provider from paywall

### DIFF
--- a/packages/paywall/jest.config.js
+++ b/packages/paywall/jest.config.js
@@ -16,9 +16,9 @@ module.exports = {
   collectCoverage: true,
   coverageThreshold: {
     global: {
-      statements: 77,
+      statements: 76,
       branches: 58,
-      lines: 76,
+      lines: 75,
       functions: 65,
     },
   },

--- a/packages/paywall/src/Paywall.ts
+++ b/packages/paywall/src/Paywall.ts
@@ -36,6 +36,7 @@ export enum CheckoutEvents {
   transactionInfo = 'checkout.transactionInfo',
   methodCall = 'checkout.methodCall',
   onEvent = 'checkout.onEvent',
+  enable = 'checkout.enable',
 }
 
 export interface MethodCall {
@@ -160,6 +161,7 @@ export class Paywall {
     child.on(CheckoutEvents.userInfo, this.handleUserInfoEvent)
     child.on(CheckoutEvents.methodCall, this.handleMethodCallEvent)
     child.on(CheckoutEvents.onEvent, this.handleOnEventEvent)
+    child.on(CheckoutEvents.enable, this.handleEnable)
 
     // transactionInfo event also carries transaction hash.
     child.on(CheckoutEvents.transactionInfo, this.handleTransactionInfoEvent)
@@ -201,7 +203,6 @@ export class Paywall {
   }
 
   handleMethodCallEvent = async ({ method, params, id }: MethodCall) => {
-    await enableInjectedProvider(this.provider)
     ;(this.provider! as any).sendAsync(
       { method, params, id },
       (error: any, response: any) => {
@@ -211,10 +212,14 @@ export class Paywall {
   }
 
   handleOnEventEvent = async (eventName: string) => {
-    await enableInjectedProvider(this.provider)
     ;(this.provider! as any).on(eventName, () => {
       this.child!.call('resolveOnEvent', eventName)
     })
+  }
+
+  handleEnable = async () => {
+    await enableInjectedProvider(this.provider)
+    this.child!.call('resolveOnEnable')
   }
 
   showIframe = () => {

--- a/packages/paywall/src/__tests__/Paywall.test.ts
+++ b/packages/paywall/src/__tests__/Paywall.test.ts
@@ -97,7 +97,7 @@ describe('Paywall object', () => {
 
   describe('methodCall event', () => {
     it('forwards the method call to the injected provider', async () => {
-      expect.assertions(2)
+      expect.assertions(1)
 
       const provider = {
         enable: jest.fn(),
@@ -112,7 +112,6 @@ describe('Paywall object', () => {
         id: 31337,
       })
 
-      expect(provider.enable).toHaveBeenCalledWith()
       expect(provider.sendAsync).toHaveBeenCalledWith(
         {
           method: 'net_version',

--- a/packages/paywall/src/networkConfigs.ts
+++ b/packages/paywall/src/networkConfigs.ts
@@ -17,8 +17,6 @@ if (baseUrl.match('staging-paywall.unlock-protocol.com')) {
   locksmithUri = 'http://0.0.0.0:8080'
 }
 
-console.log({ baseUrl, unlockAppUrl, locksmithUri })
-
 // TODO: allow customization of these values when running the script
 // This means probably adding to the unlockProtocolConfig object to include the provider, loksmith Uri and unlockAppUrl
 export const networkConfigs: NetworkConfigs = {}

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useContext,
-  useReducer,
-  useEffect,
-  useCallback,
-} from 'react'
+import React, { useState, useContext, useReducer, useEffect } from 'react'
 import Head from 'next/head'
 import styled from 'styled-components'
 import { Web3Service } from '@unlock-protocol/unlock-js'
@@ -226,12 +220,7 @@ export const Checkout = ({
         injectedProvider={web3Provider}
         backgroundColor="var(--white)"
         activeColor="var(--offwhite)"
-        onProvider={(provider) => {
-          if (selectedLock) {
-            setCheckoutState('crypto-checkout')
-          }
-          onProvider(provider)
-        }}
+        onProvider={onProvider}
       >
         <p>Select your crypto wallet of choice.</p>
       </LoginPrompt>

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -97,7 +97,6 @@ export const useProvider = (config: any) => {
 
   const connectProvider = async (provider: any, messageToSign: string) => {
     setLoading(true)
-
     let auth
     if (provider instanceof ethers.providers.Provider) {
       auth = await resetProvider(provider, messageToSign)


### PR DESCRIPTION
# Description

An issue exists where every first connection to the paywall would actually fail to enable the wallet, rendering the app in an unexpected stated.
We are fixing it by explicitly calling `enable` from the checkout UI in the paywall.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
