### PR TITLE
feat(unlock-app): adding warning about Rinkeby going away

### DIFF
--- a/unlock-app/src/components/content/DashboardContent.js
+++ b/unlock-app/src/components/content/DashboardContent.js
@@ -111,6 +111,15 @@ export const DashboardContent = () => {
             </Warning>
           )}
 
+          {network === 4 && (
+            <Warning>
+              The Rinkeby test network has been deprecated and Unlock will
+              remove its support on December 31st 2022. Consider{' '}
+              <a href="https://unlock-protocol.com/blog/goerli">using Goerli</a>
+              !
+            </Warning>
+          )}
+
           <CreatorLocks hideForm={hideForm} formIsVisible={formIsVisible} />
         </BrowserOnly>
       )}


### PR DESCRIPTION
# Description

Adding a message in the dashboard to indicate that the dashboard will stop supporting Rinkeby on December 31st 2022.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

