### PR TITLE
Fix Unlock v10 storage layout compatibility

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -27,18 +27,18 @@ pragma solidity ^0.8.2;
  *  b. Keeping track of GNP
  */
 
-import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 import '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
 import 'hardlydifficult-eth/contracts/protocols/Uniswap/IUniswapOracle.sol';
 import './utils/UnlockOwnable.sol';
+import './utils/UnlockInitializable.sol';
 import './interfaces/IPublicLock.sol';
 import './interfaces/IMintableERC20.sol';
 
 /// @dev Must list the direct base contracts in the order from “most base-like” to “most derived”.
 /// https://solidity.readthedocs.io/en/latest/contracts.html#multiple-inheritance-and-linearization
 contract Unlock is
-  Initializable,
+  UnlockInitializable,
   UnlockOwnable
 {
 

--- a/smart-contracts/contracts/utils/UnlockContextUpgradeable.sol
+++ b/smart-contracts/contracts/utils/UnlockContextUpgradeable.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (utils/Context.sol)
+
+pragma solidity ^0.8.0;
+import "./UnlockInitializable.sol";
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract UnlockContextUpgradeable is UnlockInitializable {
+    function __Context_init() internal onlyInitializing {
+        __Context_init_unchained();
+    }
+
+    function __Context_init_unchained() internal onlyInitializing {
+    }
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+    uint256[50] private ______gap;
+}

--- a/smart-contracts/contracts/utils/UnlockInitializable.sol
+++ b/smart-contracts/contracts/utils/UnlockInitializable.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (proxy/utils/Initializable.sol)
+
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol';
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since proxied contracts do not make use of a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ *
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {ERC1967Proxy-constructor}.
+ *
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ *
+ * [CAUTION]
+ * ====
+ * Avoid leaving a contract uninitialized.
+ *
+ * An uninitialized contract can be taken over by an attacker. This applies to both a proxy and its implementation
+ * contract, which may impact the proxy. To initialize the implementation contract, you can either invoke the
+ * initializer manually, or you can include a constructor to automatically mark it as initialized when it is deployed:
+ *
+ * [.hljs-theme-light.nopadding]
+ * ```
+ * /// @custom:oz-upgrades-unsafe-allow constructor
+ * constructor() initializer {}
+ * ```
+ * ====
+ */
+abstract contract UnlockInitializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private initializing;
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier initializer() {
+        // If the contract is initializing we ignore whether initialized is set in order to support multiple
+        // inheritance patterns, but we only do this in the context of a constructor, because in other contexts the
+        // contract may have been reentered.
+        require(initializing ? _isConstructor() : !initialized, "Initializable: contract is already initialized");
+
+        bool isTopLevelCall = !initializing;
+        if (isTopLevelCall) {
+            initializing = true;
+            initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            initializing = false;
+        }
+    }
+
+    /**
+     * @dev Modifier to protect an initialization function so that it can only be invoked by functions with the
+     * {initializer} modifier, directly or indirectly.
+     */
+    modifier onlyInitializing() {
+        require(initializing, "Initializable: contract is not initializing");
+        _;
+    }
+
+    function _isConstructor() private view returns (bool) {
+        return !AddressUpgradeable.isContract(address(this));
+    }
+}

--- a/smart-contracts/contracts/utils/UnlockOwnable.sol
+++ b/smart-contracts/contracts/utils/UnlockOwnable.sol
@@ -3,8 +3,8 @@
 
 pragma solidity ^0.8.0;
 
-import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
-import '@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol';
+import './UnlockInitializable.sol';
+import './UnlockContextUpgradeable.sol';
 
 /**
  * @dev Contract module which provides a basic access control mechanism, where
@@ -19,7 +19,7 @@ import '@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol';
  * but had to be included (instead of using the one in openzeppelin/contracts-upgradeable ) 
  * because the ______gap array length was 49 instead of 50
  */
-abstract contract UnlockOwnable is Initializable, ContextUpgradeable {
+abstract contract UnlockOwnable is UnlockInitializable, UnlockContextUpgradeable {
     address private _owner;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);


### PR DESCRIPTION
# Description

When attempting an upgrade of Unlock on Rinkeby against the previous version of the following errors was thrown by the OZ upgrades lib.

```
╰─$ yarn hardhat upgrade:prepare --contract contracts/Unlock.sol --proxy 0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b --network rinkeby                                                                                   1 

Deploying new implementation contracts/Unlock.sol on rinkeby.
An unexpected error occurred:

Error: New storage layout is incompatible

@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39: Renamed `initialized` to `_initialized`

@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44: Renamed `initializing` to `_initializing`

@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31: Renamed `______gap` to `__gap`
```

The reason for this is we upgraded the OZ libs when moving to Solidity v8 ([here](https://github.com/unlock-protocol/unlock/blame/d13ae8515b10b2414995a8e4e8fb73b2ffc0a278/smart-contracts/contracts/Unlock.sol#L30)) and the variables were  renamed in the new OZ version. We were using the now deprec (`@openzeppelin/upgrades`) lib.


This PR includes a fix, which consists on checking the relevant OZ contracts directly in our repo (`ContextUpgradeable.sol` and `Initializable.sol`) and revert back the variables names so the layout is compatible again.

