### PR TITLE
feat(hardhat-plugin): bump latest contracts versions

### DIFF
--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -57,6 +57,6 @@
   "dependencies": {
     "@nomiclabs/hardhat-ethers": "2.0.5",
     "@openzeppelin/hardhat-upgrades": "1.16.1",
-    "@unlock-protocol/contracts": "0.0.3"
+    "@unlock-protocol/contracts": "0.0.4"
   }
 }

--- a/packages/hardhat-plugin/src/constants.ts
+++ b/packages/hardhat-plugin/src/constants.ts
@@ -1,5 +1,5 @@
-export const UNLOCK_LATEST_VERSION = 10
-export const PUBLIC_LOCK_LATEST_VERSION = 9
+export const UNLOCK_LATEST_VERSION = 11
+export const PUBLIC_LOCK_LATEST_VERSION = 10
 
 // task names
 export const TASK_CREATE_LOCK = 'unlock:create-lock'

--- a/yarn.lock
+++ b/yarn.lock
@@ -14451,14 +14451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unlock-protocol/contracts@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@unlock-protocol/contracts@npm:0.0.3"
-  checksum: 80988d7c7c8aff5b88c74ec74b3ccae63f2d0f1ded545c688086a61e38e4fe922bacb029c92eee2a92dee6dc0eb193d4649460cf49d0fabf6146106ddf60bb0c
-  languageName: node
-  linkType: hard
-
-"@unlock-protocol/contracts@workspace:./packages/contracts, @unlock-protocol/contracts@workspace:^, @unlock-protocol/contracts@workspace:packages/contracts":
+"@unlock-protocol/contracts@0.0.4, @unlock-protocol/contracts@workspace:./packages/contracts, @unlock-protocol/contracts@workspace:^, @unlock-protocol/contracts@workspace:packages/contracts":
   version: 0.0.0-use.local
   resolution: "@unlock-protocol/contracts@workspace:packages/contracts"
   dependencies:
@@ -14512,7 +14505,7 @@ __metadata:
     "@types/fs-extra": 9.0.13
     "@types/mocha": 9.1.0
     "@types/node": 8.10.66
-    "@unlock-protocol/contracts": 0.0.3
+    "@unlock-protocol/contracts": 0.0.4
     "@unlock-protocol/eslint-config": "workspace:^"
     "@unlock-protocol/networks": "workspace:^"
     "@unlock-protocol/tsconfig": "workspace:^"


### PR DESCRIPTION
# Description

Adds lock v10 and unlock v11 as default for contracts deployments

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

