### PR TITLE
fix(unlock-assets): Move away from legacy template format to svgr v6 format

### DIFF
--- a/packages/unlock-assets/package.json
+++ b/packages/unlock-assets/package.json
@@ -8,7 +8,7 @@
   "module": "dist/index.modern.js",
   "source": "src/index.js",
   "scripts": {
-    "svg-2-components": "./node_modules/@svgr/cli/bin/svgr --title-prop --no-dimensions --template src/svg/template.js --no-dimensions -d build/svg-component/ images/svg/",
+    "svg-2-components": "svgr --title-prop --no-dimensions --template src/svg/template.js --no-dimensions -d build/svg-component/ images/svg/",
     "build": "microbundle-crl --no-compress --format modern,cjs",
     "start": "microbundle-crl watch --no-compress --format modern,cjs",
     "prepublish": "run-s build",

--- a/packages/unlock-assets/src/svg/template.js
+++ b/packages/unlock-assets/src/svg/template.js
@@ -5,12 +5,8 @@
  * @param {*} opts: SVGR options
  * @param {*} values: Pre-computed values to use (or not) in your templates
  */
-function svgTemplate(
-  { template },
-  opts,
-  { imports, componentName, props, jsx, exports }
-) {
-  return template.ast`
+function svgTemplate({ imports, componentName, props, jsx, exports }, { tpl }) {
+  return tpl`
     ${imports}
     import PropTypes from 'prop-types'
     const ${componentName} = ${props} => ${jsx}


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

SVGR had breaking changes from v5 to v6. We updated without updating the template and script. This fixes them.

More details: https://react-svgr.com/docs/migrate/

Fixes #8221 
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

