### PR TITLE
fix(smart-contracts): remove truffle

### DIFF
--- a/smart-contracts/hardhat.config.js
+++ b/smart-contracts/hardhat.config.js
@@ -2,7 +2,7 @@
 const { copySync } = require('fs-extra')
 
 require('@nomiclabs/hardhat-ethers')
-require('@nomiclabs/hardhat-truffle5')
+// require('@nomiclabs/hardhat-truffle5')
 
 // full stack trace if needed
 require('hardhat-tracer')

--- a/smart-contracts/test/Lock/Lock.js
+++ b/smart-contracts/test/Lock/Lock.js
@@ -6,7 +6,7 @@ const erc777abi = require('../helpers/ABIs/erc777.json')
 
 let lock
 
-contract('Lock / Lock', (accounts) => {
+describe('Lock / Lock', (accounts) => {
   before(async () => {
     lock = await deployLock()
   })

--- a/smart-contracts/test/Lock/approveBeneficiary.js
+++ b/smart-contracts/test/Lock/approveBeneficiary.js
@@ -10,7 +10,7 @@ const { ethers } = require('hardhat')
 let unlock
 let lock
 
-contract('Lock / approveBeneficiary', (accounts) => {
+describe('Lock / approveBeneficiary', (accounts) => {
   const [daiOwner, beneficiary, keyOwner, spender, other] = accounts
   before(async () => {
     ;({ unlock } = await deployContracts())

--- a/smart-contracts/test/Lock/behaviors/lockBehaviors.js
+++ b/smart-contracts/test/Lock/behaviors/lockBehaviors.js
@@ -3,7 +3,7 @@ const lockTypes = ['FIRST', 'ERC20', 'FREE']
 
 const { deployERC20, deployAllLocks } = require('../../helpers')
 
-contract('Lock / lockBehaviors', (accounts) => {
+describe('Lock / lockBehaviors', (accounts) => {
   beforeEach(async () => {
     this.accounts = accounts
 

--- a/smart-contracts/test/Lock/burn.js
+++ b/smart-contracts/test/Lock/burn.js
@@ -1,7 +1,7 @@
 const { reverts } = require('../helpers/errors')
 const { ADDRESS_ZERO, purchaseKey, deployLock } = require('../helpers')
 
-contract('Lock / burn', (accounts) => {
+describe('Lock / burn', (accounts) => {
   let keyOwner = accounts[1]
   let lock
   let tokenId

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -12,7 +12,7 @@ const {
 let token
 let tokenIds
 
-contract('Lock / cancelAndRefund', (accounts) => {
+describe('Lock / cancelAndRefund', (accounts) => {
   let lock
   let lockFree
   const denominator = 10000

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -1,37 +1,28 @@
 const { ethers } = require('hardhat')
-const BigNumber = require('bignumber.js')
+const { assert } = require('chai')
 const {
   ADDRESS_ZERO,
   deployLock,
   deployERC20,
   getBalance,
+  purchaseKey,
   purchaseKeys,
   reverts,
 } = require('../helpers')
 
-let token
 let tokenIds
 
-describe('Lock / cancelAndRefund', (accounts) => {
+describe('Lock / cancelAndRefund', () => {
   let lock
   let lockFree
-  const denominator = 10000
-  const keyPrice = new BigNumber(web3.utils.toWei('0.01', 'ether'))
-  const lockCreator = accounts[0]
-
-  const keyOwners = [
-    accounts[1],
-    accounts[2],
-    accounts[3],
-    accounts[4],
-    accounts[5],
-  ]
+  let keyOwners
+  let approvedUser
+  const keyPrice = ethers.utils.parseEther('0.01')
 
   before(async () => {
-    token = await deployERC20(accounts[0])
-    await token.mint(accounts[0], 100, {
-      from: accounts[0],
-    })
+    const [, ...signers] = await ethers.getSigners()
+    keyOwners = signers.slice(1, 7)
+    approvedUser = signers[9]
     lock = await deployLock()
     lockFree = await deployLock({ name: 'FREE' })
     await lock.setMaxKeysPerAddress(10)
@@ -39,233 +30,215 @@ describe('Lock / cancelAndRefund', (accounts) => {
   })
 
   it('should return the correct penalty', async () => {
-    const numerator = new BigNumber(await lock.refundPenaltyBasisPoints())
-    assert.equal(numerator.div(denominator).toFixed(), 0.1) // default of 10%
+    const basisPoint = await lock.refundPenaltyBasisPoints()
+    assert.equal(basisPoint.toNumber(), 1000) // default of 10%
   })
 
   it('the amount of refund should be less than the original keyPrice when purchased normally', async () => {
-    const estimatedRefund = new BigNumber(
-      await lock.getCancelAndRefundValue(tokenIds[0])
-    )
-    assert(estimatedRefund.lt(keyPrice.toString()))
+    const estimatedRefund = await lock.getCancelAndRefundValue(tokenIds[0])
+    assert(estimatedRefund.lt(keyPrice))
   })
 
   it('the amount of refund should be less than the original keyPrice when expiration is very far in the future', async () => {
     const tx = await lock.grantKeys(
-      [accounts[5]],
+      [keyOwners[5].address],
       [999999999999],
-      [ADDRESS_ZERO],
-      {
-        from: accounts[0],
-      }
+      [ADDRESS_ZERO]
     )
-    const { args } = tx.logs.find((v) => v.event === 'Transfer')
-    const estimatedRefund = new BigNumber(
-      await lock.getCancelAndRefundValue(args.tokenId)
-    )
-    assert(estimatedRefund.lt(keyPrice.toString()))
+    const { events } = await tx.wait()
+    const { args } = events.find((v) => v.event === 'Transfer')
+    const estimatedRefund = await lock.getCancelAndRefundValue(args.tokenId)
+    assert(estimatedRefund.lt(keyPrice))
   })
 
   it('the estimated refund for a free Key should be 0', async () => {
     const tx = await lockFree.grantKeys(
-      [accounts[5]],
+      [keyOwners[5].address],
       [999999999999],
-      [ADDRESS_ZERO],
-      {
-        from: accounts[0],
-      }
+      [ADDRESS_ZERO]
     )
-    const { args } = tx.logs.find((v) => v.event === 'Transfer')
-    const estimatedRefund = new BigNumber(
-      await lockFree.getCancelAndRefundValue(args.tokenId)
-    )
-    assert(estimatedRefund, 0)
+    const { events } = await tx.wait()
+    const { args } = events.find((v) => v.event === 'Transfer')
+    const estimatedRefund = await lockFree.getCancelAndRefundValue(args.tokenId)
+    assert.equal(estimatedRefund.toNumber(), 0)
   })
 
   describe('should cancel and refund when enough time remains', () => {
     let initialLockBalance
     let initialKeyOwnerBalance
     let estimatedRefund
-    let txObj
+    let gasUsed
+    let eventsObj
+    let transactionHash
     let withdrawalAmount
+    let tokenId
 
     before(async () => {
+      ;({ tokenId } = await purchaseKey(lock, keyOwners[0]))
       initialLockBalance = await getBalance(lock.address)
+      initialKeyOwnerBalance = await getBalance(keyOwners[0].address)
+      estimatedRefund = await lock.getCancelAndRefundValue(tokenId)
 
-      initialKeyOwnerBalance = await getBalance(keyOwners[0])
-
-      estimatedRefund = new BigNumber(
-        await lock.getCancelAndRefundValue(tokenIds[0])
-      )
-      txObj = await lock.cancelAndRefund(tokenIds[0], {
-        from: keyOwners[0],
-      })
-      withdrawalAmount = (await getBalance(lock.address)).minus(
+      const tx = await lock.connect(keyOwners[0]).cancelAndRefund(tokenId)
+      ;({ events: eventsObj, transactionHash, gasUsed } = await tx.wait())
+      withdrawalAmount = (await getBalance(lock.address)).sub(
         initialLockBalance
       )
     })
 
     it('should emit a CancelKey event', async () => {
-      assert.equal(txObj.logs[0].event, 'CancelKey')
+      assert.equal(eventsObj[0].event, 'CancelKey')
     })
 
     it('the amount of refund should be greater than 0', async () => {
-      const refund = new BigNumber(txObj.logs[0].args.refund)
+      const { refund } = eventsObj[0].args
       assert(refund.gt(0))
     })
 
     it('the amount of refund should be less than or equal to the original key price', async () => {
-      const refund = new BigNumber(txObj.logs[0].args.refund)
-      assert(refund.lt(keyPrice.toString()))
+      const { refund } = eventsObj[0].args
+      assert(refund.lt(keyPrice))
     })
 
     it('the amount of refund should be less than or equal to the estimated refund', async () => {
-      const refund = new BigNumber(txObj.logs[0].args.refund)
+      const { refund } = eventsObj[0].args
       assert(refund.lte(estimatedRefund))
     })
 
     it('should make the key no longer valid (i.e. expired)', async () => {
-      const isValid = await lock.getHasValidKey(keyOwners[0])
+      const isValid = await lock.isValidKey(tokenId)
       assert.equal(isValid, false)
     })
 
     it("should increase the owner's balance with the amount of funds withdrawn from the lock", async () => {
-      const txHash = await ethers.provider.getTransaction(txObj.tx)
-      const gasUsed = new BigNumber(txObj.receipt.gasUsed)
-      const gasPrice = new BigNumber(txHash.gasPrice)
-      const txFee = gasPrice.times(gasUsed)
-      const finalOwnerBalance = await getBalance(keyOwners[0])
+      const { gasPrice } = await ethers.provider.getTransaction(transactionHash)
+      const txFee = gasPrice.mul(gasUsed)
+      const finalOwnerBalance = await getBalance(keyOwners[0].address)
       assert(
-        finalOwnerBalance.toFixed(),
-        initialKeyOwnerBalance.plus(withdrawalAmount).minus(txFee).toFixed()
+        finalOwnerBalance.toString(),
+        initialKeyOwnerBalance.add(withdrawalAmount).sub(txFee).toString()
       )
     })
   })
 
   it('can cancel a free key', async () => {
     const tx = await lockFree.grantKeys(
-      [accounts[1]],
+      [keyOwners[0].address],
       [999999999999],
-      [ADDRESS_ZERO],
-      {
-        from: accounts[0],
-      }
+      [ADDRESS_ZERO]
     )
-    const { args } = tx.logs.find((v) => v.event === 'Transfer')
-    const txObj = await lockFree.cancelAndRefund(args.tokenId, {
-      from: accounts[1],
-    })
-    assert.equal(txObj.logs[0].event, 'CancelKey')
+    const { events } = await tx.wait()
+    const { args } = events.find((v) => v.event === 'Transfer')
+
+    const txObj = await lockFree
+      .connect(keyOwners[0])
+      .cancelAndRefund(args.tokenId)
+    const { events: eventsObj } = await txObj.wait()
+
+    assert.equal(eventsObj[0].event, 'CancelKey')
   })
 
   it('approved user can cancel a key', async () => {
     const tx = await lockFree.grantKeys(
-      [keyOwners[1]],
+      [keyOwners[1].address],
       [999999999999],
-      [ADDRESS_ZERO],
-      {
-        from: accounts[0],
-      }
+      [ADDRESS_ZERO]
     )
-    const { args } = tx.logs.find((v) => v.event === 'Transfer')
-    await lockFree.approve(accounts[9], args.tokenId, { from: keyOwners[1] })
-    const txObj = await lockFree.cancelAndRefund(args.tokenId, {
-      from: accounts[9],
-    })
-    assert.equal(txObj.logs[0].event, 'CancelKey')
+    const { events } = await tx.wait()
+    const { args } = events.find((v) => v.event === 'Transfer')
+    await lockFree
+      .connect(keyOwners[1])
+      .approve(approvedUser.address, args.tokenId)
+
+    const txObj = await lockFree
+      .connect(approvedUser)
+      .cancelAndRefund(args.tokenId)
+    const { events: eventsObj } = await txObj.wait()
+
+    assert.equal(eventsObj[0].event, 'CancelKey')
   })
 
   describe('allows the Lock owner to specify a different cancellation penalty', () => {
-    let tx
+    let events
 
     before(async () => {
-      tx = await lock.updateRefundPenalty(0, 2000) // 20%
+      const tx = await lock.updateRefundPenalty(0, 2000) // 20%
+      ;({ events } = await tx.wait())
     })
 
     it('should trigger an event', async () => {
-      const event = tx.logs.find((log) => {
+      const event = events.find((log) => {
         return log.event === 'RefundPenaltyChanged'
       })
-      assert.equal(
-        new BigNumber(event.args.refundPenaltyBasisPoints).toFixed(),
-        2000
-      )
+      assert.equal(event.args.refundPenaltyBasisPoints.toNumber(), 2000)
     })
 
     it('should return the correct penalty', async () => {
-      const numerator = new BigNumber(await lock.refundPenaltyBasisPoints())
-      assert.equal(numerator.div(denominator).toFixed(), 0.2) // updated to 20%
+      const numerator = await lock.refundPenaltyBasisPoints()
+      assert.equal(numerator, 2000) // updated to 20%
     })
 
     it('should still allow refund', async () => {
-      const txObj = await lock.cancelAndRefund(tokenIds[2], {
-        from: keyOwners[2],
-      })
-      const refund = new BigNumber(txObj.logs[0].args.refund)
+      const { tokenId } = await purchaseKey(lock, keyOwners[4])
+      const txObj = await lock.connect(keyOwners[4]).cancelAndRefund(tokenId)
+      const { events: eventsObj } = await txObj.wait()
+      const { refund } = eventsObj[0].args
       assert(refund.gt(0))
     })
   })
 
   describe('should fail when', () => {
     it('should fail if the Lock owner withdraws too much funds', async () => {
-      await lock.withdraw(await lock.tokenAddress(), 0, {
-        from: lockCreator,
-      })
-      await reverts(
-        lock.cancelAndRefund(tokenIds[3], {
-          from: keyOwners[3],
-        }),
-        ''
-      )
+      await lock.withdraw(await lock.tokenAddress(), 0)
+      await reverts(lock.connect(keyOwners[3]).cancelAndRefund(tokenIds[3]), '')
     })
 
     it('non-managers should fail to update the fee', async () => {
       await reverts(
-        lock.updateRefundPenalty(0, 0, { from: accounts[1] }),
+        lock.connect(keyOwners[1]).updateRefundPenalty(0, 0),
         'ONLY_LOCK_MANAGER'
       )
     })
 
     it('the key is expired', async () => {
-      await lock.expireAndRefundFor(tokenIds[3], 0, {
-        from: lockCreator,
-      })
+      await lock.expireAndRefundFor(tokenIds[3], 0)
       await reverts(
-        lock.cancelAndRefund(tokenIds[3], {
-          from: keyOwners[3],
-        }),
+        lock.connect(keyOwners[3]).cancelAndRefund(tokenIds[3]),
         'KEY_NOT_VALID'
       )
     })
 
     it('the key does not exist', async () => {
       await reverts(
-        lock.cancelAndRefund(132, {
-          from: accounts[7],
-        }),
+        lock.connect(keyOwners[4]).cancelAndRefund(132),
         'NO_SUCH_KEY'
       )
     })
   })
 
   it('should refund in the new token after token address is changed', async () => {
+    // deploy erc20
+    const [daiOwner] = await ethers.getSigners()
+    const token = await deployERC20()
+    await token.mint(daiOwner.address, 100)
+
+    const { tokenId } = await purchaseKey(lock, keyOwners[4])
     // Confirm user has a key paid in eth
-    assert.equal(await lock.getHasValidKey(keyOwners[4]), true)
+    assert.equal(await lock.getHasValidKey(keyOwners[4].address), true)
     assert.equal(await lock.tokenAddress(), 0)
     // check user's token balance
-    assert.equal(await token.balanceOf(keyOwners[4]), 0)
+    assert.equal(await token.balanceOf(keyOwners[4].address), 0)
     // update token address and price
-    await lock.updateKeyPricing(11, token.address, {
-      from: lockCreator,
-    })
+    await lock.updateKeyPricing(11, token.address)
     // fund lock with new erc20 tokens to deal enable refunds
-    await token.mint(lock.address, 100, {
-      from: accounts[0],
-    })
+    await token.mint(lock.address, 100)
     assert.equal(await token.balanceOf(lock.address), 100)
     // cancel and refund
-    await lock.cancelAndRefund(tokenIds[4], { from: keyOwners[4] })
+    await lock.connect(keyOwners[4]).cancelAndRefund(tokenId)
     // check user's token balance
-    assert(new BigNumber(await token.balanceOf(keyOwners[4])).gt(0))
+    assert((await token.balanceOf(keyOwners[4].address)).gt(0))
+
+    //revert price back
+    await lock.updateKeyPricing(keyPrice, ADDRESS_ZERO)
   })
 })

--- a/smart-contracts/test/Lock/convenienceOwner.js
+++ b/smart-contracts/test/Lock/convenienceOwner.js
@@ -7,7 +7,7 @@ const { ADDRESS_ZERO } = require('../helpers/constants')
 
 const keyPrice = ethers.utils.parseEther('0.01')
 
-contract('Lock / mimick owner()', () => {
+describe('Lock / mimick owner()', () => {
   let lock
   let deployer
 

--- a/smart-contracts/test/Lock/convenienceOwner.js
+++ b/smart-contracts/test/Lock/convenienceOwner.js
@@ -1,9 +1,9 @@
 const { ethers } = require('hardhat')
-const { expectRevert } = require('@openzeppelin/test-helpers')
+const { assert } = require('chai')
 
 const deployContracts = require('../fixtures/deploy')
 const createLockHash = require('../helpers/createLockCalldata')
-const { ADDRESS_ZERO } = require('../helpers/constants')
+const { ADDRESS_ZERO, reverts } = require('../helpers')
 
 const keyPrice = ethers.utils.parseEther('0.01')
 
@@ -20,7 +20,7 @@ describe('Lock / mimick owner()', () => {
     const tokenAddress = ADDRESS_ZERO
     const args = [60 * 30, tokenAddress, keyPrice, 10, 'Test lock']
 
-    const calldata = await createLockHash({ args, from: deployer.address })
+    const calldata = await createLockHash({ args, from: deployer })
     const tx = await unlock.createUpgradeableLock(calldata)
     const { events } = await tx.wait()
     const {
@@ -45,18 +45,18 @@ describe('Lock / mimick owner()', () => {
       assert.equal(await lock.owner(), wallet.address)
     })
     it('should revert on address zero', async () => {
-      await expectRevert(
+      await reverts(
         lock.connect(deployer).setOwner(ADDRESS_ZERO),
         'OWNER_CANT_BE_ADDRESS_ZERO'
       )
     })
     it('should revert if not lock manager', async () => {
       const [, notManager, anotherAddress] = await ethers.getSigners()
-      await expectRevert(
+      await reverts(
         lock.connect(notManager).setOwner(notManager.address),
         'ONLY_LOCK_MANAGER'
       )
-      await expectRevert(
+      await reverts(
         lock.connect(notManager).setOwner(anotherAddress.address),
         'ONLY_LOCK_MANAGER'
       )

--- a/smart-contracts/test/Lock/createLockWithInfiniteKeys.js
+++ b/smart-contracts/test/Lock/createLockWithInfiniteKeys.js
@@ -1,12 +1,12 @@
 const { ethers } = require('hardhat')
 const BigNumber = require('bignumber.js')
 const { ADDRESS_ZERO, MAX_UINT, deployContracts } = require('../helpers')
-const PublicLock = artifacts.require('PublicLock')
 const createLockHash = require('../helpers/createLockCalldata')
+const { assert } = require('chai')
 
 let unlock
 
-contract('Lock / createLockWithInfiniteKeys', () => {
+describe('Lock / createLockWithInfiniteKeys', () => {
   before(async () => {
     ;({ unlock } = await deployContracts())
   })
@@ -26,7 +26,8 @@ contract('Lock / createLockWithInfiniteKeys', () => {
     })
 
     it('should have created the lock with an infinite number of keys', async () => {
-      let publicLock = await PublicLock.at(
+      const publicLock = await ethers.getContractAt(
+        'PublicLock',
         transaction.logs[0].args.newLockAddress
       )
       const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())
@@ -53,7 +54,8 @@ contract('Lock / createLockWithInfiniteKeys', () => {
     })
 
     it('should have created the lock with 0 keys', async () => {
-      let publicLock = await PublicLock.at(
+      const publicLock = await ethers.getContractAt(
+        'PublicLock',
         transaction.logs[0].args.newLockAddress
       )
       const maxNumberOfKeys = new BigNumber(await publicLock.maxNumberOfKeys())

--- a/smart-contracts/test/Lock/disableTransfers.js
+++ b/smart-contracts/test/Lock/disableTransfers.js
@@ -1,14 +1,15 @@
-const BigNumber = require('bignumber.js')
+const { assert } = require('chai')
+const { ethers } = require('hardhat')
 const { purchaseKey, reverts, deployLock } = require('../helpers')
 
-describe('Lock / disableTransfers', (accounts) => {
+describe('Lock / disableTransfers', () => {
   let lock
   let tokenId
-  const keyOwner = accounts[1]
-  const accountWithNoKey = accounts[2]
-  const oneDay = new BigNumber(60 * 60 * 24)
+  let keyOwner, accountWithNoKey, anotherAccount
+  const oneDay = ethers.BigNumber.from(60 * 60 * 24)
 
   before(async () => {
+    ;[, keyOwner, accountWithNoKey, anotherAccount] = await ethers.getSigners()
     lock = await deployLock()
     ;({ tokenId } = await purchaseKey(lock, keyOwner))
 
@@ -20,21 +21,21 @@ describe('Lock / disableTransfers', (accounts) => {
     describe('disabling transferFrom', () => {
       it('should prevent key transfers by reverting', async () => {
         // check owner has a key
-        assert.equal(await lock.getHasValidKey(keyOwner), true)
+        assert.equal(await lock.getHasValidKey(keyOwner.address), true)
         // try to transfer it
         await reverts(
-          lock.transferFrom(keyOwner, accountWithNoKey, tokenId, {
-            from: keyOwner,
-          }),
+          lock
+            .connect(keyOwner)
+            .transferFrom(keyOwner.address, accountWithNoKey.address, tokenId),
           'KEY_TRANSFERS_DISABLED'
         )
         // check owner still has a key
-        assert.equal(await lock.getHasValidKey(keyOwner), true)
+        assert.equal(await lock.getHasValidKey(keyOwner.address), true)
         // check recipient never received a key
         assert.equal(
-          await lock.keyExpirationTimestampFor(accountWithNoKey, {
-            from: accountWithNoKey,
-          }),
+          await lock
+            .connect(accountWithNoKey)
+            .keyExpirationTimestampFor(accountWithNoKey.address),
           0
         )
       })
@@ -43,9 +44,9 @@ describe('Lock / disableTransfers', (accounts) => {
     describe('disabling setApprovalForAll', () => {
       it('should prevent user from setting setApprovalForAll', async () => {
         await reverts(
-          lock.setApprovalForAll(accounts[8], true, {
-            from: keyOwner,
-          }),
+          lock
+            .connect(keyOwner)
+            .setApprovalForAll(anotherAccount.address, true),
           'KEY_TRANSFERS_DISABLED'
         )
       })
@@ -54,21 +55,21 @@ describe('Lock / disableTransfers', (accounts) => {
     describe('disabling shareKey', () => {
       it('should prevent key sharing by reverting', async () => {
         // check owner has a key
-        assert.equal(await lock.getHasValidKey(keyOwner), true)
+        assert.equal(await lock.getHasValidKey(keyOwner.address), true)
         // try to share it
         await reverts(
-          lock.shareKey(accountWithNoKey, tokenId, oneDay, {
-            from: keyOwner,
-          }),
+          lock
+            .connect(keyOwner)
+            .shareKey(accountWithNoKey.address, tokenId, oneDay),
           'KEY_TRANSFERS_DISABLED'
         )
         // check owner still has a key
-        assert.equal(await lock.getHasValidKey(keyOwner), true)
+        assert.equal(await lock.getHasValidKey(keyOwner.address), true)
         // check recipient never received a key
         assert.equal(
-          await lock.keyExpirationTimestampFor(accountWithNoKey, {
-            from: accountWithNoKey,
-          }),
+          await lock
+            .connect(accountWithNoKey)
+            .keyExpirationTimestampFor(accountWithNoKey.address),
           0
         )
       })
@@ -80,14 +81,14 @@ describe('Lock / disableTransfers', (accounts) => {
       // Change the fee to 99%
       await lock.updateTransferFee(1000)
       // check owner has a key
-      assert.equal(await lock.getHasValidKey(keyOwner), true)
-      assert.equal(await lock.getHasValidKey(accountWithNoKey), false)
+      assert.equal(await lock.getHasValidKey(keyOwner.address), true)
+      assert.equal(await lock.getHasValidKey(accountWithNoKey.address), false)
       // attempt a transfer
-      await lock.transferFrom(keyOwner, accountWithNoKey, tokenId, {
-        from: keyOwner,
-      })
+      await lock
+        .connect(keyOwner)
+        .transferFrom(keyOwner.address, accountWithNoKey.address, tokenId)
       // check that recipient received a key
-      assert.equal(await lock.getHasValidKey(accountWithNoKey), true)
+      assert.equal(await lock.getHasValidKey(accountWithNoKey.address), true)
     })
   })
 })

--- a/smart-contracts/test/Lock/disableTransfers.js
+++ b/smart-contracts/test/Lock/disableTransfers.js
@@ -1,7 +1,7 @@
 const BigNumber = require('bignumber.js')
 const { purchaseKey, reverts, deployLock } = require('../helpers')
 
-contract('Lock / disableTransfers', (accounts) => {
+describe('Lock / disableTransfers', (accounts) => {
   let lock
   let tokenId
   const keyOwner = accounts[1]

--- a/smart-contracts/test/Lock/erc165.js
+++ b/smart-contracts/test/Lock/erc165.js
@@ -1,3 +1,4 @@
+const { assert } = require('chai')
 const { deployLock } = require('../helpers')
 
 describe('Lock / erc165', () => {

--- a/smart-contracts/test/Lock/erc165.js
+++ b/smart-contracts/test/Lock/erc165.js
@@ -1,6 +1,6 @@
 const { deployLock } = require('../helpers')
 
-contract('Lock / erc165', () => {
+describe('Lock / erc165', () => {
   let lock
   before(async () => {
     lock = await deployLock()

--- a/smart-contracts/test/Lock/erc20.js
+++ b/smart-contracts/test/Lock/erc20.js
@@ -1,4 +1,5 @@
 const BigNumber = require('bignumber.js')
+const { ethers } = require('hardhat')
 const {
   deployLock,
   deployERC20,
@@ -7,9 +8,8 @@ const {
   reverts,
   purchaseKey,
 } = require('../helpers')
-const TestNoop = artifacts.require('TestNoop.sol')
 
-contract('Lock / erc20', (accounts) => {
+describe('Lock / erc20', (accounts) => {
   let token
   let lock
 
@@ -203,9 +203,13 @@ contract('Lock / erc20', (accounts) => {
 
   describe('should fail to create a lock when', () => {
     it('when creating a lock for a contract which is not an ERC20', async () => {
+      const TestNoop = await ethers.getContractFactory('TestNoop')
+      const noop = await TestNoop.deploy()
+      await noop.deployed()
+
       await reverts(
         deployLock({
-          tokenAddress: (await TestNoop.new()).address,
+          tokenAddress: noop.address,
         })
       )
     })

--- a/smart-contracts/test/Lock/erc721/approve.js
+++ b/smart-contracts/test/Lock/erc721/approve.js
@@ -8,7 +8,7 @@ let lock
 let tokenId
 let keyOwner
 
-contract('Lock / erc721 / approve', (accounts) => {
+describe('Lock / erc721 / approve', (accounts) => {
   before(async () => {
     keyOwner = accounts[1]
     lock = await deployLock()

--- a/smart-contracts/test/Lock/erc721/approveForAll.js
+++ b/smart-contracts/test/Lock/erc721/approveForAll.js
@@ -3,7 +3,7 @@ const { deployLock, purchaseKey, reverts } = require('../../helpers')
 let lock
 let tokenId
 
-contract('Lock / erc721 / approveForAll', (accounts) => {
+describe('Lock / erc721 / approveForAll', (accounts) => {
   before(async () => {
     lock = await deployLock()
     await lock.updateTransferFee(0) // disable the transfer fee for this test

--- a/smart-contracts/test/Lock/erc721/balanceOf.js
+++ b/smart-contracts/test/Lock/erc721/balanceOf.js
@@ -4,7 +4,7 @@ const { time } = require('@openzeppelin/test-helpers')
 
 const { deployLock, reverts, ADDRESS_ZERO } = require('../../helpers')
 
-contract('Lock / erc721 / balanceOf', (accounts) => {
+describe('Lock / erc721 / balanceOf', (accounts) => {
   let lock
   before(async () => {
     lock = await deployLock()

--- a/smart-contracts/test/Lock/erc721/compliance.js
+++ b/smart-contracts/test/Lock/erc721/compliance.js
@@ -1,6 +1,6 @@
 const { deployLock } = require('../../helpers')
 
-contract('Lock / erc721 / compliance', () => {
+describe('Lock / erc721 / compliance', () => {
   let lock
   before(async () => {
     lock = await deployLock()

--- a/smart-contracts/test/Lock/erc721/enumerable.js
+++ b/smart-contracts/test/Lock/erc721/enumerable.js
@@ -5,7 +5,7 @@ let lock
 let tokenIds
 let keyOwners
 
-contract('Lock / erc721 / enumerable', (accounts) => {
+describe('Lock / erc721 / enumerable', (accounts) => {
   before(async () => {
     lock = await deployLock()
 

--- a/smart-contracts/test/Lock/erc721/getApproved.js
+++ b/smart-contracts/test/Lock/erc721/getApproved.js
@@ -1,6 +1,6 @@
 const { reverts, deployLock } = require('../../helpers')
 
-contract('Lock / erc721 / getApproved', () => {
+describe('Lock / erc721 / getApproved', () => {
   let lock
   before(async () => {
     lock = await deployLock()

--- a/smart-contracts/test/Lock/erc721/ownerOf.js
+++ b/smart-contracts/test/Lock/erc721/ownerOf.js
@@ -1,7 +1,7 @@
 const { deployLock, ADDRESS_ZERO, purchaseKey } = require('../../helpers')
 let lock
 
-contract('Lock / erc721 / ownerOf', (accounts) => {
+describe('Lock / erc721 / ownerOf', (accounts) => {
   before(async () => {
     lock = await deployLock()
     await lock.setMaxKeysPerAddress(10)

--- a/smart-contracts/test/Lock/erc721/safeTransferFrom.js
+++ b/smart-contracts/test/Lock/erc721/safeTransferFrom.js
@@ -5,7 +5,7 @@ const TestERC721Recevier = artifacts.require('TestERC721Recevier')
 
 let lock
 
-contract('Lock / erc721 / safeTransferFrom', (accounts) => {
+describe('Lock / erc721 / safeTransferFrom', (accounts) => {
   // function safeTransferFrom() still uses transferFrom() under the hood
   // but adds an additional check afterwards. transferFrom is already well-tested,
   // so here we add a few checks to test only the new functionality.

--- a/smart-contracts/test/Lock/erc721/tokenName.js
+++ b/smart-contracts/test/Lock/erc721/tokenName.js
@@ -2,7 +2,7 @@ const { deployLock, reverts } = require('../../helpers')
 let unnamedlock
 let namedLock
 
-contract('Lock / erc721 / name', (accounts) => {
+describe('Lock / erc721 / name', (accounts) => {
   before(async () => {
     unnamedlock = await deployLock()
     namedLock = await deployLock({ name: 'NAMED' })

--- a/smart-contracts/test/Lock/erc721/tokenSymbol.js
+++ b/smart-contracts/test/Lock/erc721/tokenSymbol.js
@@ -5,7 +5,7 @@ let unlock
 let txObj
 let event
 
-contract('Lock / erc721 / tokenSymbol', (accounts) => {
+describe('Lock / erc721 / tokenSymbol', (accounts) => {
   before(async () => {
     ;({ unlock } = await deployContracts())
     lock = await deployLock({ unlock })

--- a/smart-contracts/test/Lock/erc721/tokenURI.js
+++ b/smart-contracts/test/Lock/erc721/tokenURI.js
@@ -27,7 +27,7 @@ function stringShifter(str) {
   return lowercaseAddress
 }
 
-contract('Lock / erc721 / tokenURI', (accounts) => {
+describe('Lock / erc721 / tokenURI', (accounts) => {
   before(async () => {
     ;({ unlock } = await deployContracts())
     lock = await deployLock({ unlock })

--- a/smart-contracts/test/Lock/erc721/transferFrom.js
+++ b/smart-contracts/test/Lock/erc721/transferFrom.js
@@ -9,7 +9,7 @@ const {
 let tokenIds
 let keyOwners
 
-contract('Lock / erc721 / transferFrom', (accounts) => {
+describe('Lock / erc721 / transferFrom', (accounts) => {
   let lock
   let lockSingleKey
   keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]

--- a/smart-contracts/test/Lock/erc721/uniqueTokenIds.js
+++ b/smart-contracts/test/Lock/erc721/uniqueTokenIds.js
@@ -1,7 +1,7 @@
 const { ADDRESS_ZERO, purchaseKeys, deployLock } = require('../../helpers')
 const { ethers } = require('hardhat')
 
-contract('Lock / uniqueTokenIds', (accounts) => {
+describe('Lock / uniqueTokenIds', (accounts) => {
   let lock
   let lockOwner = accounts[9]
   let keyOwner1 = accounts[1]

--- a/smart-contracts/test/Lock/expireAndRefundFor.js
+++ b/smart-contracts/test/Lock/expireAndRefundFor.js
@@ -3,7 +3,7 @@ const BigNumber = require('bignumber.js')
 
 const { deployLock, getBalance, purchaseKeys, reverts } = require('../helpers')
 
-contract('Lock / expireAndRefundFor', (accounts) => {
+describe('Lock / expireAndRefundFor', (accounts) => {
   let lock
   let tokenIds
   const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]

--- a/smart-contracts/test/Lock/expireAndRefundFor.js
+++ b/smart-contracts/test/Lock/expireAndRefundFor.js
@@ -1,17 +1,18 @@
 const { ethers } = require('hardhat')
-const BigNumber = require('bignumber.js')
-
 const { deployLock, getBalance, purchaseKeys, reverts } = require('../helpers')
+const { assert } = require('chai')
 
-describe('Lock / expireAndRefundFor', (accounts) => {
+const keyPrice = ethers.utils.parseUnits('0.01', 'ether')
+const refundAmount = ethers.utils.parseUnits('0.01', 'ether')
+
+describe('Lock / expireAndRefundFor', () => {
   let lock
   let tokenIds
-  const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
-  const keyPrice = ethers.utils.parseUnits('0.01', 'ether')
-  const refundAmount = ethers.utils.parseUnits('0.01', 'ether')
-  const lockCreator = accounts[0]
+  let keyOwners
 
   before(async () => {
+    const [, ...signers] = await ethers.getSigners()
+    keyOwners = signers.slice(0, 4)
     lock = await deployLock()
     ;({ tokenIds } = await purchaseKeys(lock, keyOwners.length))
   })
@@ -19,51 +20,50 @@ describe('Lock / expireAndRefundFor', (accounts) => {
   describe('should cancel and refund when enough time remains', () => {
     let initialLockBalance
     let initialKeyOwnerBalance
-    let txObj
+    let events
+    let gasUsed
+    let transactionHash
 
     before(async () => {
       initialLockBalance = await getBalance(lock.address)
-      initialKeyOwnerBalance = await getBalance(keyOwners[0])
+      initialKeyOwnerBalance = await getBalance(keyOwners[0].address)
 
-      txObj = await lock.expireAndRefundFor(tokenIds[0], refundAmount, {
-        from: lockCreator,
-      })
+      const tx = await lock.expireAndRefundFor(tokenIds[0], refundAmount)
+      ;({ events, transactionHash, gasUsed } = await tx.wait())
     })
 
     it('should emit a CancelKey event', async () => {
-      assert.equal(txObj.logs[0].event, 'CancelKey')
+      assert.equal(events[0].event, 'CancelKey')
     })
 
     it('the amount of refund should be the key price', async () => {
-      const refund = new BigNumber(txObj.logs[0].args.refund)
+      const { refund } = events[0].args
       assert.equal(refund.toString(), keyPrice.toString())
     })
 
     it('should make the key no longer valid (i.e. expired)', async () => {
-      const isValid = await lock.getHasValidKey(keyOwners[0])
+      const isValid = await lock.getHasValidKey(keyOwners[0].address)
       assert.equal(isValid, false)
     })
 
     it("should increase the owner's balance with the amount of funds refunded from the lock", async () => {
-      const txHash = await ethers.provider.getTransaction(txObj.tx)
-      const gasUsed = new BigNumber(txObj.receipt.gasUsed)
-      const gasPrice = new BigNumber(txHash.gasPrice)
-      const txFee = gasPrice.times(gasUsed)
-      const finalOwnerBalance = await getBalance(keyOwners[0])
+      const { gasPrice } = await ethers.provider.getTransaction(transactionHash)
+      const txFee = gasPrice.mul(gasUsed)
+      const finalOwnerBalance = await getBalance(keyOwners[0].address)
       assert(
         finalOwnerBalance.toString(),
-        initialKeyOwnerBalance.plus(keyPrice).minus(txFee).toString()
+        initialKeyOwnerBalance.add(keyPrice).sub(txFee).toString()
       )
     })
 
     it("should increase the lock's balance by the keyPrice", async () => {
-      const finalLockBalance = (await getBalance(lock.address)).minus(
+      const finalLockBalance = (await getBalance(lock.address)).sub(
         initialLockBalance
       )
 
       assert(
-        finalLockBalance.toFixed(),
-        initialLockBalance.minus(keyPrice).toFixed()
+        finalLockBalance.toString(),
+        initialLockBalance.sub(keyPrice).toString()
       )
     })
   })
@@ -71,53 +71,37 @@ describe('Lock / expireAndRefundFor', (accounts) => {
   describe('should fail when', () => {
     it('invoked by the key owner', async () => {
       await reverts(
-        lock.expireAndRefundFor(tokenIds[3], refundAmount, {
-          from: keyOwners[3],
-        }),
+        lock
+          .connect(keyOwners[3])
+          .expireAndRefundFor(tokenIds[3], refundAmount),
         'ONLY_LOCK_MANAGER'
       )
     })
 
     it('invoked by another user', async () => {
       await reverts(
-        lock.expireAndRefundFor(tokenIds[3], refundAmount, {
-          from: accounts[1],
-        }),
+        lock
+          .connect(keyOwners[1])
+          .expireAndRefundFor(tokenIds[3], refundAmount),
         'ONLY_LOCK_MANAGER'
       )
     })
 
     it('the Lock owner withdraws too much funds', async () => {
-      await lock.withdraw(await lock.tokenAddress(), 0, {
-        from: lockCreator,
-      })
-      await reverts(
-        lock.expireAndRefundFor(tokenIds[3], refundAmount, {
-          from: lockCreator,
-        }),
-        ''
-      )
+      await lock.withdraw(await lock.tokenAddress(), 0)
+      await reverts(lock.expireAndRefundFor(tokenIds[3], refundAmount), '')
     })
 
     it('the key is expired', async () => {
-      await lock.expireAndRefundFor(tokenIds[3], 0, {
-        from: lockCreator,
-      })
+      await lock.expireAndRefundFor(tokenIds[3], 0)
       await reverts(
-        lock.expireAndRefundFor(tokenIds[3], refundAmount, {
-          from: lockCreator,
-        }),
+        lock.expireAndRefundFor(tokenIds[3], refundAmount),
         'KEY_NOT_VALID'
       )
     })
 
     it('the key does not exist', async () => {
-      await reverts(
-        lock.expireAndRefundFor(18, refundAmount, {
-          from: lockCreator,
-        }),
-        'NO_SUCH_KEY'
-      )
+      await reverts(lock.expireAndRefundFor(18, refundAmount), 'NO_SUCH_KEY')
     })
   })
 })

--- a/smart-contracts/test/Lock/extend.js
+++ b/smart-contracts/test/Lock/extend.js
@@ -15,7 +15,7 @@ let testToken
 const keyPrice = ethers.utils.parseUnits('0.01', 'ether')
 const someTokens = ethers.utils.parseUnits('10', 'ether')
 
-contract('Lock / extend keys', (accounts) => {
+describe('Lock / extend keys', (accounts) => {
   scenarios.forEach((isErc20) => {
     let lock
     let nonExpiringLock

--- a/smart-contracts/test/Lock/extendRenewable.js
+++ b/smart-contracts/test/Lock/extendRenewable.js
@@ -16,7 +16,7 @@ const someDai = ethers.utils.parseUnits('100', 'ether')
 let dai
 let lock
 
-contract('Lock / Extend with recurring memberships', (accounts) => {
+describe('Lock / Extend with recurring memberships', (accounts) => {
   const lockOwner = accounts[0]
   const keyOwner = accounts[1]
   // const referrer = accounts[3]

--- a/smart-contracts/test/Lock/freeTrial.js
+++ b/smart-contracts/test/Lock/freeTrial.js
@@ -4,7 +4,7 @@ const { deployLock, getBalance, purchaseKeys } = require('../helpers')
 
 let tokenId
 
-contract('Lock / freeTrial', (accounts) => {
+describe('Lock / freeTrial', (accounts) => {
   let lock
   const keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
   const keyPrice = ethers.utils.parseUnits('0.01', 'ether')

--- a/smart-contracts/test/Lock/gas.js
+++ b/smart-contracts/test/Lock/gas.js
@@ -1,20 +1,21 @@
 const { ethers } = require('hardhat')
-const BigNumber = require('bignumber.js')
+const { assert } = require('chai')
 
 const { deployLock, ADDRESS_ZERO } = require('../helpers')
 const WalletService = require('../helpers/walletServiceMock.js')
 
 let lock
 
-describe('Lock / gas', (accounts) => {
+describe('Lock / gas', () => {
   before(async () => {
     lock = await deployLock()
   })
 
   it('gas used to purchaseFor is less than wallet service limit', async () => {
+    const [account] = await ethers.getSigners()
     let tx = await lock.purchase(
       [],
-      [accounts[0]],
+      [account.address],
       [ADDRESS_ZERO],
       [ADDRESS_ZERO],
       [[]],
@@ -22,7 +23,7 @@ describe('Lock / gas', (accounts) => {
         value: ethers.utils.parseUnits('0.01', 'ether'),
       }
     )
-    const gasUsed = new BigNumber(tx.receipt.gasUsed)
+    const { gasUsed } = await tx.wait()
     if (!process.env.TEST_COVERAGE) {
       assert(gasUsed.lte(WalletService.gasAmountConstants().purchaseKey))
     }

--- a/smart-contracts/test/Lock/gas.js
+++ b/smart-contracts/test/Lock/gas.js
@@ -6,7 +6,7 @@ const WalletService = require('../helpers/walletServiceMock.js')
 
 let lock
 
-contract('Lock / gas', (accounts) => {
+describe('Lock / gas', (accounts) => {
   before(async () => {
     lock = await deployLock()
   })

--- a/smart-contracts/test/Lock/gasRefund.js
+++ b/smart-contracts/test/Lock/gasRefund.js
@@ -22,7 +22,7 @@ const gasRefund = async (tx) => {
   return { gas, refund }
 }
 
-contract('Lock / GasRefund', (accounts) => {
+describe('Lock / GasRefund', (accounts) => {
   let lock
   let tokenAddress = ADDRESS_ZERO
   let userBalanceBefore

--- a/smart-contracts/test/Lock/getHasValidKey.js
+++ b/smart-contracts/test/Lock/getHasValidKey.js
@@ -1,7 +1,7 @@
 const { ADDRESS_ZERO, purchaseKey, deployLock } = require('../helpers')
 const { ethers } = require('hardhat')
 
-contract('Lock / getHasValidKey', (accounts) => {
+describe('Lock / getHasValidKey', (accounts) => {
   const [, keyOwner] = accounts
   let lock
   let tokenId

--- a/smart-contracts/test/Lock/grantKeyExtension.js
+++ b/smart-contracts/test/Lock/grantKeyExtension.js
@@ -4,7 +4,7 @@ const { deployLock, reverts, ADDRESS_ZERO } = require('../helpers')
 let lock
 let tx
 
-contract('Lock / grantKeyExtension', (accounts) => {
+describe('Lock / grantKeyExtension', (accounts) => {
   const lockCreator = accounts[1]
   const keyOwner = accounts[2]
   let tokenId

--- a/smart-contracts/test/Lock/grantKeys.js
+++ b/smart-contracts/test/Lock/grantKeys.js
@@ -4,7 +4,7 @@ const { reverts, deployLock, ADDRESS_ZERO } = require('../helpers')
 let lock
 let tx
 
-contract('Lock / grantKeys', (accounts) => {
+describe('Lock / grantKeys', (accounts) => {
   const lockCreator = accounts[1]
   const keyOwner = accounts[2]
   let validExpirationTimestamp

--- a/smart-contracts/test/Lock/hooks/erc1155BalanceOfHook.js
+++ b/smart-contracts/test/Lock/hooks/erc1155BalanceOfHook.js
@@ -14,7 +14,7 @@ let nft
 
 const GOLD = 1
 
-contract('ERC1155BalanceOfHook', (accounts) => {
+describe('ERC1155BalanceOfHook', (accounts) => {
   const from = accounts[1]
   const nftOwner = accounts[2]
   const keyOwner = accounts[3]

--- a/smart-contracts/test/Lock/hooks/erc20BalanceOfHook.js
+++ b/smart-contracts/test/Lock/hooks/erc20BalanceOfHook.js
@@ -16,7 +16,7 @@ let token
 
 const minAmount = ethers.utils.parseEther('0.05')
 
-contract('ERC20BalanceOfHook', (accounts) => {
+describe('ERC20BalanceOfHook', (accounts) => {
   const tokenOwner = accounts[2]
   const keyOwner = accounts[3]
 

--- a/smart-contracts/test/Lock/hooks/erc721BalanceOfHook.js
+++ b/smart-contracts/test/Lock/hooks/erc721BalanceOfHook.js
@@ -11,7 +11,7 @@ let lock
 let hook
 let nft
 
-contract('ERC721BalanceOfHook', (accounts) => {
+describe('ERC721BalanceOfHook', (accounts) => {
   const from = accounts[1]
   const nftOwner = accounts[2]
   const keyOwner = accounts[3]

--- a/smart-contracts/test/Lock/initializers.js
+++ b/smart-contracts/test/Lock/initializers.js
@@ -1,9 +1,10 @@
-const publicLockContract = artifacts.require('PublicLock')
+const { ethers } = require('hardhat')
 const { reverts, ADDRESS_ZERO, deployLock } = require('../helpers')
 
 contract('Lock / initializers', (accounts) => {
   it('There are exactly 1 public initializer in PublicLock', async () => {
-    const count = publicLockContract.abi.filter((x) =>
+    const { interface } = await ethers.getContractFactory('PublicLock')
+    const count = interface.filter((x) =>
       (x.name || '').includes('initialize')
     ).length
     assert.equal(count, 1)

--- a/smart-contracts/test/Lock/initializers.js
+++ b/smart-contracts/test/Lock/initializers.js
@@ -1,7 +1,7 @@
 const { ethers } = require('hardhat')
 const { reverts, ADDRESS_ZERO, deployLock } = require('../helpers')
 
-contract('Lock / initializers', (accounts) => {
+describe('Lock / initializers', (accounts) => {
   it('There are exactly 1 public initializer in PublicLock', async () => {
     const { interface } = await ethers.getContractFactory('PublicLock')
     const count = interface.filter((x) =>

--- a/smart-contracts/test/Lock/interface.js
+++ b/smart-contracts/test/Lock/interface.js
@@ -1,15 +1,23 @@
-const lockContract = artifacts.require('PublicLock')
-const lockInterface = artifacts.require('IPublicLock')
+const { assert } = require('chai')
+const { ethers } = require('hardhat')
+const { ADDRESS_ZERO } = require('../helpers')
 
-contract('Lock / interface', () => {
+describe('Lock / interface', () => {
   it('The interface includes all public functions', async () => {
+    assert
+    const PublicLock = await ethers.getContractFactory('PublicLock')
+    const IPublicLock = await ethers.getContractAt('IPublicLock', ADDRESS_ZERO)
+
+    const lockInterface = Object.keys(IPublicLock.interface.functions)
+    const lockContract = Object.keys(PublicLock.interface.functions)
+
     // log any missing entries
-    lockContract.abi
+    lockContract
       .filter((x) => x.type === 'function')
       .forEach((entry) => {
         if (
-          lockInterface.abi.filter((x) => x.name === entry.name).length ===
-          lockContract.abi.filter((x) => x.name === entry.name).length
+          lockInterface.filter((x) => x.name === entry.name).length ===
+          lockContract.filter((x) => x.name === entry.name).length
         ) {
           return
         }
@@ -18,10 +26,8 @@ contract('Lock / interface', () => {
       })
 
     // and assert the count matches
-    const count = lockInterface.abi.filter((x) => x.type === 'function').length
-    const expected = lockContract.abi.filter(
-      (x) => x.type === 'function'
-    ).length
+    const count = lockInterface.length
+    const expected = lockContract.length
     assert.notEqual(count, 0)
     assert.equal(count, expected)
   })

--- a/smart-contracts/test/Lock/isValidKey.js
+++ b/smart-contracts/test/Lock/isValidKey.js
@@ -1,11 +1,15 @@
+const { ethers } = require('hardhat')
+const { assert } = require('chai')
 const { deployLock, purchaseKey } = require('../helpers')
 
-describe('Lock / isValidKey', (accounts) => {
-  let keyOwner = accounts[1]
+describe('Lock / isValidKey', () => {
   let lock
   let tokenId
+  let keyOwner
+  let anotherAccount
 
   beforeEach(async () => {
+    ;[, keyOwner, anotherAccount] = await ethers.getSigners()
     lock = await deployLock()
     await lock.updateTransferFee(0) // disable the transfer fee for this test
     ;({ tokenId } = await purchaseKey(lock, keyOwner))
@@ -20,23 +24,19 @@ describe('Lock / isValidKey', (accounts) => {
   })
 
   it('should still be true after transfering', async () => {
-    await lock.transferFrom(keyOwner, accounts[5], tokenId, {
-      from: keyOwner,
-    })
+    await lock
+      .connect(keyOwner)
+      .transferFrom(keyOwner.address, anotherAccount.address, tokenId)
     assert.equal(await lock.isValidKey(tokenId), true)
   })
 
   it('should be false after expiring', async () => {
-    await lock.expireAndRefundFor(tokenId, 0, {
-      from: accounts[0],
-    })
+    await lock.expireAndRefundFor(tokenId, 0)
     assert.equal(await lock.isValidKey(tokenId), false)
   })
 
   it('should be false after cancelling', async () => {
-    await lock.cancelAndRefund(tokenId, {
-      from: keyOwner,
-    })
+    await lock.connect(keyOwner).cancelAndRefund(tokenId)
     assert.equal(await lock.isValidKey(tokenId), false)
   })
 })

--- a/smart-contracts/test/Lock/isValidKey.js
+++ b/smart-contracts/test/Lock/isValidKey.js
@@ -1,6 +1,6 @@
 const { deployLock, purchaseKey } = require('../helpers')
 
-contract('Lock / isValidKey', (accounts) => {
+describe('Lock / isValidKey', (accounts) => {
   let keyOwner = accounts[1]
   let lock
   let tokenId

--- a/smart-contracts/test/Lock/lendKey.js
+++ b/smart-contracts/test/Lock/lendKey.js
@@ -1,48 +1,40 @@
-const {
-  reverts,
-  ADDRESS_ZERO,
-  deployLock,
-  purchaseKeys,
-} = require('../helpers')
+const { ethers } = require('hardhat')
+const { assert } = require('chai')
+const { reverts, ADDRESS_ZERO, deployLock, purchaseKey } = require('../helpers')
 
 let lock
-let lockFree
-let lockSingleKey
-let tokenIds
-let keyOwners
-let accountApproved
-let keyManager
+let tokenId
 
-describe('Lock / lendKey', (accounts) => {
-  const from = accounts[0]
-  keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
-  accountApproved = accounts[8]
-  keyManager = accounts[9]
+let keyOwner, receiver, keyManager, anotherAccount, yetAnotherAccount
+let balanceKeyOwnerBefore
+let balanceKeyReceiverBefore
 
-  beforeEach(async () => {
+describe('Lock / lendKey', () => {
+  before(async () => {
+    ;[, keyOwner, receiver, keyManager, anotherAccount, yetAnotherAccount] =
+      await ethers.getSigners()
+
     // deploy some locks
     lock = await deployLock()
-    lockFree = await deployLock({ name: 'FREE' })
-    lockSingleKey = await deployLock({ name: 'SINGLE KEY' })
 
     await lock.updateTransferFee(0) // disable the lend fee for this test
-    await lockSingleKey.updateTransferFee(0) // disable the lend fee for this test
-    ;({ tokenIds } = await purchaseKeys(lock, keyOwners.length))
+    await lock.setMaxKeysPerAddress(10)
   })
 
   describe('failures', () => {
+    before(async () => {
+      ;({ tokenId } = await purchaseKey(lock, keyOwner))
+    })
     it('should abort when there is no key to lend', async () => {
       await reverts(
-        lock.lendKey(keyOwners[0], accounts[9], 999),
+        lock.lendKey(keyOwner.address, anotherAccount.address, 999),
         'UNAUTHORIZED'
       )
     })
 
     it('should abort if the recipient is 0x', async () => {
       await reverts(
-        lock.lendKey(keyOwners[0], ADDRESS_ZERO, tokenIds[0], {
-          from: keyOwners[0],
-        }),
+        lock.connect(keyOwner).lendKey(keyOwner.address, ADDRESS_ZERO, tokenId),
         'INVALID_ADDRESS'
       )
     })
@@ -50,56 +42,57 @@ describe('Lock / lendKey', (accounts) => {
     it('should only allow key manager or owner', async () => {
       // testing an id mismatch
       await reverts(
-        lock.lendKey(keyOwners[0], accounts[9], tokenIds[0], {
-          from: keyOwners[5],
-        }),
+        lock
+          .connect(anotherAccount)
+          .lendKey(keyOwner.address, anotherAccount.address, tokenId),
         'UNAUTHORIZED'
       )
+
       // testing a mismatched _from address
       await reverts(
-        lock.lendKey(keyOwners[2], accounts[9], tokenIds[0], {
-          from: keyOwners[0],
-        }),
+        lock
+          .connect(keyOwner)
+          .lendKey(anotherAccount.address, anotherAccount.address, tokenId),
         'UNAUTHORIZED'
       )
     })
 
     it('should prevent lending an expired key', async () => {
       // Then let's expire the key
-      await lock.expireAndRefundFor(tokenIds[0], 0, {
-        from: accounts[0],
-      })
+      await lock.expireAndRefundFor(tokenId, 0)
       await reverts(
-        lock.lendKey(keyOwners[1], accounts[7], tokenIds[0], {
-          from: keyOwners[1],
-        })
+        lock
+          .connect(receiver)
+          .lendKey(receiver.address, receiver.address, tokenId)
       )
     })
 
     it('should fail if the sender has been approved for that key', async () => {
-      await lock.approve(accountApproved, tokenIds[0], {
-        from: keyOwners[0],
-      })
+      ;({ tokenId } = await purchaseKey(lock, keyOwner))
+      await lock.connect(keyOwner).approve(anotherAccount.address, tokenId)
+
       await reverts(
-        lock.lendKey(keyOwners[0], accounts[9], tokenIds[0], {
-          from: accountApproved,
-        }),
+        lock
+          .connect(anotherAccount)
+          .lendKey(keyOwner.address, receiver.address, tokenId),
         'UNAUTHORIZED'
       )
     })
 
     it('should fail if the sender has been approved for all owner keys', async () => {
-      await lock.setApprovalForAll(accountApproved, true, {
-        from: keyOwners[0],
-      })
+      ;({ tokenId } = await purchaseKey(lock, keyOwner))
+      await lock
+        .connect(keyOwner)
+        .setApprovalForAll(anotherAccount.address, true)
+
       assert.equal(
-        await lock.isApprovedForAll(keyOwners[0], accountApproved),
+        await lock.isApprovedForAll(keyOwner.address, anotherAccount.address),
         true
       )
       await reverts(
-        lock.lendKey(keyOwners[0], accounts[9], tokenIds[0], {
-          from: accountApproved,
-        }),
+        lock
+          .connect(anotherAccount)
+          .lendKey(keyOwner.address, anotherAccount.address, tokenId),
         'UNAUTHORIZED'
       )
     })
@@ -107,43 +100,49 @@ describe('Lock / lendKey', (accounts) => {
 
   describe('when the sender is the key owner', () => {
     describe('no key manager is set', () => {
-      beforeEach(async () => {
-        await lock.lendKey(keyOwners[0], accounts[7], tokenIds[0], {
-          from: keyOwners[0],
-        })
+      before(async () => {
+        balanceKeyOwnerBefore = await lock.balanceOf(keyOwner.address)
+        balanceKeyReceiverBefore = await lock.balanceOf(receiver.address)
+        ;({ tokenId } = await purchaseKey(lock, keyOwner))
+        await lock
+          .connect(keyOwner)
+          .lendKey(keyOwner.address, receiver.address, tokenId)
       })
 
       it('should lend ownership correctly', async () => {
-        assert.equal(await lock.ownerOf(tokenIds[0]), accounts[7])
+        assert.equal(await lock.ownerOf(tokenId), receiver.address)
       })
 
       it('update balances properly', async () => {
-        assert.equal(await lock.balanceOf(accounts[7]), 1)
-        assert.equal(await lock.balanceOf(keyOwners[0]), 0)
-      })
-
-      it('update key validity properly', async () => {
-        assert.equal(await lock.getHasValidKey(accounts[7]), true)
-        assert.equal(await lock.getHasValidKey(keyOwners[0]), false)
+        assert.equal(
+          balanceKeyReceiverBefore
+            .add(await lock.balanceOf(receiver.address))
+            .toNumber(),
+          1
+        )
+        assert.equal(
+          balanceKeyOwnerBefore
+            .sub(await lock.balanceOf(keyOwner.address))
+            .toNumber(),
+          0
+        )
       })
 
       it('should set previous owner as key manager', async () => {
-        assert.equal(await lock.keyManagerOf(tokenIds[0]), keyOwners[0])
+        assert.equal(await lock.keyManagerOf(tokenId), keyOwner.address)
       })
     })
 
     describe('a key manager is set', () => {
-      beforeEach(async () => {
-        await lock.setKeyManagerOf(tokenIds[0], keyManager, {
-          from: keyOwners[0],
-        })
-      })
-
       it('should prevent from lending a key', async () => {
+        await lock
+          .connect(keyOwner)
+          .setKeyManagerOf(tokenId, keyManager.address)
+
         await reverts(
-          lock.lendKey(keyOwners[0], accounts[7], tokenIds[0], {
-            from: keyOwners[0],
-          }),
+          lock
+            .connect(keyOwner)
+            .lendKey(keyOwner.address, receiver.address, tokenId),
           'UNAUTHORIZED'
         )
       })
@@ -151,185 +150,153 @@ describe('Lock / lendKey', (accounts) => {
   })
 
   describe('when the sender is a key manager', async () => {
-    beforeEach(async () => {
-      await lock.setKeyManagerOf(tokenIds[0], keyManager, {
-        from: keyOwners[0],
-      })
-      await lock.lendKey(keyOwners[0], accounts[7], tokenIds[0], {
-        from: keyManager,
-      })
+    before(async () => {
+      ;({ tokenId } = await purchaseKey(lock, keyOwner))
+      balanceKeyOwnerBefore = await lock.balanceOf(keyOwner.address)
+      balanceKeyReceiverBefore = await lock.balanceOf(receiver.address)
+
+      await lock.connect(keyOwner).setKeyManagerOf(tokenId, keyManager.address)
+      await lock
+        .connect(keyManager)
+        .lendKey(keyOwner.address, receiver.address, tokenId)
     })
 
     it('should lend ownership correctly', async () => {
-      assert.equal(await lock.ownerOf(tokenIds[0]), accounts[7])
+      assert.equal(await lock.ownerOf(tokenId), receiver.address)
     })
 
     it('update balances properly', async () => {
-      assert.equal(await lock.balanceOf(accounts[7]), 1)
-      assert.equal(await lock.balanceOf(keyOwners[0]), 0)
-    })
-
-    it('update key validity properly', async () => {
-      assert.equal(await lock.getHasValidKey(accounts[7]), true)
-      assert.equal(await lock.getHasValidKey(keyOwners[0]), false)
+      assert.equal(
+        (await lock.balanceOf(receiver.address))
+          .sub(balanceKeyReceiverBefore)
+          .toNumber(),
+        1
+      )
+      assert.equal(
+        (await lock.balanceOf(keyOwner.address))
+          .sub(balanceKeyOwnerBefore)
+          .toNumber(),
+        -1
+      )
     })
 
     it('retains the correct key manager', async () => {
-      assert.equal(await lock.keyManagerOf(tokenIds[0]), keyManager)
+      assert.equal(await lock.keyManagerOf(tokenId), keyManager.address)
     })
   })
 
   describe('when the lock is sold out', () => {
     it('should still allow the lend of keys', async () => {
-      // first we create a lock with only 1 key
-      const tx = await lockSingleKey.purchase(
-        [],
-        [keyOwners[0]],
-        [ADDRESS_ZERO],
-        [ADDRESS_ZERO],
-        [[]],
-        {
-          value: web3.utils.toWei('0.01', 'ether'),
-          from,
-        }
-      )
-
-      const { args } = tx.logs.find((v) => v.event === 'Transfer')
-      const { tokenId } = args
+      const lockSingleKey = await deployLock({ name: 'SINGLE KEY' })
+      await lockSingleKey.updateTransferFee(0) // disable the lend fee for this test
+      ;({ tokenId } = await purchaseKey(lockSingleKey, keyOwner))
 
       // confirm that the lock is sold out
-      await reverts(
-        lockSingleKey.purchase(
-          [],
-          [accounts[8]],
-          [ADDRESS_ZERO],
-          [ADDRESS_ZERO],
-          [[]],
-          {
-            value: web3.utils.toWei('0.01', 'ether'),
-            from: accounts[8],
-          }
-        ),
-        'LOCK_SOLD_OUT'
-      )
+      await reverts(purchaseKey(lockSingleKey, anotherAccount), 'LOCK_SOLD_OUT')
 
       // set default key owner as key manager
-      await lockSingleKey.setKeyManagerOf(tokenId, accounts[1], {
-        from: accounts[1],
-      })
+      await lockSingleKey
+        .connect(keyOwner)
+        .setKeyManagerOf(tokenId, keyOwner.address)
 
       // check ownership
-      assert.equal(await lockSingleKey.ownerOf.call(tokenId), keyOwners[0])
+      assert.equal(await lockSingleKey.ownerOf(tokenId), keyOwner.address)
 
       // lend
-      await lockSingleKey.lendKey(keyOwners[0], accounts[9], tokenId, {
-        from: keyOwners[0],
-      })
+      await lockSingleKey
+        .connect(keyOwner)
+        .lendKey(keyOwner.address, receiver.address, tokenId)
 
-      assert.equal(await lockSingleKey.ownerOf.call(tokenId), accounts[9])
+      assert.equal(await lockSingleKey.ownerOf(tokenId), receiver.address)
+      assert.equal(await lockSingleKey.keyManagerOf(tokenId), keyOwner.address)
     })
   })
 
   it('can lend a FREE key', async () => {
-    const tx = await lockFree.purchase(
-      [],
-      [accounts[1]],
-      [ADDRESS_ZERO],
-      [ADDRESS_ZERO],
-      [[]],
-      {
-        from: accounts[1],
-      }
-    )
-    const { args } = tx.logs.find(
-      (v) => v.event === 'Transfer' && v.args.from === ADDRESS_ZERO
-    )
-    const { tokenId: newTokenId } = args
+    const lockFree = await deployLock({ name: 'FREE' })
+    const { tokenId: newTokenId } = await purchaseKey(lockFree, keyOwner)
 
-    await lockFree.lendKey(accounts[1], accounts[2], newTokenId, {
-      from: accounts[1],
-    })
-    assert.equal(await lockFree.ownerOf(newTokenId), accounts[2])
-    assert.equal(await lockFree.keyManagerOf(newTokenId), accounts[1])
+    await lockFree
+      .connect(keyOwner)
+      .lendKey(keyOwner.address, receiver.address, newTokenId)
+
+    assert.equal(await lockFree.ownerOf(newTokenId), receiver.address)
+    assert.equal(await lockFree.keyManagerOf(newTokenId), keyOwner.address)
   })
 
   describe('approvals with lent key', () => {
-    const approvedUser = accounts[8]
-    beforeEach(async () => {
-      await lock.lendKey(keyOwners[0], accounts[7], tokenIds[0], {
-        from: keyOwners[0],
-      })
+    before(async () => {
+      ;({ tokenId } = await purchaseKey(lock, keyOwner))
+      await lock
+        .connect(keyOwner)
+        .lendKey(keyOwner.address, receiver.address, tokenId)
     })
 
     it('can not approve another account to lend the key', async () => {
       await reverts(
-        lock.approve(approvedUser, tokenIds[0], {
-          from: accounts[7],
-        }),
+        lock.connect(receiver).approve(yetAnotherAccount.address, tokenId),
         'ONLY_KEY_MANAGER_OR_APPROVED'
       )
     })
 
     it('can not used an "approved for all" account to transfer the key', async () => {
-      await lock.setApprovalForAll(approvedUser, true, {
-        from: accounts[7],
-      })
+      await lock
+        .connect(receiver)
+        .setApprovalForAll(yetAnotherAccount.address, true)
+
       await reverts(
-        lock.transferFrom(accounts[7], accounts[9], tokenIds[0], {
-          from: approvedUser,
-        }),
+        lock
+          .connect(yetAnotherAccount)
+          .transferFrom(receiver.address, yetAnotherAccount.address, tokenId),
         'ONLY_KEY_MANAGER_OR_APPROVED'
       )
     })
   })
 
   describe('a lent key', () => {
-    beforeEach(async () => {
-      await lock.lendKey(keyOwners[2], accounts[7], tokenIds[2], {
-        from: keyOwners[2],
-      })
+    before(async () => {
+      ;({ tokenId } = await purchaseKey(lock, keyOwner))
+
+      await lock
+        .connect(keyOwner)
+        .lendKey(keyOwner.address, receiver.address, tokenId)
     })
     it('has correct ownership', async () => {
-      assert.equal(await lock.ownerOf(tokenIds[2]), accounts[7])
-      assert.equal(await lock.keyManagerOf(tokenIds[2]), keyOwners[2])
+      assert.equal(await lock.ownerOf(tokenId), receiver.address)
+      assert.equal(await lock.keyManagerOf(tokenId), keyOwner.address)
     })
     it('can not be lent by owner', async () => {
       await reverts(
-        lock.lendKey(accounts[7], accounts[8], tokenIds[2], {
-          from: accounts[7],
-        }),
+        lock
+          .connect(receiver)
+          .lendKey(receiver.address, anotherAccount.address, tokenId),
         'UNAUTHORIZED'
       )
     })
     it('can not be transferred by owner', async () => {
       await reverts(
-        lock.transferFrom(accounts[7], accounts[8], tokenIds[2], {
-          from: accounts[7],
-        }),
+        lock
+          .connect(receiver)
+          .transferFrom(receiver.address, anotherAccount.address, tokenId),
         'ONLY_KEY_MANAGER_OR_APPROVED'
       )
     })
     it('can not be burn by owner', async () => {
       await reverts(
-        lock.burn(tokenIds[2], {
-          from: accounts[7],
-        }),
+        lock.connect(receiver).burn(tokenId),
         'ONLY_KEY_MANAGER_OR_APPROVED'
       )
     })
     it('can not be merged by owner', async () => {
+      const { tokenId: anotherTokenId } = await purchaseKey(lock, keyOwner)
       await reverts(
-        lock.mergeKeys(tokenIds[2], tokenIds[3], 10, {
-          from: accounts[7],
-        }),
+        lock.connect(receiver).mergeKeys(tokenId, anotherTokenId, 10),
         'ONLY_KEY_MANAGER_OR_APPROVED'
       )
     })
     it('can not be cancelled by owner', async () => {
       await reverts(
-        lock.cancelAndRefund(tokenIds[2], {
-          from: accounts[7],
-        }),
+        lock.connect(receiver).cancelAndRefund(tokenId),
         'ONLY_KEY_MANAGER_OR_APPROVED'
       )
     })

--- a/smart-contracts/test/Lock/lendKey.js
+++ b/smart-contracts/test/Lock/lendKey.js
@@ -13,7 +13,7 @@ let keyOwners
 let accountApproved
 let keyManager
 
-contract('Lock / lendKey', (accounts) => {
+describe('Lock / lendKey', (accounts) => {
   const from = accounts[0]
   keyOwners = [accounts[1], accounts[2], accounts[3], accounts[4]]
   accountApproved = accounts[8]

--- a/smart-contracts/test/Lock/maxKeysPerAddress.js
+++ b/smart-contracts/test/Lock/maxKeysPerAddress.js
@@ -3,11 +3,14 @@ const { assert } = require('chai')
 
 const { deployLock, reverts, ADDRESS_ZERO, purchaseKey } = require('../helpers')
 
-describe('Lock / maxKeysPerAddress', (accounts) => {
-  let keyOwner = accounts[1]
+describe('Lock / maxKeysPerAddress', () => {
   let lock
+  let keyOwner
+  let anotherAccount
+  let yetAnotherAccount
 
   before(async () => {
+    ;[, keyOwner, anotherAccount, yetAnotherAccount] = await ethers.getSigners()
     lock = await deployLock()
   })
 
@@ -18,9 +21,7 @@ describe('Lock / maxKeysPerAddress', (accounts) => {
   describe('set/get maxKeysPerAddress', () => {
     it('can only be invaccounts[9]oked by lock manager', async () => {
       await reverts(
-        lock.setMaxKeysPerAddress(10, {
-          from: accounts[5],
-        }),
+        lock.connect(anotherAccount).setMaxKeysPerAddress(10),
         'ONLY_LOCK_MANAGER'
       )
     })
@@ -49,9 +50,16 @@ describe('Lock / maxKeysPerAddress', (accounts) => {
 
     it('prevent users to purchase more keys than allowed', async () => {
       await reverts(
-        lock.purchase([], [keyOwner], [ADDRESS_ZERO], [ADDRESS_ZERO], [[]], {
-          value: ethers.utils.parseUnits('0.01', 'ether'),
-        }),
+        lock.purchase(
+          [],
+          [keyOwner.address],
+          [ADDRESS_ZERO],
+          [ADDRESS_ZERO],
+          [[]],
+          {
+            value: ethers.utils.parseUnits('0.01', 'ether'),
+          }
+        ),
         'MAX_KEYS'
       )
     })
@@ -60,7 +68,7 @@ describe('Lock / maxKeysPerAddress', (accounts) => {
       await reverts(
         lock.purchase(
           [],
-          [accounts[9], accounts[9]],
+          [anotherAccount.address, anotherAccount.address],
           [ADDRESS_ZERO, ADDRESS_ZERO],
           [ADDRESS_ZERO, ADDRESS_ZERO],
           [[]],
@@ -75,7 +83,7 @@ describe('Lock / maxKeysPerAddress', (accounts) => {
     it('prevent user from sharing a key with someone who has more keys than allowed', async () => {
       await lock.purchase(
         [],
-        [accounts[9]],
+        [anotherAccount.address],
         [ADDRESS_ZERO],
         [ADDRESS_ZERO],
         [[]],
@@ -84,9 +92,7 @@ describe('Lock / maxKeysPerAddress', (accounts) => {
         }
       )
       await reverts(
-        lock.shareKey(accounts[9], tokenId, 1000, {
-          from: keyOwner,
-        }),
+        lock.connect(keyOwner).shareKey(anotherAccount.address, tokenId, 1000),
         'MAX_KEYS'
       )
     })
@@ -94,7 +100,7 @@ describe('Lock / maxKeysPerAddress', (accounts) => {
     it('prevent user from transferring a key with someone who has more keys than allowed', async () => {
       await lock.purchase(
         [],
-        [accounts[8]],
+        [yetAnotherAccount.address],
         [ADDRESS_ZERO],
         [ADDRESS_ZERO],
         [[]],
@@ -103,9 +109,9 @@ describe('Lock / maxKeysPerAddress', (accounts) => {
         }
       )
       await reverts(
-        lock.transfer(tokenId, accounts[8], 1000, {
-          from: keyOwner,
-        }),
+        lock
+          .connect(keyOwner)
+          .transfer(tokenId, yetAnotherAccount.address, 1000),
         'MAX_KEYS'
       )
     })

--- a/smart-contracts/test/Lock/maxKeysPerAddress.js
+++ b/smart-contracts/test/Lock/maxKeysPerAddress.js
@@ -3,7 +3,7 @@ const { assert } = require('chai')
 
 const { deployLock, reverts, ADDRESS_ZERO, purchaseKey } = require('../helpers')
 
-contract('Lock / maxKeysPerAddress', (accounts) => {
+describe('Lock / maxKeysPerAddress', (accounts) => {
   let keyOwner = accounts[1]
   let lock
 

--- a/smart-contracts/test/Lock/mergeKeys.js
+++ b/smart-contracts/test/Lock/mergeKeys.js
@@ -4,7 +4,7 @@ const { assert } = require('chai')
 
 const { purchaseKeys, reverts, deployLock } = require('../helpers')
 
-contract('Lock / mergeKeys', (accounts) => {
+describe('Lock / mergeKeys', (accounts) => {
   let tokenIds
   let lockCreator = accounts[0]
   let keyOwner = accounts[1]

--- a/smart-contracts/test/Lock/nonExpiring.js
+++ b/smart-contracts/test/Lock/nonExpiring.js
@@ -5,7 +5,7 @@ const BigNumber = require('bignumber.js')
 
 const { deployLock, purchaseKey, getBalance, MAX_UINT } = require('../helpers')
 
-contract('Lock / non expiring', (accounts) => {
+describe('Lock / non expiring', (accounts) => {
   let lock
   const keyOwner = accounts[2]
   let keyPrice

--- a/smart-contracts/test/Lock/onKeyCancelHook.js
+++ b/smart-contracts/test/Lock/onKeyCancelHook.js
@@ -4,7 +4,7 @@ const { deployLock, ADDRESS_ZERO, purchaseKey, reverts } = require('../helpers')
 let lock
 let testEventHooks
 
-contract('Lock / onKeyCancelHook', (accounts) => {
+describe('Lock / onKeyCancelHook', (accounts) => {
   const to = accounts[2]
 
   before(async () => {

--- a/smart-contracts/test/Lock/onKeyPurchaseHook.js
+++ b/smart-contracts/test/Lock/onKeyPurchaseHook.js
@@ -7,7 +7,7 @@ const TestEventHooks = artifacts.require('TestEventHooks.sol')
 let lock
 let testEventHooks
 
-contract('Lock / onKeyPurchaseHook', (accounts) => {
+describe('Lock / onKeyPurchaseHook', (accounts) => {
   const from = accounts[1]
   const to = accounts[2]
   const dataField = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('TestData'))

--- a/smart-contracts/test/Lock/onKeyTransferHook.js
+++ b/smart-contracts/test/Lock/onKeyTransferHook.js
@@ -6,7 +6,7 @@ const { assert } = require('chai')
 let lock
 let testEventHooks
 
-contract('Lock / onKeyTransfer hook', (accounts) => {
+describe('Lock / onKeyTransfer hook', (accounts) => {
   const keyOwner = accounts[1]
   const to = accounts[2]
   let keyPrice

--- a/smart-contracts/test/Lock/onTokenURIHook.js
+++ b/smart-contracts/test/Lock/onTokenURIHook.js
@@ -5,7 +5,7 @@ const TestEventHooks = artifacts.require('TestEventHooks.sol')
 let lock
 let testEventHooks
 
-contract('Lock / onTokenURIHook', (accounts) => {
+describe('Lock / onTokenURIHook', (accounts) => {
   const keyOwner = accounts[1]
   let tokenId
 

--- a/smart-contracts/test/Lock/onValidKeyHook.js
+++ b/smart-contracts/test/Lock/onValidKeyHook.js
@@ -6,7 +6,7 @@ let lock
 let tokenId
 let testEventHooks
 
-contract('Lock / onValidKeyHook', (accounts) => {
+describe('Lock / onValidKeyHook', (accounts) => {
   const keyOwner = accounts[1]
 
   before(async () => {

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -1,52 +1,56 @@
-const BigNumber = require('bignumber.js')
+const { ethers } = require('hardhat')
+const { assert } = require('chai')
 const { deployLock, purchaseKeys, ADDRESS_ZERO } = require('../helpers')
 
 let lock
 let tokenIds
+let keyOwners, anotherAccount
 
-describe('Lock / owners', (accounts) => {
-  const keyOwners = accounts.slice(1, 6)
+describe('Lock / owners', () => {
   before(async () => {
+    const [, ...signers] = await ethers.getSigners()
+    keyOwners = signers.slice(0, 5)
+    anotherAccount = signers[6]
+
     lock = await deployLock()
     await lock.setMaxKeysPerAddress(10)
     await lock.updateTransferFee(0) // disable the transfer fee for this test
-  })
 
-  before(async () => {
-    // Purchase keys!
+    // buy keys
     ;({ tokenIds } = await purchaseKeys(lock, keyOwners.length))
   })
 
-  it('should have the right number of keys', async () => {
-    const totalSupply = new BigNumber(await lock.totalSupply())
-    assert.equal(totalSupply.toFixed(), keyOwners.length)
-  })
+  describe('basic state', () => {
+    it('should have the right number of keys', async () => {
+      const totalSupply = await lock.totalSupply()
+      assert.equal(totalSupply.toNumber(), keyOwners.length)
+    })
 
-  it('should have the right number of owners', async () => {
-    const numberOfOwners = new BigNumber(await lock.numberOfOwners())
-    assert.equal(numberOfOwners.toFixed(), keyOwners.length)
+    it('should have the right number of owners', async () => {
+      const numberOfOwners = await lock.numberOfOwners()
+      assert.equal(numberOfOwners.toNumber(), keyOwners.length)
+    })
   })
 
   describe('after a transfer to a new address', () => {
     let numberOfOwners
-
     before(async () => {
-      numberOfOwners = new BigNumber(await lock.numberOfOwners())
-      await lock.transferFrom(keyOwners[0], accounts[8], tokenIds[0], {
-        from: keyOwners[0],
-      })
+      numberOfOwners = await lock.numberOfOwners()
+      await lock
+        .connect(keyOwners[0])
+        .transferFrom(keyOwners[0].address, anotherAccount.address, tokenIds[0])
     })
 
     it('should have the right number of keys', async () => {
-      const totalSupply = new BigNumber(await lock.totalSupply())
-      assert.equal(totalSupply.toFixed(), tokenIds.length)
+      const totalSupply = await lock.totalSupply()
+      assert.equal(totalSupply.toNumber(), tokenIds.length)
     })
 
     it('should have the right number of owners', async () => {
-      assert.equal(await lock.balanceOf(accounts[8]), 1)
-      assert.equal(await lock.balanceOf(keyOwners[0]), 0)
-      const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
-      assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed())
+      assert.equal(await lock.balanceOf(anotherAccount.address), 1)
+      assert.equal(await lock.balanceOf(keyOwners[0].address), 0)
+      const _numberOfOwners = await lock.numberOfOwners()
+      assert.equal(_numberOfOwners.toNumber(), numberOfOwners.toNumber())
     })
   })
 
@@ -54,24 +58,24 @@ describe('Lock / owners', (accounts) => {
     let numberOfOwners
 
     before(async () => {
-      numberOfOwners = new BigNumber(await lock.numberOfOwners())
+      numberOfOwners = await lock.numberOfOwners()
 
       // both have tokens
-      assert.equal(await lock.balanceOf(keyOwners[1]), 1)
-      assert.equal(await lock.balanceOf(keyOwners[2]), 1)
-      await lock.transferFrom(keyOwners[1], keyOwners[2], tokenIds[1], {
-        from: keyOwners[1],
-      })
+      assert.equal(await lock.balanceOf(keyOwners[1].address), 1)
+      assert.equal(await lock.balanceOf(keyOwners[2].address), 1)
+      await lock
+        .connect(keyOwners[1])
+        .transferFrom(keyOwners[1].address, keyOwners[2].address, tokenIds[1])
     })
 
     it('should have the right number of keys', async () => {
-      const totalSupply = new BigNumber(await lock.totalSupply())
-      assert.equal(totalSupply.toFixed(), tokenIds.length)
+      const totalSupply = await lock.totalSupply()
+      assert.equal(totalSupply.toNumber(), tokenIds.length)
     })
 
     it('should have the right number of owners', async () => {
-      const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
-      assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed() - 1)
+      const _numberOfOwners = await lock.numberOfOwners()
+      assert.equal(_numberOfOwners.toNumber(), numberOfOwners.toNumber() - 1)
     })
   })
 
@@ -79,44 +83,43 @@ describe('Lock / owners', (accounts) => {
   describe('after a transfer to a existing owner, buying a key again for someone who already owned one', () => {
     it('should preserve the right number of owners', async () => {
       // initial state
-      const numberOfOwners = new BigNumber(await lock.numberOfOwners())
-      const totalSupplyBefore = new BigNumber(await lock.totalSupply())
+      const numberOfOwners = await lock.numberOfOwners()
+      const totalSupplyBefore = await lock.totalSupply()
 
       // transfer the key to an existing owner
-      assert.equal(await lock.balanceOf(keyOwners[4]), 1)
-      await lock.transferFrom(keyOwners[3], keyOwners[4], tokenIds[3], {
-        from: keyOwners[3],
-      })
-      assert.equal(await lock.ownerOf(tokenIds[3]), keyOwners[4])
-      assert.equal(await lock.balanceOf(keyOwners[4]), 2)
-      assert.equal(await lock.balanceOf(keyOwners[3]), 0)
+      assert.equal((await lock.balanceOf(keyOwners[4].address)).toNumber(), 1)
+      await lock
+        .connect(keyOwners[3])
+        .transferFrom(keyOwners[3].address, keyOwners[4].address, tokenIds[3])
+      assert.equal(await lock.ownerOf(tokenIds[3]), keyOwners[4].address)
+      assert.equal((await lock.balanceOf(keyOwners[4].address)).toNumber(), 2)
+      assert.equal((await lock.balanceOf(keyOwners[3].address)).toNumber(), 0)
 
       // supply unchanged
-      const totalSupplyAfter = new BigNumber(await lock.totalSupply())
-      assert.equal(totalSupplyBefore.toFixed(), totalSupplyAfter.toFixed())
+      const totalSupplyAfter = await lock.totalSupply()
+      assert.equal(totalSupplyBefore.toNumber(), totalSupplyAfter.toNumber())
 
       // number of owners changed
       assert.equal(
-        (numberOfOwners - 1).toFixed(),
-        new BigNumber(await lock.numberOfOwners()).toFixed()
+        numberOfOwners.sub(1).toNumber(),
+        (await lock.numberOfOwners()).toNumber()
       )
 
       // someone buys a key again for the previous owner
       await lock.purchase(
         [],
-        [keyOwners[3]],
+        [keyOwners[3].address],
         [ADDRESS_ZERO],
         [ADDRESS_ZERO],
         [[]],
         {
           value: await lock.keyPrice(),
-          from: keyOwners[3],
         }
       )
 
       // number of owners should be left unchanged
-      const _numberOfOwners = new BigNumber(await lock.numberOfOwners())
-      assert.equal(_numberOfOwners.toFixed(), numberOfOwners.toFixed())
+      const _numberOfOwners = await lock.numberOfOwners()
+      assert.equal(_numberOfOwners.toNumber(), numberOfOwners.toNumber())
     })
   })
 })

--- a/smart-contracts/test/Lock/owners.js
+++ b/smart-contracts/test/Lock/owners.js
@@ -4,7 +4,7 @@ const { deployLock, purchaseKeys, ADDRESS_ZERO } = require('../helpers')
 let lock
 let tokenIds
 
-contract('Lock / owners', (accounts) => {
+describe('Lock / owners', (accounts) => {
   const keyOwners = accounts.slice(1, 6)
   before(async () => {
     lock = await deployLock()

--- a/smart-contracts/test/Lock/permissions/beneficiary.js
+++ b/smart-contracts/test/Lock/permissions/beneficiary.js
@@ -6,7 +6,7 @@ let notAuthorized
 let currentBeneficiary
 let newBeneficiary
 
-contract('Permissions / Beneficiary', (accounts) => {
+describe('Permissions / Beneficiary', (accounts) => {
   lockCreator = accounts[0]
   notAuthorized = accounts[9]
   newBeneficiary = accounts[1]

--- a/smart-contracts/test/Lock/permissions/isKeyManager.js
+++ b/smart-contracts/test/Lock/permissions/isKeyManager.js
@@ -9,7 +9,7 @@ let keyOwner
 let tokenId
 const expirationDuration = new BigNumber(60 * 60 * 24 * 30)
 
-contract('Permissions / isKeyManager', (accounts) => {
+describe('Permissions / isKeyManager', (accounts) => {
   keyOwner = accounts[1]
   before(async () => {
     // init template

--- a/smart-contracts/test/Lock/permissions/keyGranter.js
+++ b/smart-contracts/test/Lock/permissions/keyGranter.js
@@ -6,7 +6,7 @@ let lockCreator
 let notAuthorized
 let newKeyGranter
 
-contract('Permissions / KeyGranter', (accounts) => {
+describe('Permissions / KeyGranter', (accounts) => {
   lockCreator = accounts[0]
   notAuthorized = accounts[9]
   newKeyGranter = accounts[1]

--- a/smart-contracts/test/Lock/permissions/keyManager.js
+++ b/smart-contracts/test/Lock/permissions/keyManager.js
@@ -11,7 +11,7 @@ let lock
 let lockCreator
 let tokenIds
 
-contract('Permissions / KeyManager', (accounts) => {
+describe('Permissions / KeyManager', (accounts) => {
   lockCreator = accounts[0]
   const lockManager = lockCreator
   const keyGranter = lockCreator

--- a/smart-contracts/test/Lock/permissions/setKeyManager.js
+++ b/smart-contracts/test/Lock/permissions/setKeyManager.js
@@ -4,7 +4,7 @@ const { ethers } = require('hardhat')
 let lock
 let lockCreator
 
-contract('Permissions / KeyManager', (accounts) => {
+describe('Permissions / KeyManager', (accounts) => {
   lockCreator = accounts[0]
   const lockManager = lockCreator
   const keyPrice = ethers.utils.parseUnits('0.01', 'ether')

--- a/smart-contracts/test/Lock/purchaseFor.js
+++ b/smart-contracts/test/Lock/purchaseFor.js
@@ -4,7 +4,7 @@ const BigNumber = require('bignumber.js')
 const { getBalance, deployLock, reverts, ADDRESS_ZERO } = require('../helpers')
 
 const keyPrice = ethers.utils.parseEther('0.01', 'ether')
-contract('Lock / purchaseFor', (accounts) => {
+describe('Lock / purchaseFor', (accounts) => {
   let lock
   let anotherLock
   let lockSingleKey

--- a/smart-contracts/test/Lock/purchaseForFrom.js
+++ b/smart-contracts/test/Lock/purchaseForFrom.js
@@ -1,7 +1,7 @@
 const { deployLock, ADDRESS_ZERO } = require('../helpers')
 const { ethers } = require('hardhat')
 
-contract('Lock / purchaseForFrom', (accounts) => {
+describe('Lock / purchaseForFrom', (accounts) => {
   let lock
   let lockFree
   before(async () => {

--- a/smart-contracts/test/Lock/purchaseMultiple.js
+++ b/smart-contracts/test/Lock/purchaseMultiple.js
@@ -12,7 +12,7 @@ const scenarios = [false, true]
 let testToken
 const keyPrice = ethers.utils.parseUnits('0.01', 'ether')
 
-contract('Lock / purchase multiple keys at once', (accounts) => {
+describe('Lock / purchase multiple keys at once', (accounts) => {
   scenarios.forEach((isErc20) => {
     let lock
     let tokenAddress

--- a/smart-contracts/test/Lock/purchaseTip.js
+++ b/smart-contracts/test/Lock/purchaseTip.js
@@ -16,7 +16,7 @@ const tip = new BigNumber(keyPrice.toString()).plus(
   ethers.utils.parseUnits('1', 'ether').toString()
 )
 
-contract('Lock / purchaseTip', (accounts) => {
+describe('Lock / purchaseTip', (accounts) => {
   scenarios.forEach((isErc20, i) => {
     let lock
     let tokenAddress

--- a/smart-contracts/test/Lock/purchaseWithoutUnlock.js
+++ b/smart-contracts/test/Lock/purchaseWithoutUnlock.js
@@ -21,7 +21,7 @@ const fixUnlock = async (unlockAddress) => {
   await upgradeTx.wait()
 }
 
-contract('Lock / purchaseWithoutUnlock', () => {
+describe('Lock / purchaseWithoutUnlock', () => {
   let unlock
   let lock
 

--- a/smart-contracts/test/Lock/renewMembershipFor.js
+++ b/smart-contracts/test/Lock/renewMembershipFor.js
@@ -20,7 +20,7 @@ const keyPrice = ethers.utils.parseUnits('0.01', 'ether')
 const totalPrice = keyPrice.mul(10)
 const someDai = ethers.utils.parseUnits('10', 'ether')
 
-contract('Lock / Recurring memberships', (accounts) => {
+describe('Lock / Recurring memberships', (accounts) => {
   const lockOwner = accounts[0]
   const keyOwner = accounts[1]
   // const referrer = accounts[3]

--- a/smart-contracts/test/Lock/setExpirationDuration.js
+++ b/smart-contracts/test/Lock/setExpirationDuration.js
@@ -5,7 +5,7 @@ const deployContracts = require('../fixtures/deploy')
 
 const keyPrice = ethers.utils.parseEther('0.01')
 
-contract('Lock / setExpirationDuration', () => {
+describe('Lock / setExpirationDuration', () => {
   let lock
 
   beforeEach(async () => {

--- a/smart-contracts/test/Lock/setMaxNumberOfKeys.js
+++ b/smart-contracts/test/Lock/setMaxNumberOfKeys.js
@@ -11,7 +11,7 @@ const {
 
 const keyPrice = ethers.utils.parseEther('0.01')
 
-contract('Lock / setMaxNumberOfKeys', () => {
+describe('Lock / setMaxNumberOfKeys', () => {
   let unlock
   let lock
 

--- a/smart-contracts/test/Lock/setReferrerFee.js
+++ b/smart-contracts/test/Lock/setReferrerFee.js
@@ -13,7 +13,7 @@ const someDai = new BigNumber(web3.utils.toWei('10', 'ether'))
 
 const scenarios = [false, true]
 
-contract('Lock / setReferrerFee', (accounts) => {
+describe('Lock / setReferrerFee', (accounts) => {
   let lock
   let dai
   let referrer

--- a/smart-contracts/test/Lock/shareKey.js
+++ b/smart-contracts/test/Lock/shareKey.js
@@ -8,7 +8,7 @@ const {
   purchaseKeys,
 } = require('../helpers')
 
-contract('Lock / shareKey', (accounts) => {
+describe('Lock / shareKey', (accounts) => {
   let lock
   let tokenIds
   let event

--- a/smart-contracts/test/Lock/soldOut.js
+++ b/smart-contracts/test/Lock/soldOut.js
@@ -2,7 +2,7 @@ const { deployLock, reverts, purchaseKeys } = require('../helpers')
 
 let lock
 
-contract('Lock / soldOut', () => {
+describe('Lock / soldOut', () => {
   beforeEach(async () => {
     lock = await deployLock()
     await lock.setMaxKeysPerAddress(10)

--- a/smart-contracts/test/Lock/timeMachine.js
+++ b/smart-contracts/test/Lock/timeMachine.js
@@ -5,7 +5,7 @@ const TimeMachineMock = artifacts.require('TimeMachineMock')
 
 const { ADDRESS_ZERO, reverts } = require('../helpers')
 
-contract('Lock / timeMachine', (accounts) => {
+describe('Lock / timeMachine', (accounts) => {
   let timeMachine
   const keyOwner = accounts[2]
   const expirationDuration = new BigNumber(60 * 60 * 24 * 30)

--- a/smart-contracts/test/Lock/totalKeys.js
+++ b/smart-contracts/test/Lock/totalKeys.js
@@ -6,7 +6,7 @@ const { ADDRESS_ZERO, deployLock } = require('../helpers')
 let lock
 let tokenIds
 
-contract('Lock / totalKeys', (accounts) => {
+describe('Lock / totalKeys', (accounts) => {
   before(async () => {
     lock = await deployLock()
     await lock.setMaxKeysPerAddress(10)

--- a/smart-contracts/test/Lock/transfer.js
+++ b/smart-contracts/test/Lock/transfer.js
@@ -7,7 +7,7 @@ let newTokenId
 let originalDuration
 let blockTs
 
-contract('Lock / transfer', (accounts) => {
+describe('Lock / transfer', (accounts) => {
   const [, singleKeyOwner, multipleKeyOwner, destination] = accounts
 
   beforeEach(async () => {

--- a/smart-contracts/test/Lock/transferFee.js
+++ b/smart-contracts/test/Lock/transferFee.js
@@ -4,7 +4,7 @@ const BigNumber = require('bignumber.js')
 const { time } = require('@openzeppelin/test-helpers')
 const { deployLock, reverts, purchaseKey } = require('../helpers')
 
-contract('Lock / transferFee', (accounts) => {
+describe('Lock / transferFee', (accounts) => {
   let lock
   const keyOwner = accounts[1]
   const denominator = 10000

--- a/smart-contracts/test/Lock/updateKeyPricing.js
+++ b/smart-contracts/test/Lock/updateKeyPricing.js
@@ -11,7 +11,7 @@ let token
 let lockCreator
 let invalidTokenAddress
 
-contract('Lock / updateKeyPricing', (accounts) => {
+describe('Lock / updateKeyPricing', (accounts) => {
   invalidTokenAddress = accounts[9]
   lockCreator = accounts[0]
 

--- a/smart-contracts/test/Lock/withdraw.js
+++ b/smart-contracts/test/Lock/withdraw.js
@@ -6,7 +6,7 @@ const { getBalance, deployLock, reverts, purchaseKeys } = require('../helpers')
 let lock
 let tokenAddress
 
-contract('Lock / withdraw', (accounts) => {
+describe('Lock / withdraw', (accounts) => {
   const owner = accounts[0]
   before(async () => {
     lock = await deployLock()

--- a/smart-contracts/test/Lock/withdrawByAddress.js
+++ b/smart-contracts/test/Lock/withdrawByAddress.js
@@ -3,7 +3,7 @@ const { deployERC20, deployLock, reverts } = require('../helpers')
 let lock
 let token
 
-contract('Lock / withdrawByAddress', (accounts) => {
+describe('Lock / withdrawByAddress', (accounts) => {
   let owner = accounts[0]
 
   before(async () => {

--- a/smart-contracts/test/LockSerializer/serialize.js
+++ b/smart-contracts/test/LockSerializer/serialize.js
@@ -3,7 +3,7 @@ const compareValues = require('./_compareValues')
 
 const { deployLock, ADDRESS_ZERO } = require('../helpers')
 
-contract('LockSerializer', () => {
+describe('LockSerializer', () => {
   let lock
   let serializer
   let lockOwner

--- a/smart-contracts/test/Unlock/addLockTemplate.js
+++ b/smart-contracts/test/Unlock/addLockTemplate.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const { ethers, upgrades } = require('hardhat')
 const { reverts } = require('../helpers/errors')
 
-contract('PublicLock template versions', () => {
+describe('PublicLock template versions', () => {
   let unlock
   let publicLock
   let publicLockUpgraded

--- a/smart-contracts/test/Unlock/behaviors/UnlockProxy.js
+++ b/smart-contracts/test/Unlock/behaviors/UnlockProxy.js
@@ -5,7 +5,7 @@ const shared = require('./shared')
 
 const PublicLock = artifacts.require('PublicLock')
 
-contract('Unlock / UnlockProxy', (accounts) => {
+describe('Unlock / UnlockProxy', (accounts) => {
   const [unlockOwner] = accounts
   this.accounts = accounts
 

--- a/smart-contracts/test/Unlock/createLockAtVersion.js
+++ b/smart-contracts/test/Unlock/createLockAtVersion.js
@@ -12,7 +12,7 @@ const args = [
   'New Lock',
 ]
 
-contract('Unlock / createUpgradeableLockAtVersion', () => {
+describe('Unlock / createUpgradeableLockAtVersion', () => {
   let unlock
   let publicLock
   let publicLockUpgraded

--- a/smart-contracts/test/Unlock/createLockLegacy.js
+++ b/smart-contracts/test/Unlock/createLockLegacy.js
@@ -7,7 +7,7 @@ let unlock
 let lock
 let publicLockUpgraded
 
-contract('Unlock / createLock (Legacy)', (accounts) => {
+describe('Unlock / createLock (Legacy)', (accounts) => {
   before(async () => {
     ;({ unlock } = await deployContracts())
 

--- a/smart-contracts/test/Unlock/gas.js
+++ b/smart-contracts/test/Unlock/gas.js
@@ -8,7 +8,7 @@ const { ADDRESS_ZERO, deployContracts } = require('../helpers')
 let unlock
 let createLockGas = new BigNumber(42)
 
-contract('Unlock / gas', (accounts) => {
+describe('Unlock / gas', (accounts) => {
   before(async () => {
     ;({ unlock } = await deployContracts())
 

--- a/smart-contracts/test/Unlock/initializers.js
+++ b/smart-contracts/test/Unlock/initializers.js
@@ -1,7 +1,7 @@
 const Unlock = artifacts.require('Unlock.sol')
 const { reverts, deployContracts } = require('../helpers')
 
-contract('Unlock / initializers', (accounts) => {
+describe('Unlock / initializers', (accounts) => {
   it('There is only 1 public initializer in Unlock', async () => {
     const count = Unlock.abi.filter(
       (x) => x.name.toLowerCase() === 'initialize'

--- a/smart-contracts/test/Unlock/interface.js
+++ b/smart-contracts/test/Unlock/interface.js
@@ -1,7 +1,7 @@
 const unlockContract = artifacts.require('Unlock.sol')
 const unlockInterface = artifacts.require('IUnlock.sol')
 
-contract('Unlock / interface', () => {
+describe('Unlock / interface', () => {
   it('The interface includes all public functions', async () => {
     // log any missing entries
     unlockContract.abi

--- a/smart-contracts/test/Unlock/lockTotalSales.js
+++ b/smart-contracts/test/Unlock/lockTotalSales.js
@@ -10,7 +10,7 @@ let lock
 let unlock
 const price = ethers.utils.parseUnits('0.01', 'ether')
 
-contract('Unlock / lockTotalSales', () => {
+describe('Unlock / lockTotalSales', () => {
   before(async () => {
     ;({ unlock } = await deployContracts())
     lock = await deployLock({ unlock })

--- a/smart-contracts/test/Unlock/proxyAdmin.js
+++ b/smart-contracts/test/Unlock/proxyAdmin.js
@@ -1,7 +1,7 @@
 const { ethers, upgrades } = require('hardhat')
 const { reverts } = require('../helpers/errors')
 
-contract('proxyAdmin', () => {
+describe('proxyAdmin', () => {
   let unlock
 
   beforeEach(async () => {

--- a/smart-contracts/test/Unlock/resetTrackedValue.js
+++ b/smart-contracts/test/Unlock/resetTrackedValue.js
@@ -11,7 +11,7 @@ const keyPrice = ethers.utils.parseUnits('0.01', 'ether')
 let unlock
 let lock
 
-contract('Unlock / resetTrackedValue', (accounts) => {
+describe('Unlock / resetTrackedValue', (accounts) => {
   beforeEach(async () => {
     ;({ unlock } = await deployContracts())
     lock = await deployLock({ unlock })

--- a/smart-contracts/test/Unlock/setLockTemplate.js
+++ b/smart-contracts/test/Unlock/setLockTemplate.js
@@ -5,7 +5,7 @@ let unlock
 let lockTemplate
 let unlockOwner
 
-contract('Lock / setLockTemplate', (accounts) => {
+describe('Lock / setLockTemplate', (accounts) => {
   beforeEach(async () => {
     ;({ unlock } = await deployContracts())
     lockTemplate = await PublicLock.new()

--- a/smart-contracts/test/Unlock/uniswapValue.js
+++ b/smart-contracts/test/Unlock/uniswapValue.js
@@ -73,7 +73,7 @@ const decodeGNPEvent = (tx) => {
   }
 }
 
-contract('Unlock / uniswapValue', (accounts) => {
+describe('Unlock / uniswapValue', (accounts) => {
   const [keyOwner, liquidityOwner, protocolOwner] = accounts
 
   describe('A supported token', () => {

--- a/smart-contracts/test/Unlock/unlockConfig.js
+++ b/smart-contracts/test/Unlock/unlockConfig.js
@@ -3,7 +3,7 @@ const { reverts, deployContracts } = require('../helpers')
 let unlock
 let unlockOwner
 
-contract('Lock / configUnlock', (accounts) => {
+describe('Lock / configUnlock', (accounts) => {
   before(async () => {
     ;({ unlock } = await deployContracts())
     ;[unlockOwner] = accounts

--- a/smart-contracts/test/Unlock/upgrades.js
+++ b/smart-contracts/test/Unlock/upgrades.js
@@ -16,7 +16,7 @@ const {
 
 const unlockVersions = getUnlockVersionNumbers()
 
-contract('Unlock / upgrades', async (accounts) => {
+describe('Unlock / upgrades', async (accounts) => {
   const [unlockOwner, lockOwner, keyOwner] = await ethers.getSigners()
   const keyPrice = ethers.utils.parseUnits('0.01', 'ether')
 

--- a/smart-contracts/test/Unlock/upgrades.mainnet.js
+++ b/smart-contracts/test/Unlock/upgrades.mainnet.js
@@ -75,7 +75,7 @@ const upgradeContract = async () => {
   return Unlock.attach(ProxyContractAddress)
 }
 
-contract('Unlock (on mainnet)', async () => {
+describe('Unlock (on mainnet)', async () => {
   let unlock
   let deployer
 

--- a/smart-contracts/test/UnlockDiscountToken/UnlockDiscountToken.js
+++ b/smart-contracts/test/UnlockDiscountToken/UnlockDiscountToken.js
@@ -4,7 +4,7 @@ const { reverts } = require('../helpers')
 const deployContracts = require('../fixtures/deploy')
 const UnlockDiscountToken = artifacts.require('UnlockDiscountTokenV3.sol')
 
-contract('UnlockDiscountToken', (accounts) => {
+describe('UnlockDiscountToken', (accounts) => {
   let unlockDiscountToken
   const minter = accounts[1]
 

--- a/smart-contracts/test/UnlockDiscountToken/governance.js
+++ b/smart-contracts/test/UnlockDiscountToken/governance.js
@@ -48,7 +48,7 @@ async function batchInBlock(txs) {
   }
 }
 
-contract('UDT ERC20VotesComp extension', (accounts) => {
+describe('UDT ERC20VotesComp extension', (accounts) => {
   let udt
   const [minter, holder, recipient, holderDelegatee, other1, other2] = accounts
 

--- a/smart-contracts/test/UnlockDiscountToken/governor.js
+++ b/smart-contracts/test/UnlockDiscountToken/governor.js
@@ -9,7 +9,7 @@ const PROPOSER_ROLE = ethers.utils.keccak256(
   ethers.utils.toUtf8Bytes('PROPOSER_ROLE')
 )
 
-contract('UnlockProtocolGovernor', () => {
+describe('UnlockProtocolGovernor', () => {
   let gov
   let udt
   let updateTx

--- a/smart-contracts/test/UnlockDiscountToken/mintingTokens.js
+++ b/smart-contracts/test/UnlockDiscountToken/mintingTokens.js
@@ -23,7 +23,7 @@ const describeOrskip = process.env.IS_COVERAGE ? describe.skip : describe
 const estimateGas = 252166 * 2
 const baseFeePerGas = 1000000000 // in gwei
 
-contract('UnlockDiscountToken (mainnet) / mintingTokens', (accounts) => {
+describe('UnlockDiscountToken (mainnet) / mintingTokens', (accounts) => {
   const [protocolOwner, minter, referrer, keyBuyer] = accounts
   let rate
 

--- a/smart-contracts/test/UnlockDiscountToken/transferingTokens.js
+++ b/smart-contracts/test/UnlockDiscountToken/transferingTokens.js
@@ -22,7 +22,7 @@ const describeOrSkip = process.env.IS_COVERAGE ? describe.skip : describe
 
 const estimateGas = 252166 * 2
 
-contract('UnlockDiscountToken (l2/sidechain) / granting Tokens', (accounts) => {
+describe('UnlockDiscountToken (l2/sidechain) / granting Tokens', (accounts) => {
   const [protocolOwner, minter, referrer, keyBuyer] = accounts
   let rate
 

--- a/smart-contracts/test/UnlockDiscountToken/upgrades.js
+++ b/smart-contracts/test/UnlockDiscountToken/upgrades.js
@@ -50,7 +50,7 @@ const upgradeContract = async (contractAddress) => {
   return updated
 }
 
-contract('UnlockDiscountToken upgrade', async () => {
+describe('UnlockDiscountToken upgrade', async () => {
   let udt
   const mintAmount = 1000
 

--- a/smart-contracts/test/UnlockDiscountToken/upgrades.mainnet.js
+++ b/smart-contracts/test/UnlockDiscountToken/upgrades.mainnet.js
@@ -83,7 +83,7 @@ const upgradeContract = async () => {
   return UnlockDiscountTokenV3.attach(UDTProxyContractAddress)
 }
 
-contract('UnlockDiscountToken (on mainnet)', async () => {
+describe('UnlockDiscountToken (on mainnet)', async () => {
   let udt
   let deployer
 

--- a/smart-contracts/test/fixtures/deploy.js
+++ b/smart-contracts/test/fixtures/deploy.js
@@ -1,8 +1,6 @@
-const { ethers, upgrades, artifacts } = require('hardhat')
+const { ethers, upgrades } = require('hardhat')
 const { copySync } = require('fs-extra')
 const { addDeployment } = require('../../helpers/deployments')
-
-const UnlockTruffle = artifacts.require('Unlock')
 
 module.exports = async () => {
   // when running a mainnet fork
@@ -52,7 +50,7 @@ module.exports = async () => {
   await addDeployment('UnlockProtocolGovernor', gov, true)
 
   return {
-    unlock: await UnlockTruffle.at(unlock.address),
+    unlock,
     unlockEthers: unlock,
     publicLock,
     udt,

--- a/smart-contracts/test/helpers/createLockCalldata.js
+++ b/smart-contracts/test/helpers/createLockCalldata.js
@@ -15,9 +15,9 @@ module.exports = async ({
 
   // creator
   const [defaultSigner] = await ethers.getSigners()
-  const lockCreator = from || defaultSigner.address
+  const lockCreator = from || defaultSigner
   const calldata = await interface.encodeFunctionData(func, [
-    lockCreator,
+    lockCreator.address,
     ...args,
   ])
   return calldata

--- a/smart-contracts/test/helpers/deployLocks.js
+++ b/smart-contracts/test/helpers/deployLocks.js
@@ -15,7 +15,7 @@ async function deployLock({
   }
   if (!deployer) {
     const [defaultDeployer] = await ethers.getSigners()
-    deployer = defaultDeployer.address
+    deployer = defaultDeployer
   }
 
   const { expirationDuration, keyPrice, maxNumberOfKeys, lockName } =

--- a/smart-contracts/test/helpers/deployLocks.js
+++ b/smart-contracts/test/helpers/deployLocks.js
@@ -22,10 +22,10 @@ async function deployLock({
     Locks[name]
 
   const args = [
-    name === 'NON_EXPIRING' ? MAX_UINT : expirationDuration.toString(),
+    name === 'NON_EXPIRING' ? MAX_UINT : expirationDuration,
     tokenAddress,
-    keyPrice.toString(),
-    maxNumberOfKeys.toString(),
+    keyPrice,
+    maxNumberOfKeys,
     lockName,
   ]
 

--- a/smart-contracts/test/helpers/deployLocks.js
+++ b/smart-contracts/test/helpers/deployLocks.js
@@ -1,5 +1,4 @@
 const { ethers } = require('hardhat')
-const PublicLock = artifacts.require('PublicLock')
 const createLockHash = require('./createLockCalldata')
 const Locks = require('../fixtures/locks')
 const deployContracts = require('../fixtures/deploy')
@@ -33,7 +32,8 @@ async function deployLock({
   const calldata = await createLockHash({ args, from: deployer })
   const tx = await unlock.createUpgradeableLock(calldata)
   const evt = tx.logs.find((v) => v.event === 'NewLock')
-  const lock = await PublicLock.at(evt.args.newLockAddress)
+
+  const lock = await ethers.getContractAt('PublicLock', evt.args.newLockAddress)
   return lock
 }
 

--- a/smart-contracts/test/helpers/deployLocks.js
+++ b/smart-contracts/test/helpers/deployLocks.js
@@ -31,7 +31,8 @@ async function deployLock({
 
   const calldata = await createLockHash({ args, from: deployer })
   const tx = await unlock.createUpgradeableLock(calldata)
-  const evt = tx.logs.find((v) => v.event === 'NewLock')
+  const { events } = await tx.wait()
+  const evt = events.find((v) => v.event === 'NewLock')
 
   const lock = await ethers.getContractAt('PublicLock', evt.args.newLockAddress)
   return lock

--- a/smart-contracts/test/helpers/getTokenBalance.js
+++ b/smart-contracts/test/helpers/getTokenBalance.js
@@ -1,12 +1,11 @@
 const { ethers } = require('hardhat')
-const BigNumber = require('bignumber.js')
 const { ADDRESS_ZERO } = require('./constants')
 
 module.exports = async function getTokenBalance(account, tokenAddress) {
   // ETH balance
   if (!tokenAddress || tokenAddress === ADDRESS_ZERO) {
     const balanceETH = await ethers.provider.getBalance(account)
-    return new BigNumber(balanceETH.toString())
+    return balanceETH
   }
   // erc20 balance
   const token = await ethers.getContractAt(
@@ -14,5 +13,5 @@ module.exports = async function getTokenBalance(account, tokenAddress) {
     tokenAddress
   )
   const balance = await token.balanceOf(account)
-  return new BigNumber(balance.toString())
+  return balance
 }

--- a/smart-contracts/test/helpers/getTokenBalance.js
+++ b/smart-contracts/test/helpers/getTokenBalance.js
@@ -2,10 +2,6 @@ const { ethers } = require('hardhat')
 const BigNumber = require('bignumber.js')
 const { ADDRESS_ZERO } = require('./constants')
 
-const Erc20Token = artifacts.require(
-  '@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20'
-)
-
 module.exports = async function getTokenBalance(account, tokenAddress) {
   // ETH balance
   if (!tokenAddress || tokenAddress === ADDRESS_ZERO) {
@@ -13,7 +9,10 @@ module.exports = async function getTokenBalance(account, tokenAddress) {
     return new BigNumber(balanceETH.toString())
   }
   // erc20 balance
-  const token = await Erc20Token.at(tokenAddress)
+  const token = await ethers.getContractAt(
+    '@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20',
+    tokenAddress
+  )
   const balance = await token.balanceOf(account)
   return new BigNumber(balance.toString())
 }

--- a/smart-contracts/test/helpers/getTokenBalance.js
+++ b/smart-contracts/test/helpers/getTokenBalance.js
@@ -2,6 +2,7 @@ const { ethers } = require('hardhat')
 const { ADDRESS_ZERO } = require('./constants')
 
 module.exports = async function getTokenBalance(account, tokenAddress) {
+  account = typeof account === 'string' ? account : account.address
   // ETH balance
   if (!tokenAddress || tokenAddress === ADDRESS_ZERO) {
     const balanceETH = await ethers.provider.getBalance(account)

--- a/smart-contracts/test/helpers/index.js
+++ b/smart-contracts/test/helpers/index.js
@@ -6,6 +6,7 @@ const tokens = require('./tokens')
 const uniswap = require('./uniswap')
 const deployLocks = require('./deployLocks')
 const deployContracts = require('../fixtures/deploy.js')
+const time = require('./time')
 
 module.exports = {
   getBalance,
@@ -16,4 +17,5 @@ module.exports = {
   ...deployLocks,
   ...tokens,
   ...errors,
+  ...time,
 }

--- a/smart-contracts/test/helpers/lock.js
+++ b/smart-contracts/test/helpers/lock.js
@@ -10,9 +10,6 @@ const purchaseKey = async (lock, keyOwner, isErc20 = false) => {
     lock.address
   )
 
-  // get ethers signer
-  keyOwner = await ethers.getSigner(keyOwner)
-
   const tx = await lock
     .connect(keyOwner)
     .purchase(

--- a/smart-contracts/test/helpers/time.js
+++ b/smart-contracts/test/helpers/time.js
@@ -1,0 +1,19 @@
+const { network, ethers } = require('hardhat')
+
+async function increaseTimeTo(expirationTs) {
+  expirationTs =
+    typeof expirationTs === 'string' ? expirationTs : expirationTs.toNumber()
+
+  const { timestamp } = await ethers.provider.getBlock('latest')
+
+  if (timestamp > expirationTs) {
+    throw new Error(
+      `Cannot increase time (${timestamp}) to the past (${expirationTs})`
+    )
+  }
+  await network.provider.send('evm_increaseTime', [expirationTs])
+}
+
+module.exports = {
+  increaseTimeTo,
+}

--- a/smart-contracts/test/helpers/time.js
+++ b/smart-contracts/test/helpers/time.js
@@ -2,7 +2,11 @@ const { network, ethers } = require('hardhat')
 
 async function increaseTimeTo(expirationTs) {
   expirationTs =
-    typeof expirationTs === 'string' ? expirationTs : expirationTs.toNumber()
+    typeof expirationTs === 'number'
+      ? expirationTs
+      : expirationTs === 'string'
+      ? parseInt(expirationTs)
+      : expirationTs.toNumber()
 
   const { timestamp } = await ethers.provider.getBlock('latest')
 

--- a/smart-contracts/test/helpers/tokens.js
+++ b/smart-contracts/test/helpers/tokens.js
@@ -1,8 +1,6 @@
 const { ethers } = require('hardhat')
 const WethABI = require('./ABIs/weth.json')
 
-const TestERC20 = artifacts.require('TestERC20')
-
 const deployERC20 = async (deployer) => {
   const signer =
     typeof deployer === 'string' ? await ethers.getSigner(deployer) : deployer
@@ -10,8 +8,7 @@ const deployERC20 = async (deployer) => {
   const token = await Token.deploy()
   await token.deployed()
 
-  // return truffle artifact for now
-  return TestERC20.at(token.address)
+  return token
 }
 
 const deployWETH = async (deployer) => {

--- a/smart-contracts/test/mainnet/udt.js
+++ b/smart-contracts/test/mainnet/udt.js
@@ -6,7 +6,7 @@ const { getProxyAddress } = require('../../helpers/deployments')
 const { resetNodeState, impersonate } = require('../helpers/mainnet')
 const { getUnlockMultisigOwners } = require('../../helpers/multisig')
 
-contract('UnlockDiscountToken on mainnet', async () => {
+describe('UnlockDiscountToken on mainnet', async () => {
   let udt
   const chainId = 1 // mainnet
   let unlockAddress

--- a/smart-contracts/test/proposalHelper.js
+++ b/smart-contracts/test/proposalHelper.js
@@ -21,7 +21,7 @@ const functionArgs = [
 const calldataEncoded =
   '0xa9059cbb0000000000000000000000008d533d1a48b0d5dddef513a0b0a3677e991f3915000000000000000000000000000000000000000000000000002386f26fc10000'
 
-contract('Proposal Helper', () => {
+describe('Proposal Helper', () => {
   describe('calldata args encoder', () => {
     it('encode correctly a function call', async () => {
       const encoded = await encodeProposalArgs({

--- a/smart-contracts/test/scripts/deploy/lock.js
+++ b/smart-contracts/test/scripts/deploy/lock.js
@@ -7,7 +7,7 @@ const deployLock = require('../../../scripts/deployments/lock')
 const compareValues = require('../../LockSerializer/_compareValues')
 const { ADDRESS_ZERO } = require('../../helpers/constants')
 
-contract('Scripts/deploy:lock', () => {
+describe('Scripts/deploy:lock', () => {
   let serializer
   let unlockAddress
   let PublicLock

--- a/smart-contracts/test/unlockUtils.js
+++ b/smart-contracts/test/unlockUtils.js
@@ -1,10 +1,14 @@
-const mockArtifact = artifacts.require('UnlockUtilsMock')
 const { ethers } = require('hardhat')
+const { assert } = require('chai')
 let mock
 
-contract('unlockUtils', (accounts) => {
+describe('unlockUtils', () => {
+  let sender
   before(async () => {
-    mock = await mockArtifact.new()
+    const MockArtifact = await ethers.getContractFactory('UnlockUtilsMock')
+    mock = await MockArtifact.deploy()
+    await mock.deployed()
+    ;[sender] = await ethers.getSigners()
   })
 
   describe('function uint2str', () => {
@@ -28,11 +32,10 @@ contract('unlockUtils', (accounts) => {
   })
 
   describe('function address2Str', () => {
-    let senderAddress
     // currently returns the address as a string with all chars in lowercase
     it('should convert an ethereum address to an ASCII string', async () => {
-      senderAddress = await mock.address2Str(accounts[0])
-      assert.equal(ethers.utils.getAddress(senderAddress), accounts[0])
+      const senderAddress = await mock.address2Str(sender.address)
+      assert.equal(ethers.utils.getAddress(senderAddress), sender.address)
     })
   })
 })


### PR DESCRIPTION
# Description

This PR definitely removes Truffle. It consists mainly of replacing 

- the `{from : address}` by the `connect(address)` ethers pattern
- the `accounts` by ethers's signers
- replace use of `tx.logs` by `const { events } = tx.wait()` pattern
- get rid of some web3 dependencies (such as OZ helpers)

NB: this is a MAJOR rewriting for the tests as w e are removing the legacy test suite so this PR will affect most test files

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

