### PR TITLE
feat(smart-contracts): allow `extend`  to update stored keyPrice

### DIFF
--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -215,8 +215,16 @@ contract MixinPurchase is
       revert INSUFFICIENT_VALUE();
     }
 
-    // store the new price
-    _originalPrices[_tokenId] = inMemoryKeyPrice;
+    // if params have changed, then update them
+    if(_originalPrices[_tokenId] != inMemoryKeyPrice) {
+      _originalPrices[_tokenId] = inMemoryKeyPrice;
+    }
+    if(_originalDurations[_tokenId] != expirationDuration) {
+      _originalDurations[_tokenId] = expirationDuration;
+    }
+    if(_originalTokens[_tokenId] != tokenAddress) {
+      _originalTokens[_tokenId] = tokenAddress;
+    }
 
     // refund gas (if applicable)
     _refundGas();

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -216,7 +216,7 @@ contract MixinPurchase is
     }
 
     // store the new price
-    _originalPrices[tokenId] = inMemoryKeyPrice;
+    _originalPrices[_tokenId] = inMemoryKeyPrice;
 
     // refund gas (if applicable)
     _refundGas();

--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -215,6 +215,9 @@ contract MixinPurchase is
       revert INSUFFICIENT_VALUE();
     }
 
+    // store the new price
+    _originalPrices[tokenId] = inMemoryKeyPrice;
+
     // refund gas (if applicable)
     _refundGas();
   }

--- a/smart-contracts/test/Lock/extendRenewable.js
+++ b/smart-contracts/test/Lock/extendRenewable.js
@@ -1,0 +1,103 @@
+const { tokens } = require('hardlydifficult-ethereum-contracts')
+const { reverts } = require('../helpers/errors')
+const BigNumber = require('bignumber.js')
+const { time } = require('@openzeppelin/test-helpers')
+const { assert } = require('chai')
+const deployLocks = require('../helpers/deployLocks')
+const getContractInstance = require('../helpers/truffle-artifacts')
+const { ADDRESS_ZERO } = require('../helpers/constants')
+
+const Unlock = artifacts.require('Unlock.sol')
+
+let unlock
+let locks
+let dai
+
+const keyPrice = new BigNumber(web3.utils.toWei('0.01', 'ether'))
+const totalPrice = keyPrice.times(10)
+const someDai = new BigNumber(web3.utils.toWei('100', 'ether'))
+
+let lock
+contract('Lock / Extend with recurring memberships', (accounts) => {
+  const lockOwner = accounts[0]
+  const keyOwner = accounts[1]
+  // const referrer = accounts[3]
+
+  before(async () => {
+    dai = await tokens.dai.deploy(web3, lockOwner)
+
+    // Mint some dais for testing
+    await dai.mint(keyOwner, someDai, {
+      from: lockOwner,
+    })
+
+    unlock = await getContractInstance(Unlock)
+    locks = await deployLocks(unlock, lockOwner, dai.address)
+    lock = locks.ERC20
+    await lock.setMaxKeysPerAddress(10)
+
+    // set ERC20 approval for entire scope
+    await dai.approve(lock.address, totalPrice, {
+      from: keyOwner,
+    })
+  })
+
+  describe('Use extend() to restart recurring payments', () => {
+    let tokenId
+    before(async () => {
+      const tx = await lock.purchase(
+        [keyPrice],
+        [keyOwner],
+        [ADDRESS_ZERO],
+        [ADDRESS_ZERO],
+        [[]],
+        { from: keyOwner }
+      )
+
+      const { args } = tx.logs.find((v) => v.event === 'Transfer')
+      const { tokenId: newTokenId } = args
+      tokenId = newTokenId
+
+      const expirationTs = await lock.keyExpirationTimestampFor(tokenId)
+      await time.increaseTo(expirationTs.toNumber())
+
+      // renew once
+      await lock.renewMembershipFor(tokenId, ADDRESS_ZERO, {
+        from: keyOwner,
+      })
+    })
+
+    describe('price changed', () => {
+      it('should renew once key has been extended', async () => {
+        // change price
+        const newPrice = web3.utils.toWei('0.03', 'ether')
+        await lock.updateKeyPricing(newPrice, dai.address, { from: lockOwner })
+
+        // fails because price has changed
+        await reverts(
+          lock.renewMembershipFor(tokenId, ADDRESS_ZERO),
+          'LOCK_HAS_CHANGED'
+        )
+
+        // user extend key
+        await lock.extend(newPrice, tokenId, ADDRESS_ZERO, [], {
+          from: keyOwner,
+        })
+
+        // expire key again
+        const newExpirationTs = await lock.keyExpirationTimestampFor(tokenId)
+
+        // renewal should work
+        await time.increaseTo(newExpirationTs.toNumber() - 1)
+        await lock.renewMembershipFor(tokenId, ADDRESS_ZERO, {
+          from: keyOwner,
+        })
+        const tsAfter = await lock.keyExpirationTimestampFor(tokenId)
+        assert.equal(
+          newExpirationTs.add(await lock.expirationDuration()).toString(),
+          tsAfter.toString()
+        )
+      })
+    })
+  })
+})

