### PR TITLE
feat(unlock-js) not failing when gas estimates are failing

### DIFF
--- a/packages/unlock-js/CHANGELOG.md
+++ b/packages/unlock-js/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changes
 
+# Next patch
+
+- rescuing gas estimation errors
+
 # 0.23.1
 
-- add support for publicLock v10 
+- add support for publicLock v10
 - add ability for all versions to purchase multiple keys at once with `purchaseKeys`
-- add support for  `extendKey`, `setMaxKeysPerAddress`, `mergeKeys`
+- add support for `extendKey`, `setMaxKeysPerAddress`, `mergeKeys`
 - refactor functions us emultiple times in `./src/PublicLock/utils` folder
 
 # 0.23.0

--- a/packages/unlock-js/src/PublicLock/v10/extendKey.js
+++ b/packages/unlock-js/src/PublicLock/v10/extendKey.js
@@ -74,30 +74,40 @@ export default async function (
 
   // Estimate gas. Bump by 30% because estimates are wrong!
   if (!purchaseForOptions.gasLimit) {
-    // To get good estimates we need the gas price, because it matters in the actual execution (UDT calculation takes it into account)
-    // TODO remove once we move to use block.baseFee in UDT calculation
-    const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } =
-      await this.provider.getFeeData()
+    try {
+      // To get good estimates we need the gas price, because it matters in the actual execution (UDT calculation takes it into account)
+      // TODO remove once we move to use block.baseFee in UDT calculation
+      const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } =
+        await this.provider.getFeeData()
 
-    if (maxFeePerGas && maxPriorityFeePerGas) {
-      purchaseForOptions.maxFeePerGas = maxFeePerGas
-      purchaseForOptions.maxPriorityFeePerGas = maxPriorityFeePerGas
-    } else {
-      purchaseForOptions.gasPrice = gasPrice
+      if (maxFeePerGas && maxPriorityFeePerGas) {
+        purchaseForOptions.maxFeePerGas = maxFeePerGas
+        purchaseForOptions.maxPriorityFeePerGas = maxPriorityFeePerGas
+      } else {
+        purchaseForOptions.gasPrice = gasPrice
+      }
+
+      const gasLimit = await lockContract.estimateGas.extend(
+        actualAmount,
+        tokenId,
+        referrer,
+        data,
+        purchaseForOptions
+      )
+      // Remove the gas prices settings for the actual transaction (the wallet will set them)
+      delete purchaseForOptions.maxFeePerGas
+      delete purchaseForOptions.maxPriorityFeePerGas
+      delete purchaseForOptions.gasPrice
+      purchaseForOptions.gasLimit = gasLimit.mul(13).div(10).toNumber()
+    } catch (error) {
+      console.error(
+        'We could not estimate gas ourselves. Let wallet do it.',
+        error
+      )
+      delete purchaseForOptions.maxFeePerGas
+      delete purchaseForOptions.maxPriorityFeePerGas
+      delete purchaseForOptions.gasPrice
     }
-
-    const gasLimit = await lockContract.estimateGas.extend(
-      actualAmount,
-      tokenId,
-      referrer,
-      data,
-      purchaseForOptions
-    )
-    // Remove the gas prices settings for the actual transaction (the wallet will set them)
-    delete purchaseForOptions.maxFeePerGas
-    delete purchaseForOptions.maxPriorityFeePerGas
-    delete purchaseForOptions.gasPrice
-    purchaseForOptions.gasLimit = gasLimit.mul(13).div(10).toNumber()
   }
 
   const transactionPromise = lockContract.extend(

--- a/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
@@ -16,7 +16,7 @@ export default async function (
   },
   callback
 ) {
-  return purchaseKeys.bind(this)(
+  const keys = await purchaseKeys.bind(this)(
     {
       owners: [owner],
       keyManagers: [keyManager],
@@ -29,4 +29,5 @@ export default async function (
     },
     callback
   )
+  return keys[0] // Only a single key!
 }

--- a/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
@@ -1,17 +1,7 @@
-import { ZERO } from '../../constants'
-import { approveTransfer, getAllowance } from '../../erc20'
-import formatKeyPrice from '../utils/formatKeyPrice'
+import purchaseKeys from './purchaseKeys'
+
 /**
- * Purchase key function. This implementation requires the following
- * @param {object} params:
- * - {PropTypes.address} lockAddress
- * - {PropTypes.address} owner
- * - {string} keyPrice
- * - {PropTypes.address} erc20Address
- * - {number} decimals
- * - {PropTypes.address} referrer (address which will receive UDT - if applicable)
- * - {PropTypes.array[bytes]} data (array of bytes, not used in transaction but can be used by hooks)
- * @param {function} callback invoked with the transaction hash
+ * Purchase key function. calls the purchaseKeys function with the vlalue in array
  */
 export default async function (
   {
@@ -26,128 +16,17 @@ export default async function (
   },
   callback
 ) {
-  const lockContract = await this.getLockContract(lockAddress)
-
-  if (!owner) {
-    owner = await this.signer.getAddress()
-  }
-
-  if (!referrer) {
-    referrer = ZERO
-  }
-
-  if (!keyManager) {
-    keyManager = ZERO
-  }
-
-  if (!data) {
-    data = []
-  }
-
-  // If erc20Address was not provided, get it
-  if (!erc20Address) {
-    erc20Address = await lockContract.tokenAddress()
-  }
-  let actualAmount
-  if (!keyPrice) {
-    // We might not have the keyPrice, in which case, we need to retrieve from the the lock!
-    actualAmount = await lockContract.keyPrice()
-  } else {
-    actualAmount = await formatKeyPrice(
-      keyPrice,
+  return purchaseKeys(
+    {
+      owners: [owner],
+      keyManagers: [keyManager],
+      keyPrices: [keyPrice],
+      referrers: [referrer],
+      data: [data],
+      lockAddress,
       erc20Address,
       decimals,
-      this.provider
-    )
-  }
-
-  const purchaseForOptions = {}
-  if (erc20Address && erc20Address !== ZERO) {
-    const approvedAmount = await getAllowance(
-      erc20Address,
-      lockAddress,
-      this.provider,
-      this.signer
-    )
-    if (!approvedAmount || approvedAmount.lt(actualAmount)) {
-      await approveTransfer(
-        erc20Address,
-        lockAddress,
-        actualAmount,
-        this.provider,
-        this.signer
-      )
-      // Since we sent the approval transaction, we cannot rely on Ethers to do an estimate, because the computation would fail (since the approval might not have been mined yet)
-      purchaseForOptions.gasLimit = 400000
-    }
-  } else {
-    purchaseForOptions.value = actualAmount
-  }
-
-  // Estimate gas. Bump by 30% because estimates are wrong!
-  if (!purchaseForOptions.gasLimit) {
-    // To get good estimates we need the gas price, because it matters in the actual execution (UDT calculation takes it into account)
-    // TODO remove once we move to use block.baseFee in UDT calculation
-    const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } =
-      await this.provider.getFeeData()
-
-    if (maxFeePerGas && maxPriorityFeePerGas) {
-      purchaseForOptions.maxFeePerGas = maxFeePerGas
-      purchaseForOptions.maxPriorityFeePerGas = maxPriorityFeePerGas
-    } else {
-      purchaseForOptions.gasPrice = gasPrice
-    }
-
-    const gasLimit = await lockContract.estimateGas.purchase(
-      [actualAmount],
-      [owner],
-      [referrer],
-      [keyManager],
-      [data],
-      purchaseForOptions
-    )
-    // Remove the gas prices settings for the actual transaction (the wallet will set them)
-    delete purchaseForOptions.maxFeePerGas
-    delete purchaseForOptions.maxPriorityFeePerGas
-    delete purchaseForOptions.gasPrice
-    purchaseForOptions.gasLimit = gasLimit.mul(13).div(10).toNumber()
-  }
-
-  const transactionPromise = lockContract.purchase(
-    [actualAmount],
-    [owner],
-    [referrer],
-    [keyManager],
-    [data],
-    purchaseForOptions
+    },
+    callback
   )
-
-  const hash = await this._handleMethodCall(transactionPromise)
-
-  if (callback) {
-    callback(null, hash, await transactionPromise)
-  }
-
-  // Let's now wait for the transaction to go thru to return the token id
-  const receipt = await this.provider.waitForTransaction(hash)
-
-  if (receipt.status === 0) {
-    throw new Error('Transaction failed')
-  }
-
-  const parser = lockContract.interface
-  const transferEvent = receipt.logs
-    .map((log) => {
-      if (log.address !== lockAddress) return // Some events are triggered by the ERC20 contract
-      return parser.parseLog(log)
-    })
-    .filter((event) => {
-      return event && event.name === 'Transfer'
-    })[0]
-
-  if (transferEvent) {
-    return transferEvent.args.tokenId.toString()
-  }
-  // There was no Transfer log (transaction failed?)
-  return null
 }

--- a/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
@@ -18,11 +18,11 @@ export default async function (
 ) {
   const keys = await purchaseKeys.bind(this)(
     {
-      owners: [owner],
-      keyManagers: [keyManager],
-      keyPrices: [keyPrice],
-      referrers: [referrer],
-      data: [data],
+      owners: owner ? [owner] : null,
+      keyManagers: keyManager ? [keyManager] : null,
+      keyPrices: keyPrice ? [keyPrice] : null,
+      referrers: referrer ? [referrer] : null,
+      data: data ? [data] : null,
       lockAddress,
       erc20Address,
       decimals,

--- a/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
@@ -16,7 +16,7 @@ export default async function (
   },
   callback
 ) {
-  return purchaseKeys(
+  return purchaseKeys.bind(this)(
     {
       owners: [owner],
       keyManagers: [keyManager],

--- a/packages/unlock-js/src/PublicLock/v10/purchaseKeys.js
+++ b/packages/unlock-js/src/PublicLock/v10/purchaseKeys.js
@@ -43,12 +43,13 @@ export default async function (
   const defaultArray = Array(owners.length).fill(null)
 
   const keyPrices = await Promise.all(
-    (_keyPrices || defaultArray).map(async (kp) =>
-      kp
-        ? // We might not have the keyPrice, in which case, we need to retrieve from the the lock!
-          lockContract.keyPrice()
-        : formatKeyPrice(kp, erc20Address, decimals, this.provider)
-    )
+    (_keyPrices || defaultArray).map(async (kp) => {
+      if (!kp) {
+        // We might not have the keyPrice, in which case, we need to retrieve from the the lock!
+        return await lockContract.keyPrice()
+      }
+      return formatKeyPrice(kp, erc20Address, decimals, this.provider)
+    })
   )
   const keyManagers = (_keyManagers || defaultArray).map((km) => km || ZERO)
   const referrers = (_referrers || defaultArray).map((km) => km || ZERO)

--- a/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
@@ -78,30 +78,40 @@ export default async function (
 
   // Estimate gas. Bump by 30% because estimates are wrong!
   if (!purchaseForOptions.gasLimit) {
-    // To get good estimates we need the gas price, because it matters in the actual execution (UDT calculation takes it into account)
-    // TODO remove once we move to use block.baseFee in UDT calculation
-    const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } =
-      await this.provider.getFeeData()
+    try {
+      // To get good estimates we need the gas price, because it matters in the actual execution (UDT calculation takes it into account)
+      // TODO remove once we move to use block.baseFee in UDT calculation
+      const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } =
+        await this.provider.getFeeData()
 
-    if (maxFeePerGas && maxPriorityFeePerGas) {
-      purchaseForOptions.maxFeePerGas = maxFeePerGas
-      purchaseForOptions.maxPriorityFeePerGas = maxPriorityFeePerGas
-    } else {
-      purchaseForOptions.gasPrice = gasPrice
+      if (maxFeePerGas && maxPriorityFeePerGas) {
+        purchaseForOptions.maxFeePerGas = maxFeePerGas
+        purchaseForOptions.maxPriorityFeePerGas = maxPriorityFeePerGas
+      } else {
+        purchaseForOptions.gasPrice = gasPrice
+      }
+
+      const gasLimit = await lockContract.estimateGas.purchase(
+        actualAmount,
+        owner,
+        referrer,
+        data,
+        purchaseForOptions
+      )
+      // Remove the gas prices settings for the actual transaction (the wallet will set them)
+      delete purchaseForOptions.maxFeePerGas
+      delete purchaseForOptions.maxPriorityFeePerGas
+      delete purchaseForOptions.gasPrice
+      purchaseForOptions.gasLimit = gasLimit.mul(13).div(10).toNumber()
+    } catch (error) {
+      console.error(
+        'We could not estimate gas ourselves. Let wallet do it.',
+        error
+      )
+      delete purchaseForOptions.maxFeePerGas
+      delete purchaseForOptions.maxPriorityFeePerGas
+      delete purchaseForOptions.gasPrice
     }
-
-    const gasLimit = await lockContract.estimateGas.purchase(
-      actualAmount,
-      owner,
-      referrer,
-      data,
-      purchaseForOptions
-    )
-    // Remove the gas prices settings for the actual transaction (the wallet will set them)
-    delete purchaseForOptions.maxFeePerGas
-    delete purchaseForOptions.maxPriorityFeePerGas
-    delete purchaseForOptions.gasPrice
-    purchaseForOptions.gasLimit = gasLimit.mul(13).div(10).toNumber()
   }
 
   const transactionPromise = lockContract.purchase(

--- a/packages/unlock-js/src/PublicLock/v9/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v9/purchaseKey.js
@@ -86,30 +86,40 @@ export default async function (
 
   // Estimate gas. Bump by 30% because estimates are wrong!
   if (!purchaseForOptions.gasLimit) {
-    // To get good estimates we need the gas price, because it matters in the actual execution (UDT calculation takes it into account)
-    // TODO remove once we move to use block.baseFee in UDT calculation
-    const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } =
-      await this.provider.getFeeData()
+    try {
+      // To get good estimates we need the gas price, because it matters in the actual execution (UDT calculation takes it into account)
+      // TODO remove once we move to use block.baseFee in UDT calculation
+      const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } =
+        await this.provider.getFeeData()
 
-    if (maxFeePerGas && maxPriorityFeePerGas) {
-      purchaseForOptions.maxFeePerGas = maxFeePerGas
-      purchaseForOptions.maxPriorityFeePerGas = maxPriorityFeePerGas
-    } else {
-      purchaseForOptions.gasPrice = gasPrice
+      if (maxFeePerGas && maxPriorityFeePerGas) {
+        purchaseForOptions.maxFeePerGas = maxFeePerGas
+        purchaseForOptions.maxPriorityFeePerGas = maxPriorityFeePerGas
+      } else {
+        purchaseForOptions.gasPrice = gasPrice
+      }
+      const gasLimit = await lockContract.estimateGas.purchase(
+        actualAmount,
+        owner,
+        referrer,
+        keyManager,
+        data,
+        purchaseForOptions
+      )
+      // Remove the gas prices settings for the actual transaction (the wallet will set them)
+      delete purchaseForOptions.maxFeePerGas
+      delete purchaseForOptions.maxPriorityFeePerGas
+      delete purchaseForOptions.gasPrice
+      purchaseForOptions.gasLimit = gasLimit.mul(13).div(10).toNumber()
+    } catch (error) {
+      console.error(
+        'We could not estimate gas ourselves. Let wallet do it.',
+        error
+      )
+      delete purchaseForOptions.maxFeePerGas
+      delete purchaseForOptions.maxPriorityFeePerGas
+      delete purchaseForOptions.gasPrice
     }
-    const gasLimit = await lockContract.estimateGas.purchase(
-      actualAmount,
-      owner,
-      referrer,
-      keyManager,
-      data,
-      purchaseForOptions
-    )
-    // Remove the gas prices settings for the actual transaction (the wallet will set them)
-    delete purchaseForOptions.maxFeePerGas
-    delete purchaseForOptions.maxPriorityFeePerGas
-    delete purchaseForOptions.gasPrice
-    purchaseForOptions.gasLimit = gasLimit.mul(13).div(10).toNumber()
   }
 
   const transactionPromise = lockContract.purchase(


### PR DESCRIPTION
# Description

Our purchase function runs explicit gas calculation to make sure the limit is "bumped" based on the normal scenario. This is because the smart contract code takes different routes based on the gas price and the token price.

However, in some cases, we might be unable to run the estimate ourselves. In these cases, rather than fail the estimate we will let the wallet handle the estimate (and show an error if needed), rather than try to handle it ourselves.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

