### PR TITLE
removed custom settings in packages ts-config

### DIFF
--- a/paywall-app/tsconfig.json
+++ b/paywall-app/tsconfig.json
@@ -1,27 +1,6 @@
 /* This file is a combination of the automatically generated config produced by `tsc --init` and the recommended config suggested by zeit for next-typescript */{
   "extends": "@unlock-protocol/tsconfig",
   "compilerOptions": {
-    /* Basic Options */
-    "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-    "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": [
-      "dom",
-      "es2017"
-    ] /* Specify library files to be included in the compilation. */,
-    "jsx": "preserve" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
-    "sourceMap": true /* Generates corresponding '.map' file. */,
-    "outDir": "./dist" /* Redirect output structure to the directory. */,
-    "removeComments": false /* Do not emit comments to output. */,
-    /* Additional Checks */
-    "moduleResolution": "node",
-    "noImplicitReturns": false, /* Report error when not all code paths in function return a value. */
-    "noFallthroughCasesInSwitch": false, /* Report errors for fallthrough cases in switch statement. */
-    "experimentalDecorators": false, /* Enables experimental support for ES7 decorators. */
-    "emitDecoratorMetadata": false /* Enables experimental support for emitting type metadata for decorators. */,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true
   },
   "include": [
     "./src/**/*"

--- a/unlock-app/tsconfig.json
+++ b/unlock-app/tsconfig.json
@@ -2,23 +2,6 @@
 {
   "extends": "@unlock-protocol/tsconfig",
   "compilerOptions": {
-    /* Basic Options */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "esnext",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["dom" , "es2017"],                /* Specify library files to be included in the compilation. */
-    "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "removeComments": false,                  /* Do not emit comments to output. */
-    "noEmit": true,                           /* Do not emit outputs. */
-  
-    "noImplicitReturns": false,             /* Report error when not all code paths in function return a value. */
-    "noFallthroughCasesInSwitch": false,    /* Report errors for fallthrough cases in switch statement. */
-
-    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    
-    "experimentalDecorators": false,        /* Enables experimental support for ES7 decorators. */
-    "emitDecoratorMetadata": false,         /* Enables experimental support for emitting type metadata for decorators. */
-    "skipLibCheck": true                      /* This trusts that typings files (@types) are accurate and don't need to be checked by the compiler. This speeds build times. */
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
Thank you for your contribution to Unlock Protocol!

# Description

When starting next in `unlock-app`, it complains that the ts config is not correct:

```
ready - started server on 0.0.0.0:3000, url: http://localhost:3000
We detected TypeScript in your project and reconfigured your tsconfig.json file for you. Strict-mode is set to false by default.

The following suggested values were added to your tsconfig.json. These values can be changed to fit your project's needs:

	- forceConsistentCasingInFileNames was set to true
	- incremental was set to true

The following mandatory changes were made to your tsconfig.json:

	- resolveJsonModule was set to true (to match webpack resolution)
	- isolatedModules was set to true (requirement for babel)
	- jsx was set to preserve (next.js implements its own optimized jsx transform)

Defining routes from exportPathMap
warn  - Disabled SWC as replacement for Babel because of custom Babel configuration "babel.config.js" https://nextjs.org/docs/messages/swc-disabled
info  - Using external babel configuration from /Users/julien/repos/unlock/unlock-app/babel.config.js
event - compiled successfully in 10.8s (1399 modules)
```

I am investigating by removing what is in there...
