### PR TITLE
fix(smart-contracts): use defaults for metadata

### DIFF
--- a/smart-contracts/contracts/UnlockUtils.sol
+++ b/smart-contracts/contracts/UnlockUtils.sol
@@ -7,17 +7,6 @@ pragma solidity >=0.5.17 <=0.8.7;
 
 library UnlockUtils {
 
-  function strConcat(
-    string memory _a,
-    string memory _b,
-    string memory _c,
-    string memory _d
-  ) internal pure
-    returns (string memory _concatenatedString)
-  {
-    return string(abi.encodePacked(_a, _b, _c, _d));
-  }
-
   function uint2Str(
     uint _i
   ) internal pure

--- a/smart-contracts/contracts/mixins/MixinLockMetadata.sol
+++ b/smart-contracts/contracts/mixins/MixinLockMetadata.sol
@@ -42,7 +42,10 @@ contract MixinLockMetadata is
   ) internal
   {
     ERC165StorageUpgradeable.__ERC165Storage_init();
+
+    // set default values
     name = _lockName;
+    lockSymbol = unlockProtocol.globalTokenSymbol();
     // registering the optional erc721 metadata interface with ERC165.sol using
     // the ID specified in the standard: https://eips.ethereum.org/EIPS/eip-721
     _registerInterface(0x5b5e139f);
@@ -79,11 +82,7 @@ contract MixinLockMetadata is
     external view
     returns(string memory)
   {
-    if(bytes(lockSymbol).length == 0) {
-      return unlockProtocol.globalTokenSymbol();
-    } else {
-      return lockSymbol;
-    }
+    return lockSymbol;
   }
 
   /**

--- a/smart-contracts/contracts/mocks/UnlockUtilsMock.sol
+++ b/smart-contracts/contracts/mocks/UnlockUtilsMock.sol
@@ -9,19 +9,7 @@ contract UnlockUtilsMock
 {
   using UnlockUtils for uint;
   using UnlockUtils for address;
-  using UnlockUtils for string;
-
-  function strConcat(
-    string memory _a,
-    string memory _b,
-    string memory _c,
-    string memory _d
-  ) public pure
-    returns (string memory _concatenatedString)
-  {
-    return _a.strConcat(_b, _c, _d);
-  }
-
+  
   function uint2Str(
     uint _i
   ) public pure

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -6,10 +6,7 @@ const getProxy = require('../../helpers/proxy')
 
 let unlock
 let lock
-let txObj
 let event
-let baseTokenURI
-let uri
 
 // Helper function to deal with the lock returning the address part of the URI in lowercase.
 function lowerCase(str) {
@@ -38,7 +35,7 @@ contract('Lock / erc721 / tokenURI', (accounts) => {
 
     describe('set global base URI', () => {
       beforeEach(async () => {
-        txObj = await unlock.configUnlock(
+        const tx = await unlock.configUnlock(
           await unlock.udt(),
           await unlock.weth(),
           0,
@@ -49,7 +46,7 @@ contract('Lock / erc721 / tokenURI', (accounts) => {
             from: accounts[0],
           }
         )
-        event = txObj.logs[0]
+        event = tx.logs[0]
       })
 
       it('should allow the owner to set the global base token URI', async () => {
@@ -109,9 +106,8 @@ contract('Lock / erc721 / tokenURI', (accounts) => {
     })
 
     it('should set base tokenURI from Unlock as default', async () => {
-      baseTokenURI = await lock.tokenURI.call(0)
       assert.equal(
-        baseTokenURI,
+        await lock.tokenURI.call(0),
         `https://default.com/api/key/${lowerCase(lock.address)}/`
       )
     })

--- a/smart-contracts/test/unlockUtils.js
+++ b/smart-contracts/test/unlockUtils.js
@@ -18,15 +18,6 @@ contract('unlockUtils', (accounts) => {
     })
   })
 
-  describe('function strConcat', () => {
-    let resultingStr
-
-    it('should concatenate 4 strings', async () => {
-      resultingStr = await mock.strConcat.call('hello', '-unlock', '/', '42')
-      assert.equal(resultingStr, 'hello-unlock/42')
-    })
-  })
-
   describe('function address2Str', () => {
     let senderAddress
     // currently returns the address as a string with all chars in lowercase


### PR DESCRIPTION
# Description

This commit modifies how the `baseTokenURI` and `baseSymbol` are fetched by setting defaults value (from Unlock) at lock creation instead of calling it on each `tokenURI` / `symbol` call.

This makes code lighter and more gas efficient, but also will prevent all lock URIs from being updated in case the main Unlock config changed. 

In case the main Unlock `globalTokenBaseURI` changes, lock managers will have to call `lock.setBaseTokenURI('')` (with an empty string) from their lock to reset to the latest base URI from Unlock.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

