### PR TITLE
feat(locksmith): adding email notification on new keys

### DIFF
--- a/locksmith/README.md
+++ b/locksmith/README.md
@@ -8,45 +8,37 @@ Among these services, locksmith provides the following:
 - membership metadata hosting
 - Unlock accounts
 
+The locksmith application has several entry points. By default it provides an API server, but could also be run for our `websub` worker. For the latter, prefix all commands with `websub:` (for example: `yarn run websub:dev`)
+
 ## Getting Started
 
 ### Configure Database
 
 Locksmith uses postgres under the hood.
 
-You can spin up a local instance of postgres using docker by running `docker run --name locksmith-postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres -d postgres` or go with a traditional install or hosting provider.
+To start, you can spin up a local instance of postgres using docker by running `docker run --name locksmith-postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_USER=postgres -d postgres` or go with a traditional install or hosting provider.
 
 1. Configure environment variables (Locksmith will recognize these placed in
    an `.env.dev.local` file at the root of the monorepo)
 
-   - **DB_USERNAME** - Database User
-   - **DB_PASSWORD** - Password of User
-   - **DB_NAME** - Database Name
-   - **DB_HOSTNAME** - Database Host
+   If you used the docker command above, just add
+   `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres` (you may need to replace the IP)
+
+   Alternatively, you could set these variables:
+
+   - `DB_USERNAME` - Database User
+   - `DB_PASSWORD` - Password of User
+   - `DB_NAME` - Database Name
+   - `DB_HOSTNAME` - Database Host
 
    **Note**: The following can be used to quickly get started setting up your **local development** database.
 
-   ```sql
-   psql -c 'create database {DATABASE NAME};' -U postgres
-   psql -c "create user {DATASBASE USER NAME} with password '{PASSWORD}';" -U postgres
-   ```
+   You will also need to add the following env var: `DEFAULT_NETWORK=1`
+
+### Running tests
+
+Once the database has been configured (per above), make sure to migrate by calling `yarn run db:migrate` and then call `yarn run test:run`.
 
 ### Running Locksmith
 
 For running in production, use `yarn start` otherwise `yarn dev` which will restart the server on file changes.
-
-### Persistence Information
-
-General database administration is out of scope for this document; it is generally
-advised to provide the database user associated with the application with only the
-permissions required.
-
-In development mode, migrations will run upon start up ensuring that your persistence
-layer is up to date. In production, migrations will need to be performed manually. This
-can be performed via `yarn db:migrate`. Please review the migrations included so that you
-are aware of the items included.
-
-### Testing
-
-Tests can be run via `yarn test`. Please note that the project includes end-to-end tests that
-will require database access

