### PR TITLE
feat(unlock-app) - remove address label for recipients list

### DIFF
--- a/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
+++ b/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
@@ -175,10 +175,7 @@ export const MultipleRecipient: React.FC<MultipleRecipientProps> = ({
                 </div>
 
                 <ItemRows>
-                  <div>
-                    <span className="text-xs font-medium">address:</span>
-                    <span className="text-xs block">{userAddress}</span>
-                  </div>
+                  <span className="text-xs block">{userAddress}</span>
                   {Object.entries(metadata ?? {}).map(([key, value]) => {
                     return (
                       <div key={key}>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This PR removes the `address` label on multiple recipients list, this will save space and make the form a little smaller, here two example of the form before and after the refactor.

### before 
<img width="400" alt="Screenshot 2022-04-27 at 16 59 30" src="https://user-images.githubusercontent.com/20865711/165552238-3525a22a-1adc-44a6-a7a5-001907fcaeaf.png">

### after 
<img width="400" alt="Screenshot 2022-04-27 at 16 59 55" src="https://user-images.githubusercontent.com/20865711/165552195-f43af6e5-3469-4510-9a98-702274422371.png">

also with metadata it make sense

<img width="400" alt="Screenshot 2022-04-27 at 17 14 15" src="https://user-images.githubusercontent.com/20865711/165552389-5780bdc3-93d4-4edb-ae5c-90742bd49622.png">



<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

