### PR TITLE
feat(locksmith): Use lockAddress as tokenAddress in user metadata and other changes

### DIFF
--- a/locksmith/__tests__/controllers/v2/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/v2/metadataController.test.ts
@@ -81,14 +81,4 @@ describe('Metadata v2 endpoints for locksmith', () => {
     )
     expect(lockMetadataResponse.status).toBe(404)
   })
-
-  it('Get user metadata', async () => {
-    expect.assertions(1)
-    const lockAddress = await ethers.Wallet.createRandom().getAddress()
-    const userAddress = await ethers.Wallet.createRandom().getAddress()
-    const userMetadataResponse = await request(app).get(
-      `/v2/api/metadata/100/locks/${lockAddress}/users/${userAddress}`
-    )
-    expect(userMetadataResponse.status).toBe(404)
-  })
 })

--- a/locksmith/__tests__/controllers/v2/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/v2/metadataController.test.ts
@@ -19,9 +19,7 @@ describe('Metadata v2 endpoints for locksmith', () => {
       },
     }
     const userMetadataResponse = await request(app)
-      .post(
-        `/v2/api/metadata/100/locks/${lockAddress}/users/${walletAddress}/keys/1`
-      )
+      .post(`/v2/api/metadata/100/locks/${lockAddress}/users/${walletAddress}`)
       .send({ metadata })
 
     expect(userMetadataResponse.status).toBe(201)
@@ -89,7 +87,7 @@ describe('Metadata v2 endpoints for locksmith', () => {
     const lockAddress = await ethers.Wallet.createRandom().getAddress()
     const userAddress = await ethers.Wallet.createRandom().getAddress()
     const userMetadataResponse = await request(app).get(
-      `/v2/api/metadata/100/locks/${lockAddress}/users/${userAddress}/keys/1`
+      `/v2/api/metadata/100/locks/${lockAddress}/users/${userAddress}`
     )
     expect(userMetadataResponse.status).toBe(404)
   })

--- a/locksmith/src/controllers/v2/metadataController.ts
+++ b/locksmith/src/controllers/v2/metadataController.ts
@@ -348,7 +348,7 @@ export class MetadataController {
 
       const items = await UserTokenMetadata.bulkCreate(newUsersData)
       return response.status(201).send({
-        result: items,
+        result: items.map((item) => item.data),
       })
     } catch (error) {
       logger.error(error.message)

--- a/locksmith/src/controllers/v2/metadataController.ts
+++ b/locksmith/src/controllers/v2/metadataController.ts
@@ -19,43 +19,11 @@ const BulkUserMetadataBody = z.object({
   users: z.array(UserMetadataBody),
 })
 
-interface IsKeyOrLockOwnerOptions {
-  userAddress?: string
-  lockAddress: string
-  keyId: string
-  network: number
-}
-
 export class MetadataController {
   public web3Service: Web3Service
 
   constructor({ web3Service }: { web3Service: Web3Service }) {
     this.web3Service = web3Service
-  }
-
-  async #isKeyOrLockOwner({
-    userAddress,
-    lockAddress,
-    keyId,
-    network,
-  }: IsKeyOrLockOwnerOptions) {
-    if (!userAddress) {
-      return false
-    }
-    const loggedUserAddress = Normalizer.ethereumAddress(userAddress)
-    const isLockOwner = await this.web3Service.isLockManager(
-      lockAddress,
-      loggedUserAddress,
-      network
-    )
-
-    const keyOwner = await this.web3Service.ownerOf(lockAddress, keyId, network)
-
-    const keyOwnerAddress = Normalizer.ethereumAddress(keyOwner)
-
-    const isKeyOwner = keyOwnerAddress === loggedUserAddress
-
-    return isLockOwner || isKeyOwner
   }
 
   async getLockMetadata(request: Request, response: Response) {
@@ -89,17 +57,18 @@ export class MetadataController {
       const network = Number(request.params.network)
       const host = `${request.protocol}://${request.headers.host}`
 
-      const includeProtected = await this.#isKeyOrLockOwner({
-        keyId,
-        network,
-        lockAddress,
-        userAddress: request.user?.walletAddress,
-      })
+      const isLockOwner = request.user?.walletAddress
+        ? await this.web3Service.isLockManager(
+            lockAddress,
+            request.user.walletAddress,
+            network
+          )
+        : false
 
       const keyData = await metadataOperations.generateKeyMetadata(
         lockAddress,
         keyId,
-        includeProtected,
+        isLockOwner,
         host,
         network
       )
@@ -204,17 +173,18 @@ export class MetadataController {
         return response.status(500).send('Failed to update the key metadata.')
       }
 
