### PR TITLE
Prevent numberOfOwners from counting twice a single owner

### DIFF
--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import './MixinLockCore.sol';
 
-
 /**
  * @title Mixin for managing `Key` data, as well as the * Approval related functions needed to meet the ERC721
  * standard.
@@ -31,7 +30,6 @@ contract MixinKeys is
   );
 
   event KeyManagerChanged(uint indexed _tokenId, address indexed _newManager);
-
 
   // Keys
   // Each owner can have at most exactly one key
@@ -68,7 +66,7 @@ contract MixinKeys is
   // which is reset on transfer.
   mapping (address => mapping (address => bool)) private managerToOperatorApproved;
 
-    // Ensure that the caller is the keyManager of the key
+  // Ensure that the caller is the keyManager of the key
   // or that the caller has been approved
   // for ownership of that key
   modifier onlyKeyManagerOrApproved(
@@ -339,21 +337,16 @@ contract MixinKeys is
     uint _tokenId
   ) internal
   {
-    if (ownerOf(_tokenId) != _keyOwner) {
-      // make sure we don't add to owners list if a key was previously owned
-      bool isAlreadyRecorded = false;
-      for (uint256 i = 0; i < owners.length; i++) {
-        if(_keyOwner == owners[i]) {
-          isAlreadyRecorded = true;
-          break; 
-        }
-      }
-      if(isAlreadyRecorded == false) {
-        owners.push(_keyOwner);
-      }
-      // We register the owner of the tokenID
-      _ownerOf[_tokenId] = _keyOwner;
+
+    // check expiration ts should be set to know if owner had previously registered a key 
+    Key memory key = keyByOwner[_keyOwner];
+    if(key.expirationTimestamp == 0 ) {
+      owners.push(_keyOwner);
     }
+
+    // We register the owner of the tokenID
+    _ownerOf[_tokenId] = _keyOwner;
+
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -340,8 +340,16 @@ contract MixinKeys is
   ) internal
   {
     if (ownerOf(_tokenId) != _keyOwner) {
-      // TODO: this may include duplicate entries
-      owners.push(_keyOwner);
+      // make sure we don't add to owners list if a key was previously owned
+      bool isAlreadyRecorded = false;
+      for (uint256 i = 0; i < owners.length; i++) {
+        if(_keyOwner == owners[i]) {
+          isAlreadyRecorded = true;
+        }
+      }
+      if(isAlreadyRecorded == false) {
+        owners.push(_keyOwner);
+      }
       // We register the owner of the tokenID
       _ownerOf[_tokenId] = _keyOwner;
     }

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -345,6 +345,7 @@ contract MixinKeys is
       for (uint256 i = 0; i < owners.length; i++) {
         if(_keyOwner == owners[i]) {
           isAlreadyRecorded = true;
+          break; 
         }
       }
       if(isAlreadyRecorded == false) {

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -21,19 +21,21 @@ contract('Lock / owners', (accounts) => {
 
   before(() => {
     // Purchase keys!
-    return Promise.all([1,2,3,4].map( d =>
-      lock.purchase(
-        0,
-        accounts[d],
-        web3.utils.padLeft(0, 40),
-        web3.utils.padLeft(0, 40),
-        [],
-        {
-          value: lock.params.keyPrice.toFixed(),
-          from: accounts[0],
-        }
+    return Promise.all(
+      [1, 2, 3, 4].map((d) =>
+        lock.purchase(
+          0,
+          accounts[d],
+          web3.utils.padLeft(0, 40),
+          web3.utils.padLeft(0, 40),
+          [],
+          {
+            value: lock.params.keyPrice.toFixed(),
+            from: accounts[0],
+          }
+        )
       )
-    ))
+    )
   })
 
   it('should have the right number of keys', async () => {
@@ -48,7 +50,7 @@ contract('Lock / owners', (accounts) => {
 
   it('should allow for access to an individual key owner', async () => {
     const keyIds = [0, 1, 2, 3]
-    const owners = await Promise.all(keyIds.map(d => lock.owners.call(d)))
+    const owners = await Promise.all(keyIds.map((d) => lock.owners.call(d)))
     assert.deepEqual(owners.sort(), accounts.slice(1, 5).sort())
   })
 
@@ -113,9 +115,8 @@ contract('Lock / owners', (accounts) => {
   })
 
   // test case proofing https://github.com/code-423n4/2021-11-unlock-findings/issues/120
-  describe.only('after a transfer to a existing owner, buying a key again for someone who already owns it', () => {
+  describe('after a transfer to a existing owner, buying a key again for someone who already owns it', () => {
     it('should preserve the right number of owners', async () => {
-
       // initial state
       const numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
       const prevKeyId = await lock.getTokenIdFor.call(accounts[4])
@@ -130,7 +131,7 @@ contract('Lock / owners', (accounts) => {
       assert.equal((await lock.getTokenIdFor.call(accounts[4])).toString(), '0')
 
       // someone buys a key again for the previous owner
-      const tx = await lock.purchase(
+      await lock.purchase(
         0,
         accounts[4],
         web3.utils.padLeft(0, 40),
@@ -142,7 +143,7 @@ contract('Lock / owners', (accounts) => {
         }
       )
       assert.equal((await lock.getTokenIdFor.call(accounts[4])).toNumber(), 5)
-      
+
       // number of owners should be left unchanged
       const _numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
       assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed())

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -21,10 +21,10 @@ contract('Lock / owners', (accounts) => {
 
   before(() => {
     // Purchase keys!
-    return Promise.all([
+    return Promise.all([1,2,3,4].map( d =>
       lock.purchase(
         0,
-        accounts[1],
+        accounts[d],
         web3.utils.padLeft(0, 40),
         web3.utils.padLeft(0, 40),
         [],
@@ -32,41 +32,8 @@ contract('Lock / owners', (accounts) => {
           value: lock.params.keyPrice.toFixed(),
           from: accounts[0],
         }
-      ),
-      lock.purchase(
-        0,
-        accounts[2],
-        web3.utils.padLeft(0, 40),
-        web3.utils.padLeft(0, 40),
-        [],
-        {
-          value: lock.params.keyPrice.toFixed(),
-          from: accounts[0],
-        }
-      ),
-      lock.purchase(
-        0,
-        accounts[3],
-        web3.utils.padLeft(0, 40),
-        web3.utils.padLeft(0, 40),
-        [],
-        {
-          value: lock.params.keyPrice.toFixed(),
-          from: accounts[0],
-        }
-      ),
-      lock.purchase(
-        0,
-        accounts[4],
-        web3.utils.padLeft(0, 40),
-        web3.utils.padLeft(0, 40),
-        [],
-        {
-          value: lock.params.keyPrice.toFixed(),
-          from: accounts[0],
-        }
-      ),
-    ])
+      )
+    ))
   })
 
   it('should have the right number of keys', async () => {
@@ -80,13 +47,8 @@ contract('Lock / owners', (accounts) => {
   })
 
   it('should allow for access to an individual key owner', async () => {
-    const owners = await Promise.all([
-      lock.owners.call(0),
-      lock.owners.call(1),
-      lock.owners.call(2),
-      lock.owners.call(3),
-    ])
-
+    const keyIds = [0, 1, 2, 3]
+    const owners = await Promise.all(keyIds.map(d => lock.owners.call(d)))
     assert.deepEqual(owners.sort(), accounts.slice(1, 5).sort())
   })
 
@@ -103,7 +65,7 @@ contract('Lock / owners', (accounts) => {
     before(async () => {
       numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
       let ID = await lock.getTokenIdFor.call(accounts[1])
-      await lock.transferFrom(accounts[1], accounts[5], ID, {
+      await lock.transferFrom(accounts[1], accounts[3], ID, {
         from: accounts[1],
       })
     })
@@ -120,7 +82,7 @@ contract('Lock / owners', (accounts) => {
 
     it('should fail if I transfer from the same account again', async () => {
       await reverts(
-        lock.transferFrom(accounts[1], accounts[5], accounts[1], {
+        lock.transferFrom(accounts[1], accounts[3], accounts[1], {
           from: accounts[1],
         }),
         'KEY_NOT_VALID'
@@ -145,6 +107,43 @@ contract('Lock / owners', (accounts) => {
     })
 
     it('should have the right number of owners', async () => {
+      const _numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
+      assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed())
+    })
+  })
+
+  // test case proofing https://github.com/code-423n4/2021-11-unlock-findings/issues/120
+  describe.only('after a transfer to a existing owner, buying a key again for someone who already owns it', () => {
+    it('should preserve the right number of owners', async () => {
+
+      // initial state
+      const numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
+      const prevKeyId = await lock.getTokenIdFor.call(accounts[4])
+
+      // add key manager
+      await lock.setKeyManagerOf(prevKeyId, accounts[9], { from: accounts[4] })
+
+      // manager transfers the key
+      await lock.transferFrom(accounts[4], accounts[3], prevKeyId, {
+        from: accounts[9],
+      })
+      assert.equal((await lock.getTokenIdFor.call(accounts[4])).toString(), '0')
+
+      // someone buys a key again for the previous owner
+      const tx = await lock.purchase(
+        0,
+        accounts[4],
+        web3.utils.padLeft(0, 40),
+        web3.utils.padLeft(0, 40),
+        [],
+        {
+          value: lock.params.keyPrice.toFixed(),
+          from: accounts[9],
+        }
+      )
+      assert.equal((await lock.getTokenIdFor.call(accounts[4])).toNumber(), 5)
+      
+      // number of owners should be left unchanged
       const _numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
       assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed())
     })

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -67,7 +67,7 @@ contract('Lock / owners', (accounts) => {
     before(async () => {
       numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
       let ID = await lock.getTokenIdFor.call(accounts[1])
-      await lock.transferFrom(accounts[1], accounts[3], ID, {
+      await lock.transferFrom(accounts[1], accounts[5], ID, {
         from: accounts[1],
       })
     })
@@ -84,7 +84,7 @@ contract('Lock / owners', (accounts) => {
 
     it('should fail if I transfer from the same account again', async () => {
       await reverts(
-        lock.transferFrom(accounts[1], accounts[3], accounts[1], {
+        lock.transferFrom(accounts[1], accounts[5], accounts[1], {
           from: accounts[1],
         }),
         'KEY_NOT_VALID'

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -127,18 +127,15 @@ contract('Lock / owners', (accounts) => {
         from: accounts[4],
       })
       assert.equal((await lock.getTokenIdFor.call(accounts[4])).toString(), '0')
-      
+
       // supply unchanged
       const totalSupplyAfter = new BigNumber(await lock.totalSupply.call())
-      assert.equal(
-        totalSupplyBefore.toFixed(), 
-        totalSupplyAfter.toFixed()
-        )
-      
+      assert.equal(totalSupplyBefore.toFixed(), totalSupplyAfter.toFixed())
+
       // number of owners is identical
       assert.equal(
-        numberOfOwners.toFixed(), 
-        (new BigNumber(await lock.numberOfOwners.call())).toFixed()
+        numberOfOwners.toFixed(),
+        new BigNumber(await lock.numberOfOwners.call()).toFixed()
       )
 
       // someone buys a key again for the previous owner


### PR DESCRIPTION
# Description

If 1) a key is transferred from an account, then 2) a new key is acquired by that same account, the account end up being counted twice as owner, making the `numberOfOwners()` inaccurate. 

Detailed description at https://github.com/code-423n4/2021-11-unlock-findings/issues/120

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes code-423n4/2021-11-unlock-findings#120
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

