### PR TITLE
feat(unlock-protocol-com): Update cookie banner to be less instrusive

### DIFF
--- a/unlock-protocol-com/src/components/interface/CookieBanner/index.tsx
+++ b/unlock-protocol-com/src/components/interface/CookieBanner/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@unlock-protocol/ui'
+import { useEffect, useState } from 'react'
 import useLocalStorage from 'use-local-storage'
 
 export function CookieBanner() {
@@ -6,16 +7,28 @@ export function CookieBanner() {
     'enable_analytics',
     null
   )
-  if (enableAnalytics !== null) {
-    return <> </>
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    // wait for 5 seconds to show up cookie banner if needed
+    const timeout = setTimeout(() => {
+      setMounted(true)
+    }, 5000)
+    return () => clearTimeout(timeout)
+  }, [])
+
+  if (enableAnalytics !== null || !mounted) {
+    return null
   }
+
   return (
-    <div className="top-0 left-0 right-0 flex flex-col justify-between p-4 border gap-y-2 sm:items-center sm:flex-row bottom">
+    <div className="fixed z-20 flex flex-col items-end justify-between gap-4 px-6 py-4 left-6 lg:left-auto sm:items-center sm:flex-row glass-pane right-6 rounded-3xl bottom-6">
       <p className="text-brand-gray">
-        Allow us to collect analytics for the purpose of improving the site.
+        We use third-party cookies in order to personalize your site experience.
       </p>
-      <div className="flex justify-end gap-4">
+      <div className="flex gap-2">
         <Button
+          size="small"
           onClick={(event) => {
             event.preventDefault()
             setEnableAnalytics(false)
@@ -25,6 +38,7 @@ export function CookieBanner() {
           Disagree
         </Button>
         <Button
+          size="small"
           onClick={(event) => {
             event.preventDefault()
             setEnableAnalytics(true)

--- a/unlock-protocol-com/src/components/interface/Footer/index.tsx
+++ b/unlock-protocol-com/src/components/interface/Footer/index.tsx
@@ -67,6 +67,14 @@ const FOOTER_BOTTOM_NAVIGATION: Record<string, LinkType[]> = {
       name: 'Docs',
       href: UNLOCK_LINKS.docs,
     },
+    {
+      name: 'Privacy',
+      href: '/privacy',
+    },
+    {
+      name: 'Terms',
+      href: '/terms',
+    },
   ],
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Less intrusive cookie banner which only pops up after 5 seconds. This will avoid any layout shifts faced due to getting the value from local storage. 

![image](https://user-images.githubusercontent.com/73341821/160906539-43cccaa7-6ad8-46c2-aa27-b88c765a9fbf.png)

![image](https://user-images.githubusercontent.com/73341821/160906608-63357660-e5f9-4b7c-95fd-2bab4309e780.png)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