--- a/smart-contracts/test/Lock/renewMembershipFor.js
+++ b/smart-contracts/test/Lock/renewMembershipFor.js
@@ -35,6 +35,7 @@ contract('Lock / Recurring memberships', (accounts) => {
     unlock = await getContractInstance(Unlock)
     locks = await deployLocks(unlock, lockOwner, dai.address)
     lock = locks.ERC20
+    await lock.setMaxKeysPerAddress(10)
 
     // set ERC20 approval for entire scope
     await dai.approve(lock.address, totalPrice, {

--- a/smart-contracts/test/Lock/renewMembershipFor.js
+++ b/smart-contracts/test/Lock/renewMembershipFor.js
@@ -16,7 +16,7 @@ let dai
 
 const keyPrice = new BigNumber(web3.utils.toWei('0.01', 'ether'))
 const totalPrice = keyPrice.times(10)
-const someDai = new BigNumber(web3.utils.toWei('10', 'ether'))
+const someDai = new BigNumber(web3.utils.toWei('100', 'ether'))
 
 let lock
 contract('Lock / Recurring memberships', (accounts) => {
@@ -24,7 +24,7 @@ contract('Lock / Recurring memberships', (accounts) => {
   const keyOwner = accounts[1]
   // const referrer = accounts[3]
 
-  beforeEach(async () => {
+  before(async () => {
     dai = await tokens.dai.deploy(web3, lockOwner)
 
     // Mint some dais for testing
@@ -357,6 +357,65 @@ contract('Lock / Recurring memberships', (accounts) => {
         lock.renewMembershipFor(tokenId, ADDRESS_ZERO),
         'PURCHASE_BLOCKED_BY_HOOK'
       )
+    })
+  })
+
+  describe('Use extend() to restart recurring payments', () => {
+    let tokenId
+    before(async () => {
+      const tx = await lock.purchase(
+        [keyPrice],
+        [keyOwner],
+        [ADDRESS_ZERO],
+        [ADDRESS_ZERO],
+        [[]],
+        { from: keyOwner }
+      )
+
+      const { args } = tx.logs.find((v) => v.event === 'Transfer')
+      const { tokenId: newTokenId } = args
+      tokenId = newTokenId
+
+      const expirationTs = await lock.keyExpirationTimestampFor(tokenId)
+      await time.increaseTo(expirationTs.toNumber())
+
+      // renew once
+      await lock.renewMembershipFor(tokenId, ADDRESS_ZERO, {
+        from: keyOwner,
+      })
+    })
+
+    describe('price changed', () => {
+      it('should renew once key has been extended', async () => {
+        // change price
+        const newPrice = web3.utils.toWei('0.03', 'ether')
+        await lock.updateKeyPricing(newPrice, dai.address, { from: lockOwner })
+
+        // fails because price has changed
+        await reverts(
+          lock.renewMembershipFor(tokenId, ADDRESS_ZERO),
+          'LOCK_HAS_CHANGED'
+        )
+
+        // user extend key
+        await lock.extend(newPrice, tokenId, ADDRESS_ZERO, [], {
+          from: keyOwner,
+        })
+
+        // expire key again
+        const newExpirationTs = await lock.keyExpirationTimestampFor(tokenId)
+
+        // renewal should work
+        await time.increaseTo(newExpirationTs.toNumber() - 1)
+        await lock.renewMembershipFor(tokenId, ADDRESS_ZERO, {
+          from: keyOwner,
+        })
+        const tsAfter = await lock.keyExpirationTimestampFor(tokenId)
+        assert.equal(
+          newExpirationTs.add(await lock.expirationDuration()).toString(),
+          tsAfter.toString()
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
# Description

We store the original price of a key on purchase to make sure user isn't over charged on recurring payments. Currently the price was stored only when purchasing. This PR adds the ability to reset the price when extending an existing key

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #8771
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

