### PR TITLE
feat(unlock-app) - fix price of lock equal to zero

### DIFF
--- a/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from 'react'
+import React, { useContext, useState, useEffect, useRef } from 'react'
 import { ethers } from 'ethers'
 import Link from 'next/link'
 import styled from 'styled-components'
@@ -60,6 +60,7 @@ export const CardConfirmationCheckout = ({
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
   const now = new Date().getTime() / 1000
+  const numberOfRecipients = useRef(0)
   const hasValidkey =
     keyExpiration === -1 || (keyExpiration > now && keyExpiration < Infinity)
   const hasOptimisticKey = keyExpiration === Infinity
@@ -76,18 +77,23 @@ export const CardConfirmationCheckout = ({
   } = useAdvancedCheckout()
 
   useEffect(() => {
+    // todo: we get numbers of recipients on page load, and when list is cleared we still have the count
+    numberOfRecipients.current = recipients?.length || 1
+  }, [])
+
+  useEffect(() => {
     const fetchPricing = async () => {
       const price = await getFiatPricing(
         config,
         lock.address,
         network,
-        recipients.length
+        numberOfRecipients.current || 1
       )
       setPricing(price.usd)
     }
 
     fetchPricing()
-  }, [recipients.length, lock.address, config, network])
+  }, [numberOfRecipients.current, lock.address, config, network])
 
   let totalPrice: number = 0
   let fee: number = 0

--- a/unlock-app/src/components/interface/checkout/Lock.tsx
+++ b/unlock-app/src/components/interface/checkout/Lock.tsx
@@ -103,7 +103,7 @@ export const Lock = ({
       network,
       config.networks[network].baseCurrencySymbol,
       name,
-      numberOfRecipients
+      numberOfRecipients || 1
     ),
     selectable: true, // by default!
   }


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Lock show price equal to zero if recipient number is 0, this based on this calculation `numberOfRecipients x lockPrice`, to avoid this issue, the numbers of recipients will have a default of 1 if the is none recipients or list is cleared. 
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

