### PR TITLE
Redeploys post security breach

### DIFF
--- a/packages/networks/src/networks/polygon.ts
+++ b/packages/networks/src/networks/polygon.ts
@@ -4,7 +4,7 @@ export const polygon: NetworkConfig = {
     publicProvider: 'https://rpc-mainnet.maticvigil.com/',
     provider:
         'https://snowy-weathered-waterfall.matic.quiknode.pro/5b11a0413a62a295070c0dfb25637d5f8c591aba/',
-    unlockAddress: '0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863',
+    unlockAddress: '0x75f778379623155201B4dd7647907d3ABbDB6753',
     id: 137,
     name: 'Polygon',
     blockTime: 1000,
@@ -26,7 +26,11 @@ export const polygon: NetworkConfig = {
         symbol: 'MATIC',
         decimals: 18,
     },
-    startBlock: 15714206,
+    startBlock: 21844200,
+    previousDeploys: [{
+        unlockAddress: '0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863',
+        startBlock: 15714206
+    }]
 }
 
 export default polygon

--- a/packages/networks/src/networks/xdai.ts
+++ b/packages/networks/src/networks/xdai.ts
@@ -3,7 +3,7 @@ import { NetworkConfig } from '../types';
 export const xdai: NetworkConfig = {
     publicProvider: 'https://rpc.xdaichain.com/',
     provider: 'https://cool-empty-bird.xdai.quiknode.pro/4edba942fb43c718f24480484684e907fe3fe1d3/',
-    unlockAddress: '0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863',
+    unlockAddress: '0x8Ffbca1775af6e79480271b2C651Eec94ac414fc',
     id: 100,
     name: 'xDai',
     blockTime: 5000,
@@ -25,6 +25,11 @@ export const xdai: NetworkConfig = {
         symbol: 'xDai',
         decimals: 18,
     },
-    startBlock: 14521200,
+    startBlock: 19273300,
+    previousDeploys: [{
+        unlockAddress: '0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863',
+        startBlock: 14521200
+    }]
+
 }
 export default xdai

--- a/packages/networks/src/types/index.ts
+++ b/packages/networks/src/types/index.ts
@@ -1,3 +1,8 @@
+interface PreviousDeploy {
+    unlockAddress: string,
+    startBlock?: number
+}
+
 export interface NetworkConfig {
     id: number
     name: string
@@ -27,6 +32,7 @@ export interface NetworkConfig {
         decimals: number
     },
     startBlock?: number
+    previousDeploys?: PreviousDeploy[]
 }
 
 export interface NetworkConfigs {

--- a/smart-contracts/.openzeppelin/unknown-100.json
+++ b/smart-contracts/.openzeppelin/unknown-100.json
@@ -1,5 +1,19 @@
 {
   "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x3C6e461341AdbF7C0947085e86B4A6f35Ff2F801"
+  },
+  "proxies": [
+    {
+      "address": "0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x8Ffbca1775af6e79480271b2C651Eec94ac414fc",
+      "txHash": "0x21b9486d7e2ff0288f588a8657809d66ba02385789aecae2d3a0edc7ad880b6e",
+      "kind": "transparent"
+    }
+  ],
   "impls": {
     "1b20be2a6a26d7ebe9f2a843abc6386484f623da2b7df7fc896ac7cefb59adbf": {
       "address": "0x06de4215484E5A2B935a3124cC577336963fb56D",
@@ -143,15 +157,153 @@
           }
         }
       }
