### PR TITLE
fix(unlock-app): Handle an edge case where QR code urls have double encoded the data and missing tokenId

### DIFF
--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -61,6 +61,7 @@ export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
   const { isLoading: isKeyLoading, data: key } = useQuery(
     [network, tokenId, lockAddress],
     async () => {
+      // Some older QR codes might have been generated without a tokenId in the payload. Clean up after January 2023
       if (lockVersion && lockVersion >= 10 && tokenId) {
         return web3Service.getKeyByTokenId(lockAddress, tokenId, network)
       } else {

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -61,7 +61,7 @@ export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
   const { isLoading: isKeyLoading, data: key } = useQuery(
     [network, tokenId, lockAddress],
     async () => {
-      if (lockVersion && lockVersion >= 10) {
+      if (lockVersion && lockVersion >= 10 && tokenId) {
         return web3Service.getKeyByTokenId(lockAddress, tokenId, network)
       } else {
         return web3Service.getKeyByLockForOwner(lockAddress, account, network)
@@ -72,21 +72,24 @@ export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
     }
   )
 
+  const keyId = key?.tokenId.toString()
+
   const {
     data: membershipData,
     refetch: refetchMembershipData,
     isLoading: isMembershipDataLoading,
   } = useQuery(
-    [tokenId, lockAddress, network],
+    [keyId, lockAddress, network],
     (): Promise<MembershipData> => {
       return storageService.getKeyMetadataValues({
         lockAddress,
         network,
-        keyId: Number(tokenId),
+        keyId: Number(keyId),
       })
     },
     {
       refetchInterval: false,
+      enabled: !!key,
     }
   )
 
@@ -110,7 +113,7 @@ export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
       setIsCheckingIn(true)
       const response = await storageService.markTicketAsCheckedIn({
         lockAddress,
-        keyId: tokenId,
+        keyId: keyId!,
         network,
       })
       if (!response.ok) {
@@ -150,7 +153,7 @@ export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
   )
 
   const invalid = invalidMembership({
-    keyId: key!.tokenId.toString(),
+    keyId: keyId!,
     owner: key!.owner,
     expiration: key!.expiration,
     isSignatureValid,
@@ -207,7 +210,7 @@ export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
     <div className="flex justify-center">
       <MembershipCard
         onClose={onClose}
-        keyId={key!.tokenId.toString()}
+        keyId={keyId!}
         owner={key!.owner}
         membershipData={membershipData!}
         invalid={invalid}

--- a/unlock-app/src/components/interface/verification/invalidMembership.ts
+++ b/unlock-app/src/components/interface/verification/invalidMembership.ts
@@ -20,7 +20,8 @@ export function invalidMembership({
   if (!isSignatureValid) {
     return 'Signature does not match'
   }
-  if (keyId !== tokenId.toString()) {
+
+  if (tokenId && keyId !== tokenId.toString()) {
     return 'This key does not match the user'
   }
 

--- a/unlock-app/src/utils/verification.ts
+++ b/unlock-app/src/utils/verification.ts
@@ -3,9 +3,9 @@ import * as z from 'zod'
 export const MembershipVerificationData = z.object({
   account: z.string(),
   timestamp: z.number(),
-  tokenId: z
-    .union([z.string(), z.number()])
-    .transform((value) => value.toString()),
+  tokenId: z.optional(
+    z.union([z.string(), z.number()]).transform((value) => value.toString())
+  ),
   network: z.number(),
   lockAddress: z.string(),
 })
@@ -24,7 +24,7 @@ interface Options {
 export function getMembershipVerificationConfig({ data, sig }: Options) {
   try {
     if (sig && data) {
-      const raw = decodeURIComponent(data)
+      const raw = decodeURIComponent(decodeURIComponent(data))
       const result = MembershipVerificationConfig.parse({
         sig,
         raw,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18139,7 +18139,7 @@ __metadata:
   bin:
     asc: bin/asc
     asinit: bin/asinit
-  checksum: fda292f6b3b8b4a9bd4457c9143e50145f8473f3d664e48c057638a9bb1c8e890cd4de4e38e18dd4334240394621cfd9d01afee344ab049c5a7072fe855329b5
+  checksum: 8a407db6179addfaa5fcc637543a755ecc22ae8dd5e8259492305afd0d2bb73eae019d4178f79b515f75648d71dfda2c1ceb0c7421bff7817aebb2e2f5c8bfe7
   languageName: node
   linkType: hard
 
@@ -26662,6 +26662,51 @@ __metadata:
   bin:
     eslint: bin/eslint.js
   checksum: d9b4b7488a9cee97608343cbb5ac652d3f316436f95ef0800cd9497c1c6f877b655a3275817989c02f1ff0d5dfd1959c5092af9251c7e3fcf60659da37752a10
+  languageName: node
+  linkType: hard
+
+"eslint@npm:8.20.0":
+  version: 8.20.0
+  resolution: "eslint@npm:8.20.0"
+  dependencies:
+    "@eslint/eslintrc": ^1.3.0
+    "@humanwhocodes/config-array": ^0.9.2
+    ajv: ^6.10.0
+    chalk: ^4.0.0
+    cross-spawn: ^7.0.2
+    debug: ^4.3.2
+    doctrine: ^3.0.0
+    escape-string-regexp: ^4.0.0
+    eslint-scope: ^7.1.1
+    eslint-utils: ^3.0.0
+    eslint-visitor-keys: ^3.3.0
+    espree: ^9.3.2
+    esquery: ^1.4.0
+    esutils: ^2.0.2
+    fast-deep-equal: ^3.1.3
+    file-entry-cache: ^6.0.1
+    functional-red-black-tree: ^1.0.1
+    glob-parent: ^6.0.1
+    globals: ^13.15.0
+    ignore: ^5.2.0
+    import-fresh: ^3.0.0
+    imurmurhash: ^0.1.4
+    is-glob: ^4.0.0
+    js-yaml: ^4.1.0
+    json-stable-stringify-without-jsonify: ^1.0.1
+    levn: ^0.4.1
+    lodash.merge: ^4.6.2
+    minimatch: ^3.1.2
+    natural-compare: ^1.4.0
+    optionator: ^0.9.1
+    regexpp: ^3.2.0
+    strip-ansi: ^6.0.1
+    strip-json-comments: ^3.1.0
+    text-table: ^0.2.0
+    v8-compile-cache: ^2.0.3
+  bin:
+    eslint: bin/eslint.js
+  checksum: a31adf390d71d916925586bc8467b48f620e93dd0416bc1e897d99265af88b48d4eba3985b5ff4653ae5cc46311a360d373574002277e159bb38a4363abf9228
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a fix for QR codes generated before june.

1. There was a bug in the past which caused data to be double encoded in the URI. We fixed this sometime later but since some QR codes were generated through that bug, this fixes it by double decoding which shouldn't cause problem even if URI was only once encoded.
2. Similar to this, our old QR codes didn't include tokenId. I've made it optional.

<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

