### PR TITLE
feat(ui): Allow custom react node in the form inputs

### DIFF
--- a/packages/ui/lib/components/Form/FieldLayout.tsx
+++ b/packages/ui/lib/components/Form/FieldLayout.tsx
@@ -7,7 +7,7 @@ export interface Props {
   size?: Size
   error?: string
   success?: string
-  description?: string
+  description?: ReactNode
   children: ReactNode
 }
 
@@ -46,6 +46,7 @@ export function FieldLayout(props: Props) {
         </p>
       )
     }
+
     if (success) {
       return (
         <p id={label} className={successClass}>

--- a/packages/ui/lib/components/Form/Input.stories.tsx
+++ b/packages/ui/lib/components/Form/Input.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { MdPerson as PersonIcon } from 'react-icons/md'
 import { FiAtSign as AtSignIcon } from 'react-icons/fi'
 import { IconBaseProps } from 'react-icons'
+
 export default {
   component: Input,
   title: 'Input',
@@ -56,5 +57,24 @@ Error.args = {
   error: 'Invalid username',
   value: 'unlock',
   description: 'Type a good username',
+  copy: true,
+}
+
+export const CustomDescription = Template.bind({})
+
+const Description = () => (
+  <div>
+    Check out this{' '}
+    <a className="underline" href="https://example.com" target="#">
+      link
+    </a>
+  </div>
+)
+
+CustomDescription.args = {
+  icon: AtSignIcon,
+  label: 'Type your username',
+  value: 'unlock',
+  description: <Description />,
   copy: true,
 }

--- a/packages/ui/lib/components/Form/Input.tsx
+++ b/packages/ui/lib/components/Form/Input.tsx
@@ -1,4 +1,9 @@
-import { InputHTMLAttributes, ForwardedRef, ComponentType } from 'react'
+import {
+  InputHTMLAttributes,
+  ForwardedRef,
+  ComponentType,
+  ReactNode,
+} from 'react'
 import type { Size, SizeStyleProp } from '../../types'
 import { forwardRef } from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -17,7 +22,7 @@ export interface Props
   size?: Size
   success?: string
   error?: string
-  description?: string
+  description?: ReactNode
   icon?: IconType
   copy?: boolean
 }

--- a/packages/ui/lib/components/Form/TextBox.tsx
+++ b/packages/ui/lib/components/Form/TextBox.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, ForwardedRef } from 'react'
+import { InputHTMLAttributes, ForwardedRef, ReactNode } from 'react'
 import type { Size, SizeStyleProp } from '../../types'
 import { forwardRef } from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -13,7 +13,7 @@ export interface Props
   size?: Size
   success?: string
   error?: string
-  description?: string
+  description?: ReactNode
 }
 
 const SIZE_STYLES: SizeStyleProp = {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

<img width="454" alt="CleanShot 2022-10-25 at 12 09 36@2x" src="https://user-images.githubusercontent.com/73341821/197700660-9ba1a768-388c-4a1a-a735-6a8d0d9dbbc6.png">

https://github.com/unlock-protocol/unlock/issues/10014

Still restricted in what you can do because I'm not sure about allowing more flexibility but you can style elements which fit inside p tag so fixes the use case prescribed above.  


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

