### PR TITLE
feat(websub): Add signature to headers when notifying subscribers

### DIFF
--- a/locksmith/__mocks__/websub/subscriber.ts
+++ b/locksmith/__mocks__/websub/subscriber.ts
@@ -5,15 +5,17 @@ import { createSignature } from '../../src/websub/helpers'
 const handlers = [
   rest.post('http://localhost:4000/callback', (req, res, ctx) => {
     const signature = req.headers.get('x-hub-signature')
+
     if (!signature) {
       return res(ctx.status(400), ctx.text('Missing signature'))
     }
 
     const [algo, hash] = signature.split('=')
+
     const computedHash = createSignature({
-      content: String(req.body),
+      content: JSON.stringify(req.body),
       algorithm: algo,
-      secret: 'secret',
+      secret: 'websub',
     })
 
     if (hash !== computedHash) {

--- a/locksmith/__mocks__/websub/subscriber.ts
+++ b/locksmith/__mocks__/websub/subscriber.ts
@@ -1,0 +1,26 @@
+import { setupServer } from 'msw/node'
+import crypto from 'crypto'
+import { rest } from 'msw'
+
+const handlers = [
+  rest.post('http://localhost:4000/callback', (req, res, ctx) => {
+    const signature = req.headers.get('x-hub-signature')
+    if (!signature) {
+      return res(ctx.status(400), ctx.text('Missing signature'))
+    }
+
+    const [algo, hash] = signature.split('=')
+    const computedHash = crypto
+      .createHmac(algo, 'websub')
+      .update(JSON.stringify(req.body))
+      .digest('hex')
+
+    if (hash !== computedHash) {
+      return res(ctx.status(400), ctx.text('Invalid signature'))
+    }
+
+    return res(ctx.status(200), ctx.text('Acknowledged'))
+  }),
+]
+
+export const subscriberServer = setupServer(...handlers)

--- a/locksmith/__mocks__/websub/subscriber.ts
+++ b/locksmith/__mocks__/websub/subscriber.ts
@@ -1,6 +1,6 @@
 import { setupServer } from 'msw/node'
-import crypto from 'crypto'
 import { rest } from 'msw'
+import { createSignature } from '../../src/websub/helpers'
 
 const handlers = [
   rest.post('http://localhost:4000/callback', (req, res, ctx) => {
@@ -10,10 +10,11 @@ const handlers = [
     }
 
     const [algo, hash] = signature.split('=')
-    const computedHash = crypto
-      .createHmac(algo, 'websub')
-      .update(JSON.stringify(req.body))
-      .digest('hex')
+    const computedHash = createSignature({
+      content: String(req.body),
+      algorithm: algo,
+      secret: 'secret',
+    })
 
     if (hash !== computedHash) {
       return res(ctx.status(400), ctx.text('Invalid signature'))

--- a/locksmith/__tests__/websub/helpers.test.ts
+++ b/locksmith/__tests__/websub/helpers.test.ts
@@ -1,7 +1,7 @@
 import { networkMapToFnResult, createSignature } from '../../src/websub/helpers'
 
-describe('Test networkMapFnResult', () => {
-  it('should succeed', async () => {
+describe('Test helpers', () => {
+  it('networkMapFnResult', async () => {
     expect.assertions(1)
     expect.assertions(2)
     const map = await networkMapToFnResult((network) => {

--- a/locksmith/__tests__/websub/helpers.test.ts
+++ b/locksmith/__tests__/websub/helpers.test.ts
@@ -1,4 +1,4 @@
-import { networkMapToFnResult } from '../../src/websub/helpers'
+import { networkMapToFnResult, createSignature } from '../../src/websub/helpers'
 
 describe('Test networkMapFnResult', () => {
   it('should succeed', async () => {
@@ -10,5 +10,23 @@ describe('Test networkMapFnResult', () => {
 
     expect(map.get(1)).toBe(1)
     expect(map.get(5)).toBe(undefined)
+  })
+
+  it('Create signature test', () => {
+    expect.assertions(1)
+
+    const sig1 = createSignature({
+      secret: 'secret',
+      content: 'content',
+      algorithm: 'sha256',
+    })
+
+    const sig2 = createSignature({
+      secret: 'secret',
+      content: 'content',
+      algorithm: 'sha256',
+    })
+
+    expect(sig1).toBe(sig2)
   })
 })

--- a/locksmith/__tests__/websub/helpers.test.ts
+++ b/locksmith/__tests__/websub/helpers.test.ts
@@ -1,0 +1,14 @@
+import { networkMapToFnResult } from '../../src/websub/helpers'
+
+describe('Test networkMapFnResult', () => {
+  it('should succeed', async () => {
+    expect.assertions(1)
+    expect.assertions(2)
+    const map = await networkMapToFnResult((network) => {
+      return network
+    })
+
+    expect(map.get(1)).toBe(1)
+    expect(map.get(5)).toBe(undefined)
+  })
+})

--- a/locksmith/__tests__/websub/notify.test.ts
+++ b/locksmith/__tests__/websub/notify.test.ts
@@ -3,52 +3,50 @@ import { notify } from '../../src/websub/helpers'
 import { Hook, HookEvent } from '../../src/models'
 
 const notifyHook = jest.fn()
-
-// eslint-disable-next-line
 notifyHook.mockImplementation(() => new HookEvent())
 
-beforeAll(() => subscriberServer.listen())
+describe('Test notify helpers', () => {
+  beforeAll(() => subscriberServer.listen())
+  afterEach(() => subscriberServer.resetHandlers())
+  describe('Test notify function', () => {
+    it('should succeed', async () => {
+      expect.assertions(1)
+      const hook = new Hook()
+      hook.callback = 'http://localhost:4000/callback'
+      hook.secret = 'websub'
+      const fn = notify(hook, { test: true })
+      const response = await fn()
+      expect(response.status).toBe(200)
+    })
 
-afterEach(() => subscriberServer.resetHandlers())
+    it('should result in error with signature mismatch', async () => {
+      expect.assertions(1)
+      const hook = new Hook()
+      hook.callback = 'http://localhost:4000/callback'
+      // Change signature here
+      hook.secret = 'websu'
+      const fn = notify(hook, { test: true })
+      const response = await fn()
+      expect(response.ok).toBe(false)
+    })
 
-afterAll(() => subscriberServer.close())
-describe('Test notify function', () => {
-  it('should succeed', async () => {
-    expect.assertions(1)
-    const hook = new Hook()
-    hook.callback = 'http://localhost:4000/callback'
-    hook.secret = 'websub'
-    const fn = notify(hook, { test: true })
-    const response = await fn()
-    expect(response.status).toBe(200)
+    it('Should result in error if no signature provided to a client expecting it', async () => {
+      expect.assertions(1)
+      const hook = new Hook()
+      hook.callback = 'http://localhost:4000/callback'
+      const fn = notify(hook, { test: true })
+      const response = await fn()
+      expect(response.ok).toBe(false)
+    })
   })
 
-  it('should result in error with signature mismatch', async () => {
-    expect.assertions(1)
-    const hook = new Hook()
-    hook.callback = 'http://localhost:4000/callback'
-    // Change signature here
-    hook.secret = 'websu'
-    const fn = notify(hook, { test: true })
-    const response = await fn()
-    expect(response.ok).toBe(false)
+  describe('Test notify hook function', () => {
+    it('Test notify hook function', async () => {
+      expect.assertions(1)
+      const hook = new Hook()
+      const body = { test: true }
+      expect(notifyHook.call(hook, body)).toBeInstanceOf(HookEvent)
+    })
   })
-
-  it('Should result in error if no signature provided to a client expecting it', async () => {
-    expect.assertions(1)
-    const hook = new Hook()
-    hook.callback = 'http://localhost:4000/callback'
-    const fn = notify(hook, { test: true })
-    const response = await fn()
-    expect(response.ok).toBe(false)
-  })
-})
-
-describe('Test notify hook function', () => {
-  it('Test notify hook function', async () => {
-    expect.assertions(1)
-    const hook = new Hook()
-    const body = { test: true }
-    expect(notifyHook.call(hook, body)).toBeInstanceOf(HookEvent)
-  })
+  afterAll(() => subscriberServer.close())
 })

--- a/locksmith/__tests__/websub/notify.test.ts
+++ b/locksmith/__tests__/websub/notify.test.ts
@@ -1,6 +1,11 @@
 import { subscriberServer } from '../../__mocks__/websub/subscriber'
 import { notify } from '../../src/websub/helpers'
-import { Hook } from '../../src/models'
+import { Hook, HookEvent } from '../../src/models'
+
+const notifyHook = jest.fn()
+
+// eslint-disable-next-line
+notifyHook.mockImplementation(() => new HookEvent())
 
 beforeAll(() => subscriberServer.listen())
 
@@ -27,5 +32,14 @@ describe('Test notify function', () => {
     const fn = notify(hook, { test: true })
     const response = await fn()
     expect(response.ok).toBe(false)
+  })
+})
+
+describe('Test notify hook function', () => {
+  it('Test notify hook function', async () => {
+    expect.assertions(1)
+    const hook = new Hook()
+    const body = { test: true }
+    expect(notifyHook.call(hook, body)).toBeInstanceOf(HookEvent)
   })
 })

--- a/locksmith/__tests__/websub/notify.test.ts
+++ b/locksmith/__tests__/websub/notify.test.ts
@@ -1,0 +1,20 @@
+import { subscriberServer } from '../../__mocks__/websub/subscriber'
+import { notify } from '../../src/websub/helpers'
+import { Hook } from '../../src/models'
+
+beforeAll(() => subscriberServer.listen())
+
+afterEach(() => subscriberServer.resetHandlers())
+
+afterAll(() => subscriberServer.close())
+describe('Test notify function', () => {
+  it('should succeed', async () => {
+    expect.assertions(1)
+    const hook = new Hook()
+    hook.callback = 'http://localhost:4000/callback'
+    hook.secret = 'websub'
+    const fn = notify(hook, { test: true })
+    const response = await fn()
+    expect(response.status).toBe(200)
+  })
+})

--- a/locksmith/__tests__/websub/notify.test.ts
+++ b/locksmith/__tests__/websub/notify.test.ts
@@ -17,4 +17,15 @@ describe('Test notify function', () => {
     const response = await fn()
     expect(response.status).toBe(200)
   })
+
+  it('should throw with signature mismatch', async () => {
+    expect.assertions(1)
+    const hook = new Hook()
+    hook.callback = 'http://localhost:4000/callback'
+    // Change signature here
+    hook.secret = 'websu'
+    const fn = notify(hook, { test: true })
+    const response = await fn()
+    expect(response.ok).toBe(false)
+  })
 })

--- a/locksmith/__tests__/websub/notify.test.ts
+++ b/locksmith/__tests__/websub/notify.test.ts
@@ -23,12 +23,21 @@ describe('Test notify function', () => {
     expect(response.status).toBe(200)
   })
 
-  it('should throw with signature mismatch', async () => {
+  it('should result in error with signature mismatch', async () => {
     expect.assertions(1)
     const hook = new Hook()
     hook.callback = 'http://localhost:4000/callback'
     // Change signature here
     hook.secret = 'websu'
+    const fn = notify(hook, { test: true })
+    const response = await fn()
+    expect(response.ok).toBe(false)
+  })
+
+  it('Should result in error if no signature provided to a client expecting it', async () => {
+    expect.assertions(1)
+    const hook = new Hook()
+    hook.callback = 'http://localhost:4000/callback'
     const fn = notify(hook, { test: true })
     const response = await fn()
     expect(response.ok).toBe(false)

--- a/locksmith/__tests__/websub/notify.test.ts
+++ b/locksmith/__tests__/websub/notify.test.ts
@@ -16,7 +16,7 @@ describe('Test notify helpers', () => {
       hook.secret = 'websub'
       const fn = notify(hook, { test: true })
       const response = await fn()
-      expect(response.status).toBe(200)
+      expect(response.ok).toBe(true)
     })
 
     it('should result in error with signature mismatch', async () => {

--- a/locksmith/package.json
+++ b/locksmith/package.json
@@ -109,6 +109,7 @@
     "eslint": "8.6.0",
     "eslint-config-standard": "16.0.3",
     "jest": "27.4.5",
+    "msw": "^0.36.5",
     "nock": "13.2.1",
     "node-mocks-http": "1.11.0",
     "nodemon": "2.0.15",

--- a/locksmith/src/models/hookEvent.ts
+++ b/locksmith/src/models/hookEvent.ts
@@ -18,6 +18,9 @@ export class HookEvent extends Model<HookEvent> {
   @Column
   hookId!: number
 
+  @Column
+  topic!: string
+
   @Column({ type: DataType.JSON })
   body!: any
 

--- a/locksmith/src/websub/helpers.ts
+++ b/locksmith/src/websub/helpers.ts
@@ -1,18 +1,19 @@
 import { networks } from '@unlock-protocol/networks'
 import pRetry from 'p-retry'
 import crypto from 'crypto'
+import fetch from 'cross-fetch'
 import { Hook, HookEvent } from '../models'
 
-const notify = (hook: Hook, body: unknown) => async () => {
-  const headers = new Headers()
+export const notify = (hook: Hook, body: unknown) => async () => {
+  const headers: Record<string, string> = {}
   const bodyString = JSON.stringify(body)
-  headers.append('Content-Type', 'application/json')
+  headers['Content-Type'] = 'application/json'
   if (hook.secret) {
     const signature = crypto
       .createHmac('sha256', hook.secret)
       .update(bodyString)
       .digest('hex')
-    headers.append('X-Hub-Signature', `sha256=${signature}`)
+    headers['X-Hub-Signature'] = `sha256=${signature}`
   }
   const response = await fetch(hook.callback, {
     headers: headers,
@@ -23,7 +24,7 @@ const notify = (hook: Hook, body: unknown) => async () => {
   if (!response.ok) {
     throw new Error(`${response.status} - ${response.statusText}`)
   }
-  return response.json()
+  return response
 }
 
 export async function notifyHook(hook: Hook, body: unknown) {

--- a/locksmith/src/websub/helpers.ts
+++ b/locksmith/src/websub/helpers.ts
@@ -31,6 +31,7 @@ export async function notifyHook(hook: Hook, body: unknown) {
   hookEvent.lock = hook.lock
   hookEvent.state = 'pending'
   hookEvent.attempts = 0
+  hookEvent.topic = hook.topic
   hookEvent.body = JSON.stringify(body)
   // Save the pending state in database
   await hookEvent.save()
@@ -60,6 +61,8 @@ export async function notifyHook(hook: Hook, body: unknown) {
     hookEvent.state = 'success'
     hookEvent.save()
   }
+
+  return hookEvent
 }
 
 export async function networkMapToFnResult<T = unknown>(

--- a/locksmith/src/websub/helpers.ts
+++ b/locksmith/src/websub/helpers.ts
@@ -11,7 +11,7 @@ export const notify = (hook: Hook, body: unknown) => async () => {
   if (hook.secret) {
     const algorithm = 'sha256'
     const signature = createSignature({
-      content: content,
+      content,
       algorithm,
       secret: hook.secret,
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6224,6 +6224,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mswjs/cookies@npm:^0.1.6":
+  version: 0.1.7
+  resolution: "@mswjs/cookies@npm:0.1.7"
+  dependencies:
+    "@types/set-cookie-parser": ^2.4.0
+    set-cookie-parser: ^2.4.6
+  checksum: d9b152dfdeba08b282a236485610bcfe992626e3c638fe51ebc5c7b5273d41d74e5447ae556a6c76460a8d3c7a7de6f544c681232cb50ae05b6b1e112bb77286
+  languageName: node
+  linkType: hard
+
+"@mswjs/interceptors@npm:^0.12.7":
+  version: 0.12.7
+  resolution: "@mswjs/interceptors@npm:0.12.7"
+  dependencies:
+    "@open-draft/until": ^1.0.3
+    "@xmldom/xmldom": ^0.7.2
+    debug: ^4.3.2
+    headers-utils: ^3.0.2
+    outvariant: ^1.2.0
+    strict-event-emitter: ^0.2.0
+  checksum: 426e9a27f13f0bd1f5b8dbf5f3605c65709f0aa73cee5a4a8278bc43859968a11d72aef42266a9c07030f1949f539ac1865a1da7edecc31b1ba40406211918f5
+  languageName: node
+  linkType: hard
+
 "@napi-rs/triples@npm:1.0.3":
   version: 1.0.3
   resolution: "@napi-rs/triples@npm:1.0.3"
@@ -6523,6 +6547,13 @@ __metadata:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
   checksum: c96381d4a37448ea280951e46233f7e541058cf57a57d4094dd4bdcaae43fa5872b5f2eb6bfb004591a68e29c5877abe3cdc210cb3588cbf20ab2877f31a7de7
+  languageName: node
+  linkType: hard
+
+"@open-draft/until@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@open-draft/until@npm:1.0.3"
+  checksum: 323e92ebef0150ed0f8caedc7d219b68cdc50784fa4eba0377eef93533d3f46514eb2400ced83dda8c51bddc3d2c7b8e9cf95e5ec85ab7f62dfc015d174f62f2
   languageName: node
   linkType: hard
 
@@ -10981,6 +11012,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cookie@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@types/cookie@npm:0.4.1"
+  checksum: 3275534ed69a76c68eb1a77d547d75f99fedc80befb75a3d1d03662fb08d697e6f8b1274e12af1a74c6896071b11510631ba891f64d30c78528d0ec45a9c1a18
+  languageName: node
+  linkType: hard
+
 "@types/cookiejar@npm:*":
   version: 2.1.2
   resolution: "@types/cookiejar@npm:2.1.2"
@@ -11221,6 +11259,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/inquirer@npm:^8.1.3":
+  version: 8.1.3
+  resolution: "@types/inquirer@npm:8.1.3"
+  dependencies:
+    "@types/through": "*"
+    rxjs: ^7.2.0
+  checksum: b2f9914d1380e60a9a6d890abdd24078db63069a4bd974e77a00c5660bf5cab33a60fba6f02b56f1b2e6418e287e4697361b12cb85704b13e76f1a23c934d203
+  languageName: node
+  linkType: hard
+
 "@types/invariant@npm:^2.2.33":
   version: 2.2.35
   resolution: "@types/invariant@npm:2.2.35"
@@ -11284,6 +11332,13 @@ __metadata:
     jest-diff: ^27.0.0
     pretty-format: ^27.0.0
   checksum: d2350267f954f9a2e4a15e5f02fbf19a77abfb9fd9e57a954de1fb0e9a0d3d5f8d3646ac7d9c42aeb4b4d828d2e70624ec149c85bb50a48634a54eed8429e1f8
+  languageName: node
+  linkType: hard
+
+"@types/js-levenshtein@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@types/js-levenshtein@npm:1.1.1"
+  checksum: 1d1ff1ee2ad551909e47f3ce19fcf85b64dc5146d3b531c8d26fc775492d36e380b32cf5ef68ff301e812c3b00282f37aac579ebb44498b94baff0ace7509769
   languageName: node
   linkType: hard
 
@@ -11856,6 +11911,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/set-cookie-parser@npm:^2.4.0":
+  version: 2.4.2
+  resolution: "@types/set-cookie-parser@npm:2.4.2"
+  dependencies:
+    "@types/node": "*"
+  checksum: c31bf04eb9620829dc3c91bced74ac934ad039d20d20893fb5acac0f08769cbd4eef3bf7502a0289c7be59c3e9cfa456147b4e88bff47dd1b9efb4995ba5d5a3
+  languageName: node
+  linkType: hard
+
 "@types/sinon-chai@npm:^3.2.3":
   version: 3.2.5
   resolution: "@types/sinon-chai@npm:3.2.5"
@@ -11974,6 +12038,15 @@ __metadata:
   dependencies:
     "@types/jest": "*"
   checksum: 77fe7ad3a9d49250972a0e3289b6d536942f95f0d539f32a917cf78c9422113d55c00de53b53dd4de1de49b68c8b500faea62e3017c4a64736cfbfbade749e04
+  languageName: node
+  linkType: hard
+
+"@types/through@npm:*":
+  version: 0.0.30
+  resolution: "@types/through@npm:0.0.30"
+  dependencies:
+    "@types/node": "*"
+  checksum: 9578470db0b527c26e246a1220ae9bffc6bf47f20f89c54aac467c083ab1f7e16c00d9a7b4bb6cb4e2dfae465027270827e5908a6236063f6214625e50585d78
   languageName: node
   linkType: hard
 
@@ -12530,6 +12603,7 @@ __metadata:
     isomorphic-fetch: 3.0.0
     jest: 27.4.5
     lodash.isequal: 4.5.0
+    msw: ^0.36.5
     multer: 1.4.4
     multer-s3: 2.10.0
     nock: 13.2.1
@@ -13759,6 +13833,13 @@ __metadata:
   dependencies:
     tslib: ^2.3.0
   checksum: c3f6b200aefc64b5cd9976b7ed0dd22852eb826d835c5dccd3d03ef788d258af50ca64e8de654e5f812134afdb9d5890f334c8de2276d0dca1751785694654f9
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.7.2":
+  version: 0.7.5
+  resolution: "@xmldom/xmldom@npm:0.7.5"
+  checksum: 8d7ec35c1ef6183b4f621df08e01d7e61f244fb964a4719025e65fe6ac06fac418919be64fb40fe5908e69158ef728f2d936daa082db326fe04603012b5f2a84
   languageName: node
   linkType: hard
 
@@ -15375,7 +15456,7 @@ __metadata:
   bin:
     asc: bin/asc
     asinit: bin/asinit
-  checksum: fda292f6b3b8b4a9bd4457c9143e50145f8473f3d664e48c057638a9bb1c8e890cd4de4e38e18dd4334240394621cfd9d01afee344ab049c5a7072fe855329b5
+  checksum: 8a407db6179addfaa5fcc637543a755ecc22ae8dd5e8259492305afd0d2bb73eae019d4178f79b515f75648d71dfda2c1ceb0c7421bff7817aebb2e2f5c8bfe7
   languageName: node
   linkType: hard
 
@@ -17044,7 +17125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.0.3":
+"bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
   dependencies:
@@ -18191,6 +18272,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:4.1.1":
+  version: 4.1.1
+  resolution: "chalk@npm:4.1.1"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: 036e973e665ba1a32c975e291d5f3d549bceeb7b1b983320d4598fb75d70fe20c5db5d62971ec0fe76cdbce83985a00ee42372416abfc3a5584465005a7855ed
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^1.0.0, chalk@npm:^1.1.3":
   version: 1.1.3
   resolution: "chalk@npm:1.1.3"
@@ -18214,7 +18305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -18660,6 +18751,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-spinners@npm:^2.5.0":
+  version: 2.6.1
+  resolution: "cli-spinners@npm:2.6.1"
+  checksum: 423409baaa7a58e5104b46ca1745fbfc5888bbd0b0c5a626e052ae1387060839c8efd512fb127e25769b3dc9562db1dc1b5add6e0b93b7ef64f477feb6416a45
+  languageName: node
+  linkType: hard
+
 "cli-table3@npm:0.6.0":
   version: 0.6.0
   resolution: "cli-table3@npm:0.6.0"
@@ -18725,6 +18823,13 @@ __metadata:
   version: 2.2.1
   resolution: "cli-width@npm:2.2.1"
   checksum: 3c21b897a2ff551ae5b3c3ab32c866ed2965dcf7fb442f81adf0e27f4a397925c8f84619af7bcc6354821303f6ee9b2aa31d248306174f32c287986158cf4eed
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cli-width@npm:3.0.0"
+  checksum: 4c94af3769367a70e11ed69aa6095f1c600c0ff510f3921ab4045af961820d57c0233acfa8b6396037391f31b4c397e1f614d234294f979ff61430a6c166c3f6
   languageName: node
   linkType: hard
 
@@ -24226,7 +24331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:3.3.0, events@npm:^3.0.0":
+"events@npm:3.3.0, events@npm:^3.0.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
@@ -24860,6 +24965,15 @@ __metadata:
   dependencies:
     escape-string-regexp: ^1.0.5
   checksum: 081beb16ea57d1716f8447c694f637668322398b57017b20929376aaf5def9823b35245b734cdd87e4832dc96e9c6f46274833cada77bfe15e5f980fea1fd21f
+  languageName: node
+  linkType: hard
+
+"figures@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "figures@npm:3.2.0"
+  dependencies:
+    escape-string-regexp: ^1.0.5
+  checksum: 85a6ad29e9aca80b49b817e7c89ecc4716ff14e3779d9835af554db91bac41c0f289c418923519392a1e582b4d10482ad282021330cd045bb7b80c84152f2a2b
   languageName: node
   linkType: hard
 
@@ -26580,7 +26694,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"graphql@npm:15.8.0":
+"graphql@npm:15.8.0, graphql@npm:^15.5.1":
   version: 15.8.0
   resolution: "graphql@npm:15.8.0"
   checksum: 423325271db8858428641b9aca01699283d1fe5b40ef6d4ac622569ecca927019fce8196208b91dd1d8eb8114f00263fe661d241d0eb40c10e5bfd650f86ec5e
@@ -27177,6 +27291,13 @@ fsevents@~2.1.1:
     no-case: ^2.2.0
     upper-case: ^1.1.3
   checksum: fe1cc9a555ec9aabc2de80f4dd961a81c534fc23951694fef34297e59b0dd60f26647148731bf0dd3fdb3a1c688089d3cd147d7038db850e25be7c0a5fabb022
+  languageName: node
+  linkType: hard
+
+"headers-utils@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "headers-utils@npm:3.0.2"
+  checksum: 210fe65756d6de8a96afe68617463fb6faf675a24d864e849b17bddf051c4a24d621a510a1bb80fd9d4763b932eb44b5d8fd6fc4f14fa62fb211603456a57b4f
   languageName: node
   linkType: hard
 
@@ -28067,6 +28188,28 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"inquirer@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "inquirer@npm:8.2.0"
+  dependencies:
+    ansi-escapes: ^4.2.1
+    chalk: ^4.1.1
+    cli-cursor: ^3.1.0
+    cli-width: ^3.0.0
+    external-editor: ^3.0.3
+    figures: ^3.0.0
+    lodash: ^4.17.21
+    mute-stream: 0.0.8
+    ora: ^5.4.1
+    run-async: ^2.4.0
+    rxjs: ^7.2.0
+    string-width: ^4.1.0
+    strip-ansi: ^6.0.0
+    through: ^2.3.6
+  checksum: 861d1a9324ae933b49126b3541d94e4d6a2f2a25411b3f3cc00c34bf1bdab34146362d702cf289efe6d8034900dc5905bcf2ea716092a02b6fc390e5986dd236
+  languageName: node
+  linkType: hard
+
 "internal-slot@npm:^1.0.3":
   version: 1.0.3
   resolution: "internal-slot@npm:1.0.3"
@@ -28847,6 +28990,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"is-node-process@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-node-process@npm:1.0.1"
+  checksum: 3ddb8a892a00f6eb9c2aea7e7e1426b8683512d9419933d95114f4f64b5455e26601c23a31c0682463890032136dd98a326988a770ab6b4eed54a43ade8bed50
+  languageName: node
+  linkType: hard
+
 "is-npm@npm:^5.0.0":
   version: 5.0.0
   resolution: "is-npm@npm:5.0.0"
@@ -29134,6 +29284,13 @@ fsevents@~2.1.1:
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
   checksum: 3508c6cd0a9ee2e0df2fa2e9baabcdc89e911c7bd5cf64604586697212feec525aa21050e48affb5ffc3df20f0f5d2e2cf79b08caa64e1ccc9578e251763aef7
+  languageName: node
+  linkType: hard
+
+"is-unicode-supported@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "is-unicode-supported@npm:0.1.0"
+  checksum: a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
   languageName: node
   linkType: hard
 
@@ -30457,6 +30614,13 @@ fsevents@~2.1.1:
     html-beautify: js/bin/html-beautify.js
     js-beautify: js/bin/js-beautify.js
   checksum: 86a32c61364f9266d070b0a3b56c451b09d418d26030216ffdcb770b5bd06184c00ac9eb53ccf7765503bb74022a9e177b72bc043b9e6b8a8f22ca8569c3aef6
+  languageName: node
+  linkType: hard
+
+"js-levenshtein@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "js-levenshtein@npm:1.1.6"
+  checksum: 409f052a7f1141be4058d97da7860e08efd97fc588b7a4c5cfa0548bc04f6d576644dae65ab630266dff685d56fb90d494e03d4d79cb484c287746b4f1bf0694
   languageName: node
   linkType: hard
 
@@ -31992,6 +32156,16 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"log-symbols@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "log-symbols@npm:4.1.0"
+  dependencies:
+    chalk: ^4.1.0
+    is-unicode-supported: ^0.1.0
+  checksum: fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
+  languageName: node
+  linkType: hard
+
 "log-update@npm:^4.0.0":
   version: 4.0.0
   resolution: "log-update@npm:4.0.0"
@@ -33409,6 +33583,36 @@ fsevents@~2.1.1:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
+  languageName: node
+  linkType: hard
+
+"msw@npm:^0.36.5":
+  version: 0.36.5
+  resolution: "msw@npm:0.36.5"
+  dependencies:
+    "@mswjs/cookies": ^0.1.6
+    "@mswjs/interceptors": ^0.12.7
+    "@open-draft/until": ^1.0.3
+    "@types/cookie": ^0.4.1
+    "@types/inquirer": ^8.1.3
+    "@types/js-levenshtein": ^1.1.0
+    chalk: 4.1.1
+    chokidar: ^3.4.2
+    cookie: ^0.4.1
+    graphql: ^15.5.1
+    headers-utils: ^3.0.2
+    inquirer: ^8.2.0
+    is-node-process: ^1.0.1
+    js-levenshtein: ^1.1.6
+    node-fetch: ^2.6.1
+    path-to-regexp: ^6.2.0
+    statuses: ^2.0.0
+    strict-event-emitter: ^0.2.0
+    type-fest: ^1.2.2
+    yargs: ^17.3.0
+  bin:
+    msw: cli/index.js
+  checksum: 2c1b679a27631ae6349f3b0e379694dc4772c12bfb19eb71be934ab3a22924cf6b79bc320832650fd5efe60c5cbfe59376edc8b08fbc39086def1752e10accf0
   languageName: node
   linkType: hard
 
@@ -34899,6 +35103,23 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"ora@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "ora@npm:5.4.1"
+  dependencies:
+    bl: ^4.1.0
+    chalk: ^4.1.0
+    cli-cursor: ^3.1.0
+    cli-spinners: ^2.5.0
+    is-interactive: ^1.0.0
+    is-unicode-supported: ^0.1.0
+    log-symbols: ^4.1.0
+    strip-ansi: ^6.0.0
+    wcwidth: ^1.0.1
+  checksum: 28d476ee6c1049d68368c0dc922e7225e3b5600c3ede88fade8052837f9ed342625fdaa84a6209302587c8ddd9b664f71f0759833cbdb3a4cf81344057e63c63
+  languageName: node
+  linkType: hard
+
 "os-browserify@npm:0.3.0, os-browserify@npm:^0.3.0":
   version: 0.3.0
   resolution: "os-browserify@npm:0.3.0"
@@ -34948,6 +35169,13 @@ fsevents@~2.1.1:
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
   checksum: 5666560f7b9f10182548bf7013883265be33620b1c1b4a4d405c25be2636f970c5488ff3e6c48de75b55d02bde037249fe5dbfbb4c0fb7714953d56aed062e6d
+  languageName: node
+  linkType: hard
+
+"outvariant@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "outvariant@npm:1.2.1"
+  checksum: 1686113d01b6acbd23b9444ecad680f3f8b163817cde76e4c2f818631cfb6a898718b9c8a01f967b23473ed2715e0e46396ba7400cd12ade478f7532687957cd
   languageName: node
   linkType: hard
 
@@ -40435,7 +40663,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"run-async@npm:^2.2.0":
+"run-async@npm:^2.2.0, run-async@npm:^2.4.0":
   version: 2.4.1
   resolution: "run-async@npm:2.4.1"
   checksum: a2c88aa15df176f091a2878eb840e68d0bdee319d8d97bbb89112223259cebecb94bc0defd735662b83c2f7a30bed8cddb7d1674eb48ae7322dc602b22d03797
@@ -40490,6 +40718,15 @@ resolve@^2.0.0-next.3:
   dependencies:
     tslib: ^1.9.0
   checksum: bc334edef1bb8bbf56590b0b25734ba0deaf8825b703256a93714308ea36dff8a11d25533671adf8e104e5e8f256aa6fdfe39b2e248cdbd7a5f90c260acbbd1b
+  languageName: node
+  linkType: hard
+
+"rxjs@npm:^7.2.0":
+  version: 7.5.2
+  resolution: "rxjs@npm:7.5.2"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: daf1fe7289de500b25d822fd96cde3c138c7902e8bf0e6aa12a3e70847a5cabeeb4d677f10e19387e1db44b12c5b1be0ff5c79b8cd63ed6ce891d765e566cf4d
   languageName: node
   linkType: hard
 
@@ -41133,6 +41370,13 @@ resolve@^2.0.0-next.3:
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.4.6":
+  version: 2.4.8
+  resolution: "set-cookie-parser@npm:2.4.8"
+  checksum: e15b5df9a56ab06d4895286033a6aff7b318ad024310df058b5821b3539cc06f716ef529618cac0dd78df40e37830de715f388c0f97f84062dd9be2326efcd0c
   languageName: node
   linkType: hard
 
@@ -42119,6 +42363,13 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"statuses@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "statuses@npm:2.0.1"
+  checksum: 18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
+  languageName: node
+  linkType: hard
+
 "stealthy-require@npm:^1.1.1":
   version: 1.1.1
   resolution: "stealthy-require@npm:1.1.1"
@@ -42252,6 +42503,15 @@ resolve@^2.0.0-next.3:
   version: 0.1.2
   resolution: "streamsearch@npm:0.1.2"
   checksum: d2db57cbfbf7947ab9c75a7b4c80a8ef8d24850cf0a1a24258bb6956c97317ce1eab7dbcbf9c5aba3e6198611af1053b02411057bbedb99bf9c64b8275248997
+  languageName: node
+  linkType: hard
+
+"strict-event-emitter@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "strict-event-emitter@npm:0.2.0"
+  dependencies:
+    events: ^3.3.0
+  checksum: b2bc33aa01e66010f6356368df7b043cc2a96645b5a8caf47226f349d1702f844375ece9d90e69ff1714599c4ef959031d23d3ffb224738a286b88fedcb42a4a
   languageName: node
   linkType: hard
 
@@ -44416,6 +44676,13 @@ resolve@^2.0.0-next.3:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: d61c4b2eba24009033ae4500d7d818a94fd6d1b481a8111612ee141400d5f1db46f199c014766b9fa9b31a6a7374d96fc748c6d688a78a3ce5a33123839becb7
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^1.2.2":
+  version: 1.4.0
+  resolution: "type-fest@npm:1.4.0"
+  checksum: b011c3388665b097ae6a109a437a04d6f61d81b7357f74cbcb02246f2f5bd72b888ae33631b99871388122ba0a87f4ff1c94078e7119ff22c70e52c0ff828201
   languageName: node
   linkType: hard
 
@@ -49449,7 +49716,7 @@ typescript@^3.8.3:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.3.1":
+"yargs@npm:17.3.1, yargs@npm:^17.3.0":
   version: 17.3.1
   resolution: "yargs@npm:17.3.1"
   dependencies:


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Add signature to our headers using the secret from hook. 

The w3c doesn't mandate that we use sha1 but does mention that many implementation use it despite it being vulnerable to maintain compatibility. Do we want to do that or improve on the security there? (I chose the later for this PR). I can do sha1 though.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

