### PR TITLE
feature(unlock-js): by default deploying the latest version if none is et

### DIFF
--- a/packages/unlock-js/CHANGELOG.md
+++ b/packages/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+# 0.30.3
+
+- When no version is supplied, deploy the latest version of template.
+
 # 0.30.2
 
 - Add totalApproval option in purchase method
@@ -7,7 +11,6 @@
 # 0.30.1
 
 - Add `address` to schema.graphql
-
 
 # 0.30.0
 

--- a/packages/unlock-js/package.json
+++ b/packages/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.30.1",
+  "version": "0.30.3",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/unlock-js/src/Unlock/v11/createLock.js
+++ b/packages/unlock-js/src/Unlock/v11/createLock.js
@@ -30,10 +30,11 @@ async function _getKeyPrice(lock, provider) {
  * @param {function} callback invoked with the transaction hash
  */
 export default async function (lock, transactionOptions = {}, callback) {
-  // default lock version to 9
-  const lockVersion = lock.publicLockVersion || 9
-
   const unlockContract = await this.getUnlockContract()
+
+  const lockVersion =
+    lock.publicLockVersion || (await unlockContract.publicLockLatestVersion())
+
   let { maxNumberOfKeys, expirationDuration } = lock
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {
     maxNumberOfKeys = ETHERS_MAX_UINT


### PR DESCRIPTION
# Description

When no version was supplied we deployed v9... which was hardcoded.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

