### PR TITLE
fix(unlock-app): Use window.history.back instead of window.close in checkout close function

### DIFF
--- a/unlock-app/src/components/interface/checkout/Checkout.tsx
+++ b/unlock-app/src/components/interface/checkout/Checkout.tsx
@@ -246,8 +246,7 @@ export const Checkout = ({
       }
       window.location.href = redirectUrl.toString()
     } else {
-      // This will only work if the tab is the "main" tab.
-      window.close()
+      window.history.back()
     }
   }
 


### PR DESCRIPTION

<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

window.close won't work unless the script itself opens the new window using window.open due to security policies in chrome and other browsers. 

This replaces it with history.back which should redirect user to from where they landed on the checkout. This should not break anything as window.close wasn't working anyway.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

