### PR TITLE
link doesnt point to the right place

### DIFF
--- a/unlock-app/src/components/content/DashboardContent.js
+++ b/unlock-app/src/components/content/DashboardContent.js
@@ -103,7 +103,7 @@ export const DashboardContent = () => {
               deploying your lock to any of{' '}
               <a
                 target="_blank"
-                href="https://docs.unlock-protocol.com/governance/frequently-asked-questions#what-networks-are-supported"
+                href="https://docs.unlock-protocol.com/developers/smart-contracts#production-networks"
                 rel="noreferrer"
               >
                 Unlock&apos;s supported networks


### PR DESCRIPTION
# Description
current link points to FAQ item that was removed. pointing to supported networks docs page.

![image](https://user-images.githubusercontent.com/1377389/144961408-f43492ac-e1c6-4e0c-8de6-35591df9ae29.png)
