### PR TITLE
feat(unlock-app) - move close icon out of scroll bar

### DIFF
--- a/unlock-app/src/components/interface/Drawer.tsx
+++ b/unlock-app/src/components/interface/Drawer.tsx
@@ -36,9 +36,9 @@ export const Drawer = ({
       >
         <div className="absolute inset-0 overflow-hidden">
           <Transition.Child {...easeOutTransaction}>
-            <Dialog.Overlay className="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+            <Dialog.Overlay className="absolute inset-0 transition-opacity bg-gray-500 bg-opacity-75" />
           </Transition.Child>
-          <div className="fixed inset-y-0 right-0 pl-10 max-w-full flex">
+          <div className="fixed inset-y-0 right-0 flex max-w-full pl-10">
             <Transition.Child
               as={React.Fragment}
               enter="transform transition ease-in-out duration-300 sm:duration-500"
@@ -50,11 +50,11 @@ export const Drawer = ({
             >
               <div className="relative w-screen max-w-md">
                 <Transition.Child {...easeOutTransaction}>
-                  <div className="absolute top-0 right-0 h-12 w-12 p-4">
+                  <div className="absolute top-0 w-12 h-12 p-4 right-3">
                     <CloseIcon size="25px" onClick={() => setIsOpen(false)} />
                   </div>
                 </Transition.Child>
-                <div className="h-full flex flex-col py-6 bg-brand-beige shadow-xl overflow-y-scroll">
+                <div className="flex flex-col h-full py-6 overflow-y-scroll shadow-xl bg-brand-beige">
                   <div className="px-4 sm:px-6">
                     {title && (
                       <Dialog.Title className="text-lg font-medium text-gray-900">
@@ -63,7 +63,7 @@ export const Drawer = ({
                     )}
                   </div>
 
-                  <div className="mt-2 relative flex-1 px-4 sm:px-6">
+                  <div className="relative flex-1 px-4 mt-2 sm:px-6">
                     {children}
                   </div>
                 </div>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
The close icon is not clickable for windows or when the mouse is attached to the PC, in the specific when the scroll bar is present. To fix the icon is more indented 

**Before**
<img width="464" alt="Screenshot 2022-09-16 at 17 51 14" src="https://user-images.githubusercontent.com/20865711/190680115-6f94413a-c4cf-4b47-b250-96c39713d8b8.png">

**After**
<img width="485" alt="Screenshot 2022-09-16 at 17 53 00" src="https://user-images.githubusercontent.com/20865711/190680130-8c0bf992-91eb-407f-a747-b5f0b9bc440e.png">



<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

