### PR TITLE
feat(subgraph): support for new `LockConfig` event

### DIFF
--- a/docker/development/subgraph/startup.sh
+++ b/docker/development/subgraph/startup.sh
@@ -9,7 +9,7 @@ cat /home/unlock/subgraph/networks.json
 yarn workspace @unlock-protocol/subgraph codegen
 
 # build the subgraph files
-yarn workspace @unlock-protocol/subgraph graph build -- network localhost
+yarn workspace @unlock-protocol/subgraph graph build --network localhost
 
 # init the graph
 yarn workspace @unlock-protocol/subgraph run graph create testgraph --node http://graph-node:8020/ --version 0.0.1

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -45,7 +45,11 @@ contract MixinKeys is
   );
 
   event LockConfig(
+<<<<<<< HEAD
     uint expirationDuration,
+=======
+    uint newExpirationDuration,
+>>>>>>> 5066f46d3 (single function to set lock keys config)
     uint maxNumberOfKeys,
     uint maxKeysPerAcccount
   );

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -47,7 +47,7 @@ contract MixinKeys is
   event LockConfig(
     uint expirationDuration,
     uint maxNumberOfKeys,
-    uint maxKeysPerAcccount
+    uint maxKeysPerAddress
   );
 
   // Deprecated: don't use this anymore as we know enable multiple keys per owner.

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -45,11 +45,7 @@ contract MixinKeys is
   );
 
   event LockConfig(
-<<<<<<< HEAD
     uint expirationDuration,
-=======
-    uint newExpirationDuration,
->>>>>>> 5066f46d3 (single function to set lock keys config)
     uint maxNumberOfKeys,
     uint maxKeysPerAcccount
   );

--- a/smart-contracts/test/Lock/updateLockConfig.js
+++ b/smart-contracts/test/Lock/updateLockConfig.js
@@ -114,6 +114,7 @@ contract('Lock / updateLockConfig', (accounts) => {
     it('update the expiration duration of an existing lock', async () => {
       const tx = await lock.updateLockConfig(10, 20, 30)
       const { args } = tx.logs.find((v) => v.event === 'LockConfig')
+
       expect(args.expirationDuration.toNumber()).to.be.equal(10)
       expect(args.maxNumberOfKeys.toNumber()).to.be.equal(20)
       expect(args.maxKeysPerAcccount.toNumber()).to.be.equal(30)

--- a/smart-contracts/test/Lock/updateLockConfig.js
+++ b/smart-contracts/test/Lock/updateLockConfig.js
@@ -114,7 +114,6 @@ contract('Lock / updateLockConfig', (accounts) => {
     it('update the expiration duration of an existing lock', async () => {
       const tx = await lock.updateLockConfig(10, 20, 30)
       const { args } = tx.logs.find((v) => v.event === 'LockConfig')
-
       expect(args.expirationDuration.toNumber()).to.be.equal(10)
       expect(args.maxNumberOfKeys.toNumber()).to.be.equal(20)
       expect(args.maxKeysPerAcccount.toNumber()).to.be.equal(30)

--- a/smart-contracts/test/Lock/updateLockConfig.js
+++ b/smart-contracts/test/Lock/updateLockConfig.js
@@ -113,11 +113,11 @@ contract('Lock / updateLockConfig', (accounts) => {
   describe('emit correct event', () => {
     it('update the expiration duration of an existing lock', async () => {
       const tx = await lock.updateLockConfig(10, 20, 30)
-      const { args } = tx.logs.find((v) => v.event === 'LockConfig')
+      const { args } = tx.logs.find(({ event }) => event === 'LockConfig')
 
       expect(args.expirationDuration.toNumber()).to.be.equal(10)
       expect(args.maxNumberOfKeys.toNumber()).to.be.equal(20)
-      expect(args.maxKeysPerAcccount.toNumber()).to.be.equal(30)
+      expect(args.maxKeysPerAddress.toNumber()).to.be.equal(30)
     })
   })
 })

--- a/subgraph/abis/PublicLock.json
+++ b/subgraph/abis/PublicLock.json
@@ -3223,7 +3223,7 @@
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "maxKeysPerAcccount",
+        "name": "maxKeysPerAddress",
         "type": "uint256"
       }
     ],

--- a/subgraph/abis/PublicLock.json
+++ b/subgraph/abis/PublicLock.json
@@ -3185,7 +3185,7 @@
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "expirationDuration",
+        "name": "newExpiration",
         "type": "uint256"
       },
       {
@@ -3204,5 +3204,108 @@
     "name": "ExpirationChanged",
     "type": "event",
     "sig": "event ExpirationChanged(uint256 indexed,uint256,uint256,bool)"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expirationDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxNumberOfKeys",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxKeysPerAcccount",
+        "type": "uint256"
+      }
+    ],
+    "name": "LockConfig",
+    "type": "event",
+    "sig": "event LockConfig(uint256,uint256,uint256)"
+  },
+  {
+    "inputs": [],
+    "name": "onKeyExtendHook",
+    "outputs": [
+      {
+        "internalType": "contract ILockKeyExtendHook",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "sig": "function onKeyExtendHook() view returns (address)"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_onKeyPurchaseHook",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_onKeyCancelHook",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_onValidKeyHook",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_onTokenURIHook",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_onKeyTransferHook",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_onKeyExtendHook",
+        "type": "address"
+      }
+    ],
+    "name": "setEventHooks",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "sig": "function setEventHooks(address,address,address,address,address,address)"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newExpirationDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxNumberOfKeys",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxKeysPerAcccount",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateLockConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "sig": "function updateLockConfig(uint256,uint256,uint256)"
   }
 ]

--- a/subgraph/abis/PublicLockV12.json
+++ b/subgraph/abis/PublicLockV12.json
@@ -428,7 +428,7 @@
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "maxKeysPerAcccount",
+        "name": "maxKeysPerAddress",
         "type": "uint256"
       }
     ],

