### PR TITLE
fix: removed the signing message by default in the checkout url

### DIFF
--- a/unlock-app/src/components/creator/lock/AppStore.js
+++ b/unlock-app/src/components/creator/lock/AppStore.js
@@ -112,7 +112,6 @@ const AppStore = ({ lock }) => {
           network: lock.network,
         },
       },
-      messageToSign: 'Hello world',
       pessimistic: true,
       persistentCheckout: true,
       icon: `${config.services.storage.host}/lock/${lock.address}/icon`,


### PR DESCRIPTION
# Description

By default, the checkout URL should not include a message to sign.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet

Bug fix tat removes an unneeded step when building checkout urls.
