### PR TITLE
fix(unlock-app): Disable superfluid if balance is not enough for upfront buy

### DIFF
--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Payment.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Payment.tsx
@@ -86,7 +86,9 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
     recipients.length <= 1 && recipients[0] === account
 
   const enableSuperfluid =
-    (paywallConfig.superfluid || lockConfig.superfluid) && isReceiverAccountOnly
+    (paywallConfig.superfluid || lockConfig.superfluid) &&
+    isReceiverAccountOnly &&
+    isPayable
 
   const enableClaim =
     !!isClaimable && !isClaimableLoading && isReceiverAccountOnly

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/checkoutMachine.ts
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/checkoutMachine.ts
@@ -351,7 +351,7 @@ export const checkoutMachine = createMachine(
               cond: 'requireMessageToSign',
             },
             {
-              target: 'METADATA',
+              target: 'PAYMENT',
             },
           ],
           DISCONNECT: {

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/useCheckoutItems.ts
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/useCheckoutItems.ts
@@ -24,7 +24,7 @@ export function useCheckoutSteps(service: CheckoutService) {
     },
     {
       id: 4,
-      name: 'Add card',
+      name: 'Payment method',
       to: 'PAYMENT',
     },
     {


### PR DESCRIPTION

<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

As discussed, we allow superfluid only when balance is enough like the crypto button.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

