### PR TITLE
feat(unlock-app & locksmith): Add validation to user metadata endpoints and fix the metadata schema on submission on unlock app

### DIFF
--- a/locksmith/__tests__/controllers/v2/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/v2/metadataController.test.ts
@@ -25,6 +25,24 @@ describe('Metadata v2 endpoints for locksmith', () => {
     expect(userMetadataResponse.status).toBe(201)
     expect(userMetadataResponse.body).toStrictEqual(metadata)
   })
+
+  it('Add invalid user metadata', async () => {
+    expect.assertions(2)
+    const lockAddress = await ethers.Wallet.createRandom().getAddress()
+    const walletAddress = await ethers.Wallet.createRandom().getAddress()
+
+    const metadata = {
+      badMetadataForm: {},
+    }
+
+    const userMetadataResponse = await request(app)
+      .post(`/v2/api/metadata/100/locks/${lockAddress}/users/${walletAddress}`)
+      .send({ metadata })
+
+    expect(userMetadataResponse.status).toBe(400)
+    expect(userMetadataResponse.body.error).not.toBe(undefined)
+  })
+
   it('Add metadata to users in bulk', async () => {
     expect.assertions(2)
     const users = await Promise.all(
@@ -61,6 +79,41 @@ describe('Metadata v2 endpoints for locksmith', () => {
     const expectedUsersMetadata = users.map((user) => user.metadata)
     expect(userMetadataResponse.status).toBe(201)
     expect(usersMetadata).toStrictEqual(expectedUsersMetadata)
+  })
+
+  it('Add bulk broken user metadata', async () => {
+    expect.assertions(2)
+
+    const users = await Promise.all(
+      Array(3)
+        .fill(0)
+        .map(async (_, index) => {
+          const lockAddress = await ethers.Wallet.createRandom().getAddress()
+          const userAddress = await ethers.Wallet.createRandom().getAddress()
+          const metadata = {
+            public: {
+              username: userAddress.slice(5),
+            },
+            blah: {
+              private: true,
+            },
+          }
+          const keyId = String(index + 1)
+          return {
+            userAddress,
+            keyId,
+            lockAddress,
+            metadata,
+          }
+        })
+    )
+
+    const userMetadataResponse = await request(app)
+      .post('/v2/api/metadata/100/users')
+      .send({ users })
+
+    expect(userMetadataResponse.status).toBe(400)
+    expect(userMetadataResponse.body.error).not.toBe(undefined)
   })
 
   it('Get key metadata', async () => {

--- a/locksmith/__tests__/controllers/v2/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/v2/metadataController.test.ts
@@ -23,7 +23,9 @@ describe('Metadata v2 endpoints for locksmith', () => {
       .send({ metadata })
 
     expect(userMetadataResponse.status).toBe(201)
-    expect(userMetadataResponse.body).toStrictEqual(metadata)
+    expect(userMetadataResponse.body).toStrictEqual({
+      userMetadata: metadata,
+    })
   })
 
   it('Add invalid user metadata', async () => {
@@ -76,7 +78,9 @@ describe('Metadata v2 endpoints for locksmith', () => {
     const usersMetadata = userMetadataResponse.body.result.map(
       (user: any) => user.data
     )
-    const expectedUsersMetadata = users.map((user) => user.metadata)
+    const expectedUsersMetadata = users.map((user) => ({
+      userMetadata: user.metadata,
+    }))
     expect(userMetadataResponse.status).toBe(201)
     expect(usersMetadata).toStrictEqual(expectedUsersMetadata)
   })

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -132,6 +132,7 @@ export const Checkout = ({
     removeRecipient,
   } = useMultipleRecipient(
     selectedLock,
+    paywallConfig!,
     network,
     paywallConfig?.maxRecipients ?? 1
   )


### PR DESCRIPTION


<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

- Address validation added in an earlier PR seems to not accept any address. I removed the two checks which were the cause.
- Metadata sent to locksmith wasn't using the correct form in multiple recipient mode. I've fixed this.
- To make sure, non-unlock clients do not make the same mistakes - I've added stricter schema check on locksmith user metadata endpoint. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

