### PR TITLE
feat(unlock-js) waiting for erc20 approval to succeed before moving to gas estimate

### DIFF
--- a/packages/unlock-js/CHANGELOG.md
+++ b/packages/unlock-js/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changes
 
-# Next minor
+# 0.24.0
 
+- Removed hard coded gas limit and waits on erc20 approvals
 - Add locksmithService for interacting with locksmith servers.
 - Rescuing gas estimation errors
 - Add support for granting multiple keys

--- a/packages/unlock-js/src/PublicLock/utils/multiplePurchaseWrapper.js
+++ b/packages/unlock-js/src/PublicLock/utils/multiplePurchaseWrapper.js
@@ -61,13 +61,16 @@ export default async function (
       )
       // approve entire price
       if (!approvedAmount || approvedAmount.lt(totalPrice)) {
-        await approveTransfer(
-          erc20Address,
-          lockAddress,
-          totalPrice,
-          this.provider,
-          this.signer
-        )
+        // We must wait for the transaction to pass if we want the next one to succeed!
+        await (
+          await approveTransfer(
+            erc20Address,
+            lockAddress,
+            totalPrice,
+            this.provider,
+            this.signer
+          )
+        ).wait()
       }
     }
   }

--- a/packages/unlock-js/src/PublicLock/v10/extendKey.js
+++ b/packages/unlock-js/src/PublicLock/v10/extendKey.js
@@ -58,15 +58,16 @@ export default async function (
       this.signer
     )
     if (!approvedAmount || approvedAmount.lt(actualAmount)) {
-      await approveTransfer(
-        erc20Address,
-        lockAddress,
-        actualAmount,
-        this.provider,
-        this.signer
-      )
-      // Since we sent the approval transaction, we cannot rely on Ethers to do an estimate, because the computation would fail (since the approval might not have been mined yet)
-      purchaseForOptions.gasLimit = 400000
+      // We must wait for the transaction to pass if we want the next one to succeed!
+      await (
+        await approveTransfer(
+          erc20Address,
+          lockAddress,
+          actualAmount,
+          this.provider,
+          this.signer
+        )
+      ).wait()
     }
   } else {
     purchaseForOptions.value = actualAmount

--- a/packages/unlock-js/src/PublicLock/v10/purchaseKeys.js
+++ b/packages/unlock-js/src/PublicLock/v10/purchaseKeys.js
@@ -84,22 +84,22 @@ export default async function (
     )
 
     if (!approvedAmount || approvedAmount.lt(totalPrice)) {
-      await approveTransfer(
-        erc20Address,
-        lockAddress,
-        totalPrice,
-        this.provider,
-        this.signer
-      )
+      // We must wait for the transaction to pass if we want the next one to succeed!
+      await (
+        await approveTransfer(
+          erc20Address,
+          lockAddress,
+          totalPrice,
+          this.provider,
+          this.signer
+        )
+      ).wait()
     }
   }
 
   // tx options
   const purchaseForOptions = {}
-  if (erc20Address && erc20Address !== ZERO) {
-    // Since we sent the approval transaction, we cannot rely on Ethers to do an estimate, because the computation would fail (since the approval might not have been mined yet)
-    // purchaseForOptions.gasLimit = 400000
-  } else {
+  if (!erc20Address || erc20Address === ZERO) {
     purchaseForOptions.value = totalPrice
   }
 

--- a/packages/unlock-js/src/PublicLock/v4/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v4/purchaseKey.js
@@ -40,9 +40,7 @@ export default async function (
     actualAmount = utils.toDecimal(keyPrice, decimals)
   }
 
-  const purchaseForOptions = {
-    gasLimit: 400000,
-  }
+  const purchaseForOptions = {}
 
   if (erc20Address && erc20Address !== ZERO) {
     const approvedAmount = await getAllowance(
@@ -52,13 +50,16 @@ export default async function (
       this.signer
     )
     if (!approvedAmount || approvedAmount.lt(actualAmount)) {
-      await approveTransfer(
-        erc20Address,
-        lockAddress,
-        actualAmount,
-        this.provider,
-        this.signer
-      )
+      // We must wait for the transaction to pass if we want the next one to succeed!
+      await (
+        await approveTransfer(
+          erc20Address,
+          lockAddress,
+          actualAmount,
+          this.provider,
+          this.signer
+        )
+      ).wait()
     }
   } else {
     purchaseForOptions.value = actualAmount

--- a/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
@@ -62,15 +62,16 @@ export default async function (
       this.signer
     )
     if (!approvedAmount || approvedAmount.lt(actualAmount)) {
-      await approveTransfer(
-        erc20Address,
-        lockAddress,
-        actualAmount,
-        this.provider,
-        this.signer
-      )
-      // Since we sent the approval transaction, we cannot rely on Ethers to do an estimate, because the computation would fail (since the approval might not have been mined yet)
-      purchaseForOptions.gasLimit = 400000
+      // We must wait for the transaction to pass if we want the next one to succeed!
+      await (
+        await approveTransfer(
+          erc20Address,
+          lockAddress,
+          actualAmount,
+          this.provider,
+          this.signer
+        )
+      ).wait()
     }
   } else {
     purchaseForOptions.value = actualAmount

--- a/packages/unlock-js/src/PublicLock/v9/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v9/purchaseKey.js
@@ -70,15 +70,15 @@ export default async function (
       this.signer
     )
     if (!approvedAmount || approvedAmount.lt(actualAmount)) {
-      await approveTransfer(
-        erc20Address,
-        lockAddress,
-        actualAmount,
-        this.provider,
-        this.signer
-      )
-      // Since we sent the approval transaction, we cannot rely on Ethers to do an estimate, because the computation would fail (since the approval might not have been mined yet)
-      purchaseForOptions.gasLimit = 400000
+      await (
+        await approveTransfer(
+          erc20Address,
+          lockAddress,
+          actualAmount,
+          this.provider,
+          this.signer
+        )
+      ).wait()
     }
   } else {
     purchaseForOptions.value = actualAmount


### PR DESCRIPTION
# Description

I am changing the strategy here.
We used to not wait but hardcode a gas estimate for ERC20 key purchases. Unfortunately with multiple key purchases this does not work well anymore because the gas can vary based on the number of recipients.
So, we now ask users to wait for the ERC20 `approve` to go through before moving to the next step.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

