### PR TITLE
fix(locksmith): Parse string lease_seconds into number and add additional check

### DIFF
--- a/locksmith/src/controllers/hookController.ts
+++ b/locksmith/src/controllers/hookController.ts
@@ -42,7 +42,9 @@ export class HookController {
       mode: request.body['hub.mode'],
       callback: request.body['hub.callback'],
       secret: request.body['hub.secret'],
-      lease_seconds: Number(request.body['hub.lease_seconds']),
+      lease_seconds: request.body['hub.lease_seconds']
+        ? Number(request.body['hub.lease_seconds'])
+        : undefined,
     }
 
     if (!network) {

--- a/locksmith/src/controllers/hookController.ts
+++ b/locksmith/src/controllers/hookController.ts
@@ -13,7 +13,7 @@ const Hub = z.object({
   topic: z.string().url(),
   callback: z.string().url(),
   mode: z.enum(['subscribe', 'unsubscribe']),
-  lease_seconds: z.number().optional(),
+  lease_seconds: z.number().positive().optional(),
   secret: z.string().optional(),
 })
 
@@ -42,7 +42,7 @@ export class HookController {
       mode: request.body['hub.mode'],
       callback: request.body['hub.callback'],
       secret: request.body['hub.secret'],
-      lease_seconds: request.body['hub.lease_seconds'],
+      lease_seconds: Number(request.body['hub.lease_seconds']),
     }
 
     if (!network) {
@@ -56,7 +56,7 @@ export class HookController {
       response.status(202).send('Accepted')
       try {
         await this.verifySubscriber(hub)
-        logger.info(`Subscription intent confirmed for ${hub.topic}`)
+        logger.info(`${hub.mode} intent confirmed for ${hub.topic}`)
         await this.updateHook(hub, request.params)
         return
       } catch (error) {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This parses lease_seconds in string to number and add a check so they are not negative. 

> Number of seconds for which the subscriber would like to have the subscription active, given as a **positive decimal integer**.

from the spec ^

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

