### PR TITLE
feat(locksmith): Add script to send email to all users of lock

### DIFF
--- a/locksmith/package.json
+++ b/locksmith/package.json
@@ -26,7 +26,8 @@
     "authorize": "./scripts/authorize-lock",
     "websub:start": "yarn build && node -r ./src/utils/envLoader.js ./build/src/websub/server.js",
     "websub:dev": "NODE_ENV=development yarn db:migrate && ts-node-dev -r ./src/utils/envLoader.js ./src/websub/server.ts",
-    "websub:prod": "cd build && node -r ./src/utils/envLoader ./src/websub/server.js"
+    "websub:prod": "cd build && node -r ./src/utils/envLoader ./src/websub/server.js",
+    "send:email": "ts-node scripts/send_email.ts"
   },
   "lint-staged": {
     "*.{js,ts}": [
@@ -116,6 +117,7 @@
     "run-script-os": "1.1.6",
     "supertest": "6.2.4",
     "ts-jest": "27.1.5",
+    "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",
     "typescript": "4.6.4"
   },

--- a/locksmith/scripts/send_email.ts
+++ b/locksmith/scripts/send_email.ts
@@ -18,7 +18,7 @@ const argv = yargs
   .help()
   .alias('h', 'help')
   .example(
-    'yarn ts-node scripts/send_email --network 5 --lockAddress xyz',
+    'yarn ts-node scripts/send_email.ts --network 5 --lockAddress xyz',
     'send emails to all users on goerli on xyz lock address.'
   ).argv
 
@@ -39,7 +39,7 @@ async function run({ lockAddress, network }: Options) {
       networks: [network],
     }
   )
-  await notifyNewKeysToWedlocks(keys)
+  await notifyNewKeysToWedlocks(keys, network)
 }
 
 if (argv.lockAddress && argv.network) {

--- a/locksmith/scripts/send_email.ts
+++ b/locksmith/scripts/send_email.ts
@@ -1,0 +1,52 @@
+import { notifyNewKeysToWedlocks } from '../src/operations/wedlocksOperations'
+import { SubgraphService } from '@unlock-protocol/unlock-js'
+import yargs from 'yargs'
+
+const argv = yargs
+  .option('network', {
+    requiresArg: true,
+    type: 'number',
+    alias: 'n',
+    description: 'Network ID of the network',
+  })
+  .option('lockAddress', {
+    requiresArg: true,
+    type: 'string',
+    alias: 'l',
+    description: 'Lock Address to use.',
+  })
+  .help()
+  .alias('h', 'help')
+  .example(
+    'yarn ts-node scripts/send_email --network 5 --lockAddress xyz',
+    'send emails to all users on goerli on xyz lock address.'
+  ).argv
+
+interface Options {
+  lockAddress: string
+  network: number
+}
+
+async function run({ lockAddress, network }: Options) {
+  const service = new SubgraphService()
+  const keys = await service.keys(
+    {
+      where: {
+        lock_in: [lockAddress.toLowerCase()],
+      },
+    },
+    {
+      networks: [network],
+    }
+  )
+  await notifyNewKeysToWedlocks(keys)
+}
+
+if (argv.lockAddress && argv.network) {
+  run({
+    lockAddress: argv.lockAddress,
+    network: argv.network,
+  }).catch(console.error)
+} else {
+  console.log(argv)
+}

--- a/locksmith/scripts/send_email.ts
+++ b/locksmith/scripts/send_email.ts
@@ -31,6 +31,7 @@ async function run({ lockAddress, network }: Options) {
   const service = new SubgraphService()
   const keys = await service.keys(
     {
+      first: 1000,
       where: {
         lock_in: [lockAddress.toLowerCase()],
       },

--- a/locksmith/scripts/send_email.ts
+++ b/locksmith/scripts/send_email.ts
@@ -41,13 +41,20 @@ async function run({ lockAddress, network }: Options) {
     }
   )
   await notifyNewKeysToWedlocks(keys, network)
+  return keys
 }
 
 if (argv.lockAddress && argv.network) {
   run({
     lockAddress: argv.lockAddress,
     network: argv.network,
-  }).catch(console.error)
+  })
+    .then((keys) => {
+      console.log(
+        `Successfully sent emails to recipients associated with ${keys.length} keys.`
+      )
+    })
+    .catch(console.error)
 } else {
   console.log(argv)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19038,6 +19038,7 @@ __metadata:
     stripe: 8.215.0
     supertest: 6.2.4
     ts-jest: 27.1.5
+    ts-node: 10.9.1
     ts-node-dev: 2.0.0
     typescript: 4.6.4
     unlock-abi-1-1: 1.1.1
@@ -57935,25 +57936,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ts-node@npm:7.0.1":
-  version: 7.0.1
-  resolution: "ts-node@npm:7.0.1"
-  dependencies:
-    arrify: ^1.0.0
-    buffer-from: ^1.1.0
-    diff: ^3.1.0
-    make-error: ^1.1.1
-    minimist: ^1.2.0
-    mkdirp: ^0.5.1
-    source-map-support: ^0.5.6
-    yn: ^2.0.0
-  bin:
-    ts-node: dist/bin.js
-  checksum: 07ed6ea1805361828737a767cfd6c57ea6e267ee8679282afb933610af02405e1a87c1f2aea1d38ed8e66b34fcbf6272b6021ab95d78849105d2e57fc283870b
-  languageName: node
-  linkType: hard
-
-"ts-node@npm:>=8.0.0, ts-node@npm:^10.6.0, ts-node@npm:^10.8.1":
+"ts-node@npm:10.9.1, ts-node@npm:>=8.0.0, ts-node@npm:^10.6.0, ts-node@npm:^10.8.1":
   version: 10.9.1
   resolution: "ts-node@npm:10.9.1"
   dependencies:
@@ -57988,6 +57971,24 @@ resolve@^2.0.0-next.3:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
+  languageName: node
+  linkType: hard
+
+"ts-node@npm:7.0.1":
+  version: 7.0.1
+  resolution: "ts-node@npm:7.0.1"
+  dependencies:
+    arrify: ^1.0.0
+    buffer-from: ^1.1.0
+    diff: ^3.1.0
+    make-error: ^1.1.1
+    minimist: ^1.2.0
+    mkdirp: ^0.5.1
+    source-map-support: ^0.5.6
+    yn: ^2.0.0
+  bin:
+    ts-node: dist/bin.js
+  checksum: 07ed6ea1805361828737a767cfd6c57ea6e267ee8679282afb933610af02405e1a87c1f2aea1d38ed8e66b34fcbf6272b6021ab95d78849105d2e57fc283870b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Can be used to send emails to all users of a lock (`1000` in subgraph service will be removed later when we handle it in the subgraph service itself).

### Usage

```shell
yarn send:email --help
yarn send:email --lockAddress 0x0000 --network 5
```


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

