### PR TITLE
rename(networks): Xdai subgraph was renamed to gnosis with v2

### DIFF
--- a/packages/hardhat-plugin/src/networks.json
+++ b/packages/hardhat-plugin/src/networks.json
@@ -243,7 +243,7 @@
     "requiredConfirmations": 12,
     "subgraph": {
       "endpoint": "https://api.thegraph.com/subgraphs/name/unlock-protocol/xdai",
-      "endpointV2": "https://api.thegraph.com/subgraphs/name/unlock-protocol/xdai-v2"
+      "endpointV2": "https://api.thegraph.com/subgraphs/name/unlock-protocol/gnosis-v2"
     },
     "explorer": {
       "name": "Blockscout",

--- a/packages/networks/package.json
+++ b/packages/networks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@unlock-protocol/networks",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "description": "Unlock Protocol's contract addressess for various networks",

--- a/packages/networks/src/networks/xdai.ts
+++ b/packages/networks/src/networks/xdai.ts
@@ -13,7 +13,7 @@ export const xdai: NetworkConfig = {
   subgraph: {
     endpoint: 'https://api.thegraph.com/subgraphs/name/unlock-protocol/xdai',
     endpointV2:
-      'https://api.thegraph.com/subgraphs/name/unlock-protocol/xdai-v2',
+      'https://api.thegraph.com/subgraphs/name/unlock-protocol/gnosis-v2',
   },
   explorer: {
     name: 'Blockscout',


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Looks it was renamed to gnosis which is why it was hitting missing endpoint. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

