### PR TITLE
feat(unlock-app): Handle wallet icon more inline with the injected provider

### DIFF
--- a/unlock-app/src/components/interface/LoginPrompt.tsx
+++ b/unlock-app/src/components/interface/LoginPrompt.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import SvgComponents from './svg'
-
+import { RiWalletFill as WalletIcon } from 'react-icons/ri'
 import { ActionButton } from './buttons/ActionButton'
 import LogInSignUp from './LogInSignUp'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
@@ -49,9 +49,17 @@ const LoginPrompt = ({
           <WalletButton
             color={backgroundColor}
             activeColor={activeColor}
-            onClick={() => authenticateWithProvider('METAMASK')}
+            onClick={() =>
+              window.ethereum
+                ? authenticateWithProvider('METAMASK')
+                : authenticateWithProvider('WALLET_CONNECT')
+            }
           >
-            <SvgComponents.Metamask />
+            {window.ethereum?.isMetaMask ? (
+              <SvgComponents.Metamask />
+            ) : (
+              <WalletIcon />
+            )}
             In browser wallet
           </WalletButton>
 

--- a/unlock-app/src/components/interface/checkout/alpha/Connected.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Connected.tsx
@@ -7,6 +7,7 @@ import { addressMinify, minifyEmail } from '~/utils/strings'
 import SvgComponents from '../../svg'
 import { CheckoutService } from './Checkout/checkoutMachine'
 import { ConnectService } from './Connect/connectMachine'
+import { RiWalletFill as WalletIcon } from 'react-icons/ri'
 
 interface SignedInProps {
   onDisconnect?: () => void
@@ -68,7 +69,14 @@ export function SignedOut({
   authenticateWithProvider,
 }: SignedOutProps) {
   const iconButtonClass =
-    'inline-flex items-center p-1 hover:[box-shadow:_0px_4px_15px_rgba(0,0,0,0.08)] [box-shadow:_0px_8px_30px_rgba(0,0,0,0.08)] rounded-full'
+    'inline-flex items-center w-10 h-10 justify-center hover:[box-shadow:_0px_4px_15px_rgba(0,0,0,0.08)] [box-shadow:_0px_8px_30px_rgba(0,0,0,0.08)] rounded-full'
+
+  const ethereum = window.ethereum
+
+  const walletIcon = {
+    metamask: <SvgComponents.Metamask width={32} />,
+    default: <WalletIcon size={20} className="m-1.5" />,
+  }
 
   return (
     <div className="grid w-full grid-flow-col grid-cols-11">
@@ -76,11 +84,17 @@ export function SignedOut({
         <h4 className="text-sm"> Have a crypto wallet? </h4>
         <div className="flex items-center justify-around w-full">
           <button
-            onClick={() => authenticateWithProvider('METAMASK')}
+            onClick={() =>
+              ethereum
+                ? authenticateWithProvider('METAMASK')
+                : authenticateWithProvider('WALLET_CONNECT')
+            }
             type="button"
             className={iconButtonClass}
           >
-            <SvgComponents.Metamask width={32} />
+            {ethereum?.isMetaMask
+              ? walletIcon['metamask']
+              : walletIcon['default']}
           </button>
           <button
             onClick={() => authenticateWithProvider('WALLET_CONNECT')}
@@ -135,6 +149,7 @@ export function Connected({
   const { authenticateWithProvider } = useAuthenticate({
     injectedProvider,
   })
+
   const onDisconnect = () => {
     send('DISCONNECT')
     deAuthenticate()

--- a/unlock-app/src/hooks/useAuthenticate.ts
+++ b/unlock-app/src/hooks/useAuthenticate.ts
@@ -6,7 +6,6 @@ import { useAppStorage } from './useAppStorage'
 
 export interface EthereumWindow extends Window {
   ethereum?: any
-  web3?: any
 }
 
 interface RpcType {
@@ -33,11 +32,6 @@ export const selectProvider = (config: any) => {
     provider = `http://${config.httpProvider}:8545`
   } else if (ethereumWindow && ethereumWindow.ethereum) {
     provider = ethereumWindow.ethereum
-  } else if (ethereumWindow.web3) {
-    // Legacy web3 wallet/browser (should we keep supporting?)
-    provider = ethereumWindow.web3.currentProvider
-  } else {
-    // TODO: Let's let the user pick one up from the UI (including the unlock provider!)
   }
   return provider
 }


### PR DESCRIPTION


<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

<img width="760" alt="CleanShot 2022-10-01 at 00 47 55@2x" src="https://user-images.githubusercontent.com/73341821/193341454-13306792-c116-4f4e-bdd0-746f2321a9d9.png">


A slight difference from the original: We use wallet connect on both desktop and mobile when none provided since many desktop users have mobile only wallets like rainbow which they may want to use. 

So I think it makes sense to use wallet connect on both mobile and desktop when no injected provider is there.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