+    },
+    "c1cd311ce43adf0c1fea96e686ac6080a5184b3a0c75b58858174621d66d7dd9": {
+      "address": "0x16f03C4271c64618D42A4b1c0749b61941f1faf7",
+      "txHash": "0x884e079be2084b3a069632fa08fea472942a805c45079d1badbb123f90b2ce07",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/upgrades/contracts/Initializable.sol:21"
+          },
+          {
+            "contract": "Initializable",
+            "label": "initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/upgrades/contracts/Initializable.sol:26"
+          },
+          {
+            "contract": "Initializable",
+            "label": "______gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/upgrades/contracts/Initializable.sol:61"
+          },
+          {
+            "contract": "Ownable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol:17"
+          },
+          {
+            "contract": "Ownable",
+            "label": "______gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol:80"
+          },
+          {
+            "contract": "Unlock",
+            "label": "grossNetworkProduct",
+            "type": "t_uint256",
+            "src": "contracts/Unlock.sol:68"
+          },
+          {
+            "contract": "Unlock",
+            "label": "totalDiscountGranted",
+            "type": "t_uint256",
+            "src": "contracts/Unlock.sol:70"
+          },
+          {
+            "contract": "Unlock",
+            "label": "locks",
+            "type": "t_mapping(t_address,t_struct(LockBalances)2318_storage)",
+            "src": "contracts/Unlock.sol:73"
+          },
+          {
+            "contract": "Unlock",
+            "label": "globalBaseTokenURI",
+            "type": "t_string_storage",
+            "src": "contracts/Unlock.sol:77"
+          },
+          {
+            "contract": "Unlock",
+            "label": "globalTokenSymbol",
+            "type": "t_string_storage",
+            "src": "contracts/Unlock.sol:81"
+          },
+          {
+            "contract": "Unlock",
+            "label": "publicLockAddress",
+            "type": "t_address",
+            "src": "contracts/Unlock.sol:84"
+          },
+          {
+            "contract": "Unlock",
+            "label": "uniswapOracles",
+            "type": "t_mapping(t_address,t_contract(IUniswapOracle)7444)",
+            "src": "contracts/Unlock.sol:88"
+          },
+          {
+            "contract": "Unlock",
+            "label": "weth",
+            "type": "t_address",
+            "src": "contracts/Unlock.sol:91"
+          },
+          {
+            "contract": "Unlock",
+            "label": "udt",
+            "type": "t_address",
+            "src": "contracts/Unlock.sol:94"
+          },
+          {
+            "contract": "Unlock",
+            "label": "estimatedGasForPurchase",
+            "type": "t_uint256",
+            "src": "contracts/Unlock.sol:97"
+          },
+          {
+            "contract": "Unlock",
+            "label": "chainId",
+            "type": "t_uint256",
+            "src": "contracts/Unlock.sol:100"
+          }
+        ],
+        "types": {
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(LockBalances)2318_storage)": {
+            "label": "mapping(address => struct Unlock.LockBalances)"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_struct(LockBalances)2318_storage": {
+            "label": "struct Unlock.LockBalances",
+            "members": [
+              {
+                "label": "deployed",
+                "type": "t_bool"
+              },
+              {
+                "label": "totalSales",
+                "type": "t_uint256"
+              },
+              {
+                "label": "yieldedDiscountTokens",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_mapping(t_address,t_contract(IUniswapOracle)7444)": {
+            "label": "mapping(address => contract IUniswapOracle)"
+          },
+          "t_contract(IUniswapOracle)7444": {
+            "label": "contract IUniswapOracle"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
     }
-  },
-  "proxies": [
-    {
-      "address": "0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863",
-      "kind": "transparent"
-    }
-  ],
-  "admin": {
-    "address": "0x3C6e461341AdbF7C0947085e86B4A6f35Ff2F801"
   }
 }

--- a/smart-contracts/.openzeppelin/unknown-137.json
+++ b/smart-contracts/.openzeppelin/unknown-137.json
@@ -1,5 +1,19 @@
 {
   "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x3C6e461341AdbF7C0947085e86B4A6f35Ff2F801"
+  },
+  "proxies": [
+    {
+      "address": "0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x75f778379623155201B4dd7647907d3ABbDB6753",
+      "txHash": "0xe1b145402526417479746d5ded159e759d88cab7e201eca1fc3b8ea3c2af75e2",
+      "kind": "transparent"
+    }
+  ],
   "impls": {
     "1b20be2a6a26d7ebe9f2a843abc6386484f623da2b7df7fc896ac7cefb59adbf": {
       "address": "0x7633dd082406861C384309c67576a4260C5775E0",
@@ -143,15 +157,153 @@
           }
         }
       }
