### PR TITLE
fix(unlock-app): removed the limit to 1 key per address on front-end

### DIFF
--- a/unlock-app/src/hooks/useMultipleRecipient.ts
+++ b/unlock-app/src/hooks/useMultipleRecipient.ts
@@ -115,10 +115,7 @@ export const useMultipleRecipient = (
     return recipients.size < maxRecipients
   }
 
-  const getAddressAndValidation = async (
-    recipient: string,
-    isUpdate: boolean
-  ) => {
+  const getAddressAndValidation = async (recipient: string) => {
     let address = ''
     let isAddressWithKey = false
     try {
@@ -131,10 +128,6 @@ export const useMultipleRecipient = (
     } catch (err: any) {
       console.error(err?.message)
     }
-
-    const addressList = recipientsList().map(
-      ({ resolvedAddress }) => resolvedAddress
-    )
 
     // todo: need also to check how many keys the address owns to improve this logic
     const limitNotReached = !isAddressWithKey
@@ -203,11 +196,10 @@ export const useMultipleRecipient = (
     updateIndex?: number
   ): Promise<boolean> => {
     setLoading(true)
-    const isUpdate = typeof updateIndex === 'number'
-    if (canAddUser() || isUpdate) {
+    if (canAddUser()) {
       const index = updateIndex || recipients?.size + 1
       const { valid, address, isAddressWithKey, limitNotReached } =
-        await getAddressAndValidation(userAddress, isUpdate)
+        await getAddressAndValidation(userAddress)
       if (valid) {
         try {
           setRecipients((prev) =>

--- a/unlock-app/src/hooks/useMultipleRecipient.ts
+++ b/unlock-app/src/hooks/useMultipleRecipient.ts
@@ -136,19 +136,15 @@ export const useMultipleRecipient = (
       ({ resolvedAddress }) => resolvedAddress
     )
 
-    // on updates we ignore duplicates check
-    const isAddressInList = isUpdate ? false : addressList.includes(address)
-
     // todo: need also to check how many keys the address owns to improve this logic
     const limitNotReached = !isAddressWithKey
     const addressValid = address?.length > 0
 
-    const valid = addressValid && limitNotReached && !isAddressInList
+    const valid = addressValid && limitNotReached
     return {
       valid,
       address,
       isAddressWithKey,
-      isAddressInList,
       limitNotReached,
     }
   }
@@ -210,13 +206,8 @@ export const useMultipleRecipient = (
     const isUpdate = typeof updateIndex === 'number'
     if (canAddUser() || isUpdate) {
       const index = updateIndex || recipients?.size + 1
-      const {
-        valid,
-        address,
-        isAddressWithKey,
-        isAddressInList,
-        limitNotReached,
-      } = await getAddressAndValidation(userAddress, isUpdate)
+      const { valid, address, isAddressWithKey, limitNotReached } =
+        await getAddressAndValidation(userAddress, isUpdate)
       if (valid) {
         try {
           setRecipients((prev) =>
@@ -242,10 +233,6 @@ export const useMultipleRecipient = (
       } else if (isAddressWithKey) {
         ToastHelper.error(
           'This address already owns a valid key. You cannot grant them a new one.'
-        )
-      } else if (isAddressInList) {
-        ToastHelper.error(
-          'This address is already present in list. Please add a new one.'
         )
       } else if (!valid) {
         ToastHelper.error(


### PR DESCRIPTION
# Description

This limit was not solving much. In the newest versions of Unlock a lock can allow an address to own multiple keys.
The current limit did not enable for this but also would not actually raise an error when a future recipient already had a key...

In a better version of this feature, we would check if a recipient already has any keys and would check on the contract if the lock had a high enough number of keys per address... but let's do that later!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

