### PR TITLE
fix(subgraph): use `LockManagerAdded` for v8 locks

### DIFF
--- a/subgraph/src/unlock.ts
+++ b/subgraph/src/unlock.ts
@@ -43,12 +43,13 @@ export function handleNewLock(event: NewLock): void {
     lock.symbol = 'KEY'
   }
 
-  let maxKeysPerAddress = lockContract.try_maxKeysPerAddress()
-  if (!maxKeysPerAddress.reverted) {
-    lock.maxKeysPerAddress = maxKeysPerAddress.value
-  } else {
-    // set to 1 when using address instead of tokenId prior to lock v10
-    lock.maxKeysPerAddress = BigInt.fromI32(1)
+  // maxKeysPerAddress set to 1 prior to lock v10
+  lock.maxKeysPerAddress = BigInt.fromI32(1)
+  if (version.ge(BigInt.fromI32(9))) {
+    let maxKeysPerAddress = lockContract.try_maxKeysPerAddress()
+    if (!maxKeysPerAddress.reverted) {
+      lock.maxKeysPerAddress = maxKeysPerAddress.value
+    }
   }
 
   let maxNumberOfKeys = lockContract.try_maxNumberOfKeys()

--- a/subgraph/src/unlock.ts
+++ b/subgraph/src/unlock.ts
@@ -61,8 +61,14 @@ export function handleNewLock(event: NewLock): void {
   lock.version = version
   lock.createdAtBlock = event.block.number
 
-  // lock managers are parsed from RoleGranted events
-  lock.lockManagers = []
+  if (version.le(BigInt.fromI32(8))) {
+    // prior to v8, add default lock manager 
+    lock.lockManagers = [event.params.lockOwner]
+  } else {
+    // after v8, lock managers are parsed from `RoleGranted` events
+    lock.lockManagers = []
+  }
+  
 
   lock.save()
 

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -54,6 +54,8 @@ templates:
           file: ./abis/PublicLockV11.json
         - name: PublicLockV12
           file: ./abis/PublicLockV12.json
+        - name: PublicLockV8
+          file: ./abis/PublicLockV8.json
         - name: PublicLockV7
           file: ./abis/PublicLockV7.json
       eventHandlers:

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -74,6 +74,8 @@ templates:
         - event: RoleGranted(indexed bytes32,indexed address,indexed address)
           handler: handleRoleGranted
           receipt: true
+        - event: LockManagerAdded(indexed address)
+          handler: handleLockManagerAdded
         - event: LockManagerRemoved(indexed address)
           handler: handleLockManagerRemoved
         - event: PricingChanged(uint256,uint256,address,address)

--- a/subgraph/tests/keys-utils.ts
+++ b/subgraph/tests/keys-utils.ts
@@ -296,6 +296,7 @@ export function createLockManagerAddedEvent(
 ): LockManagerAdded {
   const lockManagerAddedEvent = changetype<LockManagerAdded>(newMockEvent())
 
+  lockManagerAddedEvent.address = dataSource.address()
   lockManagerAddedEvent.parameters = []
 
   lockManagerAddedEvent.parameters.push(

--- a/subgraph/tests/locks-utils.ts
+++ b/subgraph/tests/locks-utils.ts
@@ -1,14 +1,28 @@
 import { newMockEvent } from 'matchstick-as'
-import { ethereum, Address, BigInt, log, Bytes } from '@graphprotocol/graph-ts'
+import {
+  dataSourceMock,
+} from 'matchstick-as/assembly/index'
+
+import { ethereum, Address, BigInt, Value, Bytes, DataSourceContext } from '@graphprotocol/graph-ts'
 import { NewLock, LockUpgraded } from '../generated/Unlock/Unlock'
 import {
   RoleGranted,
+  LockManagerAdded,
   LockManagerRemoved,
   LockMetadata,
 } from '../generated/templates/PublicLock/PublicLock'
-import { lockAddress } from './constants'
+import { lockAddress, lockAddressV8 } from './constants'
 import { LOCK_MANAGER } from '../src/helpers'
 import { PricingChanged } from '../generated/templates/PublicLock/PublicLock'
+
+export function mockDataSourceV8(): void {
+  const v8context = new DataSourceContext()
+  v8context.set(
+    'lockAddress',
+    Value.fromAddress(Address.fromString(lockAddressV8))
+  )
+  dataSourceMock.setReturnValues(lockAddressV8, 'rinkeby', v8context)
+}
 
 export function createNewLockEvent(
   lockOwner: Address,
@@ -32,6 +46,24 @@ export function createNewLockEvent(
 }
 
 export function createLockManagerAddedEvent(
+  newLockManager: Address
+): LockManagerAdded {
+  const newLockManagerAdded = changetype<LockManagerAdded>(newMockEvent())
+
+  // set existing lock address
+  newLockManagerAdded.address = Address.fromString(lockAddress)
+
+  newLockManagerAdded.parameters = [
+    new ethereum.EventParam(
+      'account',
+      ethereum.Value.fromAddress(newLockManager)
+    ),
+  ]
+
+  return newLockManagerAdded
+}
+
+export function createRoleGrantedLockManagerAddedEvent(
   newLockManager: Address
 ): RoleGranted {
   const newRoleGranted = changetype<RoleGranted>(newMockEvent())

--- a/subgraph/tests/locks-utils.ts
+++ b/subgraph/tests/locks-utils.ts
@@ -7,7 +7,6 @@ import { ethereum, Address, BigInt, Value, Bytes, DataSourceContext } from '@gra
 import { NewLock, LockUpgraded } from '../generated/Unlock/Unlock'
 import {
   RoleGranted,
-  LockManagerAdded,
   LockManagerRemoved,
   LockMetadata,
 } from '../generated/templates/PublicLock/PublicLock'
@@ -45,23 +44,6 @@ export function createNewLockEvent(
   return newLockEvent
 }
 
-export function createLockManagerAddedEvent(
-  newLockManager: Address
-): LockManagerAdded {
-  const newLockManagerAdded = changetype<LockManagerAdded>(newMockEvent())
-
-  // set existing lock address
-  newLockManagerAdded.address = Address.fromString(lockAddress)
-
-  newLockManagerAdded.parameters = [
-    new ethereum.EventParam(
-      'account',
-      ethereum.Value.fromAddress(newLockManager)
-    ),
-  ]
-
-  return newLockManagerAdded
-}
 
 export function createRoleGrantedLockManagerAddedEvent(
   newLockManager: Address

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -96,7 +96,7 @@ describe('Describe Locks events', () => {
   })
 
   test('Lock manager added (using `LockManagerAdded`)', () => {
-    assert.fieldEquals('Lock', lockAddress, 'lockManagers', `[]`)
+    assert.fieldEquals('Lock', lockAddress, 'lockManagers', `[${lockManager}]`)
     const newLockManagerAdded = createLockManagerAddedEvent(
       Address.fromString(lockManager)
     )
@@ -106,7 +106,7 @@ describe('Describe Locks events', () => {
       'Lock',
       lockAddress,
       'lockManagers',
-      `[]`
+      `[${lockManager}, ${lockManager}]`
     )
   })
 
@@ -170,15 +170,15 @@ describe('Describe Locks events (v8)', () => {
   })
   test('Creation of a new lock (v8)', () => {
     assert.entityCount('Lock', 1)
-    assert.fieldEquals('Lock', lockAddress, 'address', lockAddressV8)
-    assert.fieldEquals('Lock', lockAddress, 'createdAtBlock', '1')
-    assert.fieldEquals('Lock', lockAddress, 'version', '8')
-    assert.fieldEquals('Lock', lockAddress, 'price', '1000')
-    assert.fieldEquals('Lock', lockAddress, 'name', 'My lock v8')
-    assert.fieldEquals('Lock', lockAddress, 'expirationDuration', `${duration}`)
-    assert.fieldEquals('Lock', lockAddress, 'tokenAddress', nullAddress)
-    assert.fieldEquals('Lock', lockAddress, 'lockManagers', `[${lockOwner}]`)
-    assert.fieldEquals('Lock', lockAddress, 'totalKeys', '0')
+    assert.fieldEquals('Lock', lockAddressV8, 'address', lockAddressV8)
+    assert.fieldEquals('Lock', lockAddressV8, 'createdAtBlock', '1')
+    assert.fieldEquals('Lock', lockAddressV8, 'version', '8')
+    assert.fieldEquals('Lock', lockAddressV8, 'price', '1000')
+    assert.fieldEquals('Lock', lockAddressV8, 'name', 'My lock v8')
+    assert.fieldEquals('Lock', lockAddressV8, 'expirationDuration', `${duration}`)
+    assert.fieldEquals('Lock', lockAddressV8, 'tokenAddress', nullAddress)
+    assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[${lockOwner}]`)
+    assert.fieldEquals('Lock', lockAddressV8, 'totalKeys', '0')
     assert.fieldEquals(
       'Lock',
       lockAddress,
@@ -194,7 +194,7 @@ describe('Describe Locks events (v8)', () => {
   })
 
   test('Lock manager added (v8)', () => {
-    assert.fieldEquals('Lock', lockAddress, 'lockManagers', `[${lockOwner}]`)
+    assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[${lockOwner}]`)
     const newLockManagerAdded = createLockManagerAddedEvent(
       Address.fromString(lockManager)
     )

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -106,7 +106,7 @@ describe('Describe Locks events', () => {
       'Lock',
       lockAddress,
       'lockManagers',
-      `[${lockManager}, ${lockManager}]`
+      `[${lockManager}]`
     )
   })
 
@@ -181,19 +181,20 @@ describe('Describe Locks events (v8)', () => {
     assert.fieldEquals('Lock', lockAddressV8, 'totalKeys', '0')
     assert.fieldEquals(
       'Lock',
-      lockAddress,
+      lockAddressV8,
       'maxNumberOfKeys',
       `${maxNumberOfKeys}`
     )
     assert.fieldEquals(
       'Lock',
-      lockAddress,
+      lockAddressV8,
       'maxKeysPerAddress',
-      `${maxKeysPerAddress}`
+      '1'
     )
   })
 
   test('Lock manager added (v8)', () => {
+    mockDataSourceV8()
     assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[${lockOwner}]`)
     const newLockManagerAdded = createLockManagerAddedEvent(
       Address.fromString(lockManager)
@@ -202,7 +203,7 @@ describe('Describe Locks events (v8)', () => {
 
     assert.fieldEquals(
       'Lock',
-      lockAddress,
+      lockAddressV8,
       'lockManagers',
       `[${lockOwner}, ${lockManager}]`
     )

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -20,13 +20,16 @@ import {
 import {
   createNewLockEvent,
   createRoleGrantedLockManagerAddedEvent, // using RoleGranted
-  createLockManagerAddedEvent, 
   createLockManagerRemovedEvent,
   createPricingChangedEvent,
   createLockUpgradedEvent,
   createLockMetadata,
   mockDataSourceV8,
 } from './locks-utils'
+import {
+  createLockManagerAddedEvent
+} from './keys-utils'
+
 import {
   duration,
   keyPrice,

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -40,6 +40,7 @@ import {
   baseTokenURI,
   maxNumberOfKeys,
   maxKeysPerAddress,
+  lockAddressV8,
 } from './constants'
 
 // mock contract functions
@@ -160,16 +161,16 @@ describe('Describe Locks events', () => {
 
 describe('Describe Locks events (v8)', () => {
   beforeAll(() => {
+    mockDataSourceV8()
     const newLockEvent = createNewLockEvent(
       Address.fromString(lockOwner),
-      Address.fromString(lockAddress)
+      Address.fromString(lockAddressV8)
     )
     handleNewLock(newLockEvent)
   })
   test('Creation of a new lock (v8)', () => {
-    mockDataSourceV8()
     assert.entityCount('Lock', 1)
-    assert.fieldEquals('Lock', lockAddress, 'address', lockAddress)
+    assert.fieldEquals('Lock', lockAddress, 'address', lockAddressV8)
     assert.fieldEquals('Lock', lockAddress, 'createdAtBlock', '1')
     assert.fieldEquals('Lock', lockAddress, 'version', '8')
     assert.fieldEquals('Lock', lockAddress, 'price', '1000')

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -157,6 +157,29 @@ createMockedFunction(
   .returns([ethereum.Value.fromString('My lock v8')])
 
 createMockedFunction(
+    Address.fromString(lockAddressV8),
+  'tokenAddress',
+  'tokenAddress():(address)'
+)
+  .withArgs([])
+  .returns([ethereum.Value.fromAddress(Address.fromString(nullAddress))])
+
+createMockedFunction(
+  Address.fromString(lockAddressV8),
+  'expirationDuration',
+  'expirationDuration():(uint256)'
+)
+  .withArgs([])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(duration))])
+
+createMockedFunction(
+  Address.fromString(lockAddressV8),
+  'symbol',
+  'symbol():(string)'
+)
+  .withArgs([])
+  .returns([ethereum.Value.fromString(symbol)])
+createMockedFunction(
   Address.fromString(lockAddressV8),
   'tokenURI',
   'tokenURI(uint256):(string)'

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -62,15 +62,6 @@ createMockedFunction(
   .withArgs([])
   .returns([ethereum.Value.fromI32(BigInt.fromString('11').toI32())])
 
-// before v9, publicLockVersion was returning uint16
-createMockedFunction(
-  Address.fromString(lockAddress),
-  'publicLockVersion',
-  'publicLockVersion():(uint256)'
-)
-  .withArgs([])
-  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('11'))])
-
 // key creation functions
 createMockedFunction(
   Address.fromString(lockAddress),
@@ -120,7 +111,7 @@ createMockedFunction(
 createMockedFunction(
   Address.fromString(lockAddressV8),
   'publicLockVersion',
-  'publicLockVersion():(uint16)'
+  'publicLockVersion():(uint256)'
 )
   .withArgs([])
   .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('8'))])

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -111,6 +111,14 @@ createMockedFunction(
 createMockedFunction(
   Address.fromString(lockAddressV8),
   'publicLockVersion',
+  'publicLockVersion():(uint16)'
+)
+  .withArgs([])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('8'))])
+
+createMockedFunction(
+  Address.fromString(lockAddressV8),
+  'publicLockVersion',
   'publicLockVersion():(uint256)'
 )
   .withArgs([])

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -62,6 +62,14 @@ createMockedFunction(
   .withArgs([])
   .returns([ethereum.Value.fromI32(BigInt.fromString('11').toI32())])
 
+createMockedFunction(
+  Address.fromString(lockAddress),
+  'publicLockVersion',
+  'publicLockVersion():(uint256)'
+)
+  .withArgs([])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('11'))])
+
 // key creation functions
 createMockedFunction(
   Address.fromString(lockAddress),

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -115,7 +115,7 @@ createMockedFunction(
   .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromU64(expiration))])
 
 /**
- * Mocks function for < v10 locks
+ * Mocks function for v8 locks
  */
 createMockedFunction(
   Address.fromString(lockAddressV8),
@@ -123,7 +123,31 @@ createMockedFunction(
   'publicLockVersion():(uint16)'
 )
   .withArgs([])
-  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('9'))])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('8'))])
+
+createMockedFunction(
+  Address.fromString(lockAddressV8),
+  'maxNumberOfKeys',
+  'maxNumberOfKeys():(uint256)'
+)
+  .withArgs([])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(maxNumberOfKeys))])
+
+createMockedFunction(
+  Address.fromString(lockAddressV8),
+  'keyPrice',
+  'keyPrice():(uint256)'
+)
+  .withArgs([])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(keyPrice))])
+
+createMockedFunction(
+  Address.fromString(lockAddressV8),
+  'name',
+  'name():(string)'
+)
+  .withArgs([])
+  .returns([ethereum.Value.fromString('My lock v8')])
 
 createMockedFunction(
   Address.fromString(lockAddressV8),


### PR DESCRIPTION
# Description

We recently switched to use OZ native role management event `RoleGranted` events to parse lock managers (https://github.com/unlock-protocol/unlock/pull/10092). This leads to a regression in locks with version prior to v9 as lock managers weren't parsed anymore (we didnt use OZ back then).

This adds support for using `LockManagerAdded` event to parse lock managers in locks up to v8 





<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

