### PR TITLE
feat(smart-contracts): script + task to verify TransparentUpgradeableProxy

### DIFF
--- a/smart-contracts/hardhat.config.js
+++ b/smart-contracts/hardhat.config.js
@@ -106,6 +106,7 @@ require('./tasks/release')
 require('./tasks/gov')
 require('./tasks/utils')
 require('./tasks/lock')
+require('./tasks/verify')
 
 /**
  * @type import('hardhat/config').HardhatUserConfig

--- a/smart-contracts/scripts/verify-proxy.js
+++ b/smart-contracts/scripts/verify-proxy.js
@@ -1,0 +1,91 @@
+/**
+ * Deploy and verify an empty TransparentProxy using the correct calldata
+ * so locks will appears as verified on the blockexplorer network
+ *
+ * usage: run using hardhat task
+ * ```
+ * // export block explorer key
+ * export XXX_KEY=<xxx>
+ *
+ * // launch verification process
+ * yarn hardhat verify-proxy \
+ *   --public-lock-address 0xa9584e6cbaf88c09e5ede06865211ba28febd077 \
+ *   --proxy-admin-address 0xa9584e6cbaf88c09e5ede06865211ba28febd077 \
+ *   --network optimism
+ * ```
+ *
+ * If you have already deployed a proxy using that script, you can
+ * pass `--transparent-proxy-address` to prevent proxy contract
+ * from being deployed again
+ *
+ * NB: the deployment wait for 10 confirmations so deployed bytecode
+ * can be picked up by the block explorer
+ */
+const { ethers, run } = require('hardhat')
+const createLockCalldata = require('../test/helpers/createLockCalldata')
+const Locks = require('../test/fixtures/locks')
+
+async function main({
+  publicLockAddress,
+  proxyAdminAddress,
+  transparentProxyAddress,
+}) {
+  const name = 'FIRST'
+  const args = [
+    Locks[name].expirationDuration.toFixed(),
+    ethers.constants.AddressZero,
+    Locks[name].keyPrice.toFixed(),
+    Locks[name].maxNumberOfKeys.toFixed(),
+    Locks[name].lockName,
+  ]
+
+  const calldata = await createLockCalldata({ args })
+
+  // eslint-disable-next-line no-console
+  console.log(calldata)
+
+  if (!transparentProxyAddress) {
+    const TransparentProxy = await ethers.getContractFactory(
+      '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy'
+    )
+    const transparentProxy = await TransparentProxy.deploy(
+      publicLockAddress,
+      proxyAdminAddress,
+      calldata
+    )
+    // eslint-disable-next-line no-console
+    console.log(
+      `TransparentUpgradeableProxy > deployed to : ${transparentProxy.address} (tx: ${transparentProxy.deployTransaction.hash})`,
+      '\n waiting for 10 blocks to confirm the tx...'
+    )
+
+    // wait for 10 confirmations
+    await transparentProxy.deployTransaction.wait(10)
+    transparentProxyAddress = transparentProxy.address
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(
+      `TransparentUpgradeableProxy already deployed to : ${transparentProxyAddress}`
+    )
+  }
+
+  await run('verify:verify', {
+    address: transparentProxyAddress,
+    contract:
+      '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy',
+    constructorArguments: [publicLockAddress, proxyAdminAddress, calldata],
+  })
+}
+
+// execute as standalone
+if (require.main === module) {
+  /* eslint-disable promise/prefer-await-to-then, no-console */
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+}
+
+module.exports = main

--- a/smart-contracts/tasks/verify.js
+++ b/smart-contracts/tasks/verify.js
@@ -1,0 +1,24 @@
+const { task } = require('hardhat/config')
+
+task('verify-proxy', 'Deploy and verify the TransparentProxy used by locks')
+  .addParam('publicLockAddress', 'the PublicLock template address')
+  .addParam('proxyAdminAddress', "Unlock's ProxyAdmin contract address")
+  .addOptionalParam(
+    'transparentProxyAddress',
+    'the address of TransparentProxy instance already deployed using this script'
+  )
+  .setAction(
+    async ({
+      publicLockAddress,
+      proxyAdminAddress,
+      transparentProxyAddress,
+    }) => {
+      // eslint-disable-next-line global-require
+      const verifyProxy = require('../scripts/verify-proxy')
+      await verifyProxy({
+        publicLockAddress,
+        proxyAdminAddress,
+        transparentProxyAddress,
+      })
+    }
+  )


### PR DESCRIPTION
# Description

 Deploy and verify an empty TransparentProxy using the correct calldata
 so locks will appears as verified on the blockexplorer network
  usage: run using hardhat task
 ```
 // export block explorer key
 export XXX_KEY=<xxx>
  // launch verification process
 yarn hardhat verify-proxy \
   --public-lock-address 0xa9584e6cbaf88c09e5ede06865211ba28febd077 \
   --proxy-admin-address 0xa9584e6cbaf88c09e5ede06865211ba28febd077 \
   --network optimism
 ```
  If you have already deployed a proxy using that script, you can
 pass `--transparent-proxy-address` to prevent proxy contract
 from being deployed again
  NB: the deployment wait for 10 confirmations so deployed bytecode
 can be picked up by the block explorer
 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

