### PR TITLE
increased gas limit multiplier

### DIFF
--- a/packages/unlock-js/CHANGELOG.md
+++ b/packages/unlock-js/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changes
 
+# 0.20.6
+- Bumped gas limit to be 40% higher than estimate
+
 # 0.20.5
 - remove `deployUnlock`, `configureUnlock` and `deployTemplate` from walletService
+
 # 0.20.4
 - @unlock-protocol/networks is a dev dependency
 

--- a/packages/unlock-js/package.json
+++ b/packages/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
@@ -96,7 +96,7 @@ export default async function (
       data,
       purchaseForOptions
     )
-    purchaseForOptions.gasLimit = gasLimit.mul(13).div(10).toNumber()
+    purchaseForOptions.gasLimit = gasLimit.mul(14).div(10).toNumber()
   }
 
   const transactionPromise = lockContract.purchase(


### PR DESCRIPTION
# Description

We are still seeing transactions fail from time to time because of gas limit too low: https://etherscan.io/tx/0x75615a3015cde9bbdeaa11f8111f1d7e3a10afa8cf155e18bd860301f6c46f9c

To succeed, this transaction would have needed 294,776 gas (btw, our new version of the lock contract will significantly reduce that!). and here, for some reason it was sent with a limit of 280,303. Bumping to 40% would have been enough 301,865.

I still believe we need to find the real reason why these estimates are initially wrong. I suspected it was because the code changes its behavior based on gas price, but "forcing" it does not seem to affect the state...

I suspect the gas reductions coming in the new version + the fact that we don't use tx.gasPrice anymore (but the basefee) might actually make things better. Let's revisit that soon!


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

