### PR TITLE
Prevent sharing key with self

### DIFF
--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -56,6 +56,8 @@ contract MixinTransfer is
     require(_to != address(0), 'INVALID_ADDRESS');
     address keyOwner = _ownerOf[_tokenId];
     require(getHasValidKey(keyOwner), 'KEY_NOT_VALID');
+    require(keyOwner != _to, 'TRANSFER_TO_SELF');
+
     Key storage fromKey = keyByOwner[keyOwner];
     Key storage toKey = keyByOwner[_to];
     uint idTo = toKey.tokenId;

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -91,6 +91,20 @@ contract('Lock / shareKey', (accounts) => {
           'INVALID_ADDRESS'
         )
       })
+
+      it('should abort if the key owner', async () => {
+        await reverts(
+          lock.shareKey(
+            keyOwners[0],
+            await lock.getTokenIdFor.call(keyOwners[0]),
+            1000,
+            {
+              from: keyOwners[0],
+            }
+          ),
+          'TRANSFER_TO_SELF'
+        )
+      })
     })
 
     it('should fail if trying to share a key with a contract which does not implement onERC721Received', async () => {


### PR DESCRIPTION
# Description

Prevent address from transferring a key to itself using `shareKey`

fix code-423n4/2021-11-unlock-findings#119

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

