### PR TITLE
feat(locksmith): Allow overriding saved empty metadata

### DIFF
--- a/locksmith/__tests__/controllers/v2/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/v2/metadataController.test.ts
@@ -62,6 +62,46 @@ describe('Metadata v2 endpoints for locksmith', () => {
     })
   })
 
+  it('Add empty metadata and update it later', async () => {
+    expect.assertions(4)
+    const lockAddress = await ethers.Wallet.createRandom().getAddress()
+    const walletAddress = await ethers.Wallet.createRandom().getAddress()
+    const metadata = {
+      public: {},
+      protected: {},
+    }
+
+    const userMetadataResponse = await request(app)
+      .post(`/v2/api/metadata/100/locks/${lockAddress}/users/${walletAddress}`)
+      .send({ metadata })
+
+    expect(userMetadataResponse.status).toBe(201)
+    expect(userMetadataResponse.body).toStrictEqual({
+      userMetadata: metadata,
+    })
+
+    const metadata2 = {
+      public: {},
+      protected: {
+        email: 'test@gmail.com',
+      },
+    }
+
+    const userMetadataResponse2 = await request(app)
+      .post(`/v2/api/metadata/100/locks/${lockAddress}/users/${walletAddress}`)
+      .send({ metadata: metadata2 })
+
+    expect(userMetadataResponse2.body).toStrictEqual({
+      userMetadata: metadata2,
+    })
+
+    const userMetadataResponse3 = await request(app)
+      .post(`/v2/api/metadata/100/locks/${lockAddress}/users/${walletAddress}`)
+      .send({ metadata: metadata2 })
+
+    expect(userMetadataResponse3.status).toBe(409)
+  })
+
   it('Add invalid user metadata', async () => {
     expect.assertions(2)
     const lockAddress = await ethers.Wallet.createRandom().getAddress()
@@ -94,11 +134,9 @@ describe('Metadata v2 endpoints for locksmith', () => {
             protected: {
               email: `${index}@example.com`,
             },
-          }
-          const keyId = String(index + 1)
+          } as const
           return {
             userAddress,
-            keyId,
             lockAddress,
             metadata,
           }
@@ -123,6 +161,54 @@ describe('Metadata v2 endpoints for locksmith', () => {
     expect(userMetadataResponse.status).toBe(201)
     expect(usersMetadata).toStrictEqual(expectedUsersMetadata)
     expect(userMetadataResponse2.body.result?.length).toBe(0)
+  })
+
+  it('Add empty users in bulk', async () => {
+    expect.assertions(4)
+    const users = await Promise.all(
+      Array(3)
+        .fill(0)
+        .map(async () => {
+          const lockAddress = await ethers.Wallet.createRandom().getAddress()
+          const userAddress = await ethers.Wallet.createRandom().getAddress()
+          const metadata: Record<
+            'public' | 'protected',
+            Record<string, any>
+          > = {
+            public: {},
+            protected: {},
+          }
+          return {
+            userAddress,
+            lockAddress,
+            metadata,
+          }
+        })
+    )
+
+    const userMetadataResponse = await request(app)
+      .post('/v2/api/metadata/100/users')
+      .send({ users })
+
+    expect(userMetadataResponse.body.result.length).toBe(3)
+
+    const metadataAddedUsers = users.map((item, index) => {
+      item.metadata.protected.email = `${index}@gmail.com`
+      return item
+    })
+
+    const userMetadataResponse2 = await request(app)
+      .post('/v2/api/metadata/100/users')
+      .send({ users: metadataAddedUsers })
+
+    expect(userMetadataResponse2.body.result.length).toBe(3)
+
+    const userMetadataResponse3 = await request(app)
+      .post('/v2/api/metadata/100/users')
+      .send({ users: metadataAddedUsers })
+
+    expect(userMetadataResponse3.body.result.length).toBe(0)
+    expect(userMetadataResponse3.status).toBe(409)
   })
 
   it('Add bulk broken user metadata', async () => {

--- a/locksmith/__tests__/controllers/v2/metadataController.test.ts
+++ b/locksmith/__tests__/controllers/v2/metadataController.test.ts
@@ -164,7 +164,7 @@ describe('Metadata v2 endpoints for locksmith', () => {
   })
 
   it('Add empty users in bulk', async () => {
-    expect.assertions(4)
+    expect.assertions(3)
     const users = await Promise.all(
       Array(3)
         .fill(0)
@@ -208,7 +208,6 @@ describe('Metadata v2 endpoints for locksmith', () => {
       .send({ users: metadataAddedUsers })
 
     expect(userMetadataResponse3.body.result.length).toBe(0)
-    expect(userMetadataResponse3.status).toBe(409)
   })
 
   it('Add bulk broken user metadata', async () => {

--- a/locksmith/src/controllers/v2/metadataController.ts
+++ b/locksmith/src/controllers/v2/metadataController.ts
@@ -9,6 +9,7 @@ import { KeyMetadata } from '../../models/keyMetadata'
 import { LockMetadata } from '../../models/lockMetadata'
 import { UserTokenMetadata } from '../../models'
 import * as lockOperations from '../../operations/lockOperations'
+import { isEmpty } from 'lodash'
 
 const UserMetadata = z
   .object({
@@ -19,14 +20,20 @@ const UserMetadata = z
   .partial()
 
 const UserMetadataBody = z.object({
-  lockAddress: z.string(),
-  userAddress: z.string(),
+  lockAddress: z.string().transform((item) => Normalizer.ethereumAddress(item)),
+  userAddress: z.string().transform((item) => Normalizer.ethereumAddress(item)),
   metadata: UserMetadata,
 })
 
 const BulkUserMetadataBody = z.object({
   users: z.array(UserMetadataBody),
 })
+
+function isMetadataEmpty(data: Record<string, any>) {
+  const publicData = isEmpty(data?.public)
+  const protectedData = isEmpty(data?.protected)
+  return publicData && protectedData
+}
 
 export class MetadataController {
   public web3Service: Web3Service
@@ -207,18 +214,23 @@ export class MetadataController {
       })
 
       // If no metadata was set previously, we let anyone set it.
-      if (!userData) {
-        const newUserData = new UserTokenMetadata()
-        newUserData.tokenAddress = tokenAddress
-        newUserData.chain = network
-        newUserData.userAddress = userAddress
-        newUserData.data = {
-          userMetadata: {
-            ...metadata,
+      if (isMetadataEmpty(userData?.data?.userMetadata)) {
+        const [createdUser] = await UserTokenMetadata.upsert(
+          {
+            tokenAddress,
+            chain: network,
+            userAddress: userAddress,
+            data: {
+              userMetadata: {
+                ...metadata,
+              },
+            },
           },
-        }
-        const createdUserMetadata = await newUserData.save()
-        return response.status(201).send(createdUserMetadata.data)
+          {
+            returning: true,
+          }
+        )
+        return response.status(201).send(createdUser.data)
       }
 
       return response.status(409).send({
@@ -345,37 +357,45 @@ export class MetadataController {
         },
       })
 
-      const newUsersData = users
-        // Filter existing users
-        .filter(
-          (nu) =>
-            !userMetadataResults.some(
-              (item) =>
-                item.tokenAddress === nu.lockAddress &&
-                item.userAddress === nu.userAddress
-            )
-        )
-        .map((user) => {
-          const userAddress = Normalizer.ethereumAddress(user.userAddress)
-          const lockAddress = Normalizer.ethereumAddress(user.lockAddress)
-          const tokenAddress = lockAddress
-          const metadata = UserMetadata.parse(user.metadata)
+      const filteredUsers = users.filter(
+        (user) =>
+          !userMetadataResults.some(
+            ({ tokenAddress, userAddress, data }) =>
+              user.lockAddress === tokenAddress &&
+              user.userAddress === userAddress &&
+              !isMetadataEmpty(data?.userMetadata)
+          )
+      )
+
+      const newUsersData = filteredUsers.map(
+        ({ userAddress, lockAddress, metadata }) => {
+          const data = UserMetadata.parse(metadata)
           const newUserData = {
             userAddress,
-            tokenAddress,
+            tokenAddress: lockAddress,
             chain: network,
             data: {
               userMetadata: {
-                ...metadata,
+                ...data,
               },
             },
           }
           return newUserData
-        })
+        }
+      )
 
-      const items = await UserTokenMetadata.bulkCreate(newUsersData)
+      // Sequelize v6.x support bulk upsert in the bulkCreate so replace
+      const result = await Promise.all(
+        newUsersData.map(async (item) => {
+          const [createdUser] = await UserTokenMetadata.upsert(item, {
+            returning: true,
+          })
+          return createdUser.toJSON()
+        })
+      )
+
       return response.status(201).send({
-        result: items,
+        result,
       })
     } catch (error) {
       logger.error(error)


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Allow users to override empty metadata even if it was saved earlier. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

