### PR TITLE
replace eth-sig-utils and ethereumjs-utils with ethers in locksmith

### DIFF
--- a/locksmith/__tests__/controllers/lockController.test.js
+++ b/locksmith/__tests__/controllers/lockController.test.js
@@ -2,6 +2,7 @@ const request = require('supertest')
 const app = require('../../src/app')
 const { Lock } = require('../../src/models')
 
+jest.setTimeout(600000)
 const validLockOwner = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
 const validLockAddress = '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83'
 const chain = 31337

--- a/locksmith/__tests__/controllers/lockController.test.js
+++ b/locksmith/__tests__/controllers/lockController.test.js
@@ -10,8 +10,8 @@ const chain = 31337
 const testLockDetails = {
   chain,
   name: 'Test Lock',
-  address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
-  owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+  address: '0xab7c74abC0C4d48d1bdad5DCB26153FC8780f83E',
+  owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
 }
 
 const ownedLocks = [
@@ -123,7 +123,7 @@ describe('lockController', () => {
           .get(`/${owner}/locks`)
           .set('Accept', /json/)
 
-        expect(response.body.locks).toHaveLength(2)
+        expect(response.body.locks).toHaveLength(3)
 
         expect(response.body.locks).toEqual(
           expect.arrayContaining([
@@ -151,7 +151,7 @@ describe('lockController', () => {
       it('returns an empty collection', async () => {
         expect.assertions(1)
         const response = await request(app)
-          .get('/0xCA750f9232C1c38e34D27e77534e1631526eC99e/locks')
+          .get('/0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2/locks')
           .set('Accept', /json/)
         expect(response.body).toEqual({ locks: [] })
       })

--- a/locksmith/__tests__/controllers/lockController.test.js
+++ b/locksmith/__tests__/controllers/lockController.test.js
@@ -9,37 +9,27 @@ const chain = 31337
 const testLockDetails = {
   chain,
   name: 'Test Lock',
-  address: '0xab7c74abC0C4d48d1bdad5DCB26153FC8780f83E',
-  owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
+  address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
+  owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
 }
 
 const ownedLocks = [
   {
     chain,
     name: 'a mighty fine lock',
-    address: 'jqfqod74',
-    owner: '0x423893453',
+    address: '0xab7c74abC0C4d48d1bdad5DCB26153FC8780f83A',
+    owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
   },
   {
     chain,
     name: 'A random other lock',
-    address: 'jqfqod75',
-    owner: '0x423893453',
+    address: '0xab7c74abC0C4d48d1bdad5DCB26153FC8780f83B',
+    owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
   },
 ]
 
 const lockPayload = {
   types: {
-    EIP712Domain: [
-      { name: 'name', type: 'string' },
-      { name: 'version', type: 'string' },
-      { name: 'chainId', type: 'uint256' },
-      { name: 'verifyingContract', type: 'address' },
-      {
-        name: 'salt',
-        type: 'bytes32',
-      },
-    ],
     Lock: [
       { name: 'name', type: 'string' },
       { name: 'owner', type: 'address' },
@@ -55,6 +45,7 @@ const lockPayload = {
       address: validLockAddress,
     },
   },
+  messageKey: 'lock',
 }
 
 beforeEach(async () => {
@@ -123,7 +114,7 @@ describe('lockController', () => {
     })
 
     describe('when the address owns locks', () => {
-      const owner = '0x423893453'
+      const owner = '0xCA750f9232C1c38e34D27e77534e1631526eC99e'
 
       it('return the details of the owned locks', async () => {
         expect.assertions(3)
@@ -137,8 +128,8 @@ describe('lockController', () => {
           expect.arrayContaining([
             expect.objectContaining({
               name: 'A random other lock',
-              address: 'jqfqod75',
-              owner: '0x423893453',
+              address: '0xab7c74abC0C4d48d1bdad5DCB26153FC8780f83B',
+              owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
             }),
           ])
         )
@@ -147,8 +138,8 @@ describe('lockController', () => {
           expect.arrayContaining([
             expect.objectContaining({
               name: 'a mighty fine lock',
-              address: 'jqfqod74',
-              owner: '0x423893453',
+              address: '0xab7c74abC0C4d48d1bdad5DCB26153FC8780f83A',
+              owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
             }),
           ])
         )
@@ -159,7 +150,7 @@ describe('lockController', () => {
       it('returns an empty collection', async () => {
         expect.assertions(1)
         const response = await request(app)
-          .get('/0xd489fF3/locks')
+          .get('/0xCA750f9232C1c38e34D27e77534e1631526eC99e/locks')
           .set('Accept', /json/)
         expect(response.body).toEqual({ locks: [] })
       })

--- a/locksmith/__tests__/controllers/lockController.test.js
+++ b/locksmith/__tests__/controllers/lockController.test.js
@@ -2,7 +2,7 @@ const request = require('supertest')
 const app = require('../../src/app')
 const { Lock } = require('../../src/models')
 
-jest.setTimeout(600000)
+jest.setTimeout(60000)
 const validLockOwner = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
 const validLockAddress = '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83'
 const chain = 31337

--- a/locksmith/__tests__/controllers/metadataController/readAddressHolderMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/readAddressHolderMetadata.test.ts
@@ -49,15 +49,22 @@ describe('reading address holder metadata', () => {
 
   it('yields the stored passed data if the timestamp is recent', async () => {
     expect.assertions(2)
-    const typedData = keyTypedData({
-      UserMetaData: {
-        owner: keyHolder[0],
-        timestamp: Date.now(),
+    const typedData = keyTypedData(
+      {
+        UserMetaData: {
+          owner: keyHolder[0],
+          timestamp: Date.now(),
+        },
       },
-    })
+      'UserMetaData'
+    )
 
     const { domain, types, message } = typedData
-    const sig = await wallet._signTypedData(domain, types, message)
+    const sig = await wallet._signTypedData(
+      domain,
+      types,
+      message['UserMetaData']
+    )
 
     const response = await request(app)
       .get(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
@@ -80,15 +87,22 @@ describe('reading address holder metadata', () => {
 
   it('does not yield the stored passed data if the timestamp is old', async () => {
     expect.assertions(2)
-    const typedData = keyTypedData({
-      UserMetaData: {
-        owner: keyHolder[0],
-        timestamp: 0,
+    const typedData = keyTypedData(
+      {
+        UserMetaData: {
+          owner: keyHolder[0],
+          timestamp: 0,
+        },
       },
-    })
+      'UserMetaData'
+    )
 
     const { domain, types, message } = typedData
-    const sig = await wallet._signTypedData(domain, types, message)
+    const sig = await wallet._signTypedData(
+      domain,
+      types,
+      message['UserMetaData']
+    )
 
     const response = await request(app)
       .get(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
@@ -104,20 +118,27 @@ describe('reading address holder metadata', () => {
     it('returns unauthorized', async () => {
       expect.assertions(2)
 
-      const typedData = keyTypedData({
-        UserMetaData: {
-          owner: keyHolder[0],
-          protected: {
-            hidden: 'metadata',
-          },
-          public: {
-            mock: 'values',
+      const typedData = keyTypedData(
+        {
+          UserMetaData: {
+            owner: keyHolder[0],
+            protected: {
+              hidden: 'metadata',
+            },
+            public: {
+              mock: 'values',
+            },
           },
         },
-      })
+        'UserMetaData'
+      )
 
       const { domain, types, message } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(
+        domain,
+        types,
+        message['UserMetaData']
+      )
 
       const response = await request(app)
         .get(`/api/key/${lockAddress}/user/${keyHolder[0]}`)

--- a/locksmith/__tests__/controllers/metadataController/readAddressHolderMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/readAddressHolderMetadata.test.ts
@@ -1,6 +1,5 @@
+import { ethers } from 'ethers'
 import request from 'supertest'
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
 import { keyTypedData } from '../../test-helpers/typeDataGenerators'
 import { addMetadata } from '../../../src/operations/userMetadataOperations'
 
@@ -14,7 +13,7 @@ const keyHolder = [
   '0x6f7a54d6629b7416e17fc472b4003ae8ef18ef4c',
 ]
 const lockAddress = '0x95de5F777A3e283bFf0c47374998E10D8A2183C7'
-const privateKey = ethJsUtil.toBuffer(
+const wallet = new ethers.Wallet(
   '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
 )
 
@@ -57,9 +56,8 @@ describe('reading address holder metadata', () => {
       },
     })
 
-    const sig = sigUtil.signTypedData(privateKey, {
-      data: typedData,
-    })
+    const { domain, types, message } = typedData
+    const sig = await wallet._signTypedData(domain, types, message)
 
     const response = await request(app)
       .get(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
@@ -89,9 +87,8 @@ describe('reading address holder metadata', () => {
       },
     })
 
-    const sig = sigUtil.signTypedData(privateKey, {
-      data: typedData,
-    })
+    const { domain, types, message } = typedData
+    const sig = await wallet._signTypedData(domain, types, message)
 
     const response = await request(app)
       .get(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
@@ -119,9 +116,8 @@ describe('reading address holder metadata', () => {
         },
       })
 
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+      const { domain, types, message } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const response = await request(app)
         .get(`/api/key/${lockAddress}/user/${keyHolder[0]}`)

--- a/locksmith/__tests__/controllers/metadataController/requestingKeyholderMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/requestingKeyholderMetadata.test.ts
@@ -14,21 +14,14 @@ const lockOwningAddress = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
 const lockAddress = '0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691'
 const chain = 31337
 
-function generateTypedData(message: any) {
+function generateTypedData(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       LockMetadata: [
         { name: 'address', type: 'address' },
-        { name: 'name', type: 'string' },
-        { name: 'description', type: 'string' },
-        { name: 'image', type: 'string' },
+        { name: 'owner', type: 'address' },
+        { name: 'timestamp', type: 'uint256' },
+        { name: 'owners', type: 'address[]' },
       ],
     },
     domain: {
@@ -37,6 +30,7 @@ function generateTypedData(message: any) {
     },
     primaryType: 'LockMetadata',
     message,
+    messageKey,
   }
 }
 
@@ -113,17 +107,24 @@ describe('Metadata Controller', () => {
 
         mockWeb3Service.isLockManager = jest.fn(() => Promise.resolve(true))
 
-        const typedData = generateTypedData({
-          LockMetaData: {
-            address: lockAddress,
-            owner: lockOwningAddress,
-            timestamp: Date.now(),
-            owners: ['0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'],
+        const typedData = generateTypedData(
+          {
+            LockMetaData: {
+              address: lockAddress,
+              owner: lockOwningAddress,
+              timestamp: Date.now(),
+              owners: ['0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'],
+            },
           },
-        })
+          'LockMetaData'
+        )
 
         const { domain, types, message } = typedData
-        const sig = await wallet._signTypedData(domain, types, message)
+        const sig = await wallet._signTypedData(
+          domain,
+          types,
+          message['LockMetaData']
+        )
 
         const response = await request(app)
           .get(`/api/key/${lockAddress}/keyHolderMetadata`)

--- a/locksmith/__tests__/controllers/metadataController/requestingKeyholderMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/requestingKeyholderMetadata.test.ts
@@ -1,13 +1,12 @@
+import { ethers } from 'ethers'
 import request from 'supertest'
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
 import { LockMetadata } from '../../../src/models/lockMetadata'
 import { addMetadata } from '../../../src/operations/userMetadataOperations'
 
 import app = require('../../../src/app')
 import Base64 = require('../../../src/utils/base64')
 
-const privateKey = ethJsUtil.toBuffer(
+const wallet = new ethers.Wallet(
   '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
 )
 
@@ -123,9 +122,8 @@ describe('Metadata Controller', () => {
           },
         })
 
-        const sig = sigUtil.signTypedData(privateKey, {
-          data: typedData,
-        })
+        const { domain, types, message } = typedData
+        const sig = await wallet._signTypedData(domain, types, message)
 
         const response = await request(app)
           .get(`/api/key/${lockAddress}/keyHolderMetadata`)

--- a/locksmith/__tests__/controllers/metadataController/requestingTokenMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/requestingTokenMetadata.test.ts
@@ -1,12 +1,11 @@
+import { ethers } from 'ethers'
 import request from 'supertest'
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
 import { keyTypedData } from '../../test-helpers/typeDataGenerators'
 
 import app = require('../../../src/app')
 import Base64 = require('../../../src/utils/base64')
 
-const privateKey = ethJsUtil.toBuffer(
+const wallet = new ethers.Wallet(
   '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
 )
 
@@ -67,9 +66,8 @@ describe('When the signee is the Lock owner', () => {
     it('stores the provided key metadata', async () => {
       expect.assertions(1)
 
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+      const { domain, types, message } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       mockWeb3Service.isLockManager = jest.fn(() => Promise.resolve(true))
       const response = await request(app)

--- a/locksmith/__tests__/controllers/metadataController/requestingTokenMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/requestingTokenMetadata.test.ts
@@ -38,12 +38,15 @@ jest.mock('../../../src/graphql/datasource/keyholdersByLock', () => ({
 
 let typedData: any
 beforeAll(() => {
-  typedData = keyTypedData({
-    KeyMetaData: {
-      custom_field: 'custom value',
-      owner: owningAddress,
+  typedData = keyTypedData(
+    {
+      KeyMetaData: {
+        custom_field: 'custom value',
+        owner: owningAddress,
+      },
     },
-  })
+    'KeyMetaData'
+  )
 
   mockWeb3Service.isLockManager = jest.fn(() => Promise.resolve(false))
 })
@@ -67,7 +70,11 @@ describe('When the signee is the Lock owner', () => {
       expect.assertions(1)
 
       const { domain, types, message } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(
+        domain,
+        types,
+        message['KeyMetaData']
+      )
 
       mockWeb3Service.isLockManager = jest.fn(() => Promise.resolve(true))
       const response = await request(app)

--- a/locksmith/__tests__/controllers/metadataController/tokenData.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/tokenData.test.ts
@@ -19,21 +19,27 @@ const keyHolderWallet = new ethers.Wallet(
   '0xe5986c22698a3c1eb5f84455895ad6826fbdff7b82dbeee240bad0024469d93a'
 )
 
-const typedData = lockTypedData({
-  LockMetaData: {
-    address: lockAddress,
-    owner: lockOwner,
-    timestamp: Date.now(),
+const typedData = lockTypedData(
+  {
+    LockMetaData: {
+      address: lockAddress,
+      owner: lockOwner,
+      timestamp: Date.now(),
+    },
   },
-})
+  'LockMetaData'
+)
 
-const keyHolderStructuredData = lockTypedData({
-  LockMetaData: {
-    address: lockAddress,
-    owner: keyOwner,
-    timestamp: Date.now(),
+const keyHolderStructuredData = lockTypedData(
+  {
+    LockMetaData: {
+      address: lockAddress,
+      owner: keyOwner,
+      timestamp: Date.now(),
+    },
   },
-})
+  'LockMetaData'
+)
 
 const chain = 31337
 
@@ -77,7 +83,7 @@ jest.mock('../../../src/utils/keyData', () => {
   return jest.fn().mockImplementation(() => {
     return {
       get: jest.fn().mockResolvedValue({
-        owner: '0xabcd',
+        owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
         expiration: 1567190711,
       }),
       openSeaPresentation: jest.fn().mockReturnValue({
@@ -117,7 +123,7 @@ describe('Requesting Token Data', () => {
     await addMetadata({
       chain,
       tokenAddress: lockAddress,
-      userAddress: '0xaBCD',
+      userAddress: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
       data: {
         protected: {
           hidden: 'metadata',
@@ -218,7 +224,11 @@ describe('Requesting Token Data', () => {
           mockWeb3Service.isLockManager = jest.fn(() => Promise.resolve(true))
 
           const { domain, types, message } = typedData
-          const sig = await wallet._signTypedData(domain, types, message)
+          const sig = await wallet._signTypedData(
+            domain,
+            types,
+            message['LockMetaData']
+          )
 
           const response = await request(app)
             .get(`/api/key/${lockAddress}/1`)
@@ -250,9 +260,8 @@ describe('Requesting Token Data', () => {
           const keyHolderSignature = await keyHolderWallet._signTypedData(
             domain,
             types,
-            message
+            message['LockMetaData']
           )
-
           const response = await request(app)
             .get(`/api/key/${lockAddress}/1`)
             .set('Authorization', `Bearer ${Base64.encode(keyHolderSignature)}`)

--- a/locksmith/__tests__/controllers/metadataController/updateAddressHolderMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/updateAddressHolderMetadata.test.ts
@@ -1,6 +1,5 @@
+import { ethers } from 'ethers'
 import request from 'supertest'
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
 import { keyTypedData } from '../../test-helpers/typeDataGenerators'
 
 import app = require('../../../src/app')
@@ -11,7 +10,7 @@ const keyHolder = [
   '0x6f7a54d6629b7416e17fc472b4003ae8ef18ef4c',
 ]
 const lockAddress = '0x95de5F777A3e283bFf0c47374998E10D8A2183C7'
-const privateKey = ethJsUtil.toBuffer(
+const wallet = new ethers.Wallet(
   '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
 )
 
@@ -53,9 +52,8 @@ describe('updating address holder metadata', () => {
       },
     })
 
-    const sig = sigUtil.signTypedData(privateKey, {
-      data: typedData,
-    })
+    const { domain, types, message } = typedData
+    const sig = await wallet._signTypedData(domain, types, message)
 
     const response = await request(app)
       .put(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
@@ -80,9 +78,8 @@ describe('updating address holder metadata', () => {
       },
     })
 
-    const sig = sigUtil.signTypedData(privateKey, {
-      data: typedData,
-    })
+    const { domain, types, message } = typedData
+    const sig = await wallet._signTypedData(domain, types, message)
 
     const response = await request(app)
       .put(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
@@ -108,9 +105,8 @@ describe('updating address holder metadata', () => {
         },
       })
 
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+      const { domain, types, message } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const response = await request(app)
         .put(`/api/key/${lockAddress}/user/${keyHolder[1]}`)

--- a/locksmith/__tests__/controllers/metadataController/updateAddressHolderMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/updateAddressHolderMetadata.test.ts
@@ -41,19 +41,26 @@ jest.mock('../../../src/graphql/datasource/keyholdersByLock', () => ({
 describe('updating address holder metadata', () => {
   it('stores the passed data', async () => {
     expect.assertions(1)
-    const typedData = keyTypedData({
-      UserMetaData: {
-        owner: keyHolder[0],
-        data: {
-          protected: {
-            emailAddress: 'emailAddress@example.com',
+    const typedData = keyTypedData(
+      {
+        UserMetaData: {
+          owner: keyHolder[0],
+          data: {
+            protected: {
+              emailAddress: 'emailAddress@example.com',
+            },
           },
         },
       },
-    })
+      'UserMetaData'
+    )
 
     const { domain, types, message } = typedData
-    const sig = await wallet._signTypedData(domain, types, message)
+    const sig = await wallet._signTypedData(
+      domain,
+      types,
+      message['UserMetaData']
+    )
 
     const response = await request(app)
       .put(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
@@ -67,19 +74,26 @@ describe('updating address holder metadata', () => {
   it('should update existing data if it already exists', async () => {
     expect.assertions(1)
 
-    const typedData = keyTypedData({
-      UserMetaData: {
-        owner: keyHolder[0],
-        data: {
-          protected: {
-            emailAddress: 'updatedEmailAddress@example.com',
+    const typedData = keyTypedData(
+      {
+        UserMetaData: {
+          owner: keyHolder[0],
+          data: {
+            protected: {
+              emailAddress: 'updatedEmailAddress@example.com',
+            },
           },
         },
       },
-    })
+      'UserMetaData'
+    )
 
     const { domain, types, message } = typedData
-    const sig = await wallet._signTypedData(domain, types, message)
+    const sig = await wallet._signTypedData(
+      domain,
+      types,
+      message['UserMetaData']
+    )
 
     const response = await request(app)
       .put(`/api/key/${lockAddress}/user/${keyHolder[0]}`)
@@ -94,19 +108,26 @@ describe('updating address holder metadata', () => {
     it('returns unauthorized', async () => {
       expect.assertions(1)
 
-      const typedData = keyTypedData({
-        UserMetaData: {
-          owner: keyHolder[0],
-          protected: {
-            data: {
-              emailAddress: 'updatedEmailAddress@example.com',
+      const typedData = keyTypedData(
+        {
+          UserMetaData: {
+            owner: keyHolder[0],
+            protected: {
+              data: {
+                emailAddress: 'updatedEmailAddress@example.com',
+              },
             },
           },
         },
-      })
+        'UserMetaData'
+      )
 
       const { domain, types, message } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(
+        domain,
+        types,
+        message['UserMetaData']
+      )
 
       const response = await request(app)
         .put(`/api/key/${lockAddress}/user/${keyHolder[1]}`)

--- a/locksmith/__tests__/controllers/metadataController/updateDefaults.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/updateDefaults.test.ts
@@ -1,15 +1,14 @@
+import { ethers } from 'ethers'
 import request from 'supertest'
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
 
 const app = require('../../../src/app')
 const Base64 = require('../../../src/utils/base64')
 
-const privateKey2 = ethJsUtil.toBuffer(
+const wallet2 = new ethers.Wallet(
   '0xbbabdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
 )
 
-const privateKey = ethJsUtil.toBuffer(
+const wallet = new ethers.Wallet(
   '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
 )
 
@@ -85,9 +84,9 @@ describe('updateDefaults', () => {
 
     it('returns unauthorized', async () => {
       expect.assertions(1)
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+
+      const { domain, types, message } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const response = await request(app)
         .put('/api/key/0x95de5F777A3e283bFf0c47374998E10D8A2183C7')
@@ -106,9 +105,9 @@ describe('updateDefaults', () => {
 
     it('stores the provided lock metadata', async () => {
       expect.assertions(1)
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+
+      const { domain, types, message } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const response = await request(app)
         .put('/api/key/0x95de5F777A3e283bFf0c47374998E10D8A2183C7')
@@ -122,9 +121,9 @@ describe('updateDefaults', () => {
     describe('when signature does not match', () => {
       it('return an Unauthorized status code', async () => {
         expect.assertions(1)
-        const sig = sigUtil.signTypedData(privateKey2, {
-          data: typedData,
-        })
+
+        const { domain, types, message } = typedData
+        const sig = await wallet2._signTypedData(domain, types, message)
 
         const response = await request(app)
           .put('/api/key/0x95de5F777A3e283bFf0c47374998E10D8A2183C7')

--- a/locksmith/__tests__/controllers/metadataController/updateKeyMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/updateKeyMetadata.test.ts
@@ -37,12 +37,15 @@ describe('updateKeyMetadata', () => {
   describe('when the signee does not own the lock', () => {
     let typedData: any
     beforeAll(() => {
-      typedData = keyTypedData({
-        KeyMetaData: {
-          custom_field: 'custom value',
-          owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+      typedData = keyTypedData(
+        {
+          KeyMetaData: {
+            custom_field: 'custom value',
+            owner: '0xaaadeed4c0b861cb36f4ce006a9c90ba2e43fdc2',
+          },
         },
-      })
+        'KeyMetaData'
+      )
 
       mockWeb3Service.isLockManager = jest.fn(() => Promise.resolve(false))
     })
@@ -51,7 +54,11 @@ describe('updateKeyMetadata', () => {
       expect.assertions(1)
 
       const { domain, types, message } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(
+        domain,
+        types,
+        message['KeyMetaData']
+      )
 
       const response = await request(app)
         .put('/api/key/0x95de5F777A3e283bFf0c47374998E10D8A2183C7/5')

--- a/locksmith/__tests__/controllers/metadataController/updateKeyMetadata.test.ts
+++ b/locksmith/__tests__/controllers/metadataController/updateKeyMetadata.test.ts
@@ -1,12 +1,11 @@
+import { ethers } from 'ethers'
 import request from 'supertest'
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
 import { keyTypedData } from '../../test-helpers/typeDataGenerators'
 
 import app = require('../../../src/app')
 import Base64 = require('../../../src/utils/base64')
 
-const privateKey = ethJsUtil.toBuffer(
+const wallet = new ethers.Wallet(
   '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
 )
 
@@ -51,9 +50,8 @@ describe('updateKeyMetadata', () => {
     it('returns unauthorized', async () => {
       expect.assertions(1)
 
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+      const { domain, types, message } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const response = await request(app)
         .put('/api/key/0x95de5F777A3e283bFf0c47374998E10D8A2183C7/5')

--- a/locksmith/__tests__/controllers/purchaseController.test.ts
+++ b/locksmith/__tests__/controllers/purchaseController.test.ts
@@ -1,14 +1,13 @@
+import { ethers } from 'ethers'
 import request from 'supertest'
-import * as sigUtil from 'eth-sig-util'
 
-const ethJsUtil = require('ethereumjs-util')
 const app = require('../../src/app')
 const Base64 = require('../../src/utils/base64')
 
 const participatingLock = '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267'
 const recipient = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
 
-const privateKey = ethJsUtil.toBuffer(
+const wallet = new ethers.Wallet(
   '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
 )
 const mockPaymentProcessor = {
@@ -72,12 +71,11 @@ describe('Purchase Controller', () => {
 
       const typedData = generateTypedData(message)
 
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
-
       it('responds with a 200 status code', async () => {
         expect.assertions(1)
+
+        const { domain, types } = typedData
+        const sig = await wallet._signTypedData(domain, types, message)
 
         const response = await request(app)
           .post('/purchase/USD')

--- a/locksmith/__tests__/controllers/purchaseController.test.ts
+++ b/locksmith/__tests__/controllers/purchaseController.test.ts
@@ -19,16 +19,9 @@ const mockPaymentProcessor = {
 const keyPricer = {
   keyPriceUSD: jest.fn().mockReturnValueOnce(250).mockReturnValueOnce(1000000),
 }
-function generateTypedData(message: any) {
+function generateTypedData(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       PurchaseRequest: [
         { name: 'recipient', type: 'address' },
         { name: 'lock', type: 'address' },
@@ -42,6 +35,7 @@ function generateTypedData(message: any) {
     },
     primaryType: 'PurchaseRequest',
     message,
+    messageKey,
   }
 }
 
@@ -69,13 +63,17 @@ describe('Purchase Controller', () => {
         },
       }
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'purchaseRequest')
 
       it('responds with a 200 status code', async () => {
         expect.assertions(1)
 
         const { domain, types } = typedData
-        const sig = await wallet._signTypedData(domain, types, message)
+        const sig = await wallet._signTypedData(
+          domain,
+          types,
+          message.purchaseRequest
+        )
 
         const response = await request(app)
           .post('/purchase/USD')

--- a/locksmith/__tests__/controllers/transactionController.test.js
+++ b/locksmith/__tests__/controllers/transactionController.test.js
@@ -8,29 +8,29 @@ describe('transactionController', () => {
     await Transaction.bulkCreate([
       {
         transactionHash: '0x345546565',
-        sender: '0xcAFe',
-        recipient: '0xBeeFE',
+        sender: '0xdD2FD4581271e230360230F9337D5c0430Bf44C0',
+        recipient: '0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199',
       },
       {
         transactionHash: '0x445546565',
-        sender: '0xcAFe',
-        recipient: '0xBeeFE',
+        sender: '0xdD2FD4581271e230360230F9337D5c0430Bf44C0',
+        recipient: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec',
       },
       {
         transactionHash: '0x545546565',
-        sender: '0xcAFe2',
-        recipient: '0xBeeFE',
+        sender: '0xcd3B766CCDd6AE721141F452C550Ca635964ce71',
+        recipient: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec',
       },
       {
         transactionHash: '0x645546565',
-        sender: '0xcAFe2',
-        recipient: '0xBEefb',
+        sender: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec',
+        recipient: '0xcd3B766CCDd6AE721141F452C550Ca635964ce71',
       },
       {
         transactionHash: '0x645546567',
-        sender: '0xcAFe2',
-        recipient: '0xBEefb',
-        for: '0xcAFe2',
+        sender: '0xcd3B766CCDd6AE721141F452C550Ca635964ce71',
+        recipient: '0xdD2FD4581271e230360230F9337D5c0430Bf44C0',
+        for: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec',
       },
     ])
   })
@@ -45,7 +45,7 @@ describe('transactionController', () => {
         expect.assertions(1)
         const response = await request(app)
           .get('/transactions')
-          .query({ sender: '0xd489fF3' })
+          .query({ sender: '0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc' })
           .set('Accept', /json/)
         expect(response.body).toEqual({ transactions: [] })
       })
@@ -54,7 +54,7 @@ describe('transactionController', () => {
     describe('when the address has transactions', () => {
       it("returns the addresses' transactions", async () => {
         expect.assertions(1)
-        const sender = '0xcAFe'
+        const sender = '0xdd2fd4581271e230360230f9337d5c0430bf44c0'
 
         const response = await request(app)
           .get('/transactions')
@@ -68,11 +68,17 @@ describe('transactionController', () => {
     describe('when the address has transactions to the recipient', () => {
       it("returns the addresses' transactions", async () => {
         expect.assertions(1)
-        const sender = '0xcAFe2'
+        const sender = '0xcd3b766ccdd6ae721141f452c550ca635964ce71'
 
         const response = await request(app)
           .get('/transactions')
-          .query({ sender, recipient: ['0xBeeFE', '0x4565t'] })
+          .query({
+            sender,
+            recipient: [
+              '0x1cbd3b2770909d4e10f157cabc84c7264073c9ec',
+              '0x8626f6940e2eb28930efb4cef49b2d1f2c9c1199',
+            ],
+          })
           .set('Accept', /json/)
 
         expect(response.body.transactions.length).toEqual(1)
@@ -82,13 +88,13 @@ describe('transactionController', () => {
     describe('when filtering on for', () => {
       it("returns the addresses' transactions", async () => {
         expect.assertions(2)
-        const sender = '0xcAFe2'
+        const sender = '0xcd3B766CCDd6AE721141F452C550Ca635964ce71'
 
         const response = await request(app)
           .get('/transactions')
           .query({
             sender,
-            for: '0xcAFe2',
+            for: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec',
           })
           .set('Accept', /json/)
 
@@ -105,8 +111,11 @@ describe('transactionController', () => {
         const response = await request(app)
           .get('/transactions')
           .query({
-            recipient: ['0xBeeFB', '0xBeeFB'],
-            for: '0xcAFe2',
+            recipient: [
+              '0xdD2FD4581271e230360230F9337D5c0430Bf44C0',
+              '0xdD2FD4581271e230360230F9337D5c0430Bf44C0',
+            ],
+            for: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec',
           })
           .set('Accept', /json/)
 
@@ -131,16 +140,20 @@ describe('transactionController', () => {
           .set('Accept', /json/)
           .send({
             transactionHash: '0xsdbegjkbg,egf',
-            sender: '0xSDgErGR',
-            recipient: '0xSdaG433r',
+            sender: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec',
+            recipient: '0xdD2FD4581271e230360230F9337D5c0430Bf44C0',
             data: transactionData,
             chain: 42,
           })
 
         const record = await Transaction.findOne({
-          where: { sender: '0xSDgErGR', recipient: '0xSdaG433r', chain: 42 },
+          where: {
+            sender: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec',
+            recipient: '0xdD2FD4581271e230360230F9337D5c0430Bf44C0',
+            chain: 42,
+          },
         })
-        expect(record.sender).toBe('0xSDgErGR')
+        expect(record.sender).toBe('0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec')
         expect(record.data).toEqual(transactionData)
         expect(response.statusCode).toBe(202)
       })
@@ -154,8 +167,8 @@ describe('transactionController', () => {
           .set('Accept', /json/)
           .send({
             transactionHash: '0x345546565',
-            sender: '0xcAFe',
-            recipient: '0xBeeFE',
+            sender: '0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec',
+            recipient: '0xdD2FD4581271e230360230F9337D5c0430Bf44C0',
           })
 
         expect(response.statusCode).toBe(202)

--- a/locksmith/__tests__/controllers/userController/cards.test.ts
+++ b/locksmith/__tests__/controllers/userController/cards.test.ts
@@ -1,7 +1,6 @@
+import { ethers } from 'ethers'
 import request from 'supertest'
 
-import ethJsUtil = require('ethereumjs-util')
-import sigUtil = require('eth-sig-util')
 import app = require('../../../src/app')
 import Base64 = require('../../../src/utils/base64')
 import models = require('../../../src/models')
@@ -84,14 +83,14 @@ describe('when requesting cards', () => {
         },
       }
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
       )
 
       const typedData = generateTypedData(message)
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+
+      const { domain, types } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const response = await request(app)
         .get(`/users/${publicKey}/credit-cards`)
@@ -111,14 +110,15 @@ describe('when requesting cards', () => {
         },
       }
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0x08491b7e20566b728ce21a07c88b12ed8b785b3826df93a7baceb21ddacf8b61'
       )
 
       const typedData = generateTypedData(message)
-      const sig = sigUtil.personalSign(privateKey, {
-        data: `I want to retrieve the card token for ${message['Get Card'].publicKey}`,
-      })
+
+      const sig = await wallet.signMessage(
+        `I want to retrieve the card token for ${message['Get Card'].publicKey}`
+      )
 
       const response = await request(app)
         .get(`/users/${publicKey}/credit-cards`)
@@ -169,14 +169,12 @@ describe('when updating cards', () => {
         },
       }
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
       )
 
       const typedData = generateTypedData(message)
-      const sig = sigUtil.personalSign(privateKey, {
-        data: JSON.stringify(typedData),
-      })
+      const sig = await wallet.signMessage(JSON.stringify(typedData))
 
       const response = await request(app)
         .put(`/users/${publicKey}/credit-cards`)
@@ -200,7 +198,7 @@ describe('when updating cards', () => {
         },
       }
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
       )
 
@@ -209,9 +207,9 @@ describe('when updating cards', () => {
         .mockReturnValueOnce(Promise.resolve(true))
 
       const typedData = generateTypedData(message)
-      const sig = sigUtil.personalSign(privateKey, {
-        data: `I save my payment card for my account ${message['Save Card'].publicKey}`,
-      })
+      const sig = await wallet.signMessage(
+        `I save my payment card for my account ${message['Save Card'].publicKey}`
+      )
 
       const response = await request(app)
         .put(`/users/${publicKey}/credit-cards`)
@@ -234,14 +232,14 @@ describe('when updating cards', () => {
         },
       }
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
       )
 
       const typedData = generateTypedData(message)
-      const sig = sigUtil.personalSign(privateKey, {
-        data: `I save my payment card for my account ${message['Save Card'].publicKey}`,
-      })
+      const sig = await wallet.signMessage(
+        `I save my payment card for my account ${message['Save Card'].publicKey}`
+      )
 
       jest
         .spyOn(UserOperations, 'updatePaymentDetails')
@@ -293,14 +291,12 @@ describe('when deleting cards', () => {
         },
       }
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
       )
 
       const typedData = generateTypedData(message)
-      const sig = sigUtil.personalSign(privateKey, {
-        data: JSON.stringify(typedData),
-      })
+      const sig = await wallet.signMessage(JSON.stringify(typedData))
 
       const response = await request(app)
         .delete(`/users/${publicKey}/credit-cards`)
@@ -321,7 +317,7 @@ describe('when deleting cards', () => {
         },
       }
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0x08491b7e20566b728ce21a07c88b12ed8b785b3826df93a7baceb21ddacf8b61'
       )
 
@@ -330,9 +326,9 @@ describe('when deleting cards', () => {
         .mockReturnValueOnce(Promise.resolve(true))
 
       const typedData = generateTypedData(message)
-      const sig = sigUtil.personalSign(privateKey, {
-        data: `I am deleting the card linked to my account ${message['Delete Card'].publicKey}`,
-      })
+      const sig = await wallet.signMessage(
+        `I am deleting the card linked to my account ${message['Delete Card'].publicKey}`
+      )
 
       const response = await request(app)
         .delete(`/users/${publicKey}/credit-cards`)
@@ -353,7 +349,7 @@ describe('when deleting cards', () => {
         },
       }
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0x08491b7e20566b728ce21a07c88b12ed8b785b3826df93a7baceb21ddacf8b61'
       )
 
@@ -362,9 +358,9 @@ describe('when deleting cards', () => {
         .mockReturnValueOnce(Promise.resolve(false))
 
       const typedData = generateTypedData(message)
-      const sig = sigUtil.personalSign(privateKey, {
-        data: `I am deleting the card linked to my account ${message['Delete Card'].publicKey}`,
-      })
+      const sig = await wallet.signMessage(
+        `I am deleting the card linked to my account ${message['Delete Card'].publicKey}`
+      )
 
       const response = await request(app)
         .delete(`/users/${publicKey}/credit-cards`)

--- a/locksmith/__tests__/controllers/userController/cards.test.ts
+++ b/locksmith/__tests__/controllers/userController/cards.test.ts
@@ -13,16 +13,9 @@ const { StripeCustomer } = models
 
 const publicKey = '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a'
 
-function generateTypedData(message: any) {
+function generateTypedData(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       User: [{ name: 'publicKey', type: 'address' }],
     },
     domain: {
@@ -31,6 +24,7 @@ function generateTypedData(message: any) {
     },
     primaryType: 'User',
     message,
+    messageKey,
   }
 }
 
@@ -87,10 +81,14 @@ describe('when requesting cards', () => {
         '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
       )
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Get Card')
 
       const { domain, types } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(
+        domain,
+        types,
+        message['Get Card']
+      )
 
       const response = await request(app)
         .get(`/users/${publicKey}/credit-cards`)
@@ -114,7 +112,7 @@ describe('when requesting cards', () => {
         '0x08491b7e20566b728ce21a07c88b12ed8b785b3826df93a7baceb21ddacf8b61'
       )
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Get Card')
 
       const sig = await wallet.signMessage(
         `I want to retrieve the card token for ${message['Get Card'].publicKey}`
@@ -144,7 +142,7 @@ describe('when updating cards', () => {
         },
       }
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Save Card')
 
       const response = await request(app)
         .put(`/users/${publicKey}/credit-cards`)
@@ -173,7 +171,7 @@ describe('when updating cards', () => {
         '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
       )
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Save Card')
       const sig = await wallet.signMessage(JSON.stringify(typedData))
 
       const response = await request(app)
@@ -206,7 +204,7 @@ describe('when updating cards', () => {
         .spyOn(UserOperations, 'updatePaymentDetails')
         .mockReturnValueOnce(Promise.resolve(true))
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Save Card')
       const sig = await wallet.signMessage(
         `I save my payment card for my account ${message['Save Card'].publicKey}`
       )
@@ -236,7 +234,7 @@ describe('when updating cards', () => {
         '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
       )
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Save Card')
       const sig = await wallet.signMessage(
         `I save my payment card for my account ${message['Save Card'].publicKey}`
       )
@@ -267,7 +265,7 @@ describe('when deleting cards', () => {
         },
       }
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Delete Card')
 
       const response = await request(app)
         .delete(`/users/${publicKey}/credit-cards`)
@@ -295,7 +293,7 @@ describe('when deleting cards', () => {
         '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
       )
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Delete Card')
       const sig = await wallet.signMessage(JSON.stringify(typedData))
 
       const response = await request(app)
@@ -325,7 +323,7 @@ describe('when deleting cards', () => {
         .spyOn(StripeOperations, 'deletePaymentDetailsForAddress')
         .mockReturnValueOnce(Promise.resolve(true))
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Delete Card')
       const sig = await wallet.signMessage(
         `I am deleting the card linked to my account ${message['Delete Card'].publicKey}`
       )
@@ -357,7 +355,7 @@ describe('when deleting cards', () => {
         .spyOn(StripeOperations, 'deletePaymentDetailsForAddress')
         .mockReturnValueOnce(Promise.resolve(false))
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'Delete Card')
       const sig = await wallet.signMessage(
         `I am deleting the card linked to my account ${message['Delete Card'].publicKey}`
       )

--- a/locksmith/__tests__/controllers/userController/ejection.test.ts
+++ b/locksmith/__tests__/controllers/userController/ejection.test.ts
@@ -1,7 +1,6 @@
+import { ethers } from 'ethers'
 import request from 'supertest'
 
-import ethJsUtil = require('ethereumjs-util')
-import sigUtil = require('eth-sig-util')
 import app = require('../../../src/app')
 import Base64 = require('../../../src/utils/base64')
 import models = require('../../../src/models')
@@ -54,7 +53,7 @@ describe('when ejecting an address', () => {
     it('returns 202', async () => {
       expect.assertions(1)
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0x00a7bd3ec661f15214f8a48dce017e27dd8e1b4b779aaf823d8eb74d8c960b95'
       )
 
@@ -66,9 +65,8 @@ describe('when ejecting an address', () => {
 
       const typedData = generateTypedData(message)
 
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+      const { domain, types } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const emailAddress = 'existing@example.com'
       const userCreationDetails = {
@@ -93,7 +91,7 @@ describe('when ejecting an address', () => {
     it('returns 400', async () => {
       expect.assertions(1)
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0xc7f80893d7a8eda620643280aedd684e87541555c9de450f70e11eb53c7cd02e'
       )
 
@@ -105,9 +103,8 @@ describe('when ejecting an address', () => {
 
       const typedData = generateTypedData(message)
 
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+      const { domain, types } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const response = await request(app)
         .post('/users/0xef49773e0d59f607cea8c8be4ce87bd26fd8e208/eject')
@@ -122,7 +119,7 @@ describe('when ejecting an address', () => {
     it('returns 400', async () => {
       expect.assertions(1)
 
-      const privateKey = ethJsUtil.toBuffer(
+      const wallet = new ethers.Wallet(
         '0xa272d59fbefc1eb1564b5a0f7c603f645965f02e3175f08d40e5486a5dcebd1c'
       )
 
@@ -134,9 +131,8 @@ describe('when ejecting an address', () => {
 
       const typedData = generateTypedData(message)
 
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+      const { domain, types } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const emailAddress = 'ejected_user@example.com'
       const userCreationDetails = {

--- a/locksmith/__tests__/controllers/userController/ejection.test.ts
+++ b/locksmith/__tests__/controllers/userController/ejection.test.ts
@@ -6,16 +6,9 @@ import Base64 = require('../../../src/utils/base64')
 import models = require('../../../src/models')
 import UserOperations = require('../../../src/operations/userOperations')
 
-function generateTypedData(message: any) {
+function generateTypedData(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       User: [{ name: 'publicKey', type: 'address' }],
     },
     domain: {
@@ -24,6 +17,7 @@ function generateTypedData(message: any) {
     },
     primaryType: 'User',
     message,
+    messageKey,
   }
 }
 
@@ -63,10 +57,10 @@ describe('when ejecting an address', () => {
         },
       }
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'user')
 
       const { domain, types } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(domain, types, message['user'])
 
       const emailAddress = 'existing@example.com'
       const userCreationDetails = {
@@ -101,10 +95,10 @@ describe('when ejecting an address', () => {
         },
       }
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'user')
 
       const { domain, types } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(domain, types, message['user'])
 
       const response = await request(app)
         .post('/users/0xef49773e0d59f607cea8c8be4ce87bd26fd8e208/eject')
@@ -129,10 +123,10 @@ describe('when ejecting an address', () => {
         },
       }
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'user')
 
       const { domain, types } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(domain, types, message['user'])
 
       const emailAddress = 'ejected_user@example.com'
       const userCreationDetails = {

--- a/locksmith/__tests__/controllers/userController/emailUpdate.test.ts
+++ b/locksmith/__tests__/controllers/userController/emailUpdate.test.ts
@@ -5,16 +5,9 @@ import app = require('../../../src/app')
 import UserOperations = require('../../../src/operations/userOperations')
 import Base64 = require('../../../src/utils/base64')
 
-function generateTypedData(message: any) {
+function generateTypedData(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       User: [
         { name: 'emailAddress', type: 'string' },
         { name: 'publicKey', type: 'address' },
@@ -27,6 +20,7 @@ function generateTypedData(message: any) {
     },
     primaryType: 'User',
     message,
+    messageKey,
   }
 }
 
@@ -55,7 +49,7 @@ describe("updating a user's email address", () => {
     },
   }
 
-  const typedData = generateTypedData(message)
+  const typedData = generateTypedData(message, 'user')
 
   const { domain, types } = typedData
 
@@ -65,12 +59,12 @@ describe("updating a user's email address", () => {
       const emailAddress = 'user@example.com'
       const userCreationDetails = {
         emailAddress,
-        publicKey: 'an_email_update_public_key',
+        publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
         passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
       }
       await UserOperations.createUser(userCreationDetails)
 
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(domain, types, message['user'])
 
       const response = await request(app)
         .put('/users/user@example.com')
@@ -91,7 +85,7 @@ describe("updating a user's email address", () => {
     it('returns 400', async () => {
       expect.assertions(1)
 
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(domain, types, message['user'])
 
       const response = await request(app)
         .put('/users/non-existing@example.com')
@@ -109,14 +103,14 @@ describe("updating a user's email address", () => {
       const emailAddress = 'ejected_user@example.com'
       const userCreationDetails = {
         emailAddress,
-        publicKey: 'ejected_user_phrase_public_key',
+        publicKey: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
         passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
       }
 
       await UserOperations.createUser(userCreationDetails)
       await UserOperations.eject(userCreationDetails.publicKey)
 
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(domain, types, message['user'])
 
       const response = await request(app)
         .put('/users/ejected_user@example.com')

--- a/locksmith/__tests__/controllers/userController/passwordEncryptedPrivateKey.test.ts
+++ b/locksmith/__tests__/controllers/userController/passwordEncryptedPrivateKey.test.ts
@@ -2,16 +2,9 @@ import { ethers } from 'ethers'
 
 import models = require('../../../src/models')
 
-function generateTypedData(message: any) {
+function generateTypedData(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       User: [
         { name: 'emailAddress', type: 'string' },
         { name: 'publicKey', type: 'address' },
@@ -24,6 +17,7 @@ function generateTypedData(message: any) {
     },
     primaryType: 'User',
     message,
+    messageKey,
   }
 }
 
@@ -59,7 +53,7 @@ describe("updating a user's password encrypted private key", () => {
       },
     }
 
-    const typedData = generateTypedData(message)
+    const typedData = generateTypedData(message, 'user')
 
     const { domain, types } = typedData
 
@@ -76,7 +70,7 @@ describe("updating a user's password encrypted private key", () => {
 
       await UserOperations.createUser(userCreationDetails)
 
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(domain, types, message['user'])
 
       const response = await request(app)
         .put(
@@ -103,7 +97,7 @@ describe("updating a user's password encrypted private key", () => {
       const emailAddress = 'ejected_user@example.com'
       const user = {
         emailAddress,
-        publicKey: 'ejected_user_phrase_public_key',
+        publicKey: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
         passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
       }
 
@@ -114,10 +108,10 @@ describe("updating a user's password encrypted private key", () => {
         user,
       }
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'user')
 
       const { domain, types } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(domain, types, message['user'])
 
       const response = await request(app)
         .put(`/users/${user.publicKey}/passwordEncryptedPrivateKey`)

--- a/locksmith/__tests__/controllers/userController/paymentDetails.test.ts
+++ b/locksmith/__tests__/controllers/userController/paymentDetails.test.ts
@@ -87,7 +87,7 @@ describe('payment details', () => {
       const emailAddress = 'ejected_user@example.com'
       const userCreationDetails = {
         emailAddress,
-        publicKey: 'ejected_user_phrase_public_key',
+        publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
         passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
       }
 
@@ -100,7 +100,7 @@ describe('payment details', () => {
         .send({
           message: {
             user: {
-              publicKey: 'ejected_user_phrase_public_key',
+              publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
               stripeTokenId: 'tok_RANDOM',
             },
           },

--- a/locksmith/__tests__/controllers/userController/privateKey.test.ts
+++ b/locksmith/__tests__/controllers/userController/privateKey.test.ts
@@ -66,7 +66,7 @@ describe('encrypted private key retrevial', () => {
       const emailAddress = 'ejected_user@example.com'
       const userCreationDetails = {
         emailAddress,
-        publicKey: 'ejected_user_phrase_public_key',
+        publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
         passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
       }
 

--- a/locksmith/__tests__/controllers/userController/recoveryPhrase.test.ts
+++ b/locksmith/__tests__/controllers/userController/recoveryPhrase.test.ts
@@ -21,7 +21,7 @@ describe("retrieving a user's recovery phrase", () => {
       const emailAddress = 'recovery_phrase_user@example.com'
       const userCreationDetails = {
         emailAddress,
-        publicKey: 'recovery_phrase_public_key',
+        publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
         passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
       }
 
@@ -56,7 +56,7 @@ describe("retrieving a user's recovery phrase", () => {
       const emailAddress = 'ejected_user@example.com'
       const userCreationDetails = {
         emailAddress,
-        publicKey: 'ejected_user_phrase_public_key',
+        publicKey: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
         passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
       }
 

--- a/locksmith/__tests__/controllers/userController/userCreation.test.ts
+++ b/locksmith/__tests__/controllers/userController/userCreation.test.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers'
+
 import models = require('../../../src/models')
 import app = require('../../../src/app')
 import Base64 = require('../../../src/utils/base64')
@@ -41,10 +43,8 @@ beforeAll(() => {
 
 describe('user creation', () => {
   const request = require('supertest')
-  const sigUtil = require('eth-sig-util')
-  const ethJsUtil = require('ethereumjs-util')
 
-  const privateKey = ethJsUtil.toBuffer(
+  const wallet = new ethers.Wallet(
     '0x68eec585ce3c13bf0cbe407cb05cd2679cb829fe350471846c9a8aa2ea85b6ac'
   )
 
@@ -110,9 +110,9 @@ describe('user creation', () => {
       }
 
       const typedData = generateTypedData(message)
-      const sig = sigUtil.signTypedData(privateKey, {
-        data: typedData,
-      })
+
+      const { domain, types } = typedData
+      const sig = await wallet._signTypedData(domain, types, message)
 
       const response = await request(app)
         .post('/users')

--- a/locksmith/__tests__/controllers/userController/userCreation.test.ts
+++ b/locksmith/__tests__/controllers/userController/userCreation.test.ts
@@ -6,16 +6,9 @@ import Base64 = require('../../../src/utils/base64')
 
 const UserOperations = require('../../../src/operations/userOperations')
 
-function generateTypedData(message: any) {
+function generateTypedData(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       User: [
         { name: 'emailAddress', type: 'string' },
         { name: 'publicKey', type: 'address' },
@@ -28,6 +21,7 @@ function generateTypedData(message: any) {
     },
     primaryType: 'User',
     message,
+    messageKey,
   }
 }
 
@@ -55,7 +49,7 @@ describe('user creation', () => {
       passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
     },
   }
-  const typedData = generateTypedData(message)
+  const typedData = generateTypedData(message, 'user')
 
   describe('when a user matching the public key does not exist', () => {
     const models = require('../../../src/models')
@@ -109,10 +103,10 @@ describe('user creation', () => {
         },
       }
 
-      const typedData = generateTypedData(message)
+      const typedData = generateTypedData(message, 'user')
 
       const { domain, types } = typedData
-      const sig = await wallet._signTypedData(domain, types, message)
+      const sig = await wallet._signTypedData(domain, types, message['user'])
 
       const response = await request(app)
         .post('/users')
@@ -131,7 +125,7 @@ describe('user creation', () => {
       const emailAddress = 'ejected_user@example.com'
       const userCreationDetails = {
         emailAddress,
-        publicKey: 'ejected_user_phrase_public_key',
+        publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
         passwordEncryptedPrivateKey: '{"data" : "encryptedPassword"}',
       }
 
@@ -150,7 +144,7 @@ describe('user creation', () => {
       const response = await request(app)
         .post('/users')
         .set('Accept', /json/)
-        .send(generateTypedData(message))
+        .send(generateTypedData(message, 'user'))
       expect(response.statusCode).toBe(409)
     })
   })

--- a/locksmith/__tests__/controllers/v2/ticketsController.test.ts
+++ b/locksmith/__tests__/controllers/v2/ticketsController.test.ts
@@ -6,7 +6,7 @@ const app = require('../../../src/app')
 
 jest.setTimeout(600000)
 const lockAddress = '0x3F09aD349a693bB62a162ff2ff3e097bD1cE9a8C'
-const wrongLockAddress = '0x00'
+const wrongLockAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
 const network = 4
 const tokenId = '2244'
 const wrongTokenId = '666'

--- a/locksmith/__tests__/data/lockOwnership.test.ts
+++ b/locksmith/__tests__/data/lockOwnership.test.ts
@@ -12,7 +12,7 @@ const mockWeb3Service: { getLock: any } = {
     outstandingKeys: 1,
     name: 'a mighty fine lock',
     address: '0x5Cd3FC283c42B4d5083dbA4a6bE5ac58fC0f0267',
-    owner: '0xb43333',
+    owner: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
   }),
 }
 
@@ -64,7 +64,9 @@ describe('Lock Ownership', () => {
         },
       })
 
-      expect(lock.owner.toLowerCase()).toEqual('0xb43333')
+      expect(lock.owner.toLowerCase()).toEqual(
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8'
+      )
     })
   })
 })

--- a/locksmith/__tests__/operations/lockOperations.test.js
+++ b/locksmith/__tests__/operations/lockOperations.test.js
@@ -22,7 +22,7 @@ describe('lockOperations', () => {
   describe('createLock', () => {
     it('should invoke Lock.create, with the checksummed adresses', async () => {
       expect.assertions(1)
-      const address = '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
+      const address = '0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
       const owner = '0xca750f9232c1c38e34d27e77534e1631526ec99e'
       Lock.create = jest.fn(() => {})
       await createLock({
@@ -32,7 +32,7 @@ describe('lockOperations', () => {
       })
       expect(Lock.create).toHaveBeenCalledWith({
         chain,
-        address: '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5',
+        address: '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5',
         owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
       })
     })
@@ -43,21 +43,19 @@ describe('lockOperations', () => {
       expect.assertions(4)
       Lock.findOne = jest.fn((query) => {
         expect(query.where.address[Op.eq]).toEqual(
-          '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
+          '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5'
         )
         return {
           name: 'My Lock',
-          address: '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5',
+          address: '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5',
           owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
         }
       })
       const lock = await getLockByAddress(
-        '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
+        '0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
       )
       expect(lock.name).toEqual('My Lock')
-      expect(lock.address).toEqual(
-        '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
-      )
+      expect(lock.address).toEqual('0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5')
       expect(Lock.findOne).toHaveBeenCalled()
     })
   })
@@ -78,13 +76,13 @@ describe('lockOperations', () => {
           return [
             {
               name: 'My Lock',
-              address: '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5',
+              address: '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5',
               owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
             },
           ]
         })
         const locks = await getLockAddresses()
-        expect(locks).toEqual(['0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'])
+        expect(locks).toEqual(['0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5'])
       })
     })
   })
@@ -98,7 +96,7 @@ describe('lockOperations', () => {
         )
         return {
           name: 'My Lock',
-          address: '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5',
+          address: '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5',
           owner: '0xCA750f9232C1c38e34D27e77534e1631526eC99e',
         }
       })
@@ -106,9 +104,7 @@ describe('lockOperations', () => {
         '0xca750f9232c1c38e34d27e77534e1631526ec99e'
       )
       expect(lock.name).toEqual('My Lock')
-      expect(lock.address).toEqual(
-        '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
-      )
+      expect(lock.address).toEqual('0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5')
       expect(Lock.findAll).toHaveBeenCalled()
     })
   })

--- a/locksmith/__tests__/operations/transactionOperations.test.js
+++ b/locksmith/__tests__/operations/transactionOperations.test.js
@@ -20,7 +20,7 @@ describe('lockOperations', () => {
       expect.assertions(6)
       const transactionHash =
         '0x7d6289db59c3434b6a034b4f211be52ca34f05e2aa856fc3e69b8af101355842'
-      const sender = '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
+      const sender = '0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
       const recipient = '0xca750f9232c1c38e34d27e77534e1631526ec99e'
       const chain = 31337
       Transaction.findOrCreate = jest.fn((query) => {
@@ -29,7 +29,7 @@ describe('lockOperations', () => {
         })
         expect(query.defaults.transactionHash).toEqual(transactionHash)
         expect(query.defaults.sender).toEqual(
-          '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
+          '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5'
         )
         expect(query.defaults.recipient).toEqual(
           '0xCA750f9232C1c38e34D27e77534e1631526eC99e'
@@ -50,10 +50,10 @@ describe('lockOperations', () => {
   describe('getTransactionsByFilter', () => {
     it('should get the list of transactions by that sender after having checksummed the address', async () => {
       expect.assertions(2)
-      const sender = '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
+      const sender = '0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
       Transaction.findAll = jest.fn((query) => {
         expect(query.where.sender[Op.eq]).toEqual(
-          '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
+          '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5'
         )
       })
       await getTransactionsByFilter({ sender })
@@ -63,10 +63,10 @@ describe('lockOperations', () => {
     describe('when passed a recipient filter', () => {
       it('only returns transactions for the appropriate recipient', async () => {
         expect.assertions(2)
-        const sender = '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
+        const sender = '0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
         Transaction.findAll = jest.fn((query) => {
           expect(query.where.sender[Op.eq]).toEqual(
-            '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5'
+            '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5'
           )
         })
         await getTransactionsByFilter({
@@ -78,7 +78,7 @@ describe('lockOperations', () => {
             recipient: {
               [Op.in]: ['0xCA750f9232C1c38e34D27e77534e1631526eC99e'],
             },
-            sender: { [Op.eq]: '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5' },
+            sender: { [Op.eq]: '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5' },
           },
         })
       })
@@ -87,7 +87,7 @@ describe('lockOperations', () => {
     describe('when passed a createdAfter value', () => {
       it('should only return transactions created after that date', async () => {
         expect.assertions(1)
-        const sender = '0x0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
+        const sender = '0x77cc4f1fe4555f9b9e0d1e918cac211915b079e5'
         const timestamp = 1573742842379
         Transaction.findAll = jest.fn(() => {})
         await getTransactionsByFilter({
@@ -100,7 +100,7 @@ describe('lockOperations', () => {
             recipient: {
               [Op.in]: ['0xCA750f9232C1c38e34D27e77534e1631526eC99e'],
             },
-            sender: { [Op.eq]: '0x0X77Cc4F1FE4555f9b9E0d1E918caC211915b079e5' },
+            sender: { [Op.eq]: '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5' },
             createdAt: {
               [Op.gte]: new Date(timestamp),
             },

--- a/locksmith/__tests__/operations/userMetadataOperations.test.ts
+++ b/locksmith/__tests__/operations/userMetadataOperations.test.ts
@@ -88,7 +88,7 @@ describe('userMetadataOperations', () => {
 
         const metaData = await getMetadata(
           '0x720b9F6D572C3CA4689E93CF029B40569c6b40e8',
-          '0xabbc'
+          '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
         )
         const result = await metaData
         expect(result).toBe(null)

--- a/locksmith/__tests__/operations/wedlocksOperations.test.ts
+++ b/locksmith/__tests__/operations/wedlocksOperations.test.ts
@@ -15,8 +15,8 @@ describe('Wedlocks operations', () => {
     it('should notify wedlocks if there is an email metadata', async () => {
       expect.assertions(1)
 
-      const lockAddress = '0xlock'
-      const ownerAddress = '0xowner'
+      const lockAddress = '0x95de5F777A3e283bFf0c47374998E10D8A2183C7'
+      const ownerAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
       await addMetadata({
         chain: 1,
         tokenAddress: lockAddress,
@@ -36,7 +36,7 @@ describe('Wedlocks operations', () => {
         },
       })
       expect(fetch).toHaveBeenCalledWith('http://localhost:1337', {
-        body: '{"template":"keyMined0xlock","failoverTemplate":"keyMined","recipient":"julien@unlock-protocol.com","params":{"keychainUrl":"https://app.unlock-protocol.com/keychain"},"attachments":[]}',
+        body: '{"template":"keyMined0x95de5F777A3e283bFf0c47374998E10D8A2183C7","failoverTemplate":"keyMined","recipient":"julien@unlock-protocol.com","params":{"keychainUrl":"https://app.unlock-protocol.com/keychain"},"attachments":[]}',
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       })
@@ -45,8 +45,8 @@ describe('Wedlocks operations', () => {
     it('should not notify wedlocks if there is no metadata', async () => {
       expect.assertions(1)
 
-      const lockAddress = '0xanotherlock'
-      const ownerAddress = '0xanotherowner'
+      const lockAddress = '0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691'
+      const ownerAddress = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
 
       await notifyNewKeyToWedlocks({
         lock: {
@@ -62,8 +62,8 @@ describe('Wedlocks operations', () => {
     it('should not notify wedlocks if there is no email metadata', async () => {
       expect.assertions(1)
 
-      const lockAddress = '0xanotherlock'
-      const ownerAddress = '0xanotherowner'
+      const lockAddress = '0xb0Feb7BA761A31548FF1cDbEc08affa8FFA3e691'
+      const ownerAddress = '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
 
       await addMetadata({
         chain: 1,

--- a/locksmith/__tests__/signatureValidation/signPersonal.test.ts
+++ b/locksmith/__tests__/signatureValidation/signPersonal.test.ts
@@ -20,13 +20,6 @@ const wallets: Wallet[] = [
 
 const body = {
   types: {
-    EIP712Domain: [
-      { name: 'name', type: 'string' },
-      { name: 'version', type: 'string' },
-      { name: 'chainId', type: 'uint256' },
-      { name: 'verifyingContract', type: 'address' },
-      { name: 'salt', type: 'bytes32' },
-    ],
     Lock: [
       { name: 'name', type: 'string' },
       { name: 'owner', type: 'address' },
@@ -42,6 +35,7 @@ const body = {
       address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
     },
   },
+  messageKey: 'lock',
 }
 
 let processor = signatureValidationMiddleware.generateProcessor({
@@ -74,13 +68,6 @@ describe('Signature Validation Middleware', () => {
 
         const body = {
           types: {
-            EIP712Domain: [
-              { name: 'name', type: 'string' },
-              { name: 'version', type: 'string' },
-              { name: 'chainId', type: 'uint256' },
-              { name: 'verifyingContract', type: 'address' },
-              { name: 'salt', type: 'bytes32' },
-            ],
             User: [{ name: 'publickKey', type: 'address' }],
           },
           domain: { name: 'Unlock', version: '1' },
@@ -90,6 +77,7 @@ describe('Signature Validation Middleware', () => {
               publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
             },
           },
+          messageKey: 'user',
         }
 
         const sig = await generateSignature(wallets[1], body)
@@ -98,7 +86,7 @@ describe('Signature Validation Middleware', () => {
           query: { data: encodeURIComponent(JSON.stringify(body)) },
         })
 
-        const signee = await new Promise((resolve, reject) => {
+        const signee = await new Promise((resolve) => {
           evaluator(request, response, function next() {
             resolve(request.signee)
           })
@@ -131,13 +119,6 @@ describe('Signature Validation Middleware', () => {
 
         const body = {
           types: {
-            EIP712Domain: [
-              { name: 'name', type: 'string' },
-              { name: 'version', type: 'string' },
-              { name: 'chainId', type: 'uint256' },
-              { name: 'verifyingContract', type: 'address' },
-              { name: 'salt', type: 'bytes32' },
-            ],
             User: [
               { name: 'emailAddress', type: 'string' },
               { name: 'publickKey', type: 'address' },
@@ -153,6 +134,7 @@ describe('Signature Validation Middleware', () => {
               passwordEncryptedPrivateKey: 'an encrypted value',
             },
           },
+          messageKey: 'user',
         }
 
         const sig = await generateSignature(wallets[1], body)
@@ -173,7 +155,7 @@ describe('Signature Validation Middleware', () => {
           signee: 'publicKey',
         })
 
-        const owner = await new Promise((resolve, reject) => {
+        const owner = await new Promise((resolve) => {
           processor(request, response, function next() {
             resolve(request.owner)
           })
@@ -190,13 +172,6 @@ describe('Signature Validation Middleware', () => {
 
         const body = {
           types: {
-            EIP712Domain: [
-              { name: 'name', type: 'string' },
-              { name: 'version', type: 'string' },
-              { name: 'chainId', type: 'uint256' },
-              { name: 'verifyingContract', type: 'address' },
-              { name: 'salt', type: 'bytes32' },
-            ],
             Lock: [
               { name: 'name', type: 'string' },
               { name: 'owner', type: 'address' },
@@ -212,6 +187,7 @@ describe('Signature Validation Middleware', () => {
               address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
             },
           },
+          messageKey: 'lock',
         }
 
         const sig = await generateSignature(wallets[1], body)
@@ -227,7 +203,7 @@ describe('Signature Validation Middleware', () => {
           required: ['name', 'owner', 'address'],
           signee: 'owner',
         })
-        const owner = await new Promise((resolve, reject) => {
+        const owner = await new Promise((resolve) => {
           processor(request, response, function next() {
             resolve(request.owner)
           })

--- a/locksmith/__tests__/signatureValidation/signPersonal.test.ts
+++ b/locksmith/__tests__/signatureValidation/signPersonal.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-shadow  */
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
+import { Wallet } from 'ethers'
 import signatureValidationMiddleware from '../../src/middlewares/signatureValidationMiddleware'
 
 import Base64 = require('../../src/utils/base64')
@@ -10,11 +9,11 @@ const httpMocks = require('node-mocks-http')
 let request: any
 let response: any
 
-const privateKey: Buffer[] = [
-  ethJsUtil.toBuffer(
+const wallets: Wallet[] = [
+  new Wallet(
     '0xe5986c22698a3c1eb5f84455895ad6826fbdff7b82dbeee240bad0024469d93a'
   ),
-  ethJsUtil.toBuffer(
+  new Wallet(
     '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
   ),
 ]
@@ -45,10 +44,6 @@ const body = {
   },
 }
 
-const validSignature = sigUtil.personalSign(privateKey[0], {
-  data: JSON.stringify(body),
-})
-
 let processor = signatureValidationMiddleware.generateProcessor({
   name: 'lock',
   required: ['name', 'owner', 'address'],
@@ -61,10 +56,9 @@ const evaluator = signatureValidationMiddleware.generateSignatureEvaluator({
   signee: 'publicKey',
 })
 
-const generateSignature = (privateKey: Buffer, body: any) => {
-  return sigUtil.personalSign(privateKey, {
-    data: JSON.stringify(body),
-  })
+const generateSignature = async (wallet: Wallet, body: any) => {
+  const sig = await wallet.signMessage(JSON.stringify(body))
+  return sig
 }
 
 beforeAll(() => {
@@ -75,7 +69,7 @@ beforeAll(() => {
 describe('Signature Validation Middleware', () => {
   describe('generateSignatureEvaluator', () => {
     describe('when the request has a token', () => {
-      it('returns the signee', (done) => {
+      it('returns the signee', async () => {
         expect.assertions(1)
 
         const body = {
@@ -98,18 +92,19 @@ describe('Signature Validation Middleware', () => {
           },
         }
 
-        const sig = generateSignature(privateKey[1], body)
+        const sig = await generateSignature(wallets[1], body)
         const request = httpMocks.createRequest({
           headers: { Authorization: `Bearer-Simple ${Base64.encode(sig)}` },
           query: { data: encodeURIComponent(JSON.stringify(body)) },
         })
 
-        evaluator(request, response, function next() {
-          expect(request.signee).toBe(
-            '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
-          )
-          done()
+        const signee = await new Promise((resolve, reject) => {
+          evaluator(request, response, function next() {
+            resolve(request.signee)
+          })
         })
+
+        expect(signee).toBe('0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2')
       })
     })
 
@@ -131,7 +126,7 @@ describe('Signature Validation Middleware', () => {
 
   describe('when a valid signature is received', () => {
     describe('a signature for User creation', () => {
-      it('moves the request to the application', (done) => {
+      it('moves the request to the application', async () => {
         expect.assertions(1)
 
         const body = {
@@ -160,7 +155,7 @@ describe('Signature Validation Middleware', () => {
           },
         }
 
-        const sig = generateSignature(privateKey[1], body)
+        const sig = await generateSignature(wallets[1], body)
         const request = httpMocks.createRequest({
           headers: {
             Authorization: `Bearer-Simple ${Base64.encode(sig)}`,
@@ -177,17 +172,19 @@ describe('Signature Validation Middleware', () => {
           ],
           signee: 'publicKey',
         })
-        processor(request, response, function next() {
-          expect(request.owner).toBe(
-            '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
-          )
-          done()
+
+        const owner = await new Promise((resolve, reject) => {
+          processor(request, response, function next() {
+            resolve(request.owner)
+          })
         })
+
+        expect(owner).toBe('0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2')
       })
     })
 
     describe('a signature for Lock metadata', () => {
-      it('moves the request to the application', (done) => {
+      it('moves the request to the application', async () => {
         expect.assertions(1)
         Date.now = jest.fn(() => 1546130835000)
 
@@ -217,7 +214,7 @@ describe('Signature Validation Middleware', () => {
           },
         }
 
-        const sig = generateSignature(privateKey[1], body)
+        const sig = await generateSignature(wallets[1], body)
         const request = httpMocks.createRequest({
           headers: {
             Authorization: `Bearer-Simple ${Base64.encode(sig)}`,
@@ -230,12 +227,12 @@ describe('Signature Validation Middleware', () => {
           required: ['name', 'owner', 'address'],
           signee: 'owner',
         })
-        processor(request, response, function next() {
-          expect(request.owner).toBe(
-            '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
-          )
-          done()
+        const owner = await new Promise((resolve, reject) => {
+          processor(request, response, function next() {
+            resolve(request.owner)
+          })
         })
+        expect(owner).toBe('0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2')
       })
     })
   })
@@ -251,8 +248,10 @@ describe('Signature Validation Middleware', () => {
     })
 
     describe('when the body provided is not well formed Typed Data ', () => {
-      test('returns a status 401 to the caller', () => {
+      test('returns a status 401 to the caller', async () => {
         expect.assertions(1)
+
+        const validSignature = await generateSignature(wallets[0], body)
         const request = httpMocks.createRequest({
           headers: {
             Authorization: `Bearer-Simple ${Base64.encode(validSignature)}`,
@@ -266,9 +265,10 @@ describe('Signature Validation Middleware', () => {
     })
 
     describe('when the signature is malformed', () => {
-      test('returns a  status 401 to the caller', () => {
+      test('returns a  status 401 to the caller', async () => {
         expect.assertions(1)
 
+        const validSignature = await generateSignature(wallets[0], body)
         const request = httpMocks.createRequest({
           headers: { Authorization: `Bearer-Simple ${validSignature}xyz` },
           body,
@@ -281,9 +281,10 @@ describe('Signature Validation Middleware', () => {
     })
 
     describe('when the signee does not match the item owner', () => {
-      test('returns a status 401 to the caller ', () => {
+      test('returns a status 401 to the caller ', async () => {
         expect.assertions(1)
 
+        const validSignature = await generateSignature(wallets[0], body)
         const request = httpMocks.createRequest({
           headers: { Authorization: `Bearer-Simple ${validSignature}` },
           body,

--- a/locksmith/__tests__/signatureValidation/typedData.test.ts
+++ b/locksmith/__tests__/signatureValidation/typedData.test.ts
@@ -5,6 +5,7 @@ import signatureValidationMiddleware from '../../src/middlewares/signatureValida
 const httpMocks = require('node-mocks-http')
 const Base64 = require('../../src/utils/base64')
 
+jest.setTimeout(600000)
 let request: any
 let response: any
 

--- a/locksmith/__tests__/signatureValidation/typedData.test.ts
+++ b/locksmith/__tests__/signatureValidation/typedData.test.ts
@@ -38,14 +38,7 @@ describe('Signature Validation Middleware', () => {
 
         const body = {
           types: {
-            EIP712Domain: [
-              { name: 'name', type: 'string' },
-              { name: 'version', type: 'string' },
-              { name: 'chainId', type: 'uint256' },
-              { name: 'verifyingContract', type: 'address' },
-              { name: 'salt', type: 'bytes32' },
-            ],
-            User: [{ name: 'publickKey', type: 'address' }],
+            User: [{ name: 'publicKey', type: 'address' }],
           },
           domain: { name: 'Unlock', version: '1' },
           primaryType: 'User',
@@ -54,6 +47,7 @@ describe('Signature Validation Middleware', () => {
               publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
             },
           },
+          messageKey: 'user',
         }
 
         const wallet = new ethers.Wallet(
@@ -61,7 +55,7 @@ describe('Signature Validation Middleware', () => {
         )
 
         const { domain, types, message } = body
-        const sig = await wallet._signTypedData(domain, types, message)
+        const sig = await wallet._signTypedData(domain, types, message['user'])
 
         const request = httpMocks.createRequest({
           headers: { Authorization: `Bearer ${Base64.encode(sig)}` },
@@ -70,7 +64,7 @@ describe('Signature Validation Middleware', () => {
           },
         })
 
-        const signee = await new Promise((resolve, reject) => {
+        const signee = await new Promise((resolve) => {
           evaluator(request, response, function next() {
             resolve(request.signee)
           })
@@ -104,13 +98,6 @@ describe('Signature Validation Middleware', () => {
           headers: { Authorization: `Bearer ${validSig2}` },
           body: {
             types: {
-              EIP712Domain: [
-                { name: 'name', type: 'string' },
-                { name: 'version', type: 'string' },
-                { name: 'chainId', type: 'uint256' },
-                { name: 'verifyingContract', type: 'address' },
-                { name: 'salt', type: 'bytes32' },
-              ],
               User: [
                 { name: 'emailAddress', type: 'string' },
                 { name: 'publickKey', type: 'address' },
@@ -120,11 +107,9 @@ describe('Signature Validation Middleware', () => {
             domain: { name: 'Unlock', version: '1' },
             primaryType: 'User',
             message: {
-              user: {
-                emailAddress: 'new_user@example.com',
-                publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
-                passwordEncryptedPrivateKey: 'an encrypted value',
-              },
+              emailAddress: 'new_user@example.com',
+              publicKey: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+              passwordEncryptedPrivateKey: 'an encrypted value',
             },
           },
         })
@@ -156,13 +141,6 @@ describe('Signature Validation Middleware', () => {
 
           body: {
             types: {
-              EIP712Domain: [
-                { name: 'name', type: 'string' },
-                { name: 'version', type: 'string' },
-                { name: 'chainId', type: 'uint256' },
-                { name: 'verifyingContract', type: 'address' },
-                { name: 'salt', type: 'bytes32' },
-              ],
               Lock: [
                 { name: 'name', type: 'string' },
                 { name: 'owner', type: 'address' },
@@ -172,11 +150,9 @@ describe('Signature Validation Middleware', () => {
             domain: { name: 'Unlock Dashboard', version: '1', chainId: 31337 },
             primaryType: 'Lock',
             message: {
-              lock: {
-                name: 'New Lock',
-                owner: '0x109B141fDa40c61a9eA85B77dD4727F08EcBE140',
-                address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
-              },
+              name: 'New Lock',
+              owner: '0x109B141fDa40c61a9eA85B77dD4727F08EcBE140',
+              address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
             },
           },
         })
@@ -227,13 +203,6 @@ describe('Signature Validation Middleware', () => {
 
           body: {
             types: {
-              EIP712Domain: [
-                { name: 'name', type: 'string' },
-                { name: 'version', type: 'string' },
-                { name: 'chainId', type: 'uint256' },
-                { name: 'verifyingContract', type: 'address' },
-                { name: 'salt', type: 'bytes32' },
-              ],
               Lock: [
                 { name: 'name', type: 'string' },
                 { name: 'owner', type: 'address' },
@@ -243,11 +212,9 @@ describe('Signature Validation Middleware', () => {
             domain: { name: 'Unlock Dashboard', version: '1', chainId: 31337 },
             primaryType: 'Lock',
             message: {
-              lock: {
-                name: 'New Lock',
-                owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
-                address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
-              },
+              name: 'New Lock',
+              owner: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
+              address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
             },
           },
         })
@@ -266,13 +233,6 @@ describe('Signature Validation Middleware', () => {
 
           body: {
             types: {
-              EIP712Domain: [
-                { name: 'name', type: 'string' },
-                { name: 'version', type: 'string' },
-                { name: 'chainId', type: 'uint256' },
-                { name: 'verifyingContract', type: 'address' },
-                { name: 'salt', type: 'bytes32' },
-              ],
               Lock: [
                 { name: 'name', type: 'string' },
                 { name: 'owner', type: 'address' },
@@ -282,11 +242,9 @@ describe('Signature Validation Middleware', () => {
             domain: { name: 'Unlock Dashboard', version: '1', chainId: 31337 },
             primaryType: 'Lock',
             message: {
-              lock: {
-                name: 'New Lock',
-                owner: '0xc66ef2e0d0edcce723b3fdd4307db6c5f0dda1b8',
-                address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
-              },
+              name: 'New Lock',
+              owner: '0xc66ef2e0d0edcce723b3fdd4307db6c5f0dda1b8',
+              address: '0x21cC9C438D9751A3225496F6FD1F1215C7bd5D83',
             },
           },
         })

--- a/locksmith/__tests__/signatureValidation/typedData.test.ts
+++ b/locksmith/__tests__/signatureValidation/typedData.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-shadow  */
+import { ethers } from 'ethers'
 import signatureValidationMiddleware from '../../src/middlewares/signatureValidationMiddleware'
 
-const ethJsUtil = require('ethereumjs-util')
-const sigUtil = require('eth-sig-util')
 const httpMocks = require('node-mocks-http')
 const Base64 = require('../../src/utils/base64')
 
@@ -34,7 +33,7 @@ beforeAll(() => {
 describe('Signature Validation Middleware', () => {
   describe('generateSignatureEvaluator', () => {
     describe('when the request has a token', () => {
-      it('returns the signee', (done) => {
+      it('returns the signee', async () => {
         expect.assertions(1)
 
         const body = {
@@ -57,13 +56,12 @@ describe('Signature Validation Middleware', () => {
           },
         }
 
-        const privateKey = ethJsUtil.toBuffer(
+        const wallet = new ethers.Wallet(
           '0xfd8abdd241b9e7679e3ef88f05b31545816d6fbcaf11e86ebd5a57ba281ce229'
         )
 
-        const sig = sigUtil.signTypedData(privateKey, {
-          data: body,
-        })
+        const { domain, types, message } = body
+        const sig = await wallet._signTypedData(domain, types, message)
 
         const request = httpMocks.createRequest({
           headers: { Authorization: `Bearer ${Base64.encode(sig)}` },
@@ -72,12 +70,13 @@ describe('Signature Validation Middleware', () => {
           },
         })
 
-        evaluator(request, response, function next() {
-          expect(request.signee).toBe(
-            '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2'
-          )
-          done()
+        const signee = await new Promise((resolve, reject) => {
+          evaluator(request, response, function next() {
+            resolve(request.signee)
+          })
         })
+
+        expect(signee).toBe('0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2')
       })
     })
 

--- a/locksmith/__tests__/test-helpers/typeDataGenerators.ts
+++ b/locksmith/__tests__/test-helpers/typeDataGenerators.ts
@@ -1,18 +1,10 @@
-export function lockTypedData(message: any) {
+export function lockTypedData(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       LockMetadata: [
         { name: 'address', type: 'address' },
-        { name: 'name', type: 'string' },
-        { name: 'description', type: 'string' },
-        { name: 'image', type: 'string' },
+        { name: 'owner', type: 'address' },
+        { name: 'timestamp', type: 'uint256' },
       ],
     },
     domain: {
@@ -21,19 +13,13 @@ export function lockTypedData(message: any) {
     },
     primaryType: 'LockMetadata',
     message,
+    messageKey,
   }
 }
 
-export function keyTypedData(message: any) {
+export function keyTypedData(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       KeyMetadata: [],
     },
     domain: {
@@ -42,5 +28,6 @@ export function keyTypedData(message: any) {
     },
     primaryType: 'KeyMetadata',
     message,
+    messageKey,
   }
 }

--- a/locksmith/__tests__/utils/keyPricer.test.ts
+++ b/locksmith/__tests__/utils/keyPricer.test.ts
@@ -47,7 +47,10 @@ describe('KeyPricer', () => {
       it('returns the key price in USD', async () => {
         expect.assertions(1)
         mockWeb3Service.getLock.mockResolvedValueOnce(standardLock)
-        await keyPricer.keyPriceUSD('an address', 1) // default to Eth
+        await keyPricer.keyPriceUSD(
+          '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+          1
+        ) // default to Eth
         expect(spy).toBeCalledWith('ETH', '0.01')
       })
     })
@@ -57,7 +60,10 @@ describe('KeyPricer', () => {
     it('Generate price for a single quantity key', async () => {
       expect.assertions(3)
       mockWeb3Service.getLock.mockResolvedValueOnce(standardLock)
-      const pricing = await keyPricer.generate('0x', 100)
+      const pricing = await keyPricer.generate(
+        '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5',
+        100
+      )
 
       expect(pricing.keyPrice).toBe(1)
       expect(pricing.creditCardProcessing).toBe(31)
@@ -67,7 +73,11 @@ describe('KeyPricer', () => {
     it('Generate price for multiple quantity keys', async () => {
       expect.assertions(3)
       mockWeb3Service.getLock.mockResolvedValueOnce(standardLock)
-      const pricing = await keyPricer.generate('0x', 100, 100)
+      const pricing = await keyPricer.generate(
+        '0x77Cc4f1FE4555F9B9E0d1E918caC211915B079e5',
+        100,
+        100
+      )
 
       expect(pricing.keyPrice).toBe(100)
       expect(pricing.unlockServiceFee).toBe(10.01)

--- a/locksmith/config/config.js
+++ b/locksmith/config/config.js
@@ -18,7 +18,7 @@ const config = {
   recaptchaSecret: process.env.RECAPTCHA_SECRET,
 }
 
-if (Boolean(process.env.ON_HEROKU)) {
+if (process.env.ON_HEROKU) {
   // Heroku needs this:
   config.database.ssl = true
   config.database.dialectOptions = {
@@ -35,6 +35,7 @@ if (process.env.DATABASE_URL) {
   config.database.username = databaseConfigUrl.username
   config.database.password = databaseConfigUrl.password
   config.database.host = databaseConfigUrl.hostname
+  config.database.port = databaseConfigUrl.port
   config.database.database = databaseConfigUrl.pathname.substring(1)
 } else {
   config.database.username = process.env.DB_USERNAME

--- a/locksmith/package.json
+++ b/locksmith/package.json
@@ -55,8 +55,6 @@
     "cors": "2.8.5",
     "cross-fetch": "3.1.5",
     "dotenv": "16.0.1",
-    "eth-sig-util": "2.5.4",
-    "ethereumjs-util": "6.2.1",
     "ethers": "5.6.8",
     "express": "4.17.3",
     "express-jwt": "7.5.2",
@@ -93,8 +91,6 @@
   "devDependencies": {
     "@types/cookie-parser": "1.4.3",
     "@types/cors": "2.8.12",
-    "@types/eth-sig-util": "2.1.1",
-    "@types/ethereumjs-util": "5.2.0",
     "@types/express": "4.17.13",
     "@types/express-serve-static-core": "4.17.28",
     "@types/isomorphic-fetch": "0.0.36",

--- a/locksmith/scripts/connectedPurchase.ts
+++ b/locksmith/scripts/connectedPurchase.ts
@@ -1,6 +1,5 @@
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
 import * as Base64 from '../src/utils/base64'
+import { generateTypedSignature } from '../src/utils/signature'
 
 // const args = require('yargs').argv
 const request = require('request-promise-native')
@@ -32,14 +31,6 @@ function generatePurchasePayload(message: any) {
   }
 }
 
-function generateSignature(privateKey: string, data: any) {
-  const pk = ethJsUtil.toBuffer(privateKey)
-
-  return sigUtil.signTypedData(pk, {
-    data,
-  })
-}
-
 const recipient = '0xd8fdbf2302b13d4cf00bac1a25efb786759c7788'
 const pk = '0x00a7bd3ec661f15214f8a48dce017e27dd8e1b4b779aaf823d8eb74d8c960b95'
 const lock = '0xEE9FE39966DF737eECa5920ABa975c283784Faf8'
@@ -59,7 +50,7 @@ async function postPurchaseRequest(
   metadata: any,
   endpoint: string
 ) {
-  const signature = generateSignature(privateKey, metadata)
+  const signature = await generateTypedSignature(privateKey, metadata)
   const params = {
     uri: endpoint,
     method: 'POST',

--- a/locksmith/scripts/connectedPurchase.ts
+++ b/locksmith/scripts/connectedPurchase.ts
@@ -4,17 +4,9 @@ import { generateTypedSignature } from '../src/utils/signature'
 // const args = require('yargs').argv
 const request = require('request-promise-native')
 
-function generatePurchasePayload(message: any) {
+function generatePurchasePayload(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
-
       PurchaseRequest: [
         { name: 'recipient', type: 'address' },
         { name: 'lock', type: 'address' },
@@ -28,6 +20,7 @@ function generatePurchasePayload(message: any) {
     },
     primaryType: 'PurchaseRequest',
     message: message,
+    messageKey,
   }
 }
 
@@ -44,7 +37,7 @@ const message = {
   },
 }
 
-const typedData = generatePurchasePayload(message)
+const typedData = generatePurchasePayload(message, 'purchaseRequest')
 async function postPurchaseRequest(
   privateKey: string,
   metadata: any,

--- a/locksmith/scripts/metadataUpload/metadata_upload.ts
+++ b/locksmith/scripts/metadataUpload/metadata_upload.ts
@@ -24,7 +24,7 @@ async function updateMetadata(
   await request(options)
 }
 
-function generateLockMetadataPayload(message: any) {
+function generateLockMetadataPayload(message: any, messageKey: string) {
   return {
     types: {
       LockMetadata: [
@@ -40,10 +40,11 @@ function generateLockMetadataPayload(message: any) {
     },
     primaryType: 'LockMetadata',
     message: message,
+    messageKey,
   }
 }
 
-function generateKeyMetadataPayload(message: any) {
+function generateKeyMetadataPayload(message: any, messageKey: string) {
   return {
     types: {
       KeyMetadata: [],
@@ -54,6 +55,7 @@ function generateKeyMetadataPayload(message: any) {
     },
     primaryType: 'KeyMetadata',
     message: message,
+    messageKey,
   }
 }
 
@@ -77,10 +79,16 @@ async function main(
   const message = JSON.parse(contents)
 
   if (scope == 'default') {
-    const data = generateLockMetadataPayload(message)
+    const data = generateLockMetadataPayload(
+      { lockMetadata: message },
+      'lockMetadata'
+    )
     updateMetadata(privateKey, data, `${host}/api/key/${lockAddress}`)
   } else {
-    const data = generateKeyMetadataPayload(message)
+    const data = generateKeyMetadataPayload(
+      { keyMetadata: message },
+      'keyMetadata'
+    )
     updateMetadata(privateKey, data, `${host}/api/key/${lockAddress}/1`)
   }
 }

--- a/locksmith/scripts/metadataUpload/metadata_upload.ts
+++ b/locksmith/scripts/metadataUpload/metadata_upload.ts
@@ -1,27 +1,18 @@
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
 import * as Base64 from '../../src/utils/base64'
+import { generateTypedSignature } from '../../src/utils/signature'
 
 const args = require('yargs').argv
-let request = require('request-promise-native')
-var fs = require('fs')
+const request = require('request-promise-native')
+const fs = require('fs')
 const resolve = require('path').resolve
-
-function generateSignature(privateKey: string, data: any) {
-  let pk = ethJsUtil.toBuffer(privateKey)
-
-  return sigUtil.signTypedData(pk, {
-    data,
-  })
-}
 
 async function updateMetadata(
   privateKey: string,
   metadata: any,
   endpoint: string
 ) {
-  let signature = generateSignature(privateKey, metadata)
-  let options = {
+  const signature = await generateTypedSignature(privateKey, metadata)
+  const options = {
     uri: endpoint,
     method: 'PUT',
     headers: {
@@ -96,14 +87,14 @@ async function main(
   host: string,
   scope: string
 ) {
-  var contents = fs.readFileSync(resolve(inputFile), 'utf8')
-  let message = JSON.parse(contents)
+  const contents = fs.readFileSync(resolve(inputFile), 'utf8')
+  const message = JSON.parse(contents)
 
   if (scope == 'default') {
-    let data = generateLockMetadataPayload(message)
+    const data = generateLockMetadataPayload(message)
     updateMetadata(privateKey, data, `${host}/api/key/${lockAddress}`)
   } else {
-    let data = generateKeyMetadataPayload(message)
+    const data = generateKeyMetadataPayload(message)
     updateMetadata(privateKey, data, `${host}/api/key/${lockAddress}/1`)
   }
 }
@@ -112,11 +103,11 @@ async function main(
 //'/Users/akeem/projects/unlock/locksmith/scripts/data.json'
 //'http://localhost:8080'
 
-let privateKey = args.privateKey
-let lockAddress = args.lockAddress
-let host = args.host
-let inputFile = args.inputFile
-let scope = args.scope
+const privateKey = args.privateKey
+const lockAddress = args.lockAddress
+const host = args.host
+const inputFile = args.inputFile
+const scope = args.scope
 
 if (preflightCheck(privateKey, lockAddress, inputFile, host)) {
   main(privateKey, lockAddress, inputFile, host, scope)

--- a/locksmith/scripts/metadataUpload/metadata_upload.ts
+++ b/locksmith/scripts/metadataUpload/metadata_upload.ts
@@ -27,13 +27,6 @@ async function updateMetadata(
 function generateLockMetadataPayload(message: any) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       LockMetadata: [
         { name: 'name', type: 'string' },
         { name: 'description', type: 'string' },
@@ -53,13 +46,6 @@ function generateLockMetadataPayload(message: any) {
 function generateKeyMetadataPayload(message: any) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       KeyMetadata: [],
     },
     domain: {

--- a/locksmith/scripts/metadataUpload/user_metadata_upload.ts
+++ b/locksmith/scripts/metadataUpload/user_metadata_upload.ts
@@ -24,16 +24,9 @@ async function updateMetadata(
   await request(options)
 }
 
-function generateUserMetadataPayload(message: any) {
+function generateUserMetadataPayload(message: any, messageKey: string) {
   return {
     types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
       UserMetaData: [],
     },
     domain: {
@@ -42,6 +35,7 @@ function generateUserMetadataPayload(message: any) {
     },
     primaryType: 'UserMetaData',
     message: message,
+    messageKey,
   }
 }
 
@@ -65,7 +59,7 @@ async function main(
   const contents = fs.readFileSync(resolve(inputFile), 'utf8')
   const message = JSON.parse(contents)
 
-  const data = generateUserMetadataPayload(message)
+  const data = generateUserMetadataPayload(message, 'key')
   updateMetadata(privateKey, data, endpoint)
 }
 

--- a/locksmith/scripts/metadataUpload/user_metadata_upload.ts
+++ b/locksmith/scripts/metadataUpload/user_metadata_upload.ts
@@ -1,27 +1,18 @@
-import * as sigUtil from 'eth-sig-util'
-import * as ethJsUtil from 'ethereumjs-util'
 import * as Base64 from '../../src/utils/base64'
+import { generateTypedSignature } from '../../src/utils/signature'
 
 const args = require('yargs').argv
-let request = require('request-promise-native')
-var fs = require('fs')
+const request = require('request-promise-native')
+const fs = require('fs')
 const resolve = require('path').resolve
-
-function generateSignature(privateKey: string, data: any) {
-  let pk = ethJsUtil.toBuffer(privateKey)
-
-  return sigUtil.signTypedData(pk, {
-    data,
-  })
-}
 
 async function updateMetadata(
   privateKey: string,
   metadata: any,
   endpoint: string
 ) {
-  let signature = generateSignature(privateKey, metadata)
-  let options = {
+  const signature = await generateTypedSignature(privateKey, metadata)
+  const options = {
     uri: endpoint,
     method: 'PUT',
     headers: {
@@ -71,10 +62,10 @@ async function main(
 ) {
   const userAddress = '0xe29ec42f0b620b1c9a716f79a02e9dc5a5f5f98a'
   const endpoint = `${host}/api/key/${lockAddress}/user/${userAddress}`
-  var contents = fs.readFileSync(resolve(inputFile), 'utf8')
-  let message = JSON.parse(contents)
+  const contents = fs.readFileSync(resolve(inputFile), 'utf8')
+  const message = JSON.parse(contents)
 
-  let data = generateUserMetadataPayload(message)
+  const data = generateUserMetadataPayload(message)
   updateMetadata(privateKey, data, endpoint)
 }
 
@@ -82,10 +73,10 @@ async function main(
 //'/Users/akeem/projects/unlock/locksmith/scripts/data.json'
 //'http://localhost:8080'
 
-let privateKey = args.privateKey
-let lockAddress = args.lockAddress
-let host = args.host
-let inputFile = args.inputFile
+const privateKey = args.privateKey
+const lockAddress = args.lockAddress
+const host = args.host
+const inputFile = args.inputFile
 
 if (preflightCheck(privateKey, lockAddress, inputFile, host)) {
   main(privateKey, lockAddress, inputFile, host)

--- a/locksmith/src/controllers/lockController.js
+++ b/locksmith/src/controllers/lockController.js
@@ -29,8 +29,8 @@ const lockSave = async (req, res) => {
   if (!databaseLock) {
     lock.chain = req.chain
     await createLock(lock)
-    return res.sendStatus(200)
   }
+  return res.sendStatus(200)
 }
 
 const lockGet = async (req, res) => {
@@ -39,7 +39,6 @@ const lockGet = async (req, res) => {
     req.params.lockAddress,
     `${req.protocol}://${req.headers.host}`
   )
-
   res.json(baseTokenData)
 }
 

--- a/locksmith/src/middlewares/signatureValidationMiddleware.ts
+++ b/locksmith/src/middlewares/signatureValidationMiddleware.ts
@@ -13,12 +13,12 @@ namespace SignatureValidationMiddleware {
 
   const extractTypeDataSignee = (header: string, body: any) => {
     const decodedSignature = Base64.decode(header)
-    const { domain, types, message } = body
+    const { domain, types, message, messageKey } = body
     try {
       return ethers.utils.verifyTypedData(
         domain,
         types,
-        message,
+        message[messageKey],
         decodedSignature
       )
     } catch (error) {

--- a/locksmith/src/middlewares/signatureValidationMiddleware.ts
+++ b/locksmith/src/middlewares/signatureValidationMiddleware.ts
@@ -1,4 +1,4 @@
-import * as sigUtil from 'eth-sig-util'
+import { ethers } from 'ethers'
 import { Request, Response } from 'express-serve-static-core'
 import * as Base64 from '../utils/base64'
 import Normalizer from '../utils/normalizer'
@@ -13,12 +13,14 @@ namespace SignatureValidationMiddleware {
 
   const extractTypeDataSignee = (header: string, body: any) => {
     const decodedSignature = Base64.decode(header)
-
+    const { domain, types, message } = body
     try {
-      return sigUtil.recoverTypedSignature({
-        data: body,
-        sig: decodedSignature,
-      })
+      return ethers.utils.verifyTypedData(
+        domain,
+        types,
+        message,
+        decodedSignature
+      )
     } catch (error) {
       logger.error('Failed to extractTypeDataSignee', error)
       return null
@@ -29,10 +31,7 @@ namespace SignatureValidationMiddleware {
     const decodedSignature = Base64.decode(header)
 
     try {
-      return sigUtil.recoverPersonalSignature({
-        data,
-        sig: decodedSignature,
-      })
+      return ethers.utils.verifyMessage(data, decodedSignature)
     } catch (error) {
       logger.error('Failed to extractPersonalSignSignee', error)
       return null

--- a/locksmith/src/operations/lockOperations.ts
+++ b/locksmith/src/operations/lockOperations.ts
@@ -1,4 +1,3 @@
-import ethJsUtil = require('ethereumjs-util')
 import Sequelize = require('sequelize')
 import { ethers } from 'ethers'
 import networks from '@unlock-protocol/networks'
@@ -16,8 +15,8 @@ const { Lock, UserTokenMetadata, LockMigrations } = models
 export async function createLock(lock: any) {
   return Lock.create({
     chain: lock.chain,
-    address: ethJsUtil.toChecksumAddress(lock.address),
-    owner: ethJsUtil.toChecksumAddress(lock.owner),
+    address: ethers.utils.getAddress(lock.address),
+    owner: ethers.utils.getAddress(lock.owner),
   })
 }
 
@@ -29,7 +28,7 @@ export async function getLockByAddress(address: string) {
   return Lock.findOne({
     attributes: Lock.publicFields,
     where: {
-      address: { [Op.eq]: ethJsUtil.toChecksumAddress(address) },
+      address: { [Op.eq]: ethers.utils.getAddress(address) },
     },
   })
 }
@@ -42,7 +41,7 @@ export async function getLocksByOwner(owner: string) {
   return Lock.findAll({
     attributes: Lock.publicFields,
     where: {
-      owner: { [Op.eq]: ethJsUtil.toChecksumAddress(owner) },
+      owner: { [Op.eq]: ethers.utils.getAddress(owner) },
     },
   })
 }
@@ -60,8 +59,8 @@ export async function updateLockOwnership(
   return Lock.upsert(
     {
       chain,
-      address: ethJsUtil.toChecksumAddress(address),
-      owner: ethJsUtil.toChecksumAddress(owner),
+      address: ethers.utils.getAddress(address),
+      owner: ethers.utils.getAddress(owner),
     },
     {
       fields: ['owner'],

--- a/locksmith/src/operations/transactionOperations.ts
+++ b/locksmith/src/operations/transactionOperations.ts
@@ -1,6 +1,6 @@
+import { ethers } from 'ethers'
 import { Transaction } from '../models/transaction'
 
-const ethJsUtil = require('ethereumjs-util')
 const Sequelize = require('sequelize')
 
 const { Op } = Sequelize
@@ -16,8 +16,8 @@ export const findOrCreateTransaction = async (transaction: Transaction) => {
     },
     defaults: {
       transactionHash: transaction.transactionHash,
-      sender: ethJsUtil.toChecksumAddress(transaction.sender),
-      recipient: ethJsUtil.toChecksumAddress(transaction.recipient),
+      sender: ethers.utils.getAddress(transaction.sender),
+      recipient: ethers.utils.getAddress(transaction.recipient),
       for: transactionForPackaging(transaction.for),
       chain: transaction.chain,
       data: transaction.data,
@@ -26,7 +26,7 @@ export const findOrCreateTransaction = async (transaction: Transaction) => {
 }
 
 const transactionForPackaging = (transactionFor: string) => {
-  return transactionFor ? ethJsUtil.toChecksumAddress(transactionFor) : null
+  return transactionFor ? ethers.utils.getAddress(transactionFor) : null
 }
 
 /**
@@ -45,17 +45,17 @@ const queryFilter = (filter: any) => {
   if (filter.recipient) {
     target.recipient = {
       [Op.in]: filter.recipient.map((recipient: string) =>
-        ethJsUtil.toChecksumAddress(recipient)
+        ethers.utils.getAddress(recipient)
       ),
     }
   }
 
   if (filter.for) {
-    target.for = { [Op.eq]: ethJsUtil.toChecksumAddress(filter.for) }
+    target.for = { [Op.eq]: ethers.utils.getAddress(filter.for) }
   }
 
   if (filter.sender) {
-    target.sender = { [Op.eq]: ethJsUtil.toChecksumAddress(filter.sender) }
+    target.sender = { [Op.eq]: ethers.utils.getAddress(filter.sender) }
   }
 
   // createdAfter is a timestamp in microseconds Time. (new Date().getTime())

--- a/locksmith/src/utils/normalizer.ts
+++ b/locksmith/src/utils/normalizer.ts
@@ -1,11 +1,11 @@
-const ethJsUtil = require('ethereumjs-util')
+import { ethers } from 'ethers'
 
 export function emailAddress(input: string): string {
   return input.toLocaleLowerCase()
 }
 
 export function ethereumAddress(input: string): string {
-  return ethJsUtil.toChecksumAddress(input)
+  return ethers.utils.getAddress(input)
 }
 
 export function toLowerCaseKeys(obj: Record<string, unknown>) {

--- a/locksmith/src/utils/signature.ts
+++ b/locksmith/src/utils/signature.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers'
+
 export const expiredSignature = (
   signatureTimestamp: number,
   gracePeriod = 10000
@@ -6,4 +8,12 @@ export const expiredSignature = (
   const signatureTime = signatureTimestamp / 1000
 
   return signatureTime + gracePeriod < serverTime
+}
+
+export const generateTypedSignature = async (privateKey: string, data: any) => {
+  const wallet = new ethers.Wallet(privateKey)
+  const { domain, types, message } = data
+  const signature = await wallet._signTypedData(domain, types, message)
+
+  return signature
 }

--- a/locksmith/src/utils/signature.ts
+++ b/locksmith/src/utils/signature.ts
@@ -12,8 +12,12 @@ export const expiredSignature = (
 
 export const generateTypedSignature = async (privateKey: string, data: any) => {
   const wallet = new ethers.Wallet(privateKey)
-  const { domain, types, message } = data
-  const signature = await wallet._signTypedData(domain, types, message)
+  const { domain, types, message, messageKey } = data
+  const signature = await wallet._signTypedData(
+    domain,
+    types,
+    message[messageKey]
+  )
 
   return signature
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13274,16 +13274,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ethereumjs-util@npm:5.2.0":
-  version: 5.2.0
-  resolution: "@types/ethereumjs-util@npm:5.2.0"
-  dependencies:
-    "@types/bn.js": "*"
-    "@types/node": "*"
-  checksum: 08c9a47eb03fbf023e774b6eeae8370623cd7d6d898214c262525a94c30390d23a82212b6c19ff62f53589d4d90189c6e93e02e115bb58d31fb443dcd1539b1e
-  languageName: node
-  linkType: hard
-
 "@types/express-serve-static-core@npm:*":
   version: 4.17.27
   resolution: "@types/express-serve-static-core@npm:4.17.27"
@@ -15102,8 +15092,6 @@ __metadata:
     "@sentry/tracing": 7.0.0
     "@types/cookie-parser": 1.4.3
     "@types/cors": 2.8.12
-    "@types/eth-sig-util": 2.1.1
-    "@types/ethereumjs-util": 5.2.0
     "@types/express": 4.17.13
     "@types/express-serve-static-core": 4.17.28
     "@types/isomorphic-fetch": 0.0.36
@@ -15137,8 +15125,6 @@ __metadata:
     dotenv: 16.0.1
     eslint: 8.12.0
     eslint-config-standard: 17.0.0
-    eth-sig-util: 2.5.4
-    ethereumjs-util: 6.2.1
     ethers: 5.6.8
     express: 4.17.3
     express-jwt: 7.5.2


### PR DESCRIPTION
# Description

Replace eth-sig-utils and ethereum-js with ethers in locksmith workspace.
This PR should close #9057 and #9058

# Issues

Fixes #9057 and #9058


# Checklist:
- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
