### PR TITLE
fix(unlock-app): Handle metamask and unlock provider disconnect

### DIFF
--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -148,8 +148,15 @@ export const useProvider = (config: any) => {
     setEncryptedPrivateKey(null)
     clearStorage()
     try {
+      // unlock provider does not support removing listeners or closing.
+      if (provider?.isUnlock) {
+        return
+      }
       provider.provider.removeAllListeners()
-      await provider.provider.close()
+      // metamask does not support disconnect
+      if (provider?.connection?.url !== 'metamask') {
+        await provider.provider.close()
+      }
     } catch (error) {
       console.error(
         'We could not disconnect provider properly using provider.disconnect()'


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Removes a long standing issue where we throw error on the console because both of these providers lack an `close` or `disconnect` method. 

I've had bunch of users who complained or reported it as an issue so this PR removes the error thrown on disconnect.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