-      const includeProtected = await this.#isKeyOrLockOwner({
-        lockAddress,
-        keyId,
-        network,
-        userAddress: loggedUserAddress,
-      })
+      const isLockOwner = request.user?.walletAddress
+        ? await this.web3Service.isLockManager(
+            lockAddress,
+            request.user.walletAddress,
+            network
+          )
+        : false
 
       const keyData = await metadataOperations.generateKeyMetadata(
         lockAddress,
         keyId,
-        includeProtected,
+        isLockOwner,
         host,
         network
       )

--- a/locksmith/src/controllers/v2/metadataController.ts
+++ b/locksmith/src/controllers/v2/metadataController.ts
@@ -52,7 +52,7 @@ export class MetadataController {
 
   async getKeyMetadata(request: Request, response: Response) {
     try {
-      const { keyId } = request.params
+      const keyId = request.params.keyId.toLowerCase()
       const lockAddress = Normalizer.ethereumAddress(request.params.lockAddress)
       const network = Number(request.params.network)
       const host = `${request.protocol}://${request.headers.host}`
@@ -176,9 +176,10 @@ export class MetadataController {
 
   async createUserMetadata(request: Request, response: Response) {
     try {
-      const lockAddress = Normalizer.ethereumAddress(request.params.lockAddress)
+      const tokenAddress = Normalizer.ethereumAddress(
+        request.params.lockAddress
+      )
       const userAddress = Normalizer.ethereumAddress(request.params.userAddress)
-      const tokenAddress = lockAddress
       const network = Number(request.params.network)
       const { metadata } = request.body
 
@@ -212,20 +213,20 @@ export class MetadataController {
 
   async updateUserMetadata(request: Request, response: Response) {
     try {
-      const lockAddress = Normalizer.ethereumAddress(request.params.lockAddress)
+      const tokenAddress = Normalizer.ethereumAddress(
+        request.params.lockAddress
+      )
       const userAddress = Normalizer.ethereumAddress(request.params.userAddress)
       const loggedUserAddress = Normalizer.ethereumAddress(
         request.user!.walletAddress
       )
-      const tokenAddress = lockAddress
-
       const network = Number(request.params.network)
       const { metadata } = request.body
 
       const isUserMetadataOwner = userAddress === loggedUserAddress
 
       const isLockOwner = this.web3Service.isLockManager(
-        lockAddress,
+        tokenAddress,
         loggedUserAddress,
         network
       )

--- a/locksmith/src/controllers/v2/metadataController.ts
+++ b/locksmith/src/controllers/v2/metadataController.ts
@@ -91,36 +91,35 @@ export class MetadataController {
         request.user!.walletAddress!
       )
 
-      const isLockerOwner = await this.web3Service.isLockManager(
+      const isLockOwner = await this.web3Service.isLockManager(
         lockAddress,
         loggedUserAddress,
         network
       )
 
-      if (!isLockerOwner) {
+      if (!isLockOwner) {
         return response
           .status(401)
           .send(
             `${loggedUserAddress} is not a lock manager for ${lockAddress} on ${network}`
           )
-      } else {
-        const [updatedLockMetadata, success] = await LockMetadata.upsert(
-          {
-            address: lockAddress,
-            chain: network,
-            data: {
-              ...metadata,
-            },
+      }
+      const [updatedLockMetadata, success] = await LockMetadata.upsert(
+        {
+          address: lockAddress,
+          chain: network,
+          data: {
+            ...metadata,
           },
-          {
-            returning: true,
-          }
-        )
-        if (success) {
-          return response.status(202).send(updatedLockMetadata.data)
-        } else {
-          return response.status(400).send('update failed')
+        },
+        {
+          returning: true,
         }
+      )
+      if (success) {
+        return response.status(202).send(updatedLockMetadata.data)
+      } else {
+        return response.status(400).send('update failed')
       }
     } catch (error) {
       logger.error(error.message)
@@ -140,13 +139,13 @@ export class MetadataController {
       )
       const network = Number(request.params.network)
       const host = `${request.protocol}://${request.headers.host}`
-      const isLockerOwner = await this.web3Service.isLockManager(
+      const isLockOwner = await this.web3Service.isLockManager(
         lockAddress,
         loggedUserAddress,
         network
       )
 
-      if (!isLockerOwner) {
+      if (!isLockOwner) {
         return response
           .status(401)
           .send('You are not authorized to update this key.')
@@ -172,14 +171,6 @@ export class MetadataController {
       if (!rows) {
         return response.status(500).send('Failed to update the key metadata.')
       }
-
-      const isLockOwner = request.user?.walletAddress
-        ? await this.web3Service.isLockManager(
-            lockAddress,
-            request.user.walletAddress,
-            network
-          )
-        : false
 
       const keyData = await metadataOperations.generateKeyMetadata(
         lockAddress,

--- a/locksmith/src/controllers/v2/metadataController.ts
+++ b/locksmith/src/controllers/v2/metadataController.ts
@@ -131,7 +131,7 @@ export class MetadataController {
 
   async updateKeyMetadata(request: Request, response: Response) {
     try {
-      const { keyId } = request.params
+      const keyId = request.params.keyId.toLowerCase()
       const { metadata } = request.body
       const lockAddress = Normalizer.ethereumAddress(request.params.lockAddress)
       const loggedUserAddress = Normalizer.ethereumAddress(
@@ -151,24 +151,16 @@ export class MetadataController {
           .send('You are not authorized to update this key.')
       }
 
-      const [rows] = await KeyMetadata.update(
-        {
-          data: {
-            ...metadata,
-          },
+      const success = await KeyMetadata.upsert({
+        chain: network,
+        address: lockAddress,
+        id: keyId,
+        data: {
+          ...metadata,
         },
-        {
-          where: {
-            chain: network,
-            address: lockAddress,
-            id: keyId,
-          },
+      })
 
-          returning: true,
-        }
-      )
-
-      if (!rows) {
+      if (!success) {
         return response.status(500).send('Failed to update the key metadata.')
       }
 

--- a/locksmith/src/controllers/v2/metadataController.ts
+++ b/locksmith/src/controllers/v2/metadataController.ts
@@ -291,7 +291,11 @@ export class MetadataController {
         },
       })
 
-      if (!(isLockOwner || (userData && isUserMetadataOwner))) {
+      if (!userData) {
+        return response.status(404).send("User metadata doesn't exist.")
+      }
+
+      if (!(isLockOwner || isUserMetadataOwner)) {
         return response
           .status(401)
           .send('You are not authorized to update user metadata for this key.')
@@ -330,8 +334,8 @@ export class MetadataController {
       const network = Number(request.params.network)
       const { users } = await BulkUserMetadataBody.parseAsync(request.body)
       const tokenAddresses = users.map((user) => {
-        const lockAddress = Normalizer.ethereumAddress(user.lockAddress)
-        return lockAddress
+        const tokenAddress = Normalizer.ethereumAddress(user.lockAddress)
+        return tokenAddress
       })
 
       const userMetadataResults = await UserTokenMetadata.findAll({

--- a/locksmith/src/controllers/v2/metadataController.ts
+++ b/locksmith/src/controllers/v2/metadataController.ts
@@ -348,7 +348,7 @@ export class MetadataController {
 
       const items = await UserTokenMetadata.bulkCreate(newUsersData)
       return response.status(201).send({
-        result: items.map((item) => item.data),
+        result: items,
       })
     } catch (error) {
       logger.error(error.message)

--- a/locksmith/src/routes/v2/metadata.ts
+++ b/locksmith/src/routes/v2/metadata.ts
@@ -33,16 +33,12 @@ router.put(
   }
 )
 
-router.get(
-  '/:network/locks/:lockAddress/users/:userAddress/keys/:keyId',
-  (req, res) => {
-    metadataController.getUserMetadata(req, res)
-  }
-)
+router.get('/:network/locks/:lockAddress/users/:userAddress', (req, res) => {
+  metadataController.getUserMetadata(req, res)
+})
 
-router.post(
-  '/:network/locks/:lockAddress/users/:userAddress/keys/:keyId',
-  (req, res) => metadataController.createUserMetadata(req, res)
+router.post('/:network/locks/:lockAddress/users/:userAddress', (req, res) =>
+  metadataController.createUserMetadata(req, res)
 )
 
 router.post('/:network/users', (req, res) =>
@@ -50,7 +46,7 @@ router.post('/:network/users', (req, res) =>
 )
 
 router.put(
-  '/:network/locks/:lockAddress/users/:userAddress/keys/:keyId',
+  '/:network/locks/:lockAddress/users/:userAddress',
   authenticatedMiddleware,
   (req, res) => metadataController.updateUserMetadata(req, res)
 )

--- a/locksmith/src/routes/v2/metadata.ts
+++ b/locksmith/src/routes/v2/metadata.ts
@@ -33,10 +33,6 @@ router.put(
   }
 )
 
-router.get('/:network/locks/:lockAddress/users/:userAddress', (req, res) => {
-  metadataController.getUserMetadata(req, res)
-})
-
 router.post('/:network/locks/:lockAddress/users/:userAddress', (req, res) =>
   metadataController.createUserMetadata(req, res)
 )


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This fixes an earlier instance of using key ID in building the tokenAddress. 

Based on discussions, get user metadata route is removed.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

