### PR TITLE
feat(smart-contracts): disable `shareKey` when lock is sold out

### DIFF
--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -52,6 +52,7 @@ contract MixinTransfer is
   {
     _onlyIfAlive();
     _lockIsUpToDate();
+    require(maxNumberOfKeys > _totalSupply, 'LOCK_SOLD_OUT');
     _onlyKeyManagerOrApproved(_tokenIdFrom);
     _isValidKey(_tokenIdFrom);
     require(transferFeeBasisPoints < BASIS_POINTS_DEN, 'KEY_TRANSFERS_DISABLED');

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -11,26 +11,21 @@ let locks
 let tokenIds
 
 contract('Lock / shareKey', (accounts) => {
-  before(async () => {
-    unlock = await getProxy(unlockContract)
-    locks = await deployLocks(unlock, accounts[0])
-  })
-
   let lock
   let event
   let event1
   let event2
-  let tx1
   let tx2
 
   const keyOwners = [accounts[1], accounts[2], accounts[3]]
-  const accountWithNoKey1 = accounts[4]
   const accountWithNoKey2 = accounts[5]
   const accountWithNoKey3 = accounts[6]
   const approvedAddress = accounts[7]
   const keyPrice = new BigNumber(web3.utils.toWei('0.01', 'ether'))
 
-  before(async () => {
+  beforeEach(async () => {
+    unlock = await getProxy(unlockContract)
+    locks = await deployLocks(unlock, accounts[0])
     lock = locks.FIRST
     const tx = await lock.purchase(
       [],
@@ -54,7 +49,7 @@ contract('Lock / shareKey', (accounts) => {
       it('sender is not approved', async () => {
         await reverts(
           lock.shareKey(accounts[7], 11, 1000, {
-            from: accountWithNoKey1,
+            from: accounts[4],
           }),
           'ONLY_KEY_MANAGER_OR_APPROVED'
         )
@@ -127,22 +122,28 @@ contract('Lock / shareKey', (accounts) => {
     })
 
     describe('fallback behaviors', () => {
-      it('transfers all remaining time if amount to share >= remaining time', async () => {
-        let tooMuchTime = new BigNumber(60 * 60 * 24 * 30 * 2) // 60 days
+      let remaining
+      let tx
+
+      beforeEach(async () => {
+        const tooMuchTime = new BigNumber(60 * 60 * 24 * 30 * 2) // 60 days
         assert.equal(await lock.isValidKey.call(tokenIds[1]), true)
 
-        const remaining = await lock.keyExpirationTimestampFor(tokenIds[1])
-        assert.equal(await lock.balanceOf(accountWithNoKey1), 0)
+        remaining = await lock.keyExpirationTimestampFor(tokenIds[1])
+        assert.equal(await lock.balanceOf(accounts[4]), 0)
 
-        tx1 = await lock.shareKey(accountWithNoKey1, tokenIds[1], tooMuchTime, {
+        tx = await lock.shareKey(accounts[4], tokenIds[1], tooMuchTime, {
           from: keyOwners[1],
         })
-        const { args } = tx1.logs.find((v) => v.event === 'Transfer')
+      })
+
+      it('transfers all remaining time if amount to share >= remaining time', async () => {
+        const { args } = tx.logs.find((v) => v.event === 'Transfer')
         assert.equal(await lock.isValidKey(args.tokenId), true)
 
         // new owner now has a fresh key
-        assert.equal(await lock.balanceOf(accountWithNoKey1), 1)
-        assert.equal(await lock.getHasValidKey.call(accountWithNoKey1), true)
+        assert.equal(await lock.balanceOf(accounts[4]), 1)
+        assert.equal(await lock.getHasValidKey.call(accounts[4]), true)
 
         let newExpirationTimestamp = new BigNumber(
           await lock.keyExpirationTimestampFor.call(args.tokenId)
@@ -151,10 +152,11 @@ contract('Lock / shareKey', (accounts) => {
       })
 
       it('should emit the expireKey Event', async () => {
-        assert.equal(tx1.logs[0].event, 'ExpireKey')
+        assert.equal(tx.logs[0].event, 'ExpireKey')
       })
 
       it('The origin key is expired', async () => {
+        assert.equal(await lock.isValidKey(tokenIds[1]), false)
         assert.equal(await lock.getHasValidKey.call(keyOwners[1]), false)
       })
 
@@ -175,7 +177,7 @@ contract('Lock / shareKey', (accounts) => {
     let timestampAfterSharing
     let newTokenId
 
-    before(async () => {
+    beforeEach(async () => {
       // Change the fee to 5%
       await lock.updateTransferFee(500)
       // approve an address

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -86,6 +86,28 @@ contract('Lock / shareKey', (accounts) => {
           'TRANSFER_TO_SELF'
         )
       })
+
+      it('should revert if keys are sold out', async () => {
+        const buyers = accounts.slice(3, 10)
+        await lock.purchase(
+          [],
+          buyers,
+          buyers.map(() => web3.utils.padLeft(0, 40)),
+          buyers.map(() => web3.utils.padLeft(0, 40)),
+          [],
+          {
+            value: (keyPrice * buyers.length).toFixed(),
+            from: keyOwners[0],
+          }
+        )
+
+        await reverts(
+          lock.shareKey(keyOwners[0], tokenIds[0], 1000, {
+            from: keyOwners[0],
+          }),
+          'LOCK_SOLD_OUT'
+        )
+      })
     })
 
     it('should fail if trying to share a key with a contract which does not implement onERC721Received', async () => {


### PR DESCRIPTION
# Description

As `shareKey` create of a new key, we need to make sure it fails if the lock is sold out. This PR address it

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #8471
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

