### PR TITLE
fix(hardhat-plugin): allow to pass `unlockAddress` when creating a lock

### DIFF
--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 0.0.16
+
+- Allow to pass `unlockAddress` when creating a lock
+
 ### 0.0.11
 
 - add `deployAndSetTemplate`

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/hardhat-plugin",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Hardhat Plugin for Unlock Protocol",
   "author": "Unlock Protocol",
   "license": "MIT",

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/hardhat-plugin",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Hardhat Plugin for Unlock Protocol",
   "author": "Unlock Protocol",
   "license": "MIT",

--- a/packages/hardhat-plugin/src/createLock.ts
+++ b/packages/hardhat-plugin/src/createLock.ts
@@ -15,6 +15,7 @@ export interface CreateLockArgs {
   maxNumberOfKeys?: number
   beneficiary?: string
   version?: number
+  unlockAddress?: string
 }
 
 export interface CreateLockFunction {
@@ -35,6 +36,7 @@ export async function createLock(
     maxNumberOfKeys,
     beneficiary,
     version = PUBLIC_LOCK_LATEST_VERSION,
+    unlockAddress,
   }: CreateLockArgs
 ): Promise<{
   lock: Contract
@@ -63,7 +65,7 @@ export async function createLock(
   ])
 
   // create the lock
-  const unlock = await getUnlockContract(hre)
+  const unlock = await getUnlockContract(hre, unlockAddress)
   const tx = await unlock.createUpgradeableLockAtVersion(calldata, version)
   const { events, transactionHash } = await tx.wait()
   const { args } = events.find(({ event }: any) => event === 'NewLock')


### PR DESCRIPTION
# Description

A simple thing that was already built-in but the setter was not there

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

