### PR TITLE
Token uri hook

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -177,7 +177,8 @@ interface IPublicLock
    */
   function setEventHooks(
     address _onKeyPurchaseHook,
-    address _onKeyCancelHook
+    address _onKeyCancelHook,
+    address _onTokenURIHook
   ) external;
 
   /**

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -300,6 +300,8 @@ interface IPublicLock
   function onKeyPurchaseHook() external view returns(address);
 
   function onKeyCancelHook() external view returns(address);
+  
+  function onTokenURIHook() external view returns(string memory);
 
   function revokeKeyGranter(address _granter) external;
 

--- a/smart-contracts/contracts/interfaces/hooks/ILockTokenURIHook.sol
+++ b/smart-contracts/contracts/interfaces/hooks/ILockTokenURIHook.sol
@@ -20,6 +20,7 @@ interface ILockTokenURIHook
   function tokenURI(
     address lockAddress,
     address operator,
+    address owner,
     uint256 keyId,
     uint expirationTimestamp
   ) external view returns(string memory);

--- a/smart-contracts/contracts/interfaces/hooks/ILockTokenURIHook.sol
+++ b/smart-contracts/contracts/interfaces/hooks/ILockTokenURIHook.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.17 <0.9.0;
+
+/**
+ * @notice Functions to be implemented by a tokenURIHook.
+ * @dev Lock hooks are configured by calling `setEventHooks` on the lock.
+ */
+interface ILockTokenURIHook
+{
+  /**
+   * @notice If the lock owner has registered an implementer
+   * then this hook is called with every key cancel.
+   * @param lockAddress the address of the lock
+   * @param operator the msg.sender issuing the call
+   * @param keyId the id (tokenId) of the key (if applicable)
+   * @param expirationTimestamp the key expiration timestamp
+   */
+  function tokenURI(
+    address lockAddress,
+    address operator,
+    uint256 keyId,
+    uint expirationTimestamp
+  ) external view returns(string memory);
+}

