### PR TITLE
feat(unlock-app) - add container wrapper to align elements

### DIFF
--- a/unlock-app/src/components/interface/AppFooter.tsx
+++ b/unlock-app/src/components/interface/AppFooter.tsx
@@ -1,3 +1,5 @@
+import { Container } from './Container'
+
 interface Link {
   label: string
   url: string
@@ -24,29 +26,27 @@ const Link = ({ label, url }: Link) => {
 }
 export const AppFooter = ({ sticky = false }) => {
   return (
-    <div
-      className={`px-4 py-8 bg-black md:px-0 ${
-        sticky ? 'sticky bottom-0' : ''
-      }`}
-    >
-      <div className="flex flex-col items-start w-full gap-10 md:gap-0 md:mx-auto md:justify-between md:items-center md:flex-row md:max-w-screen-lg lg:max-w-screen-xl">
-        <a href="/">
-          <img
-            className="h-6"
-            src="/images/svg/logo-monogram-square.svg"
-            alt="logo monogram"
-          />
-        </a>
-        <ul className="flex flex-col gap-8 md:px-0 md:flex-row">
-          {links?.map((link, index) => {
-            return (
-              <li key={index}>
-                <Link {...link}></Link>
-              </li>
-            )
-          })}
-        </ul>
-      </div>
+    <div className={`py-8 bg-black md:px-0 ${sticky ? 'sticky bottom-0' : ''}`}>
+      <Container>
+        <div className="flex flex-col items-start w-full gap-10 md:gap-0 md:mx-auto md:justify-between md:items-center md:flex-row">
+          <a href="/">
+            <img
+              className="h-6"
+              src="/images/svg/logo-monogram-square.svg"
+              alt="logo monogram"
+            />
+          </a>
+          <ul className="flex flex-col gap-8 md:px-0 md:flex-row">
+            {links?.map((link, index) => {
+              return (
+                <li key={index}>
+                  <Link {...link}></Link>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      </Container>
     </div>
   )
 }

--- a/unlock-app/src/components/interface/AppHeader.tsx
+++ b/unlock-app/src/components/interface/AppHeader.tsx
@@ -10,6 +10,7 @@ import { Popover, Transition } from '@headlessui/react'
 import { Fragment, useState } from 'react'
 import { AiOutlineMenu as MenuIcon } from 'react-icons/ai'
 import { GrClose as MenuCloseIcon } from 'react-icons/gr'
+import { Container } from './Container'
 interface Link {
   label: string
   url: string
@@ -130,55 +131,57 @@ export const AppHeader = () => {
 
   return (
     <div className="pt-5 bg-ui-secondary-200">
-      <div className="flex justify-between px-4 mx-auto lg:container">
-        <div className="flex items-center gap-10">
-          <div className="flex gap-2">
-            <button
-              className="flex md:hidden"
-              onClick={() => setIsOpen(!isOpen)}
-              aria-label="menu-button"
-            >
-              {isOpen ? <MenuCloseIcon size={20} /> : <MenuIcon size={20} />}
-            </button>
+      <Container>
+        <div className="flex justify-between">
+          <div className="flex items-center gap-10">
+            <div className="flex gap-2">
+              <button
+                className="flex md:hidden"
+                onClick={() => setIsOpen(!isOpen)}
+                aria-label="menu-button"
+              >
+                {isOpen ? <MenuCloseIcon size={20} /> : <MenuIcon size={20} />}
+              </button>
 
-            <div className="h-5 md:h-6">
-              <img
-                className="h-full"
-                src="/images/svg/unlock-logo.svg"
-                alt="logo"
-              />
+              <div className="h-5 md:h-6">
+                <img
+                  className="h-full"
+                  src="/images/svg/unlock-logo.svg"
+                  alt="logo"
+                />
+              </div>
+            </div>
+
+            <div className="hidden md:block">
+              <Links />
+            </div>
+
+            <div className="md:hidden">
+              {isOpen && (
+                <div className="">
+                  <Links mobile={true} />
+                </div>
+              )}
             </div>
           </div>
-
-          <div className="hidden md:block">
-            <Links />
-          </div>
-
-          <div className="md:hidden">
-            {isOpen && (
-              <div className="">
-                <Links mobile={true} />
+          <div>
+            {account ? (
+              <div className="flex gap-2">
+                <SwitchNetworkButton network={network!} />
+                <Button variant="outlined-primary">
+                  <span className="text-brand-ui-primary">
+                    {addressMinify(account)}
+                  </span>
+                </Button>
               </div>
+            ) : (
+              <Link href={loginUrl}>
+                <Button>Connect</Button>
+              </Link>
             )}
           </div>
         </div>
-        <div>
-          {account ? (
-            <div className="flex gap-2">
-              <SwitchNetworkButton network={network!} />
-              <Button variant="outlined-primary">
-                <span className="text-brand-ui-primary">
-                  {addressMinify(account)}
-                </span>
-              </Button>
-            </div>
-          ) : (
-            <Link href={loginUrl}>
-              <Button>Connect</Button>
-            </Link>
-          )}
-        </div>
-      </div>
+      </Container>
     </div>
   )
 }

--- a/unlock-app/src/components/interface/Container.tsx
+++ b/unlock-app/src/components/interface/Container.tsx
@@ -1,0 +1,7 @@
+interface Props {
+  children?: React.ReactNode
+}
+
+export const Container = ({ children }: Props) => {
+  return <div className="px-4 mx-auto lg:container">{children}</div>
+}

--- a/unlock-app/src/components/interface/locks/Create/index.tsx
+++ b/unlock-app/src/components/interface/locks/Create/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useAuth } from '~/contexts/AuthenticationContext'
 import { ConnectWalletModal } from '../../ConnectWalletModal'
+import { Container } from '../../Container'
 
 import { CreateLockSteps } from './CreateLock'
 
@@ -13,9 +14,11 @@ export const CreateLockPage = () => {
 
   return (
     <div className="min-w-full min-h-screen bg-ui-secondary-200">
-      <div className="px-4 mx-auto lg:container pt-9">
-        <CreateLockSteps />
-      </div>
+      <Container>
+        <div className="pt-9">
+          <CreateLockSteps />
+        </div>
+      </Container>
     </div>
   )
 }

--- a/unlock-app/src/components/interface/locks/List/index.tsx
+++ b/unlock-app/src/components/interface/locks/List/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@unlock-protocol/ui'
 import Link from 'next/link'
 import React from 'react'
 import { useAuth } from '~/contexts/AuthenticationContext'
+import { Container } from '../../Container'
 import { ImageBar } from '../Manage/elements/ImageBar'
 import { LockList } from './elements/LockList'
 
@@ -72,18 +73,20 @@ export const LocksListPage = () => {
 
   return (
     <div className="min-w-full min-h-screen bg-ui-secondary-200">
-      <div className="px-4 mx-auto lg:container pt-9">
-        <div className="flex flex-col gap-10">
-          <PageHeader />
-          {!network ? (
-            <WalletNotConnected />
-          ) : noItems ? (
-            <NoItems />
-          ) : (
-            <LockList />
-          )}
-        </div>
-      </div>
+      <Container>
+        <div className="pt-9">
+          <div className="flex flex-col gap-10">
+            <PageHeader />
+            {!network ? (
+              <WalletNotConnected />
+            ) : noItems ? (
+              <NoItems />
+            ) : (
+              <LockList />
+            )}
+          </div>
+        </div>{' '}
+      </Container>
     </div>
   )
 }

--- a/unlock-app/src/components/interface/locks/Manage/index.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/index.tsx
@@ -17,6 +17,7 @@ import { AirdropKeysDrawer } from '~/components/interface/members/airdrop/Airdro
 import { useQuery } from 'react-query'
 import { useWeb3Service } from '~/utils/withWeb3Service'
 import { useConfig } from '~/utils/withConfig'
+import { Container } from '../../Container'
 
 interface ActionBarProps {
   lockAddress: string
@@ -229,8 +230,8 @@ export const ManageLockPage = () => {
 
   return (
     <div className="min-h-screen bg-ui-secondary-200 pb-60">
-      <div className="w-full px-4 lg:px-40">
-        <div className="px-4 mx-auto lg:container pt-9">
+      <Container>
+        <div className="pt-9">
           <div className="mb-7">
             <TopActionBar lockAddress={lockAddress} network={lockNetwork} />
           </div>
@@ -245,7 +246,7 @@ export const ManageLockPage = () => {
             </div>
           </div>
         </div>
-      </div>
+      </Container>
     </div>
   )
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Add `Container` wrapper to avoid different styling around the dashboard and have all elements aligned 

before: 
<img width="1598" alt="Screenshot 2022-09-30 at 18 12 46" src="https://user-images.githubusercontent.com/20865711/193313144-4f708ab3-568c-46c6-ad70-7c236cf6ade4.png">

after:
<img width="1563" alt="Screenshot 2022-09-30 at 18 13 28" src="https://user-images.githubusercontent.com/20865711/193313155-d74a52fc-48fb-4dc4-b5ee-9a1a56fde296.png">


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

