### PR TITLE
fix(subgraph): don't remove entire list on handleLockManagerRemoved

### DIFF
--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -210,7 +210,7 @@ export function handleLockManagerRemoved(event: LockManagerRemovedEvent): void {
   if (lock && lock.lockManagers) {
     const lockManagers = lock.lockManagers
     const i = lockManagers.indexOf(event.params.account)
-    lockManagers.splice(i)
+    lockManagers.splice(i, 1)
     lock.lockManagers = lockManagers
     lock.save()
   }

--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -208,8 +208,13 @@ export function handleRoleGranted(event: RoleGrantedEvent): void {
 export function handleLockManagerRemoved(event: LockManagerRemovedEvent): void {
   const lock = Lock.load(event.address.toHexString())
   if (lock && lock.lockManagers) {
-    const lockManagers = lock.lockManagers
-    lock.lockManagers = lockManagers.filter(managerAddress => managerAddress != event.params.account)
+    for (let i = 0; i < lock.lockManagers.length; i++) {
+      const managerAddress = lock.lockManagers[i]
+      if (managerAddress != event.params.account) {
+        newManagers.push(managerAddress)
+      }
+    }
+    lock.lockManagers = newManagers;
     lock.save()
   }
 }

--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -208,6 +208,7 @@ export function handleRoleGranted(event: RoleGrantedEvent): void {
 export function handleLockManagerRemoved(event: LockManagerRemovedEvent): void {
   const lock = Lock.load(event.address.toHexString())
   if (lock && lock.lockManagers) {
+    let newManagers: Bytes[] = []
     for (let i = 0; i < lock.lockManagers.length; i++) {
       const managerAddress = lock.lockManagers[i]
       if (managerAddress != event.params.account) {

--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -209,9 +209,7 @@ export function handleLockManagerRemoved(event: LockManagerRemovedEvent): void {
   const lock = Lock.load(event.address.toHexString())
   if (lock && lock.lockManagers) {
     const lockManagers = lock.lockManagers
-    const i = lockManagers.indexOf(event.params.account)
-    lockManagers.splice(i, 1)
-    lock.lockManagers = lockManagers
+    lock.lockManagers = lockManagers.filter(managerAddress => managerAddress != event.params.account)
     lock.save()
   }
 }


### PR DESCRIPTION
Updated the `splice` function to only remove i. Before it was removing all lock managers after i. 

(If `splice` doesn't have second argument (number to delete) it assumes to delete until it reaches the `array.length`)

# Description

PR to fix issue #10220 . Which removes more LockManagers on the subgraph than it should.

# Issues
#10220
