### PR TITLE
feat(unlock-app) - fix set default currency

### DIFF
--- a/unlock-app/src/components/interface/locks/Create/modals/SelectCurrencyModal.tsx
+++ b/unlock-app/src/components/interface/locks/Create/modals/SelectCurrencyModal.tsx
@@ -3,7 +3,7 @@ import { Token } from '@unlock-protocol/types'
 import { Button, Input } from '@unlock-protocol/ui'
 import { Fragment, useEffect, useState } from 'react'
 import { useDebounce } from 'react-use'
-import { utils } from 'ethers'
+import { ethers, utils } from 'ethers'
 import { useConfig } from '~/utils/withConfig'
 import { CryptoIcon } from '../../elements/KeyPrice'
 import { addressMinify } from '~/utils/strings'
@@ -18,6 +18,8 @@ interface SelectCurrencyModalProps {
   onSelect: (token: Token) => void
   defaultCurrency: string
 }
+
+export const ZERO = ethers.constants.AddressZero
 
 export const SelectCurrencyModal = ({
   isOpen,
@@ -56,7 +58,7 @@ export const SelectCurrencyModal = ({
 
   useEffect(() => {
     setTokens([
-      { name: defaultCurrency, symbol: defaultCurrency },
+      { name: defaultCurrency, symbol: defaultCurrency, address: ZERO },
       ...tokenItems,
     ])
   }, [network])
@@ -86,7 +88,7 @@ export const SelectCurrencyModal = ({
   const addToken = ({
     name,
     symbol,
-    address = undefined,
+    address,
     decimals = 18,
   }: Partial<Token>) => {
     const currentList = tokens || []

--- a/unlock-app/src/components/interface/locks/Manage/modals/UpdatePriceModal.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/modals/UpdatePriceModal.tsx
@@ -50,7 +50,6 @@ export const UpdatePriceModal = ({
   const {
     register,
     handleSubmit,
-    getValues,
     setValue,
     reset,
     formState: { isValid, errors },
@@ -77,9 +76,10 @@ export const UpdatePriceModal = ({
     getLock()
   )
 
-  const updatePrice = async (): Promise<any> => {
-    const { keyPrice = '', currencyContractAddress } = getValues()
-
+  const updatePrice = async ({
+    keyPrice = '',
+    currencyContractAddress,
+  }: EditFormProps): Promise<any> => {
     const erc20Address =
       currencyContractAddress || lock?.currencyContractAddress || 0
 
@@ -94,9 +94,9 @@ export const UpdatePriceModal = ({
 
   const updatePriceMutation = useMutation(updatePrice)
 
-  const onHandleSubmit = async () => {
+  const onHandleSubmit = async (fields: EditFormProps) => {
     if (isValid) {
-      await ToastHelper.promise(updatePriceMutation.mutateAsync(), {
+      await ToastHelper.promise(updatePriceMutation.mutateAsync(fields), {
         loading: 'Updating price...',
         success: 'Price updated',
         error: 'There is some unexpected issue, please try again',


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Currency change is not working for the default one, to fix `ZERO` address is set by default in order to avoid fallback to the current currency. Also `getValues` is removed to use `fields` value passed directly on `handleSubmit`
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

