### PR TITLE
chore(smart-contracts): remove all `.call` patterns from tests

### DIFF
--- a/smart-contracts/test/Lock/Lock.js
+++ b/smart-contracts/test/Lock/Lock.js
@@ -27,11 +27,11 @@ contract('Lock / Lock', (accounts) => {
       totalSupply,
       numberOfOwners,
     ] = await Promise.all([
-      lock.expirationDuration.call(),
-      lock.keyPrice.call(),
-      lock.maxNumberOfKeys.call(),
-      lock.totalSupply.call(),
-      lock.numberOfOwners.call(),
+      lock.expirationDuration(),
+      lock.keyPrice(),
+      lock.maxNumberOfKeys(),
+      lock.totalSupply(),
+      lock.numberOfOwners(),
     ])
     expirationDuration = new BigNumber(expirationDuration)
     keyPrice = new BigNumber(keyPrice)

--- a/smart-contracts/test/Lock/behaviors/lockBehaviors.js
+++ b/smart-contracts/test/Lock/behaviors/lockBehaviors.js
@@ -36,7 +36,7 @@ contract('Lock / lockBehaviors', (accounts) => {
         for (let i = 0; i < accounts.length; i++) {
           await this.testToken.approve(
             this.lock.address,
-            await this.lock.keyPrice.call(),
+            await this.lock.keyPrice(),
             {
               from: accounts[i],
             }

--- a/smart-contracts/test/Lock/burn.js
+++ b/smart-contracts/test/Lock/burn.js
@@ -34,10 +34,10 @@ contract('Lock / burn', (accounts) => {
   })
 
   it('should delete ownership record', async () => {
-    assert.equal(await lock.getHasValidKey.call(keyOwner), true)
+    assert.equal(await lock.getHasValidKey(keyOwner), true)
     assert.equal(await lock.ownerOf(tokenId), keyOwner)
     await lock.burn(tokenId, { from: keyOwner })
-    assert.equal(await lock.getHasValidKey.call(keyOwner), false)
+    assert.equal(await lock.getHasValidKey(keyOwner), false)
     assert.equal(await lock.ownerOf(tokenId), ADDRESS_ZERO)
   })
 
@@ -51,10 +51,10 @@ contract('Lock / burn', (accounts) => {
 
   it('allow key manager to burn a key', async () => {
     await lock.setKeyManagerOf(tokenId, accounts[9], { from: keyOwner })
-    assert.equal(await lock.getHasValidKey.call(keyOwner), true)
+    assert.equal(await lock.getHasValidKey(keyOwner), true)
     assert.equal(await lock.ownerOf(tokenId), keyOwner)
     await lock.burn(tokenId, { from: accounts[9] })
-    assert.equal(await lock.getHasValidKey.call(keyOwner), false)
+    assert.equal(await lock.getHasValidKey(keyOwner), false)
     assert.equal(await lock.ownerOf(tokenId), ADDRESS_ZERO)
   })
 

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -57,13 +57,13 @@ contract('Lock / cancelAndRefund', (accounts) => {
   })
 
   it('should return the correct penalty', async () => {
-    const numerator = new BigNumber(await lock.refundPenaltyBasisPoints.call())
+    const numerator = new BigNumber(await lock.refundPenaltyBasisPoints())
     assert.equal(numerator.div(denominator).toFixed(), 0.1) // default of 10%
   })
 
   it('the amount of refund should be less than the original keyPrice when purchased normally', async () => {
     const estimatedRefund = new BigNumber(
-      await lock.getCancelAndRefundValue.call(tokenIds[0])
+      await lock.getCancelAndRefundValue(tokenIds[0])
     )
     assert(estimatedRefund.lt(keyPrice))
   })
@@ -95,7 +95,7 @@ contract('Lock / cancelAndRefund', (accounts) => {
     )
     const { args } = tx.logs.find((v) => v.event === 'Transfer')
     const estimatedRefund = new BigNumber(
-      await locks.FREE.getCancelAndRefundValue.call(args.tokenId)
+      await locks.FREE.getCancelAndRefundValue(args.tokenId)
     )
     assert(estimatedRefund, 0)
   })
@@ -115,7 +115,7 @@ contract('Lock / cancelAndRefund', (accounts) => {
         await web3.eth.getBalance(keyOwners[0])
       )
       estimatedRefund = new BigNumber(
-        await lock.getCancelAndRefundValue.call(tokenIds[0])
+        await lock.getCancelAndRefundValue(tokenIds[0])
       )
       txObj = await lock.cancelAndRefund(tokenIds[0], {
         from: keyOwners[0],
@@ -145,7 +145,7 @@ contract('Lock / cancelAndRefund', (accounts) => {
     })
 
     it('should make the key no longer valid (i.e. expired)', async () => {
-      const isValid = await lock.getHasValidKey.call(keyOwners[0])
+      const isValid = await lock.getHasValidKey(keyOwners[0])
       assert.equal(isValid, false)
     })
 
@@ -215,9 +215,7 @@ contract('Lock / cancelAndRefund', (accounts) => {
     })
 
     it('should return the correct penalty', async () => {
-      const numerator = new BigNumber(
-        await lock.refundPenaltyBasisPoints.call()
-      )
+      const numerator = new BigNumber(await lock.refundPenaltyBasisPoints())
       assert.equal(numerator.div(denominator).toFixed(), 0.2) // updated to 20%
     })
 
@@ -232,7 +230,7 @@ contract('Lock / cancelAndRefund', (accounts) => {
 
   describe('should fail when', () => {
     it('should fail if the Lock owner withdraws too much funds', async () => {
-      await lock.withdraw(await lock.tokenAddress.call(), 0, {
+      await lock.withdraw(await lock.tokenAddress(), 0, {
         from: lockCreator,
       })
       await reverts(
@@ -274,8 +272,8 @@ contract('Lock / cancelAndRefund', (accounts) => {
 
   it('should refund in the new token after token address is changed', async () => {
     // Confirm user has a key paid in eth
-    assert.equal(await lock.getHasValidKey.call(keyOwners[4]), true)
-    assert.equal(await lock.tokenAddress.call(), 0)
+    assert.equal(await lock.getHasValidKey(keyOwners[4]), true)
+    assert.equal(await lock.tokenAddress(), 0)
     // check user's token balance
     assert.equal(await token.balanceOf(keyOwners[4]), 0)
     // update token address and price

--- a/smart-contracts/test/Lock/disableTransfers.js
+++ b/smart-contracts/test/Lock/disableTransfers.js
@@ -47,7 +47,7 @@ contract('Lock / disableTransfers', (accounts) => {
     describe('disabling transferFrom', () => {
       it('should prevent key transfers by reverting', async () => {
         // check owner has a key
-        assert.equal(await lock.getHasValidKey.call(keyOwner), true)
+        assert.equal(await lock.getHasValidKey(keyOwner), true)
         // try to transfer it
         await reverts(
           lock.transferFrom(keyOwner, accountWithNoKey, tokenId, {
@@ -56,10 +56,10 @@ contract('Lock / disableTransfers', (accounts) => {
           'KEY_TRANSFERS_DISABLED'
         )
         // check owner still has a key
-        assert.equal(await lock.getHasValidKey.call(keyOwner), true)
+        assert.equal(await lock.getHasValidKey(keyOwner), true)
         // check recipient never received a key
         assert.equal(
-          await lock.keyExpirationTimestampFor.call(accountWithNoKey, {
+          await lock.keyExpirationTimestampFor(accountWithNoKey, {
             from: accountWithNoKey,
           }),
           0
@@ -81,7 +81,7 @@ contract('Lock / disableTransfers', (accounts) => {
     describe('disabling shareKey', () => {
       it('should prevent key sharing by reverting', async () => {
         // check owner has a key
-        assert.equal(await lock.getHasValidKey.call(keyOwner), true)
+        assert.equal(await lock.getHasValidKey(keyOwner), true)
         // try to share it
         await reverts(
           lock.shareKey(accountWithNoKey, tokenId, oneDay, {
@@ -90,10 +90,10 @@ contract('Lock / disableTransfers', (accounts) => {
           'KEY_TRANSFERS_DISABLED'
         )
         // check owner still has a key
-        assert.equal(await lock.getHasValidKey.call(keyOwner), true)
+        assert.equal(await lock.getHasValidKey(keyOwner), true)
         // check recipient never received a key
         assert.equal(
-          await lock.keyExpirationTimestampFor.call(accountWithNoKey, {
+          await lock.keyExpirationTimestampFor(accountWithNoKey, {
             from: accountWithNoKey,
           }),
           0
@@ -107,14 +107,14 @@ contract('Lock / disableTransfers', (accounts) => {
       // Change the fee to 99%
       await lock.updateTransferFee(1000)
       // check owner has a key
-      assert.equal(await lock.getHasValidKey.call(keyOwner), true)
-      assert.equal(await lock.getHasValidKey.call(accountWithNoKey), false)
+      assert.equal(await lock.getHasValidKey(keyOwner), true)
+      assert.equal(await lock.getHasValidKey(accountWithNoKey), false)
       // attempt a transfer
       await lock.transferFrom(keyOwner, accountWithNoKey, tokenId, {
         from: keyOwner,
       })
       // check that recipient received a key
-      assert.equal(await lock.getHasValidKey.call(accountWithNoKey), true)
+      assert.equal(await lock.getHasValidKey(accountWithNoKey), true)
     })
   })
 })

--- a/smart-contracts/test/Lock/erc165.js
+++ b/smart-contracts/test/Lock/erc165.js
@@ -14,19 +14,19 @@ contract('Lock / erc165', (accounts) => {
 
   it('should support the erc165 interface()', async () => {
     // 0x01ffc9a7 === bytes4(keccak256('supportsInterface(bytes4)'))
-    const result = await locks.FIRST.supportsInterface.call('0x01ffc9a7')
+    const result = await locks.FIRST.supportsInterface('0x01ffc9a7')
     assert.equal(result, true)
   })
 
   it('should support the erc721 metadata interface', async () => {
     // ID specified in the standard: https://eips.ethereum.org/EIPS/eip-721
-    const result = await locks.FIRST.supportsInterface.call('0x5b5e139f')
+    const result = await locks.FIRST.supportsInterface('0x5b5e139f')
     assert.equal(result, true)
   })
 
   it('should support the erc721 enumerable interface', async () => {
     // ID specified in the standard: https://eips.ethereum.org/EIPS/eip-721
-    const result = await locks.FIRST.supportsInterface.call('0x780e9d63')
+    const result = await locks.FIRST.supportsInterface('0x780e9d63')
     assert.equal(result, true)
   })
 })

--- a/smart-contracts/test/Lock/erc20.js
+++ b/smart-contracts/test/Lock/erc20.js
@@ -54,7 +54,7 @@ contract('Lock / erc20', (accounts) => {
       await token.approve(lock.address, MAX_UINT, { from: keyOwner2 })
       await token.approve(lock.address, MAX_UINT, { from: keyOwner3 })
 
-      keyPrice = new BigNumber(await lock.keyPrice.call())
+      keyPrice = new BigNumber(await lock.keyPrice())
       refundAmount = keyPrice.toFixed()
     })
 
@@ -145,7 +145,7 @@ contract('Lock / erc20', (accounts) => {
         const lockBalance = new BigNumber(await token.balanceOf(lock.address))
         const ownerBalance = new BigNumber(await token.balanceOf(accounts[0]))
 
-        await lock.withdraw(await lock.tokenAddress.call(), 0, {
+        await lock.withdraw(await lock.tokenAddress(), 0, {
           from: accounts[0],
         })
 

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -75,7 +75,7 @@ contract('Lock / erc721 / approve', (accounts) => {
       })
 
       it('should assign the approvedForTransfer value', async () => {
-        const approved = await locks.FIRST.getApproved.call(tokenId)
+        const approved = await locks.FIRST.getApproved(tokenId)
         assert.equal(approved, accounts[2])
       })
 
@@ -111,10 +111,7 @@ contract('Lock / erc721 / approve', (accounts) => {
         })
 
         it('The zero address indicates there is no approved address', async () => {
-          assert.equal(
-            await locks.FIRST.getApproved.call(tokenId),
-            ADDRESS_ZERO
-          )
+          assert.equal(await locks.FIRST.getApproved(tokenId), ADDRESS_ZERO)
         })
       })
     })

--- a/smart-contracts/test/Lock/erc721/approveForAll.js
+++ b/smart-contracts/test/Lock/erc721/approveForAll.js
@@ -38,7 +38,7 @@ contract('Lock / erc721 / approveForAll', (accounts) => {
     })
 
     it('isApprovedForAll defaults to false', async () => {
-      assert.equal(await lock.isApprovedForAll.call(owner, approvedUser), false)
+      assert.equal(await lock.isApprovedForAll(owner, approvedUser), false)
     })
 
     describe('when the sender is self approving', () => {
@@ -62,10 +62,7 @@ contract('Lock / erc721 / approveForAll', (accounts) => {
       })
 
       it('isApprovedForAll is true', async () => {
-        assert.equal(
-          await lock.isApprovedForAll.call(owner, approvedUser),
-          true
-        )
+        assert.equal(await lock.isApprovedForAll(owner, approvedUser), true)
       })
 
       it('should trigger the ApprovalForAll event', () => {
@@ -82,7 +79,7 @@ contract('Lock / erc721 / approveForAll', (accounts) => {
           from: approvedUser,
         })
 
-        assert.equal(await lock.getApproved.call(tokenId), newApprovedUser)
+        assert.equal(await lock.getApproved(tokenId), newApprovedUser)
       })
 
       it('should allow the approved user to transferFrom', async () => {
@@ -97,10 +94,7 @@ contract('Lock / erc721 / approveForAll', (accounts) => {
       })
 
       it('isApprovedForAll is still true (not lost after transfer)', async () => {
-        assert.equal(
-          await lock.isApprovedForAll.call(owner, approvedUser),
-          true
-        )
+        assert.equal(await lock.isApprovedForAll(owner, approvedUser), true)
       })
 
       describe('allows for multiple operators per owner', () => {
@@ -114,16 +108,13 @@ contract('Lock / erc721 / approveForAll', (accounts) => {
 
         it('new operator is approved', async () => {
           assert.equal(
-            await lock.isApprovedForAll.call(owner, newApprovedUser),
+            await lock.isApprovedForAll(owner, newApprovedUser),
             true
           )
         })
 
         it('original operator is still approved', async () => {
-          assert.equal(
-            await lock.isApprovedForAll.call(owner, approvedUser),
-            true
-          )
+          assert.equal(await lock.isApprovedForAll(owner, approvedUser), true)
         })
       })
     })
@@ -142,10 +133,7 @@ contract('Lock / erc721 / approveForAll', (accounts) => {
       })
 
       it('isApprovedForAll is false again', async () => {
-        assert.equal(
-          await lock.isApprovedForAll.call(owner, approvedUser),
-          false
-        )
+        assert.equal(await lock.isApprovedForAll(owner, approvedUser), false)
       })
 
       it('This emits when an operator is (enabled or) disabled for an owner.', async () => {
@@ -173,7 +161,7 @@ contract('Lock / erc721 / approveForAll', (accounts) => {
 
       it('operator is approved', async () => {
         assert.equal(
-          await lock.isApprovedForAll.call(ownerWithoutAKey, approvedUser),
+          await lock.isApprovedForAll(ownerWithoutAKey, approvedUser),
           true
         )
       })

--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -19,11 +19,11 @@ contract('Lock / erc721 / balanceOf', (accounts) => {
   })
 
   it('should fail if the user address is 0', async () => {
-    await reverts(locks.FIRST.balanceOf.call(ADDRESS_ZERO), 'INVALID_ADDRESS')
+    await reverts(locks.FIRST.balanceOf(ADDRESS_ZERO), 'INVALID_ADDRESS')
   })
 
   it('should return 0 if the user has no key', async () => {
-    const balance = new BigNumber(await locks.FIRST.balanceOf.call(accounts[3]))
+    const balance = new BigNumber(await locks.FIRST.balanceOf(accounts[3]))
     assert.equal(balance.toFixed(), 0)
   })
 
@@ -39,7 +39,7 @@ contract('Lock / erc721 / balanceOf', (accounts) => {
         from: accounts[1],
       }
     )
-    const balance = new BigNumber(await locks.FIRST.balanceOf.call(accounts[1]))
+    const balance = new BigNumber(await locks.FIRST.balanceOf(accounts[1]))
     assert.equal(balance.toFixed(), 3)
   })
 
@@ -66,7 +66,7 @@ contract('Lock / erc721 / balanceOf', (accounts) => {
     )
     await time.increaseTo(expirationTs.toNumber() + 10)
 
-    assert.equal((await locks.FIRST.balanceOf.call(accounts[1])).toNumber(), 0)
+    assert.equal((await locks.FIRST.balanceOf(accounts[1])).toNumber(), 0)
 
     // renew one
     await locks.FIRST.extend(0, tokenIds[0], ADDRESS_ZERO, [], {
@@ -74,7 +74,7 @@ contract('Lock / erc721 / balanceOf', (accounts) => {
       from: accounts[1],
     })
 
-    assert.equal((await locks.FIRST.balanceOf.call(accounts[1])).toNumber(), 1)
+    assert.equal((await locks.FIRST.balanceOf(accounts[1])).toNumber(), 1)
   })
 
   it('should return correct number after key transfers', async () => {
@@ -89,14 +89,14 @@ contract('Lock / erc721 / balanceOf', (accounts) => {
         from: accounts[6],
       }
     )
-    let tokenId = await locks.FIRST.tokenOfOwnerByIndex.call(accounts[6], 0)
+    let tokenId = await locks.FIRST.tokenOfOwnerByIndex(accounts[6], 0)
     assert.equal(accounts[6], await locks.FIRST.ownerOf(tokenId))
-    assert.equal((await locks.FIRST.balanceOf.call(accounts[6])).toNumber(), 3)
+    assert.equal((await locks.FIRST.balanceOf(accounts[6])).toNumber(), 3)
     await locks.FIRST.transferFrom(accounts[6], accounts[5], tokenId, {
       from: accounts[6],
     })
-    let balanceOf6 = await locks.FIRST.balanceOf.call(accounts[6])
-    let balanceOf5 = await locks.FIRST.balanceOf.call(accounts[5])
+    let balanceOf6 = await locks.FIRST.balanceOf(accounts[6])
+    let balanceOf5 = await locks.FIRST.balanceOf(accounts[5])
     assert.equal(balanceOf6.toNumber(), 2)
     assert.equal(balanceOf5.toNumber(), 1)
   })

--- a/smart-contracts/test/Lock/erc721/compliance.js
+++ b/smart-contracts/test/Lock/erc721/compliance.js
@@ -14,7 +14,7 @@ contract('Lock / erc721 / compliance', (accounts) => {
 
   it('should support the erc721 interface()', async () => {
     // Note: the ERC-165 identifier for the erc721 interface is "0x80ac58cd"
-    const result = await locks.FIRST.supportsInterface.call('0x80ac58cd')
+    const result = await locks.FIRST.supportsInterface('0x80ac58cd')
     assert.equal(result, true)
   })
 })

--- a/smart-contracts/test/Lock/erc721/getApproved.js
+++ b/smart-contracts/test/Lock/erc721/getApproved.js
@@ -13,6 +13,6 @@ contract('Lock / erc721 / getApproved', (accounts) => {
   })
 
   it('should fail if the key does not exist', async () => {
-    await reverts(locks.FIRST.getApproved.call(42), 'NO_SUCH_KEY')
+    await reverts(locks.FIRST.getApproved(42), 'NO_SUCH_KEY')
   })
 })

--- a/smart-contracts/test/Lock/erc721/ownerOf.js
+++ b/smart-contracts/test/Lock/erc721/ownerOf.js
@@ -15,7 +15,7 @@ contract('Lock / erc721 / ownerOf', (accounts) => {
   })
 
   it('should return 0x0 when key is nonexistent', async () => {
-    let address = await locks.FIRST.ownerOf.call(42)
+    let address = await locks.FIRST.ownerOf(42)
     assert.equal(address, ADDRESS_ZERO)
   })
 
@@ -32,7 +32,7 @@ contract('Lock / erc721 / ownerOf', (accounts) => {
       }
     )
     const { args } = tx.logs.find((v) => v.event === 'Transfer')
-    let address = await locks.FIRST.ownerOf.call(args.tokenId)
+    let address = await locks.FIRST.ownerOf(args.tokenId)
     assert.equal(address, accounts[1])
   })
 
@@ -49,13 +49,13 @@ contract('Lock / erc721 / ownerOf', (accounts) => {
       }
     )
     const { args } = tx.logs.find((v) => v.event === 'Transfer')
-    let address = await locks.FIRST.ownerOf.call(args.tokenId)
+    let address = await locks.FIRST.ownerOf(args.tokenId)
     assert.equal(address, accounts[1])
 
     // transfer
     await locks.FIRST.transferFrom(accounts[1], accounts[7], args.tokenId, {
       from: accounts[1],
     })
-    assert.equal(await locks.FIRST.ownerOf.call(args.tokenId), accounts[7])
+    assert.equal(await locks.FIRST.ownerOf(args.tokenId), accounts[7])
   })
 })

--- a/smart-contracts/test/Lock/erc721/safeTransferFrom.js
+++ b/smart-contracts/test/Lock/erc721/safeTransferFrom.js
@@ -44,7 +44,7 @@ contract('Lock / erc721 / safeTransferFrom', (accounts) => {
     await lock.safeTransferFrom(from, to, tokenId, {
       from,
     })
-    let ownerOf = await lock.ownerOf.call(tokenId)
+    let ownerOf = await lock.ownerOf(tokenId)
     assert.equal(ownerOf, to)
   })
 
@@ -72,7 +72,7 @@ contract('Lock / erc721 / safeTransferFrom', (accounts) => {
         from: accounts[7],
       }
     )
-    let ownerOf = await lock.ownerOf.call(tokenId)
+    let ownerOf = await lock.ownerOf(tokenId)
     assert.equal(ownerOf, accounts[6])
     // while we may pass data to the safeTransferFrom function, it is not currently utilized in any way other than being passed to the `onERC721Received` function in MixinTransfer.sol
   })
@@ -99,7 +99,7 @@ contract('Lock / erc721 / safeTransferFrom', (accounts) => {
       })
     )
     // make sure the key was not transferred
-    let ownerOf = await lock.ownerOf.call(tokenId)
+    let ownerOf = await lock.ownerOf(tokenId)
     assert.equal(ownerOf, accounts[5])
   })
 
@@ -130,7 +130,7 @@ contract('Lock / erc721 / safeTransferFrom', (accounts) => {
     )
 
     // make sure the key was not transferred
-    let ownerOf = await lock.ownerOf.call(tokenId)
+    let ownerOf = await lock.ownerOf(tokenId)
     assert.equal(ownerOf, compliantContract.address)
   })
 })

--- a/smart-contracts/test/Lock/erc721/tokenName.js
+++ b/smart-contracts/test/Lock/erc721/tokenName.js
@@ -18,7 +18,7 @@ contract('Lock / erc721 / name', (accounts) => {
 
   describe('when no name has been set on creation', () => {
     it('should return the default name when attempting to read the name', async () => {
-      assert.equal(await unnamedlock.name.call(), 'Unlock-Protocol Lock')
+      assert.equal(await unnamedlock.name(), 'Unlock-Protocol Lock')
     })
 
     it('should fail if someone other than the owner tries to set the name', async () => {
@@ -39,7 +39,7 @@ contract('Lock / erc721 / name', (accounts) => {
 
   describe('when the Lock has a name', () => {
     it('should return return the expected name', async () => {
-      assert.equal(await namedLock.name.call(), 'Custom Named Lock')
+      assert.equal(await namedLock.name(), 'Custom Named Lock')
     })
 
     it('should fail if someone other than the owner tries to change the name', async () => {
@@ -58,7 +58,7 @@ contract('Lock / erc721 / name', (accounts) => {
       })
 
       it('should return return the expected name', async () => {
-        assert.equal(await namedLock.name.call(), 'Difficult')
+        assert.equal(await namedLock.name(), 'Difficult')
       })
     })
 
@@ -70,7 +70,7 @@ contract('Lock / erc721 / name', (accounts) => {
       })
 
       it('should return return the expected name', async () => {
-        assert.equal(await namedLock.name.call(), '')
+        assert.equal(await namedLock.name(), '')
       })
     })
   })

--- a/smart-contracts/test/Lock/erc721/tokenSymbol.js
+++ b/smart-contracts/test/Lock/erc721/tokenSymbol.js
@@ -19,7 +19,7 @@ contract('Lock / erc721 / tokenSymbol', (accounts) => {
 
   describe('the global token symbol stored in Unlock', () => {
     it('should return the global token symbol', async () => {
-      assert.equal(await unlock.globalTokenSymbol.call(), '')
+      assert.equal(await unlock.globalTokenSymbol(), '')
     })
 
     describe('set the global symbol', () => {
@@ -39,13 +39,13 @@ contract('Lock / erc721 / tokenSymbol', (accounts) => {
       })
 
       it('should allow the owner to set the global token Symbol', async () => {
-        assert.equal(await unlock.globalTokenSymbol.call(), 'KEY')
+        assert.equal(await unlock.globalTokenSymbol(), 'KEY')
       })
 
       it('getGlobalTokenSymbol is the same', async () => {
         assert.equal(
-          await unlock.globalTokenSymbol.call(),
-          await unlock.getGlobalTokenSymbol.call()
+          await unlock.globalTokenSymbol(),
+          await unlock.getGlobalTokenSymbol()
         )
       })
 
@@ -75,7 +75,7 @@ contract('Lock / erc721 / tokenSymbol', (accounts) => {
     it('should allow the lock owner to set a custom token symbol', async () => {
       txObj = await lock.updateLockSymbol('MYTKN', { from: accounts[0] })
       event = txObj.logs[0]
-      assert.equal(await lock.symbol.call(), 'MYTKN')
+      assert.equal(await lock.symbol(), 'MYTKN')
     })
 
     it('should fail if someone other than the owner tries to set the symbol', async () => {

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -36,7 +36,7 @@ contract('Lock / erc721 / tokenURI', (accounts) => {
 
   describe('the global tokenURI stored in Unlock', () => {
     it('should return the global base token URI', async () => {
-      assert.equal(await unlock.globalBaseTokenURI.call(), '')
+      assert.equal(await unlock.globalBaseTokenURI(), '')
     })
 
     describe('set global base URI', () => {
@@ -57,15 +57,15 @@ contract('Lock / erc721 / tokenURI', (accounts) => {
 
       it('should allow the owner to set the global base token URI', async () => {
         assert.equal(
-          await unlock.globalBaseTokenURI.call(),
+          await unlock.globalBaseTokenURI(),
           'https://globalBaseTokenURI.com/api/key/'
         )
       })
 
       it('getGlobalBaseTokenURI is the same', async () => {
         assert.equal(
-          await unlock.globalBaseTokenURI.call(),
-          await unlock.getGlobalBaseTokenURI.call()
+          await unlock.globalBaseTokenURI(),
+          await unlock.getGlobalBaseTokenURI()
         )
       })
 
@@ -111,13 +111,13 @@ contract('Lock / erc721 / tokenURI', (accounts) => {
           value: web3.utils.toWei('0.01', 'ether'),
         }
       )
-      uri = await lock.tokenURI.call(1)
+      uri = await lock.tokenURI(1)
       assert.equal(uri, 'https:/customBaseTokenURI.com/api/key/' + '1')
     })
 
     it('should let anyone get the baseTokenURI for a lock by passing tokenId 0', async () => {
       // here we pass 0 as the tokenId to get the baseTokenURI
-      baseTokenURI = await lock.tokenURI.call(0)
+      baseTokenURI = await lock.tokenURI(0)
       // should be the same as the previously set URI
       assert.equal(baseTokenURI, 'https:/customBaseTokenURI.com/api/key/')
     })
@@ -126,7 +126,7 @@ contract('Lock / erc721 / tokenURI', (accounts) => {
       await lock.setBaseTokenURI('', {
         from: accounts[0],
       })
-      baseTokenURI = await lock.tokenURI.call(0)
+      baseTokenURI = await lock.tokenURI(0)
       const lockAddressStr = lock.address.toString()
       const lowerCaseAddress = stringShifter(lockAddressStr)
       // should now return the globalBaseTokenURI + the lock address
@@ -134,7 +134,7 @@ contract('Lock / erc721 / tokenURI', (accounts) => {
         baseTokenURI,
         `https://globalBaseTokenURI.com/api/key/${lowerCaseAddress}` + '/'
       )
-      uri = await lock.tokenURI.call(1)
+      uri = await lock.tokenURI(1)
       assert.equal(
         uri,
         `https://globalBaseTokenURI.com/api/key/${lowerCaseAddress}` + '/1'

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -151,7 +151,7 @@ contract('Lock / erc721 / transferFrom', (accounts) => {
           from: accountApproved,
         })
         assert.equal(await locks.FIRST.ownerOf(tokenIds[0]), accounts[9])
-        assert.equal(await locks.FIRST.balanceOf.call(accounts[9]), 1)
+        assert.equal(await locks.FIRST.balanceOf(accounts[9]), 1)
       })
 
       it('approval should be cleared after a transfer', async () => {
@@ -243,10 +243,7 @@ contract('Lock / erc721 / transferFrom', (accounts) => {
         )
 
         // check ownership
-        assert.equal(
-          await locks['SINGLE KEY'].ownerOf.call(tokenId),
-          keyOwners[0]
-        )
+        assert.equal(await locks['SINGLE KEY'].ownerOf(tokenId), keyOwners[0])
 
         // transfer
         await locks['SINGLE KEY'].transferFrom(
@@ -258,10 +255,7 @@ contract('Lock / erc721 / transferFrom', (accounts) => {
           }
         )
 
-        assert.equal(
-          await locks['SINGLE KEY'].ownerOf.call(tokenId),
-          accounts[9]
-        )
+        assert.equal(await locks['SINGLE KEY'].ownerOf(tokenId), accounts[9])
       })
     })
   })

--- a/smart-contracts/test/Lock/expireAndRefundFor.js
+++ b/smart-contracts/test/Lock/expireAndRefundFor.js
@@ -69,7 +69,7 @@ contract('Lock / expireAndRefundFor', (accounts) => {
     })
 
     it('should make the key no longer valid (i.e. expired)', async () => {
-      const isValid = await lock.getHasValidKey.call(keyOwners[0])
+      const isValid = await lock.getHasValidKey(keyOwners[0])
       assert.equal(isValid, false)
     })
 
@@ -119,7 +119,7 @@ contract('Lock / expireAndRefundFor', (accounts) => {
     })
 
     it('the Lock owner withdraws too much funds', async () => {
-      await lock.withdraw(await lock.tokenAddress.call(), 0, {
+      await lock.withdraw(await lock.tokenAddress(), 0, {
         from: lockCreator,
       })
       await reverts(

--- a/smart-contracts/test/Lock/extend.js
+++ b/smart-contracts/test/Lock/extend.js
@@ -92,7 +92,7 @@ contract('Lock / extend keys', (accounts) => {
         describe('extend a valid key', () => {
           let tx
           beforeEach(async () => {
-            assert.equal(await lock.isValidKey.call(tokenId), true)
+            assert.equal(await lock.isValidKey(tokenId), true)
             tsBefore = await lock.keyExpirationTimestampFor(tokenId)
 
             // extend
@@ -109,7 +109,7 @@ contract('Lock / extend keys', (accounts) => {
           })
 
           it('key should stay valid', async () => {
-            assert.equal(await lock.isValidKey.call(tokenId), true)
+            assert.equal(await lock.isValidKey(tokenId), true)
           })
 
           it('duration has been extended accordingly', async () => {
@@ -135,7 +135,7 @@ contract('Lock / extend keys', (accounts) => {
             await lock.expireAndRefundFor(tokenId, 0, {
               from: lockOwner,
             })
-            assert.equal(await lock.isValidKey.call(tokenId), false)
+            assert.equal(await lock.isValidKey(tokenId), false)
 
             // extend
             await lock.extend(
@@ -151,7 +151,7 @@ contract('Lock / extend keys', (accounts) => {
           })
 
           it('key should stay valid', async () => {
-            assert.equal(await lock.isValidKey.call(tokenId), true)
+            assert.equal(await lock.isValidKey(tokenId), true)
           })
 
           it('duration has been extended accordingly', async () => {
@@ -217,7 +217,7 @@ contract('Lock / extend keys', (accounts) => {
           await nonExpiringLock.expireAndRefundFor(tokenId, 0, {
             from: lockOwner,
           })
-          assert.equal(await nonExpiringLock.isValidKey.call(tokenId), false)
+          assert.equal(await nonExpiringLock.isValidKey(tokenId), false)
 
           // extend
           await nonExpiringLock.extend(
@@ -231,7 +231,7 @@ contract('Lock / extend keys', (accounts) => {
             }
           )
 
-          assert.equal(await nonExpiringLock.isValidKey.call(tokenId), true)
+          assert.equal(await nonExpiringLock.isValidKey(tokenId), true)
 
           it('duration has been extended accordingly', async () => {
             assert.equal(

--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -37,7 +37,7 @@ contract('Lock / freeTrial', (accounts) => {
   })
 
   it('No free trial by default', async () => {
-    const freeTrialLength = new BigNumber(await lock.freeTrialLength.call())
+    const freeTrialLength = new BigNumber(await lock.freeTrialLength())
     assert.equal(freeTrialLength.toFixed(), 0)
   })
 

--- a/smart-contracts/test/Lock/getHasValidKey.js
+++ b/smart-contracts/test/Lock/getHasValidKey.js
@@ -21,7 +21,7 @@ contract('Lock / getHasValidKey', (accounts) => {
   })
 
   it('should be false before purchasing a key', async () => {
-    const isValid = await lock.getHasValidKey.call(keyOwner)
+    const isValid = await lock.getHasValidKey(keyOwner)
     assert.equal(isValid, false)
   })
 
@@ -45,7 +45,7 @@ contract('Lock / getHasValidKey', (accounts) => {
 
     it('should be true', async () => {
       assert.equal((await lock.balanceOf(keyOwner)).toNumber(), 1)
-      const isValid = await lock.getHasValidKey.call(keyOwner)
+      const isValid = await lock.getHasValidKey(keyOwner)
       assert.equal(isValid, true)
     })
 
@@ -57,7 +57,7 @@ contract('Lock / getHasValidKey', (accounts) => {
       })
 
       it('should be false', async () => {
-        const isValid = await lock.getHasValidKey.call(keyOwner)
+        const isValid = await lock.getHasValidKey(keyOwner)
         assert.equal(isValid, false)
       })
     })
@@ -85,7 +85,7 @@ contract('Lock / getHasValidKey', (accounts) => {
     })
 
     it('should be true', async () => {
-      const isValid = await lock.getHasValidKey.call(keyOwner)
+      const isValid = await lock.getHasValidKey(keyOwner)
       assert.equal(isValid, true)
     })
 
@@ -97,9 +97,9 @@ contract('Lock / getHasValidKey', (accounts) => {
       })
 
       it('should still be true', async () => {
-        const isValid = await lock.getHasValidKey.call(keyOwner)
+        const isValid = await lock.getHasValidKey(keyOwner)
         assert.equal(isValid, true)
-        assert.equal(await lock.getHasValidKey.call(accounts[5]), true)
+        assert.equal(await lock.getHasValidKey(accounts[5]), true)
       })
     })
 
@@ -111,7 +111,7 @@ contract('Lock / getHasValidKey', (accounts) => {
       })
 
       it('should be true', async () => {
-        const isValid = await lock.getHasValidKey.call(keyOwner)
+        const isValid = await lock.getHasValidKey(keyOwner)
         assert.equal(isValid, true)
       })
     })
@@ -130,7 +130,7 @@ contract('Lock / getHasValidKey', (accounts) => {
       it('should be false', async () => {
         assert.equal((await lock.balanceOf(keyOwner)).toNumber(), 0)
         assert.equal((await lock.balanceOf(accounts[5])).toNumber(), 3)
-        const isValid = await lock.getHasValidKey.call(keyOwner)
+        const isValid = await lock.getHasValidKey(keyOwner)
         assert.equal(isValid, false)
       })
     })

--- a/smart-contracts/test/Lock/grantKeyExtension.js
+++ b/smart-contracts/test/Lock/grantKeyExtension.js
@@ -45,7 +45,7 @@ contract('Lock / grantKeyExtension', (accounts) => {
     let tx
     let tsBefore
     before(async () => {
-      assert.equal(await lock.isValidKey.call(tokenId), true)
+      assert.equal(await lock.isValidKey(tokenId), true)
       tsBefore = await lock.keyExpirationTimestampFor(tokenId)
       // extend
       tx = await lock.grantKeyExtension(tokenId, {
@@ -54,7 +54,7 @@ contract('Lock / grantKeyExtension', (accounts) => {
     })
 
     it('key should stay valid', async () => {
-      assert.equal(await lock.isValidKey.call(tokenId), true)
+      assert.equal(await lock.isValidKey(tokenId), true)
     })
 
     it('duration has been extended accordingly', async () => {
@@ -80,7 +80,7 @@ contract('Lock / grantKeyExtension', (accounts) => {
       await lock.expireAndRefundFor(tokenId, 0, {
         from: lockCreator,
       })
-      assert.equal(await lock.isValidKey.call(tokenId), false)
+      assert.equal(await lock.isValidKey(tokenId), false)
 
       // extend
       tx = await lock.grantKeyExtension(tokenId, {
@@ -89,7 +89,7 @@ contract('Lock / grantKeyExtension', (accounts) => {
     })
 
     it('key should stay valid', async () => {
-      assert.equal(await lock.isValidKey.call(tokenId), true)
+      assert.equal(await lock.isValidKey(tokenId), true)
     })
 
     it('duration has been extended accordingly', async () => {

--- a/smart-contracts/test/Lock/grantKeys.js
+++ b/smart-contracts/test/Lock/grantKeys.js
@@ -50,11 +50,11 @@ contract('Lock / grantKeys', (accounts) => {
       })
 
       it('should acknowledge that user owns key', async () => {
-        assert.equal(await lock.ownerOf.call(evt.args.tokenId), keyOwner)
+        assert.equal(await lock.ownerOf(evt.args.tokenId), keyOwner)
       })
 
       it('getHasValidKey is true', async () => {
-        assert.equal(await lock.getHasValidKey.call(keyOwner), true)
+        assert.equal(await lock.getHasValidKey(keyOwner), true)
       })
     })
 
@@ -93,13 +93,13 @@ contract('Lock / grantKeys', (accounts) => {
 
       it('should acknowledge that user owns key', async () => {
         for (let i = 0; i < keyOwnerList.length; i++) {
-          assert.equal(await lock.balanceOf.call(keyOwnerList[i]), 1)
+          assert.equal(await lock.balanceOf(keyOwnerList[i]), 1)
         }
       })
 
       it('getHasValidKey is true', async () => {
         for (let i = 0; i < keyOwnerList.length; i++) {
-          assert.equal(await lock.getHasValidKey.call(keyOwnerList[i]), true)
+          assert.equal(await lock.getHasValidKey(keyOwnerList[i]), true)
         }
       })
     })

--- a/smart-contracts/test/Lock/isValidKey.js
+++ b/smart-contracts/test/Lock/isValidKey.js
@@ -38,27 +38,27 @@ contract('Lock / isValidKey', (accounts) => {
   })
 
   it('should be true after purchase', async () => {
-    assert.equal(await lock.isValidKey.call(tokenId), true)
+    assert.equal(await lock.isValidKey(tokenId), true)
   })
 
   it('should still be true after transfering', async () => {
     await lock.transferFrom(keyOwner, accounts[5], tokenId, {
       from: keyOwner,
     })
-    assert.equal(await lock.isValidKey.call(tokenId), true)
+    assert.equal(await lock.isValidKey(tokenId), true)
   })
 
   it('should be false after expiring', async () => {
     await lock.expireAndRefundFor(tokenId, 0, {
       from: accounts[0],
     })
-    assert.equal(await lock.isValidKey.call(tokenId), false)
+    assert.equal(await lock.isValidKey(tokenId), false)
   })
 
   it('should be false after cancelling', async () => {
     await lock.cancelAndRefund(tokenId, {
       from: keyOwner,
     })
-    assert.equal(await lock.isValidKey.call(tokenId), false)
+    assert.equal(await lock.isValidKey(tokenId), false)
   })
 })

--- a/smart-contracts/test/Lock/mergeKeys.js
+++ b/smart-contracts/test/Lock/mergeKeys.js
@@ -59,8 +59,8 @@ contract('Lock / mergeKeys', (accounts) => {
         ).toString()
       )
 
-      assert.equal(await lock.getHasValidKey.call(keyOwner2), true)
-      assert.equal(await lock.getHasValidKey.call(keyOwner), true)
+      assert.equal(await lock.getHasValidKey(keyOwner2), true)
+      assert.equal(await lock.getHasValidKey(keyOwner), true)
     })
     it('should allow key manager to call', async () => {
       const expTs = [
@@ -92,8 +92,8 @@ contract('Lock / mergeKeys', (accounts) => {
         ).toString()
       )
 
-      assert.equal(await lock.getHasValidKey.call(keyOwner2), true)
-      assert.equal(await lock.getHasValidKey.call(keyOwner), true)
+      assert.equal(await lock.getHasValidKey(keyOwner2), true)
+      assert.equal(await lock.getHasValidKey(keyOwner), true)
     })
   })
 
@@ -125,10 +125,10 @@ contract('Lock / mergeKeys', (accounts) => {
         ).toString()
       )
 
-      assert.equal(await lock.isValidKey.call(tokenIds[0]), false)
-      assert.equal(await lock.isValidKey.call(tokenIds[1]), true)
-      assert.equal(await lock.getHasValidKey.call(keyOwner2), true)
-      assert.equal(await lock.getHasValidKey.call(keyOwner), false)
+      assert.equal(await lock.isValidKey(tokenIds[0]), false)
+      assert.equal(await lock.isValidKey(tokenIds[1]), true)
+      assert.equal(await lock.getHasValidKey(keyOwner2), true)
+      assert.equal(await lock.getHasValidKey(keyOwner), false)
     })
   })
   describe('failures', () => {

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -40,12 +40,12 @@ contract('Lock / owners', (accounts) => {
   })
 
   it('should have the right number of keys', async () => {
-    const totalSupply = new BigNumber(await lock.totalSupply.call())
+    const totalSupply = new BigNumber(await lock.totalSupply())
     assert.equal(totalSupply.toFixed(), keyOwners.length)
   })
 
   it('should have the right number of owners', async () => {
-    const numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
+    const numberOfOwners = new BigNumber(await lock.numberOfOwners())
     assert.equal(numberOfOwners.toFixed(), keyOwners.length)
   })
 
@@ -53,21 +53,21 @@ contract('Lock / owners', (accounts) => {
     let numberOfOwners
 
     before(async () => {
-      numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
+      numberOfOwners = new BigNumber(await lock.numberOfOwners())
       await lock.transferFrom(keyOwners[0], accounts[8], tokenIds[0], {
         from: keyOwners[0],
       })
     })
 
     it('should have the right number of keys', async () => {
-      const totalSupply = new BigNumber(await lock.totalSupply.call())
+      const totalSupply = new BigNumber(await lock.totalSupply())
       assert.equal(totalSupply.toFixed(), tokenIds.length)
     })
 
     it('should have the right number of owners', async () => {
-      assert.equal(await lock.balanceOf.call(accounts[8]), 1)
-      assert.equal(await lock.balanceOf.call(keyOwners[0]), 0)
-      const _numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
+      assert.equal(await lock.balanceOf(accounts[8]), 1)
+      assert.equal(await lock.balanceOf(keyOwners[0]), 0)
+      const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
       assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed())
     })
   })
@@ -76,23 +76,23 @@ contract('Lock / owners', (accounts) => {
     let numberOfOwners
 
     before(async () => {
-      numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
+      numberOfOwners = new BigNumber(await lock.numberOfOwners())
 
       // both have tokens
-      assert.equal(await lock.balanceOf.call(keyOwners[1]), 1)
-      assert.equal(await lock.balanceOf.call(keyOwners[2]), 1)
+      assert.equal(await lock.balanceOf(keyOwners[1]), 1)
+      assert.equal(await lock.balanceOf(keyOwners[2]), 1)
       await lock.transferFrom(keyOwners[1], keyOwners[2], tokenIds[1], {
         from: keyOwners[1],
       })
     })
 
     it('should have the right number of keys', async () => {
-      const totalSupply = new BigNumber(await lock.totalSupply.call())
+      const totalSupply = new BigNumber(await lock.totalSupply())
       assert.equal(totalSupply.toFixed(), tokenIds.length)
     })
 
     it('should have the right number of owners', async () => {
-      const _numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
+      const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
       assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed() - 1)
     })
   })
@@ -101,26 +101,26 @@ contract('Lock / owners', (accounts) => {
   describe('after a transfer to a existing owner, buying a key again for someone who already owned one', () => {
     it('should preserve the right number of owners', async () => {
       // initial state
-      const numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
-      const totalSupplyBefore = new BigNumber(await lock.totalSupply.call())
+      const numberOfOwners = new BigNumber(await lock.numberOfOwners())
+      const totalSupplyBefore = new BigNumber(await lock.totalSupply())
 
       // transfer the key to an existing owner
-      assert.equal(await lock.balanceOf.call(keyOwners[4]), 1)
+      assert.equal(await lock.balanceOf(keyOwners[4]), 1)
       await lock.transferFrom(keyOwners[3], keyOwners[4], tokenIds[3], {
         from: keyOwners[3],
       })
-      assert.equal(await lock.ownerOf.call(tokenIds[3]), keyOwners[4])
-      assert.equal(await lock.balanceOf.call(keyOwners[4]), 2)
-      assert.equal(await lock.balanceOf.call(keyOwners[3]), 0)
+      assert.equal(await lock.ownerOf(tokenIds[3]), keyOwners[4])
+      assert.equal(await lock.balanceOf(keyOwners[4]), 2)
+      assert.equal(await lock.balanceOf(keyOwners[3]), 0)
 
       // supply unchanged
-      const totalSupplyAfter = new BigNumber(await lock.totalSupply.call())
+      const totalSupplyAfter = new BigNumber(await lock.totalSupply())
       assert.equal(totalSupplyBefore.toFixed(), totalSupplyAfter.toFixed())
 
       // number of owners changed
       assert.equal(
         (numberOfOwners - 1).toFixed(),
-        new BigNumber(await lock.numberOfOwners.call()).toFixed()
+        new BigNumber(await lock.numberOfOwners()).toFixed()
       )
 
       // someone buys a key again for the previous owner
@@ -137,7 +137,7 @@ contract('Lock / owners', (accounts) => {
       )
 
       // number of owners should be left unchanged
-      const _numberOfOwners = new BigNumber(await lock.numberOfOwners.call())
+      const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
       assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed())
     })
   })

--- a/smart-contracts/test/Lock/permissions/beneficiary.js
+++ b/smart-contracts/test/Lock/permissions/beneficiary.js
@@ -25,21 +25,21 @@ contract('Permissions / Beneficiary', (accounts) => {
 
   describe('default permissions on a new lock', () => {
     it('should make the lock creator the beneficiary as well', async () => {
-      const defaultBeneficiary = await lock.beneficiary.call()
+      const defaultBeneficiary = await lock.beneficiary()
       assert.equal(defaultBeneficiary, lockCreator)
     })
   })
   describe('modifying permissions on an existing lock', () => {
     it('should allow a lockManager to update the beneficiary', async () => {
       await lock.updateBeneficiary(newBeneficiary, { from: lockCreator })
-      currentBeneficiary = await lock.beneficiary.call()
+      currentBeneficiary = await lock.beneficiary()
       assert.equal(currentBeneficiary, newBeneficiary)
     })
 
     it('should allow Beneficiary to update the beneficiary', async () => {
-      currentBeneficiary = await lock.beneficiary.call()
+      currentBeneficiary = await lock.beneficiary()
       await lock.updateBeneficiary(accounts[8], { from: currentBeneficiary })
-      currentBeneficiary = await lock.beneficiary.call()
+      currentBeneficiary = await lock.beneficiary()
       assert.equal(currentBeneficiary, accounts[8])
     })
 

--- a/smart-contracts/test/Lock/permissions/isKeyManager.js
+++ b/smart-contracts/test/Lock/permissions/isKeyManager.js
@@ -32,32 +32,20 @@ contract('Permissions / isKeyManager', (accounts) => {
     let isKeyManager
 
     it('should return true if address is the KM', async () => {
-      isKeyManager = await keyManagerMock.isKeyManager.call(
-        tokenId,
-        accounts[1],
-        {
-          from: accounts[1],
-        }
-      )
+      isKeyManager = await keyManagerMock.isKeyManager(tokenId, accounts[1], {
+        from: accounts[1],
+      })
       assert.equal(isKeyManager, true)
       // it shouldn't matter who is calling
-      isKeyManager = await keyManagerMock.isKeyManager.call(
-        tokenId,
-        accounts[1],
-        {
-          from: accounts[5],
-        }
-      )
+      isKeyManager = await keyManagerMock.isKeyManager(tokenId, accounts[1], {
+        from: accounts[5],
+      })
       assert.equal(isKeyManager, true)
     })
     it('should return false if address is not the KM', async () => {
-      isKeyManager = await keyManagerMock.isKeyManager.call(
-        tokenId,
-        accounts[9],
-        {
-          from: accounts[1],
-        }
-      )
+      isKeyManager = await keyManagerMock.isKeyManager(tokenId, accounts[9], {
+        from: accounts[1],
+      })
       assert.equal(isKeyManager, false)
     })
   })

--- a/smart-contracts/test/Lock/permissions/keyGranter.js
+++ b/smart-contracts/test/Lock/permissions/keyGranter.js
@@ -25,22 +25,22 @@ contract('Permissions / KeyGranter', (accounts) => {
 
   describe('default permissions on a new lock', () => {
     it('should add the lock creator to the keyGranter role', async () => {
-      let result = await lock.isKeyGranter.call(lockCreator)
+      let result = await lock.isKeyGranter(lockCreator)
       assert.equal(result, true)
     })
   })
   describe('modifying permissions on an existing lock', () => {
     // lock creator is also added to the LockManager role by default
     it('should allow a lockManager to add a KeyGranter', async () => {
-      result = await lock.isLockManager.call(lockCreator)
+      result = await lock.isLockManager(lockCreator)
       assert.equal(result, true)
       await lock.addKeyGranter(newKeyGranter, { from: lockCreator })
-      result = await lock.isKeyGranter.call(newKeyGranter)
+      result = await lock.isKeyGranter(newKeyGranter)
       assert.equal(result, true)
     })
 
     it('should not allow anyone else to add a KeyGranter', async () => {
-      result = await lock.isLockManager.call(notAuthorized)
+      result = await lock.isLockManager(notAuthorized)
       assert.equal(result, false)
       await reverts(
         lock.addKeyGranter(accounts[5], { from: notAuthorized }),
@@ -54,7 +54,7 @@ contract('Permissions / KeyGranter', (accounts) => {
         'ONLY_LOCK_MANAGER'
       )
       await lock.revokeKeyGranter(newKeyGranter, { from: lockCreator })
-      result = await lock.isKeyGranter.call(newKeyGranter)
+      result = await lock.isKeyGranter(newKeyGranter)
       assert.equal(result, false)
     })
   })

--- a/smart-contracts/test/Lock/permissions/keyManager.js
+++ b/smart-contracts/test/Lock/permissions/keyManager.js
@@ -53,7 +53,7 @@ contract('Permissions / KeyManager', (accounts) => {
 
   describe('Key Purchases', () => {
     it('should leave the KM == 0x00(default) for new purchases', async () => {
-      const keyManager = await lock.keyManagerOf.call(tokenIds[0])
+      const keyManager = await lock.keyManagerOf(tokenIds[0])
       assert.equal(keyManager, ADDRESS_ZERO)
     })
 
@@ -70,7 +70,7 @@ contract('Permissions / KeyManager', (accounts) => {
         }
       )
       const { args } = tx.logs.find((v) => v.event === 'Transfer')
-      const newKeyManager = await lock.keyManagerOf.call(args.tokenId)
+      const newKeyManager = await lock.keyManagerOf(args.tokenId)
       assert.equal(newKeyManager, accounts[8])
     })
   })
@@ -93,23 +93,23 @@ contract('Permissions / KeyManager', (accounts) => {
       tokenId = args.tokenId
     })
     it('should reset key manager when specified', async () => {
-      assert.equal(await lock.keyManagerOf.call(tokenId), ADDRESS_ZERO)
-      assert.equal(await lock.isValidKey.call(tokenId), true)
+      assert.equal(await lock.keyManagerOf(tokenId), ADDRESS_ZERO)
+      assert.equal(await lock.isValidKey(tokenId), true)
       await lock.extend(0, tokenId, accounts[8], [], {
         value: keyPrice.toFixed(),
         from: keyOwner1,
       })
-      assert.equal(await lock.keyManagerOf.call(tokenId), ADDRESS_ZERO)
+      assert.equal(await lock.keyManagerOf(tokenId), ADDRESS_ZERO)
     })
 
     it('should left untouched when not specified', async () => {
       await lock.setKeyManagerOf(tokenId, accounts[9], { from: keyOwner1 })
-      assert.equal(await lock.keyManagerOf.call(tokenId), accounts[9])
+      assert.equal(await lock.keyManagerOf(tokenId), accounts[9])
       await lock.extend(0, tokenId, ADDRESS_ZERO, [], {
         value: keyPrice.toFixed(),
         from: keyOwner1,
       })
-      assert.equal(await lock.keyManagerOf.call(tokenId), accounts[9])
+      assert.equal(await lock.keyManagerOf(tokenId), accounts[9])
     })
   })
 
@@ -141,7 +141,7 @@ contract('Permissions / KeyManager', (accounts) => {
         from: keyOwner1,
       })
       const { args } = tx.logs.find((v) => v.event === 'Transfer')
-      keyManager = await lock.keyManagerOf.call(args.tokenId)
+      keyManager = await lock.keyManagerOf(args.tokenId)
       assert.equal(keyManager, ADDRESS_ZERO)
     })
   })
@@ -160,40 +160,40 @@ contract('Permissions / KeyManager', (accounts) => {
     })
 
     it('should leave the KM == 0x00(default) for new recipients', async () => {
-      const newKeyManager = await lock.keyManagerOf.call(newTokenId)
+      const newKeyManager = await lock.keyManagerOf(newTokenId)
       assert.equal(newKeyManager, ADDRESS_ZERO)
     })
 
     /*
     it('should not change KM for existing valid key owners', async () => {
-      keyManagerBefore = await lock.keyManagerOf.call(tokenId)
+      keyManagerBefore = await lock.keyManagerOf(tokenId)
       await lock.shareKey(keyOwner2, tokenId, oneDay, {
         from: keyOwner1,
       })
       tokenId = await lock.getTokenIdFor(keyOwner2)
-      keyManager = await lock.keyManagerOf.call(tokenId)
+      keyManager = await lock.keyManagerOf(tokenId)
       assert.equal(keyManagerBefore, keyManager)
     })
 
     it('should reset the KM to 0x00 for expired key owners', async () => {
-      tokenId = await lock.getTokenIdFor.call(keyOwner1)
+      tokenId = await lock.getTokenIdFor(keyOwner1)
       assert.notEqual(tokenId, 0)
-      let keyManager = await lock.keyManagerOf.call(tokenId)
+      let keyManager = await lock.keyManagerOf(tokenId)
       assert.equal(keyManager, ADDRESS_ZERO)
-      const owner = await lock.ownerOf.call(tokenId)
+      const owner = await lock.ownerOf(tokenId)
       assert.equal(owner, keyOwner1)
       await lock.setKeyManagerOf(tokenId, accounts[9], { from: keyOwner1 })
-      keyManager = await lock.keyManagerOf.call(tokenId)
+      keyManager = await lock.keyManagerOf(tokenId)
       assert.equal(keyManager, accounts[9])
       await lock.expireAndRefundFor(keyOwner1, 0, { from: lockCreator })
-      assert.equal(await lock.getHasValidKey.call(keyOwner1), false)
+      assert.equal(await lock.getHasValidKey(keyOwner1), false)
       tokenId = await lock.getTokenIdFor(keyOwner2)
       await lock.shareKey(keyOwner1, tokenId, oneDay, {
         from: keyOwner2,
       })
       tokenId = await lock.getTokenIdFor(keyOwner1)
-      keyManager = await lock.keyManagerOf.call(tokenId)
-      assert.equal(await lock.getHasValidKey.call(keyOwner1), true)
+      keyManager = await lock.keyManagerOf(tokenId)
+      assert.equal(await lock.getHasValidKey(keyOwner1), true)
       assert.equal(keyManager, ADDRESS_ZERO)
     })
     */
@@ -210,22 +210,22 @@ contract('Permissions / KeyManager', (accounts) => {
         }
       )
       const { args } = tx.logs.find((v) => v.event === 'Transfer')
-      assert.equal(await lock.keyManagerOf.call(args.tokenId), accounts[8])
+      assert.equal(await lock.keyManagerOf(args.tokenId), accounts[8])
     })
   })
 
   describe('configuring the key manager', () => {
     it('should allow the current keyManager to set a new KM', async () => {
-      assert.equal(await lock.keyManagerOf.call(tokenIds[0]), ADDRESS_ZERO)
+      assert.equal(await lock.keyManagerOf(tokenIds[0]), ADDRESS_ZERO)
       await lock.setKeyManagerOf(tokenIds[0], accounts[9], { from: keyOwner1 })
-      assert.equal(await lock.keyManagerOf.call(tokenIds[0]), accounts[9])
+      assert.equal(await lock.keyManagerOf(tokenIds[0]), accounts[9])
     })
 
     it('should allow a LockManager to set a new KM', async () => {
       await lock.setKeyManagerOf(tokenIds[1], accounts[7], {
         from: lockManager,
       })
-      assert.equal(await lock.keyManagerOf.call(tokenIds[1]), accounts[7])
+      assert.equal(await lock.keyManagerOf(tokenIds[1]), accounts[7])
     })
 
     it('should fail to allow anyone else to set a new KM', async () => {

--- a/smart-contracts/test/Lock/permissions/setKeyManager.js
+++ b/smart-contracts/test/Lock/permissions/setKeyManager.js
@@ -44,7 +44,7 @@ contract('Permissions / KeyManager', (accounts) => {
 
   describe('setting the key manager', () => {
     it('should have a default KM of 0x00', async () => {
-      keyManagerBefore = await lock.keyManagerOf.call(tokenId)
+      keyManagerBefore = await lock.keyManagerOf(tokenId)
       assert.equal(keyManagerBefore, ADDRESS_ZERO)
     })
 
@@ -54,23 +54,23 @@ contract('Permissions / KeyManager', (accounts) => {
       await lock.setKeyManagerOf(tokenId, accounts[9], {
         from: defaultKeyManager,
       })
-      keyManager = await lock.keyManagerOf.call(tokenId)
+      keyManager = await lock.keyManagerOf(tokenId)
       assert.equal(keyManager, accounts[9])
     })
 
     it('should allow the current keyManager to set a new KM', async () => {
-      keyManagerBefore = await lock.keyManagerOf.call(tokenId)
+      keyManagerBefore = await lock.keyManagerOf(tokenId)
       await lock.setKeyManagerOf(tokenId, accounts[3], {
         from: keyManagerBefore,
       })
-      keyManager = await lock.keyManagerOf.call(tokenId)
+      keyManager = await lock.keyManagerOf(tokenId)
       assert.equal(keyManager, accounts[3])
     })
 
     it('should allow a LockManager to set a new KM', async () => {
-      keyManagerBefore = await lock.keyManagerOf.call(tokenId)
+      keyManagerBefore = await lock.keyManagerOf(tokenId)
       await lock.setKeyManagerOf(tokenId, accounts[5], { from: lockManager })
-      keyManager = await lock.keyManagerOf.call(tokenId)
+      keyManager = await lock.keyManagerOf(tokenId)
       assert.notEqual(keyManagerBefore, keyManager)
       assert.equal(keyManager, accounts[5])
     })
@@ -89,15 +89,15 @@ contract('Permissions / KeyManager', (accounts) => {
     })
     describe('setting the KM to 0x00', () => {
       before(async () => {
-        keyManager = await lock.keyManagerOf.call(tokenId)
+        keyManager = await lock.keyManagerOf(tokenId)
         await lock.setKeyManagerOf(tokenId, accounts[9], { from: keyManager })
-        keyManager = await lock.keyManagerOf.call(tokenId)
+        keyManager = await lock.keyManagerOf(tokenId)
         assert.equal(keyManager, accounts[9])
         await lock.setKeyManagerOf(tokenId, ADDRESS_ZERO)
       })
 
       it('should reset to the default KeyManager of 0x00', async () => {
-        keyManager = await lock.keyManagerOf.call(tokenId)
+        keyManager = await lock.keyManagerOf(tokenId)
         assert.equal(keyManager, ADDRESS_ZERO)
       })
     })

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -34,10 +34,7 @@ contract('Lock / purchaseFor', (accounts) => {
         'INSUFFICIENT_VALUE'
       )
       // Making sure we do not have a key set!
-      assert.equal(
-        await locks.FIRST.keyExpirationTimestampFor.call(accounts[0]),
-        0
-      )
+      assert.equal(await locks.FIRST.keyExpirationTimestampFor(accounts[0]), 0)
     })
 
     it('should fail if we reached the max number of keys', async () => {
@@ -159,8 +156,8 @@ contract('Lock / purchaseFor', (accounts) => {
 
       beforeEach(async () => {
         balance = new BigNumber(await web3.eth.getBalance(locks.FIRST.address))
-        totalSupply = new BigNumber(await locks.FIRST.totalSupply.call())
-        numberOfOwners = new BigNumber(await locks.FIRST.numberOfOwners.call())
+        totalSupply = new BigNumber(await locks.FIRST.totalSupply())
+        numberOfOwners = new BigNumber(await locks.FIRST.numberOfOwners())
         const newKeyTx = await locks.FIRST.purchase(
           [],
           [accounts[0]],
@@ -181,10 +178,10 @@ contract('Lock / purchaseFor', (accounts) => {
 
       it('should have the right expiration timestamp for the key', async () => {
         const expirationTimestamp = new BigNumber(
-          await locks.FIRST.keyExpirationTimestampFor.call(tokenId)
+          await locks.FIRST.keyExpirationTimestampFor(tokenId)
         )
         const expirationDuration = new BigNumber(
-          await locks.FIRST.expirationDuration.call()
+          await locks.FIRST.expirationDuration()
         )
         assert(expirationTimestamp.gte(expirationDuration.plus(now)))
       })
@@ -200,13 +197,13 @@ contract('Lock / purchaseFor', (accounts) => {
       })
 
       it('should have increased the number of outstanding keys', async () => {
-        const _totalSupply = new BigNumber(await locks.FIRST.totalSupply.call())
+        const _totalSupply = new BigNumber(await locks.FIRST.totalSupply())
         assert.equal(_totalSupply.toFixed(), totalSupply.plus(1).toFixed())
       })
 
       it('should have increased the number of owners', async () => {
         const _numberOfOwners = new BigNumber(
-          await locks.FIRST.numberOfOwners.call()
+          await locks.FIRST.numberOfOwners()
         )
         assert.equal(
           _numberOfOwners.toFixed(),

--- a/smart-contracts/test/Lock/purchaseMultiple.js
+++ b/smart-contracts/test/Lock/purchaseMultiple.js
@@ -69,7 +69,7 @@ contract('Lock / purchase multiple keys at once', (accounts) => {
 
         it('users should have valid keys', async () => {
           const areValid = await Promise.all(
-            keyOwners.map((account) => lock.getHasValidKey.call(account))
+            keyOwners.map((account) => lock.getHasValidKey(account))
           )
           areValid.forEach((isValid) => assert.equal(isValid, true))
         })

--- a/smart-contracts/test/Lock/renewMembershipFor.js
+++ b/smart-contracts/test/Lock/renewMembershipFor.js
@@ -311,8 +311,8 @@ contract('Lock / Recurring memberships', (accounts) => {
         )
 
         // key expired
-        assert.equal(await lock.getHasValidKey.call(keyOwner), false)
-        assert.equal(await lock.isValidKey.call(tokenId), false)
+        assert.equal(await lock.getHasValidKey(keyOwner), false)
+        assert.equal(await lock.isValidKey(tokenId), false)
 
         // ERC20 allowance has not been cancelled
         assert.equal(

--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -36,26 +36,26 @@ contract('Lock / timeMachine', (accounts) => {
 
   describe('modifying the time remaining for a key', () => {
     it('should reduce the time by the amount specified', async () => {
-      assert.equal(await timeMachine.isValidKey.call(tokenId), true)
+      assert.equal(await timeMachine.isValidKey(tokenId), true)
       await timeMachine.timeMachine(tokenId, 1000, false, {
         from: accounts[0],
       }) // decrease the time with "false"
 
       timestampAfter = new BigNumber(
-        await timeMachine.keyExpirationTimestampFor.call(tokenId)
+        await timeMachine.keyExpirationTimestampFor(tokenId)
       )
       assert(timestampAfter.eq(timestampBefore.minus(1000)))
     })
 
     it('should increase the time by the amount specified if the key is not expired', async () => {
       timestampBefore = new BigNumber(
-        await timeMachine.keyExpirationTimestampFor.call(tokenId)
+        await timeMachine.keyExpirationTimestampFor(tokenId)
       )
       await timeMachine.timeMachine(tokenId, 42, true, {
         from: accounts[0],
       }) // increase the time with "true"
       timestampAfter = new BigNumber(
-        await timeMachine.keyExpirationTimestampFor.call(tokenId)
+        await timeMachine.keyExpirationTimestampFor(tokenId)
       )
       assert(timestampAfter.eq(timestampBefore.plus(42)))
     })
@@ -76,7 +76,7 @@ contract('Lock / timeMachine', (accounts) => {
       )
 
       timestampAfter = new BigNumber(
-        await timeMachine.keyExpirationTimestampFor.call(tokenId)
+        await timeMachine.keyExpirationTimestampFor(tokenId)
       )
       assert(timestampAfter.eq(new BigNumber(now).plus(expirationDuration)))
     })

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -41,7 +41,7 @@ contract('Lock / transferFee', (accounts) => {
   })
 
   it('has a default fee of 0%', async () => {
-    const feeNumerator = new BigNumber(await lock.transferFeeBasisPoints.call())
+    const feeNumerator = new BigNumber(await lock.transferFeeBasisPoints())
     assert.equal(feeNumerator.div(denominator).toFixed(), 0.0)
   })
 
@@ -64,7 +64,7 @@ contract('Lock / transferFee', (accounts) => {
 
     it('estimates the transfer fee, which is 5% of remaining duration or less', async () => {
       const nowBefore = (await web3.eth.getBlock('latest')).timestamp
-      fee = new BigNumber(await lock.getTransferFee.call(tokenId, 0))
+      fee = new BigNumber(await lock.getTransferFee(tokenId, 0))
       // Mine a transaction in order to ensure the block.timestamp has updated
       await lock.purchase(
         [],
@@ -78,7 +78,7 @@ contract('Lock / transferFee', (accounts) => {
       )
       const nowAfter = (await web3.eth.getBlock('latest')).timestamp
       let expiration = new BigNumber(
-        await lock.keyExpirationTimestampFor.call(tokenId)
+        await lock.keyExpirationTimestampFor(tokenId)
       )
       // Fee is <= the expected fee before the call
       assert(
@@ -95,9 +95,9 @@ contract('Lock / transferFee', (accounts) => {
     })
 
     it('calculates the fee based on the time value passed in', async () => {
-      fee1 = await lock.getTransferFee.call(tokenId, 100)
-      fee2 = await lock.getTransferFee.call(tokenId, 60 * 60 * 24 * 365)
-      fee3 = await lock.getTransferFee.call(tokenId, 60 * 60 * 24 * 30)
+      fee1 = await lock.getTransferFee(tokenId, 100)
+      fee2 = await lock.getTransferFee(tokenId, 60 * 60 * 24 * 365)
+      fee3 = await lock.getTransferFee(tokenId, 60 * 60 * 24 * 30)
       assert.equal(fee1, 5)
       assert.equal(fee2, 1576800)
       assert.equal(fee3, 129600)
@@ -171,9 +171,7 @@ contract('Lock / transferFee', (accounts) => {
       })
 
       it('has an updated fee', async () => {
-        const feeNumerator = new BigNumber(
-          await lock.transferFeeBasisPoints.call()
-        )
+        const feeNumerator = new BigNumber(await lock.transferFeeBasisPoints())
         assert.equal(feeNumerator.div(denominator).toFixed(), 0.0025)
       })
 

--- a/smart-contracts/test/Lock/updateKeyPricing.js
+++ b/smart-contracts/test/Lock/updateKeyPricing.js
@@ -31,8 +31,8 @@ contract('Lock / updateKeyPricing', (accounts) => {
     unlock = await getContractInstance(unlockContract)
     locks = await deployLocks(unlock, accounts[0])
     lock = locks.FIRST
-    keyPriceBefore = new BigNumber(await lock.keyPrice.call())
-    tokenAddressBefore = await lock.tokenAddress.call()
+    keyPriceBefore = new BigNumber(await lock.keyPrice())
+    tokenAddressBefore = await lock.tokenAddress()
     assert.equal(keyPriceBefore.toFixed(), 10000000000000000)
     transaction = await lock.updateKeyPricing(
       web3.utils.toWei('0.3', 'ether'),
@@ -46,7 +46,7 @@ contract('Lock / updateKeyPricing', (accounts) => {
   })
 
   it('should change the actual keyPrice', async () => {
-    const keyPriceAfter = new BigNumber(await lock.keyPrice.call())
+    const keyPriceAfter = new BigNumber(await lock.keyPrice())
     assert.equal(keyPriceAfter.toFixed(), 300000000000000000)
   })
 
@@ -62,8 +62,8 @@ contract('Lock / updateKeyPricing', (accounts) => {
   })
 
   it('should allow changing price to 0', async () => {
-    await lock.updateKeyPricing(0, await lock.tokenAddress.call())
-    const keyPriceAfter = new BigNumber(await lock.keyPrice.call())
+    await lock.updateKeyPricing(0, await lock.tokenAddress())
+    const keyPriceAfter = new BigNumber(await lock.keyPrice())
     assert.equal(keyPriceAfter.toFixed(), 0)
   })
 
@@ -71,11 +71,11 @@ contract('Lock / updateKeyPricing', (accounts) => {
     let keyPrice
 
     before(async () => {
-      keyPrice = new BigNumber(await lock.keyPrice.call())
+      keyPrice = new BigNumber(await lock.keyPrice())
       await reverts(
         lock.updateKeyPricing(
           web3.utils.toWei('0.3', 'ether'),
-          await lock.tokenAddress.call(),
+          await lock.tokenAddress(),
           {
             from: accounts[3],
           }
@@ -85,7 +85,7 @@ contract('Lock / updateKeyPricing', (accounts) => {
     })
 
     it('should leave the price unchanged', async () => {
-      const keyPriceAfter = new BigNumber(await lock.keyPrice.call())
+      const keyPriceAfter = new BigNumber(await lock.keyPrice())
       assert.equal(keyPrice.toFixed(), keyPriceAfter.toFixed())
     })
 
@@ -105,16 +105,16 @@ contract('Lock / updateKeyPricing', (accounts) => {
     it('should allow a LockManager to switch from eth => erc20', async () => {
       assert.equal(tokenAddressBefore, 0)
       assert.equal(await lock.isLockManager(lockCreator), true)
-      await lock.updateKeyPricing(await lock.keyPrice.call(), token.address, {
+      await lock.updateKeyPricing(await lock.keyPrice(), token.address, {
         from: lockCreator,
       })
-      let tokenAddressAfter = await lock.tokenAddress.call()
+      let tokenAddressAfter = await lock.tokenAddress()
       assert.equal(tokenAddressAfter, token.address)
     })
 
     it('should allow a LockManager to switch from erc20 => eth', async () => {
-      await lock.updateKeyPricing(await lock.keyPrice.call(), ADDRESS_ZERO)
-      assert.equal(await lock.tokenAddress.call(), 0)
+      await lock.updateKeyPricing(await lock.keyPrice(), ADDRESS_ZERO)
+      assert.equal(await lock.tokenAddress(), 0)
     })
 
     it('should allow a lock manager who is not the owner to make changes', async () => {
@@ -126,11 +126,8 @@ contract('Lock / updateKeyPricing', (accounts) => {
         token.address,
         { from: accounts[8] }
       )
-      assert.equal(await lock.tokenAddress.call(), token.address)
-      assert.equal(
-        await lock.keyPrice.call(),
-        web3.utils.toWei('0.42', 'ether')
-      )
+      assert.equal(await lock.tokenAddress(), token.address)
+      assert.equal(await lock.keyPrice(), web3.utils.toWei('0.42', 'ether'))
     })
 
     it('should allow a lockManager to renounce their role', async () => {
@@ -140,7 +137,7 @@ contract('Lock / updateKeyPricing', (accounts) => {
 
     it('should revert if trying to switch to an invalid token address', async () => {
       await reverts(
-        lock.updateKeyPricing(await lock.keyPrice.call(), invalidTokenAddress, {
+        lock.updateKeyPricing(await lock.keyPrice(), invalidTokenAddress, {
           from: lockCreator,
         })
       )

--- a/smart-contracts/test/Lock/withdraw.js
+++ b/smart-contracts/test/Lock/withdraw.js
@@ -20,7 +20,7 @@ contract('Lock / withdraw', (accounts) => {
     const locks = await deployLocks(unlock, owner)
     lock = locks.OWNED
     await lock.setMaxKeysPerAddress(10)
-    tokenAddress = await lock.tokenAddress.call()
+    tokenAddress = await lock.tokenAddress()
 
     await purchaseKeys(accounts)
   })

--- a/smart-contracts/test/Unlock/behaviors/createLock.js
+++ b/smart-contracts/test/Unlock/behaviors/createLock.js
@@ -50,7 +50,7 @@ exports.shouldCreateLock = (options) => {
 
       it('should have created the lock with the right address for unlock', async () => {
         let publicLock = await PublicLock.at(evt.args.newLockAddress)
-        let unlockProtocol = await publicLock.unlockProtocol.call()
+        let unlockProtocol = await publicLock.unlockProtocol()
         assert.equal(
           web3.utils.toChecksumAddress(unlockProtocol),
           web3.utils.toChecksumAddress(unlock.address)

--- a/smart-contracts/test/Unlock/lockTotalSales.js
+++ b/smart-contracts/test/Unlock/lockTotalSales.js
@@ -21,7 +21,7 @@ contract('Unlock / lockTotalSales', (accounts) => {
 
   it('total sales defaults to 0', async () => {
     const totalSales = new BigNumber(
-      (await unlock.locks.call(lock.address)).totalSales
+      (await unlock.locks(lock.address)).totalSales
     )
     assert.equal(totalSales.toFixed(), 0)
   })
@@ -43,7 +43,7 @@ contract('Unlock / lockTotalSales', (accounts) => {
 
     it('total sales includes the purchase', async () => {
       const totalSales = new BigNumber(
-        (await unlock.locks.call(lock.address)).totalSales
+        (await unlock.locks(lock.address)).totalSales
       )
       assert.equal(totalSales.toFixed(), price.toFixed())
     })
@@ -68,7 +68,7 @@ contract('Unlock / lockTotalSales', (accounts) => {
 
     it('total sales incluse all purchases', async () => {
       const totalSales = new BigNumber(
-        (await unlock.locks.call(lock.address)).totalSales
+        (await unlock.locks(lock.address)).totalSales
       )
       assert.equal(totalSales.toFixed(), price.times(5).toFixed())
     })

--- a/smart-contracts/test/unlockUtils.js
+++ b/smart-contracts/test/unlockUtils.js
@@ -11,9 +11,9 @@ contract('unlockUtils', (accounts) => {
     let str1
     let str2
     it('should convert a uint to a string', async () => {
-      str1 = await mock.uint2Str.call(0)
+      str1 = await mock.uint2Str(0)
       assert.equal(str1, '0')
-      str2 = await mock.uint2Str.call(42)
+      str2 = await mock.uint2Str(42)
       assert.equal(str2, '42')
     })
   })
@@ -22,7 +22,7 @@ contract('unlockUtils', (accounts) => {
     let resultingStr
 
     it('should concatenate 4 strings', async () => {
-      resultingStr = await mock.strConcat.call('hello', '-unlock', '/', '42')
+      resultingStr = await mock.strConcat('hello', '-unlock', '/', '42')
       assert.equal(resultingStr, 'hello-unlock/42')
     })
   })
@@ -31,7 +31,7 @@ contract('unlockUtils', (accounts) => {
     let senderAddress
     // currently returns the address as a string with all chars in lowercase
     it('should convert an ethereum address to an ASCII string', async () => {
-      senderAddress = await mock.address2Str.call(accounts[0])
+      senderAddress = await mock.address2Str(accounts[0])
       assert.equal(web3.utils.toChecksumAddress(senderAddress), accounts[0])
     })
   })


### PR DESCRIPTION
# Description

We still have many function calls in tests that are using the (truffle?) pattern `contract.function.call(args)`. This PR removes it in favour of the simpler `contract.function(args)`

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

