### PR TITLE
fix(locksmith/graphql): Add network in the constructor for key and lock

### DIFF
--- a/locksmith/__tests__/graphql/datasource/key.test.ts
+++ b/locksmith/__tests__/graphql/datasource/key.test.ts
@@ -1,0 +1,38 @@
+import { Key } from '../../../src/graphql/datasource'
+
+const TEST_KEY_ID = '0x0035807ec068737973d603a1f7e0fc1b12a78bf8-1'
+// Rinkeby
+const TEST_NETWORK = 4
+describe('Key', () => {
+  describe('getKey', () => {
+    describe('when data is returned for the data source', () => {
+      it('return the requested data', async () => {
+        expect.assertions(1)
+        // Instead of mocking, we make request to a known key on rinkeby network
+        const key = new Key(TEST_NETWORK)
+        const response = await key.getKey(TEST_KEY_ID)
+        expect(response.id).toEqual(TEST_KEY_ID)
+      })
+    })
+
+    describe('when an error occurs in data fetch', () => {
+      it('returns an empty collection', async () => {
+        expect.assertions(1)
+        const key = new Key(TEST_NETWORK)
+        const response = await key.getKey('non-existent-key')
+        expect(response).toBe(null)
+      })
+    })
+  })
+
+  describe('getKeys', () => {
+    describe('when data is returned for the data source', () => {
+      it('return many keys using getKeys', async () => {
+        expect.assertions(1)
+        const key = new Key(TEST_NETWORK)
+        const response = await key.getKeys({ first: 5 })
+        expect(response.length).toBe(5)
+      })
+    })
+  })
+})

--- a/locksmith/__tests__/graphql/datasource/lock.test.ts
+++ b/locksmith/__tests__/graphql/datasource/lock.test.ts
@@ -1,0 +1,38 @@
+import { Lock } from '../../../src/graphql/datasource'
+
+const TEST_LOCK_ID = '0x0035807ec068737973d603a1f7e0fc1b12a78bf8'
+// Rinkeby
+const TEST_NETWORK = 4
+describe('Lock', () => {
+  describe('getLock', () => {
+    describe('when data is returned for the data source', () => {
+      it('return the requested data', async () => {
+        expect.assertions(1)
+        // Instead of mocking, we make request to a known lock on rinkeby network
+        const lock = new Lock(TEST_NETWORK)
+        const response = await lock.getLock(TEST_LOCK_ID)
+        expect(response.id).toEqual(TEST_LOCK_ID)
+      })
+    })
+
+    describe('when an error occurs in data fetch', () => {
+      it('returns an null', async () => {
+        expect.assertions(1)
+        const lock = new Lock(TEST_NETWORK)
+        const response = await lock.getLock('non-existent-lock')
+        expect(response).toBe(null)
+      })
+    })
+  })
+
+  describe('getLocks', () => {
+    describe('when data is returned for the data source', () => {
+      it('return many locks using getLocks', async () => {
+        expect.assertions(1)
+        const lock = new Lock(TEST_NETWORK)
+        const response = await lock.getLocks({ first: 5 })
+        expect(response.length).toBe(5)
+      })
+    })
+  })
+})

