### PR TITLE
feat(unlock-app): Add close button and emit transaction info in new checkout

### DIFF
--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Minting.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Minting.tsx
@@ -21,7 +21,7 @@ interface Props {
   state: CheckoutState
 }
 
-function AnimationContent({ status }: Mint) {
+function AnimationContent({ status }: { status: Mint['status'] }) {
   switch (status) {
     case 'PROCESSING':
       return (
@@ -52,6 +52,7 @@ export function Minting({ injectedProvider, send, onClose, state }: Props) {
   const config = useConfig()
   const { mint, lock } = state.context
   const processing = mint?.status === 'PROCESSING'
+  const status = mint?.status
 
   useEffect(() => {
     async function waitForConfirmation() {
@@ -68,6 +69,7 @@ export function Minting({ injectedProvider, send, onClose, state }: Props) {
           send({
             type: 'CONFIRM_MINT',
             status: 'FINISHED',
+            transactionHash: mint.transactionHash!,
           })
         }
       } catch (error) {
@@ -87,7 +89,7 @@ export function Minting({ injectedProvider, send, onClose, state }: Props) {
     <div>
       <main className="p-6 overflow-auto h-64 sm:h-72">
         <div className="space-y-6 justify-center grid">
-          <AnimationContent {...mint!} />
+          {status && <AnimationContent status={status} />}
           <a
             href={config.networks[lock!.network].explorer.urls.transaction(
               mint?.transactionHash

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Minting.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Minting.tsx
@@ -69,7 +69,6 @@ export function Minting({ injectedProvider, send, onClose, state }: Props) {
           send({
             type: 'CONFIRM_MINT',
             status: 'FINISHED',
-            transactionHash: mint.transactionHash!,
           })
         }
       } catch (error) {

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/checkoutMachine.ts
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/checkoutMachine.ts
@@ -117,7 +117,6 @@ type Payment =
 export interface Mint {
   status: 'ERROR' | 'PROCESSING' | 'FINISHED'
   transactionHash?: string
-  tokenIds?: string[]
 }
 
 interface CheckoutMachineContext {
@@ -384,12 +383,18 @@ export const checkoutMachine = createMachine(
         },
       }),
       confirmMint: assign({
-        mint: (context, { type, ...rest }) => {
-          const result = {
-            ...context.mint,
-            ...rest,
+        mint: (context, { type, status, transactionHash }) => {
+          if (!context.paywallConfig.pessimistic) {
+            return {
+              status: 'FINISHED',
+              transactionHash,
+            } as const
+          } else {
+            return {
+              status,
+              transactionHash,
+            } as const
           }
-          return result
         },
       }),
       solveCaptcha: assign({

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/index.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import type { PaywallConfig } from '~/unlockTypes'
 import { useCheckoutCommunication } from '~/hooks/useCheckoutCommunication'
 import { checkoutMachine, CheckoutPage } from './checkoutMachine'
@@ -18,9 +18,15 @@ interface Props {
   injectedProvider: unknown
   paywallConfig: PaywallConfig
   communication: ReturnType<typeof useCheckoutCommunication>
+  redirectURI?: URL
 }
 
-export function Checkout({ paywallConfig, injectedProvider }: Props) {
+export function Checkout({
+  paywallConfig,
+  injectedProvider,
+  communication,
+  redirectURI,
+}: Props) {
   const [state, send] = useMachine(checkoutMachine, {
     context: {
       paywallConfig,
@@ -31,9 +37,42 @@ export function Checkout({ paywallConfig, injectedProvider }: Props) {
     paywallConfig,
     state.value as CheckoutPage
   )
+  const { messageToSign, mint, lock } = state.context
 
-  const onClose = () => {
-    // TODO
+  useEffect(() => {
+    if (
+      mint &&
+      mint.transactionHash &&
+      mint.status === 'FINISHED' &&
+      communication
+    ) {
+      communication.emitTransactionInfo({
+        hash: mint!.transactionHash!,
+        lock: lock!.address,
+      })
+    }
+  }, [mint, communication, lock])
+
+  const onClose = (params: Record<string, string> = {}) => {
+    communication.emitCloseModal()
+    if (redirectURI) {
+      if (!mint || mint?.status === 'ERROR') {
+        redirectURI.searchParams.append('error', 'access-denied')
+      }
+      if (messageToSign) {
+        redirectURI.searchParams.append('signature', messageToSign.signature)
+        redirectURI.searchParams.append('address', messageToSign.address)
+      }
+      if (params) {
+        for (const [key, value] of Object.entries(params)) {
+          redirectURI.searchParams.append(key, value)
+        }
+      }
+      return window.location.assign(redirectURI)
+    }
+    if (!communication.insideIframe) {
+      return window.history.back()
+    }
   }
 
   function Content() {

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/index.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/index.tsx
@@ -40,12 +40,9 @@ export function Checkout({
   const { messageToSign, mint, lock } = state.context
 
   useEffect(() => {
-    if (
-      mint &&
-      mint.transactionHash &&
-      mint.status === 'FINISHED' &&
-      communication
-    ) {
+    const isMintingFinished =
+      mint && mint.transactionHash && mint.status === 'FINISHED'
+    if (isMintingFinished && communication) {
       communication.emitTransactionInfo({
         hash: mint!.transactionHash!,
         lock: lock!.address,

--- a/unlock-app/src/components/interface/checkout/alpha/index.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/index.tsx
@@ -23,6 +23,8 @@ export function CheckoutPage() {
     communication.providerAdapter || selectProvider(config)
 
   const paywallConfig = communication.paywallConfig || paywallConfigFromQuery
+  const checkoutRedirectURI =
+    paywallConfig?.redirectUri || (query.redirectUri as string)
 
   useEffect(() => {
     document.body.querySelector('body')?.classList.add('bg-transparent')
@@ -39,7 +41,6 @@ export function CheckoutPage() {
       </Container>
     )
   }
-
   if (paywallConfig) {
     return (
       <Container>
@@ -47,6 +48,9 @@ export function CheckoutPage() {
           injectedProvider={injectedProvider}
           communication={communication}
           paywallConfig={paywallConfig}
+          redirectURI={
+            checkoutRedirectURI ? new URL(checkoutRedirectURI) : undefined
+          }
         />
       </Container>
     )


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This adds onClose function which would be invoked on using the close button or clicking the return to site after finishing mint. 

This emits the transaction info on a successful mint and respect optimistic checkout setting in paywallConfig.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