--- a/subgraph/abis/PublicLockV12.json
+++ b/subgraph/abis/PublicLockV12.json
@@ -263,7 +263,7 @@
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "expirationDuration",
+        "name": "newExpiration",
         "type": "uint256"
       },
       {
@@ -408,6 +408,31 @@
       }
     ],
     "name": "KeysMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expirationDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxNumberOfKeys",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxKeysPerAcccount",
+        "type": "uint256"
+      }
+    ],
+    "name": "LockConfig",
     "type": "event"
   },
   {
@@ -1435,6 +1460,19 @@
   },
   {
     "inputs": [],
+    "name": "onKeyExtendHook",
+    "outputs": [
+      {
+        "internalType": "contract ILockKeyExtendHook",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "onKeyPurchaseHook",
     "outputs": [
       {
@@ -1825,22 +1863,14 @@
         "internalType": "address",
         "name": "_onKeyTransferHook",
         "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_onKeyExtendHook",
+        "type": "address"
       }
     ],
     "name": "setEventHooks",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_newExpirationDuration",
-        "type": "uint256"
-      }
-    ],
-    "name": "setExpirationDuration",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1872,32 +1902,6 @@
       }
     ],
     "name": "setKeyManagerOf",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_maxKeys",
-        "type": "uint256"
-      }
-    ],
-    "name": "setMaxKeysPerAddress",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_maxNumberOfKeys",
-        "type": "uint256"
-      }
-    ],
-    "name": "setMaxNumberOfKeys",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -2218,6 +2222,29 @@
       }
     ],
     "name": "updateKeyPricing",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newExpirationDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxNumberOfKeys",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxKeysPerAcccount",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateLockConfig",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -8,6 +8,8 @@ type Lock @entity {
   lockManagers: [Bytes!]!
   version: BigInt!
   totalKeys: BigInt!
+  maxNumberOfKeys: BigInt
+  maxKeysPerAddress: BigInt
   keys: [Key!] @derivedFrom(field: "lock")
   createdAtBlock: BigInt
 }

--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -12,6 +12,7 @@ import {
   PricingChanged as PricingChangedEvent,
   RenewKeyPurchase as RenewKeyPurchaseEvent,
   Transfer as TransferEvent,
+  LockConfig as LockConfigEvent,
 } from '../generated/templates/PublicLock/PublicLock'
 
 import { PublicLockV11 as PublicLock } from '../generated/templates/PublicLock/PublicLockV11'
