### PR TITLE
feat(smart-contracts): prevent `transferFrom` from being used when a key manager is set

### DIFF
--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -65,7 +65,7 @@ contract MixinKeys is
   // the transfer of a key to another address where their key can be transferred
   // Note: the approver may actually NOT have a key... and there can only
   // be a single approved address
-  mapping (uint => address) private approved;
+  mapping (uint => address) internal approved;
 
   // Keeping track of approved operators for a given Key manager.
   // This approves a given operator for all keys managed by the calling "keyManager"

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -112,7 +112,14 @@ contract MixinTransfer is
     }
   }
 
-
+  /** 
+  * an ERC721-like function to transfer a token from one account to another
+  * @param _from the owner of token to transfer
+  * @param _recipient the address that will receive the token
+  * @param _tokenId the id of the token
+  * @notice To prevent the key manager to retain ownership rights on the token after transfer, the 
+  * operation will fail if a key manager if set. 
+  */
   function transferFrom(
     address _from,
     address _recipient,
@@ -121,8 +128,18 @@ contract MixinTransfer is
     public
   {
     _isValidKey(_tokenId);
-    _onlyKeyManagerOrApproved(_tokenId);
-    if(ownerOf(_tokenId) != _from) {
+    if(
+      // the specified address does not own the token
+      ownerOf(_tokenId) != _from
+      || 
+      ( // the sender is not owner or authorized
+        ownerOf(_tokenId) != msg.sender
+        && approved[_tokenId] != msg.sender
+        && !isApprovedForAll(_ownerOf[_tokenId], msg.sender)
+      )
+      || // a key manager is set
+      keyManagerOf[_tokenId] != address(0)
+    ) {
       revert UNAUTHORIZED();
     }
     if(transferFeeBasisPoints >= BASIS_POINTS_DEN) {

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -61,13 +61,13 @@ contract('Lock / erc721 / transferFrom', (accounts) => {
       )
     })
 
-    it('should only allow key manager, approved or owner to transfer', async () => {
+    it('should only allow approved or owner to transfer', async () => {
       // testing an id mismatch
       await reverts(
         locks.FIRST.transferFrom(keyOwners[0], accounts[9], tokenIds[0], {
           from: keyOwners[5],
         }),
-        'ONLY_KEY_MANAGER_OR_APPROVED'
+        'UNAUTHORIZED'
       )
       // testing a mismatched _from address
       await reverts(
@@ -112,6 +112,21 @@ contract('Lock / erc721 / transferFrom', (accounts) => {
       })
     })
 
+    describe('when the key owner is the sender and a key manager is set', async () => {
+      it('should revert if a key manager is set', async () => {
+        const keyManager = accounts[8]
+        await locks.FIRST.setKeyManagerOf(tokenIds[0], keyManager, {
+          from: keyOwners[0],
+        })
+        await reverts(
+          locks.FIRST.transferFrom(keyOwners[0], accounts[9], tokenIds[0], {
+            from: keyManager,
+          }),
+          'UNAUTHORIZED'
+        )
+      })
+    })
+
     describe('when the key owner is not the sender', async () => {
       let accountApproved
 
@@ -127,7 +142,7 @@ contract('Lock / erc721 / transferFrom', (accounts) => {
           locks.FIRST.transferFrom(keyOwners[0], accountApproved, tokenIds[2], {
             from: accountApproved,
           }),
-          'ONLY_KEY_MANAGER_OR_APPROVED'
+          'UNAUTHORIZED'
         )
       })
 
@@ -155,11 +170,13 @@ contract('Lock / erc721 / transferFrom', (accounts) => {
           from: keyOwners[0],
         })
       })
-      it('should reset the key manager', async () => {
-        await locks.FIRST.transferFrom(keyOwners[0], accounts[9], tokenIds[0], {
-          from: keyManager,
-        })
-        assert.equal(await locks.FIRST.keyManagerOf(tokenIds[0]), ADDRESS_ZERO)
+      it('should revert if a key manager is set', async () => {
+        await reverts(
+          locks.FIRST.transferFrom(keyOwners[0], accounts[9], tokenIds[0], {
+            from: keyManager,
+          }),
+          'UNAUTHORIZED'
+        )
       })
     })
 

--- a/smart-contracts/test/Lock/onKeyTransferHook.js
+++ b/smart-contracts/test/Lock/onKeyTransferHook.js
@@ -81,14 +81,14 @@ contract('Lock / onKeyTransfer hook', (accounts) => {
     assert.equal(args.time, expirationTs)
   })
 
-  it('pass correctly operator when different from key owner', async () => {
+  it('not fired when a key manager is set', async () => {
     await lock.setKeyManagerOf(tokenId, accounts[6], { from: keyOwner })
-    await lock.transferFrom(keyOwner, accounts[3], tokenId, {
-      from: accounts[6],
-    })
-    const args = (await testEventHooks.getPastEvents('OnKeyTransfer'))[0]
-      .returnValues
-    assert.equal(args.operator, accounts[6])
+    await reverts(
+      lock.transferFrom(keyOwner, accounts[3], tokenId, {
+        from: accounts[6],
+      }),
+      'UNAUTHORIZED'
+    )
   })
 
   it('cannot set the hook to a non-contract address', async () => {


### PR DESCRIPTION
# Description

This PR fix security issue that allows a key to be sold while retaining key manager privileges on it by preventing `transferFrom` from being used when a key manager is set.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #9005

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

