### PR TITLE
fix(unlock-app): Use lock specific constraints and hide captcha step when using credit card

### DIFF
--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Captcha.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Captcha.tsx
@@ -20,7 +20,7 @@ export function Captcha({ injectedProvider, checkoutService }: Props) {
   const config = useConfig()
   const storage = useStorageService()
   const [recaptchaValue, setRecaptchaValue] = useState<string | null>(null)
-  const { recipients } = state.context
+  const { recipients, payment } = state.context
   const [isContinuing, setIsContinuing] = useState(false)
   const { paywallConfig, skipQuantity } = state.context
   const onContinue = async () => {
@@ -83,7 +83,8 @@ export function Captcha({ injectedProvider, checkoutService }: Props) {
       id: 6,
       name: 'Solve captcha',
       to: 'CAPTCHA',
-      skip: !paywallConfig.captcha,
+      skip:
+        !paywallConfig.captcha || ['card', 'claim'].includes(payment.method),
     },
     {
       id: 7,

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/CardPayment.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/CardPayment.tsx
@@ -46,7 +46,7 @@ export function CardPayment({ checkoutService, injectedProvider }: Props) {
       enabled: !!account,
     }
   )
-  const { paywallConfig, skipQuantity } = state.context
+  const { paywallConfig, skipQuantity, payment } = state.context
 
   const card = data?.[0]
 
@@ -82,7 +82,8 @@ export function CardPayment({ checkoutService, injectedProvider }: Props) {
       id: 6,
       name: 'Solve captcha',
       to: 'CAPTCHA',
-      skip: !paywallConfig.captcha,
+      skip:
+        !paywallConfig.captcha || ['card', 'claim'].includes(payment.method),
     },
     {
       id: 7,

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Confirm.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Confirm.tsx
@@ -411,7 +411,8 @@ export function Confirm({
       id: 6,
       name: 'Solve captcha',
       to: 'CAPTCHA',
-      skip: !paywallConfig.captcha,
+      skip:
+        !paywallConfig.captcha || ['card', 'claim'].includes(payment.method),
     },
     {
       id: 7,

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/MessageToSign.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/MessageToSign.tsx
@@ -17,7 +17,7 @@ export function MessageToSign({ checkoutService, injectedProvider }: Props) {
   const [state, send] = useActor(checkoutService)
   const { account, signMessage } = useAuth()
   const [isSigning, setIsSigning] = useState(false)
-  const { paywallConfig, skipQuantity } = state.context
+  const { paywallConfig, skipQuantity, payment } = state.context
   const { messageToSign } = paywallConfig
 
   const onSign = async () => {
@@ -70,7 +70,8 @@ export function MessageToSign({ checkoutService, injectedProvider }: Props) {
       id: 6,
       name: 'Solve captcha',
       to: 'CAPTCHA',
-      skip: !paywallConfig.captcha,
+      skip:
+        !paywallConfig.captcha || ['card', 'claim'].includes(payment.method),
     },
     {
       id: 7,

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Metadata.tsx
@@ -29,7 +29,7 @@ export function Metadata({ checkoutService, injectedProvider }: Props) {
   const [state, send] = useActor(checkoutService)
   const { account, isUnlockAccount, email } = useAuth()
   const storage = useStorageService()
-  const { lock, paywallConfig, quantity, skipQuantity } = state.context
+  const { lock, paywallConfig, quantity, skipQuantity, payment } = state.context
   const web3Service = useWeb3Service()
 
   const metadataInputs =
@@ -186,7 +186,8 @@ export function Metadata({ checkoutService, injectedProvider }: Props) {
       id: 6,
       name: 'Solve captcha',
       to: 'CAPTCHA',
-      skip: !paywallConfig.captcha,
+      skip:
+        !paywallConfig.captcha || ['card', 'claim'].includes(payment.method),
     },
     {
       id: 7,

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Minting.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Minting.tsx
@@ -57,7 +57,7 @@ export function Minting({
   const { account } = useAuth()
   const config = useConfig()
   const [state, send] = useActor(checkoutService)
-  const { mint, lock, messageToSign, skipQuantity, paywallConfig } =
+  const { mint, lock, messageToSign, skipQuantity, paywallConfig, payment } =
     state.context
   const processing = mint?.status === 'PROCESSING'
   const status = mint?.status
@@ -158,7 +158,8 @@ export function Minting({
       id: 6,
       name: 'Solve captcha',
       to: 'CAPTCHA',
-      skip: !paywallConfig.captcha,
+      skip:
+        !paywallConfig.captcha || ['card', 'claim'].includes(payment.method),
     },
     {
       id: 7,

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Payment.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Payment.tsx
@@ -32,7 +32,8 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
   const [state, send] = useActor(checkoutService)
   const config = useConfig()
 
-  const { paywallConfig, quantity, recipients, skipQuantity } = state.context
+  const { paywallConfig, quantity, recipients, skipQuantity, payment } =
+    state.context
   const lock = state.context.lock!
   const wallet = useWalletService()
   const { account, network } = useAuth()
@@ -126,7 +127,8 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
       id: 6,
       name: 'Solve captcha',
       to: 'CAPTCHA',
-      skip: !paywallConfig.captcha,
+      skip:
+        !paywallConfig.captcha || ['card', 'claim'].includes(payment.method),
     },
     {
       id: 7,

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Select.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Select.tsx
@@ -30,7 +30,7 @@ interface Props {
 
 export function Select({ checkoutService, injectedProvider }: Props) {
   const [state, send] = useActor(checkoutService)
-  const { paywallConfig, lock: selectedLock } = state.context
+  const { paywallConfig, lock: selectedLock, payment } = state.context
   const lockOptions = useMemo(() => {
     return Object.entries(paywallConfig.locks).map(([lock, props]) => ({
       ...props,
@@ -169,7 +169,8 @@ export function Select({ checkoutService, injectedProvider }: Props) {
       id: 6,
       name: 'Solve captcha',
       to: 'CAPTCHA',
-      skip: !paywallConfig.captcha,
+      skip:
+        !paywallConfig.captcha || ['card', 'claim'].includes(payment.method),
     },
     {
       id: 7,


### PR DESCRIPTION


<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Currently, we show captcha step when person is using credit card in the progress bar. It is skipped but I think it should be hidden.

Refactoring in the quantity page to use lock specific constraints over global. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

