### PR TITLE
feat(unlock-app) - add numberOfRecipients on price converter and key name

### DIFF
--- a/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
+++ b/unlock-app/src/__tests__/utils/checkoutLockUtils.test.ts
@@ -2,6 +2,8 @@ import {
   lockKeysAvailable,
   lockTickerSymbol,
   userCanAffordKey,
+  formattedKeyPrice,
+  convertedKeyPrice,
 } from '../../utils/checkoutLockUtils'
 
 describe('Checkout Lock Utils', () => {
@@ -148,6 +150,66 @@ describe('Checkout Lock Utils', () => {
       }
 
       expect(userCanAffordKey(lock, '50')).toBeFalsy()
+    })
+
+    it('correctly format keyPrice prices', () => {
+      expect.assertions(2)
+      const lock1 = {
+        keyPrice: '100',
+        currencyContractAddress: 'obc3',
+        currencySymbol: 'eth',
+      }
+      const lock2 = {
+        keyPrice: '0',
+        currencyContractAddress: 'Oxbe',
+        currencySymbol: 'eth',
+      }
+
+      expect(formattedKeyPrice(lock1, lock1.currencySymbol)).toEqual('100 ETH')
+
+      expect(formattedKeyPrice(lock2, lock1.currencySymbol)).toEqual('FREE')
+    })
+
+    it('correctly format keyPrice based on numbersOfRecipients', () => {
+      expect.assertions(2)
+      const numbersOfRecipients = 3
+
+      const lock1 = {
+        keyPrice: '12.4',
+        currencyContractAddress: 'obc3',
+        currencySymbol: 'eth',
+      }
+      const lock2 = {
+        keyPrice: '0',
+        currencyContractAddress: 'Oxbe',
+        currencySymbol: 'eth',
+      }
+      expect(
+        formattedKeyPrice(lock1, lock1.currencySymbol, numbersOfRecipients)
+      ).toEqual('37.2 ETH')
+
+      expect(
+        formattedKeyPrice(lock2, lock1.currencySymbol, numbersOfRecipients)
+      ).toEqual('FREE')
+    })
+
+    it('correctly convert keyPrice', () => {
+      expect.assertions(2)
+      const numbersOfRecipients = 6
+
+      const lock = {
+        fiatPricing: {
+          usd: {
+            keyPrice: '7.4',
+          },
+        },
+        currencyContractAddress: 'obc3',
+        currencySymbol: 'eth',
+      }
+
+      expect(convertedKeyPrice(lock)).toEqual('~$0.07')
+
+      expect(convertedKeyPrice(lock, numbersOfRecipients)).toEqual('~$0.44')
     })
   })
 })

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -20,19 +20,25 @@ interface LockProps {
   purchasePending: boolean
   recipient?: string
   onLoading?: (state: boolean) => void
+  numberOfRecipients?: number
 }
 
 const getLockProps = (
   lock: any,
   network: number,
   baseCurrencySymbol: string,
-  name: string
+  name: string,
+  numberOfRecipients = 1
 ) => {
   return {
     cardEnabled: lock?.fiatPricing?.creditCardEnabled,
     formattedDuration: durationsAsTextFromSeconds(lock.expirationDuration),
-    formattedKeyPrice: formattedKeyPrice(lock, baseCurrencySymbol),
-    convertedKeyPrice: convertedKeyPrice(lock),
+    formattedKeyPrice: formattedKeyPrice(
+      lock,
+      baseCurrencySymbol,
+      numberOfRecipients
+    ),
+    convertedKeyPrice: convertedKeyPrice(lock, numberOfRecipients),
     formattedKeysAvailable: lockKeysAvailable(lock),
     name: name || lock.name,
     address: lock.address,
@@ -49,6 +55,7 @@ export const Lock = ({
   purchasePending,
   recipient,
   onLoading,
+  numberOfRecipients,
 }: LockProps) => {
   const config = useContext(ConfigContext)
   const [loading, setLoading] = useState(false)
@@ -94,7 +101,8 @@ export const Lock = ({
       lock,
       network,
       config.networks[network].baseCurrencySymbol,
-      name
+      name,
+      numberOfRecipients
     ),
     selectable: true, // by default!
   }
@@ -126,4 +134,5 @@ export const Lock = ({
 Lock.defaultProps = {
   recipient: '',
   onLoading: () => undefined,
+  numberOfRecipients: 1,
 }

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -43,6 +43,7 @@ const getLockProps = (
     name: name || lock.name,
     address: lock.address,
     network,
+    prepend: numberOfRecipients > 1 ? `${numberOfRecipients} x ` : '',
   }
 }
 export const Lock = ({

--- a/unlock-app/src/components/interface/checkout/LockVariations.tsx
+++ b/unlock-app/src/components/interface/checkout/LockVariations.tsx
@@ -313,6 +313,7 @@ export interface PurchaseableLockProps {
   network: number
   selectable: boolean
   cardEnabled: boolean
+  prepend: string
 }
 
 export const PurchaseableLock = ({
@@ -326,6 +327,7 @@ export const PurchaseableLock = ({
   selectable,
   cardEnabled,
   onClick,
+  prepend,
 }: PurchaseableLockProps) => {
   return (
     <LockContainer
@@ -334,7 +336,10 @@ export const PurchaseableLock = ({
       data-testid="PurchaseableLock"
     >
       <InfoWrapper>
-        <LockName>{name}</LockName>
+        <LockName>
+          {prepend}
+          {name}
+        </LockName>
         <NetworkName>{ETHEREUM_NETWORKS_NAMES[network]}</NetworkName>
       </InfoWrapper>
       <BaseLockBody onClick={onClick}>
@@ -365,6 +370,7 @@ export interface ProcessingLockProps {
   formattedKeysAvailable: string
   network: number
   cardEnabled: boolean
+  prepend: string
 }
 
 export const ProcessingLock = ({
@@ -376,11 +382,15 @@ export const ProcessingLock = ({
   convertedKeyPrice,
   formattedKeysAvailable,
   cardEnabled,
+  prepend,
 }: ProcessingLockProps) => {
   return (
     <LockContainer data-address={address} data-testid="ProcessingLock">
       <InfoWrapper>
-        <LockName>{name}</LockName>
+        <LockName>
+          {prepend}
+          {name}
+        </LockName>
         <NetworkName>{ETHEREUM_NETWORKS_NAMES[network]}</NetworkName>
       </InfoWrapper>
       <BaseLockBody>

--- a/unlock-app/src/utils/checkoutLockUtils.ts
+++ b/unlock-app/src/utils/checkoutLockUtils.ts
@@ -78,23 +78,29 @@ export const userCanAffordKey = (
   return keyPrice <= _balance
 }
 
-export const convertedKeyPrice = (lock: LockTickerSymbolLock) => {
+export const convertedKeyPrice = (
+  lock: LockTickerSymbolLock,
+  numberOfRecipients = 1
+) => {
   const keyPrice = lock?.fiatPricing?.usd?.keyPrice
 
   if (!keyPrice) {
     return ''
   }
-  return `~$${parseInt(keyPrice) / 100}`
+  return `~$${((parseFloat(keyPrice) * numberOfRecipients) / 100).toFixed(2)}`
 }
 
 export const formattedKeyPrice = (
   lock: LockTickerSymbolLock,
-  baseCurrencySymbol: string
+  baseCurrencySymbol: string,
+  numberOfRecipients = 1
 ) => {
+  const { keyPrice } = lock ?? {}
   if (lock.keyPrice === '0') {
     return 'FREE'
   }
-  return `${lock.keyPrice} ${lockTickerSymbol(lock, baseCurrencySymbol)}`
+  const price = keyPrice ? parseFloat(keyPrice) * numberOfRecipients : null
+  return `${price} ${lockTickerSymbol(lock, baseCurrencySymbol)}`
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
By introducing `maxRecipients` to `PaywallConfig`, we need to show the correct full price for the users who buy for multiple recipients

On the checkout page, we show the number of keys that the user will buy, with the correct total, here two example:

### buy with multiple recipients
<img width="100" alt="multiple-key-buy" src="https://user-images.githubusercontent.com/20865711/163218001-8ef40aad-f937-492a-9683-19b9835cc3a7.png">

### buy with regular flow
<img width="100" alt="Screenshot 2022-04-13 at 17 33 46" src="https://user-images.githubusercontent.com/20865711/163218023-c4e21f94-d63b-48aa-a34e-ec11d009c79a.png">





<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

