### PR TITLE
feat(unlock-app) - Allow for 0 supply

### DIFF
--- a/unlock-app/src/components/interface/locks/Create/elements/CreateLockForm.tsx
+++ b/unlock-app/src/components/interface/locks/Create/elements/CreateLockForm.tsx
@@ -208,7 +208,7 @@ export const CreateLockForm = ({
             <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between">
                 <label className="block px-1 text-base" htmlFor="">
-                  Number of memberships:
+                  Number of memberships for sale:
                 </label>
                 <ToggleSwitch
                   title="Unlimited"
@@ -232,7 +232,7 @@ export const CreateLockForm = ({
                   step={1}
                   disabled={unlimitedQuantity}
                   {...register('maxNumberOfKeys', {
-                    min: 1,
+                    min: 0,
                     required: !unlimitedQuantity,
                   })}
                 />

--- a/unlock-app/src/components/interface/locks/Create/elements/CreateLockFormSummary.tsx
+++ b/unlock-app/src/components/interface/locks/Create/elements/CreateLockFormSummary.tsx
@@ -201,7 +201,9 @@ export const CreateLockFormSummary = ({
             </span>
           </div>
           <div className="flex flex-col gap-2">
-            <span className="text-base">Maximum number of memberships</span>
+            <span className="text-base">
+              Maximum number of memberships for sale
+            </span>
             <span className="text-xl font-bold">
               {unlimitedQuantity ? 'Unlimited' : formData?.maxNumberOfKeys}
             </span>

--- a/unlock-app/src/components/interface/locks/Manage/elements/LockDetailCard.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/LockDetailCard.tsx
@@ -70,7 +70,7 @@ const Detail = ({ label, value, prepend, loading, append }: DetailProps) => {
       ) : (
         <div className="flex items-center gap-2 text-right">
           {prepend && <>{prepend}</>}
-          <span className="text-base font-bold text-black">{value || '-'}</span>
+          <span className="text-base font-bold text-black">{value ?? '-'}</span>
           {append && <>{append}</>}
         </div>
       )}

--- a/unlock-app/src/components/interface/locks/Manage/modals/UpdateQuantityModal.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/modals/UpdateQuantityModal.tsx
@@ -99,7 +99,7 @@ export const UpdateQuantityModal = ({
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between">
               <label className="block px-1 mb-4 text-base" htmlFor="">
-                Number of memberships:
+                Number of memberships for sale:
               </label>
               <ToggleSwitch
                 title="Unlimited"
@@ -132,7 +132,7 @@ export const UpdateQuantityModal = ({
               />
               {errors?.maxNumberOfKeys && (
                 <span className="absolute -mt-1 text-xs text-red-700">
-                  Please choose a number of memberships for your lock.
+                  Please choose a number of memberships for sale for your lock.
                 </span>
               )}
             </div>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

- it should be possible to create a lock with a max number of keys of 0.
- "Number of memberships" should be "Number of memberships for sale".


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

