### PR TITLE
feat(unlock-app) - fix dashboard

### DIFF
--- a/unlock-app/src/components/interface/locks/Create/elements/CreateLockFormSummary.tsx
+++ b/unlock-app/src/components/interface/locks/Create/elements/CreateLockFormSummary.tsx
@@ -195,13 +195,13 @@ export const CreateLockFormSummary = ({
             <span className="text-xl font-bold">{formData?.name}</span>
           </div>
           <div className="flex flex-col gap-2">
-            <span className="text-base">Duration</span>
+            <span className="text-base">Membership duration</span>
             <span className="text-xl font-bold">
               {unlimitedDuration ? 'Unlimited' : durationAsText}
             </span>
           </div>
           <div className="flex flex-col gap-2">
-            <span className="text-base">Quantity</span>
+            <span className="text-base">Maximum number of memberships</span>
             <span className="text-xl font-bold">
               {unlimitedQuantity ? 'Unlimited' : formData?.maxNumberOfKeys}
             </span>

--- a/unlock-app/src/components/interface/locks/Manage/modals/UpdatePriceModal.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/modals/UpdatePriceModal.tsx
@@ -132,7 +132,9 @@ export const UpdatePriceModal = ({
           className="flex flex-col gap-6 p-6 text-left"
           onSubmit={handleSubmit(onHandleSubmit)}
         >
-          <span className="text-2xl font-bold">Update Price</span>
+          <span className="text-2xl font-bold">
+            Update the price and currency on your lock
+          </span>
 
           <div>
             <label className="block px-1 mb-2 text-base" htmlFor="">
@@ -171,6 +173,14 @@ export const UpdatePriceModal = ({
               </span>
             )}
           </div>
+
+          <span className="text-sm text-gray-600">
+            When changing the price, please remember that users who have
+            approved recurring memberships will need to manually renew in order
+            to approve the price change. Similarly if users cancel their
+            membership, they will receive a refund in the new currency, and an
+            amount calculated based on the new pricing, not the old one
+          </span>
 
           <Button type="submit" disabled={updatePriceMutation.isLoading}>
             Update

--- a/unlock-app/src/components/interface/members/airdrop/AirdropManualForm.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropManualForm.tsx
@@ -43,6 +43,8 @@ export function AirdropForm({ add, defaultValues, lock }: Props) {
     }
   }
 
+  const maxKeysPerAddress = lock?.maxKeysPerAddress || 1
+
   return (
     <form
       onSubmit={handleSubmit((member) => {
@@ -73,9 +75,8 @@ export function AirdropForm({ add, defaultValues, lock }: Props) {
             }
           },
           max: {
-            value: lock?.maxKeysPerAddress || 1,
-            message:
-              "That's the max you can airdrop for this lock to a single address.",
+            value: maxKeysPerAddress,
+            message: `Your lock currently has a maximum of keys per address set to ${maxKeysPerAddress}.`,
           },
         })}
         error={errors.count?.message}
@@ -142,6 +143,7 @@ export function AirdropManualForm({ onConfirm, lock }: AirdropManualFormProps) {
           expiration,
           manager: account,
           neverExpire: lock.expirationDuration === -1,
+          count: 1,
         }}
       />
       {list.length > 0 && (


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
**Fixs:** 

- On the lock deployment UI: let's add more context. Instead of "Duration" => "Membership duration", "Quantity" => "Maximum number of memberships"...
<img width="535" alt="Screenshot 2022-09-30 at 11 05 33" src="https://user-images.githubusercontent.com/20865711/193237643-d2c5ebbd-341d-4f43-bffd-bce7ca31b4cc.png">

- On the airdrop modal, change error message for `maxKeysPerAddress` to "Your lock currently has a maximum of keys per addressset to XX."
<img width="502" alt="Screenshot 2022-09-30 at 11 08 39" src="https://user-images.githubusercontent.com/20865711/193237867-e81293f1-53d7-4566-8bbf-44c56dfa319b.png">


- On the airdrop modal, let's add a default of 1 in the "Number of keys to airdrop"
<img width="504" alt="Screenshot 2022-09-30 at 11 10 47" src="https://user-images.githubusercontent.com/20865711/193237945-0788e6ed-94df-45d9-b5d7-55708c063fde.png">

- On the modal to update the price, same: "Update Price" => "Update the price and currency on your lock" => When changing the price, please remember that users who have approved recurring memberships will need to manually renew in order to approve the price change. Similarly if users cancel their membership, they will receive a refund in the new currency, and an amount calculated based on the new pricing, not the old one".
<img width="675" alt="Screenshot 2022-09-30 at 11 13 27" src="https://user-images.githubusercontent.com/20865711/193238095-be0b5e7c-c95c-4b4f-a290-2b05f25805e1.png">




<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

