### PR TITLE
fix(smart-contracts): fix flaky tests (again)

### DIFF
--- a/smart-contracts/test/Lock/extendRenewable.js
+++ b/smart-contracts/test/Lock/extendRenewable.js
@@ -78,10 +78,14 @@ contract('Lock / Extend with recurring memberships', (accounts) => {
         await lock.renewMembershipFor(tokenId, ADDRESS_ZERO, {
           from: keyOwner,
         })
+
         const tsAfter = await lock.keyExpirationTimestampFor(tokenId)
+        const tsExpected = newExpirationTs.add(await lock.expirationDuration())
+
         assert.equal(
-          newExpirationTs.add(await lock.expirationDuration()).toString(),
-          tsAfter.toString()
+          // assert results for +/- 2 sec
+          tsAfter.toNumber() - tsExpected.toNumber() <= 2,
+          true
         )
       })
     })
@@ -111,9 +115,12 @@ contract('Lock / Extend with recurring memberships', (accounts) => {
           from: keyOwner,
         })
         const tsAfter = await lock.keyExpirationTimestampFor(tokenId)
+        const tsExpected = newExpirationTs.add(await lock.expirationDuration())
+
         assert.equal(
-          newExpirationTs.add(await lock.expirationDuration()).toString(),
-          tsAfter.toString()
+          // assert results for +/- 2 sec
+          tsAfter.toNumber() - tsExpected.toNumber() <= 2,
+          true
         )
       })
     })


### PR DESCRIPTION
# Description

This adds a. +/- 2 sec tolerance when testing a Lock time renewal extension - an error margin due to race condition in tests

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #9046
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

