### PR TITLE
fix #8389 - keep user logged in

### DIFF
--- a/packages/unlock-js/src/Unlock/v10/createLock.js
+++ b/packages/unlock-js/src/Unlock/v10/createLock.js
@@ -35,7 +35,7 @@ export default async function (lock, callback) {
     maxNumberOfKeys = ETHERS_MAX_UINT
   }
   if (expirationDuration === -1) {
-    expirationDuration = ETHERS_MAX_UINT
+    maxNumberOfKeys = ETHERS_MAX_UINT
   }
 
   const decimalKeyPrice = await _getKeyPrice(lock, this.provider)

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -23,7 +23,6 @@ import {
   isNotEmpty,
   isPositiveInteger,
   isPositiveNumber,
-  isPositiveIntegerOrZero,
   isLTE,
 } from '../../utils/validators'
 
@@ -88,17 +87,9 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
     validateAndDispatch(target, [{ name, value: value * (60 * 60 * 24) }])
   }
 
-  const handleUnlimitedNumbersOfKeys = () => {
+  const handleUnlimitedClick = () => {
     dispatch({
       change: [{ name: 'maxNumberOfKeys', value: UNLIMITED_KEYS_COUNT }],
-    })
-  }
-
-  const handleUnlimitedDuration = () => {
-    dispatch({
-      change: [
-        { name: 'expirationDuration', value: ONE_HUNDRED_YEARS_IN_SECONDS },
-      ],
     })
   }
 
@@ -149,13 +140,6 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
     return ''
   }
 
-  const expirationDurationValue =
-    lockInForm?.expirationDuration === ONE_HUNDRED_YEARS_IN_SECONDS
-      ? INFINITY
-      : isPositiveIntegerOrZero(lockInForm.expirationDuration)
-      ? lockInForm.expirationDuration / (60 * 60 * 24)
-      : ''
-
   return (
     <form method="post" onSubmit={handleSubmit}>
       <FormLockRow>
@@ -175,22 +159,16 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
           </FormLockName>
           <FormLockDuration>
             <input
-              type="text"
+              type="number"
               step="1"
               inputMode="numeric"
               name="expirationDuration"
               onChange={handleChangeExpirationDuration}
-              value={expirationDurationValue}
+              defaultValue={lockInForm.expirationDuration / (60 * 60 * 24)}
               required={isNew}
               disabled={!isNew}
             />{' '}
             days
-            {lockInForm?.expirationDuration !== ONE_HUNDRED_YEARS_IN_SECONDS &&
-              isNew && (
-                <LockLabelUnlimited onClick={handleUnlimitedDuration}>
-                  Unlimited
-                </LockLabelUnlimited>
-              )}
           </FormLockDuration>
           <FormLockKeys>
             <input
@@ -205,7 +183,7 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
               required={isNew}
             />
             {lockInForm?.maxNumberOfKeys !== UNLIMITED_KEYS_COUNT && (
-              <LockLabelUnlimited onClick={handleUnlimitedNumbersOfKeys}>
+              <LockLabelUnlimited onClick={handleUnlimitedClick}>
                 Unlimited
               </LockLabelUnlimited>
             )}

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -23,7 +23,6 @@ import {
   isNotEmpty,
   isPositiveInteger,
   isPositiveNumber,
-  isPositiveIntegerOrZero,
   isLTE,
 } from '../../utils/validators'
 
@@ -88,17 +87,9 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
     validateAndDispatch(target, [{ name, value: value * (60 * 60 * 24) }])
   }
 
-  const handleUnlimitedNumbersOfKeys = () => {
+  const handleUnlimitedClick = () => {
     dispatch({
       change: [{ name: 'maxNumberOfKeys', value: UNLIMITED_KEYS_COUNT }],
-    })
-  }
-
-  const handleUnlimitedDuration = () => {
-    dispatch({
-      change: [
-        { name: 'expirationDuration', value: ONE_HUNDRED_YEARS_IN_SECONDS },
-      ],
     })
   }
 
@@ -149,13 +140,6 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
     return ''
   }
 
