### PR TITLE
fix(unlock-app): Loading spinner is stuck inside verification scanner if not logged in

### DIFF
--- a/unlock-app/src/components/content/SettingsContent.tsx
+++ b/unlock-app/src/components/content/SettingsContent.tsx
@@ -25,7 +25,7 @@ export const PaymentSettings = () => {
   const [isSaving, setIsSaving] = useState(false)
   const {
     data: methods,
-    isLoading: isMethodLoading,
+    isInitialLoading: isMethodLoading,
     refetch,
   } = useQuery(
     ['list-cards', account],

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -71,7 +71,7 @@ export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
     }
   )
 
-  const lockVersion = lock?.version
+  const lockVersion = Number(lock?.version)
 
   const { isInitialLoading: isKeyLoading, data: key } = useQuery(
     ['key', lockAddress, tokenId, network],

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/CardPayment.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/CardPayment.tsx
@@ -42,7 +42,7 @@ export function CardPayment({ checkoutService, injectedProvider }: Props) {
 
   const {
     data: methods,
-    isLoading: isMethodLoading,
+    isInitialLoading: isMethodLoading,
     refetch,
   } = useQuery(
     ['list-cards', account],

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Metadata.tsx
@@ -53,7 +53,7 @@ export function Metadata({ checkoutService, injectedProvider }: Props) {
     name: 'metadata',
     control,
   })
-  const { isLoading: isMemberLoading, data: isMember } = useQuery(
+  const { isInitialLoading: isMemberLoading, data: isMember } = useQuery(
     ['isMember', account, lock],
     async () => {
       const total = await web3Service.totalKeys(
@@ -68,7 +68,7 @@ export function Metadata({ checkoutService, injectedProvider }: Props) {
     }
   )
 
-  const { data: address, isLoading: isEnsLoading } = useQuery(
+  const { data: address, isInitialLoading: isEnsLoading } = useQuery(
     ['ens', account],
     () => {
       return getNameOrAddressForAddress(account!)
@@ -200,7 +200,7 @@ export function Metadata({ checkoutService, injectedProvider }: Props) {
                           Change
                         </Button>
                       </div>
-                      <p className="text-gray-600 text-xs">
+                      <p className="text-xs text-gray-600">
                         The Ethereum address that will receive the membership
                         NFT
                       </p>

--- a/unlock-app/src/components/interface/checkout/alpha/Checkout/Select.tsx
+++ b/unlock-app/src/components/interface/checkout/alpha/Checkout/Select.tsx
@@ -103,34 +103,35 @@ export function Select({ checkoutService, injectedProvider }: Props) {
   const { account, network, changeNetwork, isUnlockAccount } = useAuth()
   const web3Service = useWeb3Service()
 
-  const { isLoading: isMembershipsLoading, data: memberships } = useQuery(
-    ['memberships', account, JSON.stringify(paywallConfig)],
-    async () => {
-      const memberships = await Promise.all(
-        Object.entries(paywallConfig.locks).map(
-          async ([lockAddress, props]) => {
-            const lockNetwork = props.network || paywallConfig.network || 1
-            const [member, total] = await Promise.all([
-              web3Service.getHasValidKey(lockAddress, account!, lockNetwork),
-              web3Service.totalKeys(lockAddress, account!, lockNetwork),
-            ])
-            // if not member but total is above 0
-            const expired = !member && total > 0
-            return {
-              lock: lockAddress,
-              expired,
-              member,
-              network: lockNetwork,
+  const { isInitialLoading: isMembershipsLoading, data: memberships } =
+    useQuery(
+      ['memberships', account, JSON.stringify(paywallConfig)],
+      async () => {
+        const memberships = await Promise.all(
+          Object.entries(paywallConfig.locks).map(
+            async ([lockAddress, props]) => {
+              const lockNetwork = props.network || paywallConfig.network || 1
+              const [member, total] = await Promise.all([
+                web3Service.getHasValidKey(lockAddress, account!, lockNetwork),
+                web3Service.totalKeys(lockAddress, account!, lockNetwork),
+              ])
+              // if not member but total is above 0
+              const expired = !member && total > 0
+              return {
+                lock: lockAddress,
+                expired,
+                member,
+                network: lockNetwork,
+              }
             }
-          }
+          )
         )
-      )
-      return memberships
-    },
-    {
-      enabled: !!account,
-    }
-  )
+        return memberships
+      },
+      {
+        enabled: !!account,
+      }
+    )
 
   const lockNetwork = lock?.network ? config?.networks?.[lock.network] : null
   const isNetworkSwitchRequired =

--- a/unlock-app/src/components/interface/verification/MembershipCard.tsx
+++ b/unlock-app/src/components/interface/verification/MembershipCard.tsx
@@ -34,7 +34,10 @@ export interface MembershipData {
 
 interface Props {
   timestamp: number
-  lock: Lock
+  lock: {
+    name: string
+    address: string
+  }
   membershipData: MembershipData
   network: number
   invalid?: string

--- a/unlock-app/src/components/interface/verification/MembershipCard.tsx
+++ b/unlock-app/src/components/interface/verification/MembershipCard.tsx
@@ -3,7 +3,6 @@ import {
   Fallback as AvatarFallback,
   Root as Avatar,
 } from '@radix-ui/react-avatar'
-import { Lock } from '~/unlockTypes'
 import dayjs from 'dayjs'
 import relativeTimePlugin from 'dayjs/plugin/relativeTime'
 import { addressMinify } from '~/utils/strings'


### PR DESCRIPTION


<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

React query is stuck loading if the dependent request fails which is causing issue with the verification page. 

This fixes it and also changes other instances to smooth out fallbacks. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

