### PR TITLE
feat(unlock-app) - fix flickering loading issue on change steps

### DIFF
--- a/unlock-app/src/components/interface/checkout/CheckoutCustomRecipient.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutCustomRecipient.tsx
@@ -9,6 +9,7 @@ interface CheckoutCustomRecipientProps {
   onRecipientChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   customBuyMessage?: string
   disabled?: boolean
+  loading?: boolean
 }
 
 export const CheckoutCustomRecipient: React.FC<
@@ -21,10 +22,14 @@ export const CheckoutCustomRecipient: React.FC<
   checkingRecipient,
   customBuyMessage,
   disabled,
+  loading,
 }) => {
   return (
     <>
-      <SmallButton onClick={() => setIsAdvanced(!isAdvanced)}>
+      <SmallButton
+        disabled={loading}
+        onClick={() => setIsAdvanced(!isAdvanced)}
+      >
         {isAdvanced ? 'Close advanced' : customBuyMessage ?? 'Advanced'}
       </SmallButton>
       {isAdvanced && (
@@ -68,4 +73,5 @@ export const CheckoutCustomRecipient: React.FC<
 CheckoutCustomRecipient.defaultProps = {
   customBuyMessage: undefined,
   disabled: false,
+  loading: false,
 }

--- a/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
@@ -48,6 +48,7 @@ export const CryptoCheckout = ({
 }: CryptoCheckoutProps) => {
   const { networks, services, recaptchaKey } = useContext(ConfigContext)
   const storageService = new StorageService(services.storage.host)
+  const [loading, setLoading] = useState(false)
   const [recaptchaValue, setRecaptchaValue] = useState<string | null>('')
   const {
     network: walletNetwork,
@@ -206,12 +207,14 @@ export const CryptoCheckout = ({
     setCardPurchase()
   }
 
-  const hasValidKeyOrPendingTx = hasValidOrPendingKey || transactionPending
+  const hasValidKeyOrPendingTx =
+    !loading && (hasValidOrPendingKey || transactionPending)
   const showCheckoutButtons =
-    ((recaptchaValue || !paywallConfig.captcha) &&
+    !loading &&
+    (((recaptchaValue || !paywallConfig.captcha) &&
       !transactionPending &&
       !hasValidkey) ||
-    (isAdvanced && hasValidKeyOrPendingTx && !transactionPending)
+      (isAdvanced && hasValidKeyOrPendingTx && !transactionPending))
 
   return (
     <>
@@ -226,6 +229,7 @@ export const CryptoCheckout = ({
         onSelected={null}
         hasOptimisticKey={hasOptimisticKey}
         purchasePending={purchasePending}
+        onLoading={setLoading}
       />
       {!hasValidKeyOrPendingTx && (
         <>

--- a/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
@@ -221,10 +221,11 @@ export const CryptoCheckout = ({
       !hasValidkey) ||
     (isAdvanced && hasValidKeyOrPendingTx && !transactionPending)
 
-  const onLoading = useCallback((loading: boolean) => {
+  const onLoading = (loading: boolean) => {
     setLoading(loading)
     loadingCheck.current = true
-  }, [])
+  }
+
   return (
     <>
       <Lock

--- a/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
@@ -208,7 +208,7 @@ export const CryptoCheckout = ({
   }
 
   const hasValidKeyOrPendingTx =
-    !loading && (hasValidOrPendingKey || transactionPending)
+    hasValidOrPendingKey || transactionPending || loading
   const showCheckoutButtons =
     !loading &&
     (((recaptchaValue || !paywallConfig.captcha) &&

--- a/unlock-app/src/components/interface/checkout/FormStyles.tsx
+++ b/unlock-app/src/components/interface/checkout/FormStyles.tsx
@@ -44,6 +44,10 @@ export const SmallButton = styled.button`
   &:hover {
     text-decoration: underline;
   }
+
+  &:disabled {
+    opacity: 0.4;
+  }
 `
 
 export const Select = styled.select`

--- a/unlock-app/src/components/interface/checkout/FormStyles.tsx
+++ b/unlock-app/src/components/interface/checkout/FormStyles.tsx
@@ -47,6 +47,7 @@ export const SmallButton = styled.button`
 
   &:disabled {
     opacity: 0.4;
+    cursor: default;
   }
 `
 

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -19,6 +19,7 @@ interface LockProps {
   hasOptimisticKey: boolean
   purchasePending: boolean
   recipient?: string
+  onLoading?: (state: boolean) => void
 }
 
 const getLockProps = (
@@ -47,6 +48,7 @@ export const Lock = ({
   hasOptimisticKey,
   purchasePending,
   recipient,
+  onLoading,
 }: LockProps) => {
   const config = useContext(ConfigContext)
   const [loading, setLoading] = useState(false)
@@ -61,6 +63,12 @@ export const Lock = ({
     setHasValidKey(isKeyValid)
     setHasKey(key)
   }
+
+  useEffect(() => {
+    if (typeof onLoading === 'function') {
+      onLoading(loading)
+    }
+  }, [loading])
 
   useEffect(() => {
     const getKey = async () => {
@@ -117,4 +125,5 @@ export const Lock = ({
 
 Lock.defaultProps = {
   recipient: '',
+  onLoading: () => undefined,
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This PR is to fix the flickering issue between steps.

if the user already has the key, it can see the buy options before seeing the correct message ` "You already have a valid membership!"` message.

The fix shows the loading until we retrieve all the correct states.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

### Issue video ref
https://user-images.githubusercontent.com/20865711/161980483-ba8096ba-0e0d-4c36-90ab-5fd091792e44.mov

###  fix video ref
https://user-images.githubusercontent.com/20865711/161980534-1b4981dc-8c35-4395-869c-1978e75f3461.mov



# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

