### PR TITLE
adding URL to easily identity purchaser + balance

### DIFF
--- a/locksmith/jest.config.js
+++ b/locksmith/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 58,
-      functions: 65,
+      functions: 64,
       lines: 69,
     },
   },

--- a/locksmith/src/controllers/purchaseController.ts
+++ b/locksmith/src/controllers/purchaseController.ts
@@ -16,6 +16,21 @@ import logger from '../logger'
 const config = require('../../config/config')
 
 namespace PurchaseController {
+  /**
+   *
+   * @param _req
+   * @param res
+   * @returns
+   */
+  export const info = async (
+    _req: SignedRequest,
+    res: Response
+  ): Promise<any> => {
+    const fulfillmentDispatcher = new Dispatcher()
+
+    return res.json(await fulfillmentDispatcher.balances())
+  }
+
   export const purchase = async (
     req: SignedRequest,
     res: Response

--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -13,6 +13,33 @@ interface transactionOptionsInterface {
 }
 
 export default class Dispatcher {
+  async balances() {
+    const balances = await Promise.all(
+      Object.values(networks).map(async (network: any) => {
+        try {
+          const provider = new ethers.providers.JsonRpcProvider(
+            network.publicProvider
+          )
+          const wallet = new ethers.Wallet(config.purchaserCredentials)
+          const balance = await provider.getBalance(wallet.address)
+          return [
+            network.id,
+            {
+              address: wallet.address,
+              balance: balance.toNumber(),
+            },
+          ]
+        } catch (error) {
+          logger.error(error)
+          return [network.id, {}]
+        }
+      })
+    )
+    // @ts-expect-error
+    const entries = new Map(balances)
+    return Object.fromEntries(entries)
+  }
+
   /**
    * Called to grant key to user!
    */

--- a/locksmith/src/routes/purchase.ts
+++ b/locksmith/src/routes/purchase.ts
@@ -4,6 +4,8 @@ import signatureValidationMiddleware from '../middlewares/signatureValidationMid
 const router = express.Router({ mergeParams: true })
 const purchaseController = require('../controllers/purchaseController')
 
+router.get('/', purchaseController.info)
+
 router.post(
   '/',
   signatureValidationMiddleware.generateProcessor({

--- a/packages/unlock-js/examples/networks.js
+++ b/packages/unlock-js/examples/networks.js
@@ -10,7 +10,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-const { rinkeby, xdai } = require('@unlock-protocol/networks')
+const { rinkeby, xdai, polygon } = require('@unlock-protocol/networks')
 
 module.exports = {
   4: {
@@ -21,4 +21,9 @@ module.exports = {
     unlockAddress: xdai.unlockAddress,
     provider: xdai.provider,
   },
+  137: {
+    unlockAddress: polygon.unlockAddress,
+    provider: polygon.publicProvider,
+  },
+
 }


### PR DESCRIPTION
# Description

In order to more easily debug and simplify config I am adding a API call to get the purchaser address and its balance on all networks.


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

