### PR TITLE
gas(smart-contracts): Remove owners array to save gas

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -353,8 +353,6 @@ interface IPublicLock
 
   function maxNumberOfKeys() external view returns (uint256 );
 
-  function owners(uint256 ) external view returns (address );
-
   function refundPenaltyBasisPoints() external view returns (uint256 );
 
   function tokenAddress() external view returns (address );

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -43,9 +43,9 @@ contract MixinKeys is
   // merging this with totalSupply into an array instead.
   mapping (uint => address) internal _ownerOf;
 
-  // Addresses of owners are also stored in an array.
-  // Addresses are never removed by design to avoid abuses around referals
-  address[] public owners;
+  // Keep track of the total number of unique owners for this lock (both expired and valid).
+  // This may be larger than totalSupply
+  uint public numberOfOwners;
 
   // A given key has both an owner and a manager.
   // If keyManager == address(0) then the key owner is also the manager
@@ -185,17 +185,8 @@ contract MixinKeys is
     return keyByOwner[_keyOwner].expirationTimestamp;
   }
 
-  /**
-   * Public function which returns the total number of unique owners (both expired
-   * and valid).  This may be larger than totalSupply.
-   */
-  function numberOfOwners()
-    public
-    view
-    returns (uint)
-  {
-    return owners.length;
-  }
+  
+  
 
   // Returns the owner of a given tokenId
   function ownerOf(
@@ -341,7 +332,7 @@ contract MixinKeys is
     // check expiration ts should be set to know if owner had previously registered a key 
     Key memory key = keyByOwner[_keyOwner];
     if(key.expirationTimestamp == 0 ) {
-      owners.push(_keyOwner);
+      numberOfOwners++;
     }
 
     // We register the owner of the tokenID

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -48,19 +48,6 @@ contract('Lock / owners', (accounts) => {
     assert.equal(numberOfOwners.toFixed(), 4)
   })
 
-  it('should allow for access to an individual key owner', async () => {
-    const keyIds = [0, 1, 2, 3]
-    const owners = await Promise.all(keyIds.map((d) => lock.owners.call(d)))
-    assert.deepEqual(owners.sort(), accounts.slice(1, 5).sort())
-  })
-
-  it('should fail to access to an individual key owner when out of bounds', async () => {
-    await truffleAssert.fails(
-      lock.owners.call(6),
-      'Transaction reverted without a reason string'
-    )
-  })
-
   describe('after a transfer to a new address', () => {
     let numberOfOwners
 

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -1,6 +1,4 @@
 const BigNumber = require('bignumber.js')
-
-const truffleAssert = require('truffle-assertions')
 const { reverts } = require('truffle-assertions')
 const deployLocks = require('../helpers/deployLocks')
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This PR replace the `owners` array from PublicLock template - to prevent (gas-consuming) operation of adding to it when recording a new owner. It is replaced by a simple `uint` that increments to keep track of the total number of owners.

https://github.com/code-423n4/2021-11-unlock-findings/issues/130

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

