### PR TITLE
fix(smart-contracts): disable `setApprovalFor` when transfers are disabled

### DIFF
--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -70,7 +70,7 @@ contract MixinKeys is
   // The caller may not currently be the keyManager for ANY keys.
   // These approvals are never reset/revoked automatically, unlike "approved",
   // which is reset on transfer.
-  mapping (address => mapping (address => bool)) private managerToOperatorApproved;
+  mapping (address => mapping (address => bool)) internal managerToOperatorApproved;
 
   // store all keys: tokenId => token
   mapping(uint256 => Key) internal _keys;
@@ -673,22 +673,6 @@ contract MixinKeys is
     }
 
     emit ExpirationChanged(_tokenId, _deltaT, _addTime);
-  }
-
-  /**
-   * @dev Sets or unsets the approval of a given operator
-   * An operator is allowed to transfer all tokens of the sender on their behalf
-   * @param _to operator address to set the approval
-   * @param _approved representing the status of the approval to be set
-   */
-  function setApprovalForAll(
-    address _to,
-    bool _approved
-  ) public
-  {
-    require(_to != msg.sender, 'APPROVE_SELF');
-    managerToOperatorApproved[msg.sender][_to] = _approved;
-    emit ApprovalForAll(msg.sender, _to, _approved);
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -100,6 +100,7 @@ contract MixinTransfer is
     require(_checkOnERC721Received(keyOwner, _to, tokenIdTo, ''), 'NON_COMPLIANT_ERC721_RECEIVER');
   }
 
+
   function transferFrom(
     address _from,
     address _recipient,
@@ -182,6 +183,24 @@ contract MixinTransfer is
     public
   {
     safeTransferFrom(_from, _to, _tokenId, '');
+  }
+
+   /**
+   * @dev Sets or unsets the approval of a given operator
+   * An operator is allowed to transfer all tokens of the sender on their behalf
+   * @param _to operator address to set the approval
+   * @param _approved representing the status of the approval to be set
+   * @notice disabled when transfers are disabled
+   */
+  function setApprovalForAll(
+    address _to,
+    bool _approved
+  ) public
+  {
+    require(_to != msg.sender, 'APPROVE_SELF');
+    require(transferFeeBasisPoints < BASIS_POINTS_DEN, 'KEY_TRANSFERS_DISABLED');
+    managerToOperatorApproved[msg.sender][_to] = _approved;
+    emit ApprovalForAll(msg.sender, _to, _approved);
   }
 
   /**

--- a/smart-contracts/test/Lock/disableTransfers.js
+++ b/smart-contracts/test/Lock/disableTransfers.js
@@ -66,6 +66,17 @@ contract('Lock / disableTransfers', (accounts) => {
       })
     })
 
+    describe('disabling setApprovalForAll', () => {
+      it('should prevent user from setting setApprovalForAll', async () => {
+        await reverts(
+          lock.setApprovalForAll(accounts[8], true, {
+            from: keyOwner,
+          }),
+          'KEY_TRANSFERS_DISABLED'
+        )
+      })
+    })
+
     describe('disabling shareKey', () => {
       it('should prevent key sharing by reverting', async () => {
         // check owner has a key

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -89,7 +89,7 @@ contract('Lock / shareKey', (accounts) => {
           buyers,
           buyers.map(() => web3.utils.padLeft(0, 40)),
           buyers.map(() => web3.utils.padLeft(0, 40)),
-          [],
+          buyers.map(() => []),
           {
             value: (keyPrice * buyers.length).toFixed(),
             from: keyOwners[0],


### PR DESCRIPTION
# Description

Prevent the use of `setApprovalFor` when transfers are disabled

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #8439
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

