### PR TITLE
fix(smart-contracts): add script to test storage conflict before Lock upgrade 

### DIFF
--- a/smart-contracts/README.md
+++ b/smart-contracts/README.md
@@ -122,7 +122,7 @@ Note: you need to update the `LATEST_PUBLIC_LOCK_VERSION` in the script.
 
 This script is use to check the changes in storage layout between two upgrades
 using the openzeppellin plugin. It will deploy first the version `LATEST_PUBLIC_LOCK_VERSION`
-then deploy the version in `contracts/PublicLock.sol`. The errors thrown bu the upgrades plugin
+then deploy the version in `contracts/PublicLock.sol`. The errors thrown by the upgrades plugin
 should allow to detect changes in storage layout.
 
 #### Deploy a PublicLock upgrade

--- a/smart-contracts/README.md
+++ b/smart-contracts/README.md
@@ -112,6 +112,21 @@ NB: for Polygon, you need an API key from https://polygonscan.com
 
 ### Update PublicLock template
 
+#### Detect changes in storage layout
+
+```
+yarn hardhat run scripts/lock/testUpgrage.js
+```
+
+Note: you need to update the `LATEST_PUBLIC_LOCK_VERSION` in the script.
+
+This script is use to check the changes in storage layout between two upgrades
+using the openzeppellin plugin. It will deploy first the version `LATEST_PUBLIC_LOCK_VERSION`
+then deploy the version in `contracts/PublicLock.sol`. The errors thrown bu the upgrades plugin
+should allow to detect changes in storage layout.
+
+#### Deploy a PublicLock upgrade
+
 ```
 # deploy a new template
 yarn hardhat deploy:template

--- a/smart-contracts/README.md
+++ b/smart-contracts/README.md
@@ -115,7 +115,7 @@ NB: for Polygon, you need an API key from https://polygonscan.com
 #### Detect changes in storage layout
 
 ```
-yarn hardhat run scripts/lock/testUpgrage.js
+yarn hardhat run scripts/lock/testUpgrade.js
 ```
 
 Note: you need to update the `LATEST_PUBLIC_LOCK_VERSION` in the script.

--- a/smart-contracts/scripts/lock/testUpgrade.js
+++ b/smart-contracts/scripts/lock/testUpgrade.js
@@ -4,7 +4,7 @@
  * then deploy the version in `contracts/PublicLock.sol`. The errors thrown bu the upgrades plugin
  * should allow to detect changes in storage layout.
  *
- * Usage: `yarn hardhat run scripts/lock/testUpgrage.js`
+ * Usage: `yarn hardhat run scripts/lock/testUpgrade.js`
  */
 const { ethers, upgrades, run } = require('hardhat')
 const fs = require('fs-extra')

--- a/smart-contracts/scripts/lock/testUpgrage.js
+++ b/smart-contracts/scripts/lock/testUpgrage.js
@@ -1,10 +1,15 @@
+/**
+ * This script is use to check the changes in storage layout between two upgrades
+ * using the openzeppellin plugin. It will deploy first the version `LATEST_PUBLIC_LOCK_VERSION`
+ * then deploy the version in `contracts/PublicLock.sol`. The errors thrown bu the upgrades plugin
+ * should allow to detect changes in storage layout.
+ *
+ * Usage: `yarn hardhat run scripts/lock/testUpgrage.js`
+ */
 const { ethers, upgrades, run } = require('hardhat')
 const fs = require('fs-extra')
 const path = require('path')
 
-// const {
-//   LATEST_PUBLIC_LOCK_VERSION,
-// } = require('../helpers/constants')
 const LATEST_PUBLIC_LOCK_VERSION = 9
 
 async function main() {

--- a/smart-contracts/scripts/lock/testUpgrage.js
+++ b/smart-contracts/scripts/lock/testUpgrage.js
@@ -1,0 +1,82 @@
+const { ethers, upgrades, run } = require('hardhat')
+const fs = require('fs-extra')
+const path = require('path')
+
+// const {
+//   LATEST_PUBLIC_LOCK_VERSION,
+// } = require('../helpers/constants')
+const LATEST_PUBLIC_LOCK_VERSION = 9
+
+async function main() {
+  const [, lockOwner] = await ethers.getSigners()
+
+  // files path
+  const contractsPath = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'contracts',
+    'past-versions'
+  )
+  const artifactsPath = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'artifacts',
+    'contracts',
+    'past-versions'
+  )
+
+  const pastPublicLockPath = require.resolve(
+    `@unlock-protocol/contracts/dist/PublicLock/PublicLockV${LATEST_PUBLIC_LOCK_VERSION}.sol`
+  )
+
+  await fs.copy(
+    pastPublicLockPath,
+    path.resolve(contractsPath, `PublicLockV${LATEST_PUBLIC_LOCK_VERSION}.sol`)
+  )
+
+  // re-compile contract using hardhat
+  await run('compile')
+
+  const PublicLockPast = await ethers.getContractFactory(
+    `contracts/past-versions/PublicLockV${LATEST_PUBLIC_LOCK_VERSION}.sol:PublicLock`
+  )
+
+  // deploy a simple lock
+  const args = [
+    lockOwner.address,
+    60 * 60 * 24 * 30, // 30 days
+    ethers.constants.AddressZero,
+    ethers.utils.parseEther('0.01'),
+    130,
+    'A neat upgradeable lock!',
+  ]
+  const lock = await upgrades.deployProxy(PublicLockPast, args)
+  await lock.deployed()
+
+  const PublicLockLatest = await ethers.getContractFactory(
+    'contracts/PublicLock.sol:PublicLock'
+  )
+  // deploy new implementation
+  await upgrades.upgradeProxy(lock.address, PublicLockLatest, {
+    // UNSECURE - but we need the flag as we are resizing the `__gap`
+    // unsafeSkipStorageCheck: true,
+  })
+
+  await fs.remove(contractsPath)
+  await fs.remove(artifactsPath)
+}
+
+// execute as standalone
+if (require.main === module) {
+  /* eslint-disable promise/prefer-await-to-then, no-console */
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+}
+
+module.exports = main


### PR DESCRIPTION
# Description

This adds a simple script to run the openzeppelin upgrades plugin with the last version of the Lock to detect potential conflicts in storage layout before upgrade.

```
yarn hardhat run scripts/lock/testUpgrage.js
```

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

