### PR TITLE
feature(unlock-js, locksmith): using wallet service to renewMembershipFor so we can bump gas

### DIFF
--- a/locksmith/__tests__/fulfillment/dispatcher.test.ts
+++ b/locksmith/__tests__/fulfillment/dispatcher.test.ts
@@ -48,6 +48,8 @@ class MockWalletService extends EventEmitter {
   grantKeys = jest.fn()
 
   getLockContract = jest.fn(async () => mockLockContract)
+
+  renewMembershipFor = jest.fn(async () => ({ hash: 'txhash' }))
 }
 
 const mockWalletService = new MockWalletService()
@@ -98,18 +100,19 @@ describe('Dispatcher', () => {
     })
   })
   describe('renewMembershipFor', () => {
-    it('should call the function directly on lock contract', async () => {
-      expect.assertions(2)
+    it('should call the function from walletService', async () => {
+      expect.assertions(1)
       const keyId = '1'
-      // check contract is fetched correctly
-      await new Dispatcher().renewMembershipFor(31337, lockAddress, keyId)
-      expect(mockWalletService.getLockContract).toBeCalledWith(lockAddress)
 
-      // check contract call
+      await new Dispatcher().renewMembershipFor(31337, lockAddress, keyId)
       const referrerWallet = new Wallet(config.purchaserCredentials)
-      expect(mockLockContract.renewMembershipFor).toBeCalledWith(
-        keyId,
-        referrerWallet.address,
+
+      expect(mockWalletService.renewMembershipFor).toBeCalledWith(
+        {
+          lockAddress,
+          referrer: referrerWallet.address,
+          tokenId: keyId,
+        },
         {
           maxFeePerGas: BigNumber.from(40000000000),
           maxPriorityFeePerGas: BigNumber.from(40000000000),

--- a/locksmith/__tests__/fulfillment/dispatcher.test.ts
+++ b/locksmith/__tests__/fulfillment/dispatcher.test.ts
@@ -100,7 +100,7 @@ describe('Dispatcher', () => {
   describe('renewMembershipFor', () => {
     it('should call the function directly on lock contract', async () => {
       expect.assertions(2)
-      const keyId = 1
+      const keyId = '1'
       // check contract is fetched correctly
       await new Dispatcher().renewMembershipFor(31337, lockAddress, keyId)
       expect(mockWalletService.getLockContract).toBeCalledWith(lockAddress)

--- a/locksmith/__tests__/websub/renewKey.test.ts
+++ b/locksmith/__tests__/websub/renewKey.test.ts
@@ -6,7 +6,7 @@ import { renewKey, isWorthRenewing } from '../../src/websub/helpers/renewKey'
 
 const renewalInfo = {
   network: 31137,
-  keyId: 1,
+  keyId: '1',
   lockAddress: '0xaaa',
 }
 

--- a/locksmith/__tests__/websub/renewKey.test.ts
+++ b/locksmith/__tests__/websub/renewKey.test.ts
@@ -60,6 +60,9 @@ const mockWeb3Service = {
 const mockWalletService = {
   connect: jest.fn(),
   getLockContract: mockGetLockContract,
+  renewMembershipFor: async () => ({
+    hash: 'txhash',
+  }),
 }
 
 jest.mock('@unlock-protocol/networks', () => ({

--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -162,18 +162,20 @@ export default class Dispatcher {
 
     await walletService.connect(provider, walletWithProvider)
 
-    // get lock
-    const lock = await walletService.getLockContract(lockAddress)
-
     // TODO: use team multisig here (based on network config) instead of purchaser address!
     const referrer = walletWithProvider.address
 
-    // send tx with custom gas
+    // send tx with custom gas (Polygon estimates are too often wrong...)
     const { maxFeePerGas, maxPriorityFeePerGas } = await getGasSettings(network)
-    return await lock.renewMembershipFor(keyId, referrer, {
-      maxFeePerGas,
-      maxPriorityFeePerGas,
-    })
+
+    return walletService.renewMembershipFor(
+      {
+        lockAddress,
+        referrer,
+        tokenId: keyId,
+      },
+      { maxFeePerGas, maxPriorityFeePerGas }
+    )
   }
 
   /**

--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -148,7 +148,7 @@ export default class Dispatcher {
   async renewMembershipFor(
     network: number,
     lockAddress: string,
-    keyId: number
+    keyId: string
   ) {
     const walletService = new WalletService(networks)
     const provider = new ethers.providers.JsonRpcProvider(

--- a/locksmith/src/websub/helpers/renewKey.ts
+++ b/locksmith/src/websub/helpers/renewKey.ts
@@ -15,12 +15,12 @@ const BASE_POINT_ACCURACY = 1000
 const MAX_RENEWAL_COST_COVERED = 5 * BASE_POINT_ACCURACY
 
 interface RenewKeyParams {
-  keyId: number
+  keyId: string
   lockAddress: string
   network: number
 }
 interface RenewKeyReturned {
-  keyId: number
+  keyId: string
   lockAddress: string
   network: number
   tx?: string
@@ -51,7 +51,7 @@ const getERC20AmountInUSD = async (symbol: string, amount: string) => {
 export const isWorthRenewing = async (
   network: number,
   lockAddress: string,
-  keyId: number
+  keyId: string
 ): Promise<ShouldRenew> => {
   const web3Service = new Web3Service(networks)
   const provider = new ethers.providers.JsonRpcProvider(

--- a/packages/unlock-js/CHANGELOG.md
+++ b/packages/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+# 0.26.8
+
+- add support for `renewMembershipFor`
+
 # 0.26.7
 
 - add support for `keysAvailable`

--- a/packages/unlock-js/package.json
+++ b/packages/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.26.7",
+  "version": "0.26.8",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/unlock-js/src/PublicLock/v10/index.js
+++ b/packages/unlock-js/src/PublicLock/v10/index.js
@@ -10,6 +10,7 @@ import getTokenIdForOwner from './getTokenIdForOwner'
 import getKeyExpirationByLockForOwner from './getKeyExpirationByLockForOwner'
 import getCancelAndRefundValueFor from './getCancelAndRefundValueFor'
 import getLock from './getLock'
+import renewMembershipFor from './renewMembershipFor'
 import v9 from '../v9'
 
 const {
@@ -57,4 +58,5 @@ export default {
   getCancelAndRefundValueFor,
   approveBeneficiary,
   totalKeys,
+  renewMembershipFor,
 }

--- a/packages/unlock-js/src/PublicLock/v10/renewMembershipFor.js
+++ b/packages/unlock-js/src/PublicLock/v10/renewMembershipFor.js
@@ -1,0 +1,61 @@
+import utils from '../../utils'
+import { ZERO } from '../../constants'
+import { approveTransfer, getAllowance } from '../../erc20'
+import formatKeyPrice from '../utils/formatKeyPrice'
+
+/**
+ * Function to renew a membership, callable by anyone.
+ * This is only useful for ERC20 locks for which the key owner has approved
+ * a large enough token amount!
+ * @param params
+ * @param callback
+ * @returns
+ */
+export default async function (
+  { lockAddress, referrer, tokenId },
+  purchaseForOptions,
+  callback
+) {
+  const lockContract = await this.getLockContract(lockAddress)
+
+  if (!referrer) {
+    referrer = ZERO
+  }
+
+  // Estimate gas. Bump by 30% because estimates are wrong!
+  if (!purchaseForOptions.gasLimit) {
+    try {
+      const gasLimit = await lockContract.estimateGas.renewMembershipFor(
+        tokenId,
+        referrer,
+        purchaseForOptions
+      )
+      purchaseForOptions.gasLimit = gasLimit.mul(13).div(10).toNumber()
+    } catch (error) {
+      console.error(
+        'We could not estimate gas ourselves. Let wallet do it.',
+        error
+      )
+    }
+  }
+
+  const transactionPromise = lockContract.renewMembershipFor(
+    tokenId,
+    referrer,
+    purchaseForOptions
+  )
+
+  const hash = await this._handleMethodCall(transactionPromise)
+
+  if (callback) {
+    callback(null, hash, await transactionPromise)
+  }
+
+  const receipt = await this.provider.waitForTransaction(hash)
+
+  if (receipt.status === 0) {
+    throw new Error('Transaction failed')
+  }
+
+  return tokenId
+}

--- a/packages/unlock-js/src/walletService.ts
+++ b/packages/unlock-js/src/walletService.ts
@@ -215,7 +215,11 @@ export default class WalletService extends UnlockService {
    */
   async renewMembershipFor(
     params: { lockAddress: string; referrer: string | null; tokenId: string },
-    purchaseForOptions: { gasLimit: number },
+    purchaseForOptions: {
+      gasLimit?: number
+      maxFeePerGas?: number
+      maxPriorityFeePerGas?: number
+    },
     callback?: WalletServiceCallback
   ) {
     if (!params.lockAddress) throw new Error('Missing lockAddress')

--- a/packages/unlock-js/src/walletService.ts
+++ b/packages/unlock-js/src/walletService.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers } from 'ethers'
+import { ethers } from 'ethers'
 import { Lock, WalletServiceCallback } from './types'
 import UnlockService from './unlockService'
 import utils from './utils'

--- a/packages/unlock-js/src/walletService.ts
+++ b/packages/unlock-js/src/walletService.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers'
+import { BigNumber, ethers } from 'ethers'
 import { Lock, WalletServiceCallback } from './types'
 import UnlockService from './unlockService'
 import utils from './utils'
@@ -203,6 +203,25 @@ export default class WalletService extends UnlockService {
     if (!params.lockAddress) throw new Error('Missing lockAddress')
     const version = await this.lockContractAbiVersion(params.lockAddress)
     return version.purchaseKeys.bind(this)(params, callback)
+  }
+
+  /**
+   * Function to renew a membership, callable by anyone.
+   * This is only useful for ERC20 locks for which the key owner has approved
+   * a large enough token amount!
+   * @param params
+   * @param callback
+   * @returns
+   */
+  async renewMembershipFor(
+    params: { lockAddress: string; referrer: string | null; tokenId: string },
+    purchaseForOptions: { gasLimit: number },
+    callback?: WalletServiceCallback
+  ) {
+    if (!params.lockAddress) throw new Error('Missing lockAddress')
+    if (!params.tokenId) throw new Error('Missing tokenId')
+    const version = await this.lockContractAbiVersion(params.lockAddress)
+    return version.renewMembershipFor.bind(this)(params, callback)
   }
 
   /**


### PR DESCRIPTION
# Description

I noticed that some renewal transactions are running out of gas... it is because the estimate is sometimes not accurate.
Moving the logic to unlock-js allows us to also add a way to bump gas limit!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

