### PR TITLE
feat(unlock-app) showing a message when the transaction failed

### DIFF
--- a/packages/unlock-js/src/PublicLock/v4/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v4/purchaseKey.js
@@ -74,6 +74,11 @@ export default async function (
 
   // Let's now wait for the transaction to go thru to return the token id
   const receipt = await this.provider.waitForTransaction(hash)
+
+  if (receipt.status === 0) {
+    throw new Error('Transaction failed')
+  }
+
   const parser = lockContract.interface
 
   const transferEvent = receipt.logs

--- a/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
@@ -120,6 +120,11 @@ export default async function (
 
   // Let's now wait for the transaction to go thru to return the token id
   const receipt = await this.provider.waitForTransaction(hash)
+
+  if (receipt.status === 0) {
+    throw new Error('Transaction failed')
+  }
+
   const parser = lockContract.interface
 
   const transferEvent = receipt.logs

--- a/packages/unlock-js/src/PublicLock/v9/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v9/purchaseKey.js
@@ -135,8 +135,12 @@ export default async function (
 
   // Let's now wait for the transaction to go thru to return the token id
   const receipt = await this.provider.waitForTransaction(hash)
-  const parser = lockContract.interface
 
+  if (receipt.status === 0) {
+    throw new Error('Transaction failed')
+  }
+
+  const parser = lockContract.interface
   const transferEvent = receipt.logs
     .map((log) => {
       if (log.address !== lockAddress) return // Some events are triggered by the ERC20 contract


### PR DESCRIPTION
# Description

We are now able to show an error message when the transaction fails.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

