### PR TITLE
fix(unlock-app): remove total duration in recurring checkout message

### DIFF
--- a/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
@@ -478,8 +478,8 @@ export const CryptoCheckout = ({
         <Message>
           The total amount of {lock.currencySymbol} to approve includes{' '}
           {nbPayments} renewals of your{' '}
-          <Duration seconds={lock.expirationDuration} /> key during the next 1
-          year.
+          <Duration seconds={lock.expirationDuration} /> key during the next{' '}
+          <Duration seconds={lock.expirationDuration * nbPayments} />.
         </Message>
       )}
     </>

--- a/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
@@ -478,8 +478,7 @@ export const CryptoCheckout = ({
         <Message>
           The total amount of {lock.currencySymbol} to approve includes{' '}
           {nbPayments} renewals of your{' '}
-          <Duration seconds={lock.expirationDuration} /> key during the next{' '}
-          <Duration seconds={lock.expirationDuration * nbPayments} />.
+          <Duration seconds={lock.expirationDuration} /> key.
         </Message>
       )}
     </>


### PR DESCRIPTION
# Description

Remove the total time of approval, as it makes the message a bit confusing

## Before (default to 1 year)

![image](https://user-images.githubusercontent.com/743246/167878344-cd38302b-1aa3-4369-8911-c2a37961ed36.png)

## After (calculated directly from the params)

<img width="463" alt="Screenshot 2022-05-11 at 17 03 48" src="https://user-images.githubusercontent.com/743246/167883015-6877950e-0778-4672-88a8-fb01fb90a8b4.png">


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

