### PR TITLE
Gas refund use absolute value instead of percentage

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -225,14 +225,16 @@ interface IPublicLock
   ) external payable;
 
   /**
-  * @dev Set a percentage of the key price to be refunded to the sender on purchase
+  * @param _gasRefundValue price in wei or token in smallest price unit
+  * @dev Set the value to be refunded to the sender on purchase
   */
-  function setGasRefundBasisPoints(uint128 _basisPoints) external;
+  function setGasRefundValue(uint256 _gasRefundValue) external;
   
   /**
-  * @dev Returns percentage be refunded to the sender on purchase
+  * _gasRefundValue price in wei or token in smallest price unit
+  * @dev Returns the value/rpice to be refunded to the sender on purchase
   */
-  function gasRefundBasisPoints() external view returns (uint128 basisPoints);
+  function gasRefundValue() external view returns (uint256 _gasRefundValue);
 
   /**
    * @notice returns the minimum price paid for a purchase with these params.

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -24,22 +24,22 @@ contract MixinPurchase is
   
   event UnlockCallFailed(address indexed lockAddress, address unlockAddress);
 
-  // default to 0%  
-  uint128 private _gasRefundBasisPoints = 0; 
+  // default to 0 
+  uint256 private _gasRefundValue = 0; 
 
   /**
-  * @dev Set a percentage as basis point (10000th) of the key price to be refunded to the sender on purchase
+  * @dev Set the value/price to be refunded to the sender on purchase
   */
 
-  function setGasRefundBasisPoints(uint128 _basisPoints) external onlyLockManager {
-    _gasRefundBasisPoints = _basisPoints;
+  function setGasRefundValue(uint256 _refundValue) external onlyLockManager {
+    _gasRefundValue = _refundValue;
   }
   
   /**
-  * @dev Returns percentage as basis point (10000th) to be refunded to the sender on purchase
+  * @dev Returns value/price to be refunded to the sender on purchase
   */
-  function gasRefundBasisPoints() external view returns (uint128 basisPoints) {
-    return _gasRefundBasisPoints;
+  function gasRefundValue() external view returns (uint256 _refundValue) {
+    return _gasRefundValue;
   }
 
   /**
@@ -148,16 +148,15 @@ contract MixinPurchase is
     }
 
     // refund gas
-    if (_gasRefundBasisPoints != 0) {
-      uint toRefund = _gasRefundBasisPoints * pricePaid / BASIS_POINTS_DEN;
+    if (_gasRefundValue != 0) {
       if(tokenAddress != address(0)) {
         IERC20Upgradeable token = IERC20Upgradeable(tokenAddress);
-        token.transferFrom(address(this), msg.sender, toRefund);
+        token.transferFrom(address(this), msg.sender, _gasRefundValue);
       } else {
-        (bool success, ) = msg.sender.call{value: toRefund}("");
+        (bool success, ) = msg.sender.call{value: _gasRefundValue}("");
         require(success, "Refund failed.");
       }
-      emit GasRefunded(msg.sender, toRefund, tokenAddress);
+      emit GasRefunded(msg.sender, _gasRefundValue, tokenAddress);
     }
   }
 

--- a/smart-contracts/test/Lock/purchaseGasRefund.js
+++ b/smart-contracts/test/Lock/purchaseGasRefund.js
@@ -8,8 +8,8 @@ const unlockContract = artifacts.require('Unlock.sol')
 
 let unlock
 let locks
-const keyPrice = web3.utils.toWei('0.01', 'ether')
-const gasRefundAmount = new BN(keyPrice * 0.25)
+const keyPrice = web3.utils.toWei('0.05', 'ether')
+const gasRefundAmount = new BN(web3.utils.toWei('0.01', 'ether'))
 
 // test for ERC20 and ETH
 const scenarios = [true, false]
@@ -49,15 +49,15 @@ contract('Lock / GasRefund', (accounts) => {
         )
       })
 
-      describe('gas refund basis point', () => {
+      describe('gas refund value', () => {
         it('get set properly', async () => {
-          await lock.setGasRefundBasisPoints(2500)
-          assert.equal(await lock.gasRefundBasisPoints(), 2500)
+          await lock.setGasRefundValue(gasRefundAmount)
+          assert.equal((await lock.gasRefundValue()).eq(gasRefundAmount), true)
         })
 
         it('can not be set if caller is not lock manager', async () => {
           await truffleAssert.fails(
-            lock.setGasRefundBasisPoints(2500, {
+            lock.setGasRefundValue(gasRefundAmount, {
               from: accounts[3],
             }),
             'revert',
@@ -65,10 +65,10 @@ contract('Lock / GasRefund', (accounts) => {
           )
         })
 
-        it('can set by lock manager', async () => {
+        it('can be set by lock manager', async () => {
           await lock.addLockManager(accounts[5], { from: accounts[0] })
-          await lock.setGasRefundBasisPoints(2500, { from: accounts[5] })
-          assert.equal(await lock.gasRefundBasisPoints(), 2500)
+          await lock.setGasRefundValue(gasRefundAmount, { from: accounts[5] })
+          assert.equal((await lock.gasRefundValue()).eq(gasRefundAmount), true)
         })
       })
 
@@ -76,7 +76,7 @@ contract('Lock / GasRefund', (accounts) => {
         // test with both ETH and ERC20
         beforeEach(async () => {
           // set gasRefund
-          await lock.setGasRefundBasisPoints(2500)
+          await lock.setGasRefundValue(gasRefundAmount)
 
           userBalanceBefore = isErc20
             ? await testToken.balanceOf(accounts[2])
@@ -104,7 +104,7 @@ contract('Lock / GasRefund', (accounts) => {
           } = evt.args
 
           assert.equal(receiver, accounts[2])
-          assert.equal(refundedAmount.toNumber(), keyPrice * 0.25)
+          assert.equal(refundedAmount.eq(gasRefundAmount), true)
           assert.equal(refundedTokenAddress, tokenAddress)
         })
 
@@ -120,12 +120,13 @@ contract('Lock / GasRefund', (accounts) => {
           const gasPrice = new BN(_gasPrice)
           const gas = gasPrice.mul(gasUsed)
 
+          const refund = new BN(keyPrice).sub(gasRefundAmount)
           const expected = isErc20
-            ? // buy a key, get a .25 refund
-              userBalanceBefore.sub(new BN(keyPrice * 0.75))
+            ? // buy a key, get a refund
+              userBalanceBefore.sub(refund)
             : userBalanceBefore
-                // buy a key, get a .25 refund
-                .sub(new BN(keyPrice * 0.75))
+                // buy a key, get a refund
+                .sub(refund)
                 .sub(gas) // pay for the gas
 
           assert.equal(userBalanceAfter.eq(expected), true)


### PR DESCRIPTION
# Description

Use absolute value for gas refund on purchase instead of percentage - preventing free locks from always refunding zero

# Issues

Fixes #7774 (again)
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

