### PR TITLE
fix(unlock-app): Show scan-another button always + add close button to membership card on verification page

### DIFF
--- a/unlock-app/src/components/interface/Account.tsx
+++ b/unlock-app/src/components/interface/Account.tsx
@@ -35,7 +35,7 @@ export function Account() {
   return (
     <AccountWrapper>
       <AccountDetails className="items-center">
-        {iconSeed && <UserIcon seed={iconSeed} />}
+        {account && iconSeed && <UserIcon seed={iconSeed} />}
         <div className="grid gap-2 w-[155px]">
           <div
             style={{
@@ -46,7 +46,6 @@ export function Account() {
             {account}
           </div>
           <Label>
-            {!network && <p>Not connected</p>}
             {network && (
               <div className="grid space-y-2">
                 <select

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -19,13 +19,14 @@ import { isSignatureValidForAddress } from '~/utils/signatures'
 interface Props {
   config: MembershipVerificationConfig
   onVerified: () => void
+  onClose?: () => void
 }
 
 /**
  * React components which given data, signature will verify the validity of a key
  * and display the right status
  */
-export const VerificationStatus = ({ config, onVerified }: Props) => {
+export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
   const { data, sig, raw } = config
   const { lockAddress, timestamp, network, tokenId, account } = data
   const { account: viewer } = useAuth()
@@ -161,35 +162,28 @@ export const VerificationStatus = ({ config, onVerified }: Props) => {
   const disableActions =
     !isVerifier || isCheckingIn || !!invalid || !!checkedInAt
 
-  const onVerifiedCb = () => {
+  const onClickVerified = () => {
     if (typeof onVerified === 'function') {
       onVerified()
     }
   }
 
   const CardActions = () => (
-    <div className="grid w-full">
+    <div className="grid w-full gap-2">
       {viewer ? (
-        <>
-          {checkedInAt ? (
-            <Button variant="outlined-primary" onClick={onVerifiedCb}>
-              Scan next ticket
-            </Button>
-          ) : (
-            <Button
-              loading={isCheckingIn}
-              disabled={disableActions}
-              variant={'primary'}
-              onClick={async (event) => {
-                event.preventDefault()
-                onCheckIn()
-              }}
-            >
-              {isCheckingIn ? 'Checking in' : 'Check in'}
-            </Button>
-          )}
-          {}
-        </>
+        !checkedInAt && !!isVerifier ? (
+          <Button
+            loading={isCheckingIn}
+            disabled={disableActions}
+            variant={'primary'}
+            onClick={async (event) => {
+              event.preventDefault()
+              onCheckIn()
+            }}
+          >
+            {isCheckingIn ? 'Checking in' : 'Check in'}
+          </Button>
+        ) : null
       ) : (
         <Button
           onClick={(event) => {
@@ -198,16 +192,21 @@ export const VerificationStatus = ({ config, onVerified }: Props) => {
               `/login?redirect=${encodeURIComponent(window.location.href)}`
             )
           }}
+          variant="primary"
         >
-          Connect Account
+          Connect to check-in
         </Button>
       )}
+      <Button variant="outlined-primary" onClick={onClickVerified}>
+        Scan next ticket
+      </Button>
     </div>
   )
 
   return (
     <div className="flex justify-center">
       <MembershipCard
+        onClose={onClose}
         keyId={key!.tokenId.toString()}
         owner={key!.owner}
         membershipData={membershipData!}

--- a/unlock-app/src/components/interface/verification/MembershipCard.tsx
+++ b/unlock-app/src/components/interface/verification/MembershipCard.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-icons/ri'
 import { ReactNode } from 'react'
 import { twMerge } from 'tailwind-merge'
+import { RiCloseLine as CloseIcon } from 'react-icons/ri'
 
 dayjs.extend(relativeTimePlugin)
 
@@ -42,6 +43,7 @@ interface Props {
   owner: string
   keyId: string
   children?: ReactNode
+  onClose?: () => void
 }
 
 export function MembershipCard({
@@ -53,6 +55,7 @@ export function MembershipCard({
   invalid,
   owner,
   keyId,
+  onClose,
   children = null,
 }: Props) {
   const timeSinceSigned = dayjs().from(timestamp, true)
@@ -64,22 +67,42 @@ export function MembershipCard({
       <div
         className={` ${
           invalid ? 'bg-red-500' : checkedInAt ? 'bg-amber-300' : 'bg-green-500'
-        } text-center p-6 rounded-t-xl`}
+        }   rounded-t-xl`}
       >
-        <div className="inline-flex items-center justify-center">
-          {invalid ? (
-            <InvalidIcon size={54} className="fill-white" />
-          ) : (
-            <ValidIcon size={54} className="fill-white" />
+        <div className="flex justify-end items-center">
+          {onClose && (
+            <button
+              onClick={(event) => {
+                event.preventDefault()
+                onClose()
+              }}
+              className="flex items-center justify-center p-2  rounded group"
+              aria-label="Close"
+            >
+              <CloseIcon
+                className="fill-white group-hover:fill-brand-ui-primary"
+                size={24}
+                key="close"
+              />
+            </button>
           )}
         </div>
-        <p className="text-white font-bold text-xl">
-          {invalid
-            ? invalid
-            : checkedInAt
-            ? `Checked-in ${timeSinceCheckedIn} ago`
-            : `${lock.name}`}
-        </p>
+        <div className="text-center p-6">
+          <div className="inline-flex items-center justify-center">
+            {invalid ? (
+              <InvalidIcon size={54} className="fill-white" />
+            ) : (
+              <ValidIcon size={54} className="fill-white" />
+            )}
+          </div>
+          <p className="text-white font-bold text-xl">
+            {invalid
+              ? invalid
+              : checkedInAt
+              ? `Checked-in ${timeSinceCheckedIn} ago`
+              : `${lock.name}`}
+          </p>
+        </div>
       </div>
       <div className="p-6 space-y-6">
         <div className="flex gap-6 items-center">

--- a/unlock-app/src/components/interface/verification/Scanner.tsx
+++ b/unlock-app/src/components/interface/verification/Scanner.tsx
@@ -6,7 +6,6 @@ import {
 } from '~/utils/verification'
 import VerificationStatus from '../VerificationStatus'
 import QrScanner from 'qr-scanner'
-import { IconButton } from '@unlock-protocol/ui'
 import { FaWindowClose as CloseIcon } from 'react-icons/fa'
 
 function getVerificatioConfigFromURL(text?: string) {

--- a/unlock-app/src/components/interface/verification/Scanner.tsx
+++ b/unlock-app/src/components/interface/verification/Scanner.tsx
@@ -6,6 +6,8 @@ import {
 } from '~/utils/verification'
 import VerificationStatus from '../VerificationStatus'
 import QrScanner from 'qr-scanner'
+import { IconButton } from '@unlock-protocol/ui'
+import { FaWindowClose as CloseIcon } from 'react-icons/fa'
 
 function getVerificatioConfigFromURL(text?: string) {
   try {
@@ -97,6 +99,7 @@ export function Scanner() {
                 <div className="flex min-h-full items-center justify-center text-center">
                   <Dialog.Panel className="max-w-sm w-full">
                     <VerificationStatus
+                      onClose={() => setMembershipVerificationConfig(null)}
                       onVerified={() => setMembershipVerificationConfig(null)}
                       config={membershipVerificationConfig}
                     />

--- a/unlock-app/src/components/interface/verification/Scanner.tsx
+++ b/unlock-app/src/components/interface/verification/Scanner.tsx
@@ -6,7 +6,6 @@ import {
 } from '~/utils/verification'
 import VerificationStatus from '../VerificationStatus'
 import QrScanner from 'qr-scanner'
-import { FaWindowClose as CloseIcon } from 'react-icons/fa'
 
 function getVerificatioConfigFromURL(text?: string) {
   try {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Adds close button card and make scan-another persistent + show check in button only to verifier. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #9258
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

