### PR TITLE
fix(unlock-js): Add a range for peer dependency

### DIFF
--- a/packages/unlock-js/package.json
+++ b/packages/unlock-js/package.json
@@ -23,7 +23,7 @@
   "author": "Unlock Inc",
   "license": "MIT",
   "peerDependencies": {
-    "ethers": "5.5.4"
+    "ethers": "^5.0.0"
   },
   "lint-staged": {
     "*.{js,ts}": [


### PR DESCRIPTION
This allows any 5.x.x version of ether.js as a peer to work with unlock.js. 

Currently, the peer dependency is fixed version. A user has to force resolve with npm through the `--force` flag if they are using a newer or older version than the declared version. This is not ideal.

<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

