### PR TITLE
feat(ui): Add Input and FormLayout component

### DIFF
--- a/packages/ui/lib/components/Form/FieldLayout.tsx
+++ b/packages/ui/lib/components/Form/FieldLayout.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+import { Size, State, SizeStyleProp, StateStyleProp } from '../../types'
+import { twMerge } from 'tailwind-merge'
+
+export interface Props {
+  label?: string
+  size?: Size
+  state?: State
+  message?: string
+  children: ReactNode
+}
+
+const SIZE_STYLES: SizeStyleProp = {
+  small: 'text-sm',
+  medium: 'text-base',
+  large: 'text-lg',
+}
+
+const STATE_STYLES: StateStyleProp = {
+  error: 'text-red-500',
+  success: 'text-green-500',
+}
+
+export function FieldLayout(props: Props) {
+  const { children, label, size = 'medium', state, message } = props
+  const labelSizeStyle = SIZE_STYLES[size!]
+  const labelClass = twMerge('px-1', labelSizeStyle)
+  const messageClass = twMerge('text-sm', STATE_STYLES[state!])
+  return (
+    <div className="grid gap-1">
+      {label && (
+        <label className={labelClass} htmlFor={label}>
+          {label}
+        </label>
+      )}
+      {children}
+      {message && (
+        <div>
+          <p className={messageClass}>{message} </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/ui/lib/components/Form/Input.stories.tsx
+++ b/packages/ui/lib/components/Form/Input.stories.tsx
@@ -1,0 +1,32 @@
+import { Input } from './Input'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { MdPerson as PersonIcon } from 'react-icons/md'
+import { FiAtSign as AtSignIcon } from 'react-icons/fi'
+export default {
+  component: Input,
+  title: 'Input',
+} as ComponentMeta<typeof Input>
+
+const Template: ComponentStory<typeof Input> = (args) => <Input {...args} />
+
+export const Success = Template.bind({})
+
+Success.args = {
+  icon: <PersonIcon size={20} />,
+  label: 'Enter your name',
+  size: 'medium',
+  state: 'success',
+  message: 'Correct name',
+  value: 'John Doe',
+}
+
+export const Error = Template.bind({})
+
+Error.args = {
+  icon: <AtSignIcon size={20} />,
+  label: 'Type your username',
+  size: 'large',
+  state: 'error',
+  value: 'unlock',
+  message: 'Username not available',
+}

--- a/packages/ui/lib/components/Form/Input.tsx
+++ b/packages/ui/lib/components/Form/Input.tsx
@@ -1,0 +1,64 @@
+import type { InputHTMLAttributes, ForwardedRef } from 'react'
+import type { Size, State, SizeStyleProp, StateStyleProp } from '../../types'
+import { forwardRef, ReactNode } from 'react'
+import { twMerge } from 'tailwind-merge'
+import { FieldLayout } from './FieldLayout'
+
+export interface Props
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'id' | 'children'
+  > {
+  label?: string
+  size?: Size
+  state?: State
+  message?: string
+  icon?: ReactNode
+}
+
+const SIZE_STYLES: SizeStyleProp = {
+  small: 'px-2 py-1',
+  medium: 'px-4 py-2',
+  large: 'px-4 py-3',
+}
+
+const STATE_STYLES: StateStyleProp = {
+  error: 'border-red-500',
+  success: 'border-green-500',
+}
+
+export const Input = forwardRef(
+  (props: Props, ref: ForwardedRef<HTMLInputElement>) => {
+    const {
+      size = 'medium',
+      value,
+      className,
+      state,
+      message,
+      label,
+      icon,
+      ...inputProps
+    } = props
+    const inputSizeStyle = SIZE_STYLES[size]
+    const inputStateStyle = STATE_STYLES[state!]
+    const inputClass = twMerge('relative flex items-center rounded border', inputSizeStyle, inputStateStyle)
+    return (
+      <FieldLayout label={label} size={size} state={state} message={message}>
+        <div className={inputClass}>
+          <input
+            {...inputProps}
+            id={label}
+            value={value}
+            ref={ref}
+            className="w-full outline-none"
+          />
+          <span className="absolute inset-y-0 right-0 flex items-center pr-2 ml-3 pointer-events-none">
+            {icon}
+          </span>
+        </div>
+      </FieldLayout>
+    )
+  }
+)
+
+Input.displayName = 'Input'

--- a/packages/ui/lib/types.ts
+++ b/packages/ui/lib/types.ts
@@ -1,2 +1,4 @@
 export type Size = 'small' | 'medium' | 'large'
 export type SizeStyleProp = Partial<Record<Size, string>>
+export type State = "error" | "success"
+export type StateStyleProp = Partial<Record<State, string>>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This adds a simple implementation of FormLayout and Input which we will build other input components on. For now, there isn't much styling (I'm waiting for deepwork team to get done with their design so I can match them). 


![image](https://user-images.githubusercontent.com/73341821/150157346-3aab4688-8f55-4add-9957-426a4afcfb72.png)

![image](https://user-images.githubusercontent.com/73341821/150157423-efe97c72-d007-4cdf-82e8-171e77dc3c8c.png)


# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

