### PR TITLE
feat(unlock-app) - show metadata only if check in time exists

### DIFF
--- a/unlock-app/src/components/interface/MetadataTable.tsx
+++ b/unlock-app/src/components/interface/MetadataTable.tsx
@@ -93,6 +93,8 @@ export const MetadataTable: React.FC<MetadataTableProps> = ({
     setExpandAllMetadata(!expandAllMetadata)
   }
 
+  const showCheckInTimeInfo = metadata?.some((item) => item?.checkedInAt)
+
   return (
     <section className="flex flex-col gap-3">
       <ExpireAndRefundModal
@@ -123,6 +125,7 @@ export const MetadataTable: React.FC<MetadataTableProps> = ({
             isLockManager={isLockManager}
             expireAndRefundDisabled={expireAndRefundDisabled(data)}
             onExpireAndRefund={() => onExpireAndRefund(data)}
+            showCheckInTimeInfo={showCheckInTimeInfo}
           />
         )
       })}

--- a/unlock-app/src/components/interface/members/MemberCard.tsx
+++ b/unlock-app/src/components/interface/members/MemberCard.tsx
@@ -17,6 +17,7 @@ interface MemberCardProps {
   tokenId: string
   onExpireAndRefund: (lock: any) => void
   expandAllMetadata: boolean
+  showCheckInTimeInfo: boolean
   isLockManager?: boolean
   expireAndRefundDisabled?: boolean
   metadata?: object
@@ -37,6 +38,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   tokenId,
   onExpireAndRefund,
   expandAllMetadata,
+  showCheckInTimeInfo,
   expireAndRefundDisabled = true,
   metadata = {},
 }) => {
@@ -111,25 +113,27 @@ export const MemberCard: React.FC<MemberCardProps> = ({
         {showMetaData && (
           <div>
             <span className={styles.description}>Metadata</span>
-            <span className="block py-2">
-              {isCheckedIn ? (
-                <Badge
-                  size="tiny"
-                  variant="green"
-                  iconRight={<CheckIcon size={11} />}
-                >
-                  Checked-in
-                </Badge>
-              ) : (
-                <Badge
-                  size="tiny"
-                  variant="orange"
-                  iconRight={<ExclamationIcon size={11} />}
-                >
-                  Not Checked-in
-                </Badge>
-              )}
-            </span>
+            {showCheckInTimeInfo && (
+              <span className="block py-2">
+                {isCheckedIn ? (
+                  <Badge
+                    size="tiny"
+                    variant="green"
+                    iconRight={<CheckIcon size={11} />}
+                  >
+                    Checked-in
+                  </Badge>
+                ) : (
+                  <Badge
+                    size="tiny"
+                    variant="orange"
+                    iconRight={<ExclamationIcon size={11} />}
+                  >
+                    Not Checked-in
+                  </Badge>
+                )}
+              </span>
+            )}
             {!hasExtraData && (
               <span className="block">There is no metadata</span>
             )}


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

- [x] Show metadata only if `check in times` exists in metadata list

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

