### PR TITLE
debug(unlock-app): logging statements

### DIFF
--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -107,12 +107,14 @@ export const useCheckoutCommunication = () => {
   const [config, setConfig] = useState<PaywallConfig | undefined>(undefined)
   const parent = usePostmateParent({
     setConfig: (config: PaywallConfig) => {
+      console.log('Got config from paywall app', config)
       setConfig(config)
     },
     resolveMethodCall,
     resolveOnEvent,
     resolveOnEnable,
   })
+  console.log('using config', config)
 
   let insideIframe = false
 


### PR DESCRIPTION
# Description

This is an effort to debug an issue with the demo.
I realized that for some reason the config passed by the paywall is not set correctly...
<img width="561" alt="Screen Shot 2022-06-07 at 9 37 14 AM" src="https://user-images.githubusercontent.com/17735/172394154-7da65950-19cb-40eb-be29-4c6e0aeb6cb3.png">

