### PR TITLE
feat(unlock-app) - fix show fee when loading

### DIFF
--- a/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
@@ -308,7 +308,7 @@ export const CardConfirmationCheckout = ({
             Pay {!loading && `$${formattedPrice}`} with Card
           </Button>
           {error && <ErrorMessage>{error}</ErrorMessage>}
-          {fee > 0 && (
+          {fee > 0 && !loading && (
             <FeeNotice>
               Includes ${(fee / 100).toFixed(2)} in fees{' '}
               <Link href="https://docs.unlock-protocol.com/unlock/creators/faq#what-are-the-credit-card-fees">


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
On checkout page, with CC we have 2 endpoints with 2 different load time, that's cause that wee see the fees before all the rest is loaded. this PR fix this issue
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

