### PR TITLE
[fix]Use Local Memory Type Variable Instead of Global Storage Type Variable in Event to Save Gas

### DIFF
--- a/packages/contracts/src/contracts/PublicLock/PublicLockV0.sol
+++ b/packages/contracts/src/contracts/PublicLock/PublicLockV0.sol
@@ -976,7 +976,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   {
     uint oldKeyPrice = keyPrice;
     keyPrice = _keyPrice;
-    emit PriceChanged(oldKeyPrice, keyPrice);
+    emit PriceChanged(oldKeyPrice, _keyPrice);
   }
 
   /**

--- a/packages/contracts/src/contracts/PublicLock/PublicLockV1.sol
+++ b/packages/contracts/src/contracts/PublicLock/PublicLockV1.sol
@@ -352,7 +352,7 @@ contract Ownable is Initializable {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**
@@ -892,7 +892,7 @@ contract MixinLockCore is
   {
     uint oldKeyPrice = keyPrice;
     keyPrice = _keyPrice;
-    emit PriceChanged(oldKeyPrice, keyPrice);
+    emit PriceChanged(oldKeyPrice, _keyPrice);
   }
 
   /**

--- a/packages/contracts/src/contracts/PublicLock/PublicLockV3.sol
+++ b/packages/contracts/src/contracts/PublicLock/PublicLockV3.sol
@@ -190,7 +190,7 @@ contract Ownable is Initializable {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**
@@ -772,7 +772,7 @@ contract MixinLockCore is
   {
     uint oldKeyPrice = keyPrice;
     keyPrice = _keyPrice;
-    emit PriceChanged(oldKeyPrice, keyPrice);
+    emit PriceChanged(oldKeyPrice, _keyPrice);
   }
 
   /**

--- a/packages/contracts/src/contracts/PublicLock/PublicLockV4.sol
+++ b/packages/contracts/src/contracts/PublicLock/PublicLockV4.sol
@@ -194,7 +194,7 @@ contract Ownable is Initializable {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**
@@ -860,7 +860,7 @@ contract MixinLockCore is
   {
     uint oldKeyPrice = keyPrice;
     keyPrice = _keyPrice;
-    emit PriceChanged(oldKeyPrice, keyPrice);
+    emit PriceChanged(oldKeyPrice, _keyPrice);
   }
 
   /**

--- a/packages/contracts/src/contracts/PublicLock/PublicLockV6.sol
+++ b/packages/contracts/src/contracts/PublicLock/PublicLockV6.sol
@@ -679,7 +679,7 @@ contract Ownable is Initializable, Context {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**
@@ -1710,7 +1710,7 @@ contract MixinLockCore is
     );
     keyPrice = _keyPrice;
     tokenAddress = _tokenAddress;
-    emit PricingChanged(oldKeyPrice, keyPrice, oldTokenAddress, tokenAddress);
+    emit PricingChanged(oldKeyPrice, _keyPrice, oldTokenAddress, tokenAddress);
   }
 
   /**

--- a/packages/contracts/src/contracts/PublicLock/PublicLockV7.sol
+++ b/packages/contracts/src/contracts/PublicLock/PublicLockV7.sol
@@ -1713,7 +1713,7 @@ contract MixinLockCore is
     );
     keyPrice = _keyPrice;
     tokenAddress = _tokenAddress;
-    emit PricingChanged(oldKeyPrice, keyPrice, oldTokenAddress, tokenAddress);
+    emit PricingChanged(oldKeyPrice, _keyPrice, oldTokenAddress, tokenAddress);
   }
 
   /**

--- a/packages/contracts/src/contracts/PublicLock/PublicLockV8.sol
+++ b/packages/contracts/src/contracts/PublicLock/PublicLockV8.sol
@@ -1755,7 +1755,7 @@ contract MixinLockCore is
     );
     keyPrice = _keyPrice;
     tokenAddress = _tokenAddress;
-    emit PricingChanged(oldKeyPrice, keyPrice, oldTokenAddress, tokenAddress);
+    emit PricingChanged(oldKeyPrice, _keyPrice, oldTokenAddress, tokenAddress);
   }
 
   /**

--- a/packages/contracts/src/contracts/Unlock/UnlockV0.sol
+++ b/packages/contracts/src/contracts/Unlock/UnlockV0.sol
@@ -976,7 +976,7 @@ contract PublicLock is ILockCore, ERC165, IERC721, IERC721Receiver, Ownable {
   {
     uint oldKeyPrice = keyPrice;
     keyPrice = _keyPrice;
-    emit PriceChanged(oldKeyPrice, keyPrice);
+    emit PriceChanged(oldKeyPrice, _keyPrice);
   }
 
   /**

--- a/packages/contracts/src/contracts/Unlock/UnlockV1.sol
+++ b/packages/contracts/src/contracts/Unlock/UnlockV1.sol
@@ -81,7 +81,7 @@ contract Ownable is Initializable {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**
@@ -892,7 +892,7 @@ contract MixinLockCore is
   {
     uint oldKeyPrice = keyPrice;
     keyPrice = _keyPrice;
-    emit PriceChanged(oldKeyPrice, keyPrice);
+    emit PriceChanged(oldKeyPrice, _keyPrice);
   }
 
   /**

--- a/packages/contracts/src/contracts/Unlock/UnlockV3.sol
+++ b/packages/contracts/src/contracts/Unlock/UnlockV3.sol
@@ -81,7 +81,7 @@ contract Ownable is Initializable {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**
@@ -772,7 +772,7 @@ contract MixinLockCore is
   {
     uint oldKeyPrice = keyPrice;
     keyPrice = _keyPrice;
-    emit PriceChanged(oldKeyPrice, keyPrice);
+    emit PriceChanged(oldKeyPrice, _keyPrice);
   }
 
   /**

--- a/packages/contracts/src/contracts/Unlock/UnlockV4.sol
+++ b/packages/contracts/src/contracts/Unlock/UnlockV4.sol
@@ -85,7 +85,7 @@ contract Ownable is Initializable {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**
@@ -860,7 +860,7 @@ contract MixinLockCore is
   {
     uint oldKeyPrice = keyPrice;
     keyPrice = _keyPrice;
-    emit PriceChanged(oldKeyPrice, keyPrice);
+    emit PriceChanged(oldKeyPrice, _keyPrice);
   }
 
   /**

--- a/packages/contracts/src/contracts/Unlock/UnlockV6.sol
+++ b/packages/contracts/src/contracts/Unlock/UnlockV6.sol
@@ -119,7 +119,7 @@ contract Ownable is Initializable, Context {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**

--- a/packages/contracts/src/contracts/Unlock/UnlockV7.sol
+++ b/packages/contracts/src/contracts/Unlock/UnlockV7.sol
@@ -120,7 +120,7 @@ contract Ownable is Initializable, Context {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**

--- a/packages/contracts/src/contracts/Unlock/UnlockV8.sol
+++ b/packages/contracts/src/contracts/Unlock/UnlockV8.sol
@@ -120,7 +120,7 @@ contract Ownable is Initializable, Context {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**

--- a/packages/contracts/src/contracts/Unlock/UnlockV9.sol
+++ b/packages/contracts/src/contracts/Unlock/UnlockV9.sol
@@ -120,7 +120,7 @@ contract Ownable is Initializable, Context {
      */
     function initialize(address sender) public initializer {
         _owner = sender;
-        emit OwnershipTransferred(address(0), _owner);
+        emit OwnershipTransferred(address(0), sender);
     }
 
     /**

--- a/smart-contracts/contracts/mixins/MixinLockCore.sol
+++ b/smart-contracts/contracts/mixins/MixinLockCore.sol
@@ -197,7 +197,7 @@ contract MixinLockCore is
     address oldTokenAddress = tokenAddress;
     keyPrice = _keyPrice;
     tokenAddress = _tokenAddress;
-    emit PricingChanged(oldKeyPrice, keyPrice, oldTokenAddress, tokenAddress);
+    emit PricingChanged(oldKeyPrice, _keyPrice, oldTokenAddress, tokenAddress);
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.  

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->
[#9458](https://github.com/unlock-protocol/unlock/issues/9458)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->


