### PR TITLE
feat & breaking(ui): Use the brand colors and improve the API for button

### DIFF
--- a/packages/ui/.storybook/preview-head.html
+++ b/packages/ui/.storybook/preview-head.html
@@ -1,0 +1,3 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">

--- a/packages/ui/lib/components/Button/Button.stories.tsx
+++ b/packages/ui/lib/components/Button/Button.stories.tsx
@@ -1,6 +1,8 @@
 import { Button } from './Button'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { FaLock as LockIcon } from 'react-icons/fa'
+import { CgSpinner as SpinnerIcon } from 'react-icons/cg'
+
 export default {
   component: Button,
   title: 'Button',
@@ -8,18 +10,34 @@ export default {
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
 
-export const Primary = Template.bind({})
+export const PrimaryButton = Template.bind({})
 
-Primary.args = {
-  children: 'Lock Button',
-  leftIcon: <LockIcon size={12} />,
+PrimaryButton.args = {
+  children: 'Connect',
+  iconLeft: <LockIcon size={12} />,
 }
 
+export const SecondaryButton = Template.bind({})
 
-export const ButtonWithRightIcon = Template.bind({})
+SecondaryButton.args = {
+  children: 'Create Lock',
+  size: 'large',
+  variant: 'secondary',
+  iconLeft: <LockIcon size={14} />,
+}
 
-ButtonWithRightIcon.args = {
-  children: 'Button with right icon',
-  size:"large",
-  rightIcon: <LockIcon size={14} />,
+export const DisabledButton = Template.bind({})
+
+DisabledButton.args = {
+  children: 'Disabled',
+  disabled: true,
+  iconRight: <LockIcon size={12} />,
+}
+
+export const LoadingButton = Template.bind({})
+
+LoadingButton.args = {
+  children: 'Loading Locks...',
+  disabled: true,
+  iconRight: <SpinnerIcon className='animate-spin motion-reduce:invisible' size={18} />,
 }

--- a/packages/ui/lib/components/Button/Button.tsx
+++ b/packages/ui/lib/components/Button/Button.tsx
@@ -1,40 +1,54 @@
 import type { ReactNode, ButtonHTMLAttributes, ForwardedRef } from 'react'
 import type { SizeStyleProp, Size } from '../../types'
 import { twMerge } from 'tailwind-merge'
-import { forwardRef } from 'react'
+import { forwardRef, Fragment } from 'react'
+import { CgSpinner as SpinnerIcon } from 'react-icons/cg'
 
-// Once we have a design system or language, we should omit className so user doesn't end up deviating too much.
+type Variant = 'primary' | 'secondary'
+
 interface Props
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size' | 'ref'> {
+  extends Omit<
+    ButtonHTMLAttributes<HTMLButtonElement>,
+    'size' | 'ref' | 'className'
+  > {
   size?: Size
-  leftIcon?: ReactNode
-  rightIcon?: ReactNode
+  iconRight?: ReactNode
+  iconLeft?: ReactNode
   label: string
+  variant?: Variant
 }
 
 const SIZE_STYLES: SizeStyleProp = {
-  small: 'px-4 py-1.5 text-sm',
-  medium: 'px-6 py-2 text-base',
-  large: 'px-8 py-3 text-lg',
+  small: 'px-4 py-2 text-sm',
+  medium: 'px-6 py-2.5 text-base',
+  large: 'px-8 py-3.5 text-lg',
+}
+
+const VARIANTS_STYLES: Record<Variant, string> = {
+  primary: 'bg-brand-ui-primary  transition ease-in-out duration-300 hover:bg-brand-dark text-white disabled:hover:bg-brand-ui-primary disabled:hover:bg-opacity-75',
+  secondary: 'bg-white transition ease-in-out duration-300 text-brand-dark [box-shadow:0px_8px_30px_0px_rgba(0,_0,_0,_0.08)] hover:[box-shadow:0px_0px_10px_0px_rgba(183,_19,_255,_0.1)] disabled:hover:[box-shadow:0px_8px_30px_0px_rgba(0,_0,_0,_0.08)] disabled:hover:bg-opacity-75',
 }
 
 export const Button = forwardRef(
   (props: Props, ref: ForwardedRef<HTMLButtonElement>) => {
+    const {
+      children,
+      size = 'medium',
+      variant = 'primary',
+      iconLeft,
+      iconRight,
+      ...restProps
+    } = props
     const buttonClass = twMerge(
-      'border rounded hover:bg-gray-50 flex font-semibold items-center gap-4',
-      props.size ? SIZE_STYLES[props.size] : SIZE_STYLES['medium'],
-      props.className
+      'rounded-full flex font-semibold items-center gap-2 disabled:bg-opacity-75  disabled:cursor-not-allowed',
+      SIZE_STYLES[size],
+      VARIANTS_STYLES[variant],
     )
     return (
-      <button
-        className={buttonClass}
-        {...props}
-        ref={ref}
-        aria-label={props.label}
-      >
-        {props.leftIcon}
-        {props.children}
-        {props.rightIcon}
+      <button className={buttonClass} {...restProps} ref={ref}>
+        {iconLeft}
+        <span> {children}</span>
+        {iconRight}
       </button>
     )
   }

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -1,9 +1,14 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
 module.exports = {
   content: ['./lib/**/*.{tsx,jsx,ts,js}'],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
       colors: {
-        // Primary Blue Dark
+        // Primar Blue Dark
         'brand-dark': '#020207',
         // Dark Gray
         'brand-gray': '#535353',
@@ -13,6 +18,8 @@ module.exports = {
         'brand-secondary': '#FF6771',
         // Primary blue
         'brand-ui-primary': '#603DEB',
+        // Primar Blue Dark
+        'brand-ui-secondary': '#020207',
       },
     },
   },


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This adds branding to our button and force the use of correct font that is specified in the figma file in development.

![image](https://user-images.githubusercontent.com/73341821/151976628-3f199f9f-39c4-4098-bcd5-68a79336546b.png)

![image](https://user-images.githubusercontent.com/73341821/151985215-35491efd-bffd-4274-8f53-36feac156179.png)

![image](https://user-images.githubusercontent.com/73341821/151976699-e384d38f-0174-4ad7-8a47-e475949926d5.png)

![image](https://user-images.githubusercontent.com/73341821/151976485-4a253ec5-1a86-440d-abda-bef062b865e4.png)

https://user-images.githubusercontent.com/73341821/151985468-90a5fb9e-2fa0-47a7-b00c-3006a480ccf5.mp4


# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