--- a/locksmith/__tests__/operations/wedlocksOperations.test.ts
+++ b/locksmith/__tests__/operations/wedlocksOperations.test.ts
@@ -1,0 +1,86 @@
+import fetch from 'cross-fetch'
+import { addMetadata } from '../../src/operations/userMetadataOperations'
+import {
+  sendEmail,
+  notifyNewKeyToWedlocks,
+} from '../../src/operations/wedlocksOperations'
+
+jest.mock('cross-fetch')
+
+describe('Wedlocks operations', () => {
+  describe('notifyNewKeyToWedlocks', () => {
+    it('should notify wedlocks if there is an email metadata', async () => {
+      expect.assertions(1)
+
+      const lockAddress = '0xlock'
+      const ownerAddress = '0xowner'
+      await addMetadata({
+        chain: 1,
+        tokenAddress: lockAddress,
+        userAddress: ownerAddress,
+        data: {
+          protected: {
+            email: 'julien@unlock-protocol.com',
+          },
+        },
+      })
+      await notifyNewKeyToWedlocks({
+        lock: {
+          address: lockAddress,
+        },
+        owner: {
+          address: ownerAddress,
+        },
+      })
+      expect(fetch).toHaveBeenCalledWith('http://localhost:1337', {
+        body: '{"template":"template","failoverTemplate":"failover","recipient":"julien@unlock-protocol.com","params":{"hello":"world"},"attachments":[]}',
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      })
+    })
+
+    it('should not notify wedlocks if there is no email metadata', async () => {
+      expect.assertions(1)
+
+      const lockAddress = '0xlock'
+      const ownerAddress = '0xowner'
+      await addMetadata({
+        chain: 1,
+        tokenAddress: lockAddress,
+        userAddress: ownerAddress,
+        data: {
+          protected: {
+            name: 'Julien',
+          },
+        },
+      })
+      await notifyNewKeyToWedlocks({
+        lock: {
+          address: lockAddress,
+        },
+        owner: {
+          address: ownerAddress,
+        },
+      })
+      expect(fetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('sendEmail', () => {
+    it('should call the API with the right values', async () => {
+      expect.assertions(1)
+      await sendEmail(
+        'template',
+        'failover',
+        'julien@unlock-protocol.com',
+        { hello: 'world' },
+        []
+      )
+      expect(fetch).toHaveBeenCalledWith('http://localhost:1337', {
+        body: '{"template":"template","failoverTemplate":"failover","recipient":"julien@unlock-protocol.com","params":{"hello":"world"},"attachments":[]}',
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      })
+    })
+  })
+})

--- a/locksmith/__tests__/operations/wedlocksOperations.test.ts
+++ b/locksmith/__tests__/operations/wedlocksOperations.test.ts
@@ -36,7 +36,7 @@ describe('Wedlocks operations', () => {
         },
       })
       expect(fetch).toHaveBeenCalledWith('http://localhost:1337', {
-        body: '{"template":"keyMined-0xowner","failoverTemplate":"keyMined","recipient":"julien@unlock-protocol.com","params":{"keychainUrl":""},"attachments":[]}',
+        body: '{"template":"keyMined-0xowner","failoverTemplate":"keyMined","recipient":"julien@unlock-protocol.com","params":{"keychainUrl":"https://app.unlock-protocol.com/keychain"},"attachments":[]}',
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       })

--- a/locksmith/__tests__/operations/wedlocksOperations.test.ts
+++ b/locksmith/__tests__/operations/wedlocksOperations.test.ts
@@ -8,6 +8,9 @@ import {
 jest.mock('cross-fetch')
 
 describe('Wedlocks operations', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
   describe('notifyNewKeyToWedlocks', () => {
     it('should notify wedlocks if there is an email metadata', async () => {
       expect.assertions(1)
@@ -33,17 +36,35 @@ describe('Wedlocks operations', () => {
         },
       })
       expect(fetch).toHaveBeenCalledWith('http://localhost:1337', {
-        body: '{"template":"template","failoverTemplate":"failover","recipient":"julien@unlock-protocol.com","params":{"hello":"world"},"attachments":[]}',
+        body: '{"template":"keyMined-0xowner","failoverTemplate":"keyMined","recipient":"julien@unlock-protocol.com","params":{"keychainUrl":""},"attachments":[]}',
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       })
     })
 
+    it('should not notify wedlocks if there is no metadata', async () => {
+      expect.assertions(1)
+
+      const lockAddress = '0xanotherlock'
+      const ownerAddress = '0xanotherowner'
+
+      await notifyNewKeyToWedlocks({
+        lock: {
+          address: lockAddress,
+        },
+        owner: {
+          address: ownerAddress,
+        },
+      })
+      expect(fetch).not.toHaveBeenCalled()
+    })
+
     it('should not notify wedlocks if there is no email metadata', async () => {
       expect.assertions(1)
 
-      const lockAddress = '0xlock'
-      const ownerAddress = '0xowner'
+      const lockAddress = '0xanotherlock'
+      const ownerAddress = '0xanotherowner'
+
       await addMetadata({
         chain: 1,
         tokenAddress: lockAddress,
@@ -54,6 +75,7 @@ describe('Wedlocks operations', () => {
           },
         },
       })
+
       await notifyNewKeyToWedlocks({
         lock: {
           address: lockAddress,

--- a/locksmith/config/config.js
+++ b/locksmith/config/config.js
@@ -2,6 +2,7 @@ const urlParser = require('url')
 
 const config = {
   database: {
+    logging: false,
     dialect: 'postgres', // sequelize v4 needs this
   },
   stripeSecret: process.env.STRIPE_SECRET,

--- a/locksmith/config/config.js
+++ b/locksmith/config/config.js
@@ -11,6 +11,9 @@ const config = {
     '0x08491b7e20566b728ce21a07c88b12ed8b785b3826df93a7baceb21ddacf8b61',
   metadataHost: process.env.METADATA_HOST,
   logging: false,
+  services: {
+    wedlocks: 'http://localhost:1337'
+  },
 }
 
 if (Boolean(process.env.ON_HEROKU)) {
@@ -40,5 +43,10 @@ if (process.env.DATABASE_URL) {
     dialect: 'postgres',
   }
 }
+
+if (process.env.UNLOCK_ENV === 'prod' || process.env.UNLOCK_ENV === 'staging') {
+  config.services.wedlocks = 'https://wedlocks.unlock-protocol.com/.netlify/functions/handler'
+} 
+
 
 module.exports = config

--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch'
+import * as Normalizer from '../utils/normalizer'
 import { UserTokenMetadata } from '../models'
 import config from '../../config/config'
 
@@ -59,17 +60,18 @@ export const notifyNewKeysToWedlocks = async (keys: any[]) => {
  * @param key
  */
 export const notifyNewKeyToWedlocks = async (key: any) => {
-  const UserTokenMetadataRecord = await UserTokenMetadata.findOne({
+  const userTokenMetadataRecord = await UserTokenMetadata.findOne({
     where: {
-      tokenAddress: key.lock.address,
-      userAddress: key.owner.address,
+      tokenAddress: Normalizer.ethereumAddress(key.lock.address),
+      userAddress: Normalizer.ethereumAddress(key.owner.address),
     },
   })
-  if (UserTokenMetadataRecord?.data?.userMetadata?.protected?.email) {
+
+  if (userTokenMetadataRecord?.data?.userMetadata?.protected?.email) {
     await sendEmail(
       `keyMined-${key.owner.address}`,
       'keyMined',
-      UserTokenMetadataRecord.data.userMetadata.protected.email,
+      userTokenMetadataRecord.data.userMetadata.protected.email,
       {
         keychainUrl: '',
       }

--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -1,0 +1,78 @@
+import fetch from 'cross-fetch'
+import { UserTokenMetadata } from '../models'
+import config from '../../config/config'
+
+type Params = {
+  [key: string]: any
+}
+
+type Attachment = {
+  path: string
+}
+
+/**
+ * Function to send an email with the Wedlocks service
+ * Pass a template, a recipient, some params and attachements
+ * @param template
+ * @param failoverTemplate
+ * @param recipient
+ * @param params
+ * @param attachments
+ * @returns
+ */
+export const sendEmail = async (
+  template: string,
+  failoverTemplate: string,
+  recipient: string,
+  params: Params = {},
+  attachments: Attachment[] = []
+) => {
+  const payload = {
+    template,
+    failoverTemplate,
+    recipient,
+    params,
+    attachments,
+  }
+  return fetch(config.services.wedlocks, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+}
+
+/**
+ * Resolves when all new keys have been processed
+ * @param keys
+ */
+export const notifyNewKeysToWedlocks = async (keys: any[]) => {
+  for (const key of keys) {
+    await notifyNewKeyToWedlocks(key)
+  }
+}
+
+/**
+ * Check if there are metadata with an email address for a key and sends
+ * and email based on the lock's template if applicable
+ * @param key
+ */
+export const notifyNewKeyToWedlocks = async (key: any) => {
+  const UserTokenMetadataRecord = await UserTokenMetadata.findOne({
+    where: {
+      tokenAddress: key.lock.address,
+      userAddress: key.owner.address,
+    },
+  })
+  if (UserTokenMetadataRecord?.data?.userMetadata?.protected?.email) {
+    await sendEmail(
+      `keyMined-${key.owner.address}`,
+      'keyMined',
+      UserTokenMetadataRecord.data.userMetadata.protected.email,
+      {
+        keychainUrl: '',
+      }
+    )
+  }
+}

--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -70,7 +70,8 @@ export const notifyNewKeyToWedlocks = async (key: any) => {
     userTokenMetadataRecord?.data?.userMetadata?.protected?.email
   if (recipient) {
     await sendEmail(`keyMined-${key.owner.address}`, 'keyMined', recipient, {
-      keychainUrl: '',
+      lockName: key.lock.name,
+      keychainUrl: 'https://app.unlock-protocol.com/keychain',
     })
   }
 }

--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -66,15 +66,11 @@ export const notifyNewKeyToWedlocks = async (key: any) => {
       userAddress: Normalizer.ethereumAddress(key.owner.address),
     },
   })
-
-  if (userTokenMetadataRecord?.data?.userMetadata?.protected?.email) {
-    await sendEmail(
-      `keyMined-${key.owner.address}`,
-      'keyMined',
-      userTokenMetadataRecord.data.userMetadata.protected.email,
-      {
-        keychainUrl: '',
-      }
-    )
+  const recipient =
+    userTokenMetadataRecord?.data?.userMetadata?.protected?.email
+  if (recipient) {
+    await sendEmail(`keyMined-${key.owner.address}`, 'keyMined', recipient, {
+      keychainUrl: '',
+    })
   }
 }

--- a/locksmith/src/websub/jobs/keys.ts
+++ b/locksmith/src/websub/jobs/keys.ts
@@ -40,7 +40,7 @@ async function notifyHooksOfAllUnprocessedKeys(hooks: Hook[], network: number) {
       break
     }
 
-    await await Promise.all([
+    await await Promise.allSettled([
       notifyNewKeysToWedlocks(keys), // send emails when applicable!
       ...hooks.map(async (hook) => {
         const data = keys.filter((key: any) => key.lock.id === hook.lock)

--- a/locksmith/src/websub/jobs/keys.ts
+++ b/locksmith/src/websub/jobs/keys.ts
@@ -4,6 +4,7 @@ import { Key } from '../../graphql/datasource'
 import { Hook, ProcessedHookItem } from '../../models'
 import { TOPIC_KEYS } from '../topics'
 import { notifyHook, filterHooksByTopic } from '../helpers'
+import { notifyNewKeysToWedlocks } from '../../operations/wedlocksOperations'
 
 const FETCH_LIMIT = 25
 
@@ -38,6 +39,9 @@ async function notifyHooksOfAllUnprocessedKeys(hooks: Hook[], network: number) {
     if (!keys.length) {
       break
     }
+
+    // Notify all new keys to wedlocks!
+    await notifyNewKeysToWedlocks(keys)
 
     await Promise.all(
       hooks.map(async (hook) => {

--- a/locksmith/src/websub/jobs/keys.ts
+++ b/locksmith/src/websub/jobs/keys.ts
@@ -40,19 +40,17 @@ async function notifyHooksOfAllUnprocessedKeys(hooks: Hook[], network: number) {
       break
     }
 
-    // Notify all new keys to wedlocks!
-    await notifyNewKeysToWedlocks(keys)
-
-    await Promise.all(
-      hooks.map(async (hook) => {
+    await await Promise.all([
+      notifyNewKeysToWedlocks(keys), // send emails when applicable!
+      ...hooks.map(async (hook) => {
         const data = keys.filter((key: any) => key.lock.id === hook.lock)
         const hookEvent = await notifyHook(hook, {
           data,
           network,
         })
         return hookEvent
-      })
-    )
+      }),
+    ])
 
     const processedHookItems = keys.map((key: any) => {
       return {

--- a/wedlocks/src/__tests__/templates/keyMined.test.js
+++ b/wedlocks/src/__tests__/templates/keyMined.test.js
@@ -23,8 +23,8 @@ describe('keyMined', () => {
     ).toBe(
       `Hello!
 
-A new key (#1337) to the lock "Ethereal NYC 202" was just mined for you!
-It has been added to your Unlock keychain, where you can view it and, if needed, print it!
+A new key to the lock "Ethereal NYC 202" was just mined for you!
+It has been added to your Unlock Keychain, where you can view it and, if needed, print it as a signed QR Code!
 
 Check out your keychain: https://app.unlock-protocol.com/keychain
 

--- a/wedlocks/src/templates/keyMined.js
+++ b/wedlocks/src/templates/keyMined.js
@@ -3,8 +3,8 @@ export default {
   text: (params) =>
     `Hello!
 
-A new key (#${params.keyId}) to the lock "${params.lockName}" was just mined for you!
-It has been added to your Unlock keychain, where you can view it and, if needed, print it!
+A new key to the lock "${params.lockName}" was just mined for you!
+It has been added to your Unlock Keychain, where you can view it and, if needed, print it as a signed QR Code!
 
 Check out your keychain: ${params.keychainUrl}
 


### PR DESCRIPTION
# Description

Adding a mechanism to automatically send an email notification when a new key is sold on a lock.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

## Release Note Draft Snippet

Automated emails sent when new key is sold and has a metadata field set for the owner.
