### PR TITLE
fix(subgraph): make sure `tokenURI` doesnt revert

### DIFF
--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -29,7 +29,10 @@ function newKey(event: TransferEvent): void {
   key.createdAtBlock = event.block.number
 
   const lockContract = PublicLock.bind(event.address)
-  key.tokenURI = lockContract.tokenURI(event.params.tokenId)
+  const tokenURI = lockContract.try_tokenURI(event.params.tokenId)
+  if (!tokenURI.reverted) {
+    key.tokenURI = tokenURI.value
+  }
   key.expiration = getKeyExpirationTimestampFor(
     event.address,
     event.params.tokenId,


### PR DESCRIPTION
# Description

As we are allowing hooks for `tokenURI()`, we need to make sure the call does not revert - as it breaks our subgraph.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

