### PR TITLE
feature(unlock-app): adding metadata call to action back

### DIFF
--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -306,6 +306,7 @@ export const Checkout = ({
           network={lockProps?.network || paywallConfig?.network}
           lock={selectedLock}
           fields={paywallConfig!.metadataInputs!}
+          callToAction={paywallConfig!.callToAction?.metadata}
           onSubmit={setSavedMetadata}
           recipients={recipients}
           maxRecipients={maxRecipients}

--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -93,7 +93,7 @@ export const MetadataForm = ({
 
   if (!callToAction) {
     callToAction =
-      'The creator requires some additional information for each attendee. Please complete the form below.'
+      'The creator requires some additional information for each owner. Please complete the form below.'
   }
 
   if (showMultipleRecipient) {

--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -20,6 +20,7 @@ interface Props {
   hasMinimumRecipients: boolean
   addRecipient: any
   loading: boolean
+  callToAction: string
   submitBulkRecipients: () => Promise<boolean>
   clear: () => void
   removeRecipient: (index: number) => void
@@ -34,6 +35,7 @@ export const MetadataForm = ({
   lock,
   fields = [],
   onSubmit,
+  callToAction,
   recipients,
   maxRecipients,
   minRecipients,
@@ -89,6 +91,11 @@ export const MetadataForm = ({
 
   const withMetadata = fields?.length > 0
 
+  if (!callToAction) {
+    callToAction =
+      'The creator requires some additional information for each attendee. Please complete the form below.'
+  }
+
   if (showMultipleRecipient) {
     return (
       <MultipleRecipient
@@ -99,6 +106,7 @@ export const MetadataForm = ({
         addRecipient={addRecipient}
         loading={loading}
         fields={fields}
+        callToAction={callToAction}
         submitBulkRecipients={submitBulkRecipients}
         removeRecipient={removeRecipient}
         withMetadata={withMetadata}
@@ -110,10 +118,7 @@ export const MetadataForm = ({
   }
   return (
     <form onSubmit={handleSubmit(wrappedOnSubmit)}>
-      <Message>
-        The creator of this lock requires some additional information. Please
-        complete the form below.
-      </Message>
+      <Message>{callToAction}</Message>
       {error && <Error>{error}</Error>}
 
       {fields.map(({ name, type, required, placeholder }) => (

--- a/unlock-app/src/components/interface/checkout/MetadataForm.tsx
+++ b/unlock-app/src/components/interface/checkout/MetadataForm.tsx
@@ -20,7 +20,7 @@ interface Props {
   hasMinimumRecipients: boolean
   addRecipient: any
   loading: boolean
-  callToAction: string
+  callToAction?: string
   submitBulkRecipients: () => Promise<boolean>
   clear: () => void
   removeRecipient: (index: number) => void
@@ -142,6 +142,10 @@ export const MetadataForm = ({
       )}
     </form>
   )
+}
+
+MetadataForm.defaultProps = {
+  callToAction: '',
 }
 
 export default MetadataForm

--- a/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
+++ b/unlock-app/src/components/interface/checkout/MultipleRecipients.tsx
@@ -24,6 +24,7 @@ export interface MultipleRecipientProps {
   hasMinimumRecipients: boolean
   addRecipient: any
   loading: boolean
+  callToAction: string
   fields: Array<MetadataInput & { value?: any }>
   submitBulkRecipients: () => Promise<boolean>
   onContinue: () => void
@@ -37,6 +38,7 @@ export const MultipleRecipient: React.FC<MultipleRecipientProps> = ({
   hasMinimumRecipients,
   addRecipient,
   loading,
+  callToAction,
   fields = [],
   submitBulkRecipients,
   onContinue,
@@ -274,6 +276,7 @@ export const MultipleRecipient: React.FC<MultipleRecipientProps> = ({
             value={recipient}
             disabled={loading}
           />
+          {callToAction}
           {fields.map(({ name, type, required, placeholder }) => (
             <label key={name} htmlFor={name}>
               <span className="text-xs font-normal uppercase">


### PR DESCRIPTION
# Description

I realized our `metadata` call to action was not used anymore...
This fixes it!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
