### PR TITLE
feat(paywall): Add support for loading alpha flagged checkout

### DIFF
--- a/packages/paywall/src/Paywall.ts
+++ b/packages/paywall/src/Paywall.ts
@@ -1,5 +1,4 @@
 import Postmate from 'postmate'
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { PaywallConfig, NetworkConfigs } from '@unlock-protocol/types'
 import './iframe.css'
 import { dispatchEvent, unlockEvents, injectProviderInfo } from './utils'

--- a/packages/paywall/src/urls.ts
+++ b/packages/paywall/src/urls.ts
@@ -4,15 +4,30 @@ let _locksmithUri: string
 const baseUrl =
   document?.currentScript?.getAttribute('src') || 'paywall.unlock-protocol.com' // assume prod
 
+const endpoint = new URL(baseUrl)
+const alpha = endpoint.searchParams.get('alpha')
+
 if (baseUrl.match('staging-paywall.unlock-protocol.com')) {
-  _unlockAppUrl = 'https://staging-app.unlock-protocol.com'
+  if (alpha) {
+    _unlockAppUrl = 'https://staging-app.unlock-protocol.com/alpha'
+  } else {
+    _unlockAppUrl = 'https://staging-app.unlock-protocol.com'
+  }
   _locksmithUri = 'https://staging-locksmith.unlock-protocol.com'
 } else if (baseUrl.match('paywall.unlock-protocol.com')) {
-  _unlockAppUrl = 'https://app.unlock-protocol.com'
+  if (alpha) {
+    _unlockAppUrl = 'https://app.unlock-protocol.com/alpha'
+  } else {
+    _unlockAppUrl = 'https://app.unlock-protocol.com'
+  }
   _locksmithUri = 'https://locksmith.unlock-protocol.com'
 } else {
-  _unlockAppUrl = 'http://0.0.0.0:3000'
-  _locksmithUri = 'http://0.0.0.0:8080'
+  if (alpha) {
+    _unlockAppUrl = 'http://localhost:3000/alpha'
+  } else {
+    _unlockAppUrl = 'http://localhost:3000'
+  }
+  _locksmithUri = 'http://localhost:8080'
 }
 export const unlockAppUrl: string = _unlockAppUrl
 export const locksmithUri: string = _locksmithUri

--- a/packages/paywall/src/urls.ts
+++ b/packages/paywall/src/urls.ts
@@ -2,10 +2,11 @@
 let _unlockAppUrl: string
 let _locksmithUri: string
 const baseUrl =
-  document?.currentScript?.getAttribute('src') || 'paywall.unlock-protocol.com' // assume prod
+  document?.currentScript?.getAttribute('src') ||
+  'https://paywall.unlock-protocol.com' // assume prod
 
 const endpoint = new URL(baseUrl)
-const alpha = endpoint.searchParams.get('alpha')
+const alpha = !!endpoint.searchParams.get('alpha')
 
 if (baseUrl.match('staging-paywall.unlock-protocol.com')) {
   if (alpha) {

--- a/unlock-app/src/pages/alpha/checkout.tsx
+++ b/unlock-app/src/pages/alpha/checkout.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
 import type { NextPage } from 'next'
 import { CheckoutPage } from '~/components/interface/checkout/alpha'
+import BrowserOnly from '~/components/helpers/BrowserOnly'
 
 const Checkout: NextPage = () => {
-  return <CheckoutPage />
+  return (
+    <BrowserOnly>
+      <CheckoutPage />
+    </BrowserOnly>
+  )
 }
 
 export default Checkout


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Add flag to allow alpha checkout to load. 

The user will need to add `?alpha=true` to their paywall URL to trigger this. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