+    },
+    "c1cd311ce43adf0c1fea96e686ac6080a5184b3a0c75b58858174621d66d7dd9": {
+      "address": "0x419195a71d6ae592bB4846266E907B5c1202f9eE",
+      "txHash": "0xd8346b634c6ccd3ba5aebbe1484ed73ff6d42c3cdffd38b904613d2b1d36837f",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/upgrades/contracts/Initializable.sol:21"
+          },
+          {
+            "contract": "Initializable",
+            "label": "initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/upgrades/contracts/Initializable.sol:26"
+          },
+          {
+            "contract": "Initializable",
+            "label": "______gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/upgrades/contracts/Initializable.sol:61"
+          },
+          {
+            "contract": "Ownable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol:17"
+          },
+          {
+            "contract": "Ownable",
+            "label": "______gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol:80"
+          },
+          {
+            "contract": "Unlock",
+            "label": "grossNetworkProduct",
+            "type": "t_uint256",
+            "src": "contracts/Unlock.sol:68"
+          },
+          {
+            "contract": "Unlock",
+            "label": "totalDiscountGranted",
+            "type": "t_uint256",
+            "src": "contracts/Unlock.sol:70"
+          },
+          {
+            "contract": "Unlock",
+            "label": "locks",
+            "type": "t_mapping(t_address,t_struct(LockBalances)2318_storage)",
+            "src": "contracts/Unlock.sol:73"
+          },
+          {
+            "contract": "Unlock",
+            "label": "globalBaseTokenURI",
+            "type": "t_string_storage",
+            "src": "contracts/Unlock.sol:77"
+          },
+          {
+            "contract": "Unlock",
+            "label": "globalTokenSymbol",
+            "type": "t_string_storage",
+            "src": "contracts/Unlock.sol:81"
+          },
+          {
+            "contract": "Unlock",
+            "label": "publicLockAddress",
+            "type": "t_address",
+            "src": "contracts/Unlock.sol:84"
+          },
+          {
+            "contract": "Unlock",
+            "label": "uniswapOracles",
+            "type": "t_mapping(t_address,t_contract(IUniswapOracle)7444)",
+            "src": "contracts/Unlock.sol:88"
+          },
+          {
+            "contract": "Unlock",
+            "label": "weth",
+            "type": "t_address",
+            "src": "contracts/Unlock.sol:91"
+          },
+          {
+            "contract": "Unlock",
+            "label": "udt",
+            "type": "t_address",
+            "src": "contracts/Unlock.sol:94"
+          },
+          {
+            "contract": "Unlock",
+            "label": "estimatedGasForPurchase",
+            "type": "t_uint256",
+            "src": "contracts/Unlock.sol:97"
+          },
+          {
+            "contract": "Unlock",
+            "label": "chainId",
+            "type": "t_uint256",
+            "src": "contracts/Unlock.sol:100"
+          }
+        ],
+        "types": {
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(LockBalances)2318_storage)": {
+            "label": "mapping(address => struct Unlock.LockBalances)"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_struct(LockBalances)2318_storage": {
+            "label": "struct Unlock.LockBalances",
+            "members": [
+              {
+                "label": "deployed",
+                "type": "t_bool"
+              },
+              {
+                "label": "totalSales",
+                "type": "t_uint256"
+              },
+              {
+                "label": "yieldedDiscountTokens",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_mapping(t_address,t_contract(IUniswapOracle)7444)": {
+            "label": "mapping(address => contract IUniswapOracle)"
+          },
+          "t_contract(IUniswapOracle)7444": {
+            "label": "contract IUniswapOracle"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
     }
-  },
-  "proxies": [
-    {
-      "address": "0x14bb3586Ce2946E71B95Fe00Fc73dd30ed830863",
-      "kind": "transparent"
-    }
-  ],
-  "admin": {
-    "address": "0x3C6e461341AdbF7C0947085e86B4A6f35Ff2F801"
   }
 }

