### PR TITLE
feature(locksmith, networks): adding the team multisig in config, setting it as default key manager

### DIFF
--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -62,6 +62,8 @@ export default class Dispatcher {
 
     const transactionOptions = await getGasSettings(network)
 
+    const teamMultisig = networks[network]?.teamMultisig
+
     const recipients: string[] = []
     const keyManagers: string[] = []
     const expirations: string[] = []
@@ -69,6 +71,8 @@ export default class Dispatcher {
       recipients.push(recipient)
       if (manager) {
         keyManagers.push(manager)
+      } else if (teamMultisig) {
+        keyManagers.push(teamMultisig)
       }
       if (expiration) {
         expirations.push(expiration.toString())

--- a/packages/networks/src/networks/bsc.ts
+++ b/packages/networks/src/networks/bsc.ts
@@ -39,6 +39,7 @@ export const bsc: NetworkConfig = {
   ],
   description: 'EVM compatible network. Cheaper transaction cost.',
   isTestNetwork: false,
+  teamMultisig: '0x373D7cbc4F2700719DEa237500c7a154310B0F9B',
 }
 
 export default bsc

--- a/packages/networks/src/networks/celo.ts
+++ b/packages/networks/src/networks/celo.ts
@@ -35,6 +35,7 @@ export const celo: NetworkConfig = {
   startBlock: 7179039,
   previousDeploys: [],
   isTestNetwork: false,
+  teamMultisig: '0xc293E2da9E558bD8B1DFfC4a7b174729fAb2e4E8',
 }
 
 export default celo

--- a/packages/networks/src/networks/goerli.ts
+++ b/packages/networks/src/networks/goerli.ts
@@ -34,6 +34,7 @@ export const goerli: NetworkConfig = {
   startBlock: 7179039,
   previousDeploys: [],
   isTestNetwork: true,
+  teamMultisig: '0x95C06469e557d8645966077891B4aeDe8D55A755',
 }
 
 export default goerli

--- a/packages/networks/src/networks/mainnet.ts
+++ b/packages/networks/src/networks/mainnet.ts
@@ -39,6 +39,7 @@ export const mainnet: NetworkConfig = {
   startBlock: 7120795,
   description: 'The most popular network',
   isTestNetwork: false,
+  teamMultisig: '0xa39b44c4AFfbb56b76a1BF1d19Eb93a5DfC2EBA9',
 }
 
 export default mainnet

--- a/packages/networks/src/networks/mumbai.ts
+++ b/packages/networks/src/networks/mumbai.ts
@@ -34,6 +34,7 @@ export const mumbai: NetworkConfig = {
   previousDeploys: [],
   description: 'Polygon test network. Do not use for production',
   isTestNetwork: true,
+  teamMultisig: '0x12E37A8880801E1e5290c815a894d322ac591607',
 }
 
 export default mumbai

--- a/packages/networks/src/networks/optimism.ts
+++ b/packages/networks/src/networks/optimism.ts
@@ -33,6 +33,7 @@ export const optimism: NetworkConfig = {
   },
   description: 'Layer 2 network. Cheaper transaction cost.',
   isTestNetwork: false,
+  teamMultisig: '0x6E78b4447e34e751EC181DCBed63633aA753e145',
 }
 
 export default optimism

--- a/packages/networks/src/networks/polygon.ts
+++ b/packages/networks/src/networks/polygon.ts
@@ -43,6 +43,7 @@ export const polygon: NetworkConfig = {
   ],
   description: 'Popular side chain network. Cheaper transaction cost.',
   isTestNetwork: false,
+  teamMultisig: '0x479f3830fbd715342868BA95E438609BCe443DFB',
 }
 
 export default polygon

--- a/packages/networks/src/networks/rinkeby.ts
+++ b/packages/networks/src/networks/rinkeby.ts
@@ -41,6 +41,7 @@ export const rinkeby: NetworkConfig = {
   startBlock: 3530008,
   description: 'Ethereum test network. Do not use for production',
   isTestNetwork: true,
+  teamMultisig: '0x04e855D82c079222d6bDBc041F6202d5A0137267',
 }
 
 export default rinkeby

--- a/packages/networks/src/networks/xdai.ts
+++ b/packages/networks/src/networks/xdai.ts
@@ -40,7 +40,9 @@ export const xdai: NetworkConfig = {
       startBlock: 14521200,
     },
   ],
-  description: 'EVM compatible network whose base currency is a stable coin. Cheaper transaction cost.',
+  description:
+    'EVM compatible network whose base currency is a stable coin. Cheaper transaction cost.',
   isTestNetwork: false,
+  teamMultisig: '0xfAC611a5b5a578628C28F77cEBDDB8C6159Ae79D',
 }
 export default xdai

--- a/packages/types/src/types/unlockTypes.ts
+++ b/packages/types/src/types/unlockTypes.ts
@@ -66,6 +66,7 @@ export interface NetworkConfig {
   startBlock?: number
   previousDeploys?: NetworkDeploy[]
   description?: string
+  teamMultisig?: string
 }
 
 export interface NetworkConfigs {


### PR DESCRIPTION
# Description

In the future we want to rotate the purchaser in locksmith. By making the key manager our multisigs on each network, we do not "tie" the key to the purchaser address.

# Issues

Fixes #8201

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

