### PR TITLE
fix(README): Fix path to unlock-word-icon

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,4 +1,4 @@
-![Unlock](https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-branding/src/unlock-logo.svg?sanitize=true)
+![Unlock](/unlock-app/public/images/unlock-word-mark.png)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Unlock](https://raw.githubusercontent.com/unlock-protocol/unlock/master/unlock-app/src/static/images/unlock-word-mark.png)
+![Unlock](/unlock-app/public/images/unlock-word-mark.png)
 
 ---
 


### PR DESCRIPTION


# Description
A recent [0]commit ended up moving some files from a static folder to base public folder which broke the unlock icon image in README.

0] https://github.com/unlock-protocol/unlock/commit/84f2d039190d34c0feea7f3089c1a45a80361842#diff-4a7aa60cf378808cac60cb38fc81fff3d2f500e29bbdd45bca0d111149a22309

This PR fixes it.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

