### PR TITLE
Remove fallback function from PublicLock 

### DIFF
--- a/smart-contracts/contracts/PublicLock.sol
+++ b/smart-contracts/contracts/PublicLock.sol
@@ -67,10 +67,6 @@ contract PublicLock is
    */
   receive() external payable {}
   
-  
-  // TODO: what should be done here?
-  fallback() external payable {}
-
   /**
    Overrides
   */

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -29,7 +29,6 @@ interface IPublicLock
    * @dev This is okay to use even if the lock is priced in ERC-20 tokens
    */
   // receive() external payable;
-  // fallback() external payable;
 
   // roles
   function DEFAULT_ADMIN_ROLE() external pure returns (bytes32);


### PR DESCRIPTION
# Description

the current `fallback()` default function in PublicLock contract is not useful and can be confusing. Better to have none so the tx reverts if the function does not exist

code-423n4/2021-11-unlock-findings#94

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

