### PR TITLE
feat(unlock-app) - skip metadata endpoint call if not needed

### DIFF
--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -83,6 +83,8 @@ export const MetadataForm = ({
     }
   }
 
+  const withMetadata = fields?.length > 0
+
   if (showMultipleRecipient) {
     return (
       <MultipleRecipient
@@ -93,6 +95,7 @@ export const MetadataForm = ({
         fields={fields}
         submitBulkRecipients={submitBulkRecipients}
         removeRecipient={removeRecipient}
+        withMetadata={withMetadata}
         onContinue={() => {
           onSubmit(true as any)
         }}

--- a/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
+++ b/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
@@ -19,6 +19,7 @@ export interface MultipleRecipientProps {
   submitBulkRecipients: () => Promise<boolean>
   onContinue: () => void
   removeRecipient: (address: string) => void
+  withMetadata: boolean
 }
 export const MultipleRecipient: React.FC<MultipleRecipientProps> = ({
   recipients,
@@ -29,6 +30,7 @@ export const MultipleRecipient: React.FC<MultipleRecipientProps> = ({
   submitBulkRecipients,
   onContinue,
   removeRecipient,
+  withMetadata,
 }) => {
   const { account } = useContext(AuthenticationContext)
   const [addNewRecipient, setNewRecipient] = useState(false)
@@ -71,10 +73,15 @@ export const MultipleRecipient: React.FC<MultipleRecipientProps> = ({
   const onSubmit = async () => {
     setIsLoading(true)
     setConfirmCount(confirmCount + 1)
-    const valid = await submitBulkRecipients()
-    if (valid) {
+    if (withMetadata) {
+      const valid = await submitBulkRecipients()
+      if (valid) {
+        onContinue()
+      }
+    } else {
       onContinue()
     }
+
     setIsLoading(false)
   }
 

--- a/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
+++ b/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
@@ -73,6 +73,7 @@ export const MultipleRecipient: React.FC<MultipleRecipientProps> = ({
   const onSubmit = async () => {
     setIsLoading(true)
     setConfirmCount(confirmCount + 1)
+    // send metadata only if forms contains some metadata
     if (withMetadata) {
       const valid = await submitBulkRecipients()
       if (valid) {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
With multiple recipients on checkout flow, we always call endpoints for metadata also when is not needed. This PR fix this issue
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

