### PR TITLE
fix(smart-contracts): remove use of 0 to set infinite duration

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -203,7 +203,7 @@ contract Unlock is
   /**
   * @notice Create lock (legacy)
   * This deploys a lock for a creator. It also keeps track of the deployed lock.
-  * @param _expirationDuration the duration of the lock (pass 0 for unlimited duration)
+  * @param _expirationDuration the duration of the lock (pass type(uint).max for unlimited duration)
   * @param _tokenAddress set to the ERC20 token address, or 0 for ETH.
   * @param _keyPrice the price of each key
   * @param _maxNumberOfKeys the maximum nimbers of keys to be edited

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -105,7 +105,6 @@ contract MixinLockCore is
     uint _maxNumberOfKeys
   ) internal
   {
-    require(_expirationDuration <= 100 * 365 * 24 * 60 * 60, 'MAX_EXPIRATION_100_YEARS');
     unlockProtocol = IUnlock(msg.sender); // Make sure we link back to Unlock's smart contract.
     beneficiary = _beneficiary;
     expirationDuration = _expirationDuration;

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -108,7 +108,7 @@ contract MixinLockCore is
     require(_expirationDuration <= 100 * 365 * 24 * 60 * 60, 'MAX_EXPIRATION_100_YEARS');
     unlockProtocol = IUnlock(msg.sender); // Make sure we link back to Unlock's smart contract.
     beneficiary = _beneficiary;
-    expirationDuration = _expirationDuration == 0 ? type(uint).max : _expirationDuration;
+    expirationDuration = _expirationDuration;
     keyPrice = _keyPrice;
     maxNumberOfKeys = _maxNumberOfKeys;
   }

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -1,4 +1,3 @@
-const { reverts } = require('truffle-assertions')
 const createLockHash = require('../../helpers/createLockCalldata')
 
 const PublicLock = artifacts.require('PublicLock')

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -57,23 +57,5 @@ exports.shouldCreateLock = (options) => {
         )
       })
     })
-
-    describe('lock creation fails', () => {
-      it('should fail if expirationDuration is too large', async () => {
-        const args = [
-          60 * 60 * 24 * 365 * 101, // expirationDuration: 101 years
-          web3.utils.padLeft(0, 40),
-          web3.utils.toWei('1', 'ether'), // keyPrice: in wei
-          100, // maxNumberOfKeys
-          'Too Big Expiration Lock',
-        ]
-        const calldata = await createLockHash({ args, from: accounts[0] })
-        reverts(
-          unlock.createUpgradeableLock(calldata, {
-            gas: 4000000,
-          })
-        )
-      })
-    })
   })
 }

--- a/smart-contracts/test/fixtures/locks.js
+++ b/smart-contracts/test/fixtures/locks.js
@@ -1,4 +1,5 @@
 const BigNumber = require('bignumber.js')
+const { constants } = require('hardlydifficult-eth')
 
 let publicLock = {
   expirationDuration: new BigNumber(60 * 60 * 24 * 30), // 30 days
@@ -29,6 +30,6 @@ module.exports = {
     isErc20: true, // indicates the test should deploy a test token
   }),
   NON_EXPIRING: Object.assign({}, publicLock, {
-    expirationDuration: 0, // indicates that the lock should not expired
+    expirationDuration: constants.MAX_UINT, // indicates that the lock should not expired
   }),
 }

--- a/smart-contracts/test/fixtures/locks.js
+++ b/smart-contracts/test/fixtures/locks.js
@@ -30,6 +30,6 @@ module.exports = {
     isErc20: true, // indicates the test should deploy a test token
   }),
   NON_EXPIRING: Object.assign({}, publicLock, {
-    expirationDuration: constants.MAX_UINT, // indicates that the lock should not expired
+    expirationDuration: new BigNumber(constants.MAX_UINT), // indicates that the lock should not expired
   }),
 }


### PR DESCRIPTION
# Description

Removes the ability to use 0 to set infinite duration at lock creation.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #8222
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

