### PR TITLE
only enabling cc if the purchaser has enough to cover for gas

### DIFF
--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -27,7 +27,6 @@ export default class Dispatcher {
       provider
     )
     await walletService.connect(provider, walletWithProvider)
-
     return await walletService.grantKey(
       {
         lockAddress,
@@ -47,8 +46,7 @@ export default class Dispatcher {
     const gasPrice = await provider.getGasPrice()
 
     const balance = await provider.getBalance(wallet.address)
-
-    if (balance < gasPrice.mul(GAS_COST)) {
+    if (balance.lt(gasPrice.mul(GAS_COST))) {
       logger.warn(
         `Purchaser ${
           wallet.address
@@ -59,9 +57,9 @@ export default class Dispatcher {
           gasPrice.mul(GAS_COST)
         )}) on ${network}`
       )
+      return false
     }
-
-    return balance >= gasPrice.mul(GAS_COST)
+    return true
   }
 
   async purchaseKey(


### PR DESCRIPTION
# Description

This will prevent users from going to flow to purchase by CC when the purchaser does not have enough to pay for gas.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