--- a/smart-contracts/contracts/interfaces/hooks/ILockTokenURIHook.sol
+++ b/smart-contracts/contracts/interfaces/hooks/ILockTokenURIHook.sol
@@ -9,11 +9,12 @@ interface ILockTokenURIHook
 {
   /**
    * @notice If the lock owner has registered an implementer
-   * then this hook is called with every key cancel.
+   * then this hook is called every time `tokenURI()` is called
    * @param lockAddress the address of the lock
    * @param operator the msg.sender issuing the call
    * @param keyId the id (tokenId) of the key (if applicable)
    * @param expirationTimestamp the key expiration timestamp
+   * @return the tokenURI
    */
   function tokenURI(
     address lockAddress,

--- a/smart-contracts/contracts/interfaces/hooks/ILockTokenURIHook.sol
+++ b/smart-contracts/contracts/interfaces/hooks/ILockTokenURIHook.sol
@@ -12,6 +12,7 @@ interface ILockTokenURIHook
    * then this hook is called every time `tokenURI()` is called
    * @param lockAddress the address of the lock
    * @param operator the msg.sender issuing the call
+   * @param owner the owner of the key for which we are retrieving the `tokenUri`
    * @param keyId the id (tokenId) of the key (if applicable)
    * @param expirationTimestamp the key expiration timestamp
    * @return the tokenURI

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -9,7 +9,7 @@ import '../interfaces/IUnlock.sol';
 import './MixinFunds.sol';
 import '../interfaces/hooks/ILockKeyCancelHook.sol';
 import '../interfaces/hooks/ILockKeyPurchaseHook.sol';
-
+import '../interfaces/hooks/ILockTokenURIHook.sol';
 
 /**
  * @title Mixin for core lock data and functions.
@@ -80,6 +80,7 @@ contract MixinLockCore is
 
   ILockKeyPurchaseHook public onKeyPurchaseHook;
   ILockKeyCancelHook public onKeyCancelHook;
+  ILockTokenURIHook public onTokenURIHook;
 
   // Ensure that the Lock has not sold all of its keys.
   modifier notSoldOut() {
@@ -203,14 +204,17 @@ contract MixinLockCore is
    */
   function setEventHooks(
     address _onKeyPurchaseHook,
-    address _onKeyCancelHook
+    address _onKeyCancelHook,
+    address _onTokenURIHook
   ) external
     onlyLockManager()
   {
     require(_onKeyPurchaseHook == address(0) || _onKeyPurchaseHook.isContract(), 'INVALID_ON_KEY_SOLD_HOOK');
     require(_onKeyCancelHook == address(0) || _onKeyCancelHook.isContract(), 'INVALID_ON_KEY_CANCEL_HOOK');
+    require(_onTokenURIHook == address(0) || _onTokenURIHook.isContract(), 'INVALID_ON_TOKEN_URI_HOOK');
     onKeyPurchaseHook = ILockKeyPurchaseHook(_onKeyPurchaseHook);
     onKeyCancelHook = ILockKeyCancelHook(_onKeyCancelHook);
+    onTokenURIHook = ILockTokenURIHook(_onTokenURIHook);
   }
 
   function totalSupply()

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -123,6 +123,19 @@ contract MixinLockMetadata is
       tokenId = '';
     }
 
+    if(address(onTokenURIHook) != address(0))
+    {
+      address tokenOwner = ownerOf(_tokenId);
+      uint expirationTimestamp = keyExpirationTimestampFor(tokenOwner);
+
+      return onTokenURIHook.tokenURI(
+        address(this),
+        msg.sender,
+        _tokenId,
+        expirationTimestamp
+        );
+    }
+
     if(bytes(baseTokenURI).length == 0) {
       URI = unlockProtocol.globalBaseTokenURI();
       seperator = '/';

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -131,6 +131,7 @@ contract MixinLockMetadata is
       return onTokenURIHook.tokenURI(
         address(this),
         msg.sender,
+        tokenOwner,
         _tokenId,
         expirationTimestamp
         );

--- a/smart-contracts/contracts/test-artifacts/TestEventHooks.sol
+++ b/smart-contracts/contracts/test-artifacts/TestEventHooks.sol
@@ -2,15 +2,21 @@ pragma solidity 0.5.17;
 
 import '../interfaces/hooks/ILockKeyPurchaseHook.sol';
 import '../interfaces/hooks/ILockKeyCancelHook.sol';
+import '../interfaces/hooks/ILockTokenURIHook.sol';
 import '../interfaces/IPublicLock.sol';
+import '../UnlockUtils.sol';
 
 
 /**
  * @title Test contract for lock event hooks.
  * @author Nick Mancuso (unlock-protocol.com)
  */
-contract TestEventHooks is ILockKeyPurchaseHook, ILockKeyCancelHook
+contract TestEventHooks is ILockKeyPurchaseHook, ILockKeyCancelHook, ILockTokenURIHook
 {
+
+  using UnlockUtils for uint;
+  using UnlockUtils for address;
+
   event OnKeyPurchase(
     address lock,
     address from,
@@ -24,6 +30,13 @@ contract TestEventHooks is ILockKeyPurchaseHook, ILockKeyCancelHook
     address operator,
     address to,
     uint refund
+  );
+  event OnTokenURI(
+    address lockAddress,
+    address operator,
+    uint256 tokenId,
+    uint expirationTimestamp,
+    string tokenURI
   );
 
   uint public discount;
@@ -77,5 +90,39 @@ contract TestEventHooks is ILockKeyPurchaseHook, ILockKeyCancelHook
   ) external
   {
     emit OnKeyCancel(msg.sender, _operator, _to, _refund);
+  }
+
+  string public baseURI = 'https://unlock-uri-hook.test/';
+
+  function tokenURI(
+    address _lockAddress,
+    address _operator,
+    uint256 _tokenId,
+    uint _expirationTimestamp
+  ) external view returns(string memory) {
+
+    string memory tokenId;
+    string memory lockAddress = _lockAddress.address2Str();
+    string memory operator = _operator.address2Str();
+    string memory expirationTimestamp = _expirationTimestamp.uint2Str();
+
+    if(_tokenId != 0) {
+      tokenId = _tokenId.uint2Str();
+    } else {
+      tokenId = '';
+    }
+
+    return string(
+      abi.encodePacked(
+        baseURI,
+        lockAddress,
+        '/',
+        operator,
+        '/',
+        expirationTimestamp,
+        '/',
+        tokenId
+      )
+    );
   }
 }

--- a/smart-contracts/contracts/test-artifacts/TestEventHooks.sol
+++ b/smart-contracts/contracts/test-artifacts/TestEventHooks.sol
@@ -90,6 +90,7 @@ contract TestEventHooks is ILockKeyPurchaseHook, ILockKeyCancelHook, ILockTokenU
   function tokenURI(
     address _lockAddress,
     address _operator,
+    address _owner,
     uint256 _tokenId,
     uint _expirationTimestamp
   ) external view returns(string memory) {
@@ -97,6 +98,7 @@ contract TestEventHooks is ILockKeyPurchaseHook, ILockKeyCancelHook, ILockTokenU
     string memory tokenId;
     string memory lockAddress = _lockAddress.address2Str();
     string memory operator = _operator.address2Str();
+    string memory owner = _owner.address2Str();
     string memory expirationTimestamp = _expirationTimestamp.uint2Str();
 
     if(_tokenId != 0) {
@@ -108,9 +110,13 @@ contract TestEventHooks is ILockKeyPurchaseHook, ILockKeyCancelHook, ILockTokenU
     return string(
       abi.encodePacked(
         baseURI,
-        lockAddress,
-        '/',
-        operator,
+        abi.encodePacked(
+          lockAddress,
+          '/',
+          owner,
+          '/',
+          operator
+        ),
         '/',
         expirationTimestamp,
         '/',

--- a/smart-contracts/contracts/test-artifacts/TestEventHooks.sol
+++ b/smart-contracts/contracts/test-artifacts/TestEventHooks.sol
@@ -31,13 +31,6 @@ contract TestEventHooks is ILockKeyPurchaseHook, ILockKeyCancelHook, ILockTokenU
     address to,
     uint refund
   );
-  event OnTokenURI(
-    address lockAddress,
-    address operator,
-    uint256 tokenId,
-    uint expirationTimestamp,
-    string tokenURI
-  );
 
   uint public discount;
   bool public isPurchaseSupported;

--- a/smart-contracts/test/Lock/onKeyCancelHook.js
+++ b/smart-contracts/test/Lock/onKeyCancelHook.js
@@ -21,7 +21,11 @@ contract('Lock / onKeyCancelHook', (accounts) => {
     locks = await deployLocks(unlock, accounts[0])
     lock = locks.FIRST
     testEventHooks = await TestEventHooks.new()
-    await lock.setEventHooks(constants.ZERO_ADDRESS, testEventHooks.address)
+    await lock.setEventHooks(
+      constants.ZERO_ADDRESS,
+      testEventHooks.address,
+      constants.ZERO_ADDRESS
+    )
     keyPrice = await lock.keyPrice()
     await lock.purchase(0, to, constants.ZERO_ADDRESS, [], {
       from,
@@ -42,7 +46,11 @@ contract('Lock / onKeyCancelHook', (accounts) => {
 
   it('cannot set the hook to a non-contract address', async () => {
     await reverts(
-      lock.setEventHooks(constants.ZERO_ADDRESS, accounts[1]),
+      lock.setEventHooks(
+        constants.ZERO_ADDRESS,
+        accounts[1],
+        constants.ZERO_ADDRESS
+      ),
       'INVALID_ON_KEY_CANCEL_HOOK'
     )
   })

--- a/smart-contracts/test/Lock/onKeyPurchaseHook.js
+++ b/smart-contracts/test/Lock/onKeyPurchaseHook.js
@@ -23,7 +23,11 @@ contract('Lock / onKeyPurchaseHook', (accounts) => {
     locks = await deployLocks(unlock, accounts[0])
     lock = locks.FIRST
     testEventHooks = await TestEventHooks.new()
-    await lock.setEventHooks(testEventHooks.address, constants.ZERO_ADDRESS)
+    await lock.setEventHooks(
+      testEventHooks.address,
+      constants.ZERO_ADDRESS,
+      constants.ZERO_ADDRESS
+    )
     keyPrice = new BigNumber(await lock.keyPrice())
   })
 
@@ -69,7 +73,11 @@ contract('Lock / onKeyPurchaseHook', (accounts) => {
 
     it('cannot set the hook to a non-contract address', async () => {
       await reverts(
-        lock.setEventHooks(accounts[1], constants.ZERO_ADDRESS),
+        lock.setEventHooks(
+          accounts[1],
+          constants.ZERO_ADDRESS,
+          constants.ZERO_ADDRESS
+        ),
         'INVALID_ON_KEY_SOLD_HOOK'
       )
     })

--- a/smart-contracts/test/Lock/onTokenURIHook.js
+++ b/smart-contracts/test/Lock/onTokenURIHook.js
@@ -1,0 +1,54 @@
+const { constants } = require('hardlydifficult-ethereum-contracts')
+const { reverts } = require('truffle-assertions')
+const deployLocks = require('../helpers/deployLocks')
+
+const unlockContract = artifacts.require('Unlock.sol')
+const TestEventHooks = artifacts.require('TestEventHooks.sol')
+const getProxy = require('../helpers/proxy')
+
+let lock
+let locks
+let unlock
+let testEventHooks
+
+contract('Lock / onKeyCancelHook', (accounts) => {
+  const from = accounts[1]
+  const to = accounts[2]
+  let tokenId
+
+  before(async () => {
+    unlock = await getProxy(unlockContract)
+    locks = await deployLocks(unlock, accounts[0])
+    lock = locks.FIRST
+    testEventHooks = await TestEventHooks.new()
+    await lock.setEventHooks(
+      constants.ZERO_ADDRESS,
+      constants.ZERO_ADDRESS,
+      testEventHooks.address
+    )
+    const keyPrice = await lock.keyPrice()
+    await lock.purchase(0, to, constants.ZERO_ADDRESS, [], {
+      from,
+      value: keyPrice,
+    })
+    tokenId = await lock.getTokenIdFor.call(to)
+  })
+
+  it('key cancels should log the hook event', async () => {
+    const baseTokenURI = 'https://unlock-uri-hook.test/'
+    const expirationTimestamp = await lock.keyExpirationTimestampFor(to)
+    const tokenURI = `${baseTokenURI}${lock.address.toLowerCase()}/${accounts[3].toLowerCase()}/${expirationTimestamp}/${tokenId}`
+    assert.equal(await lock.tokenURI(tokenId, { from: accounts[3] }), tokenURI)
+  })
+
+  it('cannot set the hook to a non-contract address', async () => {
+    await reverts(
+      lock.setEventHooks(
+        constants.ZERO_ADDRESS,
+        constants.ZERO_ADDRESS,
+        accounts[3]
+      ),
+      'INVALID_ON_TOKEN_URI_HOOK'
+    )
+  })
+})

--- a/smart-contracts/test/Lock/onTokenURIHook.js
+++ b/smart-contracts/test/Lock/onTokenURIHook.js
@@ -37,7 +37,15 @@ contract('Lock / onTokenURIHook', (accounts) => {
   it('tokenURI should returns a custom value', async () => {
     const baseTokenURI = 'https://unlock-uri-hook.test/'
     const expirationTimestamp = await lock.keyExpirationTimestampFor(to)
-    const tokenURI = `${baseTokenURI}${lock.address.toLowerCase()}/${accounts[3].toLowerCase()}/${expirationTimestamp}/${tokenId}`
+    const params = [
+      lock.address.toLowerCase(), // lockAddress
+      to.toLowerCase(), // owner
+      accounts[3].toLowerCase(), // operator
+      expirationTimestamp, // expirationTimestamp
+      tokenId, // tokenId
+    ]
+
+    const tokenURI = `${baseTokenURI}${params.join('/')}`
     assert.equal(await lock.tokenURI(tokenId, { from: accounts[3] }), tokenURI)
   })
 

--- a/smart-contracts/test/Lock/onTokenURIHook.js
+++ b/smart-contracts/test/Lock/onTokenURIHook.js
@@ -11,7 +11,7 @@ let locks
 let unlock
 let testEventHooks
 
-contract('Lock / onKeyCancelHook', (accounts) => {
+contract('Lock / onTokenURIHook', (accounts) => {
   const from = accounts[1]
   const to = accounts[2]
   let tokenId
@@ -34,7 +34,7 @@ contract('Lock / onKeyCancelHook', (accounts) => {
     tokenId = await lock.getTokenIdFor.call(to)
   })
 
-  it('key cancels should log the hook event', async () => {
+  it('tokenURI should returns a custom value', async () => {
     const baseTokenURI = 'https://unlock-uri-hook.test/'
     const expirationTimestamp = await lock.keyExpirationTimestampFor(to)
     const tokenURI = `${baseTokenURI}${lock.address.toLowerCase()}/${accounts[3].toLowerCase()}/${expirationTimestamp}/${tokenId}`


### PR DESCRIPTION
# Description

Add support for a `onTokenURI` hook that allow a 3rd party contract to return a custom `tokenURI` based on lock address, key expiration and user/caller address.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #7786
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

