### PR TITLE
feat(unlock-app) - fix message to sign issue

### DIFF
--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useContext, useReducer, useEffect } from 'react'
+import React, {
+  useState,
+  useContext,
+  useReducer,
+  useEffect,
+  useRef,
+} from 'react'
 import Head from 'next/head'
 import styled from 'styled-components'
 import { Web3Service } from '@unlock-protocol/unlock-js'
@@ -112,6 +118,7 @@ export const Checkout = ({
   const [storedLoginEmail, setStoredLoginEmail] = useState<string>('')
   const { getAutoLoginEmail } = useAutoLogin()
   const storedEmail = getAutoLoginEmail()
+  const messageSigned = useRef(false)
 
   // state change
   useEffect(() => {
@@ -132,9 +139,10 @@ export const Checkout = ({
     const handleUser = async (account?: string) => {
       if (account) {
         let signedMessage
-        if (paywallConfig?.messageToSign) {
+        if (paywallConfig?.messageToSign && !messageSigned.current) {
           signedMessage = await signMessage(paywallConfig?.messageToSign)
           setSignedMessage(signedMessage)
+          messageSigned.current = true
         }
         setHasKey(-1)
         emitUserInfo({
@@ -147,7 +155,6 @@ export const Checkout = ({
         // Reset card details if user disconnected.
         setCardDetails(null)
       }
-
       if (selectedLock) {
         if (!isUnlockAccount) {
           // Check if we have card details.
@@ -158,6 +165,8 @@ export const Checkout = ({
         } else {
           cardCheckoutOrClaim(selectedLock)
         }
+      } else if (messageSigned.current) {
+        setCheckoutState('pick-lock')
       } else {
         setCheckoutState(defaultState)
         if (!account && storedEmail) showLoginForm()


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
After auto-login, if user have message to sign, is stucked with loading spinner, this PR fix this issue by setting `pick-lock` state instead of default `loading` state


https://user-images.githubusercontent.com/20865711/161833496-58341341-d21f-4f80-9791-76f401e9594f.mov



<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

