### PR TITLE
fix(unlock-app): Arrayify data before signing with signMessage in personal_sign method in unlock provider

### DIFF
--- a/unlock-app/src/__tests__/services/unlockProvider.test.js
+++ b/unlock-app/src/__tests__/services/unlockProvider.test.js
@@ -147,7 +147,7 @@ describe('Unlock Provider', () => {
         // second param is unused, but in keeping with what we receive from WalletService
         const sig = await provider.personal_sign([messageHash, ''])
 
-        expect(utils.verifyMessage(messageHash, sig)).toEqual(
+        expect(utils.verifyMessage(utils.arrayify(messageHash), sig)).toEqual(
           utils.getAddress(publicKey)
         )
       })

--- a/unlock-app/src/services/unlockProvider.ts
+++ b/unlock-app/src/services/unlockProvider.ts
@@ -87,7 +87,9 @@ export default class UnlockProvider extends ethers.providers.JsonRpcProvider {
    */
   // eslint-disable-next-line no-unused-vars
   async personal_sign([data, _]: any[]) {
-    return await this.wallet?.signMessage(data)
+    const content = ethers.utils.arrayify(data)
+    const signature = await this.wallet?.signMessage(content)
+    return signature
   }
 
   async eth_signTypedData([_, data]: any[]) {


### PR DESCRIPTION


<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This fixes a breaking change introduced in https://github.com/unlock-protocol/unlock/pull/9087 which broke unlock provider.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

