### PR TITLE
fix(unlock-app): Use the same number of recipients for data field regardless

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Confirm.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm.tsx
@@ -149,7 +149,8 @@ export function Confirm({
     useQuery(
       ['purchaseData', lockAddress, lockNetwork, JSON.stringify(recipients)],
       async () => {
-        let purchaseData = password || captcha || ['0x']
+        let purchaseData =
+          password || captcha || Array.from({ length: recipients.length })
         const dataBuilder =
           paywallConfig.locks[lock!.address].dataBuilder ||
           paywallConfig.dataBuilder
@@ -182,13 +183,13 @@ export function Confirm({
       ['purchasePriceFor', lockAddress, lockNetwork],
       async () => {
         const prices = await Promise.all(
-          recipients.map(async (recipient) => {
+          recipients.map(async (recipient, index) => {
             const options = {
               lockAddress: lockAddress,
               network: lockNetwork,
               userAddress: recipient,
               referrer: paywallConfig.referrer || recipient,
-              data: purchaseData?.[0] || '0x',
+              data: purchaseData?.[index] || '0x',
             }
             const price = await web3Service.purchasePriceFor(options)
 


### PR DESCRIPTION


<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

