### PR TITLE
add view/pure function to unlock v10 exports

### DIFF
--- a/packages/unlock-js/src/Unlock/v10/index.js
+++ b/packages/unlock-js/src/Unlock/v10/index.js
@@ -1,0 +1,20 @@
+import abis from '../../abis'
+import createUpgradeableLock from './createUpgradeableLock'
+import upgradeLock from './upgradeLock'
+import { parseGetters } from '../../parser'
+
+import v9 from '../v9'
+
+const { createLock, configureUnlock } = v9
+
+const getters = parseGetters(abis.Unlock.v10.abi)
+
+export default {
+  ...getters,
+  configureUnlock,
+  createUpgradeableLock,
+  createLock,
+  upgradeLock,
+  version: 'v9',
+  Unlock: abis.Unlock.v10,
+}

--- a/packages/unlock-js/src/__tests__/exports.test.js
+++ b/packages/unlock-js/src/__tests__/exports.test.js
@@ -1,0 +1,27 @@
+import UnlockVersions from '../Unlock'
+import { latestUnlock } from '../index'
+
+describe('UnlockVersions', () => {
+  it('contains latest version', () => {
+    expect.assertions(1)
+    const versions = Object.keys(UnlockVersions)
+    expect(versions[versions.length - 1]).toBe(latestUnlock)
+  })
+
+  describe('getters', () => {
+    expect.assertions(1)
+    const versionNumbers = Object.keys(UnlockVersions)
+      .map((d) => parseInt(d.replace('v', '')))
+      .filter((v) => v >= 10) // getters starts on Unlock v10
+
+    describe.each(versionNumbers)('Unlock v%s', (versionNumber) => {
+      it('contains pure/view functions', () => {
+        expect.assertions(3)
+        const abi = UnlockVersions[`v${versionNumber}`]
+        expect(Object.keys(abi)).toContain('owner()')
+        expect(Object.keys(abi)).toContain('proxyAdminAddress()')
+        expect(Object.keys(abi)).toContain('weth()')
+      })
+    })
+  })
+})

--- a/packages/unlock-js/src/parser.js
+++ b/packages/unlock-js/src/parser.js
@@ -1,0 +1,23 @@
+/**
+ * An helper function to return possible getters
+ * @param {string} signature the signature of the function
+ */
+export function parseGetters(abi) {
+  const getters = {}
+  const signatures = abi
+    .map((signature) => signature.split(' '))
+    .filter(
+      ([type, , arg1, arg2]) =>
+        type === 'function' && // get only functions
+        (arg1 === 'pure' ||
+          arg2 === 'pure' || // pure function
+          arg1 === 'view' ||
+          arg2 === 'view') // view function
+    )
+
+  signatures.forEach(([, signature]) => {
+    getters[signature] = async () => await this.getUnlockContract()[signature]
+  })
+
+  return getters
+}


### PR DESCRIPTION
# Description

We define a way to expose getters - i.e `view` and `pure` functions in solidity contracts - in the unlock-js interface.

This can be added once #8017 is merged


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

