### PR TITLE
feat(unlock-app) - show spinner on mark ticket as checkin

### DIFF
--- a/unlock-app/src/__tests__/components/interface/MetadataTable.test.tsx
+++ b/unlock-app/src/__tests__/components/interface/MetadataTable.test.tsx
@@ -6,6 +6,7 @@ import {
   AuthenticationContext,
   defaultValues,
 } from '../../../contexts/AuthenticationContext'
+import { QueryClient, QueryClientProvider } from 'react-query'
 
 const metadata = [
   {
@@ -60,22 +61,24 @@ const render = (component: any) => {
     </AuthenticationContext.Provider>
   )
 }
-
+const queryClient = new QueryClient()
 describe('MetadataTable', () => {
   describe('MetadataTable component', () => {
     it('renders members cards correctly', () => {
       expect.assertions(1)
 
       const { container } = render(
-        <MetadataTable
-          columns={[
-            'lockName',
-            'keyholderAddress',
-            'expiration',
-            'emailAddress',
-          ]}
-          metadata={metadata}
-        />
+        <QueryClientProvider client={queryClient}>
+          <MetadataTable
+            columns={[
+              'lockName',
+              'keyholderAddress',
+              'expiration',
+              'emailAddress',
+            ]}
+            metadata={metadata}
+          />
+        </QueryClientProvider>
       )
 
       const memberCards = container.querySelectorAll(

--- a/unlock-app/src/components/content/MembersContent.tsx
+++ b/unlock-app/src/components/content/MembersContent.tsx
@@ -33,7 +33,7 @@ const Pagination = ({
     return null
   }
   return (
-    <div className="flex gap-2 items-center">
+    <div className="flex items-center gap-2">
       <span>{`Page: ${currentPage + 1}`}</span>
       <Button
         variant="outlined-primary"
@@ -105,7 +105,7 @@ export const MembersContent = ({ query }: MembersContentProps) => {
           <>
             <div className="grid items-center justify-between grid-cols-1 gap-3 sm:grid-cols-2">
               <Account />
-              <div className="flex gap-2 justify-end">
+              <div className="flex justify-end gap-2">
                 <Button
                   onClick={() => setLockAddresses(() => [])}
                   disabled={!hasLocks}

--- a/unlock-app/src/components/interface/MetadataTable.tsx
+++ b/unlock-app/src/components/interface/MetadataTable.tsx
@@ -64,10 +64,10 @@ const TotalMemberCount = ({ membersCount }: MemberCountProps) => {
   return (
     <div className="flex divide-x-2">
       {showTotal && (
-        <div className="font-semibold text-lg px-1">Total members: {total}</div>
+        <div className="px-1 text-lg font-semibold">Total members: {total}</div>
       )}
       {showActiveTotalRatio && (
-        <div className="font-semibold text-lg px-1">
+        <div className="px-1 text-lg font-semibold">
           Active members: {active}/{total}
         </div>
       )}

--- a/unlock-app/src/components/interface/members/MemberCard.tsx
+++ b/unlock-app/src/components/interface/members/MemberCard.tsx
@@ -63,7 +63,6 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   isLockManager,
   expireAndRefundDisabled = true,
   metadata = {},
-  refetchKeys,
 }) => {
   const storageService = useContext(StorageServiceContext)
   const walletService = useContext(WalletServiceContext)

--- a/unlock-app/src/components/interface/members/MemberCard.tsx
+++ b/unlock-app/src/components/interface/members/MemberCard.tsx
@@ -2,7 +2,10 @@ import React, { useState, useEffect, useContext } from 'react'
 import { Badge, Button, Input, Modal } from '@unlock-protocol/ui'
 import { addressMinify } from '../../../utils/strings'
 import { RiArrowDropDownLine as ArrowDown } from 'react-icons/ri'
-import { FaCheckCircle as CheckIcon } from 'react-icons/fa'
+import {
+  FaCheckCircle as CheckIcon,
+  FaSpinner as Spinner,
+} from 'react-icons/fa'
 import {
   StorageServiceContext,
   useStorageService,
@@ -14,6 +17,7 @@ import useClipboard from 'react-use-clipboard'
 import { FieldValues, useForm } from 'react-hook-form'
 import useEns from '~/hooks/useEns'
 import { expirationAsDate } from '~/utils/durations'
+import { useMutation } from 'react-query'
 
 const styles = {
   title: 'text-base font-medium text-black break-all	',
@@ -59,6 +63,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   isLockManager,
   expireAndRefundDisabled = true,
   metadata = {},
+  refetchKeys,
 }) => {
   const storageService = useContext(StorageServiceContext)
   const walletService = useContext(WalletServiceContext)
@@ -110,12 +115,18 @@ export const MemberCard: React.FC<MemberCardProps> = ({
     try {
       if (!storageService) return
       const { lockAddress, token: keyId } = data
-      const response = await storageService.markTicketAsCheckedIn({
+      return storageService.markTicketAsCheckedIn({
         lockAddress,
         keyId,
         network: network!,
       })
+    } catch (err) {
+      ToastHelper.error('Error on marking ticket as checked-in')
+    }
+  }
 
+  const markAsCheckInMutation = useMutation(onMarkAsCheckIn, {
+    onSuccess: (response: any) => {
       if (!response.ok && response.status === 409) {
         ToastHelper.error('Ticket already checked in')
       }
@@ -124,10 +135,8 @@ export const MemberCard: React.FC<MemberCardProps> = ({
         setCheckedInTimestamp(new Date().toLocaleString())
         ToastHelper.success('Successfully marked ticket as checked-in')
       }
-    } catch (err) {
-      ToastHelper.error('Error on marking ticket as checked-in')
-    }
-  }
+    },
+  })
 
   const onSendQrCode = async () => {
     if (!network) return
@@ -168,7 +177,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   return (
     <div
       data-testid="member-card"
-      className="border-2 rounded-lg py-4 px-10 hover:shadow-sm bg-white"
+      className="px-10 py-4 bg-white border-2 rounded-lg hover:shadow-sm"
     >
       <UpdateEmailModal
         isOpen={addEmailModalOpen ?? false}
@@ -182,16 +191,16 @@ export const MemberCard: React.FC<MemberCardProps> = ({
         extraDataItems={extraDataItems}
         onEmailChange={onEmailChange}
       />
-      <div className="grid gap-2 justify-between grid-cols-7 mb-2">
-        <div className="col-span-full	flex flex-col md:col-span-1">
+      <div className="grid justify-between grid-cols-7 gap-2 mb-2">
+        <div className="flex flex-col col-span-full md:col-span-1">
           <span className={styles.description}>Lock name</span>
           <span className={styles.title}>{lockName}</span>
         </div>
-        <div className="col-span-full	flex flex-col md:col-span-1">
+        <div className="flex flex-col col-span-full md:col-span-1">
           <span className={styles.description}>Token ID</span>
           <span className={styles.title}>{tokenId}</span>
         </div>
-        <div className="col-span-full	flex flex-col md:col-span-2">
+        <div className="flex flex-col col-span-full md:col-span-2">
           <span className={styles.description}>Owner</span>
           <span className={[styles.title, 'flex gap-2'].join(' ')}>
             <span className="min-w-[120px]">
@@ -209,11 +218,11 @@ export const MemberCard: React.FC<MemberCardProps> = ({
             </button>
           </span>
         </div>
-        <div className="col-span-full	flex flex-col md:col-span-1">
+        <div className="flex flex-col col-span-full md:col-span-1">
           <span className={styles.description}>Expiration</span>
           <span className={styles.title}>{expirationAsDate(expiration)}</span>
         </div>
-        <div className="col-span-full flex gap-2 justify-start items-center lg:col-span-2 lg:justify-end">
+        <div className="flex items-center justify-start gap-2 col-span-full lg:col-span-2 lg:justify-end">
           <Button
             size="small"
             variant="outlined-primary"
@@ -240,11 +249,17 @@ export const MemberCard: React.FC<MemberCardProps> = ({
             <div className="flex gap-[1rem] my-3">
               {!isCheckedIn && (
                 <Button
-                  onClick={onMarkAsCheckIn}
+                  onClick={() => markAsCheckInMutation.mutate()}
                   variant="outlined-primary"
                   size="tiny"
+                  disabled={markAsCheckInMutation.isLoading}
                 >
-                  Mark as Checked-in
+                  <div className="flex">
+                    {markAsCheckInMutation.isLoading && (
+                      <Spinner className="mr-1 animate-spin" />
+                    )}
+                    <span>Mark as Checked-in</span>
+                  </div>
                 </Button>
               )}
               {hasEmailMetadata ? (
@@ -428,8 +443,8 @@ const UpdateEmailModal = ({
 
   return (
     <Modal isOpen={isOpen} setIsOpen={setIsOpen}>
-      <div className="flex flex-col p-4 gap-3">
-        <span className="font-semibold text-md mr-0">
+      <div className="flex flex-col gap-3 p-4">
+        <span className="mr-0 font-semibold text-md">
           {hasEmail ? 'Update email address' : 'Add email address to metadata'}
         </span>
         <form onSubmit={handleSubmit(onUpdateValue)}>
@@ -439,7 +454,7 @@ const UpdateEmailModal = ({
               required: true,
             })}
           />
-          <div className="flex gap-2 items-center justify-end">
+          <div className="flex items-center justify-end gap-2">
             <Button
               variant="secondary"
               onClick={() => setIsOpen(false)}

--- a/unlock-app/src/components/interface/members/MemberCard.tsx
+++ b/unlock-app/src/components/interface/members/MemberCard.tsx
@@ -112,17 +112,13 @@ export const MemberCard: React.FC<MemberCardProps> = ({
   const hasExtraData = extraDataItems?.length > 0 || isCheckedIn
 
   const onMarkAsCheckIn = async () => {
-    try {
-      if (!storageService) return
-      const { lockAddress, token: keyId } = data
-      return storageService.markTicketAsCheckedIn({
-        lockAddress,
-        keyId,
-        network: network!,
-      })
-    } catch (err) {
-      ToastHelper.error('Error on marking ticket as checked-in')
-    }
+    if (!storageService) return
+    const { lockAddress, token: keyId } = data
+    return storageService.markTicketAsCheckedIn({
+      lockAddress,
+      keyId,
+      network: network!,
+    })
   }
 
   const markAsCheckInMutation = useMutation(onMarkAsCheckIn, {
@@ -135,6 +131,9 @@ export const MemberCard: React.FC<MemberCardProps> = ({
         setCheckedInTimestamp(new Date().toLocaleString())
         ToastHelper.success('Successfully marked ticket as checked-in')
       }
+    },
+    onError: () => {
+      ToastHelper.error('Error on marking ticket as checked-in')
     },
   })
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
When "mark as check-in" is clicked, there is no feedback to the user when check-in process is running.

A spinner is now visible when the button is clicked untill the proccess is done:
- on success: the ticket is marked as check-in, "checked in" green label is show and also a success popup message
- on error: the ticket is not marked as check-in, an error popop message will show

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #
**Flow**
https://user-images.githubusercontent.com/20865711/186630643-8fc392a8-836d-434e-89d7-2ff0c79c7c20.mov

**Loading status on "mark ask checked-in"**
<img width="1033" alt="Screenshot 2022-08-25 at 11 34 44" src="https://user-images.githubusercontent.com/20865711/186630489-21c559de-a8a8-44f6-ac41-73c00f811e29.png">



# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

