### PR TITLE
Fix mistake in time machine test

### DIFF
--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -26,7 +26,7 @@ contract('Lock / timeMachine', (accounts) => {
     await unlock.setLockTemplate((await TimeMachineMock.new()).address)
 
     const args = [
-      expirationDuration,
+      expirationDuration.toNumber(),
       web3.utils.padLeft(0, 40), // beneficiary
       web3.utils.toWei('0.01', 'ether'),
       11,
@@ -90,8 +90,8 @@ contract('Lock / timeMachine', (accounts) => {
       // The resulting timestamp should be larger than Date.now() - tooMuchTime + expirationDuration
       // It should in fact be Date.now() + expirationDuration (but there is maybe a few seconds difference because of latency)
       assert(
-        timestampAfter.lte(
-          new BigNumber(Date.now() / 1000)
+        timestampAfter.gte(
+          new BigNumber(Math.floor(Date.now() / 1000))
             .minus(tooMuchTime)
             .plus(expirationDuration)
         )

--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -80,7 +80,7 @@ contract('Lock / timeMachine', (accounts) => {
       timestampAfter = new BigNumber(
         await lock.keyExpirationTimestampFor.call(keyOwner)
       )
-      assert(timestampAfter.lte(expirationDuration.plus(Date.now())))
+      assert(timestampAfter.lte(expirationDuration.plus(Date.now() / 1000)))
     })
 
     it('should emit the ExpirationChanged event', async () => {


### PR DESCRIPTION
# Description

As discovered in #7927 , the current test for `_timeMachine` had a small mistake.

https://github.com/unlock-protocol/unlock/blob/b3588227d5cdd2968158044de2ee54ad6cc7851a/smart-contracts/test/Lock/timeMachine.js#L76-L84

the `timestampAfter` value is derived from Solidity's `block.timestamp` which is expressed [in seconds](https://docs.soliditylang.org/en/latest/units-and-global-variables.html?highlight=block#block-and-transaction-properties) while js `Date.now()` is [in ms](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Date/now). If we correct ` Date.now() / 1000` then the test fails (as demonstrated here).

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

