### PR TITLE
fix(locksmith): rescuing invalid metadata requests

### DIFF
--- a/locksmith/src/controllers/metadataController.ts
+++ b/locksmith/src/controllers/metadataController.ts
@@ -85,23 +85,28 @@ namespace MetadataController {
   }
 
   export const data = async (req: any, res: Response): Promise<any> => {
-    const address = Normalizer.ethereumAddress(req.params.address)
-    const keyId = req.params.keyId.toLowerCase()
-    const base = `${req.protocol}://${req.headers.host}`
-    const lockOwner = await presentProtectedData(req, Number(keyId), address)
+    try {
+      const address = Normalizer.ethereumAddress(req.params.address)
+      const keyId = req.params.keyId.toLowerCase()
+      const base = `${req.protocol}://${req.headers.host}`
+      const lockOwner = await presentProtectedData(req, Number(keyId), address)
 
-    const keyMetadata = await metadataOperations.generateKeyMetadata(
-      address,
-      keyId,
-      lockOwner,
-      base,
-      parseInt(req.params.chain || req.chain)
-    )
+      const keyMetadata = await metadataOperations.generateKeyMetadata(
+        address,
+        keyId,
+        lockOwner,
+        base,
+        parseInt(req.params.chain || req.chain)
+      )
 
-    if (Object.keys(keyMetadata).length === 0) {
-      res.sendStatus(404)
-    } else {
-      res.json(keyMetadata)
+      if (Object.keys(keyMetadata).length === 0) {
+        res.sendStatus(404)
+      } else {
+        res.json(keyMetadata)
+      }
+    } catch (error) {
+      logger.error(`Error serving metadata`)
+      res.json({})
     }
   }
 


### PR DESCRIPTION
# Description

For reasons that I ignore we're getting lots of requests on our locksmith endpoint that are invalid and triggering the Heroku alerts...
This should reduce that noise!

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