-  const expirationDurationValue =
-    lockInForm?.expirationDuration === ONE_HUNDRED_YEARS_IN_SECONDS
-      ? INFINITY
-      : isPositiveIntegerOrZero(lockInForm.expirationDuration)
-      ? lockInForm.expirationDuration / (60 * 60 * 24)
-      : ''
-
   return (
     <form method="post" onSubmit={handleSubmit}>
       <FormLockRow>
@@ -175,20 +159,16 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
           </FormLockName>
           <FormLockDuration>
             <input
-              type="text"
+              type="number"
+              step="1"
+              inputMode="numeric"
               name="expirationDuration"
               onChange={handleChangeExpirationDuration}
-              value={expirationDurationValue}
+              defaultValue={lockInForm.expirationDuration / (60 * 60 * 24)}
               required={isNew}
               disabled={!isNew}
             />{' '}
             days
-            {lockInForm?.expirationDuration !== ONE_HUNDRED_YEARS_IN_SECONDS &&
-              isNew && (
-                <LockLabelUnlimited onClick={handleUnlimitedDuration}>
-                  Unlimited
-                </LockLabelUnlimited>
-              )}
           </FormLockDuration>
           <FormLockKeys>
             <input
@@ -203,7 +183,7 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
               required={isNew}
             />
             {lockInForm?.maxNumberOfKeys !== UNLIMITED_KEYS_COUNT && (
-              <LockLabelUnlimited onClick={handleUnlimitedNumbersOfKeys}>
+              <LockLabelUnlimited onClick={handleUnlimitedClick}>
                 Unlimited
               </LockLabelUnlimited>
             )}

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -176,7 +176,6 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
           <FormLockDuration>
             <input
               type="text"
-              step="1"
               inputMode="numeric"
               name="expirationDuration"
               onChange={handleChangeExpirationDuration}

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -23,6 +23,7 @@ import {
   isNotEmpty,
   isPositiveInteger,
   isPositiveNumber,
+  isPositiveIntegerOrZero,
   isLTE,
 } from '../../utils/validators'
 
@@ -87,9 +88,17 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
     validateAndDispatch(target, [{ name, value: value * (60 * 60 * 24) }])
   }
 
-  const handleUnlimitedClick = () => {
+  const handleUnlimitedNumbersOfKeys = () => {
     dispatch({
       change: [{ name: 'maxNumberOfKeys', value: UNLIMITED_KEYS_COUNT }],
+    })
+  }
+
+  const handleUnlimitedDuration = () => {
+    dispatch({
+      change: [
+        { name: 'expirationDuration', value: ONE_HUNDRED_YEARS_IN_SECONDS },
+      ],
     })
   }
 
@@ -140,6 +149,13 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
     return ''
   }
 
