### PR TITLE
feat(unlock-app) - members page doesnt display address with multiple keys

### DIFF
--- a/unlock-app/src/__tests__/hooks/useMembers.test.js
+++ b/unlock-app/src/__tests__/hooks/useMembers.test.js
@@ -39,6 +39,13 @@ const lock = {
         address: '0x252',
       },
     },
+    {
+      keyId: '3',
+      expiration: '123458',
+      owner: {
+        address: '0x252',
+      },
+    },
   ],
 }
 const storedMetata = [
@@ -128,19 +135,26 @@ describe('useMembers', () => {
       expect.assertions(1)
       const members = buildMembersWithMetadata(lock, [])
       expect(members).toEqual({
-        '0xlockAddress-0x126': {
+        '0xlockAddress-0x126-1': {
           expiration: 'Expired',
           keyholderAddress: '0x126',
           lockAddress: '0xlockAddress',
           lockName: 'my lock',
           token: '1',
         },
-        '0xlockAddress-0x252': {
+        '0xlockAddress-0x252-2': {
           expiration: 'Expired',
           keyholderAddress: '0x252',
           lockAddress: '0xlockAddress',
           lockName: 'my lock',
           token: '2',
+        },
+        '0xlockAddress-0x252-3': {
+          expiration: 'Expired',
+          keyholderAddress: '0x252',
+          lockAddress: '0xlockAddress',
+          lockName: 'my lock',
+          token: '3',
         },
       })
     })
@@ -150,7 +164,7 @@ describe('useMembers', () => {
 
       const members = buildMembersWithMetadata(lock, storedMetata)
       expect(members).toEqual({
-        '0xlockAddress-0x126': {
+        '0xlockAddress-0x126-1': {
           email: 'julien@unlock-protocol.com',
           expiration: 'Expired',
           keyholderAddress: '0x126',
@@ -158,7 +172,7 @@ describe('useMembers', () => {
           lockName: 'my lock',
           token: '1',
         },
-        '0xlockAddress-0x252': {
+        '0xlockAddress-0x252-2': {
           email: 'chris@unlock-protocol.com',
           expiration: 'Expired',
           keyholderAddress: '0x252',
@@ -166,7 +180,26 @@ describe('useMembers', () => {
           lockName: 'my lock',
           token: '2',
         },
+        '0xlockAddress-0x252-3': {
+          email: 'chris@unlock-protocol.com',
+          expiration: 'Expired',
+          keyholderAddress: '0x252',
+          lockAddress: '0xlockAddress',
+          lockName: 'my lock',
+          token: '3',
+        },
       })
+    })
+
+    it('return all keys with unique identifier', () => {
+      expect.assertions(2)
+      const members = buildMembersWithMetadata(lock, [])
+      expect(Object.keys(members).length).toBe(3)
+      expect(Object.keys(members)).toEqual([
+        '0xlockAddress-0x126-1',
+        '0xlockAddress-0x252-2',
+        '0xlockAddress-0x252-3',
+      ])
     })
   })
 })

--- a/unlock-app/src/hooks/useMembers.ts
+++ b/unlock-app/src/hooks/useMembers.ts
@@ -165,7 +165,6 @@ export const useMembers = (
     })
 
     const membersByLock = await Promise.all(membersForLocksPromise)
-    console.log(membersByLock)
     const members = Object.values(
       membersByLock.reduce((acc, array) => {
         return {

--- a/unlock-app/src/hooks/useMembers.ts
+++ b/unlock-app/src/hooks/useMembers.ts
@@ -165,6 +165,7 @@ export const useMembers = (
     })
 
     const membersByLock = await Promise.all(membersForLocksPromise)
+
     const members = Object.values(
       membersByLock.reduce((acc, array) => {
         return {

--- a/unlock-app/src/hooks/useMembers.ts
+++ b/unlock-app/src/hooks/useMembers.ts
@@ -39,7 +39,7 @@ export const buildMembersWithMetadata = (
   )
   lockWithKeys.keys?.forEach((key: any) => {
     const keyOwner = key.owner.address.toLowerCase()
-    const index = `${lockWithKeys.address}-${keyOwner}`
+    const index = `${lockWithKeys.address}-${keyOwner}-${key.keyId}` // lets add keyId to see mutiple keys for the same address
     let member: any = members[index]
 
     if (!member) {
@@ -165,6 +165,7 @@ export const useMembers = (
     })
 
     const membersByLock = await Promise.all(membersForLocksPromise)
+    console.log(membersByLock)
     const members = Object.values(
       membersByLock.reduce((acc, array) => {
         return {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Address with multiple keys are not displayed in members page, this PR this issue by adding also `keyId` when unique identifier is build 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

