### PR TITLE
feat(unlock-app) - fix catch prepare charge card if fails

### DIFF
--- a/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
@@ -115,23 +115,29 @@ export const CardConfirmationCheckout = ({
     }
 
     const prepareCharge = async () => {
-      const response = await prepareChargeForCard(
-        token,
-        lock.address,
-        network,
-        formattedPrice,
-        purchaseRecipients
-      )
-      if (response.error || !response.clientSecret) {
-        setError(
-          `There was an error preparing your payment: ${
-            response.error || 'please try again.'
-          }`
-        )
-      } else if (response.clientSecret) {
-        setPaymentIntent(response)
+      const paymentMessageError = (error?: string): string => {
+        return `There was an error preparing your payment: ${
+          error || 'please try again.'
+        }`
       }
-      setLoading(false)
+      try {
+        const response = await prepareChargeForCard(
+          token,
+          lock.address,
+          network,
+          formattedPrice,
+          purchaseRecipients
+        )
+        if (response?.error || !response?.clientSecret) {
+          setError(paymentMessageError(response?.error))
+        } else if (response.clientSecret) {
+          setPaymentIntent(response)
+        }
+        setLoading(false)
+      } catch (err: any) {
+        setLoading(false)
+        setError(paymentMessageError(err?.error))
+      }
     }
     if (account) {
       prepareCharge()


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Fix stuck loading state when `/prepare` endpoints returns an error 

<img width="200" alt="Screenshot 2022-04-28 at 18 51 11" src="https://user-images.githubusercontent.com/20865711/165815518-50c07d54-e7db-441a-8578-200b5f0fd777.png">


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

