### PR TITLE
Unlock account users should not be prompted for a crypto payment

### DIFF
--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -59,12 +59,9 @@ export const useProvider = (config: any) => {
       setWalletService(_walletService)
       // @ts-expect-error
       if (!provider.isUnlock) {
-        // @ts-expect-error
-        setIsUnlockAccount(provider.isUnlock)
-        // @ts-expect-error
-        setEmail(provider.emailAddress)
-        // @ts-expect-error
-        setEncryptedPrivateKey(provider.passwordEncryptedPrivateKey)
+        setIsUnlockAccount(false)
+        setEmail(undefined)
+        setEncryptedPrivateKey(null)
         // Doing this last because usually consuming components will change their behavior based on it
         setAccount(_account || undefined)
         return {
@@ -72,12 +69,17 @@ export const useProvider = (config: any) => {
           account: _account,
         }
       }
+      setIsUnlockAccount(true)
+      // @ts-expect-error
+      setEmail(provider.emailAddress)
+      // @ts-expect-error
+      setEncryptedPrivateKey(provider.passwordEncryptedPrivateKey)
+      // Doing this last because usually consuming components will change their behavior based on it
       setAccount(_account || undefined)
       return {
         network: _network,
         account: _account,
-        // @ts-expect-error
-        isUnlock: provider.isUnlock,
+        isUnlock: true,
         // @ts-expect-error
         email: provider.emailAddress,
         // @ts-expect-error


### PR DESCRIPTION
# Description

We had a bug where our authentication provider did not recognize Unlock accounts correctly. This is now fixed.

# Issues

Fixes #8391

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

