### PR TITLE
feat(unlock-app) - cache access token

### DIFF
--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -33,7 +33,7 @@ export const useProvider = (config: any) => {
   const [encryptedPrivateKey, setEncryptedPrivateKey] = useState<
     any | undefined
   >(undefined)
-  const { getStorage, setStorage, clearStorage } = useAppStorage()
+  const { getStorage, setStorage, clearStorage, removeKey } = useAppStorage()
   const { addNetworkToWallet } = useAddToNetwork(account)
 
   useEffect(() => {
@@ -46,10 +46,14 @@ export const useProvider = (config: any) => {
     }
   }, [account, network])
 
+  const removeAccessToken = () => {
+    removeKey('token', true)
+  }
+
   const resetProvider = async (provider: ethers.providers.Provider) => {
     try {
+      removeAccessToken()
       const _walletService = new WalletService(config.networks)
-
       setProvider(provider)
       // @ts-expect-error TODO fix walletService signature
       const _network = await _walletService.connect(provider)


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
- To avoid multiple requirements to sign in, this PR adds an access token in localStorage and asks for login when the access token expires.
- When the wallet address or network is changed, the stored access token will be removed because the new user does not matches the previous one. In this particular scenario, the user need to sign-in again 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

