### PR TITLE
fix(locksmith): `convertToUSD` should always returns a number

### DIFF
--- a/locksmith/__tests__/utils/keyPricer.test.ts
+++ b/locksmith/__tests__/utils/keyPricer.test.ts
@@ -52,7 +52,7 @@ describe('KeyPricer', () => {
 
       expect(pricing.keyPrice).toBe(1)
       expect(pricing.creditCardProcessing).toBe(31)
-      expect(pricing.unlockServiceFee).toBe(2)
+      expect(pricing.unlockServiceFee).toBe(1.04)
     })
 
     it('Generate price for multiple quantity keys', async () => {
@@ -61,7 +61,7 @@ describe('KeyPricer', () => {
       const pricing = await keyPricer.generate('0x', 100, 100)
 
       expect(pricing.keyPrice).toBe(100)
-      expect(pricing.unlockServiceFee).toBe(11)
+      expect(pricing.unlockServiceFee).toBe(10.04)
       expect(pricing.creditCardProcessing).toBe(34)
     })
   })

--- a/locksmith/__tests__/utils/keyPricer.test.ts
+++ b/locksmith/__tests__/utils/keyPricer.test.ts
@@ -14,6 +14,7 @@ const standardLock = {
   currencyContractAddress: '0x0000000000000000000000000000000000000000',
   currencySymbol: null,
 }
+
 const mockWeb3Service: { getLock: any } = {
   getLock: jest.fn(),
 }
@@ -26,9 +27,17 @@ jest.mock('@unlock-protocol/unlock-js', () => ({
   Web3Service: getMockWeb3Service,
 }))
 
-jest.mock('../../src/utils/ethPrice', () => ({
+jest.mock('../../src/utils/ethPrice', () => async () => ({
   getPrice: jest.fn(() => Promise.resolve(101.18)),
 }))
+
+jest.mock('../../src/utils/gasPrice', () => {
+  return jest.fn(() => {
+    return {
+      gasPriceUSD: () => 0.01,
+    }
+  })
+})
 
 const keyPricer = new KeyPricer()
 const spy = jest.spyOn(PriceConversion.prototype, 'convertToUSD')
@@ -52,7 +61,7 @@ describe('KeyPricer', () => {
 
       expect(pricing.keyPrice).toBe(1)
       expect(pricing.creditCardProcessing).toBe(31)
-      expect(pricing.unlockServiceFee).toBe(1.04)
+      expect(pricing.unlockServiceFee).toBe(1.01)
     })
 
     it('Generate price for multiple quantity keys', async () => {
@@ -61,7 +70,7 @@ describe('KeyPricer', () => {
       const pricing = await keyPricer.generate('0x', 100, 100)
 
       expect(pricing.keyPrice).toBe(100)
-      expect(pricing.unlockServiceFee).toBe(10.04)
+      expect(pricing.unlockServiceFee).toBe(10.01)
       expect(pricing.creditCardProcessing).toBe(34)
     })
   })

--- a/locksmith/src/utils/priceConversion.ts
+++ b/locksmith/src/utils/priceConversion.ts
@@ -10,12 +10,12 @@ export default class PriceConversion {
   client: any
 
   // Returns the price in $
-  async convertToUSD(currency: string, amount: number) {
+  async convertToUSD(currency: string, amount: number): Promise<number> {
     const cached = cache[currency]
 
     // Cache is valid for 5 minutes!
     if (cached && cached[0] > new Date().getTime() - 1000 * 60 * 5) {
-      return (cached[1] * amount * 100).toFixed(2)
+      return parseFloat((cached[1] * amount * 100).toFixed(2))
     }
 
     const response = await fetch(
@@ -27,6 +27,6 @@ export default class PriceConversion {
       return 0
     }
     cache[currency] = [new Date().getTime(), parseFloat(data.amount)]
-    return (parseFloat(data.amount) * amount * 100).toFixed(2)
+    return parseFloat((parseFloat(data.amount) * amount * 100).toFixed(2))
   }
 }


### PR DESCRIPTION
# Description

Fix ts error introduced in [e0f4e6f](https://github.com/unlock-protocol/unlock/commit/e0f4e6f403f6241ef43e48f4778f6653a70e7e15)

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