--- a/smart-contracts/scripts/setters/unlock-config.js
+++ b/smart-contracts/scripts/setters/unlock-config.js
@@ -39,9 +39,10 @@ async function main({
     .configUnlock(
       udtAddress,
       wethAddress,
-      estimatedGasForPurchase || 0,
+      estimatedGasForPurchase || 200000,
       'KEY',
-      locksmithURI || `http://127.0.0.1:3000/api/key/${chainId}/`,
+      locksmithURI ||
+        `https://locksmith.unlock-protocol.com/api/key/${chainId}/`,
       chainId
     )
 

--- a/smart-contracts/tasks/set.js
+++ b/smart-contracts/tasks/set.js
@@ -87,6 +87,7 @@ task('set:unlock-config', 'Configure Unlock contract')
     'publicLockAddress',
     'the address of an existing public Lock contract'
   )
+  .addOptionalParam('udtAddress', 'the address of an existing UDT contract')
   .addOptionalParam('wethAddress', 'the address of the WETH token contract')
   .addOptionalParam('estimatedGasForPurchase', 'gas estimate for buying a key')
   .addOptionalParam('locksmithURI', 'the locksmith URL to use in Unlock config')

--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -43,3 +43,5 @@ With `subgraph.yaml` created, we should generate the associated code with the fo
 These command require the passing of the following command line arguments `--network` & `--environment`.
 
 * `yarn run deploy` - Deploy the latest subgraph code to the graph node
+
+Note: `polygon` is called `matic` in the graph. Please change the subgraph.yaml file manually.

--- a/subgraph/bin/subgraph_generator.js
+++ b/subgraph/bin/subgraph_generator.js
@@ -6,14 +6,21 @@ const path = require('path')
 const fs = require('fs-extra')
 const networksConfig = require('@unlock-protocol/networks')
 
-const templateValues = (network) => {
-  if (!networksConfig[network]) {
+const templateValues = (networkName) => {
+  if (!networksConfig[networkName]) {
+    console.error('Please specify network!')
     process.exit(1)
   }
+  const network = networksConfig[networkName]
   return {
-    network,
-    startBlock: networksConfig[network].startBlock,
-    unlockContractAddress: networksConfig[network].unlockAddress,
+    network: networkName,
+    startBlock: network.startBlock,
+    unlockContractAddress: network.unlockAddress,
+    previousDeploys: (network.previousDeploys || []).map((details, index) => ({
+      ...details,
+      index,
+      network: networkName,
+    })),
   }
 }
 

--- a/subgraph/subgraph.template.yaml
+++ b/subgraph/subgraph.template.yaml
@@ -36,6 +36,39 @@ dataSources:
         - event: OwnershipTransferred(indexed address,indexed address)
           handler: handleOwnershipTransferred
       file: ./src/mapping.ts
+  {{#previousDeploys}}
+  - kind: ethereum/contract
+    name: Contract-{{index}}
+    network: {{network}}
+    source:
+      address: "{{unlockAddress}}"
+      abi: Contract-{{index}}
+      startBlock: {{startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - NewLock
+        - NewTokenURI
+        - NewGlobalTokenSymbol
+        - OwnershipTransferred
+      abis:
+        - name: Contract-{{index}}
+          file: ./abis/Contract.json
+        - name: PublicLock
+          file: ./abis/PublicLock.json
+      eventHandlers:
+        - event: NewLock(indexed address,indexed address)
+          handler: handleNewLock
+        - event: NewTokenURI(string)
+          handler: handleNewTokenURI
+        - event: NewGlobalTokenSymbol(string)
+          handler: handleNewGlobalTokenSymbol
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleOwnershipTransferred
+      file: ./src/mapping.ts
+  {{/previousDeploys}}
 
 templates:
   - kind: ethereum/contract


### PR DESCRIPTION
# Description

As a follow-up to the security breach we suffered on November 21st 2021, we had to redeploy the Polygon and xDAI Unlock contracts. This PR shows that.
Once merged and deployed all new locks will be deployed using the new Unlock contracts on xDAI and Polygon. The subgraph has been modified to include data from both deployments.

I still need to update the docs.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet

