### PR TITLE
feat(unlock-app) - keep correct lock manager based on lockAddress

### DIFF
--- a/unlock-app/src/__tests__/components/interface/MetadataTable.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/MetadataTable.test.tsx
@@ -13,24 +13,28 @@ const metadata = [
     keyholderAddress: '0xAaAdEED4c0B861cB36f4cE006a9C90BA2E43fdc2',
     expiration: '123456789',
     emailAddress: 'support@tether.to',
+    lockAddress: '0xx23',
   },
   {
     lockName: 'Giant Martian Insect Party',
     keyholderAddress: '0x84BCb1DFF32Ee9e7Bc7c6868954C3E6F346046b4',
     expiration: '123456789',
     emailAddress: 'rex.smythe@higgi.ns',
+    lockAddress: '0xx23',
   },
   {
     lockName: 'Giant Martian Insect Party',
     keyholderAddress: '0xD6858301c9F434cCcDbFaB8E984bea08BbDBFDCE',
     expiration: '123456789',
     emailAddress: 'ssgt_jones@area51.gov',
+    lockAddress: '0xx23',
   },
   {
     lockName: 'Giant Martian Insect Party',
     keyholderAddress: '0xaFAEfc6dd3C9feF66f92BA838b132644451F0715',
     expiration: '123456789',
     emailAddress: "we don't validate email inputs",
+    lockAddress: '0xx23',
   },
 ]
 

--- a/unlock-app/src/components/content/MembersContent.tsx
+++ b/unlock-app/src/components/content/MembersContent.tsx
@@ -16,6 +16,7 @@ import 'cross-fetch/polyfill'
 import { LocksByNetwork } from '../creator/lock/LocksByNetwork'
 import { Lock } from '@unlock-protocol/types'
 import { getAddressForName } from '~/hooks/useEns'
