### PR TITLE
fix(unlock-protocol-com): Alignment of items in about updates

### DIFF
--- a/unlock-protocol-com/src/components/pages/About/index.tsx
+++ b/unlock-protocol-com/src/components/pages/About/index.tsx
@@ -60,34 +60,39 @@ export function About({ updates }: Props) {
               </div>
             </div>
             {updates && (
-              <div className="grid gap-6">
+              <div className="grid gap-6 pb-6">
                 <header className="space-y-2">
                   <h2 className="text-2xl font-semibold sm:text-3xl">News</h2>
-                  <p className="text-brand-gray">Latest updates from Unlock.</p>
+                  <p className="text-lg text-brand-gray">
+                    Latest updates from Unlock.
+                  </p>
                 </header>
-                <div className="grid gap-4">
+                <ol className="grid gap-4">
                   {updates.map((item, index) => {
                     const date = new Date(
                       item.frontMatter.publishDate
                     ).toLocaleDateString()
                     return (
-                      <div
+                      <li
                         key={index}
                         className="flex flex-col gap-y-0 sm:flex-row sm:gap-x-4 md:gap-x-6 lg:gap-x-8"
                       >
-                        <time dateTime={date} className="text-brand-gray">
-                          {date}
-                        </time>
+                        <div className="w-full max-w-[100px]">
+                          <time dateTime={date} className="text-brand-gray">
+                            {date}
+                          </time>
+                        </div>
+
                         <Link
                           className="hover:text-brand-ui-primary"
                           href={`/blog/${item.slug}`}
                         >
                           {item.frontMatter.title}
                         </Link>
-                      </div>
+                      </li>
                     )
                   })}
-                </div>
+                </ol>
               </div>
             )}
           </main>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Fix alignment issue on about page 

![image](https://user-images.githubusercontent.com/73341821/158372840-81fe231c-cc0c-4427-b40d-38246075ba75.png)


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

