### PR TITLE
feat(unlock-app) - update background when input is disabled

### DIFF
--- a/packages/ui/lib/components/Form/Input.tsx
+++ b/packages/ui/lib/components/Form/Input.tsx
@@ -72,7 +72,7 @@ export const Input = forwardRef(
       INPUT_BUTTON_SIZE[size]
     )
     const inputClass = twMerge(
-      'block w-full box-border rounded-lg transition-all shadow-sm border border-gray-400 hover:border-gray-500 focus:ring-gray-500 focus:border-gray-500 focus:outline-none flex-1',
+      'block w-full box-border rounded-lg transition-all shadow-sm border border-gray-400 hover:border-gray-500 focus:ring-gray-500 focus:border-gray-500 focus:outline-none flex-1 disabled:bg-gray-100',
       inputSizeStyle,
       inputStateStyles,
       icon ? 'pl-10' : undefined


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Lets make more when our `Input` component is `disabled`

**Before**
<img width="456" alt="Screenshot 2022-09-30 at 11 43 19" src="https://user-images.githubusercontent.com/20865711/193243223-2140420c-b7f0-4c87-ae09-ef4c6bd94026.png">

**After**
<img width="459" alt="Screenshot 2022-09-30 at 11 43 07" src="https://user-images.githubusercontent.com/20865711/193243327-a7f3ff12-fe43-426d-a431-53a06c77e9a2.png">


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

