### PR TITLE
check if key can be granted

### DIFF
--- a/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
+++ b/unlock-app/src/components/creator/members/GrantKeysDrawer.tsx
@@ -17,6 +17,7 @@ import { ToastHelper } from '../../helpers/toast.helper'
 import { useStorageService } from '~/utils/withStorageService'
 import { formResultToMetadata } from '~/utils/userMetadata'
 import { Button, Input } from '@unlock-protocol/ui'
+import { addressMinify } from '~/utils/strings'
 
 interface GrantKeyFormProps {
   lock: Lock
@@ -319,9 +320,9 @@ const GrantKeyForm = ({ onGranted, lock }: GrantKeyFormProps) => {
                 <span className="text-sm font-medium text-gray-900">
                   Airdrop recipients list:
                 </span>
-                <ul className="list-disc px-3">
+                <ul className="px-3 list-disc">
                   {recipientItems?.map(({ userAddress, index }) => {
-                    return <li key={index}>{userAddress}</li>
+                    return <li key={index}>{addressMinify(userAddress)}</li>
                   })}
                 </ul>
               </div>

--- a/unlock-app/src/hooks/useMultipleRecipient.ts
+++ b/unlock-app/src/hooks/useMultipleRecipient.ts
@@ -117,7 +117,7 @@ export const useMultipleRecipient = (
     return recipients.size < maxRecipients
   }
 
-  const isKeyCanBeGranted = async ({
+  const canKeyBeGranted = async ({
     lockAddress,
     owner,
   }: {
@@ -147,7 +147,7 @@ export const useMultipleRecipient = (
     const owner = await getAddressForName(recipient)
     const lockAddress = lock.address
 
-    const keyCanBeGranted = await isKeyCanBeGranted({
+    const keyCanBeGranted = await canKeyBeGranted({
       lockAddress,
       owner,
     })

--- a/unlock-app/src/hooks/useMultipleRecipient.ts
+++ b/unlock-app/src/hooks/useMultipleRecipient.ts
@@ -136,7 +136,7 @@ export const useMultipleRecipient = (
     ).length
 
     /**
-     * make so to check the actual keys for address and the keys on list to prevent to try to
+     * make sure to check the actual keys for address and the keys on list to prevent to try to
      * airdrop more keys allowed for the lock
      */
     const totalKeysForAddress = keysInAirdropList + keyPerAddress

--- a/unlock-app/src/hooks/useMultipleRecipient.ts
+++ b/unlock-app/src/hooks/useMultipleRecipient.ts
@@ -139,8 +139,8 @@ export const useMultipleRecipient = (
      * make sure to check the actual keys for address and the keys on list to prevent to try to
      * airdrop more keys allowed for the lock
      */
-    const totalKeysForAddress = keysInAirdropList + totalKeysOwned
-    return totalKeysForAddress < maxKeysPerAddress
+    const totalKeys = keysInAirdropList + totalKeysOwned
+    return totalKeys < maxKeysPerAddress
   }
 
   const getAddressAndValidation = async (recipient: string) => {

--- a/unlock-app/src/hooks/useMultipleRecipient.ts
+++ b/unlock-app/src/hooks/useMultipleRecipient.ts
@@ -125,7 +125,7 @@ export const useMultipleRecipient = (
     owner: string
   }): Promise<boolean> => {
     const maxKeysPerAddress = lock?.maxKeysPerAddress || 1
-    const keyPerAddress = await web3Service.totalKeys(
+    const totalKeysOwned = await web3Service.totalKeys(
       lockAddress,
       owner,
       network
@@ -139,7 +139,7 @@ export const useMultipleRecipient = (
      * make sure to check the actual keys for address and the keys on list to prevent to try to
      * airdrop more keys allowed for the lock
      */
-    const totalKeysForAddress = keysInAirdropList + keyPerAddress
+    const totalKeysForAddress = keysInAirdropList + totalKeysOwned
     return totalKeysForAddress < maxKeysPerAddress
   }
 

--- a/unlock-app/src/hooks/useMultipleRecipient.ts
+++ b/unlock-app/src/hooks/useMultipleRecipient.ts
@@ -5,6 +5,7 @@ import { Web3ServiceContext } from '../utils/withWeb3Service'
 import { getAddressForName } from './useEns'
 import { Lock, PaywallConfig } from '../unlockTypes'
 import { formResultToMetadata } from '../utils/userMetadata'
+import AuthenticationContext from '~/contexts/AuthenticationContext'
 
 const MAX_RETRY_COUNT = 5
 interface User {
@@ -32,6 +33,8 @@ export const useMultipleRecipient = (
   lock: Lock,
   paywallConfig?: PaywallConfig
 ) => {
+  const { network } = useContext(AuthenticationContext)
+  console.log(network)
   let maxRecipients = 1
   if (paywallConfig?.maxRecipients) {
     maxRecipients = paywallConfig.maxRecipients
@@ -115,30 +118,48 @@ export const useMultipleRecipient = (
     return recipients.size < maxRecipients
   }
 
+  const isKeyCanBeGranted = async ({
+    lockAddress,
+    owner,
+  }: {
+    lockAddress: string
+    owner: string
+  }): Promise<boolean> => {
+    const maxKeysPerAddress = lock?.maxKeysPerAddress || 1
+    const keyPerAddress = await web3Service.totalKeys(
+      lockAddress,
+      owner,
+      network
+    )
+
+    const keysInAirdropList = normalizeRecipients()?.users.filter(
+      ({ userAddress }) => userAddress.toLowerCase() === owner.toLowerCase()
+    ).length
+
+    /**
+     * make so to check the actual keys for address and the keys on list to prevent to try to
+     * airdrop more keys allowed for the lock
+     */
+    const totalKeysForAddress = keysInAirdropList + keyPerAddress
+    return totalKeysForAddress < maxKeysPerAddress
+  }
+
   const getAddressAndValidation = async (recipient: string) => {
-    let address = ''
-    let isAddressWithKey = false
-    try {
-      address = await getAddressForName(recipient)
-      isAddressWithKey = await web3Service.getHasValidKey(
-        lock.address,
-        address,
-        lock.network
-      )
-    } catch (err: any) {
-      console.error(err?.message)
-    }
+    const owner = await getAddressForName(recipient)
+    const lockAddress = lock.address
 
-    // todo: need also to check how many keys the address owns to improve this logic
-    const limitNotReached = !isAddressWithKey
-    const addressValid = address?.length > 0
+    const keyCanBeGranted = await isKeyCanBeGranted({
+      lockAddress,
+      owner,
+    })
 
-    const valid = addressValid && limitNotReached
+    const addressValid = owner?.length > 0
+
+    const valid = addressValid && keyCanBeGranted
     return {
       valid,
-      address,
-      isAddressWithKey,
-      limitNotReached,
+      owner,
+      keyCanBeGranted,
     }
   }
 
@@ -198,8 +219,9 @@ export const useMultipleRecipient = (
     setLoading(true)
     if (canAddUser()) {
       const index = updateIndex || recipients?.size + 1
-      const { valid, address, isAddressWithKey, limitNotReached } =
-        await getAddressAndValidation(userAddress)
+      const { valid, owner, keyCanBeGranted } = await getAddressAndValidation(
+        userAddress
+      )
       if (valid) {
         try {
           setRecipients((prev) =>
@@ -207,7 +229,7 @@ export const useMultipleRecipient = (
               userAddress,
               metadata,
               index,
-              resolvedAddress: address ?? userAddress,
+              resolvedAddress: owner ?? userAddress,
               valid,
             })
           )
@@ -218,13 +240,11 @@ export const useMultipleRecipient = (
         }
       }
 
-      if (!limitNotReached && isAddressWithKey) {
+      if (!keyCanBeGranted) {
         ToastHelper.error(
-          'This address reached max keys limit. You cannot grant them a new one.'
-        )
-      } else if (isAddressWithKey) {
-        ToastHelper.error(
-          'This address already owns a valid key. You cannot grant them a new one.'
+          `This address reached max keys limit (${
+            lock?.maxKeysPerAddress || 1
+          }). You cannot grant them a new one.`
         )
       } else if (!valid) {
         ToastHelper.error(

--- a/unlock-app/src/hooks/useMultipleRecipient.ts
+++ b/unlock-app/src/hooks/useMultipleRecipient.ts
@@ -34,7 +34,6 @@ export const useMultipleRecipient = (
   paywallConfig?: PaywallConfig
 ) => {
   const { network } = useContext(AuthenticationContext)
-  console.log(network)
   let maxRecipients = 1
   if (paywallConfig?.maxRecipients) {
     maxRecipients = paywallConfig.maxRecipients


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Check if key can be granted based on `maxKeysPerAddress`.
If the limit is reached (total keys owned + total keys to aidrop) the error message will show to the user to inform that the limit is reached.

**extra:**
- Also added address minify for better reading to user

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues 

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes # https://github.com/unlock-protocol/unlock/issues/9451 
Refs #

<img width="1117" alt="Screenshot 2022-08-29 at 22 00 39" src="https://user-images.githubusercontent.com/20865711/187288329-c9fa4604-e263-493d-a127-9460de2515f0.png">

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

