### PR TITLE
fix(locksmith): Add graphql-tag dependency explicitly

### DIFF
--- a/locksmith/package.json
+++ b/locksmith/package.json
@@ -60,6 +60,7 @@
     "express-winston": "4.2.0",
     "fuse.js": "6.6.2",
     "graphql": "16.6.0",
+    "graphql-tag": "2.12.6",
     "html-template-tag": "4.0.1",
     "isomorphic-fetch": "3.0.0",
     "jsonwebtoken": "8.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19101,6 +19101,7 @@ __metadata:
     express-winston: 4.2.0
     fuse.js: 6.6.2
     graphql: 16.6.0
+    graphql-tag: 2.12.6
     html-template-tag: 4.0.1
     isomorphic-fetch: 3.0.0
     jest: 27.5.1
@@ -36117,6 +36118,17 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"graphql-tag@npm:2.12.6, graphql-tag@npm:^2.12.6":
+  version: 2.12.6
+  resolution: "graphql-tag@npm:2.12.6"
+  dependencies:
+    tslib: ^2.1.0
+  peerDependencies:
+    graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: b15162a3d62f17b9b79302445b9ee330e041582f1c7faca74b9dec5daa74272c906ec1c34e1c50592bb6215e5c3eba80a309103f6ba9e4c1cddc350c46f010df
+  languageName: node
+  linkType: hard
+
 "graphql-tag@npm:^2.11.0, graphql-tag@npm:^2.12.3, graphql-tag@npm:^2.4.2":
   version: 2.12.5
   resolution: "graphql-tag@npm:2.12.5"
@@ -36125,17 +36137,6 @@ fsevents@~2.1.1:
   peerDependencies:
     graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
   checksum: 7afe8b0a261bc81278e8350cbc48a641986665fa88521ece137feb8d1d62aacbe79afd4e159b618d56af106291ae8369592e46584fd8fbaf4f440201ea884fdd
-  languageName: node
-  linkType: hard
-
-"graphql-tag@npm:^2.12.6":
-  version: 2.12.6
-  resolution: "graphql-tag@npm:2.12.6"
-  dependencies:
-    tslib: ^2.1.0
-  peerDependencies:
-    graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: b15162a3d62f17b9b79302445b9ee330e041582f1c7faca74b9dec5daa74272c906ec1c34e1c50592bb6215e5c3eba80a309103f6ba9e4c1cddc350c46f010df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Missing from package.json of locksmith so yarn uses from the monorepo node_modules. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

