### PR TITLE
feat(unlock-app) - edit item on recipient list

### DIFF
--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -20,7 +20,7 @@ interface Props {
   loading: boolean
   submitBulkRecipients: () => Promise<boolean>
   clear: () => void
-  removeRecipient: (address: string) => void
+  removeRecipient: (index: number) => void
 }
 
 interface DefautltValues {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
With multiple recipients, we need to have the ability to edit a recipient from the list. This PR adds this feature

also added some improvements on UI side
- By adding or updating a recipient the list will not show, this to give space at the form  
- By adding or updating a recipient we now have the possibility to close the form and back to the list

https://user-images.githubusercontent.com/20865711/165507576-ad40f572-f1c4-4415-96dd-ba8c87529464.mov




<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

