### PR TITLE
feat(locksmith) - only keyManager should call send-email API

### DIFF
--- a/locksmith/__tests__/controllers/v2/ticketsController.test.ts
+++ b/locksmith/__tests__/controllers/v2/ticketsController.test.ts
@@ -186,7 +186,7 @@ describe('sign endpoint', () => {
     expect(loginResponse.status).toBe(200)
 
     const response = await request(app)
-      .post(`/v2/api/ticket/${network}/${lockAddress}/${wrongTokenId}/email`)
+      .post(`/v2/api/ticket/${network}/${wrongLockAddress}/${tokenId}/email`)
       .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
 
     expect(response.status).toBe(401)

--- a/locksmith/__tests__/controllers/v2/ticketsController.test.ts
+++ b/locksmith/__tests__/controllers/v2/ticketsController.test.ts
@@ -179,7 +179,7 @@ describe('sign endpoint', () => {
     expect(response.status).toBe(403)
   })
 
-  it('does not send email when auhentication is present but the user is not the key owner', async () => {
+  it('does not send email when auhentication is present but the user is not the key manager', async () => {
     expect.assertions(2)
 
     const { loginResponse } = await loginRandomUser(app)
@@ -192,7 +192,7 @@ describe('sign endpoint', () => {
     expect(response.status).toBe(401)
   })
 
-  it('send email when user is athenticated and is the key owner', async () => {
+  it('send email when user is athenticated and is the key manager', async () => {
     expect.assertions(2)
 
     const { loginResponse, address } = await loginRandomUser(app)

--- a/locksmith/src/routes/v2/ticket.ts
+++ b/locksmith/src/routes/v2/ticket.ts
@@ -33,7 +33,6 @@ router.put(
 router.post(
   '/:network/:lockAddress/:tokenId/email',
   authenticatedMiddleware,
-  keyOwnerMiddleware,
   lockManagerMiddleware,
   (req, res) => {
     ticketsController.sendEmail(req, res)


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
- As description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

