### PR TITLE
fix(smart-contracts): remove events when setting roles

### DIFF
--- a/smart-contracts/contracts/mixins/MixinRoles.sol
+++ b/smart-contracts/contracts/mixins/MixinRoles.sol
@@ -13,12 +13,6 @@ contract MixinRoles is AccessControlUpgradeable, MixinErrors {
   bytes32 public constant LOCK_MANAGER_ROLE = keccak256("LOCK_MANAGER");
   bytes32 public constant KEY_GRANTER_ROLE = keccak256("KEY_GRANTER");
 
-  // events
-  event LockManagerAdded(address indexed account);
-  event LockManagerRemoved(address indexed account);
-  event KeyGranterAdded(address indexed account);
-  event KeyGranterRemoved(address indexed account);
-
   // initializer
   function _initializeMixinRoles(address sender) internal {
 
@@ -55,14 +49,11 @@ contract MixinRoles is AccessControlUpgradeable, MixinErrors {
   function addLockManager(address account) public {
     _onlyLockManager();
     grantRole(LOCK_MANAGER_ROLE, account);
-    emit LockManagerAdded(account);
   }
 
   function renounceLockManager() public {
     renounceRole(LOCK_MANAGER_ROLE, msg.sender);
-    emit LockManagerRemoved(msg.sender);
   }
-
 
   // key granter functions
   function isKeyGranter(address account) public view returns (bool) {
@@ -72,13 +63,11 @@ contract MixinRoles is AccessControlUpgradeable, MixinErrors {
   function addKeyGranter(address account) public {
     _onlyLockManager();
     grantRole(KEY_GRANTER_ROLE, account);
-    emit KeyGranterAdded(account);
   }
 
   function revokeKeyGranter(address _granter) public {
     _onlyLockManager();
     revokeRole(KEY_GRANTER_ROLE, _granter);
-    emit KeyGranterRemoved(_granter);
   }
 
   uint256[1000] private __safe_upgrade_gap;


### PR DESCRIPTION
# Description

Here we remove the custom Lock events that are fired when setting roles (mostly to save on contract size). We will rely on the [`RoleGranted` event](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/3dac7bbed7b4c0dbf504180c33e8ed8e350b93eb/contracts/access/AccessControl.sol#L230) fired by OpenZeppelin AccessControl contract

Influence on contract size:

```
 ····························|·············|················
 |  PublicLock               ·     24.201  ·       -0.210  │
 ·---------------------------|-------------|---------------·
```

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

