### PR TITLE
feat(unlock-app) - get locks by network for useLocks

### DIFF
--- a/unlock-app/src/__tests__/hooks/useLocks.test.js
+++ b/unlock-app/src/__tests__/hooks/useLocks.test.js
@@ -129,10 +129,7 @@ describe('useLocks', () => {
     const { loading, locks } = result.current
     expect(loading).toBe(false)
     expect(locks.length).toBe(2)
-    expect(mockGraphService.locksByManager).toHaveBeenCalledWith(
-      ownerAddress,
-      network
-    )
+    expect(mockGraphService.locksByManager).toHaveBeenCalledWith(ownerAddress)
   })
 
   describe('getLockAtAddress', () => {

--- a/unlock-app/src/__tests__/hooks/useLocks.test.js
+++ b/unlock-app/src/__tests__/hooks/useLocks.test.js
@@ -98,7 +98,7 @@ describe('useLocks', () => {
   it.skip('should default to loading and an empty list', async () => {
     expect.assertions(4)
     const { result, waitForNextUpdate } = renderHook(() =>
-      useLocks(ownerAddress)
+      useLocks(ownerAddress, network)
     )
     const { loading, locks } = result.current
     expect(loading).toBe(true)
@@ -120,14 +120,19 @@ describe('useLocks', () => {
       },
     ]
 
-    const { result, waitFor } = renderHook(() => useLocks(ownerAddress))
+    const { result, waitFor } = renderHook(() =>
+      useLocks(ownerAddress, network)
+    )
     await waitFor(() => {
       return result.current.loading === false
     })
     const { loading, locks } = result.current
     expect(loading).toBe(false)
     expect(locks.length).toBe(2)
-    expect(mockGraphService.locksByManager).toHaveBeenCalledWith(ownerAddress)
+    expect(mockGraphService.locksByManager).toHaveBeenCalledWith(
+      ownerAddress,
+      network
+    )
   })
 
   describe('getLockAtAddress', () => {

--- a/unlock-app/src/components/creator/CreatorLocks.jsx
+++ b/unlock-app/src/components/creator/CreatorLocks.jsx
@@ -98,7 +98,7 @@ const BalanceWarning = () => {
 
 export const CreatorLocks = ({ formIsVisible, hideForm }) => {
   const { account, network } = useContext(AuthenticationContext)
-  const { loading, locks, addLock, error } = useLocks(account)
+  const { loading, locks, addLock, error } = useLocks(account, network)
 
   return (
     <Locks>

--- a/unlock-app/src/components/interface/locks/Create/CreateLock.tsx
+++ b/unlock-app/src/components/interface/locks/Create/CreateLock.tsx
@@ -58,7 +58,7 @@ export const CreateLockSteps = () => {
   const { account: owner, network } = useAuth()
   const [step, setStep] = useState<Step>('data')
   const [values, setValues] = useState<LockFormProps | undefined>(undefined)
-  const { addLock } = useLocks(owner!)
+  const { addLock } = useLocks(owner!, network)
   const [transactionHash, setTransactionHash] = useState<string | undefined>(
     undefined
   )

--- a/unlock-app/src/components/interface/locks/Create/CreateLock.tsx
+++ b/unlock-app/src/components/interface/locks/Create/CreateLock.tsx
@@ -58,7 +58,7 @@ export const CreateLockSteps = () => {
   const { account: owner, network } = useAuth()
   const [step, setStep] = useState<Step>('data')
   const [values, setValues] = useState<LockFormProps | undefined>(undefined)
-  const { addLock } = useLocks(owner!, network)
+  const { addLock } = useLocks(owner!, network!)
   const [transactionHash, setTransactionHash] = useState<string | undefined>(
     undefined
   )

--- a/unlock-app/src/hooks/useLocks.js
+++ b/unlock-app/src/hooks/useLocks.js
@@ -11,11 +11,9 @@ import {
 } from '../utils/withWalletService'
 import { GraphServiceContext } from '../utils/withGraphService'
 import { ConfigContext } from '../utils/withConfig'
-import {
-  AuthenticationContext,
-  useAuth,
-} from '../contexts/AuthenticationContext'
 import { processTransaction } from './useLock'
+import { useConfig } from '~/utils/withConfig'
+import GraphService from '~/services/graphService'
 
 /**
  * Retrieves a lock object at the address
@@ -170,16 +168,20 @@ export const createLock = async (
  * A hook which yields locks
  * This hook yields the list of locks for the owner based on data from the graph and the chain
  * @param {*} address
+ * @param {*} network
  */
-export const useLocks = (owner) => {
-  const { network } = useAuth()
+export const useLocks = (owner, network) => {
+  const networks = useConfig()
   const web3Service = useWeb3Service()
   const walletService = useWalletService()
   const storageService = useStorageService()
-  const graphService = useContext(GraphServiceContext)
   const config = useContext(ConfigContext)
   const [error, setError] = useState(undefined)
   const [loading, setLoading] = useState(true)
+
+  const { subgraphURI } = networks[network] ?? {}
+  const graphService = new GraphService()
+  graphService.connect(subgraphURI)
 
   graphService.connect(config.networks[network].subgraphURI)
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
convert `useLocks` hooks to get network as parameter in order to use it in the new lock dashboard, where we need to list all locks by network.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

