### PR TITLE
fix(smart-contracts): make lock layout upgrade-compatible

### DIFF
--- a/packages/contracts/src/contracts/PublicLock/PublicLockV9.sol
+++ b/packages/contracts/src/contracts/PublicLock/PublicLockV9.sol
@@ -3139,7 +3139,7 @@ contract MixinPurchase is
   event UnlockCallFailed(address indexed lockAddress, address unlockAddress);
 
   // default to 0 
-  uint256 private _gasRefundValue = 0; 
+  uint256 private _gasRefundValue;
 
   /**
   * @dev Set the value/price to be refunded to the sender on purchase

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -25,7 +25,7 @@ contract MixinPurchase is
   event UnlockCallFailed(address indexed lockAddress, address unlockAddress);
 
   // default to 0 
-  uint256 private _gasRefundValue = 0; 
+  uint256 private _gasRefundValue;
 
   /**
   * @dev Set the value/price to be refunded to the sender on purchase

--- a/smart-contracts/test/Lock/purchaseGasRefund.js
+++ b/smart-contracts/test/Lock/purchaseGasRefund.js
@@ -56,7 +56,7 @@ contract('Lock / GasRefund', (accounts) => {
 
         it('get set properly', async () => {
           await lock.setGasRefundValue(gasRefundAmount)
-          assert.equal((await lock.gasRefundValue()).toNumber(), 0)
+          assert.equal((await lock.gasRefundValue()).eq(gasRefundAmount), true)
         })
 
         it('can not be set if caller is not lock manager', async () => {

--- a/smart-contracts/test/Lock/purchaseGasRefund.js
+++ b/smart-contracts/test/Lock/purchaseGasRefund.js
@@ -50,9 +50,13 @@ contract('Lock / GasRefund', (accounts) => {
       })
 
       describe('gas refund value', () => {
+        it('default to zero', async () => {
+          assert.equal((await lock.gasRefundValue()).toNumber(), 0)
+        })
+
         it('get set properly', async () => {
           await lock.setGasRefundValue(gasRefundAmount)
-          assert.equal((await lock.gasRefundValue()).eq(gasRefundAmount), true)
+          assert.equal((await lock.gasRefundValue()).toNumber(), 0)
         })
 
         it('can not be set if caller is not lock manager', async () => {


### PR DESCRIPTION
# Description

Currently we explicitely initialize `_gasRefundValue` to zero in `contracts/mixins/MixinPurchase.sol:28`.

The leads to OZ upgrader complaining that the layout is not upgrade-safe

```
 Variable `_gasRefundValue` is assigned an initial value
    Move the assignment to the initializer https://zpl.in/upgrades/error-004
```

We don't have an initiliazer in that mixin but `uint` get initialized to 0 in Solidity anyways, so this just remove the explicit equality part.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

