### PR TITLE
Lock: add method to update expiration duration

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -85,6 +85,15 @@ interface IPublicLock
   function updateKeyPricing( uint _keyPrice, address _tokenAddress ) external;
 
   /**
+   * A function to change the default duration of each key in the lock
+   * @notice keys previously bought are unaffected by this change (i.e.
+   * existing keys timestamps are not recalculated/updated)
+   * @param _newExpirationDuration the new amount of time for each key purchased 
+   * or zero (0) for a non-expiring key
+   */
+  function setExpirationDuration(uint _newExpirationDuration) external;
+
+  /**
    * A function which lets a Lock manager update the beneficiary account,
    * which receives funds on withdrawal.
    * @dev Throws if called by other than a Lock manager or beneficiary
@@ -118,7 +127,7 @@ interface IPublicLock
   function keyExpirationTimestampFor(
     address _keyOwner
   ) external view returns (uint timestamp);
-
+  
   /**
    * Public function which returns the total number of unique owners (both expired
    * and valid).  This may be larger than totalSupply.

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -430,4 +430,15 @@ contract MixinKeys is
      require (_maxNumberOfKeys > _totalSupply, "maxNumberOfKeys is smaller than existing supply");
      maxNumberOfKeys = _maxNumberOfKeys;
    }
+
+   /**
+   * A function to change the default duration of each key in the lock
+   * @notice keys previously bought are unaffected by this change (i.e.
+   * existing keys timestamps are not recalculated/updated)
+   * @param _newExpirationDuration the new amount of time for each key purchased 
+   * or zero (0) for a non-expiring key
+   */
+   function setExpirationDuration(uint _newExpirationDuration) external onlyLockManager {
+     expirationDuration = _newExpirationDuration;
+   }
 }

--- a/smart-contracts/test/Lock/setExpirationDuration.js
+++ b/smart-contracts/test/Lock/setExpirationDuration.js
@@ -1,0 +1,104 @@
+const { ethers } = require('hardhat')
+const { getProxyAddress } = require('../../helpers/deployments')
+const createLockHash = require('../helpers/createLockCalldata')
+
+const keyPrice = ethers.utils.parseEther('0.01')
+
+contract('Lock / setExpirationDuration', () => {
+  let unlock
+  let lock
+
+  beforeEach(async () => {
+    const chainId = 31337
+    const unlockAddress = getProxyAddress(chainId, 'Unlock')
+
+    // parse unlock
+    const [from] = await ethers.getSigners()
+    const Unlock = await ethers.getContractFactory('Unlock')
+    unlock = Unlock.attach(unlockAddress)
+
+    // create a new lock
+    const tokenAddress = web3.utils.padLeft(0, 40)
+    const args = [60 * 30, tokenAddress, keyPrice, 10, 'Test lock']
+
+    const calldata = await createLockHash({ args, from: from.address })
+    const tx = await unlock.createLock(calldata)
+    const { events } = await tx.wait()
+    const {
+      args: { newLockAddress },
+    } = events.find(({ event }) => event === 'NewLock')
+
+    const PublicLock = await ethers.getContractFactory('PublicLock')
+    lock = PublicLock.attach(newLockAddress)
+  })
+
+  it('update the expiration duration of an existing lock', async () => {
+    expect((await lock.expirationDuration()).toString()).to.be.equal('1800')
+
+    await lock.setExpirationDuration(1000)
+    expect((await lock.expirationDuration()).toString()).to.be.equal('1000')
+  })
+
+  it('affects newly purchased keys', async () => {
+    const [, , buyer, buyer2] = await ethers.getSigners()
+    const tx = await lock
+      .connect(buyer)
+      .purchase(
+        keyPrice.toString(),
+        buyer.address,
+        web3.utils.padLeft(0, 40),
+        [],
+        {
+          value: keyPrice.toString(),
+        }
+      )
+    await tx.wait()
+    const receipt = await tx.wait()
+    const transfer1Block = await ethers.provider.getBlock(receipt.blockNumber)
+    expect(
+      (await lock.keyExpirationTimestampFor(buyer.address)).toNumber()
+    ).to.be.equals(transfer1Block.timestamp + 1800)
+
+    // update duration
+    await lock.setExpirationDuration(5000)
+    const tx2 = await lock
+      .connect(buyer2)
+      .purchase(
+        keyPrice.toString(),
+        buyer2.address,
+        web3.utils.padLeft(0, 40),
+        [],
+        {
+          value: keyPrice.toString(),
+        }
+      )
+    const receipt2 = await tx2.wait()
+    const transfer2Block = await ethers.provider.getBlock(receipt2.blockNumber)
+    expect(
+      (await lock.keyExpirationTimestampFor(buyer2.address)).toNumber()
+    ).to.be.equals(transfer2Block.timestamp + 5000)
+    expect((await lock.expirationDuration()).toString()).to.be.equal('5000')
+  })
+
+  it('does not affect the timestamps of existing keys', async () => {
+    const [, , buyer] = await ethers.getSigners()
+    const tx = await lock
+      .connect(buyer)
+      .purchase(
+        keyPrice.toString(),
+        buyer.address,
+        web3.utils.padLeft(0, 40),
+        [],
+        {
+          value: keyPrice.toString(),
+        }
+      )
+    await tx.wait()
+
+    const tsBefore = await lock.keyExpirationTimestampFor(buyer.address)
+    await lock.setExpirationDuration(1000)
+    const tsAfter = await lock.keyExpirationTimestampFor(buyer.address)
+
+    expect(tsBefore.toString()).to.be.equal(tsAfter.toString())
+  })
+})


### PR DESCRIPTION
# Description

As discussed in #7927 , this adds a simple setter method to update  `expirationDuration` of an existing lock. Note that the method does NOT update the existing keys - just the ones purchased after the setting update.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

