### PR TITLE
fix(locksmith): use random signer to estimate gas erc20 on refund

### DIFF
--- a/locksmith/__tests__/websub/renewKey.test.ts
+++ b/locksmith/__tests__/websub/renewKey.test.ts
@@ -23,7 +23,7 @@ const mockLock = {
   }),
 }
 
-const mockGetLockContract = jest.fn((lockAddress: string) => {
+const mockLockFunctions = jest.fn((lockAddress: string) => {
   switch (lockAddress) {
     case 'v9':
       return { ...mockLock, publicLockVersion: async () => 9 }
@@ -44,9 +44,19 @@ const mockGetLockContract = jest.fn((lockAddress: string) => {
   }
 })
 
+const mockGetLockContract = jest.fn((lockAddress: string) => ({
+  ...mockLockFunctions(lockAddress),
+  connect: jest.fn(() => mockLockFunctions(lockAddress)),
+}))
+
 const mockWeb3Service = {
   getLockContract: mockGetLockContract,
+  getLock: jest.fn(() => ({
+    currencyContractAddress: '0xtestToken',
+    currencySymbol: 'TEST',
+  })),
 }
+
 const mockWalletService = {
   connect: jest.fn(),
   getLockContract: mockGetLockContract,
@@ -61,11 +71,23 @@ jest.mock('ethers', () => {
   const original = jest.requireActual('ethers')
   return {
     ...original,
+    Wallet: {
+      createRandom: jest.fn(() => ({
+        address: '0x',
+        connect: jest.fn(),
+      })),
+    },
+    Contract: jest.fn(() => ({
+      decimals: jest.fn(),
+    })),
     ethers: {
       providers: {
         JsonRpcProvider: jest.fn(),
       },
       Wallet: jest.fn(),
+      utils: {
+        formatUnits: jest.fn(() => '0.01'),
+      },
     },
   }
 })
@@ -90,27 +112,22 @@ jest.mock('../../src/utils/keyPricer', () => {
 jest.mock('../../src/utils/gasPrice', () => {
   return jest.fn(() => {
     return {
-      gasPriceUSD: (network: number, gasCost: number) =>
-        Promise.resolve((network === 1 ? 0.13 : 0.00000001) * gasCost),
+      gasPriceUSD: (network: number) => Promise.resolve(network === 1 ? 10 : 1),
     }
   })
 })
 
+jest.mock('isomorphic-fetch', () => async () => ({
+  json: async () => ({
+    data: { base: 'USDT', currency: 'USD', amount: 1 },
+  }),
+}))
+
 describe('isWorthRenewing', () => {
-  it('should return gas refund value', async () => {
-    expect.assertions(2)
-    const { shouldRenew, gasRefund } = await isWorthRenewing(
-      network,
-      lockAddress,
-      keyId
-    )
-    expect(gasRefund).toEqual(150000)
-    expect(shouldRenew).toBeTruthy()
-  })
   it('should return true when gas refund is enough', async () => {
     expect.assertions(2)
     const { shouldRenew, gasRefund } = await isWorthRenewing(
-      1,
+      network,
       lockAddress,
       keyId
     )
@@ -124,8 +141,8 @@ describe('isWorthRenewing', () => {
       'noRefund',
       keyId
     )
-    expect(gasRefund).toEqual(0)
     expect(shouldRenew).toBeTruthy()
+    expect(gasRefund).toEqual(0)
   })
   it('should return false when both conditions arent unmet (gasrefund too low + higher than max covered)', async () => {
     expect.assertions(2)

--- a/locksmith/src/websub/helpers/renewKey.ts
+++ b/locksmith/src/websub/helpers/renewKey.ts
@@ -1,4 +1,4 @@
-import { ethers, constants } from 'ethers'
+import { ethers, Wallet, Contract, constants } from 'ethers'
 import { Web3Service } from '@unlock-protocol/unlock-js'
 import networks from '@unlock-protocol/networks'
 
@@ -67,18 +67,14 @@ export const isWorthRenewing = async (
     const { currencySymbol, currencyContractAddress } =
       await web3Service.getLock(lockAddress, network)
     const abi = ['function decimals() public view returns (uint decimals)']
-    const tokenContract = new ethers.Contract(
-      currencyContractAddress,
-      abi,
-      provider
-    )
+    const tokenContract = new Contract(currencyContractAddress, abi, provider)
     const decimals = await tokenContract.decimals()
 
     // if gas refund is set, we use a a random signer to get estimate to prevent
     // tx to reverts with msg.sender `ERC20: transfer to address zero`
     let estimateGas
     if (gasRefund.toNumber() !== 0) {
-      const randomWallet = await ethers.Wallet.createRandom().connect(provider)
+      const randomWallet = await Wallet.createRandom().connect(provider)
       estimateGas = lock.connect(randomWallet).estimateGas
     } else {
       estimateGas = lock.estimateGas

--- a/locksmith/src/websub/helpers/renewKey.ts
+++ b/locksmith/src/websub/helpers/renewKey.ts
@@ -4,13 +4,14 @@ import networks from '@unlock-protocol/networks'
 
 import { KeyRenewal } from '../../models'
 import GasPrice from '../../utils/gasPrice'
+import PriceConversion from '../../utils/priceConversion'
 import Dispatcher from '../../fulfillment/dispatcher'
 
 // multiply factor to increase precision for gas calculations
 const BASE_POINT_ACCURACY = 1000
 
-// Maximum price we're willing to pay to renew keys (1000 => 1ct)
-const MAX_RENEWAL_COST_COVERED = 1 * BASE_POINT_ACCURACY
+// Maximum price we're willing to pay to renew keys (1000 => 5ct)
+const MAX_RENEWAL_COST_COVERED = 5 * BASE_POINT_ACCURACY
 
 interface RenewKeyParams {
   keyId: number
@@ -32,11 +33,18 @@ interface ShouldRenew {
   error?: string
 }
 
-// Calculate price of gas in USD
+// Calculate price of gas in USD cents
 const getGasFee = async (network: number, gasCost: number) => {
   const gasPrice = new GasPrice()
   const gasCostUSD = await gasPrice.gasPriceUSD(network, gasCost)
   return gasCostUSD * BASE_POINT_ACCURACY
+}
+
+// calculate price of any ERC20 to USD cents
+const getERC20AmountInUSD = async (symbol: string, amount: string) => {
+  const conversion = new PriceConversion()
+  const priceUSD = await conversion.convertToUSD(symbol, parseFloat(amount))
+  return priceUSD * BASE_POINT_ACCURACY
 }
 
 export const isWorthRenewing = async (
@@ -54,7 +62,17 @@ export const isWorthRenewing = async (
 
     // get gas refund from contract
     const gasRefund = await lock.gasRefundValue()
-    const costRefunded = await getGasFee(network, gasRefund.toNumber())
+
+    // get ERC20 info
+    const { currencySymbol, currencyContractAddress } =
+      await web3Service.getLock(lockAddress, network)
+    const abi = ['function decimals() public view returns (uint decimals)']
+    const tokenContract = new ethers.Contract(
+      currencyContractAddress,
+      abi,
+      provider
+    )
+    const decimals = await tokenContract.decimals()
 
     // if gas refund is set, we use a a random signer to get estimate to prevent
     // tx to reverts with msg.sender `ERC20: transfer to address zero`
@@ -74,11 +92,15 @@ export const isWorthRenewing = async (
       .mul(10)
       .div(8)
 
-    // find cost to renew in USD cents
+    // find costs in USD cents
     const costToRenew = await getGasFee(network, gasLimit.toNumber())
+    const costRefunded = await getERC20AmountInUSD(
+      currencySymbol,
+      ethers.utils.formatUnits(gasRefund, decimals)
+    )
 
     const shouldRenew =
-      costToRenew < costRefunded || costToRenew < MAX_RENEWAL_COST_COVERED
+      costToRenew <= costRefunded || costToRenew < MAX_RENEWAL_COST_COVERED
 
     return {
       shouldRenew,


### PR DESCRIPTION
# Description

When running `gasEstimate` on Polygon tx to assess renewal when gas refund is set, the estimate will revert with `ERC20: transfer to address zero` as gasEstimate signer will set`msg.sender` to address zero and cause `_gasRefund()` to revert. We use a random signer to run the gas estimate and prevent this from happening

Also this use a proper ERC20 oracle to check pricing of the lock renewal in USD

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #8803 
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

