### PR TITLE
adding publicProvider to networks

### DIFF
--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -18,7 +18,7 @@ export default class Dispatcher {
     const walletService = new WalletService(networks)
 
     const provider = new ethers.providers.JsonRpcProvider(
-      networks[network].provider
+      networks[network].publicProvider
     )
 
     const walletWithProvider = new ethers.Wallet(
@@ -38,7 +38,7 @@ export default class Dispatcher {
 
   async hasFundsForTransaction(network: number) {
     const provider = new ethers.providers.JsonRpcProvider(
-      networks[network].provider
+      networks[network].publicProvider
     )
 
     const wallet = new ethers.Wallet(config.purchaserCredentials, provider)
@@ -59,7 +59,7 @@ export default class Dispatcher {
     const walletService = new WalletService(networks)
 
     const provider = new ethers.providers.JsonRpcProvider(
-      networks[network].provider
+      networks[network].publicProvider
     )
 
     const walletWithProvider = new ethers.Wallet(

--- a/locksmith/src/utils/keyPricer.ts
+++ b/locksmith/src/utils/keyPricer.ts
@@ -44,7 +44,7 @@ export default class KeyPricer {
     if (!base) {
       base = 1
     }
-    const providerUrl = networks[network].provider
+    const providerUrl = networks[network].publicProvider
     const provider = new ethers.providers.JsonRpcProvider(providerUrl)
 
     // Price of gas

--- a/packages/networks/src/networks/bsc.ts
+++ b/packages/networks/src/networks/bsc.ts
@@ -1,6 +1,7 @@
 import { NetworkConfig } from '../types';
 
 export const bsc: NetworkConfig = {
+    publicProvider: 'https://bsc-dataseed.binance.org/',
     provider:
         'https://bsc-dataseed.binance.org/',
     unlockAddress: '0x99b1348a9129ac49c6de7F11245773dE2f51fB0c',

--- a/packages/networks/src/networks/localhost.ts
+++ b/packages/networks/src/networks/localhost.ts
@@ -4,6 +4,7 @@ export const localhost : NetworkConfig = {
     id: 31337,
     name: 'localhost',
     provider: 'http://127.0.0.1:8545',
+    publicProvider: 'http://127.0.0.1:8545',
     locksmithUri: 'http://127.0.0.1:8080',
     unlockAppUrl: 'http://0.0.0.0:3000',
     subgraphURI: 'http://localhost:8000/subgraphs/name/unlock-protocol/unlock',

--- a/packages/networks/src/networks/mainnet.ts
+++ b/packages/networks/src/networks/mainnet.ts
@@ -1,8 +1,8 @@
 import { NetworkConfig } from '../types';
 
 export const mainnet: NetworkConfig = {
-    // httpProvider: null, // we use the injected provider!
     id: 1,
+    publicProvider: 'https://eth-mainnet.alchemyapi.io/v2/6idtzGwDtRbzil3s6QbYHr2Q_WBfn100', // Should we use Infura?
     provider:
         'https://eth-mainnet.alchemyapi.io/v2/6idtzGwDtRbzil3s6QbYHr2Q_WBfn100',
     unlockAddress: '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13',

--- a/packages/networks/src/networks/polygon.ts
+++ b/packages/networks/src/networks/polygon.ts
@@ -1,6 +1,7 @@
 import { NetworkConfig } from '../types';
 
 export const polygon: NetworkConfig = {
+    publicProvider: 'https://rpc-mainnet.maticvigil.com/',
     provider:
         'https://snowy-weathered-waterfall.matic.quiknode.pro/5b11a0413a62a295070c0dfb25637d5f8c591aba/',
     unlockAddress: '0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863',

--- a/packages/networks/src/networks/rinkeby.ts
+++ b/packages/networks/src/networks/rinkeby.ts
@@ -1,6 +1,7 @@
 import { NetworkConfig } from '../types';
 
 export const rinkeby: NetworkConfig = {
+    publicProvider:'https://eth-rinkeby.alchemyapi.io/v2/n0NXRSZ9olpkJUPDLBC00Es75jaqysyT',
     provider:
         'https://eth-rinkeby.alchemyapi.io/v2/n0NXRSZ9olpkJUPDLBC00Es75jaqysyT',
     unlockAddress: '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b',

--- a/packages/networks/src/networks/xdai.ts
+++ b/packages/networks/src/networks/xdai.ts
@@ -1,6 +1,7 @@
 import { NetworkConfig } from '../types';
 
 export const xdai: NetworkConfig = {
+    publicProvider: 'https://rpc.xdaichain.com/',
     provider: 'https://cool-empty-bird.xdai.quiknode.pro/4edba942fb43c718f24480484684e907fe3fe1d3/',
     unlockAddress: '0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863',
     id: 100,

--- a/packages/networks/src/types/index.ts
+++ b/packages/networks/src/types/index.ts
@@ -2,8 +2,9 @@ export interface NetworkConfig {
     id: number
     name: string
     provider: string
-    locksmithUri?: string
-    unlockAppUrl?: string
+    publicProvider: string
+    locksmithUri?: string // TODO: remove as this should not be network specific
+    unlockAppUrl?: string // TODO: remove as this should not be network specific
     blockTime?: number
     unlockAddress?: string
     subgraphURI?: string

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -176,7 +176,7 @@ export const useProvider = (config: any) => {
                 {
                   chainId: `0x${network.id.toString(16)}`,
                   chainName: network.name,
-                  rpcUrls: [network.provider],
+                  rpcUrls: [network.publicProvider],
                   nativeCurrency: network.nativeCurrency,
                 },
               ],


### PR DESCRIPTION
Thank you for your contribution to Unlock Protocol!

# Description

This adds a publicProvider to each network that is used in 2 ways:
* to submit transactions from locksmiths so that we know we're using the "recommended" mempool... (instead of seeing tx stuck on our custom providers)
* to ask users to add the networks to their wallets as we don't want them to use the unlock paid providers...

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

## Release Note Draft Snippet

Adding public providers to networks!