### PR TITLE
feat(unlock-app): Allow metadata in bulk airdrop template

### DIFF
--- a/unlock-app/public/templates/airdrop.csv
+++ b/unlock-app/public/templates/airdrop.csv
@@ -1,3 +1,3 @@
-recipient,count,email,expiration,manager,neverExpire
-julien51.eth,1,julien@unlock-protocol.com,,julien51.eth,FALSE
-unlock-protocol.eth,1,unlock@unlock-protocol.com,10-30-2050,,
+recipient,count,email,expiration,manager,neverExpire,twitter,website.public
+julien51.eth,1,julien@unlock-protocol.com,,julien51.eth,FALSE,https://twitter.com/julien51,https://www.ouvre-boite.com/
+unlock-protocol.eth,1,unlock@unlock-protocol.com,10-30-2050,https://twitter.com/UnlockProtocol,https://unlock-protocol.com

--- a/unlock-app/src/components/interface/members/airdrop/AirdropElements.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropElements.tsx
@@ -4,17 +4,19 @@ import { addressMinify } from '~/utils/strings'
 import { RiCloseLine as CloseIcon } from 'react-icons/ri'
 import { MouseEventHandler } from 'react'
 
-export const AirdropMember = z.object({
-  recipient: z.string(),
-  count: z.preprocess((item) => Number(item), z.number().default(1)),
-  expiration: z.string().optional(),
-  neverExpire: z.preprocess(
-    (value) => !!value,
-    z.boolean().optional().default(false)
-  ),
-  manager: z.string().optional(),
-  email: z.string().optional(),
-})
+export const AirdropMember = z
+  .object({
+    recipient: z.string(),
+    count: z.preprocess((item) => Number(item), z.number().default(1)),
+    expiration: z.string().optional(),
+    neverExpire: z.preprocess(
+      (value) => !!value,
+      z.boolean().optional().default(false)
+    ),
+    manager: z.string().optional(),
+    email: z.string().optional(),
+  })
+  .passthrough()
 
 export type AirdropMember = z.infer<typeof AirdropMember>
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Allow metadata in csv. 

Any other fields than ones explicitly labelled will be added as private metadata.

If they have `.public` suffix, it will be added public metadata. 


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

