### PR TITLE
feat(unlock-js): Add setMaxNumberOfKeys support

### DIFF
--- a/packages/unlock-js/src/PublicLock/v9/index.js
+++ b/packages/unlock-js/src/PublicLock/v9/index.js
@@ -1,5 +1,6 @@
 import abis from '../../abis'
 import purchaseKey from './purchaseKey'
+import setMaxNumberOfKeys from './setMaxNumberOfKeys'
 import v8 from '../v8'
 
 const {
@@ -34,4 +35,5 @@ export default {
   getLock,
   purchaseKey,
   keyManagerOf,
+  setMaxNumberOfKeys,
 }

--- a/packages/unlock-js/src/PublicLock/v9/setMaxNumberOfKeys.js
+++ b/packages/unlock-js/src/PublicLock/v9/setMaxNumberOfKeys.js
@@ -1,0 +1,16 @@
+export async function setMaxNumberOfKeys(
+  { lockAddress, maxNumberOfKeys },
+  callback
+) {
+  const lockContract = await this.getLockContract(lockAddress)
+  const transactionPromise = lockContract.setMaxNumberOfKeys(maxNumberOfKeys)
+  const hash = await this._handleMethodCall(transactionPromise)
+
+  if (callback) {
+    callback(null, hash, await transactionPromise)
+  }
+
+  await this.provider.waitForTransaction(hash)
+}
+
+export default setMaxNumberOfKeys

--- a/packages/unlock-js/src/__tests__/integration/walletServiceIntegration.test.js
+++ b/packages/unlock-js/src/__tests__/integration/walletServiceIntegration.test.js
@@ -649,6 +649,35 @@ describe.each(UnlockVersionNumbers)('Unlock %s', (unlockVersion) => {
         })
       })
 
+      // Test only on lock v9 and above.
+      if (['v9'].indexOf(publicLockVersion) !== -1) {
+        describe('setMaxNumberOfKeys', () => {
+          let oldMaxNumberOfKeys
+
+          beforeAll(async () => {
+            oldMaxNumberOfKeys = lock.maxNumberOfKeys
+            await walletService.setMaxNumberOfKeys(
+              {
+                lockAddress,
+                maxNumberOfKeys: parseFloat(200).toString(),
+              },
+              (error) => {
+                if (error) {
+                  throw error
+                }
+              }
+            )
+            lock = await web3Service.getLock(lockAddress, chainId)
+          })
+
+          it('Check if setMaxNumberOfKeys updated the maxNumberOfKeys', () => {
+            expect.assertions(2)
+            expect(oldMaxNumberOfKeys).not.toBe(lock.maxNumberOfKeys)
+            expect(lock.maxNumberOfKeys).toBe(200)
+          })
+        })
+      }
+
       if (['v4', 'v6'].indexOf(publicLockVersion) === -1) {
         const keyGranter = '0x8Bf9b48D4375848Fb4a0d0921c634C121E7A7fd0'
         describe('keyGranter', () => {

--- a/packages/unlock-js/src/walletService.js
+++ b/packages/unlock-js/src/walletService.js
@@ -294,4 +294,13 @@ export default class WalletService extends UnlockService {
       callback(error, null)
     }
   }
+
+  async setMaxNumberOfKeys(params = {}, callback) {
+    if (!params.lockAddress) throw new Error('Missing lockAddress')
+    const version = await this.lockContractAbiVersion(params.lockAddress)
+    if (!version.setMaxNumberOfKeys) {
+      throw new Error('Lock version not supported')
+    }
+    return version.setMaxNumberOfKeys.bind(this)(params, callback)
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This adds support for setting maxNumberOfKeys in the lock.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

