### PR TITLE
feat(unlock-app) - remove "add account address" and autofill the recipient address

### DIFF
--- a/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
+++ b/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import styled from 'styled-components'
 import { IoIosCloseCircle as CloseIcon } from 'react-icons/io'
@@ -45,6 +45,11 @@ export const MultipleRecipient: React.FC<MultipleRecipientProps> = ({
     setNewRecipient(true)
     setRecipient(account)
   }
+
+  useEffect(() => {
+    autofillAccountAddress()
+  }, [])
+
   const onAddRecipient = async () => {
     const formValid = await trigger()
     if (formValid) {
@@ -137,16 +142,6 @@ export const MultipleRecipient: React.FC<MultipleRecipientProps> = ({
         <fieldset className="pt-3" disabled={loading}>
           <span className="text-xs font-normal uppercase flex justify-between items-center mb-2">
             <span>Recipient</span>
-            {recipients?.length === 0 && (
-              <ActionButton
-                type="button"
-                className="bg-gray-100"
-                onClick={autofillAccountAddress}
-                disabled={recipient?.length > 0}
-              >
-                add account address
-              </ActionButton>
-            )}
           </span>
           <CustomRecipient
             onChange={(e) => setRecipient(e.target.value)}

--- a/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
+++ b/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
@@ -236,14 +236,3 @@ const ItemRows = styled.div`
   display: flex;
   flex-direction: column;
 `
-
-const ActionButton = styled.button`
-  font-size: 12px;
-  padding: 5px 10px;
-  background: var(--lightgrey);
-  border-radius: 4px;
-
-  &:disabled {
-    opacity: 0.4;
-  }
-`


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This PR removes the button `add account address` that is visibile when we add the first recipient. The recipient by default is autofilled with the account address 
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

