### PR TITLE
fix(unlock-app): make sure `recurringPayments` param from checkout URL is an integer

### DIFF
--- a/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
@@ -103,7 +103,11 @@ export const CryptoCheckout = ({
   const hasRecipients = recipients?.length > 0
 
   // for recurring purchases
-  const nbPayments = paywallConfig?.locks[lock.address]?.recurringPayments
+  let nbPayments = paywallConfig?.locks[lock.address]?.recurringPayments
+  nbPayments =
+    typeof nbPayments === 'number'
+      ? Math.abs(Math.floor(nbPayments))
+      : undefined
 
   const cantBuyWithCrypto = isAdvanced
     ? !(


### PR DESCRIPTION
# Description

Prevent passing wrong/failing `recurringPayments` values in checkout URL params.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #8798
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

