### PR TITLE
fix(smart-contracts): `balanceOf` counts only valid keys

### DIFF
--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -442,7 +442,7 @@ interface IPublicLock
   /**
    * @return The number of keys owned by `_keyOwner` (expired or not)
   */
-  function totalKeysForUser(address _keyOwner) public view returns (uint);
+  function totalKeys(address _keyOwner) external view returns (uint);
   
   /// @notice A descriptive name for a collection of NFTs in this contract
   function name() external view returns (string memory _name);
@@ -455,7 +455,7 @@ interface IPublicLock
   /// From ERC-721
   /**
    * In the specific case of a Lock, `balanceOf` returns only the tokens with a valid expiration timerange
-   * @return The number of valid keys owned by `_keyOwner`
+   * @return balance The number of valid keys owned by `_keyOwner`
   */
   function balanceOf(address _owner) external view returns (uint256 balance);
 

--- a/smart-contracts/contracts/interfaces/IPublicLock.sol
+++ b/smart-contracts/contracts/interfaces/IPublicLock.sol
@@ -439,6 +439,11 @@ interface IPublicLock
     view
     returns (bool);
   
+  /**
+   * @return The number of keys owned by `_keyOwner` (expired or not)
+  */
+  function totalKeysForUser(address _keyOwner) public view returns (uint);
+  
   /// @notice A descriptive name for a collection of NFTs in this contract
   function name() external view returns (string memory _name);
   ///===================================================================
@@ -449,8 +454,9 @@ interface IPublicLock
 
   /// From ERC-721
   /**
-    * @dev Returns the number of NFTs in `owner`'s account.
-    */
+   * In the specific case of a Lock, `balanceOf` returns only the tokens with a valid expiration timerange
+   * @return The number of valid keys owned by `_keyOwner`
+  */
   function balanceOf(address _owner) external view returns (uint256 balance);
 
   /**

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import './MixinLockCore.sol';
 import './MixinErrors.sol';
+import 'hardhat/console.sol';
 
 /**
  * @title Mixin for managing `Key` data, as well as the * Approval related functions needed to meet the ERC721
@@ -190,7 +191,7 @@ contract MixinKeys is
     view
     returns (uint256)
   {
-      if(_index >= balanceOf(_keyOwner)) {
+      if(_index >= totalKeys(_keyOwner)) {
         revert OUT_OF_RANGE();
       }
       return _ownedKeyIds[_keyOwner][_index];
@@ -382,7 +383,7 @@ contract MixinKeys is
   /**
    * @return The number of keys owned by `_keyOwner` (expired or not)
   */
