### PR TITLE
not showing option to create account when grant is not possible

### DIFF
--- a/unlock-app/src/components/interface/checkout/CheckoutMethod.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutMethod.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { ActionButton } from '../buttons/ActionButton'
 import Svg from '../svg'
+import { inClaimDisallowList } from '../../../utils/checkoutLockUtils'
 
 interface CheckoutMethodProps {
   onWalletSelected: () => void
@@ -20,7 +21,11 @@ export const CheckoutMethod = ({
 }: CheckoutMethodProps) => {
   const isCreditCardEnabled = lock.fiatPricing?.creditCardEnabled
 
-  if (lock.keyPrice === '0' && lock.fiatPricing?.creditCardEnabled) {
+  if (
+    lock.keyPrice === '0' &&
+    lock.fiatPricing?.creditCardEnabled &&
+    !inClaimDisallowList(lock.address)
+  ) {
     // We can grant keys for free!
     return (
       <Wrapper>


### PR DESCRIPTION
# Description

Not showing option to create an account when not able to grant.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

