### PR TITLE
feat(unlock-app) - show price when loading is done

### DIFF
--- a/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
@@ -299,7 +299,7 @@ export const CardConfirmationCheckout = ({
         <>
           <Button disabled={payDisabled} onClick={charge}>
             {loading && <Svg.Loading title="loading" alt="loading" />}
-            Pay ${formattedPrice} with Card
+            Pay {!loading && `$${formattedPrice}`} with Card
           </Button>
           {error && <ErrorMessage>{error}</ErrorMessage>}
           {fee > 0 && (


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
The price of lock is 0 until price in get from the endpoint, during loading price will be hide.

https://user-images.githubusercontent.com/20865711/165784682-cb0f57f0-904f-4ce4-931f-c050782dba70.mov



<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