@@ -40,6 +41,16 @@ function newKey(event: TransferEvent): void {
   const lock = Lock.load(event.address.toHexString())
   if (lock) {
     lock.totalKeys = lock.totalKeys.plus(BigInt.fromI32(1))
+    lock.save()
+  }
+}
+
+export function handleLockConfig(event: LockConfigEvent): void {
+  const lock = Lock.load(event.address.toHexString())
+  if (lock) {
+    lock.expirationDuration = event.params.expirationDuration
+    lock.maxNumberOfKeys = event.params.maxNumberOfKeys
+    lock.maxKeysPerAddress = event.params.maxKeysPerAddress
     lock.save()
   }
 }
@@ -99,6 +110,7 @@ export function handleExpirationChangedUntilV11(
     key.save()
   }
 }
+
 export function handleExpirationChanged(event: ExpirationChangedEvent): void {
   const keyID = genKeyID(event.address, event.params.tokenId.toString())
   const key = Key.load(keyID)

--- a/subgraph/src/unlock.ts
+++ b/subgraph/src/unlock.ts
@@ -34,6 +34,9 @@ export function handleNewLock(event: NewLock): void {
   let maxKeysPerAddress = lockContract.try_maxKeysPerAddress()
   if (!maxKeysPerAddress.reverted) {
     lock.maxKeysPerAddress = maxKeysPerAddress.value
+  } else {
+    // set to 1 when using address instead of tokenId prior to lock v10
+    lock.maxKeysPerAddress = BigInt.fromI32(1)
   }
 
   let maxNumberOfKeys = lockContract.try_maxNumberOfKeys()

--- a/subgraph/src/unlock.ts
+++ b/subgraph/src/unlock.ts
@@ -31,6 +31,16 @@ export function handleNewLock(event: NewLock): void {
   lock.expirationDuration = lockContract.expirationDuration()
   lock.totalKeys = BigInt.fromI32(0)
 
+  let maxKeysPerAddress = lockContract.try_maxKeysPerAddress()
+  if (!maxKeysPerAddress.reverted) {
+    lock.maxKeysPerAddress = maxKeysPerAddress.value
+  }
+
+  let maxNumberOfKeys = lockContract.try_maxNumberOfKeys()
+  if (!maxNumberOfKeys.reverted) {
+    lock.maxNumberOfKeys = maxNumberOfKeys.value
+  }
+
   // store info from event
   lock.address = lockAddress
   lock.version = version

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -57,10 +57,12 @@ templates:
         - name: PublicLockV11
           file: ./abis/PublicLockV11.json
         - name: PublicLockV12
-          file: ./abis/PublicLockV11.json
+          file: ./abis/PublicLockV12.json
         - name: PublicLockV7
           file: ./abis/PublicLockV7.json
       eventHandlers:
+        - event: LockConfig(uint256,uint256,uint256)
+          handler: handleLockConfig
         - event: CancelKey(indexed uint256,indexed address,indexed address,uint256)
           handler: handleCancelKey
         - event: ExpirationChanged(indexed uint256,uint256,bool)

--- a/subgraph/tests/constants.ts
+++ b/subgraph/tests/constants.ts
@@ -9,6 +9,8 @@ export const tokenId = 1234
 export const now = 16613300000
 export const expiration = 16613302653
 export const tokenURI = 'http://token-api'
+export const maxNumberOfKeys = 10
+export const maxKeysPerAddress = 5
 
 // prices
 export const keyPrice = 1000

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -30,6 +30,8 @@ import {
   lockOwner,
   tokenAddress,
   nullAddress,
+  maxNumberOfKeys,
+  maxKeysPerAddress,
 } from './constants'
 
 // mock contract functions
@@ -61,6 +63,18 @@ describe('Describe Locks events', () => {
     assert.fieldEquals('Lock', lockAddress, 'tokenAddress', nullAddress)
     assert.fieldEquals('Lock', lockAddress, 'lockManagers', `[${lockOwner}]`)
     assert.fieldEquals('Lock', lockAddress, 'totalKeys', '0')
+    assert.fieldEquals(
+      'Lock',
+      lockAddress,
+      'maxNumberOfKeys',
+      `${maxNumberOfKeys}`
+    )
+    assert.fieldEquals(
+      'Lock',
+      lockAddress,
+      'maxKeysPerAddress',
+      `${maxKeysPerAddress}`
+    )
   })
 
   test('Lock manager added', () => {

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -10,6 +10,8 @@ import {
   tokenURI,
   nullAddress,
   keyPrice,
+  maxNumberOfKeys,
+  maxKeysPerAddress,
 } from './constants'
 
 createMockedFunction(
@@ -66,6 +68,24 @@ createMockedFunction(
 )
   .withArgs([])
   .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(duration))])
+
+createMockedFunction(
+  Address.fromString(lockAddress),
+  'maxNumberOfKeys',
+  'maxNumberOfKeys():(uint256)'
+)
+  .withArgs([])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(maxNumberOfKeys))])
+
+createMockedFunction(
+  Address.fromString(lockAddress),
+  'maxKeysPerAddress',
+  'maxKeysPerAddress():(uint256)'
+)
+  .withArgs([])
+  .returns([
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(maxKeysPerAddress)),
+  ])
 
 createMockedFunction(
   Address.fromString(lockAddress),

--- a/tests/test/helpers/subgraph.ts
+++ b/tests/test/helpers/subgraph.ts
@@ -48,6 +48,8 @@ const getLockQuery = gql`
       name
       totalKeys
       createdAtBlock
+      maxNumberOfKeys
+      maxKeysPerAddress
     }
   }
 `

--- a/tests/test/subgraph.ts
+++ b/tests/test/subgraph.ts
@@ -127,3 +127,51 @@ describe('Upgrade a lock', function () {
     expect(parseInt(lockInGraphAfterUpgrade.version)).to.equals(latestVersion)
   })
 })
