### PR TITLE
fix(unlock-app): using the lock's network instead of the user's network

### DIFF
--- a/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
+++ b/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
@@ -66,7 +66,8 @@ const GrantKeyForm = ({ onGranted, lock }: GrantKeyFormProps) => {
     recipients: recipientItems,
     addRecipientItem,
     clear,
-  } = useMultipleRecipient(lock, network, Infinity)
+  } = useMultipleRecipient(lock, Infinity)
+
   const disableGrantKeys = recipientItems?.length === 0 && !loading
 
   const defaultValues = {

--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -104,7 +104,7 @@ export const Checkout = ({
   web3Provider, // provider passed from the website which implements the paywall so we can support any wallet!
   defaultState,
 }: CheckoutProps) => {
-  const { account, isUnlockAccount, signMessage, network } = useContext(
+  const { account, isUnlockAccount, signMessage } = useContext(
     AuthenticationContext
   )
   const [skipPaywallIcon, setSkipPaywallIcon] = useState(false)
@@ -120,7 +120,6 @@ export const Checkout = ({
   const { getAutoLoginEmail } = useAutoLogin()
   const storedEmail = getAutoLoginEmail()
   const messageSigned = useRef(false)
-
   const {
     recipients,
     hasMultipleRecipients,
@@ -132,7 +131,6 @@ export const Checkout = ({
     removeRecipient,
   } = useMultipleRecipient(
     selectedLock,
-    network,
     paywallConfig?.maxRecipients ?? 1,
     paywallConfig?.metadataInputs
   )

--- a/unlock-app/src/hooks/useMultipleRecipient.ts
+++ b/unlock-app/src/hooks/useMultipleRecipient.ts
@@ -30,7 +30,6 @@ interface RecipientPayload {
 
 export const useMultipleRecipient = (
   lock: Lock,
-  network?: number,
   maxRecipients = 1,
   metadataInputs: PaywallConfig['metadataInputs'] = []
 ) => {
@@ -102,7 +101,7 @@ export const useMultipleRecipient = (
     const isAddressWithKey = await web3Service.getHasValidKey(
       lock.address,
       address,
-      network
+      lock.network
     )
     const addressList = recipientsList().map(
       ({ resolvedAddress }) => resolvedAddress
@@ -125,8 +124,8 @@ export const useMultipleRecipient = (
   }
 
   const submitBulkRecipients = async () => {
-    if (!network) return
-    const url = `${config.services.storage.host}/v2/api/metadata/${network}/users`
+    if (!lock) return
+    const url = `${config.services.storage.host}/v2/api/metadata/${lock.network}/users`
     const opts = {
       method: 'POST',
       body: JSON.stringify(normalizeRecipients()),

--- a/unlock-app/src/unlockTypes.ts
+++ b/unlock-app/src/unlockTypes.ts
@@ -114,6 +114,7 @@ export interface Lock {
   canGrant?: boolean
   name: string
   address: string
+  network: number
   keyPrice: string
   expirationDuration: number
   key: Key


### PR DESCRIPTION
# Description

When checking if an address has a key for a recipient, we need to use the lock's network, not the network that the user is connected to.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

