### PR TITLE
fix(smart-contracts): allow to share key with self

### DIFF
--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -65,9 +65,6 @@ contract MixinTransfer is
     }
 
     address keyOwner = _ownerOf[_tokenIdFrom];
-    if(keyOwner == _to) {
-      revert TRANSFER_TO_SELF();
-    }
 
     // store time to be added
     uint time;

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -75,15 +75,6 @@ contract('Lock / shareKey', (accounts) => {
         )
       })
 
-      it('should abort if the key owner', async () => {
-        await reverts(
-          lock.shareKey(keyOwners[0], tokenIds[0], 1000, {
-            from: keyOwners[0],
-          }),
-          'TRANSFER_TO_SELF'
-        )
-      })
-
       it('should revert if keys are sold out', async () => {
         const buyers = accounts.slice(3, 10)
         await lock.purchase(

--- a/smart-contracts/test/Lock/transfer.js
+++ b/smart-contracts/test/Lock/transfer.js
@@ -108,15 +108,6 @@ contract('Lock / transfer', (accounts) => {
     })
   })
 
-  it('reverts when attempting to transfer to self', async () => {
-    await reverts(
-      lock.transfer(tokenIds[0], singleKeyOwner, 1000, {
-        from: singleKeyOwner,
-      }),
-      'TRANSFER_TO_SELF'
-    )
-  })
-
   it('fails if key is expired', async () => {
     // Push the clock forward 1 second so that the test failure reason is consistent
     await lock.expireAndRefundFor(tokenIds[0], 0, {


### PR DESCRIPTION
# Description

this allow to specify  oneself as recipient of `shareKey` as this will just split one key into two 2 keys and this can be a desirable outcome.

Note: I made a mess by pushing this change directly to master woops :/ I reverted the original commit, so this reverts the reverted commit... fa724f1b5951a1f2b7d36ae74ce67e89914e0518 


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #9012 
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

