### PR TITLE
fix(unlock-app): Grant Key Button style and revert previous changes

### DIFF
--- a/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
+++ b/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
@@ -212,7 +212,14 @@ const GrantKeyForm = ({ onGranted, lock }: GrantKeyFormProps) => {
         </div>
       </div>
 
-      {!loading && <Button type="submit">Grant Key</Button>}
+      {!loading && (
+        <button
+          className="bg-[#74ce63] text-white flex justify-center w-full px-4 py-3 font-medium rounded hover:bg-[#59c245]"
+          type="submit"
+        >
+          Grant Key
+        </button>
+      )}
       {loading && network && (
         <TransactionPendingButton network={network} transaction={transaction} />
       )}

--- a/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
+++ b/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
@@ -11,7 +11,6 @@ import {
   Label,
   Select,
   TransactionPendingButton,
-  Button,
 } from '../../interface/checkout/FormStyles'
 import { ACCOUNT_REGEXP } from '../../../constants'
 import { getAddressForName } from '../../../hooks/useEns'

--- a/unlock-app/src/components/interface/buttons/ActionButton.tsx
+++ b/unlock-app/src/components/interface/buttons/ActionButton.tsx
@@ -10,9 +10,9 @@ interface ActionButtonProps {
 }
 
 export const ActionButton = styled.button<ActionButtonProps>`
-  height: 40px;
-  padding-left: 25px !important;
-  padding-right: 25px !important;
+  height: 60px;
+  padding-left: 15px;
+  padding-right: 15px;
   font-size: 16px;
 
   color: ${(props) =>
@@ -26,9 +26,7 @@ export const ActionButton = styled.button<ActionButtonProps>`
   border: 2px solid;
 
   border-color: ${(props) =>
-    props.disabled
-      ? 'var(--grey) !important'
-      : props.borderColor || 'var(--green) !important'};
+    props.disabled ? 'var(--grey)' : props.borderColor || 'var(--green) '};
 
   background-color: ${(props) =>
     props.disabled ? 'var(--grey)' : props.color || 'var(--green)'};
@@ -36,18 +34,18 @@ export const ActionButton = styled.button<ActionButtonProps>`
   &:hover {
     color: ${(props) =>
       props.disabled
-        ? 'var(--white) !important'
-        : props.fontActiveColor || 'var(--white) !important'};
+        ? 'var(--white) '
+        : props.fontActiveColor || 'var(--white) '};
 
     border-color: ${(props) =>
       props.disabled
         ? 'var(--grey)'
-        : props.activeBorderColor || 'var(--activegreen) !important'};
+        : props.activeBorderColor || 'var(--activegreen) '};
 
     background-color: ${(props) =>
       props.disabled
         ? 'var(--grey)'
-        : props.activeColor || 'var(--activegreen) !important'};
+        : props.activeColor || 'var(--activegreen) '};
   }
 `
 

--- a/unlock-app/src/components/interface/user-account/PaymentDetails.tsx
+++ b/unlock-app/src/components/interface/user-account/PaymentDetails.tsx
@@ -113,7 +113,7 @@ export const Form = ({
       {loading && <LoadingButton>Saving</LoadingButton>}
       {!loading && (
         <button
-          className="bg-[#74ce63] text-white flex justify-center w-full px-4 py-2 font-medium rounded hover:bg-[#59c245]"
+          className="bg-[#74ce63] text-white flex justify-center w-full px-4 py-3 font-medium rounded hover:bg-[#59c245]"
           type="submit"
           disabled={!stripe}
         >


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Reverting style changes because our layout doesn't adjust to changes in screen resolution properly. There are also inheriting buttons which depend on overriding styles so `!important` block those. 

We should reduce the number of buttons and dependence on inheritance.

![image](https://user-images.githubusercontent.com/73341821/153894572-6e033baf-c001-401a-8589-36447269869e.png)
![image](https://user-images.githubusercontent.com/73341821/153894852-4a605066-ad2e-450d-b86a-386a43230423.png)


# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

