### PR TITLE
feat(unlock-app) - add message when locks are not present for network

### DIFF
--- a/unlock-app/src/components/interface/locks/CheckoutUrl/elements/LocksForm.tsx
+++ b/unlock-app/src/components/interface/locks/CheckoutUrl/elements/LocksForm.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useAuth } from '~/contexts/AuthenticationContext'
 import {
-  Lock,
   MetadataInput,
   MetadataInputSchema,
   PaywallConfigLock,
@@ -13,6 +12,7 @@ import { Button, Select, Tooltip } from '@unlock-protocol/ui'
 import { SubgraphService } from '@unlock-protocol/unlock-js'
 import { addressMinify } from '~/utils/strings'
 import { FiDelete as DeleteIcon, FiEdit as EditIcon } from 'react-icons/fi'
+import { useQuery } from '@tanstack/react-query'
 
 const LockSchema = PaywallConfigLockSchema.omit({
   network: true, // network will managed with a custom input with the lock address
@@ -65,6 +65,12 @@ const MetadataDetail = ({ title, value }: MetadataDetailProps) => {
   )
 }
 
+const SelectPlaceholder = () => {
+  return (
+    <span className="w-full h-8 rounded-lg animate-pulse bg-slate-200"></span>
+  )
+}
+
 export const LocksForm = ({
   onChange,
   locks: locksDefault = {},
@@ -73,7 +79,6 @@ export const LocksForm = ({
   const { account } = useAuth()
   const [network, setNetwork] = useState<string | number>()
   const [lockAddress, setLockAddress] = useState<string>('')
-  const [locksByNetwork, setLocksByNetwork] = useState<any[]>([])
   const [addLock, setAddLock] = useState(false)
   const [defaultValue, setDefaultValue] = useState<Record<string, any>>({})
 
@@ -89,26 +94,26 @@ export const LocksForm = ({
     reset()
   }
 
-  useEffect(() => {
-    const getLocksByNetwork = async () => {
-      if (!network) return null
-      const service = new SubgraphService()
-      const locksByNetwork =
-        (await service.locks(
-          {
-            first: 1000,
-            where: {
-              lockManagers_contains: [account!],
-            },
+  const getLocksByNetwork = async () => {
+    if (!network) return null
+
+    const service = new SubgraphService()
+    return (
+      (await service.locks(
+        {
+          first: 1000,
+          where: {
+            lockManagers_contains: [account!],
           },
-          {
-            networks: [`${network!}`],
-          }
-        )) ?? []
-      setLocksByNetwork(locksByNetwork)
-    }
-    getLocksByNetwork()
-  }, [account, network])
+        },
+        {
+          networks: [`${network!}`],
+        }
+      )) ?? []
+    )
+  }
+  const { isLoading: isLoadingLocksByNetwork, data: locksByNetwork = [] } =
+    useQuery([network, account], async () => getLocksByNetwork())
 
   const networksOptions = Object.entries(networks).map(
     ([id, { name: label }]: [string, any]) => ({
@@ -135,7 +140,7 @@ export const LocksForm = ({
     onChange(newObj)
   }
 
-  const locksOptions: any = locksByNetwork?.map(({ address, name }: Lock) => {
+  const locksOptions: any = locksByNetwork?.map(({ address, name }: any) => {
     const disabled = Object.keys(locks)?.find(
       (lockAddress: string) =>
         lockAddress?.toLowerCase() === address?.toLowerCase()
@@ -311,6 +316,7 @@ export const LocksForm = ({
   const showForm = !hasLocks || addLock
 
   const [addMetadata, setAddMetadata] = useState(false)
+  const networkHasLocks = (locksByNetwork ?? [])?.length > 0
 
   return (
     <>
@@ -327,18 +333,32 @@ export const LocksForm = ({
                 options={networksOptions}
                 size="small"
                 defaultValue={network}
-                onChange={setNetwork}
-              />
-              <Select
-                label="Lock"
-                options={locksOptions}
-                size="small"
-                defaultValue={lockAddress}
-                onChange={(lockAddress: any) => {
-                  setLockAddress(`${lockAddress}`)
-                  onAddLock(lockAddress, network!)
+                onChange={(network) => {
+                  setNetwork(network)
+                  onRemoveFromList(lockAddress)
+                  setLockAddress('')
                 }}
               />
+              {isLoadingLocksByNetwork ? (
+                <SelectPlaceholder />
+              ) : (
+                <>
+                  {networkHasLocks ? (
+                    <Select
+                      label="Lock"
+                      options={locksOptions}
+                      size="small"
+                      defaultValue={lockAddress}
+                      onChange={(lockAddress: any) => {
+                        setLockAddress(`${lockAddress}`)
+                        onAddLock(lockAddress, network!)
+                      }}
+                    />
+                  ) : (
+                    <span className="text-base">This network has no locks</span>
+                  )}
+                </>
+              )}
             </div>
           </div>
           {hasMinValue && (


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

**Loading when retrieving locks** 
<img width="703" alt="Screenshot 2022-10-25 at 10 50 27" src="https://user-images.githubusercontent.com/20865711/197731925-12198d92-4127-4878-adc8-83b3c1c3b16e.png">

**Message when there is no locks** 
<img width="659" alt="Screenshot 2022-10-25 at 10 51 01" src="https://user-images.githubusercontent.com/20865711/197732059-2ac0ad74-c7bf-4af8-a34f-f1f751ef46f1.png">

**Lock list for network** 
<img width="653" alt="Screenshot 2022-10-25 at 10 50 21" src="https://user-images.githubusercontent.com/20865711/197732169-a5f208d7-1494-42f2-bfed-b682be5223e1.png">


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

