### PR TITLE
feat(unlock-app) - emit user info with validKey

### DIFF
--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -334,6 +334,7 @@ export const Checkout = ({
           numberOfRecipients={recipients?.length}
           recipients={recipients}
           clearMultipleRecipients={clear}
+          emitUserInfo={emitUserInfo}
         />
       )
     }

--- a/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
+++ b/unlock-app/src/components/interface/checkout/CryptoCheckout.tsx
@@ -5,7 +5,10 @@ import { Lock } from './Lock'
 import { CheckoutCustomRecipient } from './CheckoutCustomRecipient'
 import { AuthenticationContext } from '../../../contexts/AuthenticationContext'
 import { useLock } from '../../../hooks/useLock'
-import { TransactionInfo } from '../../../hooks/useCheckoutCommunication'
+import {
+  TransactionInfo,
+  UserInfo,
+} from '../../../hooks/useCheckoutCommunication'
 import { PaywallConfig } from '../../../unlockTypes'
 import { EnjoyYourMembership } from './EnjoyYourMembership'
 import { useAccount } from '../../../hooks/useAccount'
@@ -35,6 +38,7 @@ interface CryptoCheckoutProps {
   numberOfRecipients?: number
   recipients?: any[]
   clearMultipleRecipients?: () => void
+  emitUserInfo: (info: UserInfo) => void
 }
 
 export const CryptoCheckout = ({
@@ -49,6 +53,7 @@ export const CryptoCheckout = ({
   numberOfRecipients = 1,
   recipients = [],
   clearMultipleRecipients,
+  emitUserInfo,
 }: CryptoCheckoutProps) => {
   const { networks, services, recaptchaKey } = useContext(ConfigContext)
   const storageService = new StorageService(services.storage.host)
@@ -83,6 +88,13 @@ export const CryptoCheckout = ({
   const now = new Date().getTime() / 1000
   const hasValidkey =
     keyExpiration === -1 || (keyExpiration > now && keyExpiration < Infinity)
+
+  useEffect(() => {
+    if (!hasValidkey) return
+    emitUserInfo({
+      address: account,
+    })
+  }, [hasValidkey])
 
   const hasOptimisticKey = keyExpiration === Infinity
   const hasValidOrPendingKey = hasValidkey || hasOptimisticKey


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
userInfo is not emitted when the user select a lock where it has a valid key, this PR fix this issue.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