+import { useKeys } from '~/hooks/useKeys'
 
 interface PaginationProps {
   currentPage: number
@@ -159,7 +160,7 @@ const MetadataTableWrapper = ({
   lockAddresses,
   page,
 }: MetadataTableWrapperProps) => {
-  const { account } = useContext(AuthenticationContext)
+  const { account, network } = useContext(AuthenticationContext)
   const [currentPage, setCurrentPage] = useState(page)
   const [query, setQuery] = useState<string>('')
   const [filterKey, setFilteKey] = useState<string>('owner')
@@ -168,21 +169,20 @@ const MetadataTableWrapper = ({
   const [expiration, setExpiration] = useState<MemberFilter>('active')
   const queryValue = useDebounce<string>(query)
 
-  const {
-    loading,
-    list,
-    columns,
-    hasNextPage,
-    lockManagerMapping,
-    loadMembers,
-    membersCount,
-  } = useMembers({
+  const { loading, list, columns, hasNextPage, loadMembers, membersCount } =
+    useMembers({
+      viewer: account!,
+      lockAddresses,
+      expiration,
+      page: currentPage,
+      query: queryValue,
+      filterKey,
+    })
+
+  const { lockManagerMapping } = useKeys({
     viewer: account!,
-    lockAddresses,
-    expiration,
-    page: currentPage,
-    query: queryValue,
-    filterKey,
+    locks: lockAddresses,
+    network: network!,
   })
 
   const search = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/unlock-app/src/components/content/MembersContent.tsx
+++ b/unlock-app/src/components/content/MembersContent.tsx
@@ -173,7 +173,7 @@ const MetadataTableWrapper = ({
     list,
     columns,
     hasNextPage,
-    isLockManager,
+    lockManagerMapping,
     loadMembers,
     membersCount,
   } = useMembers({
@@ -273,7 +273,7 @@ const MetadataTableWrapper = ({
       <MetadataTable
         columns={columns}
         metadata={list}
-        isLockManager={isLockManager}
+        lockManagerMapping={lockManagerMapping}
         lockAddresses={lockAddresses}
         loading={loading}
         loadMembers={loadMembers}

--- a/unlock-app/src/components/interface/MetadataTable.tsx
+++ b/unlock-app/src/components/interface/MetadataTable.tsx
@@ -190,7 +190,7 @@ export const MetadataTable: React.FC<MetadataTableProps> = ({
       {metadata?.map((data: any) => {
         const { lockName, expiration, keyholderAddress, token, lockAddress } =
           data
-        const key = `${lockName}${expiration}${keyholderAddress}${token}`
+        const key = `${lockName}${expiration}${keyholderAddress}`
         const isLockManager =
           lockManagerMapping?.[lockAddress.toLowerCase()] ?? false
 

--- a/unlock-app/src/hooks/useKeys.ts
+++ b/unlock-app/src/hooks/useKeys.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import { useWeb3Service } from '~/utils/withWeb3Service'
+
+export const useKeys = ({
+  viewer,
+  network,
+  locks,
+}: {
+  viewer: string
+  network: number
+  locks: string[]
+}) => {
+  const web3Service = useWeb3Service()
+  // in case of multiple locks lets keep track where the user has lockManager status
+  const [lockManagerMapping, setLockManagerMapping] = useState<{
+    [lockAddress: string]: boolean
+  }>()
+
+  useEffect(() => {
+    const getLockManagerStatus = async () => {
+      const lockManagerPromise = locks?.map((lock: string) =>
+        web3Service.isLockManager(lock, viewer!, network!)
+      )
+      const status = await Promise.all(lockManagerPromise)
+
+      let mapping = {}
+      locks?.map(
+        (lock: string, index: number) =>
+          (mapping = {
+            ...mapping,
+            [lock.toLowerCase()]: status[index] ?? false, // set lockManager status or false is value is not valid
+          })
+      )
+      setLockManagerMapping(mapping)
+    }
+    getLockManagerStatus()
+  }, [viewer, locks, network, web3Service])
+
+  return {
+    lockManagerMapping,
+  }
+}

--- a/unlock-app/src/hooks/useMembers.ts
+++ b/unlock-app/src/hooks/useMembers.ts
@@ -103,7 +103,6 @@ export const useMembers = ({
   const [members, setMembers] = useState({})
   const [loading, setLoading] = useState(true)
   const [isLockManager, setIsLockManager] = useState(false)
-
   const [membersCount, setMembersCount] = useState<{
     total: number
     active: number
@@ -223,25 +222,6 @@ export const useMembers = ({
       total: locksTotalList.reduce((acc, curr) => acc + curr),
     })
   }
-
-  useEffect(() => {
-    const getLockManagerStatus = async (locks: string[]) => {
-      const lockManagerPromise = locks?.map((lock) =>
-        web3Service.isLockManager(lock, account!, network!)
-      )
-      const status = await Promise.all(lockManagerPromise)
-
-      let mapping = {}
-      locks?.map(
-        (lock, index) =>
-          (mapping = {
-            ...mapping,
-            [lock.toLowerCase()]: status[index] ?? false, // set lockManager status or false is value is not valid
-          })
-      )
-    }
-    getLockManagerStatus(lockAddresses)
-  }, [account, lockAddresses, network, web3Service])
   /**
    * When the keyHolders object changes, load the metadata
    */

--- a/unlock-app/src/hooks/useMembers.ts
+++ b/unlock-app/src/hooks/useMembers.ts
@@ -97,7 +97,7 @@ export const useMembers = ({
   const web3Service = useContext(Web3ServiceContext)
   const storageService = useStorageService()
   const graphService = useContext(GraphServiceContext)
-  // in case of multiple locks lets keep track where the use is the lockManager
+  // in case of multiple locks lets keep track where the user has lockManager status
   const [lockManagerMapping, setLockManagerMapping] = useState<{
     [lockAddress: string]: boolean
   }>()

--- a/unlock-app/src/hooks/useMembers.ts
+++ b/unlock-app/src/hooks/useMembers.ts
@@ -24,7 +24,7 @@ export const buildMembersWithMetadata = (
     (byKeyOwner: any, key: any) => {
       return {
         ...byKeyOwner,
-        [key.userAddress.toLowerCase()]: {
+        [key?.userAddress?.toLowerCase()]: {
           protected: {
             ...key.data?.userMetadata?.protected,
             ...key.data?.extraMetadata,
@@ -172,6 +172,7 @@ export const useMembers = ({
             return buildMembersWithMetadata(lock, storedMetadata)
           }
         } catch (error) {
+          console.error(error)
           ToastHelper.error(`Could not list members - ${error}`)
           return []
         }

--- a/unlock-app/src/hooks/useMembers.ts
+++ b/unlock-app/src/hooks/useMembers.ts
@@ -172,7 +172,6 @@ export const useMembers = ({
             return buildMembersWithMetadata(lock, storedMetadata)
           }
         } catch (error) {
-          console.error(error)
           ToastHelper.error(`Could not list members - ${error}`)
           return []
         }


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This fix issue related to lockAddress and how we get the lockManager status for multiple locks.

to solve, every `lockAddress` is mapped to the `lockManager` status to make sure we use the specific.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

