### PR TITLE
Show login option

### DIFF
--- a/unlock-app/src/components/interface/checkout/NewAccountCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/NewAccountCheckout.tsx
@@ -71,46 +71,55 @@ export const NewAccountCheckout = ({
   }
 
   return (
-    <PaymentDetails
-      saveCard={onCardSaved}
-      buttonLabel="Save and go to payment"
-      renderError={() => {
-        if (!error) {
-          return null
-        }
-        if (error === 'ACCOUNT_ALREADY_EXISTS') {
+    <>
+      <p>
+        Have you already created an Unlock account?{' '}
+        <LinkButton onClick={() => showLogin()}>Please login</LinkButton>.
+      </p>
+      <PaymentDetails
+        saveCard={onCardSaved}
+        buttonLabel="Save and go to payment"
+        renderError={() => {
+          if (!error) {
+            return null
+          }
+          if (error === 'ACCOUNT_ALREADY_EXISTS') {
+            return (
+              <>
+                An account with this email already exists,{' '}
+                <LinkButton onClick={() => showLogin()}>
+                  please login
+                </LinkButton>
+                .
+              </>
+            )
+          }
           return (
             <>
-              An account with this email already exists,{' '}
-              <LinkButton onClick={() => showLogin()}>please login</LinkButton>.
+              There was an error creating your account. Please try again in a
+              few seconds.
             </>
           )
-        }
-        return (
-          <>
-            There was an error creating your account. Please try again in a few
-            seconds.
-          </>
-        )
-      }}
-      renderChildren={({ register }) => {
-        return (
-          <>
-            <Label>Email</Label>
-            <Input
-              autoComplete="username"
-              {...register('email', { required: true })}
-            />
-            <Label>Set a password</Label>
-            <Input
-              autoComplete="new-password"
-              type="password"
-              {...register('password', { required: true })}
-            />
-          </>
-        )
-      }}
-    />
+        }}
+        renderChildren={({ register }) => {
+          return (
+            <>
+              <Label>Email</Label>
+              <Input
+                autoComplete="username"
+                {...register('email', { required: true })}
+              />
+              <Label>Set a password</Label>
+              <Input
+                autoComplete="new-password"
+                type="password"
+                {...register('password', { required: true })}
+              />
+            </>
+          )
+        }}
+      />
+    </>
   )
 }
 

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -59,12 +59,9 @@ export const useProvider = (config: any) => {
       setWalletService(_walletService)
       // @ts-expect-error
       if (!provider.isUnlock) {
-        // @ts-expect-error
-        setIsUnlockAccount(provider.isUnlock)
-        // @ts-expect-error
-        setEmail(provider.emailAddress)
-        // @ts-expect-error
-        setEncryptedPrivateKey(provider.passwordEncryptedPrivateKey)
+        setIsUnlockAccount(false)
+        setEmail(undefined)
+        setEncryptedPrivateKey(null)
         // Doing this last because usually consuming components will change their behavior based on it
         setAccount(_account || undefined)
         return {
@@ -72,12 +69,17 @@ export const useProvider = (config: any) => {
           account: _account,
         }
       }
+      setIsUnlockAccount(true)
+      // @ts-expect-error
+      setEmail(provider.emailAddress)
+      // @ts-expect-error
+      setEncryptedPrivateKey(provider.passwordEncryptedPrivateKey)
+      // Doing this last because usually consuming components will change their behavior based on it
       setAccount(_account || undefined)
       return {
         network: _network,
         account: _account,
-        // @ts-expect-error
-        isUnlock: provider.isUnlock,
+        isUnlock: true,
         // @ts-expect-error
         email: provider.emailAddress,
         // @ts-expect-error


### PR DESCRIPTION
# Description

@ccarfi rightfully identified that our user flow "pushes" people down flow to create a 2nd account when they already have one.
Here, we add an option to go back on the login flow.
https://share.getcloudapp.com/Wnuydl2D

# Issues


Fixes #8390


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet

Adding option to login.

