### PR TITLE
feat(unlokc-app) - expire and refund should always be visible but disabled if key expired

### DIFF
--- a/unlock-app/src/components/interface/MetadataTable.tsx
+++ b/unlock-app/src/components/interface/MetadataTable.tsx
@@ -83,6 +83,7 @@ export const MetadataTable: React.FC<MetadataTableProps> = ({
   }
 
   const onExpireAndRefund = (lock: any) => {
+    if (expireAndRefundDisabled(lock)) return
     setShowExpireAndRefundModal(true)
     setCurrentLock(lock)
   }
@@ -97,6 +98,10 @@ export const MetadataTable: React.FC<MetadataTableProps> = ({
     const now = new Date().getTime()
     const expiration = new Date(metadata?.expiration).getTime()
     return expiration > now
+  }
+
+  const expireAndRefundDisabled = (metadata: unknown): boolean => {
+    return !(isLockManager && isKeyValid(metadata))
   }
 
   return (
@@ -133,18 +138,16 @@ export const MetadataTable: React.FC<MetadataTableProps> = ({
                     </Td>
                   )
                 })}
-                {isLockManager && isKeyValid(datum) && (
-                  <Td className="text-center">
-                    <button
-                      className="bg-gray-200 rounded px-2 py-1 text-sm"
-                      type="button"
-                      disabled={!isLockManager}
-                      onClick={() => onExpireAndRefund(datum)}
-                    >
-                      Expire and Refund
-                    </button>
-                  </Td>
-                )}
+                <Td className="text-center">
+                  <button
+                    className="bg-gray-200 rounded px-2 py-1 text-sm disabled:opacity-50"
+                    type="button"
+                    disabled={expireAndRefundDisabled(datum)}
+                    onClick={() => onExpireAndRefund(datum)}
+                  >
+                    Expire and Refund
+                  </button>
+                </Td>
               </tr>
             )
           })}

--- a/unlock-app/src/components/interface/MetadataTable.tsx
+++ b/unlock-app/src/components/interface/MetadataTable.tsx
@@ -118,11 +118,9 @@ export const MetadataTable: React.FC<MetadataTableProps> = ({
             {columns.map((col) => {
               return <Th key={col}>{camelCaseToTitle(col)}</Th>
             })}
-            {isLockManager && (
-              <Th className="text-center" key="actions">
-                Actions
-              </Th>
-            )}
+            <Th className="text-center" key="actions">
+              Actions
+            </Th>
           </tr>
         </thead>
         <Tbody>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

- [x] Expire and refund should always be visible (but disabled when the membership is expired). Right now it is not visible when the membership does not expire but it should be

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

