### PR TITLE
fix(ci): Add third build directory parameter to heroku script and CI deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,10 @@ jobs:
       app-name:
         description: "The Heroku app name to which the application should be deployed"
         type: string
+      build-dir:
+        description: "The build directory to use. By default, it will use name of the service as build directory"
+        type: string
+        default: ""
     steps:
       - checkout
       - run:
@@ -109,7 +113,7 @@ jobs:
       - run:
           name: Build container & deploy to heroku
           command: |
-            sh ./scripts/heroku.sh << parameters.service >> << parameters.app-name >>
+            sh ./scripts/heroku.sh << parameters.service >> << parameters.app-name >> << parameters.build-dir >>
 
   open-prod-pull-request:
     executor: ubuntu_20-executor
@@ -178,6 +182,7 @@ workflows:
       - build-and-deploy-to-heroku:
           name: "deploy-locksmith-websub-staging"
           service: locksmith-websub
+          build-dir: locksmith
           app-name: locksmith-websub-staging
           requires:
             - integration-tests
@@ -187,6 +192,7 @@ workflows:
       - build-and-deploy-to-heroku:
           name: "deploy-locksmith-websub-production"
           service: locksmith-websub
+          build-dir: locksmith
           app-name: locksmith-websub-production
           requires:
             - integration-tests

--- a/.github/disabled-workflows/_heroku.yml
+++ b/.github/disabled-workflows/_heroku.yml
@@ -11,6 +11,10 @@ on:
         description: "The Heroku app name to which the application should be deployed"
         type: string
         required: true
+      build-dir:
+        description: 'The build directory to use. By default, it will use name of the service as build directory.'
+        type: string
+        required: false
 
 jobs:
   deploy-to-heroku:
@@ -31,4 +35,4 @@ jobs:
       - name: Build & deploy to heroku
         if: ${{ steps.check_changes.outputs.changed == 'changed' }}
         run: |
-          sh ./scripts/heroku.sh ${{ inputs.service }} ${{ inputs.app-name }}
+          sh ./scripts/heroku.sh ${{ inputs.service }} ${{ inputs.app-name }} ${{ inputs.build-dir }}

--- a/.github/disabled-workflows/deploy.yml
+++ b/.github/disabled-workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
     uses: unlock-protocol/unlock/.github/workflows/_heroku.yml@gh-actions
     with:
       service: locksmith-websub
+      build-dir: locksmith
       app-name: locksmith-websub-staging
   
   deploy-locksmith-websub-production:    
@@ -32,6 +33,7 @@ jobs:
     uses: unlock-protocol/unlock/.github/workflows/_heroku.yml@gh-actions
     with:
       service: locksmith-websub
+      build-dir: locksmith
       app-name: locksmith-websub-production
   # netlify deploys
   deploy-unlock-app-netlify:

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -150,7 +150,7 @@ services:
     depends_on:
       - postgres
   locksmith-websub:
-    image: locksmith
+    image: locksmith-websub
     build:
       context: ../
       target: dev

--- a/scripts/heroku.sh
+++ b/scripts/heroku.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
-set -eu
+set -e
 
 # two args
 SERVICE=$1
 HEROKU_APP_NAME=$2
+BUILD_DIRECTORY=$1
+
+# if build directory argument provided, use it instead
+if [ -n "${3}" ]; then
+    BUILD_DIRECTORY=$3
+fi
+
+echo "Using $BUILD_DIRECTORY as build directory"
 
 echo "Deploying $SERVICE to Heroku $HEROKU_APP_NAME ..."
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Websub exists as part of locksmith directory but we are deploying it separately. So the existing way to reuse service name as a build directory parameter for caching purposes in docker breaks. This PR adds an explicit build-dir argument to CI which is optional but can be configured to change build directory. 

This also fixes websub deployment which is broken as a reason.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

