### PR TITLE
not closing modal when clicking outside

### DIFF
--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -433,9 +433,7 @@ export const Checkout = ({
 
   return (
     <Web3ServiceContext.Provider value={web3Service}>
-      <CheckoutContainer
-        close={() => allowClose && closeModal(false, redirectUri)}
-      >
+      <CheckoutContainer>
         <CheckoutWrapper
           showBack={showBack}
           back={back}

--- a/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
@@ -3,15 +3,13 @@ import styled from 'styled-components'
 import Media from '../../../theme/media'
 
 interface Props {
-  close: () => void
   children: React.ReactNode
 }
 
 export const CheckoutContainer: React.FunctionComponent<Props> = ({
-  close,
   children,
 }: React.PropsWithChildren<Props>) => {
-  return <Container onClick={close}>{children}</Container>
+  return <Container>{children}</Container>
 }
 
 export const Container = styled.div`


### PR DESCRIPTION
# Description

Closing the modal is only explicit (by clicking the close icon) to reduce unexpected behabvior.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

