### PR TITLE
feat(unlock-app) - show the actual NFT image on verification page

### DIFF
--- a/unlock-app/src/components/interface/verification/Key.tsx
+++ b/unlock-app/src/components/interface/verification/Key.tsx
@@ -9,7 +9,11 @@ import {
 import { ActionButton } from '../buttons/ActionButton'
 import Loading from '../Loading'
 import { ToastHelper } from '../../helpers/toast.helper'
-
+import {
+  AvatarImage,
+  Root as Avatar,
+  Fallback as AvatarFallback,
+} from '@radix-ui/react-avatar'
 interface InvalidKeyProps {
   reason: string
 }
@@ -56,6 +60,7 @@ export const ValidKeyWithMetadata = ({
   checkedIn,
   lock,
 }: ValidKeyWithMetadataProps) => {
+  let tokenURI
   const expirationDate = expirationAsDate(unlockKey.expiration)
   let box = (
     <Box color="--green">
@@ -97,9 +102,29 @@ export const ValidKeyWithMetadata = ({
     <Wrapper>
       {box}
       <KeyInfo>
-        <Label>Lock Name</Label>
-        <Value>{lock.name}</Value>
-        <Label>Token Id</Label>
+        <div className="flex mb-3">
+          <Avatar className="flex items-center justify-center w-12 h-12 border rounded-full">
+            <AvatarImage
+              className="rounded-full"
+              alt={lock.name}
+              src={keyData.image}
+              width={50}
+              height={50}
+            />
+            <AvatarFallback className="uppercase" delayMs={100}>
+              {lock.name.slice(0, 2)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="ml-3">
+            <div className="flex">
+              <Label>
+                Lock Name
+                <strong className="text-sm block"> {lock.name}</strong>
+              </Label>
+            </div>
+          </div>
+        </div>
+        <Label>Token id</Label>
         <Value>{unlockKey.tokenId}</Value>
         <Label>Owner Address</Label>
         <Value>{owner}</Value>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This PR is part of https://github.com/unlock-protocol/unlock/issues/8663 and adds: 

- [x] Show the actual NFT image in verification page 



<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #
<img width="386" alt="Screenshot 2022-06-16 at 12 10 03" src="https://user-images.githubusercontent.com/20865711/174048414-2bd12b2b-1d16-425e-83f0-a4583084b40b.png">


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

