### PR TITLE
feat(unlock-app) - force login before checkIn tickets

### DIFF
--- a/unlock-app/src/components/content/VerificationContent.tsx
+++ b/unlock-app/src/components/content/VerificationContent.tsx
@@ -51,7 +51,7 @@ export const VerificationContent: React.FC<unknown> = () => {
         </Head>
         <Account />
         <main>
-          <Scanner />
+          <Scanner account={account} />
         </main>
       </Layout>
     )

--- a/unlock-app/src/components/interface/verification/Scanner.tsx
+++ b/unlock-app/src/components/interface/verification/Scanner.tsx
@@ -6,6 +6,8 @@ import {
 } from '~/utils/verification'
 import VerificationStatus from '../VerificationStatus'
 import QrScanner from 'qr-scanner'
+import { Button } from '@unlock-protocol/ui'
+import { useRouter } from 'next/router'
 
 function getVerificatioConfigFromURL(text?: string) {
   try {
@@ -25,11 +27,11 @@ function getVerificatioConfigFromURL(text?: string) {
   }
 }
 
-export function Scanner() {
+export function Scanner({ account }: { account?: string }) {
   const [membershipVerificationConfig, setMembershipVerificationConfig] =
     useState<MembershipVerificationConfig | null>(null)
   const videoRef = useRef<HTMLVideoElement | null>(null)
-
+  const router = useRouter()
   useEffect(() => {
     const videoElement = videoRef.current
     if (!videoElement) {
@@ -55,6 +57,24 @@ export function Scanner() {
     }
     return () => qrScanner.stop()
   }, [membershipVerificationConfig])
+
+  if (!account && !membershipVerificationConfig) {
+    return (
+      <div className="grid justify-center gap-3">
+        <h3 className="font-bold text-lg">Login to start check in Ticket</h3>
+        <Button
+          onClick={(event) => {
+            event.preventDefault()
+            router.push(
+              `/login?redirect=${encodeURIComponent(window.location.href)}`
+            )
+          }}
+        >
+          Connect Account
+        </Button>
+      </div>
+    )
+  }
 
   return (
     <>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
When ticket is checked for the first time without authentication, after the verifiers logs in, he need to scan a second time the ticket. To prevent this double scanning, lets force to login in before starting to scan tickets.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

https://user-images.githubusercontent.com/20865711/178756577-6d54f85b-82d9-43c0-9774-13c1c82e1d05.mov
# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

