### PR TITLE
feat(unlock-app) -  skip metadata collection when all fields are optional

### DIFF
--- a/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
@@ -16,21 +16,27 @@ export const CheckoutContainer: React.FunctionComponent<Props> = ({
 
 export const Container = styled.div`
   position: fixed;
-  height: 100%;
-  width: 100%;
+  height: 100vh;
+  width: 100vw;
   left: 0;
   top: 0;
-  padding-top: 10%;
-  padding-bottom: 5%;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   overflow-y: scroll;
   overflow-x: hidden;
   ${Media.phone`
     padding-top: 0;
     padding-bottom: 0;
   `}
+
+  &:before {
+    content: '';
+    background: rgba(0, 0, 0, 25%);
+    position: absolute;
+    inset: 0;
+  }
 `
 
 export default CheckoutContainer

--- a/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutWrapper.tsx
@@ -70,7 +70,6 @@ const Wrapper = styled.section`
   color: var(--darkgrey);
   border-radius: 4px;
   position: relative;
-  box-shadow: 0px 0px 60px rgba(0, 0, 0, 0.25);
   ${Media.nophone`
     width: 380px;
   `}

--- a/unlock-app/src/components/interface/checkout/FormStyles.tsx
+++ b/unlock-app/src/components/interface/checkout/FormStyles.tsx
@@ -31,6 +31,20 @@ export const Label = styled.label`
   margin-bottom: 3px;
 `
 
+export const ActionLabel = styled.button`
+  cursor: pointer;
+  width: 100%;
+  display: block;
+  text-align: right;
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--grey);
+
+  &:hover {
+    text-decoration: underline;
+  }
+`
+
 export const Select = styled.select`
   height: 48px;
   width: 100%;

--- a/unlock-app/src/components/interface/checkout/FormStyles.tsx
+++ b/unlock-app/src/components/interface/checkout/FormStyles.tsx
@@ -91,6 +91,17 @@ export const NeutralButton = styled(Button)`
   background-color: var(--grey);
 `
 
+export const DefaultButton = styled(Button)`
+  background-color: var(--lightgrey);
+  color: #000;
+  font-weight: 600;
+
+  &:hover {
+    background-color: var(--lightgrey);
+    border: 1px solid var(--blue);
+  }
+`
+
 export const FormError = styled.p`
   font-size: 12px;
   color: var(--red);

--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -2,7 +2,13 @@ import React, { useState, useContext } from 'react'
 import { useForm } from 'react-hook-form'
 import styled from 'styled-components'
 import { MetadataInput, UserMetadata } from '../../../unlockTypes'
-import { Button, LoadingButton, Input, Label } from './FormStyles'
+import {
+  Button,
+  LoadingButton,
+  Input,
+  Label,
+  DefaultButton,
+} from './FormStyles'
 import { formResultToMetadata } from '../../../utils/userMetadata'
 import { AuthenticationContext } from '../../../contexts/AuthenticationContext'
 import { useAccount } from '../../../hooks/useAccount'
@@ -40,6 +46,10 @@ export const MetadataForm = ({ network, lock, fields, onSubmit }: Props) => {
     defaultValues,
   })
   const [submittedForm, setSubmittedForm] = useState(false)
+  const [skipOptionalFields, setSkipOptionalFields] = useState(false)
+
+  const showSkipButton =
+    fields.every((field) => field.required === false) && !submittedForm
 
   // The form returns a map of key-value pair strings. We need to
   // process those into the expected metadata format so that the typed
@@ -47,10 +57,13 @@ export const MetadataForm = ({ network, lock, fields, onSubmit }: Props) => {
   // TODO: IS THIS USED?
   const wrappedOnSubmit = async (formResult: { [key: string]: string }) => {
     const metadata = formResultToMetadata(formResult, fields)
+    console.log(formResult, fields, skipOptionalFields)
     setSubmittedForm(true)
     setError('')
     try {
-      await setUserMetadataData(lock.address, metadata, network)
+      if (!skipOptionalFields) {
+        await setUserMetadataData(lock.address, metadata, network)
+      }
       onSubmit(metadata)
     } catch (error: any) {
       setError('We could not save your info, please try again.')
@@ -80,6 +93,11 @@ export const MetadataForm = ({ network, lock, fields, onSubmit }: Props) => {
       {submittedForm && <LoadingButton>Saving</LoadingButton>}
 
       {!submittedForm && <Button type="submit">Save and Continue</Button>}
+      {showSkipButton && (
+        <DefaultButton onClick={() => setSkipOptionalFields(true)}>
+          Skip
+        </DefaultButton>
+      )}
     </form>
   )
 }

--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -57,7 +57,6 @@ export const MetadataForm = ({ network, lock, fields, onSubmit }: Props) => {
   // TODO: IS THIS USED?
   const wrappedOnSubmit = async (formResult: { [key: string]: string }) => {
     const metadata = formResultToMetadata(formResult, fields)
-    console.log(formResult, fields, skipOptionalFields)
     setSubmittedForm(true)
     setError('')
     try {

--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -2,13 +2,7 @@ import React, { useState, useContext } from 'react'
 import { useForm } from 'react-hook-form'
 import styled from 'styled-components'
 import { MetadataInput, UserMetadata } from '../../../unlockTypes'
-import {
-  Button,
-  LoadingButton,
-  Input,
-  Label,
-  DefaultButton,
-} from './FormStyles'
+import { Button, LoadingButton, Input, Label, ActionLabel } from './FormStyles'
 import { formResultToMetadata } from '../../../utils/userMetadata'
 import { AuthenticationContext } from '../../../contexts/AuthenticationContext'
 import { useAccount } from '../../../hooks/useAccount'
@@ -93,9 +87,9 @@ export const MetadataForm = ({ network, lock, fields, onSubmit }: Props) => {
 
       {!submittedForm && <Button type="submit">Save and Continue</Button>}
       {showSkipButton && (
-        <DefaultButton onClick={() => setSkipOptionalFields(true)}>
+        <ActionLabel onClick={() => setSkipOptionalFields(true)}>
           Skip
-        </DefaultButton>
+        </ActionLabel>
       )}
     </form>
   )


### PR DESCRIPTION
# Description
- Added the ability to skip metadata collection when all fields are optional, in this case a show button will be visible under the "Save and Continue" button, and when the skip button is clicked `setUserMetadataData` will not be executed
- Fix and improvement on popup styling
# Issues
https://github.com/unlock-protocol/unlock/issues/8361 

# Fixes
- Remove box-shadow on checkout modal, to add a black transparent backdrop like others checkouts popups 
- Fixed some style to center the modal

| Before | After | 
| -- | -- | 
| <img width="886" alt="8361-before" src="https://user-images.githubusercontent.com/20865711/157229600-27812432-4be3-44df-ac7c-2583a6c4c99c.png">  |  <img width="879" alt="8361-after" src="https://user-images.githubusercontent.com/20865711/157280133-b04c127f-830d-481b-a48d-efb572b7df1d.png"> |


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->


