### PR TITLE
fix(smart-contracts): remove duplicate `safeTransferFrom`

### DIFF
--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -275,24 +275,6 @@ contract MixinTransfer is
     return true;
   }
 
-  /**
-  * @notice Transfers the ownership of an NFT from one address to another address
-  * @dev This works identically to the other function with an extra data parameter,
-  *  except this function just sets data to ''
-  * @param _from The current owner of the NFT
-  * @param _to The new owner
-  * @param _tokenId The NFT to transfer
-  */
-  function safeTransferFrom(
-    address _from,
-    address _to,
-    uint _tokenId
-  )
-    public
-  {
-    safeTransferFrom(_from, _to, _tokenId, '');
-  }
-
    /**
    * @dev Sets or unsets the approval of a given operator
    * An operator is allowed to transfer all tokens of the sender on their behalf


### PR DESCRIPTION
# Description

This removes an additional `safeTransferFrom` signature that was just a shortcut to pass empty bytes data and can be easily reproduce by explicitly passing it to the other sig

Influence on contract size

```
 ····························|·············|················
 |  PublicLock               ·     24.325  ·       -0.086  │
 ·---------------------------|-------------|---------------·
```

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

