### PR TITLE
feat(locksmith): Handle MAX UINT value expiration in key metadata

### DIFF
--- a/locksmith/__tests__/utils/keyData.test.ts
+++ b/locksmith/__tests__/utils/keyData.test.ts
@@ -23,13 +23,7 @@ describe('KeyData', () => {
       it('passes the data through', () => {
         expect.assertions(1)
         expect(keyData.openSeaPresentation({})).toEqual({
-          attributes: [
-            {
-              trait_type: 'Expiration',
-              value: 0,
-              display_type: 'date',
-            },
-          ],
+          attributes: [],
         })
       })
     })

--- a/locksmith/src/utils/keyData.ts
+++ b/locksmith/src/utils/keyData.ts
@@ -1,7 +1,14 @@
 import { SubgraphService } from '@unlock-protocol/unlock-js'
 import logger from '../logger'
+import { ethers } from 'ethers'
+import { Attribute } from '../types'
 
-type Data = Partial<Record<'expiration' | 'tokenId' | 'owner', string>>
+interface Key {
+  expiration?: number
+  tokenId: string
+  owner: string
+}
+
 export default class KeyData {
   async get(lockAddress: string, tokenId: string, network: number) {
     try {
@@ -17,30 +24,44 @@ export default class KeyData {
           network,
         }
       )
-      const data: Data = {
-        expiration: key?.expiration,
+
+      let keyExpiration = key?.expiration
+
+      // If max uint, then there is no expiration
+      if (
+        keyExpiration &&
+        keyExpiration === ethers.constants.MaxUint256.toString()
+      ) {
+        keyExpiration = undefined
+      }
+
+      const data: Key = {
+        expiration: keyExpiration ? parseInt(keyExpiration) : undefined,
         tokenId: key?.tokenId,
         owner: key?.owner,
       }
+
       return data
     } catch (error) {
       logger.error(
         `There was an error retrieving info for metadata ${lockAddress} ${tokenId} on ${network}`,
         error
       )
-      return {} as Data
+      return {} as Key
     }
   }
 
-  openSeaPresentation(data: any) {
+  openSeaPresentation(data: Partial<Key>) {
+    const attributes: Attribute[] = []
+    if (data.expiration) {
+      attributes.push({
+        trait_type: 'Expiration',
+        display_type: 'date',
+        value: data.expiration,
+      })
+    }
     return {
-      attributes: [
-        {
-          trait_type: 'Expiration',
-          value: data.expiration || 0,
-          display_type: 'date',
-        },
-      ],
+      attributes,
     }
   }
 }


### PR DESCRIPTION


<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

As discussed, I've removed the expiration attributes when we receive a MAX_UINT value which means there is no expiration but kept an expiration property otherwise if there is one because It's valuable to showcase time-bound NFTies on opensea. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