-  function totalKeysForUser(
+  function totalKeys(
     address _keyOwner
   )
     public
@@ -398,7 +399,7 @@ contract MixinKeys is
 
   /**
    * In the specific case of a Lock, `balanceOf` returns only the tokens with a valid expiration timerange
-   * @return The number of valid keys owned by `_keyOwner`
+   * @return balance The number of valid keys owned by `_keyOwner`
   */
   function balanceOf(
     address _keyOwner
@@ -407,7 +408,7 @@ contract MixinKeys is
     view
     returns (uint balance)
   {
-    uint length = totalKeysForUser(_keyOwner);
+    uint length = totalKeys(_keyOwner);
     if(length == 0) return 0;
     for (uint i = 0; i < length; i++) {
       if(isValidKey(tokenOfOwnerByIndex(_keyOwner, i))) {

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -380,10 +380,9 @@ contract MixinKeys is
   }
 
   /**
-   * In the specific case of a Lock, each owner can own only at most 1 key.
-   * @return The number of NFTs owned by `_keyOwner`, either 0 or 1.
+   * @return The number of keys owned by `_keyOwner` (expired or not)
   */
-  function balanceOf(
+  function totalKeysForUser(
     address _keyOwner
   )
     public
@@ -393,7 +392,28 @@ contract MixinKeys is
     if(_keyOwner == address(0)) { 
       revert INVALID_ADDRESS();
     }
+
     return _balances[_keyOwner];
+  }
+
+  /**
+   * In the specific case of a Lock, `balanceOf` returns only the tokens with a valid expiration timerange
+   * @return The number of valid keys owned by `_keyOwner`
+  */
+  function balanceOf(
+    address _keyOwner
+  )
+    public
+    view
+    returns (uint balance)
+  {
+    uint length = totalKeysForUser(_keyOwner);
+    if(length == 0) return 0;
+    for (uint i = 0; i < length; i++) {
+      if(isValidKey(tokenOfOwnerByIndex(_keyOwner, i))) {
+        balance++;
+      }
+    }
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import './MixinLockCore.sol';
 import './MixinErrors.sol';
-import 'hardhat/console.sol';
 
 /**
  * @title Mixin for managing `Key` data, as well as the * Approval related functions needed to meet the ERC721
@@ -409,7 +408,6 @@ contract MixinKeys is
     returns (uint balance)
   {
     uint length = totalKeys(_keyOwner);
-    if(length == 0) return 0;
     for (uint i = 0; i < length; i++) {
       if(isValidKey(tokenOfOwnerByIndex(_keyOwner, i))) {
         balance++;

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -220,7 +220,7 @@ contract MixinKeys is
     _keys[tokenId] = Key(tokenId, expirationTimestamp);
     
     // increase total number of unique owners
-    if(balanceOf(_recipient) == 0 ) {
+    if(totalKeys(_recipient) == 0 ) {
       numberOfOwners++;
     }
 
@@ -353,7 +353,7 @@ contract MixinKeys is
     delete _ownedKeyIds[previousOwner][lastTokenIndex];
 
     // remove from owner count if thats the only key 
-    if(balanceOf(previousOwner) == 1 ) {
+    if(totalKeys(previousOwner) == 1 ) {
       numberOfOwners--;
     }
     // update balance

--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -1,4 +1,5 @@
 const BigNumber = require('bignumber.js')
+const { time } = require('@openzeppelin/test-helpers')
 
 const { reverts } = require('../../helpers/errors')
 const deployLocks = require('../../helpers/deployLocks')
@@ -40,6 +41,40 @@ contract('Lock / erc721 / balanceOf', (accounts) => {
     )
     const balance = new BigNumber(await locks.FIRST.balanceOf.call(accounts[1]))
     assert.equal(balance.toFixed(), 3)
+  })
+
+  it('should count only valid keys', async () => {
+    const tx = await locks.FIRST.purchase(
+      [],
+      [accounts[1], accounts[1], accounts[1]],
+      [ADDRESS_ZERO, ADDRESS_ZERO, ADDRESS_ZERO],
+      [ADDRESS_ZERO, ADDRESS_ZERO, ADDRESS_ZERO],
+      [[], [], []],
+      {
+        value: web3.utils.toWei('0.03', 'ether'),
+        from: accounts[1],
+      }
+    )
+
+    const tokenIds = tx.logs
+      .filter((v) => v.event === 'Transfer')
+      .map(({ args }) => args.tokenId)
+
+    // expire all keys
+    const expirationTs = await locks.FIRST.keyExpirationTimestampFor(
+      tokenIds[0]
+    )
+    await time.increaseTo(expirationTs.toNumber() + 10)
+
+    assert.equal((await locks.FIRST.balanceOf.call(accounts[1])).toNumber(), 0)
+
+    // renew one
+    await locks.FIRST.extend(0, tokenIds[0], ADDRESS_ZERO, [], {
+      value: web3.utils.toWei('0.03', 'ether'),
+      from: accounts[1],
+    })
+
+    assert.equal((await locks.FIRST.balanceOf.call(accounts[1])).toNumber(), 1)
   })
 
   it('should return correct number after key transfers', async () => {

--- a/smart-contracts/test/Lock/totalKeys.js
+++ b/smart-contracts/test/Lock/totalKeys.js
@@ -1,0 +1,73 @@
+const { time } = require('@openzeppelin/test-helpers')
+
+const { reverts } = require('../helpers/errors')
+const deployLocks = require('../helpers/deployLocks')
+
+const unlockContract = artifacts.require('Unlock.sol')
+const getContractInstance = require('../helpers/truffle-artifacts')
+const { ADDRESS_ZERO } = require('../helpers/constants')
+
+let unlock
+let lock
+let tokenIds
+
+contract('Lock / totalKeys', (accounts) => {
+  let owner = accounts[0]
+
+  before(async () => {
+    unlock = await getContractInstance(unlockContract)
+    const locks = await deployLocks(unlock, owner)
+    lock = locks.FIRST
+    await lock.setMaxKeysPerAddress(10)
+
+    const tx = await lock.purchase(
+      [],
+      [accounts[1], accounts[1], accounts[1]],
+      [ADDRESS_ZERO, ADDRESS_ZERO, ADDRESS_ZERO],
+      [ADDRESS_ZERO, ADDRESS_ZERO, ADDRESS_ZERO],
+      [[], [], []],
+      {
+        value: web3.utils.toWei('0.03', 'ether'),
+        from: accounts[1],
+      }
+    )
+
+    tokenIds = tx.logs
+      .filter((v) => v.event === 'Transfer')
+      .map(({ args }) => args.tokenId)
+  })
+
+  it('should count all valid keys', async () => {
+    assert.equal((await lock.totalKeys(accounts[1])).toNumber(), 3)
+  })
+
+  it('should count expired keys', async () => {
+    // expire all keys
+    const expirationTs = await lock.keyExpirationTimestampFor(tokenIds[0])
+    await time.increaseTo(expirationTs.toNumber() + 10)
+
+    assert.equal((await lock.totalKeys(accounts[1])).toNumber(), 3)
+  })
+
+  it('should count both expired and renewed keys', async () => {
+    // extend once to fix block time in the past in test
+    await lock.extend(0, tokenIds[0], ADDRESS_ZERO, [], {
+      value: web3.utils.toWei('0.03', 'ether'),
+      from: accounts[1],
+    })
+
+    // expire all keys
+    const expirationTs = await lock.keyExpirationTimestampFor(tokenIds[0])
+    await time.increaseTo(expirationTs.toNumber() + 10)
+
+    assert.equal((await lock.totalKeys(accounts[1])).toNumber(), 3)
+
+    // renew one
+    await lock.extend(0, tokenIds[0], ADDRESS_ZERO, [], {
+      value: web3.utils.toWei('0.03', 'ether'),
+      from: accounts[1],
+    })
+
+    assert.equal((await lock.totalKeys(accounts[1])).toNumber(), 3)
+  })
+})


### PR DESCRIPTION
# Description

With this PR, `balanceOf` now takes only valid keys into account. Another function `totalKeys` has been added to have the total amount of both expired and valid keys.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #8693 
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

