### PR TITLE
fix(smart-contracts): reset key manager after a `transferFrom`

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -483,8 +483,22 @@ interface IPublicLock
     */
   function getApproved(uint256 _tokenId) external view returns (address operator);
 
-  function setApprovalForAll(address operator, bool _approved) external;
-  function isApprovedForAll(address _owner, address operator) external view returns (bool);
+   /**
+   * @dev Sets or unsets the approval of a given operator
+   * An operator is allowed to transfer all tokens of the sender on their behalf
+   * @param _operator operator address to set the approval
+   * @param _approved representing the status of the approval to be set
+   * @notice disabled when transfers are disabled
+   */
+  function setApprovalForAll(address _operator, bool _approved) external;
+
+   /**
+   * @dev Tells whether an operator is approved by a given keyManager
+   * @param _owner owner address which you want to query the approval of
+   * @param _operator operator address which you want to query the approval of
+   * @return bool whether the given operator is approved by the given owner
+   */
+  function isApprovedForAll(address _owner, address _operator) external view returns (bool);
 
   function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
 

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -138,6 +138,7 @@ contract MixinTransfer is
     _createOwnershipRecord(_tokenId, _recipient);
 
     // clear any previous approvals
+    _setKeyManagerOf(_tokenId, address(0));
     _clearApproval(_tokenId);
 
     // make future reccuring transactions impossible

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -156,6 +156,25 @@ contract('Lock / erc721 / transferFrom', (accounts) => {
       })
     })
 
+    describe('when the sender is a key manager', async () => {
+      let keyManager
+      beforeEach(async () => {
+        keyManager = accounts[8]
+        await locks.FIRST.setKeyManagerOf(tokenIds[0], keyManager, {
+          from: keyOwners[0],
+        })
+      })
+      it('should reset the key manager', async () => {
+        await locks.FIRST.transferFrom(keyOwners[0], accounts[9], tokenIds[0], {
+          from: keyManager,
+        })
+        assert.equal(
+          await locks.FIRST.keyManagerOf(tokenIds[0]),
+          constants.ZERO_ADDRESS
+        )
+      })
+    })
+
     describe('when the lock is sold out', () => {
       it('should still allow the transfer of keys', async () => {
         // first we create a lock with only 1 key

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -175,6 +175,34 @@ contract('Lock / erc721 / transferFrom', (accounts) => {
       })
     })
 
+    describe('when the sender is approved', async () => {
+      let approved
+      beforeEach(async () => {
+        approved = accounts[8]
+        await locks.FIRST.setApprovalForAll(approved, true, {
+          from: keyOwners[0],
+        })
+        assert.equal(
+          await locks.FIRST.isApprovedForAll(keyOwners[0], approved),
+          true
+        )
+      })
+      it('should allow the transfer', async () => {
+        await locks.FIRST.transferFrom(keyOwners[0], accounts[9], tokenIds[0], {
+          from: approved,
+        })
+        assert.equal(
+          await locks.FIRST.isApprovedForAll(keyOwners[0], approved),
+          true
+        )
+        await reverts(
+          locks.FIRST.transferFrom(accounts[9], approved, tokenIds[0], {
+            from: approved,
+          })
+        )
+      })
+    })
+
     describe('when the lock is sold out', () => {
       it('should still allow the transfer of keys', async () => {
         // first we create a lock with only 1 key


### PR DESCRIPTION
# Description

Following the refactoring, the key manager was not properly reset after calling `transferFrom`. This also fixes #8448 as approvals are now systematically clear.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

