### PR TITLE
fix(smart-contracts): check Unlock contract has code before calling from Lock

### DIFF
--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -113,13 +113,16 @@ contract MixinPurchase is
         require(inMemoryKeyPrice <= _values[i], 'INSUFFICIENT_ERC20_VALUE');
       }
 
-      // call Unlock contract to record GNP
-      // the function is capped by gas to prevent running out of gas
-      try unlockProtocol.recordKeyPurchase{gas: 300000}(inMemoryKeyPrice, _referrers[i]) 
-      {} 
-      catch {
-        // emit missing unlock
-        emit UnlockCallFailed(address(this), address(unlockProtocol));
+      // make sure unlock is a contract, and we catch possible reverts
+      if (address(unlockProtocol).code.length > 0) {
+        // call Unlock contract to record GNP
+        // the function is capped by gas to prevent running out of gas
+        try unlockProtocol.recordKeyPurchase{gas: 300000}(inMemoryKeyPrice, _referrers[i]) 
+        {} 
+        catch {
+          // emit missing unlock
+          emit UnlockCallFailed(address(this), address(unlockProtocol));
+        }
       }
 
       // fire hook


### PR DESCRIPTION
# Description

This improves the fallback - as solidity `try/catch` pattern won't catch revert for non-existing code 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

