### PR TITLE
Remove manual copy function due to moving files directly into public

### DIFF
--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -81,7 +81,7 @@
     "build": "next build",
     "deploy": "yarn build && next export -o out",
     "deploy-netlify": "./scripts/deploy-netlify.sh",
-    "start": "yarn build && NODE_ENV=production next start --port ${PORT:=3000}",
+    "start": "yarn build && NODE_ENV=production next start",
     "test": "UNLOCK_ENV=test jest --env=jsdom",
     "lint": "eslint --resolve-plugins-relative-to ../packages/eslint-config --ext .tsx,.ts,.js src/",
     "storybook": "start-storybook -p 9001 -c .storybook -s src",

--- a/unlock-app/src/__tests__/utils/exportStatic.test.js
+++ b/unlock-app/src/__tests__/utils/exportStatic.test.js
@@ -7,32 +7,6 @@ describe('exportStatic', () => {
     }))
   })
 
-  it('should copy files when not in dev mode', async () => {
-    expect.assertions(7)
-
-    const { copyFileSync } = require('fs')
-    const { moveStaticFiles } = require('../../utils/exportStatic')
-    moveStaticFiles(false, '/foo/bar', '/alice/bob')
-
-    expect(copyFileSync.mock.calls.length).toBe(3)
-    expect(copyFileSync.mock.calls[0][0]).toBe('/foo/bar/static/robots.txt')
-    expect(copyFileSync.mock.calls[0][1]).toBe('/alice/bob/robots.txt')
-    expect(copyFileSync.mock.calls[1][0]).toBe('/foo/bar/static/humans.txt')
-    expect(copyFileSync.mock.calls[1][1]).toBe('/alice/bob/humans.txt')
-    expect(copyFileSync.mock.calls[2][0]).toBe('/foo/bar/static/_redirects')
-    expect(copyFileSync.mock.calls[2][1]).toBe('/alice/bob/_redirects')
-  })
-
-  it('should not copy files when in dev mode', () => {
-    expect.assertions(1)
-
-    const { copyFileSync } = require('fs')
-    const { moveStaticFiles } = require('../../utils/exportStatic')
-    moveStaticFiles(true, '/foo/bar', '/alice/bob')
-
-    expect(copyFileSync.mock.calls.length).toBe(0)
-  })
-
   it('should generate path map', () => {
     expect.assertions(1)
     const { exportPaths } = require('../../utils/exportStatic')

--- a/unlock-app/src/utils/exportStatic.js
+++ b/unlock-app/src/utils/exportStatic.js
@@ -1,31 +1,4 @@
-const { copyFileSync } = require('fs')
 const { join } = require('path')
-
-/**
- * Exports useful files from the static folder to the root deployment
- * @param {bool} dev Are we in dev mode or not?
- * @param {string} inDir The incoming root folder
- * @param {string} outDir The outgoing root folder
- * @returns {Promise<void>}
- */
-const moveStaticFiles = async (dev, inDir, outDir) => {
-  // Export robots.txt and humans.txt in non-dev environments
-  if (!dev && outDir) {
-    copyFileSync(
-      join(inDir, 'static', 'robots.txt'),
-      join(outDir, 'robots.txt')
-    )
-    copyFileSync(
-      join(inDir, 'static', 'humans.txt'),
-      join(outDir, 'humans.txt')
-    )
-    // Export _redirects which is used by netlify for URL rewrites
-    copyFileSync(
-      join(inDir, 'static', '_redirects'),
-      join(outDir, '_redirects')
-    )
-  }
-}
 
 /**
  * Exports static files and generates a path map, as used by next.config.js
@@ -36,8 +9,6 @@ const moveStaticFiles = async (dev, inDir, outDir) => {
  * @returns {{}}
  */
 const exportPaths = (defaultPathMap, { dev, dir, outDir }) => {
-  moveStaticFiles(dev, dir, outDir)
-
   // Our statically-defined pages to export
   return {
     '/': { page: '/home' },
@@ -55,6 +26,5 @@ const exportPaths = (defaultPathMap, { dev, dir, outDir }) => {
 }
 
 module.exports = {
-  moveStaticFiles,
   exportPaths,
 }


### PR DESCRIPTION
# Description

This PR removes `moveStaticFiles` which is made redundant by https://github.com/unlock-protocol/unlock/commit/84f2d039190d34c0feea7f3089c1a45a80361842, I believe. This is causing build for unlock-app to fail.

PS: The `${PORT:=3000}` added to yarn start end won't work. Do you want to load PORT from environment and provide 3000 as default? If so, you will need to use another utility package to do it or write a shell script.  I have reverted it for now.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