--- a/locksmith/src/graphql/datasource/key.ts
+++ b/locksmith/src/graphql/datasource/key.ts
@@ -3,13 +3,15 @@ import { GraphQLDataSource } from 'apollo-datasource-graphql'
 import networks from '@unlock-protocol/networks'
 
 export class Key extends GraphQLDataSource {
-  async getKeys(args: any, network: number) {
+  constructor(public network: number) {
+    super()
     this.baseURL = networks[network].subgraphURI
-    const queryPredicate = args.first ? `(first: ${args.first})` : ''
+  }
 
+  async getKeys(args: any) {
     const keysQuery = gql`
       query Keys($first: Int) {
-        keys${queryPredicate}{
+        keys(first: $first) {
           id
           lock {
             id

--- a/locksmith/src/graphql/datasource/lock.ts
+++ b/locksmith/src/graphql/datasource/lock.ts
@@ -3,9 +3,12 @@ import { GraphQLDataSource } from 'apollo-datasource-graphql'
 import networks from '@unlock-protocol/networks'
 
 export class Lock extends GraphQLDataSource {
-  async getLocks(args: any, network: number) {
+  constructor(public network: number) {
+    super()
     this.baseURL = networks[network].subgraphURI
+  }
 
+  async getLocks(args: any) {
     const LocksQuery = gql`
       query Locks($first: Int) {
         locks(first: $first) {

--- a/locksmith/src/graphql/resolvers.ts
+++ b/locksmith/src/graphql/resolvers.ts
@@ -19,10 +19,10 @@ export const resolvers = {
       new KeyPurchase().getKeyPurchases(network),
     // eslint-disable-next-line no-unused-vars
     keys: (_root: any, args: any, network: number) =>
-      new Key().getKeys(args, network),
+      new Key(network).getKeys(args),
     // eslint-disable-next-line no-unused-vars
-    key: async (_root: any, args: any, _context: any, _info: any) =>
-      new Key().getKey(args.id),
+    key: async (_root: any, args: any, network: number, _info: any) =>
+      new Key(network).getKey(args.id),
     keyHolders: async (_root: any, args: any, network: number) =>
       new KeyHolder().get(args.where.address, network),
   },

--- a/locksmith/src/websub/helpers.ts
+++ b/locksmith/src/websub/helpers.ts
@@ -42,17 +42,18 @@ export async function notifyHook(hook: Hook, body: unknown) {
 }
 
 export async function networkMapToFnResult<T = unknown>(
-  run: (network: string) => Promise<T>
+  run: (network: number) => Promise<T>
 ) {
   const items = await Promise.allSettled(
-    Object.keys(networks).map(async (network) => {
+    Object.values(networks).map(async (network) => {
+      const networkId = network.id
       return {
-        network,
-        data: await run(network),
+        network: networkId,
+        data: await run(networkId),
       }
     })
   )
-  const map = new Map<string, T>()
+  const map = new Map<number, T>()
 
   for (const item of items) {
     if (item.status === 'fulfilled') {

--- a/locksmith/src/websub/jobs/keys.ts
+++ b/locksmith/src/websub/jobs/keys.ts
@@ -10,13 +10,14 @@ export async function notifyOfKeys(hooks: Hook[]) {
     return TOPIC_KEYS.test(path)
   })
 
-  const keySource = new Key()
-  const networkToLocksMap = await networkMapToFnResult((network) =>
-    keySource.getKeys({ first: 25 }, Number(network))
-  )
+  const networkToLocksMap = await networkMapToFnResult((network) => {
+    const keySource = new Key(Number(network))
+    return keySource.getKeys({ first: 25 })
+  })
+
   for (const hook of subscribed) {
     const data = networkToLocksMap
-      .get(hook.network)
+      .get(Number(hook.network))
       .filter((key: any) => key.lock.id === hook.lock)
     notifyHook(hook, data)
   }

--- a/locksmith/src/websub/jobs/locks.ts
+++ b/locksmith/src/websub/jobs/locks.ts
@@ -10,12 +10,12 @@ export async function notifyOfLocks(hooks: Hook[]) {
     return TOPIC_LOCKS.test(path)
   })
 
-  const lockSource = new Lock()
-  const networkToLocksMap = await networkMapToFnResult((network) =>
-    lockSource.getLocks({ first: 25 }, Number(network))
-  )
+  const networkToLocksMap = await networkMapToFnResult((network) => {
+    const lockSource = new Lock(network)
+    return lockSource.getLocks({ first: 25 })
+  })
   for (const hook of subscribed) {
-    const data = networkToLocksMap.get(hook.network)
+    const data = networkToLocksMap.get(Number(hook.network))
     notifyHook(hook, data)
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This fixes an issue where a method in our datasource class for key and lock was responsible for adding the base URL which meant other methods couldn't access the baseURL unless that method was invoked first. I've moved the network up as an argument in constructor instead so every method can access it and refactored the code to reflect this change.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

