### PR TITLE
feat(unlock-app) remove "add to network" button dashboard

### DIFF
--- a/unlock-app/src/components/interface/Account.tsx
+++ b/unlock-app/src/components/interface/Account.tsx
@@ -5,7 +5,6 @@ import Media from '../../theme/media'
 import { AuthenticationContext } from '../../contexts/AuthenticationContext'
 
 import { ConfigContext } from '../../utils/withConfig'
-import { useAddToNetwork } from '../../hooks/useAddToNetwork'
 
 interface NetworkType {
   name: string
@@ -31,8 +30,6 @@ export function Account() {
   const networkSelected = (event: any) => {
     changeNetwork(networks[event?.target?.value])
   }
-
-  const { addNetworkToWallet, currentNetwork } = useAddToNetwork(account)
 
   return (
     <AccountWrapper>
@@ -68,14 +65,6 @@ export function Account() {
                   onClick={deAuthenticate}
                 >
                   Disconnect
-                </button>
-                <button
-                  className="px-2 py-1 text-gray-900 bg-gray-200 rounded"
-                  type="button"
-                  onClick={() => addNetworkToWallet(network)}
-                  disabled={currentNetwork === network}
-                >
-                  Add Network
                 </button>
               </div>
             )}


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
On the dashboard, we currently have an "add to network" button that allows the user to add the selected network.
The button is always disabled because when the user change network and the selected one is not present on the user wallet a prompt will show to ask the user to add the network automatically.
Because of this we don't need  to keep "Add to Network" button in dashboard 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

