### PR TITLE
fix(unlock-app)" API does not return JSON

### DIFF
--- a/unlock-app/src/services/storageService.ts
+++ b/unlock-app/src/services/storageService.ts
@@ -589,7 +589,7 @@ export class StorageService extends EventEmitter {
         ...opts.headers,
       },
     })
-    return await response?.json()
+    return response.ok
   }
 
   /**


### PR DESCRIPTION
# Description

We are incorrectly showing errors to users even though the image was saved just fine because we try to parse the response as JSON when it is not.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

