### PR TITLE
feat(smart-contracts): deploy new lock template and submit txs 

### DIFF
--- a/smart-contracts/scripts/deployments/template.js
+++ b/smart-contracts/scripts/deployments/template.js
@@ -3,14 +3,14 @@ const { addDeployment } = require('../../helpers/deployments')
 const { getNetworkName } = require('../../helpers/network')
 const contracts = require('@unlock-protocol/contracts')
 
-async function main({ publicLockVersion = 10 }) {
+async function main({ publicLockVersion }) {
   // fetch chain info
   const { chainId } = await ethers.provider.getNetwork()
   const networkName = getNetworkName(chainId)
   const isLocalNet = networkName === 'localhost'
 
   let PublicLock
-  if (publicLockVersion < 11) {
+  if (publicLockVersion) {
     const { abi, bytecode } = contracts[`PublicLockV${publicLockVersion}`]
     PublicLock = await ethers.getContractFactory(abi, bytecode)
   } else {
@@ -22,12 +22,18 @@ async function main({ publicLockVersion = 10 }) {
 
   // eslint-disable-next-line no-console
   console.log(
-    `PUBLIC LOCK > deployed v${publicLockVersion} to : ${publicLock.address} (tx: ${publicLock.deployTransaction.hash})`
+    `PUBLIC LOCK > deployed v${await publicLock.publicLockVersion} to : ${
+      publicLock.address
+    } (tx: ${publicLock.deployTransaction.hash})`
   )
 
   // verify
   if (!isLocalNet) {
-    await run(`yarn hardhat verify`, { address: publicLock.address })
+    try {
+      await run(`verify`, { address: publicLock.address })
+    } catch (error) {
+      console.log(error)
+    }
   }
 
   // save deployment info

--- a/smart-contracts/scripts/multisig/submitTx.js
+++ b/smart-contracts/scripts/multisig/submitTx.js
@@ -34,7 +34,7 @@ async function main({ safeAddress, tx, signer }) {
   console.log(
     `Tx submitted to multisig with id '${nonce}' (txid: ${transactionHash})`
   )
-  return receipt
+  return nonce
 }
 
 module.exports = main

--- a/smart-contracts/scripts/upgrade/submitLockVersion.js
+++ b/smart-contracts/scripts/upgrade/submitLockVersion.js
@@ -1,0 +1,106 @@
+/**
+ * Send the txs to the multisig to add and set the new Lock template
+ * to the Unlock contract.
+ *
+ * NB: You can test on mainnet (without the template being deployed) with:
+ *
+ * ```
+ * RUN_MAINNET_FORK=1 yarn hardhat run scripts/upgrade/submitLockVersion.js
+ * ```
+ */
+const { ethers } = require('hardhat')
+const { networks } = require('@unlock-protocol/networks')
+const submitTx = require('../multisig/submitTx')
+
+const {
+  addSomeETH,
+  confirmMultisigTx,
+  getMultisigSigner,
+  deployLock,
+} = require('../../test/helpers')
+
+async function main({ publicLockAddress }) {
+  // make sure we get the correct chain id on local mainnet fork
+  const { chainId } = process.env.RUN_MAINNET_FORK
+    ? { chainId: '1' }
+    : await ethers.provider.getNetwork()
+
+  const { unlockAddress, multisig } = networks[chainId]
+  if (!publicLockAddress && !process.env.RUN_MAINNET_FORK) {
+    throw new Error('Missing public lock address')
+  }
+
+  // get multisig signer
+  const [signer] = process.env.RUN_MAINNET_FORK
+    ? [await getMultisigSigner(multisig)]
+    : await ethers.getSigners()
+
+  let publicLock
+  if (process.env.RUN_MAINNET_FORK) {
+    // deploy latest public lock
+    const PublicLock = await ethers.getContractFactory('PublicLock')
+    publicLock = await PublicLock.deploy()
+    await publicLock.deployed()
+
+    // some ETH for the issuer
+    await addSomeETH(signer.address)
+  } else {
+    publicLock = await ethers.getContractAt('PublicLock', publicLockAddress)
+  }
+  const version = await publicLock.publicLockVersion()
+
+  console.log(`Setting PublicLock v${version} on network ${chainId}`)
+  console.log(`Unlock: ${unlockAddress} - PublicLock ${publicLock.address}`)
+  console.log(`Multisig: ${multisig} - Signer: ${signer.address}`)
+
+  const submit = async (functionName, functionArgs) => {
+    const tx1 = {
+      contractName: 'Unlock',
+      contractAddress: unlockAddress,
+      functionName,
+      functionArgs,
+    }
+    console.log(`submitting ${functionName} to multisig...`)
+    console.log(functionArgs)
+
+    const txId1 = await submitTx({
+      safeAddress: multisig,
+      tx: tx1,
+      signer,
+    })
+
+    return txId1
+  }
+
+  // send txsx
+  const txId1 = await submit('addLockTemplate', [publicLock.address, version])
+  const txId2 = await submit('setLockTemplate', [publicLock.address])
+
+  // validate multisig txs and test
+  if (process.env.RUN_MAINNET_FORK) {
+    console.log(`Signing multisigs: ${txId1} ${txId2}`)
+    await confirmMultisigTx({
+      transactionId: txId1,
+      multisigAddress: multisig,
+    })
+    await confirmMultisigTx({
+      transactionId: txId2,
+      multisigAddress: multisig,
+    })
+    const unlock = await ethers.getContractAt('Unlock', unlockAddress)
+    const lock = await deployLock({ unlock })
+    console.log(`Lock ${await lock.name()} deployed at ${lock.address}.`)
+  }
+}
+
+// execute as standalone
+if (require.main === module) {
+  main({})
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+}
+
+module.exports = main

--- a/smart-contracts/scripts/upgrade/submitLockVersion.js
+++ b/smart-contracts/scripts/upgrade/submitLockVersion.js
@@ -1,9 +1,15 @@
 /**
- * Deploy latest PublicLock template and send the txs to the multisig
- * to add/set it to the Unlock contract.
- * If no existing address is specified, it will deploy the latest public lock.
+ * Deploy latest PublicLock template and send the txs to the multisig to add/set
+ * it to the Unlock contract.
  *
- * NB: You can test on mainnet (without the template being deployed) with:
+ * ```
+ * # If no existing address is specified, it will deploy the latest public lock.
+ * yarn hardhat submit:version
+ *
+ * # with an existing address, contract gets deployed and specified
+ * yarn hardhat submit:version --network rinkeby --public-lock-address <TEMPLATE_ADDRESS>
+ * ```
+ * NB: You can first test on mainnet to make sure the template is deploying correctly * :
  *
  * ```
  * RUN_MAINNET_FORK=1 yarn hardhat run scripts/upgrade/submitLockVersion.js

--- a/smart-contracts/tasks/upgrade.js
+++ b/smart-contracts/tasks/upgrade.js
@@ -129,3 +129,14 @@ task('upgrade:propose', 'Send an upgrade implementation proposal to multisig')
       implementation,
     })
   })
+
+task(
+  'submit:version',
+  'Send txs to multisig to add and set new PublicLock version'
+)
+  .addParam('publicLockAddress', 'The deployed contract address')
+  .setAction(async ({ publicLockAddress }) => {
+    // eslint-disable-next-line global-require
+    const prepareLockUpgrade = require('../scripts/upgrade/submitLockVersion')
+    await prepareLockUpgrade({ publicLockAddress })
+  })

--- a/smart-contracts/tasks/upgrade.js
+++ b/smart-contracts/tasks/upgrade.js
@@ -134,7 +134,7 @@ task(
   'submit:version',
   'Send txs to multisig to add and set new PublicLock version'
 )
-  .addParam('publicLockAddress', 'The deployed contract address')
+  .addOptionalParam('publicLockAddress', 'The deployed contract address')
   .setAction(async ({ publicLockAddress }) => {
     // eslint-disable-next-line global-require
     const prepareLockUpgrade = require('../scripts/upgrade/submitLockVersion')

--- a/smart-contracts/test/helpers/multisig.js
+++ b/smart-contracts/test/helpers/multisig.js
@@ -1,4 +1,4 @@
-const { ethers } = require('hardhat')
+const { ethers, network } = require('hardhat')
 const { impersonate } = require('./mainnet')
 
 const multisigABI = require('./ABIs/multisig.json')
@@ -6,11 +6,11 @@ const UNLOCK_MULTISIG_ADDRESS = '0xa39b44c4AFfbb56b76a1BF1d19Eb93a5DfC2EBA9'
 const MULTISIG_ADDRESS_OWNER = '0xF5C28ce24Acf47849988f147d5C75787c0103534'
 
 // test helper to reach concensus on multisig
-const confirmMultisigTx = async ({ transactionId }) => {
-  const multisig = await ethers.getContractAt(
-    multisigABI,
-    UNLOCK_MULTISIG_ADDRESS
-  )
+const confirmMultisigTx = async ({
+  transactionId,
+  multisigAddress = UNLOCK_MULTISIG_ADDRESS,
+}) => {
+  const multisig = await ethers.getContractAt(multisigABI, multisigAddress)
   const signers = await multisig.getOwners()
   const txs = await Promise.all(
     signers.slice(1, 4).map(async (signerAddress) => {
@@ -42,8 +42,22 @@ const confirmMultisigTx = async ({ transactionId }) => {
   }
 }
 
+const getMultisigSigner = async (multisigAddress = UNLOCK_MULTISIG_ADDRESS) => {
+  // update contract implementation address in proxy admin using multisig
+  const multisig = await ethers.getContractAt(multisigABI, multisigAddress)
+
+  const signers = await multisig.getOwners()
+  await network.provider.request({
+    method: 'hardhat_impersonateAccount',
+    params: [signers[0]],
+  })
+  const issuer = await ethers.getSigner(signers[0])
+  return issuer
+}
+
 module.exports = {
   confirmMultisigTx,
+  getMultisigSigner,
   UNLOCK_MULTISIG_ADDRESS,
   MULTISIG_ADDRESS_OWNER,
 }


### PR DESCRIPTION
# Description

Deploy latest PublicLock template and send the txs to the multisig to add/set it to the Unlock contract. 

```
# If no existing address is specified, it will deploy the latest public lock.
yarn hardhat submit:version

# with an existing address, contract gets deployed and specified 
yarn hardhat submit:version --network rinkeby --public-lock-address <TEMPLATE_ADDRESS>
```

NB: You can first test on mainnet to make sure the template is deploying correctly :
 
```
 RUN_MAINNET_FORK=1 yarn hardhat run scripts/upgrade/submitLockVersion.js
 ```

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

