### PR TITLE
debug(websub): adding logging statements for websub

### DIFF
--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -2,6 +2,7 @@ import fetch from 'cross-fetch'
 import * as Normalizer from '../utils/normalizer'
 import { UserTokenMetadata } from '../models'
 import config from '../../config/config'
+import { logger } from '../logger'
 
 type Params = {
   [key: string]: any
@@ -69,6 +70,11 @@ export const notifyNewKeyToWedlocks = async (key: any) => {
   const recipient =
     userTokenMetadataRecord?.data?.userMetadata?.protected?.email
   if (recipient) {
+    logger.info('Notifying wedlock for new key', {
+      recipient,
+      lock: key.lock.address,
+      keyId: key.keyId,
+    })
     await sendEmail(`keyMined-${key.owner.address}`, 'keyMined', recipient, {
       lockName: key.lock.name,
       keychainUrl: 'https://app.unlock-protocol.com/keychain',

--- a/locksmith/src/websub/jobs/keys.ts
+++ b/locksmith/src/websub/jobs/keys.ts
@@ -5,6 +5,7 @@ import { Hook, ProcessedHookItem } from '../../models'
 import { TOPIC_KEYS } from '../topics'
 import { notifyHook, filterHooksByTopic } from '../helpers'
 import { notifyNewKeysToWedlocks } from '../../operations/wedlocksOperations'
+import { logger } from '../../logger'
 
 const FETCH_LIMIT = 25
 
@@ -39,6 +40,9 @@ async function notifyHooksOfAllUnprocessedKeys(hooks: Hook[], network: number) {
     if (!keys.length) {
       break
     }
+    logger.info('Found new keys', {
+      keys: keys.map((key: any) => [key.lock.address, key.keyId]),
+    })
 
     await await Promise.allSettled([
       notifyNewKeysToWedlocks(keys), // send emails when applicable!


### PR DESCRIPTION
# Description

In order to debug missing notifications, I am adding a few logging statements to the websub job.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

