### PR TITLE
skips credit card form if credit card details are already present

### DIFF
--- a/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
@@ -111,7 +111,6 @@ export const CardConfirmationCheckout = ({
   const handleHasKey = (key: any) => {
     setKeyExpiration(key.expiration)
   }
-
   if (!lock.fiatPricing?.creditCardEnabled) {
     return (
       <Wrapper>

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -100,7 +100,6 @@ export const Checkout = ({
   const [existingKeys, setHasKey] = useReducer(keysReducer, {})
   const [selectedLock, selectLock] = useState<any>(null)
   const [savedMetadata, setSavedMetadata] = useState<any>(false)
-
   // state change
   useEffect(() => {
     setState(defaultState)
@@ -124,7 +123,12 @@ export const Checkout = ({
 
       if (selectedLock) {
         if (!isUnlockAccount) {
-          setCheckoutState('crypto-checkout')
+          // Check if we have card details.
+          if (cardDetails) {
+            setCheckoutState('confirm-card-purchase')
+          } else {
+            setCheckoutState('crypto-checkout')
+          }
         } else {
           cardCheckoutOrClaim(selectedLock)
         }
@@ -211,7 +215,6 @@ export const Checkout = ({
   }
 
   const lockProps = selectedLock && paywallConfig?.locks[selectedLock.address]
-
   if (state === 'login') {
     content = (
       <LogIn


### PR DESCRIPTION
# Description

Minor fix to prevent asking the credit card details twice to users.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

