### PR TITLE
Replace use of require by existing modifier

### DIFF
--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -194,8 +194,8 @@ contract MixinLockCore is
   function updateBeneficiary(
     address payable _beneficiary
   ) external
+    onlyLockManagerOrBeneficiary()
   {
-    require(msg.sender == beneficiary || isLockManager(msg.sender), 'ONLY_BENEFICIARY_OR_LOCKMANAGER');
     require(_beneficiary != address(0), 'INVALID_ADDRESS');
     beneficiary = _beneficiary;
   }

--- a/smart-contracts/test/Lock/permissions/beneficiary.js
+++ b/smart-contracts/test/Lock/permissions/beneficiary.js
@@ -46,7 +46,7 @@ contract('Permissions / Beneficiary', (accounts) => {
     it('should not allow anyone else to update the beneficiary', async () => {
       await reverts(
         lock.updateBeneficiary(accounts[5], { from: notAuthorized }),
-        'ONLY_BENEFICIARY_OR_LOCKMANAGER'
+        'ONLY_LOCK_MANAGER_OR_BENEFICIARY'
       )
     })
   })


### PR DESCRIPTION
# Description

 require statement in `updateBeneficiary`  can be replaced by modifier `onlyLockManagerOrBeneficiary`

fix code-423n4/2021-11-unlock-findings#48

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

