### PR TITLE
feat(smart-contracts): use `transfer` in erc20 gas refund

### DIFF
--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -290,7 +290,8 @@ contract MixinPurchase is
     if (_gasRefundValue != 0) { 
       if(tokenAddress != address(0)) {
         IERC20Upgradeable token = IERC20Upgradeable(tokenAddress);
-        token.transferFrom(address(this), msg.sender, _gasRefundValue);
+        // send tokens to refun gas
+        token.transfer(msg.sender, _gasRefundValue);
       } else {
         (bool success, ) = msg.sender.call{value: _gasRefundValue}("");
         if(!success) {


### PR DESCRIPTION
# Description

This replace unwanted `transferFrom` in erc20 gas refund by a simpler `transfer` - so we dont have to self-approve locks...

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #8679
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

