### PR TITLE
fix(locksmith): workaround for polygon `maxFeePerGas` setttings in ethers 5

### DIFF
--- a/locksmith/__tests__/fulfillment/dispatcher.test.ts
+++ b/locksmith/__tests__/fulfillment/dispatcher.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events'
+import { BigNumber } from 'ethers'
 import Dispatcher, { getGasSettings } from '../../src/fulfillment/dispatcher'
 
 const lockAddress = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
@@ -53,6 +54,7 @@ jest.mock('@unlock-protocol/unlock-js', () => ({
 jest.mock('ethers', () => {
   const { ethers, BigNumber } = jest.requireActual('ethers')
   return {
+    BigNumber,
     ethers: {
       ...ethers,
       providers: {
@@ -80,14 +82,14 @@ describe('Dispatcher', () => {
     it('returns correct default value', async () => {
       expect.assertions(2)
       const { maxFeePerGas, maxPriorityFeePerGas } = await getGasSettings(1)
-      expect(maxFeePerGas.toNumber()).toBe(10)
-      expect(maxPriorityFeePerGas.toNumber()).toBe(20)
+      expect(maxFeePerGas?.toNumber()).toBe(40000000000)
+      expect(maxPriorityFeePerGas?.toNumber()).toBe(40000000000)
     })
     it('returns value from gas station on Polygon mainnet', async () => {
       expect.assertions(2)
       const { maxFeePerGas, maxPriorityFeePerGas } = await getGasSettings(137)
-      expect(maxFeePerGas.toNumber()).toBe(37000000000)
-      expect(maxPriorityFeePerGas.toNumber()).toBe(37000000000)
+      expect(maxFeePerGas?.toNumber()).toBe(37000000000)
+      expect(maxPriorityFeePerGas?.toNumber()).toBe(37000000000)
     })
   })
 
@@ -106,7 +108,10 @@ describe('Dispatcher', () => {
         {
           lockAddress: '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267',
           recipients: ['0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'],
-          transactionOptions: {},
+          transactionOptions: {
+            maxFeePerGas: BigNumber.from(40000000000),
+            maxPriorityFeePerGas: BigNumber.from(40000000000),
+          },
         },
         callback
       )

--- a/locksmith/__tests__/utils/gasSettings.test.ts
+++ b/locksmith/__tests__/utils/gasSettings.test.ts
@@ -45,7 +45,7 @@ describe('getGasSettings', () => {
   it('returns value from gas station on Polygon mainnet', async () => {
     expect.assertions(2)
     const { maxFeePerGas, maxPriorityFeePerGas } = await getGasSettings(137)
-    expect(maxFeePerGas?.toNumber()).toBe(37000000000)
+    expect(maxFeePerGas?.toNumber()).toBe(74000000000)
     expect(maxPriorityFeePerGas?.toNumber()).toBe(74000000000)
   })
   it('returns default value if gasFee fails ', async () => {

--- a/locksmith/__tests__/utils/gasSettings.test.ts
+++ b/locksmith/__tests__/utils/gasSettings.test.ts
@@ -1,0 +1,57 @@
+import { getGasSettings } from '../../src/utils/gasSettings'
+
+jest.mock('@unlock-protocol/networks', () => {
+  const networks = jest.requireActual('@unlock-protocol/networks')
+  networks.networks[123] = { publicProvider: null }
+  return networks
+})
+
+jest.mock('ethers', () => {
+  const { ethers, BigNumber } = jest.requireActual('ethers')
+  return {
+    BigNumber,
+    ethers: {
+      ...ethers,
+      providers: {
+        JsonRpcProvider: jest.fn((providerUrl: string) => ({
+          // when providerUrl is undefined gasFeeData throws
+          getFeeData: providerUrl
+            ? jest.fn(async () => ({
+                maxFeePerGas: BigNumber.from(10000000000),
+                maxPriorityFeePerGas: BigNumber.from(10000000000),
+                catch: jest.fn(() => null),
+              }))
+            : jest.fn(() => Promise.reject()),
+        })),
+      },
+      Wallet: jest.fn(),
+    },
+  }
+})
+
+jest.mock('isomorphic-fetch', () => async () => ({
+  json: async () => ({
+    data: { standard: { maxPriorityFee: 36.37, maxFee: 36.37 } },
+  }),
+}))
+
+describe('getGasSettings', () => {
+  it('returns correct value from provider', async () => {
+    expect.assertions(2)
+    const { maxFeePerGas, maxPriorityFeePerGas } = await getGasSettings(1)
+    expect(maxFeePerGas?.toNumber()).toBe(10000000000)
+    expect(maxPriorityFeePerGas?.toNumber()).toBe(20000000000)
+  })
+  it('returns value from gas station on Polygon mainnet', async () => {
+    expect.assertions(2)
+    const { maxFeePerGas, maxPriorityFeePerGas } = await getGasSettings(137)
+    expect(maxFeePerGas?.toNumber()).toBe(37000000000)
+    expect(maxPriorityFeePerGas?.toNumber()).toBe(74000000000)
+  })
+  it('returns default value if gasFee fails ', async () => {
+    expect.assertions(2)
+    const { maxFeePerGas, maxPriorityFeePerGas } = await getGasSettings(123)
+    expect(maxFeePerGas?.toNumber()).toBe(40000000000)
+    expect(maxPriorityFeePerGas?.toNumber()).toBe(40000000000)
+  })
+})

--- a/locksmith/__tests__/utils/gasSettings.test.ts
+++ b/locksmith/__tests__/utils/gasSettings.test.ts
@@ -31,7 +31,7 @@ jest.mock('ethers', () => {
 
 jest.mock('isomorphic-fetch', () => async () => ({
   json: async () => ({
-    data: { standard: { maxPriorityFee: 36.37, maxFee: 36.37 } },
+    data: { fast: { maxPriorityFee: 36.37, maxFee: 36.37 } },
   }),
 }))
 

--- a/locksmith/__tests__/websub/renewKey.test.ts
+++ b/locksmith/__tests__/websub/renewKey.test.ts
@@ -62,8 +62,15 @@ jest.mock('ethers', () => {
   return {
     ...original,
     ethers: {
+      ...original.ethers,
       providers: {
-        JsonRpcProvider: jest.fn(),
+        JsonRpcProvider: jest.fn(() => ({
+          getFeeData: jest.fn(() => ({
+            maxFeePerGas: BigNumber.from(10),
+            maxPriorityFeePerGas: BigNumber.from(20),
+            catch: jest.fn(),
+          })),
+        })),
       },
       Wallet: jest.fn(),
     },

--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -1,68 +1,11 @@
 import { WalletService } from '@unlock-protocol/unlock-js'
 import networks from '@unlock-protocol/networks'
 import { ethers } from 'ethers'
-import fetch from 'isomorphic-fetch'
 import logger from '../logger'
 
 const config = require('../../config/config')
 const { GAS_COST } = require('../utils/keyPricer')
-
-interface GasSettings {
-  maxFeePerGas?: ethers.BigNumber
-  maxPriorityFeePerGas?: ethers.BigNumber
-  gasPrice?: ethers.BigNumber
-}
-
-export const getGasSettings = async (network: number): Promise<GasSettings> => {
-  // workaround for polygon: get max fees from gas station
-  // see https://github.com/ethers-io/ethers.js/issues/2828
-  if (network === 137) {
-    try {
-      const resp = await fetch('https://gasstation-mainnet.matic.network/v2')
-      const { data } = await resp.json()
-
-      const maxFeePerGas = ethers.utils
-        .parseUnits(`${Math.ceil(data.standard.maxFee)}`, 'gwei')
-        .mul(2)
-
-      const maxPriorityFeePerGas = ethers.utils
-        .parseUnits(`${Math.ceil(data.standard.maxPriorityFee)}`, 'gwei')
-        .mul(2)
-
-      return {
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-      }
-    } catch {
-      // ignore
-    }
-  }
-
-  // get fees from network provider
-  const provider = new ethers.providers.JsonRpcProvider(
-    networks[network].publicProvider
-  )
-
-  const feedata = await provider.getFeeData().catch(() => null)
-
-  if (feedata) {
-    const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = feedata
-
-    // We double to increase speed of execution
-    // We may end up paying *more* but we get mined earlier
-    return {
-      maxPriorityFeePerGas: maxFeePerGas?.mul(ethers.BigNumber.from('2')),
-      maxFeePerGas: maxPriorityFeePerGas || undefined,
-      gasPrice: gasPrice?.mul(ethers.BigNumber.from('2')),
-    }
-  }
-
-  // fallback to 40 gwei if no feeData
-  return {
-    maxFeePerGas: ethers.BigNumber.from(40000000000),
-    maxPriorityFeePerGas: ethers.BigNumber.from(40000000000),
-  }
-}
+const { getGasSettings } = require('../utils/gasSettings')
 
 export default class Dispatcher {
   async balances() {

--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -21,14 +21,13 @@ export const getGasSettings = async (network: number): Promise<GasSettings> => {
       const resp = await fetch('https://gasstation-mainnet.matic.network/v2')
       const { data } = await resp.json()
 
-      const maxFeePerGas = ethers.utils.parseUnits(
-        `${Math.ceil(data.standard.maxFee)}`,
-        'gwei'
-      )
-      const maxPriorityFeePerGas = ethers.utils.parseUnits(
-        `${Math.ceil(data.standard.maxPriorityFee)}`,
-        'gwei'
-      )
+      const maxFeePerGas = ethers.utils
+        .parseUnits(`${Math.ceil(data.standard.maxFee)}`, 'gwei')
+        .mul(2)
+
+      const maxPriorityFeePerGas = ethers.utils
+        .parseUnits(`${Math.ceil(data.standard.maxPriorityFee)}`, 'gwei')
+        .mul(2)
 
       return {
         maxFeePerGas,

--- a/locksmith/src/utils/gasSettings.ts
+++ b/locksmith/src/utils/gasSettings.ts
@@ -1,0 +1,66 @@
+import fetch from 'isomorphic-fetch'
+import { ethers } from 'ethers'
+import networks from '@unlock-protocol/networks'
+
+interface GasSettings {
+  maxFeePerGas?: ethers.BigNumber
+  maxPriorityFeePerGas?: ethers.BigNumber
+  gasPrice?: ethers.BigNumber
+}
+
+export const getGasSettings = async (network: number): Promise<GasSettings> => {
+  // workaround for polygon: get max fees from gas station
+  // see https://github.com/ethers-io/ethers.js/issues/2828
+  if (network === 137) {
+    try {
+      const resp = await fetch('https://gasstation-mainnet.matic.network/v2')
+      const { data } = await resp.json()
+
+      const maxFeePerGas = ethers.utils.parseUnits(
+        `${Math.ceil(data.standard.maxFee)}`,
+        'gwei'
+      )
+
+      const maxPriorityFeePerGas = ethers.utils
+        .parseUnits(`${Math.ceil(data.standard.maxPriorityFee)}`, 'gwei')
+        .mul(2)
+
+      return {
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  // get fees from network provider
+  const provider = new ethers.providers.JsonRpcProvider(
+    networks[network].publicProvider
+  )
+
+  let feedata
+  try {
+    feedata = await provider.getFeeData()
+  } catch (error) {
+    // do nothing
+  }
+
+  if (feedata) {
+    const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = feedata
+
+    // We double to increase speed of execution
+    // We may end up paying *more* but we get mined earlier
+    return {
+      maxPriorityFeePerGas: maxFeePerGas?.mul(2),
+      maxFeePerGas: maxPriorityFeePerGas || undefined,
+      gasPrice: gasPrice?.mul(2),
+    }
+  }
+
+  // fallback to 40 gwei if no feeData
+  return {
+    maxFeePerGas: ethers.BigNumber.from(40000000000),
+    maxPriorityFeePerGas: ethers.BigNumber.from(40000000000),
+  }
+}

--- a/locksmith/src/utils/gasSettings.ts
+++ b/locksmith/src/utils/gasSettings.ts
@@ -17,12 +17,12 @@ export const getGasSettings = async (network: number): Promise<GasSettings> => {
       const { data } = await resp.json()
 
       const maxFeePerGas = ethers.utils.parseUnits(
-        `${Math.ceil(data.standard.maxFee)}`,
+        `${Math.ceil(data.fast.maxFee)}`,
         'gwei'
       )
 
       const maxPriorityFeePerGas = ethers.utils
-        .parseUnits(`${Math.ceil(data.standard.maxPriorityFee)}`, 'gwei')
+        .parseUnits(`${Math.ceil(data.fast.maxPriorityFee)}`, 'gwei')
         .mul(2)
 
       return {

--- a/locksmith/src/utils/gasSettings.ts
+++ b/locksmith/src/utils/gasSettings.ts
@@ -16,10 +16,9 @@ export const getGasSettings = async (network: number): Promise<GasSettings> => {
       const resp = await fetch('https://gasstation-mainnet.matic.network/v2')
       const { data } = await resp.json()
 
-      const maxFeePerGas = ethers.utils.parseUnits(
-        `${Math.ceil(data.fast.maxFee)}`,
-        'gwei'
-      ).mul(2)
+      const maxFeePerGas = ethers.utils
+        .parseUnits(`${Math.ceil(data.fast.maxFee)}`, 'gwei')
+        .mul(2)
 
       const maxPriorityFeePerGas = ethers.utils
         .parseUnits(`${Math.ceil(data.fast.maxPriorityFee)}`, 'gwei')

--- a/locksmith/src/utils/gasSettings.ts
+++ b/locksmith/src/utils/gasSettings.ts
@@ -19,7 +19,7 @@ export const getGasSettings = async (network: number): Promise<GasSettings> => {
       const maxFeePerGas = ethers.utils.parseUnits(
         `${Math.ceil(data.fast.maxFee)}`,
         'gwei'
-      )
+      ).mul(2)
 
       const maxPriorityFeePerGas = ethers.utils
         .parseUnits(`${Math.ceil(data.fast.maxPriorityFee)}`, 'gwei')

--- a/locksmith/src/utils/lockMigrate.ts
+++ b/locksmith/src/utils/lockMigrate.ts
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 import { ethers, Wallet } from 'ethers'
 import * as contracts from '@unlock-protocol/contracts'
 import { networks } from '@unlock-protocol/networks'

--- a/locksmith/src/utils/lockMigrate.ts
+++ b/locksmith/src/utils/lockMigrate.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { ethers, Wallet } from 'ethers'
 import * as contracts from '@unlock-protocol/contracts'
 import { networks } from '@unlock-protocol/networks'


### PR DESCRIPTION
# Description

Because of settings introduced in Ethers 5.6.1 (described [here](https://github.com/ethers-io/ethers.js/issues/2828)), tx sent on polygon from locksmith are failing with a `tx underpriced` error. This adds a workaround where we fetch expected gas fees directly from Polygon gas station

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