+
+describe('(v12) Lock config', function () {
+  let lock: Contract
+  let lockAddress: string
+  before(async () => {
+    ;({ lock } = await unlock.createLock({ ...lockParams }))
+    lockAddress = lock.address.toLowerCase()
+  })
+
+  it('stores default values correctly', async () => {
+    expect(await lock.expirationDuration()).to.equals(
+      lockParams.expirationDuration
+    )
+    expect(await lock.maxNumberOfKeys()).to.equals(lockParams.maxNumberOfKeys)
+    expect(await lock.maxKeysPerAddress()).to.equals(1)
+
+    await awaitTimeout(2000)
+    const lockInGraph = await subgraph.getLock(lockAddress)
+    expect(parseInt(lockInGraph.expirationDuration)).to.equals(
+      lockParams.expirationDuration
+    )
+    expect(parseInt(lockInGraph.maxNumberOfKeys)).to.equals(
+      lockParams.maxNumberOfKeys
+    )
+    expect(parseInt(lockInGraph.maxKeysPerAddress)).to.equals(1)
+  })
+
+  it('stores new values correctly', async () => {
+    const config = {
+      expirationDuration: 100,
+      maxNumberOfKeys: 50,
+      maxKeysPerAddress: 10,
+    }
+
+    await lock.updateLockConfig(...Object.values(config))
+    await awaitTimeout(2000)
+    const lockInGraph = await subgraph.getLock(lockAddress)
+    expect(parseInt(lockInGraph.expirationDuration)).to.equals(
+      config.expirationDuration
+    )
+    expect(parseInt(lockInGraph.maxNumberOfKeys)).to.equals(
+      config.maxNumberOfKeys
+    )
+    expect(parseInt(lockInGraph.maxKeysPerAddress)).to.equals(
+      config.maxKeysPerAddress
+    )
+  })
+})


### PR DESCRIPTION
# Description

This adds `LockConfig` new event to the subgraph, as well as `maxNumberOfKeys` and `maxKeysPerAddress` to the lock schema.

Needs to rebase once #9888 is merged


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

