### PR TITLE
fix(smart-contracts): reset original price when a key is cancelled

### DIFF
--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -28,13 +28,13 @@ contract MixinPurchase is
   uint256 internal _gasRefundValue;
 
   // Keep track of ERC20 price when purchased
-  mapping(uint256 => uint256) private _originalPrices;
+  mapping(uint256 => uint256) internal _originalPrices;
   
   // Keep track of duration when purchased
   mapping(uint256 => uint256) internal _originalDurations;
   
   // keep track of token pricing when purchased
-  mapping(uint256 => address) private _originalTokens;
+  mapping(uint256 => address) internal _originalTokens;
 
   /**
   * @dev Set the value/price to be refunded to the sender on purchase

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -108,7 +108,7 @@ contract MixinRefunds is
 
     // make future reccuring transactions impossible
     _originalDurations[_tokenId] = 0;
-    _originalPrices [_tokenId] = 0;
+    _originalPrices[_tokenId] = 0;
     
     // inform the hook if there is one registered
     if(address(onKeyCancelHook) != address(0))

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -108,6 +108,7 @@ contract MixinRefunds is
 
     // make future reccuring transactions impossible
     _originalDurations[_tokenId] = 0;
+    _originalPrices [_tokenId] = 0;
     
     // inform the hook if there is one registered
     if(address(onKeyCancelHook) != address(0))

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -161,6 +161,7 @@ contract MixinTransfer is
 
     // make future reccuring transactions impossible
     _originalDurations[_tokenId] = 0;
+    _originalPrices[_tokenId] = 0;
 
     // trigger event
     emit Transfer(


### PR DESCRIPTION
# Description

This PR resets the `_originalPrices` in case of explicit expiration/cancellation (on top of `_originalDurations`), to prevent future key renewals

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #8692

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

