### PR TITLE
fix(unlock-js): pass address to `getAllowance` instead of signer

### DIFF
--- a/packages/unlock-js/src/PublicLock/utils/multiplePurchaseWrapper.js
+++ b/packages/unlock-js/src/PublicLock/utils/multiplePurchaseWrapper.js
@@ -57,7 +57,7 @@ export default async function (
         erc20Address,
         lockAddress,
         this.provider,
-        this.signer
+        this.signer.address
       )
       // approve entire price
       if (!approvedAmount || approvedAmount.lt(totalPrice)) {

--- a/packages/unlock-js/src/PublicLock/v10/extendKey.js
+++ b/packages/unlock-js/src/PublicLock/v10/extendKey.js
@@ -55,7 +55,7 @@ export default async function (
       erc20Address,
       lockAddress,
       this.provider,
-      this.signer
+      this.signer.address
     )
     if (!approvedAmount || approvedAmount.lt(actualAmount)) {
       // We must wait for the transaction to pass if we want the next one to succeed!

--- a/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v10/purchaseKey.js
@@ -1,7 +1,7 @@
 import purchaseKeys from './purchaseKeys'
 
 /**
- * Purchase key function. calls the purchaseKeys function with the vlalue in array
+ * Purchase key function. calls the purchaseKeys function with the value in array
  */
 export default async function (
   {

--- a/packages/unlock-js/src/PublicLock/v10/purchaseKeys.js
+++ b/packages/unlock-js/src/PublicLock/v10/purchaseKeys.js
@@ -80,7 +80,7 @@ export default async function (
       erc20Address,
       lockAddress,
       this.provider,
-      this.signer
+      this.signer.address
     )
 
     if (!approvedAmount || approvedAmount.lt(totalPrice)) {

--- a/packages/unlock-js/src/PublicLock/v4/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v4/purchaseKey.js
@@ -47,7 +47,7 @@ export default async function (
       erc20Address,
       lockAddress,
       this.provider,
-      this.signer
+      this.signer.address
     )
     if (!approvedAmount || approvedAmount.lt(actualAmount)) {
       // We must wait for the transaction to pass if we want the next one to succeed!

--- a/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v6/purchaseKey.js
@@ -59,7 +59,7 @@ export default async function (
       erc20Address,
       lockAddress,
       this.provider,
-      this.signer
+      this.signer.address
     )
     if (!approvedAmount || approvedAmount.lt(actualAmount)) {
       // We must wait for the transaction to pass if we want the next one to succeed!

--- a/packages/unlock-js/src/PublicLock/v9/purchaseKey.js
+++ b/packages/unlock-js/src/PublicLock/v9/purchaseKey.js
@@ -67,7 +67,7 @@ export default async function (
       erc20Address,
       lockAddress,
       this.provider,
-      this.signer
+      this.signer.address
     )
     if (!approvedAmount || approvedAmount.lt(actualAmount)) {
       await (

--- a/packages/unlock-js/src/erc20.ts
+++ b/packages/unlock-js/src/erc20.ts
@@ -70,13 +70,12 @@ export async function getAllowance(
   erc20ContractAddress: string,
   lockContractAddress: string,
   provider: ethers.providers.Provider,
-  signer: ethers.Signer
+  spenderAddress: string
 ) {
-  const purchaser = await signer.getAddress()
   const contract = new ethers.Contract(erc20ContractAddress, erc20abi, provider)
   let amount = '0'
   try {
-    amount = await contract.allowance(purchaser, lockContractAddress)
+    amount = await contract.allowance(spenderAddress, lockContractAddress)
   } catch (e) {
     // if no amount was allowed, some provider will fail.
   }


### PR DESCRIPTION
# Description

This PR introduces a small change in `getAllowance` params: an address is passed instead of the Ethers signer object.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Relates to #8765

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

