### PR TITLE
BREAKING(locksmith/config): Detect Heroku from an explicit ON_HEROKU …

### DIFF
--- a/locksmith/config/config.js
+++ b/locksmith/config/config.js
@@ -13,14 +13,7 @@ const config = {
   logging: false,
 }
 
-// Heroku sets DATABASE_URL
-if (process.env.DATABASE_URL) {
-  const databaseConfigUrl = new urlParser.URL(process.env.DATABASE_URL)
-  config.database.username = databaseConfigUrl.username
-  config.database.password = databaseConfigUrl.password
-  config.database.host = databaseConfigUrl.hostname
-  config.database.database = databaseConfigUrl.pathname.substring(1)
-
+if (Boolean(process.env.ON_HEROKU)) {
   // Heroku needs this:
   config.database.ssl = true
   config.database.dialectOptions = {
@@ -29,6 +22,15 @@ if (process.env.DATABASE_URL) {
       rejectUnauthorized: false,
     },
   }
+}
+
+// Database URL
+if (process.env.DATABASE_URL) {
+  const databaseConfigUrl = new urlParser.URL(process.env.DATABASE_URL)
+  config.database.username = databaseConfigUrl.username
+  config.database.password = databaseConfigUrl.password
+  config.database.host = databaseConfigUrl.hostname
+  config.database.database = databaseConfigUrl.pathname.substring(1)
 } else {
   config.database.username = process.env.DB_USERNAME
   config.database.password = process.env.DB_PASSWORD


### PR DESCRIPTION


Thank you for your contribution to Unlock Protocol!

# Description

This adds an explicit ON_HEROKU environment variable check for managing some parts of the database config so a local user can use both a DATABASE_URL and individual DATABASE_X options.

This will require adding a `ON_HEROKU=true` using heroku set config to enable though in production so feel free to close if not worth it.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

