### PR TITLE
fix(unlock-app) #8263 - fix not allow number of keys to be smaller

### DIFF
--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -94,18 +94,14 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
   }
 
   const toggleCurrency = () => {
-    if (lockInForm.currencyContractAddress) {
-      return dispatch({
-        change: [
-          { name: 'currencyContractAddress', value: null },
-          { name: 'currencySymbol', value: null },
-        ],
-      })
-    }
+    const erc20Address = lockInForm.currencyContractAddress
+      ? null
+      : erc20.address
+    const erc20Symbol = lockInForm.currencyContractAddress ? null : erc20.symbol
     dispatch({
       change: [
-        { name: 'currencyContractAddress', value: erc20.address },
-        { name: 'currencySymbol', value: erc20.symbol },
+        { name: 'currencyContractAddress', value: erc20Address },
+        { name: 'currencySymbol', value: erc20Symbol },
       ],
     })
   }
@@ -131,8 +127,11 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
         }
         break
       case 'maxNumberOfKeys':
-        if (value !== UNLIMITED_KEYS_COUNT && !isPositiveInteger(value)) {
+        if (!isPositiveInteger(value)) {
           return 'The number of keys needs to be greater than 0'
+        }
+        if (parseInt(value, 10) < lock.outstandingKeys) {
+          return `The number of keys needs to be greater than existing number of keys (${lock.outstandingKeys})`
         }
         break
       case 'keyPrice':


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This prevent the possibility to set smaller number of keys than the existing number of keys

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
- https://github.com/unlock-protocol/unlock/issues/8264

<img width="868" alt="fix-8264" src="https://user-images.githubusercontent.com/20865711/157910849-b5bd6d96-ea47-47b3-8541-6715732a86aa.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

