### PR TITLE
feat(unlock-app): Show superfluid button always if enabled

### DIFF
--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Payment.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Payment.tsx
@@ -227,16 +227,18 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
                 className="flex flex-col w-full p-4 space-y-2 border border-gray-400 rounded-lg shadow cursor-pointer group hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white"
               >
                 <div className="flex items-center justify-between w-full">
-                  <h3 className="font-bold"> Pay via superfluid </h3>
+                  <h3 className="font-bold"> Stream payment via superfluid </h3>
                   <div className="flex items-center gap-x-1 px-2 py-0.5 rounded border font-medium text-sm">
                     {symbol.toUpperCase()}
                     <CryptoIcon name={symbol.toLowerCase()} size={18} />
                   </div>
                 </div>
                 <div className="flex items-center justify-between w-full gap-2">
-                  <div className="text-sm text-left text-gray-500">
-                    Stream your payment in real time.
-                    {!isPayable && ' Balance is low'}
+                  <div className="flex items-center w-full text-sm text-left text-gray-500">
+                    Your balance ({symbol.toUpperCase()})
+                    <p className="w-20 ml-2 font-medium truncate">
+                      {balanceAmount?.toString()}
+                    </p>
                   </div>
                   <RightArrowIcon
                     className="transition-transform duration-300 ease-out group-hover:fill-brand-ui-primary group-hover:translate-x-1 group-disabled:translate-x-0 group-disabled:transition-none group-disabled:group-hover:fill-black"


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

As per creator request, we show superfluid even if user cannot use it due to low balance but disable it. 

<img width="476" alt="CleanShot 2022-09-03 at 00 08 28@2x" src="https://user-images.githubusercontent.com/73341821/188217239-aa3e3b8d-b624-4d5b-8715-f69114a67c58.png">


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

