### PR TITLE
cancelling toast messages if the promised is resolved in less than 300ms

### DIFF
--- a/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
+++ b/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useContext } from 'react'
 import { useForm } from 'react-hook-form'
-import { toast } from 'react-hot-toast'
 import { Locks, Lock } from '../../../unlockTypes'
 import Drawer from '../../interface/Drawer'
 import { WalletServiceContext } from '../../../utils/withWalletService'
@@ -17,6 +16,7 @@ import {
 import { ACCOUNT_REGEXP, MAX_UINT } from '../../../constants'
 import { getAddressForName } from '../../../hooks/useEns'
 import { useMultipleRecipient } from '../../../hooks/useMultipleRecipient'
+import { ToastHelper } from '../../helpers/toast.helper'
 
 interface GrantKeyFormProps {
   lock: Lock
@@ -108,7 +108,7 @@ const GrantKeyForm = ({ onGranted, lock }: GrantKeyFormProps) => {
       const keyManagers = recipientItems?.map(
         ({ metadata }) => metadata?.keyManager || account
       )
-      await toast.promise(
+      await ToastHelper.promise(
         walletService.grantKeys(
           {
             lockAddress: lock.address,
@@ -118,7 +118,7 @@ const GrantKeyForm = ({ onGranted, lock }: GrantKeyFormProps) => {
           },
           (error: any, hash: string) => {
             if (error) {
-              toast.error(
+              ToastHelper.error(
                 'There was an error and the keys could not be granted. Please refresh the page and try again.'
               )
             }

--- a/unlock-app/src/components/helpers/toast.helper.ts
+++ b/unlock-app/src/components/helpers/toast.helper.ts
@@ -38,7 +38,11 @@ export const ToastHelper: ToastHelperProps = {
   success: (message) => toast.success(message),
   error: (message) => toast.error(message),
   promise: async (promise, msgs, opts = {}) => {
+    const start = new Date().getTime()
     await toast.promise(promise, msgs, opts)
+    if (new Date().getTime() - start < 300) {
+      toast.remove() // This cancels the toast immediately
+    }
   },
   // TODO: we need to provide an errors pages 404/500
   redirectErrorPage: (page) => {

--- a/unlock-app/src/components/interface/ExpireAndRefundModal.tsx
+++ b/unlock-app/src/components/interface/ExpireAndRefundModal.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useContext } from 'react'
-import toast from 'react-hot-toast'
 import { WalletServiceContext } from '../../utils/withWalletService'
 import Loading from './Loading'
 import InlineModal from './InlineModal'
+import { ToastHelper } from '../helpers/toast.helper'
 
 interface ExpireAndRefundProps {
   active: boolean
@@ -48,14 +48,14 @@ export const ExpireAndRefundModal: React.FC<ExpireAndRefundProps> = ({
     try {
       await walletService.expireAndRefundFor(params)
       onCloseCallback()
-      toast.success('Key successfully refunded.')
+      ToastHelper.success('Key successfully refunded.')
       // reload page to show updated list of keys
       setTimeout(() => {
         window.location.reload()
       }, 2000)
     } catch (err: any) {
       onCloseCallback()
-      toast.error(
+      ToastHelper.error(
         err?.error?.message ??
           err?.message ??
           'There was an error in refund process. Please try again.'

--- a/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CardConfirmationCheckout.tsx
@@ -3,7 +3,6 @@ import { ethers } from 'ethers'
 import Link from 'next/link'
 import styled from 'styled-components'
 import { loadStripe } from '@stripe/stripe-js'
-import { toast } from 'react-hot-toast'
 import { Lock } from './Lock'
 import { CheckoutCustomRecipient } from './CheckoutCustomRecipient'
 
@@ -17,6 +16,7 @@ import { PaywallConfig } from '../../../unlockTypes'
 import { ConfigContext } from '../../../utils/withConfig'
 import { useAdvancedCheckout } from '../../../hooks/useAdvancedCheckout'
 import { getFiatPricing } from '../../../hooks/useCards'
+import { ToastHelper } from '../../helpers/toast.helper'
 
 interface CardConfirmationCheckoutProps {
   emitTransactionInfo: (info: TransactionInfo) => void
@@ -169,7 +169,7 @@ export const CardConfirmationCheckout = ({
 
   const charge = async () => {
     if (!intent) {
-      return toast.error('Purchase not ready.')
+      return ToastHelper.error('Purchase not ready.')
     }
     setError('')
     setPurchasePending(true)

--- a/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
@@ -1,4 +1,3 @@
-import toast from 'react-hot-toast'
 import React, { useContext, useState, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import ReCAPTCHA from 'react-google-recaptcha'
@@ -153,7 +152,7 @@ export const CryptoCheckout = ({
         if (response.error || !response.signatures) {
           setPurchasePending(false)
           setRecaptchaValue('')
-          toast.error(
+          ToastHelper.error(
             'The Captcha value could not ve verified. Please try again.'
           )
           return false
@@ -226,7 +225,7 @@ export const CryptoCheckout = ({
           if (response.error) {
             setPurchasePending(false)
             setRecaptchaValue('')
-            return toast.error(
+            return ToastHelper.error(
               'The Captcha value could not ve verified. Please try again.'
             )
           }
@@ -251,15 +250,15 @@ export const CryptoCheckout = ({
       } catch (error: any) {
         if (error.message == 'Transaction failed') {
           // Transaction was sent but failed!
-          toast.error(
+          ToastHelper.error(
             'Your purchase transaction failed. Please check a block explorer for more details.'
           )
         } else if (error?.code === 4001) {
           // Transaction was not sent
-          toast.error('Please confirm the transaction in your wallet.')
+          ToastHelper.error('Please confirm the transaction in your wallet.')
         } else {
           // Other reason...
-          toast.error(
+          ToastHelper.error(
             `This transaction could not be sent as it appears to fail. ${
               error?.error?.message || ''
             }`

--- a/unlock-app/src/components/interface/keychain/CancelAndRefundModal.tsx
+++ b/unlock-app/src/components/interface/keychain/CancelAndRefundModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useEffect } from 'react'
-import toast from 'react-hot-toast'
 import { WalletServiceContext } from '../../../utils/withWalletService'
+import { ToastHelper } from '../../helpers/toast.helper'
 import InlineModal from '../InlineModal'
 import Loading from '../Loading'
 
@@ -61,14 +61,14 @@ export const CancelAndRefundModal: React.FC<ICancelAndRefundProps> = ({
     try {
       await walletService.cancelAndRefund(params)
       onCloseCallback()
-      toast.success('Key cancelled and successfully refunded.')
+      ToastHelper.success('Key cancelled and successfully refunded.')
       // reload page to show updated list of keys
       setTimeout(() => {
         window.location.reload()
       }, 2000)
     } catch (err: any) {
       onCloseCallback()
-      toast.error(
+      ToastHelper.error(
         err?.error?.message ??
           err?.message ??
           'There was an error in refund process. Please try again.'

--- a/unlock-app/src/hooks/useAddToNetwork.ts
+++ b/unlock-app/src/hooks/useAddToNetwork.ts
@@ -1,5 +1,5 @@
-import { toast } from 'react-hot-toast'
 import { useContext, useEffect, useState } from 'react'
+import { ToastHelper } from '../components/helpers/toast.helper'
 import { ProviderContext } from '../contexts/ProviderContext'
 import { ConfigContext } from '../utils/withConfig'
 
@@ -36,7 +36,7 @@ export const useAddToNetwork = (account?: string) => {
     }
 
     const promise = provider.send('wallet_addEthereumChain', [params], account)
-    await toast.promise(promise, {
+    await ToastHelper.promise(promise, {
       loading: `Changing network to ${chainName}. Please Approve on your wallet.`,
       error: `Error in changing network to ${chainName}`,
       success: `Successfully changed network to ${chainName}`,

--- a/unlock-app/src/hooks/useAuthenticateHandler.ts
+++ b/unlock-app/src/hooks/useAuthenticateHandler.ts
@@ -1,6 +1,6 @@
-import toast from 'react-hot-toast'
 import { useAuthenticate } from './useAuthenticate'
 import { useAppStorage } from './useAppStorage'
+import { ToastHelper } from '../components/helpers/toast.helper'
 
 enum WALLET_PROVIDER {
   METAMASK,
@@ -42,7 +42,7 @@ export function useAuthenticateHandler({
       removeKey('provider')
     }
     const connectedProvider = walletHandlers[providerType](provider)
-    await toast.promise(
+    await ToastHelper.promise(
       connectedProvider.then((p) => {
         if (!p?.account) {
           return Promise.reject('Unable to get provider')

--- a/unlock-app/src/hooks/useMembers.js
+++ b/unlock-app/src/hooks/useMembers.js
@@ -1,5 +1,4 @@
 import { useEffect, useState, useContext } from 'react'
-import toast from 'react-hot-toast'
 import { expirationAsDate } from '../utils/durations'
 import generateKeyTypedData from '../structured_data/keyMetadataTypedData'
 import { WalletServiceContext } from '../utils/withWalletService'
@@ -39,7 +38,7 @@ export const getAllKeysMetadataForLock = async (
   // TODO prevent replays by adding timestamp?
   const message = `I want to access member data for ${lock.address}`
   const signaturePromise = walletService.signMessage(message, 'personal_sign')
-  toast.promise(signaturePromise, {
+  ToastHelper.promise(signaturePromise, {
     error: 'There was an error in getting signature. Please try again.',
     loading: 'Please sign request to get members.',
     success: 'Successfully signed request to get members.',

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -1,7 +1,6 @@
 import { ethers } from 'ethers'
 import { useState, useContext, useEffect } from 'react'
 import { WalletService } from '@unlock-protocol/unlock-js'
-import { toast } from 'react-hot-toast'
 import { useAddToNetwork } from './useAddToNetwork'
 import ProviderContext from '../contexts/ProviderContext'
 import UnlockProvider from '../services/unlockProvider'
@@ -164,7 +163,7 @@ export const useProvider = (config: any) => {
       resetProvider(newProvider)
     } else {
       try {
-        await toast.promise(
+        await ToastHelper.promise(
           provider.send(
             'wallet_switchEthereumChain',
             [
@@ -186,7 +185,7 @@ export const useProvider = (config: any) => {
           try {
             await addNetworkToWallet(network.id)
           } catch (addError) {
-            toast.error(
+            ToastHelper.error(
               'Network could not be added. Please try manually adding it to your wallet'
             )
           }
@@ -212,7 +211,7 @@ export const useProvider = (config: any) => {
   }
 
   const signMessage = async (messageToSign: string) => {
-    return toast.promise(
+    return ToastHelper.promise(
       walletService.signMessage(messageToSign, 'personal_sign'),
       {
         loading: 'Please sign the message from your wallet',

--- a/unlock-app/src/services/graphService.ts
+++ b/unlock-app/src/services/graphService.ts
@@ -1,8 +1,8 @@
 import ApolloClient from 'apollo-boost'
 import { utils } from 'ethers'
-import toast from 'react-hot-toast'
 import locksByManager from '../queries/locksByManager'
 import keyHoldersByLocks from '../queries/keyholdersByLock'
+import { ToastHelper } from '../components/helpers/toast.helper'
 
 export class GraphService {
   public client: any
@@ -36,7 +36,7 @@ export class GraphService {
       })
     } catch (error) {
       console.error(error)
-      toast.error(
+      ToastHelper.error(
         'We could not load your locks. Please retry and let us know if that keeps failing'
       )
       return []


### PR DESCRIPTION
# Description

In looking at #8783 I found that we probably show too many messages in general (not just for that use case). I decided to debounce all toast messages if they have been "triggered" in less than 300ms. My heuristic is that in that scenario it's probably not worth showing a message to the user.

For this I moved to using the Helper rather than the library directly. This also provides better isolation... should we want to replace that dependency one day!

Fixes #8783

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


