### PR TITLE
fix(smart-contracts): add `_recordKeyPurchase` to `extend`

### DIFF
--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -204,6 +204,9 @@ contract MixinPurchase is
     // transfer the tokens
     uint inMemoryKeyPrice = purchasePriceFor(ownerOf(_tokenId), _referrer, _data);
 
+    // process in unlock
+    _recordKeyPurchase(inMemoryKeyPrice, _referrer);
+
     if(tokenAddress != address(0)) {
       if(_value < inMemoryKeyPrice) {
         revert INSUFFICIENT_ERC20_VALUE();

--- a/smart-contracts/test/UnlockDiscountToken/mintingTokens.js
+++ b/smart-contracts/test/UnlockDiscountToken/mintingTokens.js
@@ -269,4 +269,77 @@ contract('UnlockDiscountToken (mainnet) / mintingTokens', (accounts) => {
       )
     })
   })
+
+  describe('extend()', () => {
+    let gasSpent
+    let tokenId
+    let balanceBefore
+    let balanceOwnerBefore
+
+    before(async () => {
+      const { logs } = await lock.purchase(
+        [],
+        [keyBuyer],
+        [referrer],
+        [ADDRESS_ZERO],
+        [[]],
+        {
+          from: keyBuyer,
+          value: await lock.keyPrice(),
+        }
+      )
+
+      const { args } = logs.find((v) => v.event === 'Transfer')
+      const { tokenId: newTokenId } = args
+      tokenId = newTokenId
+
+      balanceBefore = new BigNumber(await udt.balanceOf(referrer))
+      balanceOwnerBefore = new BigNumber(
+        await udt.balanceOf(await unlock.owner())
+      )
+
+      const { blockNumber } = await lock.extend(0, tokenId, referrer, [], {
+        from: keyBuyer,
+        value: await lock.keyPrice(),
+      })
+
+      const { baseFeePerGas: baseFeePerGasBlock } =
+        await ethers.provider.getBlock(blockNumber)
+
+      // using estimatedGas instead of the actual gas used so this test does not regress as other features are implemented
+      gasSpent = new BigNumber(baseFeePerGasBlock.toString()).times(estimateGas)
+    })
+
+    it('referrer has some UDT now', async () => {
+      const actual = new BigNumber(await udt.balanceOf(referrer)).minus(
+        balanceBefore
+      )
+      assert.notEqual(actual.toString(), 0)
+    })
+
+    it('amount minted for referrer ~= gas spent', async () => {
+      // 120 UDT minted * 0.000042 ETH/UDT == 0.005 ETH spent
+      assert.equal(
+        new BigNumber(await udt.balanceOf(referrer))
+          .minus(balanceBefore)
+          .shiftedBy(-18) // shift UDT balance
+          .times(rate)
+          .shiftedBy(-18) // shift the rate
+          .toFixed(3),
+        gasSpent.shiftedBy(-18).toFixed(3)
+      )
+    })
+
+    it('amount minted for dev ~= gas spent * 20%', async () => {
+      assert.equal(
+        new BigNumber(await udt.balanceOf(await unlock.owner()))
+          .minus(balanceOwnerBefore)
+          .shiftedBy(-18) // shift UDT balance
+          .times(rate)
+          .shiftedBy(-18) // shift the rate
+          .toFixed(3),
+        gasSpent.times(0.25).shiftedBy(-18).toFixed(3)
+      )
+    })
+  })
 })


### PR DESCRIPTION
# Description

This PR adds the logic to record GDP and grant UDT while extending an existing key.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #9022
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