+  const expirationDurationValue =
+    lockInForm?.expirationDuration === ONE_HUNDRED_YEARS_IN_SECONDS
+      ? INFINITY
+      : isPositiveIntegerOrZero(lockInForm.expirationDuration)
+      ? lockInForm.expirationDuration / (60 * 60 * 24)
+      : ''
+
   return (
     <form method="post" onSubmit={handleSubmit}>
       <FormLockRow>
@@ -159,16 +175,22 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
           </FormLockName>
           <FormLockDuration>
             <input
-              type="number"
+              type="text"
               step="1"
               inputMode="numeric"
               name="expirationDuration"
               onChange={handleChangeExpirationDuration}
-              defaultValue={lockInForm.expirationDuration / (60 * 60 * 24)}
+              value={expirationDurationValue}
               required={isNew}
               disabled={!isNew}
             />{' '}
             days
+            {lockInForm?.expirationDuration !== ONE_HUNDRED_YEARS_IN_SECONDS &&
+              isNew && (
+                <LockLabelUnlimited onClick={handleUnlimitedDuration}>
+                  Unlimited
+                </LockLabelUnlimited>
+              )}
           </FormLockDuration>
           <FormLockKeys>
             <input
@@ -183,7 +205,7 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
               required={isNew}
             />
             {lockInForm?.maxNumberOfKeys !== UNLIMITED_KEYS_COUNT && (
-              <LockLabelUnlimited onClick={handleUnlimitedClick}>
+              <LockLabelUnlimited onClick={handleUnlimitedNumbersOfKeys}>
                 Unlimited
               </LockLabelUnlimited>
             )}

--- a/unlock-app/src/components/creator/CreatorLockForm.js
+++ b/unlock-app/src/components/creator/CreatorLockForm.js
@@ -176,7 +176,6 @@ const CreatorLockForm = ({ hideAction, lock, saveLock }) => {
           <FormLockDuration>
             <input
               type="text"
-              inputMode="numeric"
               name="expirationDuration"
               onChange={handleChangeExpirationDuration}
               value={expirationDurationValue}

--- a/unlock-app/src/components/interface/Authenticate.jsx
+++ b/unlock-app/src/components/interface/Authenticate.jsx
@@ -73,10 +73,8 @@ const Providers = ({
   })
 
   useEffect(() => {
-    if (!skipAutoLogin) {
-      tryAutoLogin()
-    }
-  }, [skipAutoLogin])
+    tryAutoLogin()
+  }, [])
   return (
     <ApolloProvider client={apolloClient}>
       <StorageServiceProvider value={storageService}>
@@ -108,7 +106,6 @@ export const Authenticate = ({
   embedded,
   onAuthenticated,
   providerAdapter,
-  skipAutoLogin,
 }) => {
   const config = useContext(ConfigContext)
 
@@ -166,7 +163,6 @@ export const Authenticate = ({
             email={email}
             encryptedPrivateKey={encryptedPrivateKey}
             authenticate={authenticate}
-            skipAutoLogin={skipAutoLogin}
           >
             {children}
           </Providers>
@@ -186,7 +182,6 @@ Authenticate.propTypes = {
   onAuthenticated: PropTypes.func,
   // eslint-disable-next-line react/forbid-prop-types
   providerAdapter: PropTypes.object,
-  skipAutoLogin: PropTypes.bool,
 }
 
 Authenticate.defaultProps = {
@@ -197,7 +192,6 @@ Authenticate.defaultProps = {
   embedded: false,
   onAuthenticated: () => {},
   providerAdapter: null,
-  skipAutoLogin: false,
 }
 
 export default Authenticate

--- a/unlock-app/src/components/interface/Authenticate.jsx
+++ b/unlock-app/src/components/interface/Authenticate.jsx
@@ -39,13 +39,7 @@ const Web3ServiceProvider = Web3ServiceContext.Provider
  * Utility providers set to retrieve content based on network settings
  * @returns
  */
-const Providers = ({
-  network,
-  networkConfig,
-  children,
-  authenticate,
-  skipAutoLogin,
-}) => {
+const Providers = ({ network, networkConfig, children, authenticate }) => {
   const apolloClient = useMemo(
     () =>
       new ApolloClient({

--- a/unlock-app/src/components/interface/GlobalWrapper.tsx
+++ b/unlock-app/src/components/interface/GlobalWrapper.tsx
@@ -13,10 +13,9 @@ const wedlockService = new WedlockService(config.services.wedlocks.host)
 
 interface GlobalWrapperProps {
   children: React.ReactNode
-  pageProps: any
 }
 
-export const GlobalWrapper = ({ children, pageProps }: GlobalWrapperProps) => {
+export const GlobalWrapper = ({ children }: GlobalWrapperProps) => {
   const [provider, setProvider] = useState<any>(null)
   useEffect(() => {
     /* eslint-disable no-console */

--- a/unlock-app/src/components/interface/GlobalWrapper.tsx
+++ b/unlock-app/src/components/interface/GlobalWrapper.tsx
@@ -31,9 +31,7 @@ export const GlobalWrapper = ({ children, pageProps }: GlobalWrapperProps) => {
         <ConfigContext.Provider value={config}>
           <WedlockServiceContext.Provider value={wedlockService}>
             <ProviderContext.Provider value={{ provider, setProvider }}>
-              <Authenticate skipAutoLogin={pageProps.skipAutoLogin}>
-                {children}
-              </Authenticate>
+              <Authenticate>{children}</Authenticate>
             </ProviderContext.Provider>
           </WedlockServiceContext.Provider>
         </ConfigContext.Provider>

--- a/unlock-app/src/components/interface/LogIn.tsx
+++ b/unlock-app/src/components/interface/LogIn.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import React, { FormEvent, useState, useReducer } from 'react'
+import React, { FormEvent, useState, useReducer, useEffect } from 'react'
 import styled from 'styled-components'
 import { useAccount } from '../../hooks/useAccount'
 import {
@@ -16,9 +16,15 @@ interface LogInProps {
   onCancel?: () => void
   network: number
   useWallet?: () => void
+  storedLoginEmail?: string
 }
 
-const LogIn = ({ onCancel, network, useWallet }: LogInProps) => {
+const LogIn = ({
+  onCancel,
+  network,
+  useWallet,
+  storedLoginEmail,
+}: LogInProps) => {
   const { retrieveUserAccount } = useAccount('', network)
   const [loginState, dispatch] = useReducer(
     (state: any, action: any) => {
@@ -81,6 +87,12 @@ const LogIn = ({ onCancel, network, useWallet }: LogInProps) => {
     })
   }
 
+  useEffect(() => {
+    dispatch({
+      change: [{ name: 'emailAddress', value: storedLoginEmail }],
+    })
+  }, [])
+
   return (
     <Container>
       <Form onSubmit={handleSubmit}>
@@ -92,6 +104,7 @@ const LogIn = ({ onCancel, network, useWallet }: LogInProps) => {
           type="email"
           placeholder="Enter your email"
           onChange={handleInputChange}
+          value={emailAddress}
         />
         <Label htmlFor="passwordInput">Password</Label>
         <Input
@@ -104,9 +117,14 @@ const LogIn = ({ onCancel, network, useWallet }: LogInProps) => {
         />
         {submitted && <LoadingButton>Logging In...</LoadingButton>}
         {!submitted && (
-          <Button type="submit" value="Submit">
-            Login
-          </Button>
+          <>
+            {storedLoginEmail?.length > 0 && (
+              <small>Welcome back, type your password to login</small>
+            )}
+            <Button type="submit" value="Submit">
+              Login
+            </Button>
+          </>
         )}
         {error && <FormError>{error}</FormError>}
       </Form>
@@ -125,6 +143,7 @@ const LogIn = ({ onCancel, network, useWallet }: LogInProps) => {
 LogIn.defaultProps = {
   onCancel: undefined,
   useWallet: undefined,
+  storedLoginEmail: '',
 }
 
 export default LogIn

--- a/unlock-app/src/components/interface/LogIn.tsx
+++ b/unlock-app/src/components/interface/LogIn.tsx
@@ -23,7 +23,7 @@ const LogIn = ({
   onCancel,
   network,
   useWallet,
-  storedLoginEmail,
+  storedLoginEmail = '',
 }: LogInProps) => {
   const { retrieveUserAccount } = useAccount('', network)
   const [loginState, dispatch] = useReducer(
@@ -88,6 +88,7 @@ const LogIn = ({
   }
 
   useEffect(() => {
+    if (storedLoginEmail?.length === 0) return
     dispatch({
       change: [{ name: 'emailAddress', value: storedLoginEmail }],
     })
@@ -118,8 +119,8 @@ const LogIn = ({
         {submitted && <LoadingButton>Logging In...</LoadingButton>}
         {!submitted && (
           <>
-            {storedLoginEmail?.length > 0 && (
-              <small>Welcome back, type your password to login</small>
+            {storedLoginEmail.length > 0 && (
+              <small>Welcome back, type your password to continue</small>
             )}
             <Button type="submit" value="Submit">
               Login

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -39,6 +39,7 @@ import { AuthenticationContext } from '../../../contexts/AuthenticationContext'
 
 import { PaywallConfig, OAuthConfig } from '../../../unlockTypes'
 import { OAuthConnect } from './OauthConnect'
+import { useAppStorage } from '../../../hooks/useAppStorage'
 
 interface CheckoutProps {
   emitCloseModal: (success: boolean) => void

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useContext,
-  useReducer,
-  useEffect,
-  useRef,
-} from 'react'
+import React, { useState, useContext, useReducer, useEffect } from 'react'
 import Head from 'next/head'
 import styled from 'styled-components'
 import { Web3Service } from '@unlock-protocol/unlock-js'

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -39,7 +39,6 @@ import { AuthenticationContext } from '../../../contexts/AuthenticationContext'
 
 import { PaywallConfig, OAuthConfig } from '../../../unlockTypes'
 import { OAuthConnect } from './OauthConnect'
-import { useAppStorage } from '../../../hooks/useAppStorage'
 
 interface CheckoutProps {
   emitCloseModal: (success: boolean) => void

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -117,6 +117,7 @@ export const Checkout = ({
   const [savedMetadata, setSavedMetadata] = useState<any>(false)
   const [storedLoginEmail, setStoredLoginEmail] = useState<string>('')
   const { getAutoLoginEmail } = useAutoLogin()
+  const storedEmail = getAutoLoginEmail();
 
   const checkUnlockLogin = useRef(false)
   const firstLoading = useRef(false)
@@ -130,11 +131,12 @@ export const Checkout = ({
   }, [])
 
   const showLoginForm = () => {
-    const email = getAutoLoginEmail()
-    if (email.length > 0 && !account) {
+    if (storedEmail.length > 0) {
       checkUnlockLogin.current = true
-      setStoredLoginEmail(email)
+      setStoredLoginEmail(storedEmail)
       setCheckoutState('login')
+    } else {
+      setCheckoutState('pick-lock')
     }
   }
 
@@ -171,7 +173,7 @@ export const Checkout = ({
         }
       } else {
         setCheckoutState(defaultState)
-        if (firstLoading.current) showLoginForm()
+        if (!account && storedEmail) showLoginForm()
       }
     }
     handleUser(account)
@@ -411,7 +413,7 @@ export const Checkout = ({
         />
         <Locks
           network={paywallConfig?.network}
-          locks={paywallConfig?.locks}
+          locks={paywallConfig?.locks ?? {}}
           setHasKey={setHasKey}
           onSelected={onSelected}
         />

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -119,20 +119,13 @@ export const Checkout = ({
   const { getAutoLoginEmail } = useAutoLogin()
   const storedEmail = getAutoLoginEmail()
 
-  const checkUnlockLogin = useRef(false)
-  const firstLoading = useRef(false)
   // state change
   useEffect(() => {
     setState(defaultState)
   }, [defaultState])
 
-  useEffect(() => {
-    firstLoading.current = true
-  }, [])
-
   const showLoginForm = () => {
     if (storedEmail.length > 0) {
-      checkUnlockLogin.current = true
       setStoredLoginEmail(storedEmail)
       setCheckoutState('login')
     } else {
@@ -143,7 +136,7 @@ export const Checkout = ({
   // When the account is changed, make sure we ping!
   useEffect(() => {
     const handleUser = async (account?: string) => {
-      if (account && !firstLoading.current) {
+      if (account) {
         let signedMessage
         if (paywallConfig?.messageToSign) {
           signedMessage = await signMessage(paywallConfig?.messageToSign)
@@ -177,7 +170,7 @@ export const Checkout = ({
       }
     }
     handleUser(account)
-  }, [account, firstLoading.current])
+  }, [account])
 
   const allowClose = !(!paywallConfig || paywallConfig?.persistentCheckout)
 

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -117,7 +117,7 @@ export const Checkout = ({
   const [savedMetadata, setSavedMetadata] = useState<any>(false)
   const [storedLoginEmail, setStoredLoginEmail] = useState<string>('')
   const { getAutoLoginEmail } = useAutoLogin()
-  const storedEmail = getAutoLoginEmail();
+  const storedEmail = getAutoLoginEmail()
 
   const checkUnlockLogin = useRef(false)
   const firstLoading = useRef(false)

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -55,11 +55,7 @@ export const Lock = ({
 
   const alreadyHasKey = (key: any) => {
     const now = new Date().getTime() / 1000
-    if (key && (key.expiration === -1 || key.expiration > now)) {
-      setHasValidKey(true)
-    } else {
-      setHasValidKey(false)
-    }
+    setHasValidKey(key && (key.expiration === -1 || key.expiration > now))
     setHasKey(key)
   }
 

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -55,7 +55,10 @@ export const Lock = ({
 
   const alreadyHasKey = (key: any) => {
     const now = new Date().getTime() / 1000
-    setHasValidKey(key && (key.expiration === -1 || key.expiration > now))
+    const { expiration } = key
+    const isKeyNotExpired = expiration > now || expiration === -1
+    const isKeyValid = key || isKeyNotExpired
+    setHasValidKey(isKeyValid)
     setHasKey(key)
   }
 

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -55,7 +55,7 @@ export const Lock = ({
 
   const alreadyHasKey = (key: any) => {
     const now = new Date().getTime() / 1000
-    const { expiration } = key
+    const { expiration } = key ?? {}
     const isKeyNotExpired = expiration > now || expiration === -1
     const isKeyValid = key || isKeyNotExpired
     setHasValidKey(isKeyValid)

--- a/unlock-app/src/hooks/useAppStorage.ts
+++ b/unlock-app/src/hooks/useAppStorage.ts
@@ -15,7 +15,7 @@ export function useAppStorage() {
   }, [])
 
   const removeKey = useCallback((key: string) => {
-    localStorage.removeItem(key)
+    localStorage.removeItem(getKey(key))
   }, [])
 
   const getStorage = useCallback((key: string): string | null => {

--- a/unlock-app/src/hooks/useAuthenticateHandler.ts
+++ b/unlock-app/src/hooks/useAuthenticateHandler.ts
@@ -47,6 +47,13 @@ export function useAuthenticateHandler({
         if (!p?.account) {
           return Promise.reject('Unable to get provider')
         }
+
+        if (p?.isUnlock && p?.email) {
+          setStorage('email', p.email)
+        } else {
+          removeKey('email')
+        }
+        setStorage('provider', providerType)
       }),
       {
         error:
@@ -56,10 +63,6 @@ export function useAuthenticateHandler({
           'Trying to connect with wallet provider. Please approve request on your wallet.',
       }
     )
-    // We can't autologin with Unlock accounts
-    if (providerType !== 'UNLOCK') {
-      setStorage('provider', providerType)
-    }
     return connectedProvider
   }
 

--- a/unlock-app/src/hooks/useAutoLogin.ts
+++ b/unlock-app/src/hooks/useAutoLogin.ts
@@ -27,12 +27,19 @@ export function useAutoLogin() {
     })
   }, [])
 
+  const getAutoLoginEmail = (): string => {
+    if (getStorage('provider') !== 'UNLOCK') return ''
+    return getStorage('email') ?? ''
+  }
+
   const tryAutoLogin = useCallback(async () => {
     setLoading(true)
     const [canAutoLogin, storedProvider] = await getAutoLoginData()
     if (canAutoLogin && storedProvider) {
       try {
-        await authenticateWithProvider(storedProvider)
+        if (storedProvider !== 'UNLOCK') {
+          await authenticateWithProvider(storedProvider)
+        }
       } catch (error: any) {
         console.error('Autologin failed.')
         console.error(error)
@@ -44,5 +51,6 @@ export function useAutoLogin() {
   return {
     tryAutoLogin,
     isLoading,
+    getAutoLoginEmail,
   }
 }

--- a/unlock-app/src/pages/_app.tsx
+++ b/unlock-app/src/pages/_app.tsx
@@ -8,7 +8,7 @@ import GlobalWrapper from '../components/interface/GlobalWrapper'
 import '../index.css'
 
 const config = configure()
-const UnlockApp = ({ Component, pageProps }: AppProps) => {
+const UnlockApp = ({ Component }: AppProps) => {
   useEffect(() => {
     if (!config.isServer) {
       if (config.env === 'prod' && config.tagManagerArgs) {
@@ -18,8 +18,8 @@ const UnlockApp = ({ Component, pageProps }: AppProps) => {
   }, [])
 
   return (
-    <GlobalWrapper pageProps={pageProps}>
-      <Component {...pageProps} />
+    <GlobalWrapper>
+      <Component />
       <Toaster />
     </GlobalWrapper>
   )

--- a/unlock-app/src/pages/checkout.js
+++ b/unlock-app/src/pages/checkout.js
@@ -13,10 +13,4 @@ const Checkout = () => {
   )
 }
 
-export async function getStaticProps() {
-  // Disabling auto login for the checkout page because it messes withe the need to sign a message for some implementations...
-  return {
-    props: { skipAutoLogin: true },
-  }
-}
 export default Checkout


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This PR fixes problem with `autologin`, in detail
- Fix sign for a message that's shown immediately on opening the page
- If the user previously logged with `Unlock`, the login form will be shown if restart the flow 
<!--
Please include a summary of the change and which issue is fixed -including its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #8389 
Refs #

https://user-images.githubusercontent.com/20865711/159791097-2efd898f-e28b-4481-b318-bb0b8f13d6be.mov




# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

