### PR TITLE
fix(subgraph): don't index locks below v5

### DIFF
--- a/subgraph/src/unlock.ts
+++ b/subgraph/src/unlock.ts
@@ -21,6 +21,9 @@ export function handleNewLock(event: NewLock): void {
     version = BigInt.fromI32(publicLockVersion.value.toI32())
   }
 
+  // dont index locks with versions lower than 5
+  if (version.lt(BigInt.fromI32(5))) return
+
   // store lock info from contract
   lock.tokenAddress = lockContract.tokenAddress()
   lock.price = lockContract.keyPrice()


### PR DESCRIPTION
# Description

Don't index locks below v5 on our subgraph v2 (they are missing `name` and `tokenAddress`)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

