### PR TITLE
feat(unlock-app) - add explicit button to scan next ticket

### DIFF
--- a/unlock-app/src/components/content/VerificationContent.tsx
+++ b/unlock-app/src/components/content/VerificationContent.tsx
@@ -19,6 +19,7 @@ export const VerificationContent: React.FC<unknown> = () => {
   const storageService = useStorageService()
   const walletService = useWalletService()
   const { account, network } = useAuth()
+  const router = useRouter()
 
   const membershipVerificationConfig = getMembershipVerificationConfig({
     data: query.data?.toString(),
@@ -76,7 +77,12 @@ export const VerificationContent: React.FC<unknown> = () => {
           addLock,
         }}
       >
-        <VerificationStatus config={membershipVerificationConfig} />
+        <VerificationStatus
+          config={membershipVerificationConfig}
+          onVerified={() => {
+            router.push('/verification')
+          }}
+        />
       </LocksContext.Provider>
     </Layout>
   )

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -18,13 +18,14 @@ import { isSignatureValidForAddress } from '~/utils/signatures'
 
 interface Props {
   config: MembershipVerificationConfig
+  setConfig: (config: MembershipVerificationConfig | null) => void
 }
 
 /**
  * React components which given data, signature will verify the validity of a key
  * and display the right status
  */
-export const VerificationStatus = ({ config }: Props) => {
+export const VerificationStatus = ({ config, setConfig }: Props) => {
   const { data, sig, raw } = config
   const { lockAddress, timestamp, network, tokenId, account } = data
   const { account: viewer } = useAuth()
@@ -123,6 +124,10 @@ export const VerificationStatus = ({ config }: Props) => {
     }
   }
 
+  const onScanNext = () => {
+    setConfig(null)
+  }
+
   if (
     isLockLoading ||
     isMembershipDataLoading ||
@@ -154,24 +159,32 @@ export const VerificationStatus = ({ config }: Props) => {
 
   const checkedInAt = membershipData?.metadata?.checkedInAt
 
+  const disableActions =
+    !isVerifier || isCheckingIn || !!invalid || !!checkedInAt
+
   const CardActions = () => (
     <div className="grid w-full">
       {viewer ? (
-        <Button
-          loading={isCheckingIn}
-          disabled={!isVerifier || isCheckingIn || !!invalid || !!checkedInAt}
-          variant={!checkedInAt ? 'primary' : 'outlined-primary'}
-          onClick={async (event) => {
-            event.preventDefault()
-            onCheckIn()
-          }}
-        >
-          {isCheckingIn
-            ? 'Checking in'
-            : checkedInAt
-            ? 'Checked in'
-            : 'Check in'}
-        </Button>
+        <>
+          {checkedInAt ? (
+            <Button variant="outlined-primary" onClick={onScanNext}>
+              Scan next
+            </Button>
+          ) : (
+            <Button
+              loading={isCheckingIn}
+              disabled={disableActions}
+              variant={'primary'}
+              onClick={async (event) => {
+                event.preventDefault()
+                onCheckIn()
+              }}
+            >
+              {isCheckingIn ? 'Checking in' : 'Check in'}
+            </Button>
+          )}
+          {}
+        </>
       ) : (
         <Button
           onClick={(event) => {

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -168,7 +168,7 @@ export const VerificationStatus = ({ config, setConfig }: Props) => {
         <>
           {checkedInAt ? (
             <Button variant="outlined-primary" onClick={onScanNext}>
-              Scan next
+              Scan next ticket
             </Button>
           ) : (
             <Button

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -18,7 +18,7 @@ import { isSignatureValidForAddress } from '~/utils/signatures'
 
 interface Props {
   config: MembershipVerificationConfig
-  onVerified?: () => void
+  onVerified: () => void
 }
 
 /**
@@ -159,6 +159,7 @@ export const VerificationStatus = ({ config, onVerified }: Props) => {
     !isVerifier || isCheckingIn || !!invalid || !!checkedInAt
 
   const onVerifiedCb = () => {
+    console.log('onVerifiedCb', onVerified)
     if (typeof onVerified === 'function') {
       onVerified()
     }

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -18,7 +18,7 @@ import { isSignatureValidForAddress } from '~/utils/signatures'
 
 interface Props {
   config: MembershipVerificationConfig
-  onVerified: () => void
+  onVerified?: () => void
 }
 
 /**
@@ -158,12 +158,18 @@ export const VerificationStatus = ({ config, onVerified }: Props) => {
   const disableActions =
     !isVerifier || isCheckingIn || !!invalid || !!checkedInAt
 
+  const onVerifiedCb = () => {
+    if (typeof onVerified === 'function') {
+      onVerified()
+    }
+  }
+
   const CardActions = () => (
     <div className="grid w-full">
       {viewer ? (
         <>
           {checkedInAt ? (
-            <Button variant="outlined-primary" onClick={onVerified}>
+            <Button variant="outlined-primary" onClick={onVerifiedCb}>
               Scan next ticket
             </Button>
           ) : (

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -159,7 +159,6 @@ export const VerificationStatus = ({ config, onVerified }: Props) => {
     !isVerifier || isCheckingIn || !!invalid || !!checkedInAt
 
   const onVerifiedCb = () => {
-    console.log('onVerifiedCb', onVerified)
     if (typeof onVerified === 'function') {
       onVerified()
     }

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -18,14 +18,14 @@ import { isSignatureValidForAddress } from '~/utils/signatures'
 
 interface Props {
   config: MembershipVerificationConfig
-  setConfig: (config: MembershipVerificationConfig | null) => void
+  onScanNext: () => void
 }
 
 /**
  * React components which given data, signature will verify the validity of a key
  * and display the right status
  */
-export const VerificationStatus = ({ config, setConfig }: Props) => {
+export const VerificationStatus = ({ config, onScanNext }: Props) => {
   const { data, sig, raw } = config
   const { lockAddress, timestamp, network, tokenId, account } = data
   const { account: viewer } = useAuth()
@@ -122,10 +122,6 @@ export const VerificationStatus = ({ config, setConfig }: Props) => {
       console.error(error)
       ToastHelper.error('Failed to check in')
     }
-  }
-
-  const onScanNext = () => {
-    setConfig(null)
   }
 
   if (

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -18,14 +18,14 @@ import { isSignatureValidForAddress } from '~/utils/signatures'
 
 interface Props {
   config: MembershipVerificationConfig
-  onScanNext: () => void
+  onVerified: () => void
 }
 
 /**
  * React components which given data, signature will verify the validity of a key
  * and display the right status
  */
-export const VerificationStatus = ({ config, onScanNext }: Props) => {
+export const VerificationStatus = ({ config, onVerified }: Props) => {
   const { data, sig, raw } = config
   const { lockAddress, timestamp, network, tokenId, account } = data
   const { account: viewer } = useAuth()
@@ -163,7 +163,7 @@ export const VerificationStatus = ({ config, onScanNext }: Props) => {
       {viewer ? (
         <>
           {checkedInAt ? (
-            <Button variant="outlined-primary" onClick={onScanNext}>
+            <Button variant="outlined-primary" onClick={onVerified}>
               Scan next ticket
             </Button>
           ) : (

--- a/unlock-app/src/components/interface/verification/Scanner.tsx
+++ b/unlock-app/src/components/interface/verification/Scanner.tsx
@@ -56,6 +56,10 @@ export function Scanner() {
     return () => qrScanner.stop()
   }, [membershipVerificationConfig])
 
+  const onScanNext = () => {
+    setMembershipVerificationConfig(null)
+  }
+
   return (
     <>
       <div className="grid justify-center">
@@ -97,7 +101,7 @@ export function Scanner() {
                 <div className="flex min-h-full items-center justify-center text-center">
                   <Dialog.Panel className="max-w-sm w-full">
                     <VerificationStatus
-                      setConfig={setMembershipVerificationConfig}
+                      onScanNext={onScanNext}
                       config={membershipVerificationConfig}
                     />
                   </Dialog.Panel>

--- a/unlock-app/src/components/interface/verification/Scanner.tsx
+++ b/unlock-app/src/components/interface/verification/Scanner.tsx
@@ -56,10 +56,6 @@ export function Scanner() {
     return () => qrScanner.stop()
   }, [membershipVerificationConfig])
 
-  const onScanNext = () => {
-    setMembershipVerificationConfig(null)
-  }
-
   return (
     <>
       <div className="grid justify-center">
@@ -101,7 +97,7 @@ export function Scanner() {
                 <div className="flex min-h-full items-center justify-center text-center">
                   <Dialog.Panel className="max-w-sm w-full">
                     <VerificationStatus
-                      onScanNext={onScanNext}
+                      onVerified={() => setMembershipVerificationConfig(null)}
                       config={membershipVerificationConfig}
                     />
                   </Dialog.Panel>

--- a/unlock-app/src/components/interface/verification/Scanner.tsx
+++ b/unlock-app/src/components/interface/verification/Scanner.tsx
@@ -96,7 +96,10 @@ export function Scanner() {
               <div className="fixed p-6 inset-0 overflow-y-auto">
                 <div className="flex min-h-full items-center justify-center text-center">
                   <Dialog.Panel className="max-w-sm w-full">
-                    <VerificationStatus config={membershipVerificationConfig} />
+                    <VerificationStatus
+                      setConfig={setMembershipVerificationConfig}
+                      config={membershipVerificationConfig}
+                    />
                   </Dialog.Panel>
                 </div>
               </div>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Add ability to scan next ticket from the UI when ticket is already marked as check-in 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #
<img width="821" alt="Screenshot 2022-07-13 at 19 14 03" src="https://user-images.githubusercontent.com/20865711/178792193-89b1d64b-4703-4c9d-92d7-39ab37a061ba.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

