### PR TITLE
fix(locksmith): Don't run renewal jobs for crypto in production

### DIFF
--- a/locksmith/src/websub/jobs/renewFiatKeys.ts
+++ b/locksmith/src/websub/jobs/renewFiatKeys.ts
@@ -69,6 +69,7 @@ async function renewFiatKeys(network: number) {
 export async function renewAllFiatKeys() {
   const tasks: Promise<void>[] = []
   for (const network of Object.values(networks)) {
+    // Don't run renewal jobs on test networks in production
     if (process.env.UNLOCK_ENV === 'prod' && network.isTestNetwork) {
       continue
     }

--- a/locksmith/src/websub/jobs/renewKeys.ts
+++ b/locksmith/src/websub/jobs/renewKeys.ts
@@ -67,10 +67,15 @@ async function renewKeys(network: number) {
 export async function renewAllKeys() {
   const tasks: Promise<void>[] = []
   for (const network of Object.values(networks)) {
-    if (network.id !== 31337) {
-      const task = renewKeys(network.id)
-      tasks.push(task)
+    // Don't run renewal jobs on test networks in production
+    if (process.env.UNLOCK_ENV === 'prod' && network.isTestNetwork) {
+      continue
     }
+    if (network.id === 31337) {
+      continue
+    }
+    const task = renewKeys(network.id)
+    tasks.push(task)
   }
   await Promise.allSettled(tasks)
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

This turns off renewal jobs in production for test network similar to fiat to bring parity. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

