### PR TITLE
feat(unlock-app): Reduce the amount of text on the airdrop

### DIFF
--- a/packages/ui/lib/components/Drawer/Drawer.tsx
+++ b/packages/ui/lib/components/Drawer/Drawer.tsx
@@ -39,9 +39,9 @@ export const Drawer = ({
       >
         <div className="absolute inset-0 overflow-y-auto">
           <Transition.Child {...easeOutTransaction}>
-            <Dialog.Overlay className="absolute inset-0 transition-opacity bg-opacity-50 bg-zinc-500 backdrop-blur" />
+            <Dialog.Overlay className="absolute inset-0 transition-opacity bg-gray-500 bg-opacity-50 backdrop-blur" />
           </Transition.Child>
-          <div className="fixed inset-y-0 right-0 max-w-full">
+          <div className="fixed inset-y-0 right-0 w-full max-w-lg">
             <Transition.Child
               as={React.Fragment}
               enter="transform transition ease-in-out duration-300 sm:duration-500"

--- a/unlock-app/src/components/interface/members/airdrop/AirdropBulkForm.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropBulkForm.tsx
@@ -131,18 +131,22 @@ export function AirdropBulkForm({ lock, onConfirm }: Props) {
           )}
           {!isLoadingMembers && (
             <div className="space-y-6">
-              <p>
-                Once you upload the csv, you can see all the list of memberships
-                to be granted.
-              </p>
-              <a
-                href="/templates/airdrop.csv"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm font-semibold text-brand-ui-primary"
-              >
-                Download .CSV template
-              </a>
+              <div className="space-y-2">
+                <p>
+                  Once you upload the csv, you can see all the list of
+                  memberships to be granted.
+                </p>
+                <div>
+                  <a
+                    href="/templates/airdrop.csv"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm font-semibold text-brand-ui-primary"
+                  >
+                    Download .CSV template
+                  </a>
+                </div>
+              </div>
 
               <div
                 className="flex flex-col items-center justify-center bg-white border rounded cursor-pointer group aspect-1 group-hover:border-gray-300"

--- a/unlock-app/src/components/interface/members/airdrop/AirdropBulkForm.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropBulkForm.tsx
@@ -132,10 +132,18 @@ export function AirdropBulkForm({ lock, onConfirm }: Props) {
           {!isLoadingMembers && (
             <div className="space-y-6">
               <p>
-                Once you upload the csv, you can see all the members. Once you
-                upload the csv, you can see all the list of memberships to be
-                granted.
+                Once you upload the csv, you can see all the list of memberships
+                to be granted.
               </p>
+              <a
+                href="/templates/airdrop.csv"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm font-semibold text-brand-ui-primary"
+              >
+                Download .CSV template
+              </a>
+
               <div
                 className="flex flex-col items-center justify-center bg-white border rounded cursor-pointer group aspect-1 group-hover:border-gray-300"
                 {...getRootProps()}

--- a/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
@@ -108,21 +108,8 @@ export function AirdropKeysDrawer({
   }
 
   return (
-    <Drawer
-      isOpen={isOpen}
-      setIsOpen={setIsOpen}
-      title="Airdrop Keys"
-      description="To any single address, or bulk airdrop Keys to a group of members. Set up a custom expiration date and send over email notification."
-    >
+    <Drawer isOpen={isOpen} setIsOpen={setIsOpen} title="Airdrop Keys">
       <div className="mt-2 space-y-6">
-        <a
-          href="/templates/airdrop.csv"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sm font-semibold text-brand-ui-primary"
-        >
-          Download .CSV template
-        </a>
         <div>
           {isLockDataLoading ? (
             <div className="space-y-6">


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

<img width="984" alt="CleanShot 2022-09-29 at 21 29 17@2x" src="https://user-images.githubusercontent.com/73341821/193080959-9fe9d1e5-8651-4f45-bd3f-8e01ebb33ee3.png">

<img width="1116" alt="CleanShot 2022-09-29 at 21 32 03@2x" src="https://user-images.githubusercontent.com/73341821/193081448-9d0dcb77-9cb0-4055-882f-149cf6b01f13.png">


Reduced the text and moved it from top to have more space in both to see members. 

I think the intent of the page is clear without explicit description but I can add text too if required. 

The email part is mentioned on the input already. 

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

